### PR TITLE
Disable String interning on field names for JSON parsing

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContent.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContent.java
@@ -58,6 +58,8 @@ public class JsonXContent implements XContent {
         // Do not automatically close unclosed objects/arrays in com.fasterxml.jackson.core.json.UTF8JsonGenerator#close() method
         jsonFactory.configure(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT, false);
         jsonFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
+        // Disable String interning to improve performance
+        jsonFactory.disable(JsonFactory.Feature.INTERN_FIELD_NAMES);
         jsonXContent = new JsonXContent();
     }
 


### PR DESCRIPTION
This is based on a decision from (https://github.com/elastic/elasticsearch/issues/39890).

@hub-cap Just to be clear, the decision made in the above issue is to cover all uses of JsonXContent parsing?  Not just as part of the HLRC?