### PR TITLE
Create heap dump on OOME

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 org.gradle.daemon=true
-org.gradle.jvmargs=-Xmx2g
+org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError
 options.forkOptions.memoryMaximumSize=2g


### PR DESCRIPTION
When we run into Gradle memory issues it's pretty much impossible to troubleshoot without heap dumps. This PR adds a JVM argument to the Gradle daemon so that it automatically creates a heap dump on an OOME. We can then upload these to GCP in CI or share manually for local failures.