### PR TITLE
Remove parent query string parameter

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
@@ -26,10 +26,6 @@
           "type" : "string",
           "description" : "Sets the number of shard copies that must be active before proceeding with the index operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"
         },
-        "parent": {
-          "type" : "string",
-          "description" : "ID of the parent document"
-        },
         "refresh": {
           "type" : "enum",
           "options": ["true", "false", "wait_for"],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json
@@ -26,10 +26,6 @@
           "type" : "string",
           "description" : "Sets the number of shard copies that must be active before proceeding with the delete operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"
         },
-        "parent": {
-          "type" : "string",
-          "description" : "ID of parent document"
-        },
         "refresh": {
           "type" : "enum",
           "options": ["true", "false", "wait_for"],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/exists.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/exists.json
@@ -26,10 +26,6 @@
           "type": "list",
           "description" : "A comma-separated list of stored fields to return in the response"
         },
-        "parent": {
-          "type" : "string",
-          "description" : "The ID of the parent document"
-        },
         "preference": {
           "type" : "string",
           "description" : "Specify the node or shard the operation should be performed on (default: random)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/exists_source.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/exists_source.json
@@ -23,10 +23,6 @@
         }
       },
       "params": {
-        "parent": {
-          "type" : "string",
-          "description" : "The ID of the parent document"
-        },
         "preference": {
           "type" : "string",
           "description" : "Specify the node or shard the operation should be performed on (default: random)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/explain.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/explain.json
@@ -48,10 +48,6 @@
           "type" : "boolean",
           "description" : "Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"
         },
-        "parent": {
-          "type" : "string",
-          "description" : "The ID of the parent document"
-        },
         "preference": {
           "type" : "string",
           "description" : "Specify the node or shard the operation should be performed on (default: random)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get.json
@@ -26,10 +26,6 @@
           "type": "list",
           "description" : "A comma-separated list of stored fields to return in the response"
         },
-        "parent": {
-          "type" : "string",
-          "description" : "The ID of the parent document"
-        },
         "preference": {
           "type" : "string",
           "description" : "Specify the node or shard the operation should be performed on (default: random)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get_source.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get_source.json
@@ -23,10 +23,6 @@
         }
       },
       "params": {
-        "parent": {
-          "type" : "string",
-          "description" : "The ID of the parent document"
-        },
         "preference": {
           "type" : "string",
           "description" : "Specify the node or shard the operation should be performed on (default: random)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
@@ -31,10 +31,6 @@
           "default" : "index",
           "description" : "Explicit operation type"
         },
-        "parent": {
-          "type" : "string",
-          "description" : "ID of the parent document"
-        },
         "refresh": {
           "type" : "enum",
           "options": ["true", "false", "wait_for"],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/mtermvectors.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/mtermvectors.json
@@ -66,11 +66,6 @@
           "description" : "Specific routing value. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".",
           "required" : false
         },
-        "parent" : {
-          "type" : "string",
-          "description" : "Parent id of documents. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".",
-          "required" : false
-        },
         "realtime": {
           "type": "boolean",
           "description": "Specifies if requests are real-time as opposed to near-real-time (default: true).",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/termvectors.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/termvectors.json
@@ -68,11 +68,6 @@
           "description" : "Specific routing value.",
           "required" : false
         },
-        "parent": {
-          "type" : "string",
-          "description" : "Parent id of documents.",
-          "required" : false
-        },
         "realtime": {
           "type": "boolean",
           "description": "Specifies if request is real-time as opposed to near-real-time (default: true).",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
@@ -42,10 +42,6 @@
           "type": "string",
           "description": "The script language (default: painless)"
         },
-        "parent": {
-          "type": "string",
-          "description": "ID of the parent document. Is is only used for routing and when for the upsert request"
-        },
         "refresh": {
           "type" : "enum",
           "options": ["true", "false", "wait_for"],


### PR DESCRIPTION
This commit removes the deprecated `parent` query string parameter. The routing parameter should be used instead.
