### PR TITLE
Splits :client:rest-high-level and :x-pack:plugin:core modules in Eclipse

### DIFF
--- a/client/rest-high-level/build.gradle
+++ b/client/rest-high-level/build.gradle
@@ -63,9 +63,13 @@ dependencies {
   testCompile "junit:junit:${versions.junit}"
   //this is needed to make RestHighLevelClientTests#testApiNamingConventions work from IDEs
   testCompile "org.elasticsearch:rest-api-spec:${version}"
-  // Needed for serialization tests: 
+  // Needed for serialization tests:
   // (In order to serialize a server side class to a client side class or the other way around)
-  testCompile "org.elasticsearch.plugin:x-pack-core:${version}"
+  if (isEclipse == false || project.path == ":client:rest-high-level-tests") {
+    testCompile("org.elasticsearch.plugin:x-pack-core:${version}") {
+        exclude group: 'org.elasticsearch', module: 'elasticsearch-rest-high-level-client'
+    }
+  }
 
   restSpec "org.elasticsearch:rest-api-spec:${version}"
 }
@@ -92,6 +96,20 @@ forbiddenApisMain {
   addSignatureFiles 'http-signatures'
   signaturesFiles += files('src/main/resources/forbidden/rest-high-level-signatures.txt')
 }
+
+if (isEclipse) {
+    // in eclipse the project is under a fake root, we need to change around the source sets
+    sourceSets {
+        if (project.path == ":client:rest-high-level") {
+            main.java.srcDirs = ['java']
+            main.resources.srcDirs = ['resources']
+        } else {
+            test.java.srcDirs = ['java']
+            test.resources.srcDirs = ['resources']
+        }
+    }
+}
+
 File nodeCert = file("./testnode.crt")
 File nodeTrustStore = file("./testnode.jks")
 

--- a/client/rest-high-level/src/main/eclipse-build.gradle
+++ b/client/rest-high-level/src/main/eclipse-build.gradle
@@ -1,0 +1,2 @@
+// this is just shell gradle file for eclipse to have separate projects for core src and tests
+apply from: '../../build.gradle'

