### PR TITLE
SQL: Change schema calls to empty set

### DIFF
--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcDatabaseMetaData.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcDatabaseMetaData.java
@@ -754,22 +754,14 @@ class JdbcDatabaseMetaData implements DatabaseMetaData, JdbcWrapper {
 
     @Override
     public ResultSet getSchemas() throws SQLException {
-        Object[][] data = { { EMPTY, defaultCatalog() } };
-        return memorySet(con.cfg, columnInfo("SCHEMATA",
-                                    "TABLE_SCHEM",
-                                    "TABLE_CATALOG"), data);
+        return emptySet(con.cfg, "SCHEMATA",
+                "TABLE_SCHEM",
+                "TABLE_CATALOG");
     }
 
     @Override
     public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
-        List<JdbcColumnInfo> info = columnInfo("SCHEMATA",
-                                           "TABLE_SCHEM",
-                                           "TABLE_CATALOG");
-        if (!isDefaultCatalog(catalog) || !isDefaultSchema(schemaPattern)) {
-            return emptySet(con.cfg, info);
-        }
-        Object[][] data = { { EMPTY, defaultCatalog() } };
-        return memorySet(con.cfg, info, data);
+        return getSchemas();
     }
 
     @Override

--- a/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/JdbcDatabaseMetaDataTests.java
+++ b/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/JdbcDatabaseMetaDataTests.java
@@ -104,6 +104,11 @@ public class JdbcDatabaseMetaDataTests extends ESTestCase {
         testEmptySet(() -> md.getPseudoColumns(null, null, null, null));
     }
 
+    public void testGetSchemas() throws Exception {
+        testEmptySet(() -> md.getSchemas());
+        testEmptySet(() -> md.getSchemas(null, null));
+    }
+
     private static void testEmptySet(CheckedSupplier<ResultSet, SQLException> supplier) throws SQLException {
         try (ResultSet result = supplier.get()) {
             assertNotNull(result);


### PR DESCRIPTION
As empty string has a certain meaning, the JDBC driver returns an empty
set instead for better client compatibility.

Fix #41028