### PR TITLE
Disable TestingConventions Check in Reindex Module (#41100)

### DIFF
--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -97,6 +97,7 @@ dependencies {
 
 // Issue tracked in https://github.com/elastic/elasticsearch/issues/40904
 if (project.inFipsJvm) {
+  testingConventions.enabled = false
   integTest.enabled = false
 }
 


### PR DESCRIPTION
* This is currently failing with:

```
Test classes are not included in any enabled task (:modules:reindex:test):
  * org.elasticsearch.client.documentation.ReindexDocumentationIT
  * org.elasticsearch.index.reindex.ManyDocumentsIT
  * org.elasticsearch.index.reindex.ReindexClientYamlTestSuiteIT
  * org.elasticsearch.index.reindex.ReindexWithoutContentIT
  * org.elasticsearch.index.reindex.remote.ReindexFromOldRemoteIT
```

* Same fix as in #38546
* Backport of #41100