### PR TITLE
Add deprecation check for ILM poll interval <1s

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -34,7 +34,8 @@ public class DeprecationChecks {
     static List<Function<ClusterState, DeprecationIssue>> CLUSTER_SETTINGS_CHECKS =
         Collections.unmodifiableList(Arrays.asList(
             ClusterDeprecationChecks::checkUserAgentPipelines,
-            ClusterDeprecationChecks::checkTemplatesWithTooManyFields
+            ClusterDeprecationChecks::checkTemplatesWithTooManyFields,
+            ClusterDeprecationChecks::checkPollIntervalTooLow
         ));
 
 


### PR DESCRIPTION
ILM poll intervals of less than 1 second will not be allowed, so add a
deprecation check for that.

Even though I'm pretty sure zero production clusters will do this, it's
best to be thorough.

Relates to https://github.com/elastic/elasticsearch/issues/39163