### PR TITLE
Add feature field to 7.0.0 release highlights

### DIFF
--- a/docs/reference/release-notes/highlights-7.0.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.0.0.asciidoc
@@ -302,19 +302,20 @@ WAND: Faster Retrieval of Top Hits in Elasticsearch].
 [float]
 === Faster boosting with feature fields
 
-The Query DSL provides a multitude of ways to boost or modulate how documents are
-scored.  But a common scenario is boosting an entire document based on some kind
-of static criteria recorded on the document itself.  A common example is a pre-computed
-scoring factor (PageRank-esque metric, global popularity score, etc), or 
-metadata about the data itself.
+The Query DSL provides a multitude of ways to boost or modulate how documents
+are scored. But a common scenario is boosting an entire document based on some
+kind of static criteria recorded on the document itself. A common example is a
+pre-computed scoring factor (PageRank-esque metric, global popularity score,
+etc), or  metadata about the data itself. 
 
-Elasticsearch now exposes a new `feature` field type, which can be used to index
-a numeric value dedicated to scoring.  At query time, a `feature` can make use of this field
-to boost the relevance of the entire document.  But unlike using query boosts or
-a `function_score` , this new field and query can efficiently skip documents
-that no longer have competitive scores.  This speedup is enabled due to the new
-Block-max WAND support in Lucene, and can lead to astonishingly large
-speedups because large stretches of the index can now be skipped entirely.
+Elasticsearch now exposes a new `feature` field type, which can be used to
+index a numeric value dedicated to scoring. At query time, a `feature` can
+make use of this field to boost the relevance of the entire document. But
+unlike using query boosts or a `function_score`, this new field and query can
+efficiently skip documents that no longer have competitive scores. This
+speedup is enabled due to the new Block-max WAND support in Lucene, and can
+lead to astonishingly large speedups because large stretches of the index can
+now be skipped entirely.
 //end::notable-highlights[]
 
 //tag::notable-highlights[]

--- a/docs/reference/release-notes/highlights-7.0.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.0.0.asciidoc
@@ -300,7 +300,7 @@ WAND: Faster Retrieval of Top Hits in Elasticsearch].
 
 //tag::notable-highlights[]
 [float]
-=== Faster Boosting with Feature Fields
+=== Faster boosting with feature fields
 
 The Query DSL provides a multitude of ways to boost or modulate how documents are
 scored.  But a common scenario is boosting an entire document based on some kind

--- a/docs/reference/release-notes/highlights-7.0.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.0.0.asciidoc
@@ -5,7 +5,7 @@
 ++++
 
 See also <<breaking-changes-7.0,Breaking changes>> and
-<<release-notes-7.0.0-alpha1,Release notes>>.
+<<release-notes-7.0.0,Release notes>>.
 
 //NOTE: The notable-highlights tagged regions are re-used in the
 //Installation and Upgrade Guide
@@ -297,6 +297,25 @@ powerful algorithmic development in our blog post
 https://www.elastic.co/blog/faster-retrieval-of-top-hits-in-elasticsearch-with-block-max-wand[Magic
 WAND: Faster Retrieval of Top Hits in Elasticsearch].
 //end::notable-highlights[]
+
+//tag::notable-highlights[]
+[float]
+=== Faster Boosting with Feature Fields
+
+The Query DSL provides a multitude of ways to boost or modulate how documents are
+scored.  But a common scenario is boosting an entire document based on some kind
+of static criteria recorded on the document itself.  A common example is a pre-computed
+scoring factor (PageRank-esque metric, global popularity score, etc), or 
+metadata about the data itself.
+
+Elasticsearch now exposes a new `feature` field type, which can be used to index
+a numeric value dedicated to scoring.  At query time, a `feature` can make use of this field
+to boost the relevance of the entire document.  But unlike using query boosts or
+a `function_score` , this new field and query can efficiently skip documents
+that no longer have competitive scores.  This speedup is enabled due to the new
+Block-max WAND support in Lucene, and can lead to astonishingly large
+speedups because large stretches of the index can now be skipped entirely.
+
 
 //tag::notable-highlights[]
 [float]

--- a/docs/reference/release-notes/highlights-7.0.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.0.0.asciidoc
@@ -315,7 +315,7 @@ a `function_score` , this new field and query can efficiently skip documents
 that no longer have competitive scores.  This speedup is enabled due to the new
 Block-max WAND support in Lucene, and can lead to astonishingly large
 speedups because large stretches of the index can now be skipped entirely.
-
+//end::notable-highlights[]
 
 //tag::notable-highlights[]
 [float]


### PR DESCRIPTION
Adds the new feature field to the release highlights.  It's implicitly covered by the Lucene upgrade item, and sorta related to the block-max WAND item... but it seemed sufficiently exciting to call out on it's own.  

Happy to close if other's don't feel the same though.  Also happy to tweak language if I described it poorly/incorrectly/whatever. :)

Also fixed the link to point to 7.0 release notes instead of alpha