### PR TITLE
Add OS matrix for ci

### DIFF
--- a/.ci/matrix-unix-compatibility-distros.yml
+++ b/.ci/matrix-unix-compatibility-distros.yml
@@ -1,0 +1,19 @@
+# This file is used as part of a matrix build in Jenkins where the
+# values below are included as an axis of the matrix.
+
+# This axis of the build matrix represents the distros on which the
+# tests will be run. Valid entries are Jenkins label expressions.
+
+OS:
+  - amazon
+  - centos-6
+  - "centos-7&&immutable"
+  - debian-8
+  - debian-9
+  - fedora-28
+  - opensuse
+  - oraclelinux-7
+  - oraclelinux-6
+  - sles-12
+  - "ubuntu-16.04&&immutable"
+  - "ubuntu-18.04&&immutable"


### PR DESCRIPTION
Add a matrix axis file for unix compatibility jobs. The intent is to move the list of distros to test out of the unix compatibility job itself and into a matrix file that lives on a branch. If this looks good, I'll add this same file to `7.x` and then a version _with_ `"ubuntu-14.04&&immutable"` to `7.0` and `6.7`.
