### PR TITLE
[DOCS] Restructure `ids` query to pilot new query docs format

### DIFF
--- a/docs/reference/query-dsl/ids-query.asciidoc
+++ b/docs/reference/query-dsl/ids-query.asciidoc
@@ -1,8 +1,9 @@
 [[query-dsl-ids-query]]
 === Ids Query
+Returns documents based on their IDs. This query uses document IDs stored in
+the <<mapping-id-field,`_id`>> field.
 
-Filters documents that only have the provided ids. Note, this query
-uses the <<mapping-id-field,_id>> field.
+==== Example request
 
 [source,js]
 --------------------------------------------------
@@ -16,3 +17,11 @@ GET /_search
 }    
 --------------------------------------------------
 // CONSOLE
+
+==== Top-level parameters for `ids`
+
+[cols="v,v",options="header"]
+|======
+|Parameter  |Description
+|`values`   |An array of <<mapping-id-field, document IDs>>.
+|======


### PR DESCRIPTION
Makes following changes to `ids` query docs:
- Rewrites the introductory description
- Adds headings for 'Example request' and 'Top-level parameters'
- Adds a table for top-level parameters

This is part of #40977, an effort to standardize documentation for query types.

Any and all feedback welcome!