### PR TITLE
[DOCS] Improve docs for 'elasticsearch-keystore add-file' command

### DIFF
--- a/docs/plugins/repository-gcs.asciidoc
+++ b/docs/plugins/repository-gcs.asciidoc
@@ -152,7 +152,7 @@ Some settings are sensitive and must be stored in the
 
 [source,sh]
 ----
-bin/elasticsearch-keystore add-file gcs.client.default.credentials_file
+bin/elasticsearch-keystore add-file gcs.client.default.credentials_file /path/service-account.json
 ----
 
 The following are the available client settings. Those that must be stored in the keystore

--- a/docs/reference/setup/secure-settings.asciidoc
+++ b/docs/reference/setup/secure-settings.asciidoc
@@ -65,6 +65,18 @@ cat /file/containing/setting/value | bin/elasticsearch-keystore add --stdin the.
 ----------------------------------------------------------------
 
 [float]
+[[add-file-to-keystore]]
+=== Adding file settings
+You can add sensitive files, like authentication key files for cloud plugins,
+using the `add-file` command. Be sure to include your file path as an argument
+after the setting name.
+
+[source,sh]
+----------------------------------------------------------------
+bin/elasticsearch-keystore add-file the.setting.name.to.set /path/example-file.json
+----------------------------------------------------------------
+
+[float]
 [[remove-settings]]
 === Removing settings
 


### PR DESCRIPTION
- Documents the `elasticsearch-keystore add-file` command on the [Secure settings](https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html) page
- Adds required file path argument to `elasticsearch-keystore add-file` example on GCS Plugin's [Client Settings ](https://www.elastic.co/guide/en/elasticsearch/plugins/master/repository-gcs-client.html)page.

Resolves #35433