### PR TITLE
Increase maximum forecast interval to 10 years.

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ForecastJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ForecastJobAction.java
@@ -48,9 +48,6 @@ public class ForecastJobAction extends Action<ForecastJobAction.Response> {
         public static final ParseField DURATION = new ParseField("duration");
         public static final ParseField EXPIRES_IN = new ParseField("expires_in");
 
-        // Max allowed duration: 8 weeks
-        private static final TimeValue MAX_DURATION = TimeValue.parseTimeValue("56d", "");
-
         private static final ObjectParser<Request, Void> PARSER = new ObjectParser<>(NAME, Request::new);
 
         static {
@@ -103,10 +100,6 @@ public class ForecastJobAction extends Action<ForecastJobAction.Response> {
             if (this.duration.compareTo(TimeValue.ZERO) <= 0) {
                 throw new IllegalArgumentException("[" + DURATION.getPreferredName() + "] must be positive: ["
                         + duration.getStringRep() + "]");
-            }
-            if (this.duration.compareTo(MAX_DURATION) > 0) {
-                throw new IllegalArgumentException("[" + DURATION.getPreferredName() + "] must be "
-                        + MAX_DURATION.getStringRep() + " or less: [" + duration.getStringRep() + "]");
             }
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ForecastJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ForecastJobAction.java
@@ -48,6 +48,9 @@ public class ForecastJobAction extends Action<ForecastJobAction.Response> {
         public static final ParseField DURATION = new ParseField("duration");
         public static final ParseField EXPIRES_IN = new ParseField("expires_in");
 
+        // Max allowed duration: 10 years
+        private static final TimeValue MAX_DURATION = TimeValue.parseTimeValue("3650d", "");
+
         private static final ObjectParser<Request, Void> PARSER = new ObjectParser<>(NAME, Request::new);
 
         static {
@@ -100,6 +103,10 @@ public class ForecastJobAction extends Action<ForecastJobAction.Response> {
             if (this.duration.compareTo(TimeValue.ZERO) <= 0) {
                 throw new IllegalArgumentException("[" + DURATION.getPreferredName() + "] must be positive: ["
                         + duration.getStringRep() + "]");
+            }
+            if (this.duration.compareTo(MAX_DURATION) > 0) {
+                throw new IllegalArgumentException("[" + DURATION.getPreferredName() + "] must be "
+                        + MAX_DURATION.getStringRep() + " or less: [" + duration.getStringRep() + "]");
             }
         }
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/forecast.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/forecast.yml
@@ -48,6 +48,14 @@ setup:
         duration: "-1s"
 
 ---
+"Test forecast given duration is too large":
+  - do:
+      catch: /\[duration\] must be 3650d or less[:] \[3651d\]/
+      ml.forecast:
+        job_id: "forecast-job"
+        duration: "3651d"
+
+---
 "Test forecast given expires_in is negative":
   - do:
       catch: /\[expires_in\] must be non-negative[:] \[-1\]/

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/forecast.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/forecast.yml
@@ -48,6 +48,14 @@ setup:
         duration: "-1s"
 
 ---
+"Test forecast given duration is too large":
+  - do:
+      catch: /\[duration\] must be 56d or less[:] \[57d\]/
+      ml.forecast:
+        job_id: "forecast-job"
+        duration: "57d"
+
+---
 "Test forecast given expires_in is negative":
   - do:
       catch: /\[expires_in\] must be non-negative[:] \[-1\]/

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/forecast.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/forecast.yml
@@ -48,14 +48,6 @@ setup:
         duration: "-1s"
 
 ---
-"Test forecast given duration is too large":
-  - do:
-      catch: /\[duration\] must be 56d or less[:] \[57d\]/
-      ml.forecast:
-        job_id: "forecast-job"
-        duration: "57d"
-
----
 "Test forecast given expires_in is negative":
   - do:
       catch: /\[expires_in\] must be non-negative[:] \[-1\]/


### PR DESCRIPTION
Increase maximum forecast interval from 8 weeks (56 days) to ~10 years (3650 days).
Add a YML test for the validation being modified.

Closes #41103