### PR TITLE
Add deprecation check for Java version

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -40,7 +40,7 @@ public class DeprecationChecks {
 
     static List<BiFunction<Settings, PluginsAndModules, DeprecationIssue>> NODE_SETTINGS_CHECKS =
         Collections.unmodifiableList(Arrays.asList(
-            // STUB
+            NodeDeprecationChecks::javaVersionCheck
         ));
 
     static List<Function<IndexMetaData, DeprecationIssue>> INDEX_SETTINGS_CHECKS =

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.deprecation;
+
+import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
+import org.elasticsearch.bootstrap.JavaVersion;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
+
+/**
+ * Node-specific deprecation checks
+ */
+public class NodeDeprecationChecks {
+    static DeprecationIssue javaVersionCheck(Settings nodeSettings, PluginsAndModules plugins) {
+        if (JavaVersion.current().compareTo(JavaVersion.parse("11")) < 0) {
+            return new DeprecationIssue(DeprecationIssue.Level.CRITICAL,
+                "Java 11 is required",
+                "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html" +
+                    "#_java_11_is_required",
+                "Java 11 will be required for future versions of Elasticsearch, this node is running version "
+                    + JavaVersion.current().toString());
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Adds a deprecation check for Java version, as Java 11 will be required
in the next version of Elasticsearch.

Relates to https://github.com/elastic/elasticsearch/pull/40756 and https://github.com/elastic/elasticsearch/pull/40754

---

Marked as a draft because this will cause test failures when running on jdk8, as there exist tests which assume there are no deprecation warnings under normal testing circumstances.