### PR TITLE
[DOCS] Updates doc version and removes coming tags

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -1,4 +1,4 @@
-:version:               7.0.0-rc2
+:version:               7.0.0
 :major-version:         7.x
 :prev-major-version:    6.x
 :lucene_version:        8.0.0
@@ -13,7 +13,7 @@
 release-state can be: released | prerelease | unreleased
 //////////
 
-:release-state:   prerelease
+:release-state:   released
 
 :issue:           https://github.com/elastic/elasticsearch/issues/
 :ml-issue:        https://github.com/elastic/ml-cpp/issues/

--- a/docs/reference/release-notes/7.0.0.asciidoc
+++ b/docs/reference/release-notes/7.0.0.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-7.0.0]]
 == {es} version 7.0.0
 
-coming[7.0.0]
-
 //These release notes include all changes made in the alpha, beta, and RC
 //releases of 7.0.0. 
 


### PR DESCRIPTION
This PR updates the version information in the Versions.asciidoc file and removes the coming[7.0.0] tags in advance of the documentation release.