--- a/client/rest-high-level/src/test/eclipse-build.gradle
+++ b/client/rest-high-level/src/test/eclipse-build.gradle
@@ -1,0 +1,6 @@
+// this is just shell gradle file for eclipse to have separate projects for core src and tests
+apply from: '../../build.gradle'
+
+dependencies {
+  testCompile project(':client:rest-high-level')
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -110,6 +110,7 @@ if (isEclipse) {
   projects << 'libs:grok-tests'
   projects << 'libs:geo-tests'
   projects << 'libs:ssl-config-tests'
+  projects << 'client:rest-high-level-tests'
 }
 
 include projects.toArray(new String[0])
@@ -153,6 +154,11 @@ if (isEclipse) {
   project(":libs:ssl-config").buildFileName = 'eclipse-build.gradle'
   project(":libs:ssl-config-tests").projectDir = new File(rootProject.projectDir, 'libs/ssl-config/src/test')
   project(":libs:ssl-config-tests").buildFileName = 'eclipse-build.gradle'
+  project(":client:rest-high-level").projectDir = new File(rootProject.projectDir, 'client/rest-high-level/src/main')
+  project(":client:rest-high-level").buildFileName = 'eclipse-build.gradle'
+  project(":client:rest-high-level-tests").projectDir = new File(rootProject.projectDir, 'client/rest-high-level/src/test')
+  project(":client:rest-high-level-tests").buildFileName = 'eclipse-build.gradle'
+
 }
 
 // look for extra plugins for elasticsearch

--- a/settings.gradle
+++ b/settings.gradle
@@ -111,6 +111,7 @@ if (isEclipse) {
   projects << 'libs:geo-tests'
   projects << 'libs:ssl-config-tests'
   projects << 'client:rest-high-level-tests'
+  projects << 'x-pack:plugin:core-tests'
 }
 
 include projects.toArray(new String[0])
@@ -158,6 +159,10 @@ if (isEclipse) {
   project(":client:rest-high-level").buildFileName = 'eclipse-build.gradle'
   project(":client:rest-high-level-tests").projectDir = new File(rootProject.projectDir, 'client/rest-high-level/src/test')
   project(":client:rest-high-level-tests").buildFileName = 'eclipse-build.gradle'
+  project(":x-pack:plugin:core").projectDir = new File(rootProject.projectDir, 'x-pack/plugin/core/src/main')
+  project(":x-pack:plugin:core").buildFileName = 'eclipse-build.gradle'
+  project(":x-pack:plugin:core-tests").projectDir = new File(rootProject.projectDir, 'x-pack/plugin/core/src/test')
+  project(":x-pack:plugin:core-tests").buildFileName = 'eclipse-build.gradle'
 
 }
 

--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -21,6 +21,9 @@ dependencies {
     // "org.elasticsearch.plugin:x-pack-core:${version}" doesn't work with idea because the testArtifacts are also here
     testCompile project(path: xpackModule('core'), configuration: 'default')
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
     testCompile project(path: xpackProject('plugin').path, configuration: 'testArtifacts')
 }
 
@@ -741,11 +744,11 @@ setups['app0102_privileges'] = '''
                   "name": "read",
                   "actions": [
                     "data:read/*",
-                    "action:login" ], 
+                    "action:login" ],
                   "metadata": {
                     "description": "Read access to myapp"
                   }
                 }
-              } 
+              }
             }
 '''

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -11,6 +11,9 @@ archivesBaseName = 'x-pack'
 
 dependencies {
   testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  if (isEclipse) {
+    testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+  }
 }
 
 subprojects {
@@ -187,4 +190,3 @@ integTestCluster {
 if (integTestCluster.distribution.startsWith("oss-")) {
   integTest.enabled = false
 }
-

--- a/x-pack/plugin/ccr/build.gradle
+++ b/x-pack/plugin/ccr/build.gradle
@@ -18,7 +18,7 @@ String[] noSecurityManagerITClasses = [ "**/CloseFollowerIndexIT.class" ]
 
 task internalClusterTestNoSecurityManager(type: Test) {
     description = 'Java fantasy integration tests with no security manager'
-    
+
     include noSecurityManagerITClasses
     systemProperty 'es.set.netty.runtime.available.processors', 'false'
     systemProperty 'tests.security.manager', 'false'
@@ -30,7 +30,7 @@ task internalClusterTest(type: Test) {
     description = 'Java fantasy integration tests'
     dependsOn internalClusterTestNoSecurityManager
     mustRunAfter test
-    
+
     include '**/*IT.class'
     exclude noSecurityManagerITClasses
     systemProperty 'es.set.netty.runtime.available.processors', 'false'
@@ -52,6 +52,9 @@ dependencies {
 
     compileOnly project(path: xpackModule('core'), configuration: 'default')
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
     testCompile project(path: xpackModule('monitoring'), configuration: 'testArtifacts')
 }
 

--- a/x-pack/plugin/ccr/qa/downgrade-to-basic-license/build.gradle
+++ b/x-pack/plugin/ccr/qa/downgrade-to-basic-license/build.gradle
@@ -4,6 +4,9 @@ apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
     testCompile project(path: xpackModule('ccr'), configuration: 'runtime')
     testCompile project(':x-pack:plugin:ccr:qa')
 }

--- a/x-pack/plugin/ccr/qa/multi-cluster/build.gradle
+++ b/x-pack/plugin/ccr/qa/multi-cluster/build.gradle
@@ -4,6 +4,9 @@ apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
     testCompile project(path: xpackModule('ccr'), configuration: 'runtime')
     testCompile project(':x-pack:plugin:ccr:qa')
 }

--- a/x-pack/plugin/ccr/qa/non-compliant-license/build.gradle
+++ b/x-pack/plugin/ccr/qa/non-compliant-license/build.gradle
@@ -4,6 +4,9 @@ apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
     testCompile project(path: xpackModule('ccr'), configuration: 'runtime')
     testCompile project(':x-pack:plugin:ccr:qa:')
 }

--- a/x-pack/plugin/ccr/qa/rest/build.gradle
+++ b/x-pack/plugin/ccr/qa/rest/build.gradle
@@ -4,6 +4,9 @@ apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
     testCompile project(path: xpackModule('ccr'), configuration: 'runtime')
 }
 

--- a/x-pack/plugin/ccr/qa/security/build.gradle
+++ b/x-pack/plugin/ccr/qa/security/build.gradle
@@ -4,6 +4,9 @@ apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
     testCompile project(path: xpackModule('ccr'), configuration: 'runtime')
     testCompile project(':x-pack:plugin:ccr:qa')
 }

