### PR TITLE
BACKPORT Deprecate permission over aliases (#38059)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
@@ -53,7 +53,7 @@ public final class IndicesPermission {
         this.groups = groups;
     }
 
-    static Predicate<String> indexMatcher(Collection<String> indices) {
+    public static Predicate<String> indexMatcher(Collection<String> indices) {
         Set<String> exactMatch = new HashSet<>();
         List<String> nonExactMatch = new ArrayList<>();
         for (String indexPattern : indices) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -182,6 +182,7 @@ import org.elasticsearch.xpack.security.authz.interceptor.ResizeRequestIntercept
 import org.elasticsearch.xpack.security.authz.interceptor.SearchRequestInterceptor;
 import org.elasticsearch.xpack.security.authz.interceptor.UpdateRequestInterceptor;
 import org.elasticsearch.xpack.security.authz.store.CompositeRolesStore;
+import org.elasticsearch.xpack.security.authz.store.DeprecationRoleDescriptorConsumer;
 import org.elasticsearch.xpack.security.authz.store.FileRolesStore;
 import org.elasticsearch.xpack.security.authz.store.NativePrivilegeStore;
 import org.elasticsearch.xpack.security.authz.store.NativeRolesStore;
@@ -443,8 +444,10 @@ public class Security extends Plugin implements ActionPlugin, IngestPlugin, Netw
             threadPool);
         components.add(apiKeyService);
         final CompositeRolesStore allRolesStore = new CompositeRolesStore(settings, fileRolesStore, nativeRolesStore, reservedRolesStore,
-            privilegeStore, rolesProviders, threadPool.getThreadContext(), getLicenseState(), fieldPermissionsCache, apiKeyService);
+            privilegeStore, rolesProviders, threadPool.getThreadContext(), getLicenseState(), fieldPermissionsCache, apiKeyService,
+            new DeprecationRoleDescriptorConsumer(clusterService, threadPool));
         securityIndex.get().addIndexStateListener(allRolesStore::onSecurityIndexStateChange);
+
         // to keep things simple, just invalidate all cached entries on license change. this happens so rarely that the impact should be
         // minimal
         getLicenseState().addListener(allRolesStore::invalidateAll);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/DeprecationRoleDescriptorConsumer.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/DeprecationRoleDescriptorConsumer.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.security.authz.store;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.Operations;
+import org.elasticsearch.cluster.metadata.AliasOrIndex;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor.IndicesPrivileges;
+import org.elasticsearch.xpack.core.security.authz.permission.IndicesPermission;
+import org.elasticsearch.xpack.core.security.authz.privilege.IndexPrivilege;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * Inspects all aliases that have greater privileges than the indices that they point to and logs the role descriptor, granting privileges
+ * in this manner, as deprecated and requiring changes. This is done in preparation for the removal of the ability to define privileges over
+ * aliases. The log messages are generated asynchronously and do not generate deprecation response headers. One log entry is generated for
+ * each role descriptor and alias pair, and it contains all the indices for which privileges are a subset of those of the alias. In this
+ * case, the administrator has to adjust the index privileges definition of the respective role such that name patterns do not cover aliases
+ * (or rename aliases). If no logging is generated then the roles used for the current indices and aliases are not vulnerable to the
+ * subsequent breaking change. However, there could be role descriptors that are not used (not mapped to a user that is currently using the
+ * system) which are invisible to this check. Moreover, role descriptors can be dynamically added by role providers. In addition, role
+ * descriptors are merged when building the effective role, so a role-alias pair reported as deprecated might not actually have an impact if
+ * other role descriptors cover its indices. The check iterates over all indices and aliases for each role descriptor so it is quite
+ * expensive computationally. For this reason the check is done only once a day for each role. If the role definitions stay the same, the
+ * deprecations can change from one day to another only if aliases or indices are added.
+ */
+public final class DeprecationRoleDescriptorConsumer implements Consumer<Collection<RoleDescriptor>> {
+
+    private static final String ROLE_PERMISSION_DEPRECATION_STANZA = "Role [%s] contains index privileges covering the [%s] alias but"
+            + " which do not cover some of the indices that it points to [%s]. Granting privileges over an alias and hence granting"
+            + " privileges over all the indices that the alias points to is deprecated and will be removed in a future version of"
+            + " Elasticsearch. Instead define permissions exclusively on index names or index name patterns.";
+
+    private static final Logger logger = LogManager.getLogger(DeprecationRoleDescriptorConsumer.class);
+
+    private final DeprecationLogger deprecationLogger;
+    private final ClusterService clusterService;
+    private final ThreadPool threadPool;
+    private final Object mutex;
+    private final Queue<RoleDescriptor> workQueue;
+    private boolean workerBusy;
+    private final Set<String> dailyRoleCache;
+
+    public DeprecationRoleDescriptorConsumer(ClusterService clusterService, ThreadPool threadPool) {
+        this(clusterService, threadPool, new DeprecationLogger(logger));
+    }
+
+    // package-private for testing
+    DeprecationRoleDescriptorConsumer(ClusterService clusterService, ThreadPool threadPool, DeprecationLogger deprecationLogger) {
+        this.deprecationLogger = deprecationLogger;
+        this.clusterService = clusterService;
+        this.threadPool = threadPool;
+        this.mutex = new Object();
+        this.workQueue = new LinkedList<>();
+        this.workerBusy = false;
+        // this String Set keeps "<date>-<role>" pairs so that we only log a role once a day.
+        this.dailyRoleCache = Collections.newSetFromMap(new LinkedHashMap<String, Boolean>() {
+            @Override
+            protected boolean removeEldestEntry(final Map.Entry<String, Boolean> eldest) {
+                return false == eldest.getKey().startsWith(todayISODate());
+            }
+        });
+    }
+
+    @Override
+    public void accept(Collection<RoleDescriptor> effectiveRoleDescriptors) {
+        synchronized (mutex) {
+            for (RoleDescriptor roleDescriptor : effectiveRoleDescriptors) {
+                if (dailyRoleCache.add(buildCacheKey(roleDescriptor))) {
+                    workQueue.add(roleDescriptor);
+                }
+            }
+            if (false == workerBusy) {
+                workerBusy = true;
+                try {
+                    // spawn another worker on the generic thread pool
+                    threadPool.generic().execute(new AbstractRunnable() {
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            logger.warn("Failed to produce role deprecation messages", e);
+                            synchronized (mutex) {
+                                final boolean hasMoreWork = workQueue.peek() != null;
+                                if (hasMoreWork) {
+                                    workerBusy = true; // just being paranoid :)
+                                    try {
+                                        threadPool.generic().execute(this);
+                                    } catch (RejectedExecutionException e1) {
+                                        workerBusy = false;
+                                        logger.warn("Failed to start working on role alias permisssion deprecation messages", e1);
+                                    }
+                                } else {
+                                    workerBusy = false;
+                                }
+                            }
+                        }
+
+                        @Override
+                        protected void doRun() throws Exception {
+                            while (true) {
+                                final RoleDescriptor workItem;
+                                synchronized (mutex) {
+                                    workItem = workQueue.poll();
+                                    if (workItem == null) {
+                                        workerBusy = false;
+                                        break;
+                                    }
+                                }
+                                logger.trace("Begin role [" + workItem.getName() + "] check for alias permission deprecation");
+                                // executing the check asynchronously will not conserve the generated deprecation response headers (which is
+                                // what we want, because it's not the request that uses deprecated features, but rather the role definition.
+                                // Furthermore, due to caching, we can't reliably associate response headers to every request).
+                                logDeprecatedPermission(workItem);
+                                logger.trace("Completed role [" + workItem.getName() + "] check for alias permission deprecation");
+                            }
+                        }
+                    });
+                } catch (RejectedExecutionException e) {
+                    workerBusy = false;
+                    logger.warn("Failed to start working on role alias permisssion deprecation messages", e);
+                }
+            }
+        }
+    }
+
+    private void logDeprecatedPermission(RoleDescriptor roleDescriptor) {
+        final SortedMap<String, AliasOrIndex> aliasOrIndexMap = clusterService.state().metaData().getAliasAndIndexLookup();
+        final Map<String, Set<String>> privilegesByAliasMap = new HashMap<>();
+        // sort answer by alias for tests
+        final SortedMap<String, Set<String>> privilegesByIndexMap = new TreeMap<>();
+        // collate privileges by index and by alias separately
+        for (final IndicesPrivileges indexPrivilege : roleDescriptor.getIndicesPrivileges()) {
+            final Predicate<String> namePatternPredicate = IndicesPermission.indexMatcher(Arrays.asList(indexPrivilege.getIndices()));
+            for (final Map.Entry<String, AliasOrIndex> aliasOrIndex : aliasOrIndexMap.entrySet()) {
+                final String aliasOrIndexName = aliasOrIndex.getKey();
+                if (namePatternPredicate.test(aliasOrIndexName)) {
+                    if (aliasOrIndex.getValue().isAlias()) {
+                        final Set<String> privilegesByAlias = privilegesByAliasMap.computeIfAbsent(aliasOrIndexName,
+                                k -> new HashSet<String>());
+                        privilegesByAlias.addAll(Arrays.asList(indexPrivilege.getPrivileges()));
+                    } else {
+                        final Set<String> privilegesByIndex = privilegesByIndexMap.computeIfAbsent(aliasOrIndexName,
+                                k -> new HashSet<String>());
+                        privilegesByIndex.addAll(Arrays.asList(indexPrivilege.getPrivileges()));
+                    }
+                }
+            }
+        }
+        // compute privileges Automaton for each alias and for each of the indices it points to
+        final Map<String, Automaton> indexAutomatonMap = new HashMap<>();
+        for (Map.Entry<String, Set<String>> privilegesByAlias : privilegesByAliasMap.entrySet()) {
+            final String aliasName = privilegesByAlias.getKey();
+            final Set<String> aliasPrivilegeNames = privilegesByAlias.getValue();
+            final Automaton aliasPrivilegeAutomaton = IndexPrivilege.get(aliasPrivilegeNames).getAutomaton();
+            final SortedSet<String> inferiorIndexNames = new TreeSet<>();
+            // check if the alias grants superiors privileges than the indices it points to
+            for (IndexMetaData indexMetadata : aliasOrIndexMap.get(aliasName).getIndices()) {
+                final String indexName = indexMetadata.getIndex().getName();
+                final Set<String> indexPrivileges = privilegesByIndexMap.get(indexName);
+                // null iff the index does not have *any* privilege
+                if (indexPrivileges != null) {
+                    // compute automaton once per index no matter how many times it is pointed to
+                    final Automaton indexPrivilegeAutomaton = indexAutomatonMap.computeIfAbsent(indexName,
+                            i -> IndexPrivilege.get(indexPrivileges).getAutomaton());
+                    if (false == Operations.subsetOf(indexPrivilegeAutomaton, aliasPrivilegeAutomaton)) {
+                        inferiorIndexNames.add(indexName);
+                    }
+                } else {
+                    inferiorIndexNames.add(indexName);
+                }
+            }
+            // log inferior indices for this role, for this alias
+            if (false == inferiorIndexNames.isEmpty()) {
+                final String logMessage = String.format(Locale.ROOT, ROLE_PERMISSION_DEPRECATION_STANZA, roleDescriptor.getName(),
+                        aliasName, String.join(", ", inferiorIndexNames));
+                deprecationLogger.deprecated(logMessage);
+            }
+        }
+    }
+
+    private static String todayISODate() {
+        return ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.BASIC_ISO_DATE);
+    }
+
+    // package-private for testing
+    static String buildCacheKey(RoleDescriptor roleDescriptor) {
+        return todayISODate() + "-" + roleDescriptor.getName();
+    }
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/DeprecationRoleDescriptorConsumerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/DeprecationRoleDescriptorConsumerTests.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.security.authz.store;
+
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.AliasMetaData;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.mock.orig.Mockito;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.VersionUtils;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+import org.junit.Before;
+import org.mockito.stubbing.Answer;
+
+import java.util.Arrays;
+import java.util.concurrent.ExecutorService;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public final class DeprecationRoleDescriptorConsumerTests extends ESTestCase {
+
+    private ThreadPool threadPool;
+
+    @Before
+    public void init() throws Exception {
+        this.threadPool = mock(ThreadPool.class);
+        ExecutorService executorService = mock(ExecutorService.class);
+        Mockito.doAnswer((Answer) invocation -> {
+            final Runnable arg0 = (Runnable) invocation.getArguments()[0];
+            arg0.run();
+            return null;
+        }).when(executorService).execute(Mockito.isA(Runnable.class));
+        when(threadPool.generic()).thenReturn(executorService);
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+    }
+
+    public void testSimpleAliasAndIndexPair() throws Exception {
+        final DeprecationLogger deprecationLogger = mock(DeprecationLogger.class);
+        final MetaData.Builder metaDataBuilder = MetaData.builder();
+        addIndex(metaDataBuilder, "index", "alias");
+        final RoleDescriptor roleOverAlias = new RoleDescriptor("roleOverAlias", new String[] { "read" },
+                new RoleDescriptor.IndicesPrivileges[] { indexPrivileges(randomFrom("read", "write", "delete", "index"), "alias") }, null);
+        final RoleDescriptor roleOverIndex = new RoleDescriptor("roleOverIndex", new String[] { "manage" },
+                new RoleDescriptor.IndicesPrivileges[] { indexPrivileges(randomFrom("read", "write", "delete", "index"), "index") }, null);
+        DeprecationRoleDescriptorConsumer deprecationConsumer = new DeprecationRoleDescriptorConsumer(
+                mockClusterService(metaDataBuilder.build()), threadPool, deprecationLogger);
+        deprecationConsumer.accept(Arrays.asList(roleOverAlias, roleOverIndex));
+        verifyLogger(deprecationLogger, "roleOverAlias", "alias", "index");
+        verifyNoMoreInteractions(deprecationLogger);
+    }
+
+    public void testRoleGrantsOnIndexAndAliasPair() throws Exception {
+        final DeprecationLogger deprecationLogger = mock(DeprecationLogger.class);
+        final MetaData.Builder metaDataBuilder = MetaData.builder();
+        addIndex(metaDataBuilder, "index", "alias");
+        addIndex(metaDataBuilder, "index1", "alias2");
+        final RoleDescriptor roleOverIndexAndAlias = new RoleDescriptor("roleOverIndexAndAlias", new String[] { "manage_watcher" },
+                new RoleDescriptor.IndicesPrivileges[] {
+                        indexPrivileges(randomFrom("read", "write", "delete", "index"), "index", "alias") },
+                null);
+        DeprecationRoleDescriptorConsumer deprecationConsumer = new DeprecationRoleDescriptorConsumer(
+                mockClusterService(metaDataBuilder.build()), threadPool, deprecationLogger);
+        deprecationConsumer.accept(Arrays.asList(roleOverIndexAndAlias));
+        verifyNoMoreInteractions(deprecationLogger);
+    }
+
+    public void testMultiplePrivilegesLoggedOnce() throws Exception {
+        final DeprecationLogger deprecationLogger = mock(DeprecationLogger.class);
+        final MetaData.Builder metaDataBuilder = MetaData.builder();
+        addIndex(metaDataBuilder, "index", "alias");
+        addIndex(metaDataBuilder, "index2", "alias2");
+        final RoleDescriptor roleOverAlias = new RoleDescriptor("roleOverAlias", new String[] { "manage_watcher" },
+                new RoleDescriptor.IndicesPrivileges[] {
+                        indexPrivileges("write", "alias"),
+                        indexPrivileges("manage_ilm", "alias") },
+                null);
+        DeprecationRoleDescriptorConsumer deprecationConsumer = new DeprecationRoleDescriptorConsumer(
+                mockClusterService(metaDataBuilder.build()), threadPool, deprecationLogger);
+        deprecationConsumer.accept(Arrays.asList(roleOverAlias));
+        verifyLogger(deprecationLogger, "roleOverAlias", "alias", "index");
+        verifyNoMoreInteractions(deprecationLogger);
+    }
+
+    public void testMultiplePrivilegesLoggedForEachAlias() throws Exception {
+        final DeprecationLogger deprecationLogger = mock(DeprecationLogger.class);
+        final MetaData.Builder metaDataBuilder = MetaData.builder();
+        addIndex(metaDataBuilder, "index", "alias", "alias3");
+        addIndex(metaDataBuilder, "index2", "alias2", "alias", "alias4");
+        addIndex(metaDataBuilder, "index3", "alias3", "alias");
+        addIndex(metaDataBuilder, "index4", "alias4", "alias");
+        addIndex(metaDataBuilder, "foo", "bar");
+        final RoleDescriptor roleMultiplePrivileges = new RoleDescriptor("roleMultiplePrivileges", new String[] { "manage_watcher" },
+                new RoleDescriptor.IndicesPrivileges[] {
+                        indexPrivileges("write", "index2", "alias"),
+                        indexPrivileges("read", "alias4"),
+                        indexPrivileges("delete_index", "alias3", "index"),
+                        indexPrivileges("create_index", "alias3", "index3")},
+                null);
+        DeprecationRoleDescriptorConsumer deprecationConsumer = new DeprecationRoleDescriptorConsumer(
+                mockClusterService(metaDataBuilder.build()), threadPool, deprecationLogger);
+        deprecationConsumer.accept(Arrays.asList(roleMultiplePrivileges));
+        verifyLogger(deprecationLogger, "roleMultiplePrivileges", "alias", "index, index3, index4");
+        verifyLogger(deprecationLogger, "roleMultiplePrivileges", "alias4", "index2, index4");
+        verifyNoMoreInteractions(deprecationLogger);
+    }
+
+    public void testPermissionsOverlapping() throws Exception {
+        final DeprecationLogger deprecationLogger = mock(DeprecationLogger.class);
+        final MetaData.Builder metaDataBuilder = MetaData.builder();
+        addIndex(metaDataBuilder, "index1", "alias1", "bar");
+        addIndex(metaDataBuilder, "index2", "alias2", "baz");
+        addIndex(metaDataBuilder, "foo", "bar");
+        final RoleDescriptor roleOverAliasAndIndex = new RoleDescriptor("roleOverAliasAndIndex", new String[] { "read_ilm" },
+                new RoleDescriptor.IndicesPrivileges[] {
+                        indexPrivileges("monitor", "index2", "alias1"),
+                        indexPrivileges("monitor", "index1", "alias2")},
+                null);
+        DeprecationRoleDescriptorConsumer deprecationConsumer = new DeprecationRoleDescriptorConsumer(
+                mockClusterService(metaDataBuilder.build()), threadPool, deprecationLogger);
+        deprecationConsumer.accept(Arrays.asList(roleOverAliasAndIndex));
+        verifyNoMoreInteractions(deprecationLogger);
+    }
+
+    public void testOverlappingAcrossMultipleRoleDescriptors() throws Exception {
+        final DeprecationLogger deprecationLogger = mock(DeprecationLogger.class);
+        final MetaData.Builder metaDataBuilder = MetaData.builder();
+        addIndex(metaDataBuilder, "index1", "alias1", "bar");
+        addIndex(metaDataBuilder, "index2", "alias2", "baz");
+        addIndex(metaDataBuilder, "foo", "bar");
+        final RoleDescriptor role1 = new RoleDescriptor("role1", new String[] { "monitor_watcher" },
+                new RoleDescriptor.IndicesPrivileges[] {
+                        indexPrivileges("monitor", "index2", "alias1")},
+                null);
+        final RoleDescriptor role2 = new RoleDescriptor("role2", new String[] { "read_ccr" },
+                new RoleDescriptor.IndicesPrivileges[] {
+                        indexPrivileges("monitor", "index1", "alias2")},
+                null);
+        final RoleDescriptor role3 = new RoleDescriptor("role3", new String[] { "monitor_ml" },
+                new RoleDescriptor.IndicesPrivileges[] {
+                        indexPrivileges("index", "bar")},
+                null);
+        DeprecationRoleDescriptorConsumer deprecationConsumer = new DeprecationRoleDescriptorConsumer(
+                mockClusterService(metaDataBuilder.build()), threadPool, deprecationLogger);
+        deprecationConsumer.accept(Arrays.asList(role1, role2, role3));
+        verifyLogger(deprecationLogger, "role1", "alias1", "index1");
+        verifyLogger(deprecationLogger, "role2", "alias2", "index2");
+        verifyLogger(deprecationLogger, "role3", "bar", "foo, index1");
+        verifyNoMoreInteractions(deprecationLogger);
+    }
+
+    public void testDailyRoleCaching() throws Exception {
+        final DeprecationLogger deprecationLogger = mock(DeprecationLogger.class);
+        final MetaData.Builder metaDataBuilder = MetaData.builder();
+        addIndex(metaDataBuilder, "index1", "alias1", "far");
+        addIndex(metaDataBuilder, "index2", "alias2", "baz");
+        addIndex(metaDataBuilder, "foo", "bar");
+        final MetaData metaData = metaDataBuilder.build();
+        RoleDescriptor someRole = new RoleDescriptor("someRole", new String[] { "monitor_rollup" },
+                new RoleDescriptor.IndicesPrivileges[] {
+                        indexPrivileges("monitor", "i*", "bar")},
+                null);
+        final DeprecationRoleDescriptorConsumer deprecationConsumer = new DeprecationRoleDescriptorConsumer(mockClusterService(metaData),
+                threadPool, deprecationLogger);
+        final String cacheKeyBefore = DeprecationRoleDescriptorConsumer.buildCacheKey(someRole);
+        deprecationConsumer.accept(Arrays.asList(someRole));
+        verifyLogger(deprecationLogger, "someRole", "bar", "foo");
+        verifyNoMoreInteractions(deprecationLogger);
+        deprecationConsumer.accept(Arrays.asList(someRole));
+        final String cacheKeyAfter = DeprecationRoleDescriptorConsumer.buildCacheKey(someRole);
+        // we don't do this test if it crosses days
+        if (false == cacheKeyBefore.equals(cacheKeyAfter)) {
+            return;
+        }
+        verifyNoMoreInteractions(deprecationLogger);
+        RoleDescriptor differentRoleSameName = new RoleDescriptor("someRole", new String[] { "manage_pipeline" },
+                new RoleDescriptor.IndicesPrivileges[] {
+                        indexPrivileges("write", "i*", "baz")},
+                null);
+        deprecationConsumer.accept(Arrays.asList(differentRoleSameName));
+        final String cacheKeyAfterParty = DeprecationRoleDescriptorConsumer.buildCacheKey(differentRoleSameName);
+        // we don't do this test if it crosses days
+        if (false == cacheKeyBefore.equals(cacheKeyAfterParty)) {
+            return;
+        }
+        verifyNoMoreInteractions(deprecationLogger);
+    }
+
+    public void testWildcards() throws Exception {
+        final DeprecationLogger deprecationLogger = mock(DeprecationLogger.class);
+        final MetaData.Builder metaDataBuilder = MetaData.builder();
+        addIndex(metaDataBuilder, "index", "alias", "alias3");
+        addIndex(metaDataBuilder, "index2", "alias", "alias2", "alias4");
+        addIndex(metaDataBuilder, "index3", "alias", "alias3");
+        addIndex(metaDataBuilder, "index4", "alias", "alias4");
+        addIndex(metaDataBuilder, "foo", "bar", "baz");
+        MetaData metaData = metaDataBuilder.build();
+        final RoleDescriptor roleGlobalWildcard = new RoleDescriptor("roleGlobalWildcard", new String[] { "manage_token" },
+                new RoleDescriptor.IndicesPrivileges[] {
+                        indexPrivileges(randomFrom("write", "delete_index", "read_cross_cluster"), "*")},
+                null);
+        new DeprecationRoleDescriptorConsumer(mockClusterService(metaData), threadPool, deprecationLogger)
+        .accept(Arrays.asList(roleGlobalWildcard));
+        verifyNoMoreInteractions(deprecationLogger);
+        final RoleDescriptor roleGlobalWildcard2 = new RoleDescriptor("roleGlobalWildcard2", new String[] { "manage_index_templates" },
+                new RoleDescriptor.IndicesPrivileges[] {
+                        indexPrivileges(randomFrom("write", "delete_index", "read_cross_cluster"), "i*", "a*")},
+                null);
+        new DeprecationRoleDescriptorConsumer(mockClusterService(metaData), threadPool, deprecationLogger)
+        .accept(Arrays.asList(roleGlobalWildcard2));
+        verifyNoMoreInteractions(deprecationLogger);
+        final RoleDescriptor roleWildcardOnIndices = new RoleDescriptor("roleWildcardOnIndices", new String[] { "manage_watcher" },
+                new RoleDescriptor.IndicesPrivileges[] {
+                        indexPrivileges("write", "index*", "alias", "alias3"),
+                        indexPrivileges("read", "foo")},
+                null);
+        new DeprecationRoleDescriptorConsumer(mockClusterService(metaData), threadPool, deprecationLogger)
+                .accept(Arrays.asList(roleWildcardOnIndices));
+        verifyNoMoreInteractions(deprecationLogger);
+        final RoleDescriptor roleWildcardOnAliases = new RoleDescriptor("roleWildcardOnAliases", new String[] { "manage_watcher" },
+                new RoleDescriptor.IndicesPrivileges[] {
+                        indexPrivileges("write", "alias*", "index", "index3"),
+                        indexPrivileges("read", "foo", "index2")},
+                null);
+        new DeprecationRoleDescriptorConsumer(mockClusterService(metaData), threadPool, deprecationLogger)
+                .accept(Arrays.asList(roleWildcardOnAliases));
+        verifyLogger(deprecationLogger, "roleWildcardOnAliases", "alias", "index2, index4");
+        verifyLogger(deprecationLogger, "roleWildcardOnAliases", "alias2", "index2");
+        verifyLogger(deprecationLogger, "roleWildcardOnAliases", "alias4", "index2, index4");
+        verifyNoMoreInteractions(deprecationLogger);
+    }
+
+    public void testMultipleIndicesSameAlias() throws Exception {
+        final DeprecationLogger deprecationLogger = mock(DeprecationLogger.class);
+        final MetaData.Builder metaDataBuilder = MetaData.builder();
+        addIndex(metaDataBuilder, "index1", "alias1");
+        addIndex(metaDataBuilder, "index2", "alias1", "alias2");
+        addIndex(metaDataBuilder, "index3", "alias2");
+        final RoleDescriptor roleOverAliasAndIndex = new RoleDescriptor("roleOverAliasAndIndex", new String[] { "manage_ml" },
+                new RoleDescriptor.IndicesPrivileges[] {
+                        indexPrivileges("delete_index", "alias1", "index1") },
+                null);
+        DeprecationRoleDescriptorConsumer deprecationConsumer = new DeprecationRoleDescriptorConsumer(
+                mockClusterService(metaDataBuilder.build()), threadPool, deprecationLogger);
+        deprecationConsumer.accept(Arrays.asList(roleOverAliasAndIndex));
+        verifyLogger(deprecationLogger, "roleOverAliasAndIndex", "alias1", "index2");
+        verifyNoMoreInteractions(deprecationLogger);
+        final RoleDescriptor roleOverAliases = new RoleDescriptor("roleOverAliases", new String[] { "manage_security" },
+                new RoleDescriptor.IndicesPrivileges[] {
+                        indexPrivileges("monitor", "alias1", "alias2") },
+                null);
+        deprecationConsumer.accept(Arrays.asList(roleOverAliases));
+        verifyLogger(deprecationLogger, "roleOverAliases", "alias1", "index1, index2");
+        verifyLogger(deprecationLogger, "roleOverAliases", "alias2", "index2, index3");
+        verifyNoMoreInteractions(deprecationLogger);
+    }
+
+    private void addIndex(MetaData.Builder metaDataBuilder, String index, String... aliases) {
+        final IndexMetaData.Builder indexMetaDataBuilder = IndexMetaData.builder(index)
+                .settings(Settings.builder().put("index.version.created", VersionUtils.randomVersion(random())))
+                .numberOfShards(1)
+                .numberOfReplicas(1);
+        for (final String alias : aliases) {
+            indexMetaDataBuilder.putAlias(AliasMetaData.builder(alias).build());
+        }
+        metaDataBuilder.put(indexMetaDataBuilder.build(), false);
+    }
+
+    private ClusterService mockClusterService(MetaData metaData) {
+        final ClusterService clusterService = mock(ClusterService.class);
+        final ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metaData(metaData).build();
+        when(clusterService.state()).thenReturn(clusterState);
+        return clusterService;
+    }
+
+    private RoleDescriptor.IndicesPrivileges indexPrivileges(String priv, String... indicesOrAliases) {
+        return RoleDescriptor.IndicesPrivileges.builder()
+                .indices(indicesOrAliases)
+                .privileges(priv)
+                .grantedFields(randomArray(0, 2, String[]::new, () -> randomBoolean() ? null : randomAlphaOfLengthBetween(1, 4)))
+                .query(randomBoolean() ? null : "{ }")
+                .build();
+    }
+
+    private void verifyLogger(DeprecationLogger deprecationLogger, String roleName, String aliasName, String indexNames) {
+        verify(deprecationLogger).deprecated("Role [" + roleName + "] contains index privileges covering the [" + aliasName
+                + "] alias but which do not cover some of the indices that it points to [" + indexNames + "]. Granting privileges over an"
+                + " alias and hence granting privileges over all the indices that the alias points to is deprecated and will be removed"
+                + " in a future version of Elasticsearch. Instead define permissions exclusively on index names or index name patterns.");
+    }
+}


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/38059

This PR generates deprecation log entries for each Role Descriptor,
used for building a Role, when the Role Descriptor grants more privileges
for an alias compared to an index that the alias points to. This is done in
preparation for the removal of the ability to define privileges over aliases.
There is one log entry for each "role descriptor name"-"alias name" pair.
On such a notice, the administrator is expected to modify the Role Descriptor
definition so that the name pattern for index names does not cover aliases.

Caveats:
* Role Descriptors that are not used in any authorization process,
either because they are not mapped to any user or the user they are mapped to
is not used by clients, are not be checked.
* Role Descriptors are merged when building the effective Role that is used in
the authorization process. Therefore some Role Descriptors can overlap others,
so even if one matches aliases in a deprecated way, and it is reported as such,
it is not at risk from the breaking behavior in the current role mapping configuration
and index-alias configuration. It is still reported because it is a best practice to
change its definition, or remove offending aliases.