### PR TITLE
Parse empty first line in msearch request body as action metadata

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
@@ -183,12 +183,6 @@ public class MultiSearchRequest extends ActionRequest implements CompositeIndice
             if (nextMarker == -1) {
                 break;
             }
-            // support first line with \n
-            if (nextMarker == 0) {
-                from = nextMarker + 1;
-                continue;
-            }
-
             SearchRequest searchRequest = new SearchRequest();
             if (indices != null) {
                 searchRequest.indices(indices);

--- a/server/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
@@ -48,6 +48,7 @@ import static java.util.Collections.singletonList;
 import static org.elasticsearch.search.RandomSearchRequestGenerator.randomSearchRequest;
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -178,6 +179,15 @@ public class MultiSearchRequestTests extends ESTestCase {
         assertThat(request.requests().get(2).types()[0], equalTo("type2"));
         assertThat(request.requests().get(2).types()[1], equalTo("type1"));
         assertThat(request.requests().get(2).routing(), equalTo("123"));
+    }
+
+    public void testNoMetadata() throws Exception {
+        MultiSearchRequest request = parseMultiSearchRequest("/org/elasticsearch/action/search/msearch-no-metadata.json");
+        assertThat(request.requests().size(), equalTo(4));
+        for (SearchRequest searchRequest : request.requests()) {
+            assertThat(searchRequest.indices().length, equalTo(0));
+            assertThat(searchRequest.source().query(), instanceOf(MatchAllQueryBuilder.class));
+        }
     }
 
     public void testResponseErrorToXContent() {

--- a/server/src/test/resources/org/elasticsearch/action/search/msearch-no-metadata.json
+++ b/server/src/test/resources/org/elasticsearch/action/search/msearch-no-metadata.json
@@ -1,0 +1,8 @@
+
+{ "query": {"match_all": {}}}
+
+{ "query": {"match_all": {}}}
+
+{ "query": {"match_all": {}}}
+
+{ "query": {"match_all": {}}}


### PR DESCRIPTION
It looks like when parsing the msearch request body, we allow for the first line to be empty, yet that causes some different treatment for the first line that ends up requiring the action metadata line, while all other lines don't as they can be just empty.

With this change we properly accept the following which we would otherwise reject due to the first line being empty:

```

{ "query": {"match_all": {}}}

{ "query": {"match_all": {}}}
```

but we stop accepting the following (note the empty line before the first action metadata line:

```

{}
{ "query": {"match_all": {}}}

{ "query": {"match_all": {}}}
```

Relates to #39841