--- a/x-pack/plugin/core/build.gradle
+++ b/x-pack/plugin/core/build.gradle
@@ -48,8 +48,12 @@ dependencies {
     testCompile project(path: ':modules:parent-join', configuration: 'runtime')
     testCompile project(path: ':modules:lang-mustache', configuration: 'runtime')
     testCompile project(path: ':modules:analysis-common', configuration: 'runtime')
-    testCompile(project(':x-pack:license-tools')) {
-        transitive = false
+    testCompile ("org.elasticsearch.client:elasticsearch-rest-high-level-client:${version}")
+
+    if (isEclipse == false || project.path == ":x-pack:plugin:core-tests") {
+      testCompile(project(':x-pack:license-tools')) {
+          transitive = false
+      }
     }
 }
 
@@ -68,7 +72,11 @@ processResources {
   if (licenseKey != null) {
     println "Using provided license key from ${licenseKey}"
   } else if (snapshot) {
-    licenseKey = Paths.get(project.projectDir.path, 'snapshot.key')
+    if (isEclipse) {
+      licenseKey = Paths.get(project.projectDir.path, '../../snapshot.key')
+    } else {
+      licenseKey = Paths.get(project.projectDir.path, 'snapshot.key')
+    }
   } else {
     throw new IllegalArgumentException('Property license.key must be set for release build')
   }
@@ -85,6 +93,19 @@ forbiddenPatterns {
     exclude '**/*.p12'
     exclude '**/*.der'
     exclude '**/*.zip'
+}
+
+if (isEclipse) {
+    // in eclipse the project is under a fake root, we need to change around the source sets
+    sourceSets {
+        if (project.path == ":libs:core") {
+            main.java.srcDirs = ['java']
+            main.resources.srcDirs = ['resources']
+        } else {
+            test.java.srcDirs = ['java']
+            test.resources.srcDirs = ['resources']
+        }
+    }
 }
 
 compileJava.options.compilerArgs << "-Xlint:-rawtypes,-unchecked"

--- a/x-pack/plugin/core/src/main/eclipse-build.gradle
+++ b/x-pack/plugin/core/src/main/eclipse-build.gradle
@@ -1,0 +1,2 @@
+// this is just shell gradle file for eclipse to have separate projects for core src and tests
+apply from: '../../build.gradle'

--- a/x-pack/plugin/core/src/test/eclipse-build.gradle
+++ b/x-pack/plugin/core/src/test/eclipse-build.gradle
@@ -1,0 +1,6 @@
+// this is just shell gradle file for eclipse to have separate projects for core src and tests
+apply from: '../../build.gradle'
+
+dependencies {
+  testCompile project(':x-pack:plugin:core')
+}

--- a/x-pack/plugin/data-frame/build.gradle
+++ b/x-pack/plugin/data-frame/build.gradle
@@ -13,6 +13,9 @@ dependencies {
 
     compileOnly project(path: xpackModule('core'), configuration: 'default')
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
 }
 
 run {

--- a/x-pack/plugin/data-frame/qa/multi-node-tests/build.gradle
+++ b/x-pack/plugin/data-frame/qa/multi-node-tests/build.gradle
@@ -4,6 +4,9 @@ apply plugin: 'elasticsearch.rest-test'
 dependencies {
   testCompile project(path: xpackModule('core'), configuration: 'default')
   testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  if (isEclipse) {
+    testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+  }
   testCompile project(path: xpackModule('data-frame'), configuration: 'runtime')
 }
 

--- a/x-pack/plugin/data-frame/qa/single-node-tests/build.gradle
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/build.gradle
@@ -4,6 +4,9 @@ apply plugin: 'elasticsearch.rest-test'
 dependencies {
   testCompile project(path: xpackModule('core'), configuration: 'default')
   testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  if (isEclipse) {
+    testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+  }
   testCompile project(path: xpackModule('data-frame'), configuration: 'runtime')
 }
 

--- a/x-pack/plugin/graph/build.gradle
+++ b/x-pack/plugin/graph/build.gradle
@@ -13,6 +13,9 @@ dependencies {
     // "org.elasticsearch.plugin:x-pack-core:${version}" doesn't work with idea because the testArtifacts are also here
     compileOnly project(path: xpackModule('core'), configuration: 'default')
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
 }
 
 // add all sub-projects of the qa sub-project

--- a/x-pack/plugin/ilm/build.gradle
+++ b/x-pack/plugin/ilm/build.gradle
@@ -16,6 +16,9 @@ dependencies {
     // "org.elasticsearch.plugin:x-pack-core:${version}" doesn't work with idea because the testArtifacts are also here
     compileOnly project(path: xpackModule('core'), configuration: 'default')
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
 }
 
 // add all sub-projects of the qa sub-project

--- a/x-pack/plugin/ilm/qa/rest/build.gradle
+++ b/x-pack/plugin/ilm/qa/rest/build.gradle
@@ -4,6 +4,9 @@ apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
     testCompile project(path: xpackModule('ilm'), configuration: 'runtime')
 }
 

--- a/x-pack/plugin/logstash/build.gradle
+++ b/x-pack/plugin/logstash/build.gradle
@@ -13,6 +13,9 @@ dependencies {
     // "org.elasticsearch.plugin:x-pack-core:${version}" doesn't work with idea because the testArtifacts are also here
     compileOnly project(path: xpackModule('core'), configuration: 'default')
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
 }
 
 run {

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -40,6 +40,9 @@ dependencies {
     compileOnly project(path: xpackModule('core'), configuration: 'default')
     compileOnly "org.elasticsearch.plugin:elasticsearch-scripting-painless-spi:${versions.elasticsearch}"
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
     // This should not be here
     testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
 

--- a/x-pack/plugin/ml/qa/ml-with-security/build.gradle
+++ b/x-pack/plugin/ml/qa/ml-with-security/build.gradle
@@ -5,6 +5,9 @@ dependencies {
   // "org.elasticsearch.plugin:x-pack-core:${version}" doesn't work with idea because the testArtifacts are also here
   testCompile project(path: xpackModule('core'), configuration: 'default')
   testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  if (isEclipse) {
+    testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+  }
   testCompile project(path: xpackProject('plugin').path, configuration: 'testArtifacts')
 }
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
@@ -5,6 +5,9 @@ dependencies {
     // "org.elasticsearch.plugin:x-pack-core:${version}" doesn't work with idea because the testArtifacts are also here
     testCompile project(path: xpackModule('core'), configuration: 'default')
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
     testCompile project(path: xpackModule('ml'), configuration: 'runtime')
     testCompile project(path: xpackModule('ml'), configuration: 'testArtifacts')
 }

--- a/x-pack/plugin/monitoring/build.gradle
+++ b/x-pack/plugin/monitoring/build.gradle
@@ -13,6 +13,9 @@ dependencies {
     // "org.elasticsearch.plugin:x-pack-core:${version}" doesn't work with idea because the testArtifacts are also here
     compileOnly project(path: xpackModule('core'), configuration: 'default')
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
 
     // monitoring deps
     compile "org.elasticsearch.client:elasticsearch-rest-client:${version}"

--- a/x-pack/plugin/rollup/build.gradle
+++ b/x-pack/plugin/rollup/build.gradle
@@ -19,6 +19,9 @@ dependencies {
     // "org.elasticsearch.plugin:x-pack-core:${version}" doesn't work with idea because the testArtifacts are also here
     compileOnly project(path: xpackModule('core'), configuration: 'default')
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
 }
 
 run {

--- a/x-pack/plugin/security/build.gradle
+++ b/x-pack/plugin/security/build.gradle
@@ -22,6 +22,9 @@ dependencies {
     testCompile project(path: xpackModule('sql:sql-action'))
 
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
 
     compile 'com.unboundid:unboundid-ldapsdk:4.0.8'
     compileOnly 'org.bouncycastle:bcprov-jdk15on:1.59'
@@ -326,4 +329,3 @@ gradle.projectsEvaluated {
             .findAll { it.path.startsWith(project.path + ":qa") }
             .each { check.dependsOn it.check }
 }
-

--- a/x-pack/plugin/security/cli/build.gradle
+++ b/x-pack/plugin/security/cli/build.gradle
@@ -13,6 +13,9 @@ dependencies {
     testImplementation 'com.google.jimfs:jimfs:1.1'
     testCompile "org.elasticsearch.test:framework:${version}"
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
 }
 
 dependencyLicenses {

--- a/x-pack/plugin/security/qa/tls-basic/build.gradle
+++ b/x-pack/plugin/security/qa/tls-basic/build.gradle
@@ -8,6 +8,9 @@ dependencies {
   testCompile project(path: xpackModule('core'), configuration: 'default')
   testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
   testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  if (isEclipse) {
+    testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+  }
 }
 
 forbiddenPatterns {
@@ -45,4 +48,3 @@ integTestCluster {
     return http.wait(5000)
   }
 }
-

--- a/x-pack/plugin/sql/build.gradle
+++ b/x-pack/plugin/sql/build.gradle
@@ -12,7 +12,7 @@ ext {
     // SQL dependency versions
     jlineVersion="3.10.0"
     antlrVersion="4.5.3"
-    
+
     // SQL test dependency versions
     csvjdbcVersion="1.0.34"
     h2Version="1.4.197"
@@ -48,6 +48,9 @@ dependencies {
     compile "org.antlr:antlr4-runtime:4.5.3"
     testCompile "org.elasticsearch.test:framework:${version}"
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
     testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
     testCompile project(path: ':modules:reindex', configuration: 'runtime')
     testCompile project(path: ':modules:parent-join', configuration: 'runtime')

--- a/x-pack/plugin/sql/jdbc/build.gradle
+++ b/x-pack/plugin/sql/jdbc/build.gradle
@@ -25,6 +25,9 @@ dependencies {
     runtime "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
     testCompile "org.elasticsearch.test:framework:${version}"
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
 }
 
 dependencyLicenses {

--- a/x-pack/plugin/watcher/build.gradle
+++ b/x-pack/plugin/watcher/build.gradle
@@ -31,6 +31,9 @@ dependencies {
     compileOnly project(path: ':plugins:transport-nio', configuration: 'runtime')
 
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
     testCompile "org.elasticsearch.plugin:x-pack-ilm:${version}"
 
     // watcher deps
@@ -47,7 +50,7 @@ dependencies {
 }
 
 // classes are missing, e.g. com.ibm.icu.lang.UCharacter
-thirdPartyAudit { 
+thirdPartyAudit {
     ignoreViolations (
         // uses internal java api: sun.misc.Unsafe
         'com.google.common.cache.Striped64',

--- a/x-pack/qa/evil-tests/build.gradle
+++ b/x-pack/qa/evil-tests/build.gradle
@@ -2,6 +2,9 @@ apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
     testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
 }
 

--- a/x-pack/qa/kerberos-tests/build.gradle
+++ b/x-pack/qa/kerberos-tests/build.gradle
@@ -14,6 +14,9 @@ integTest.enabled = false
 dependencies {
     testCompile "org.elasticsearch.plugin:x-pack-core:${version}"
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
     testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
 }
 
@@ -74,4 +77,3 @@ task copyKeytabToGeneratedResources(type: Copy) {
     dependsOn project(':test:fixtures:krb5kdc-fixture').postProcessFixture
 }
 project.sourceSets.test.output.dir(generatedResources, builtBy:copyKeytabToGeneratedResources)
-

--- a/x-pack/qa/oidc-op-tests/build.gradle
+++ b/x-pack/qa/oidc-op-tests/build.gradle
@@ -8,6 +8,9 @@ dependencies {
     // "org.elasticsearch.plugin:x-pack-core:${version}" doesn't work with idea because the testArtifacts are also here
     testCompile project(path: xpackModule('core'), configuration: 'default')
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
     testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
 }
 testFixtures.useFixture ":x-pack:test:idp-fixture"
@@ -63,7 +66,7 @@ integTestCluster {
     setting 'xpack.security.authc.realms.oidc.c2id-implicit.claims.mail', 'email'
     setting 'xpack.security.authc.realms.oidc.c2id-implicit.claims.groups', 'groups'
     setting 'xpack.ml.enabled', 'false'
-    
+
     extraConfigFile 'op-jwks.json', idpFixtureProject.file("oidc/op-jwks.json")
 
     setupCommand 'setupTestAdmin',

--- a/x-pack/qa/openldap-tests/build.gradle
+++ b/x-pack/qa/openldap-tests/build.gradle
@@ -6,6 +6,9 @@ dependencies {
     testCompile project(path: xpackModule('core'), configuration: 'default')
     testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
 }
 
 testFixtures.useFixture ":x-pack:test:idp-fixture"

--- a/x-pack/qa/reindex-tests-with-security/build.gradle
+++ b/x-pack/qa/reindex-tests-with-security/build.gradle
@@ -8,6 +8,9 @@ dependencies {
   testCompile project(path: xpackModule('core'), configuration: 'default')
   testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
   testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  if (isEclipse) {
+    testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+  }
   testCompile project(path: ':modules:reindex')
 }
 

--- a/x-pack/qa/saml-idp-tests/build.gradle
+++ b/x-pack/qa/saml-idp-tests/build.gradle
@@ -103,7 +103,7 @@ thirdPartyAudit {
       'com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator$1'
    )
 
-   ignoreMissingClasses ( 
+   ignoreMissingClasses (
        'com.ibm.icu.lang.UCharacter'
    )
 }

--- a/x-pack/qa/security-setup-password-tests/build.gradle
+++ b/x-pack/qa/security-setup-password-tests/build.gradle
@@ -6,6 +6,9 @@ dependencies {
     testCompile project(path: xpackModule('core'), configuration: 'default')
     testCompile project(path: xpackModule('security'), configuration: 'runtime')
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    if (isEclipse) {
+      testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
+    }
 }
 
 integTestRunner {


### PR DESCRIPTION
This splits the `:client:rest-high-level` module when running in Eclipse into a `:client:rest-high-level` module for the main code and a `:client:rest-high-level-tests` module for the test code. This is the same approach as we use on other modules such as `:libs:core` and fixes the circular dependency introduced by https://github.com/elastic/elasticsearch/commit/d31207a0a50a76b52aa2233f33c49a5a2e0ab2d4 between `:client:rest-high-level` and `x-pack:plugin-core`

Similarly this also splits `:x-pack:plugin::core` to avoid the circular dependency in eclipse created by https://github.com/elastic/elasticsearch/commit/71d407f13c6d82afbe4f85a5e31c5d771295145d. This change is more complex because some classes in the test source folder for `x-pack:plugin:core` are used by other modules. I wonder if we should create a `:x-pack:test-framework` module that other modules can rely on rather than mixing test classes that actually test the code in `x-pack:plugin:core` with classes that provide test utilities and frameworks which are used across the x-pack plugins?