### PR TITLE
Add ILM poll_interval limit to breaking changes

### DIFF
--- a/docs/reference/migration/migrate_8_0.asciidoc
+++ b/docs/reference/migration/migrate_8_0.asciidoc
@@ -17,6 +17,7 @@ coming[8.0.0]
 * <<breaking_80_packaging_changes>>
 * <<breaking_80_snapshots_changes>>
 * <<breaking_80_security_changes>>
+* <<breaking_80_ilm_changes>>
 * <<breaking_80_java_changes>>
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
@@ -46,4 +47,5 @@ include::migrate_8_0/mappings.asciidoc[]
 include::migrate_8_0/packaging.asciidoc[]
 include::migrate_8_0/snapshots.asciidoc[]
 include::migrate_8_0/security.asciidoc[]
+include::migrate_8_0/ilm.asciidoc[]
 include::migrate_8_0/java.asciidoc[]

--- a/docs/reference/migration/migrate_8_0/ilm.asciidoc
+++ b/docs/reference/migration/migrate_8_0/ilm.asciidoc
@@ -1,0 +1,17 @@
+[float]
+[[breaking_80_ilm_changes]]
+=== Index Lifecycle Management changes
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+
+// end::notable-breaking-changes[]
+
+[float]
+[[ilm-poll-interval-limit]]
+==== `indices.lifecycle.poll_interval` must be greater than 1 second
+
+The setting `indices.lifecycle.poll_interval`, if set too low, can cause
+excessive load on a cluster. This setting must now be set to 1 second or higher.


### PR DESCRIPTION
ILM's poll_interval setting now has a lower limit of 1 second, which is
technically a breaking change.

Follow-up to https://github.com/elastic/elasticsearch/pull/39593
Relates to https://github.com/elastic/elasticsearch/issues/39163