### PR TITLE
Make Transport Shard Bulk Action Async (#39793)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
@@ -85,14 +85,16 @@ public class TransportVerifyShardBeforeCloseAction extends TransportReplicationA
     }
 
     @Override
-    protected PrimaryResult<ShardRequest, ReplicationResponse> shardOperationOnPrimary(final ShardRequest shardRequest,
-                                                                                       final IndexShard primary) throws Exception {
-        executeShardOperation(shardRequest, primary);
-        return new PrimaryResult<>(shardRequest, new ReplicationResponse());
+    protected void shardOperationOnPrimary(final ShardRequest shardRequest, final IndexShard primary,
+            ActionListener<PrimaryResult<ShardRequest, ReplicationResponse>> listener) {
+        ActionListener.completeWith(listener, () -> {
+            executeShardOperation(shardRequest, primary);
+            return new PrimaryResult<>(shardRequest, new ReplicationResponse());
+        });
     }
 
     @Override
-    protected ReplicaResult shardOperationOnReplica(final ShardRequest shardRequest, final IndexShard replica) throws Exception {
+    protected ReplicaResult shardOperationOnReplica(final ShardRequest shardRequest, final IndexShard replica) {
         executeShardOperation(shardRequest, replica);
         return new ReplicaResult();
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportShardFlushAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportShardFlushAction.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.flush;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
@@ -51,11 +52,13 @@ public class TransportShardFlushAction
     }
 
     @Override
-    protected PrimaryResult<ShardFlushRequest, ReplicationResponse> shardOperationOnPrimary(ShardFlushRequest shardRequest,
-            IndexShard primary) {
-        primary.flush(shardRequest.getRequest());
-        logger.trace("{} flush request executed on primary", primary.shardId());
-        return new PrimaryResult<>(shardRequest, new ReplicationResponse());
+    protected void shardOperationOnPrimary(ShardFlushRequest shardRequest, IndexShard primary,
+            ActionListener<PrimaryResult<ShardFlushRequest, ReplicationResponse>> listener) {
+        ActionListener.completeWith(listener, () -> {
+            primary.flush(shardRequest.getRequest());
+            logger.trace("{} flush request executed on primary", primary.shardId());
+            return new PrimaryResult<>(shardRequest, new ReplicationResponse());
+        });
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportShardRefreshAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportShardRefreshAction.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.refresh;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.replication.BasicReplicationRequest;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
@@ -53,11 +54,13 @@ public class TransportShardRefreshAction
     }
 
     @Override
-    protected PrimaryResult<BasicReplicationRequest, ReplicationResponse> shardOperationOnPrimary(
-            BasicReplicationRequest shardRequest, IndexShard primary) {
-        primary.refresh("api");
-        logger.trace("{} refresh request executed on primary", primary.shardId());
-        return new PrimaryResult<>(shardRequest, new ReplicationResponse());
+    protected void shardOperationOnPrimary(BasicReplicationRequest shardRequest, IndexShard primary,
+            ActionListener<PrimaryResult<BasicReplicationRequest, ReplicationResponse>> listener) {
+        ActionListener.completeWith(listener, () -> {
+            primary.refresh("api");
+            logger.trace("{} refresh request executed on primary", primary.shardId());
+            return new PrimaryResult<>(shardRequest, new ReplicationResponse());
+        });
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/bulk/MappingUpdatePerformer.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/MappingUpdatePerformer.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.bulk;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.index.mapper.Mapping;
 import org.elasticsearch.index.shard.ShardId;
 
@@ -27,6 +28,6 @@ public interface MappingUpdatePerformer {
     /**
      * Update the mappings on the master.
      */
-    void updateMappings(Mapping update, ShardId shardId, String type);
+    void updateMappings(Mapping update, ShardId shardId, String type, ActionListener<Void> listener);
 
 }

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -22,7 +22,10 @@ package org.elasticsearch.action.bulk;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.logging.log4j.util.MessageSupplier;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.delete.DeleteRequest;
@@ -30,7 +33,6 @@ import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.action.support.replication.TransportWriteAction;
 import org.elasticsearch.action.update.UpdateHelper;
@@ -44,8 +46,6 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.CheckedRunnable;
-import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
@@ -57,7 +57,6 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.mapper.MapperException;
-import org.elasticsearch.index.mapper.Mapping;
 import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.IndexShard;
@@ -69,10 +68,9 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
 
-import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.LongSupplier;
 
 /** Performs shard-level bulk (index, delete or update) operations */
@@ -82,7 +80,6 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
 
     private static final Logger logger = LogManager.getLogger(TransportShardBulkAction.class);
 
-    private final ThreadPool threadPool;
     private final UpdateHelper updateHelper;
     private final MappingUpdatedAction mappingUpdatedAction;
 
@@ -92,8 +89,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
                                     MappingUpdatedAction mappingUpdatedAction, UpdateHelper updateHelper, ActionFilters actionFilters,
                                     IndexNameExpressionResolver indexNameExpressionResolver) {
         super(settings, ACTION_NAME, transportService, clusterService, indicesService, threadPool, shardStateAction, actionFilters,
-            indexNameExpressionResolver, BulkShardRequest::new, BulkShardRequest::new, ThreadPool.Names.WRITE, false);
-        this.threadPool = threadPool;
+        indexNameExpressionResolver, BulkShardRequest::new, BulkShardRequest::new, ThreadPool.Names.WRITE, false);
         this.updateHelper = updateHelper;
         this.mappingUpdatedAction = mappingUpdatedAction;
     }
@@ -114,61 +110,95 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
     }
 
     @Override
-    protected WritePrimaryResult<BulkShardRequest, BulkShardResponse> shardOperationOnPrimary(BulkShardRequest request, IndexShard primary)
-        throws Exception {
+    protected void shardOperationOnPrimary(BulkShardRequest request, IndexShard primary,
+            ActionListener<PrimaryResult<BulkShardRequest, BulkShardResponse>> listener) {
         ClusterStateObserver observer = new ClusterStateObserver(clusterService, request.timeout(), logger, threadPool.getThreadContext());
-        CheckedRunnable<Exception> waitForMappingUpdate = () -> {
-            PlainActionFuture<Void> waitingFuture = new PlainActionFuture<>();
-            observer.waitForNextChange(new ClusterStateObserver.Listener() {
+        performOnPrimary(request, primary, updateHelper, threadPool::relativeTimeInMillis,
+            (update, shardId, type, mappingListener) -> {
+                assert update != null;
+                assert shardId != null;
+                mappingUpdatedAction.updateMappingOnMaster(shardId.getIndex(), type, update, mappingListener);
+            },
+            mappingUpdateListener -> observer.waitForNextChange(new ClusterStateObserver.Listener() {
                 @Override
                 public void onNewClusterState(ClusterState state) {
-                    waitingFuture.onResponse(null);
+                    mappingUpdateListener.onResponse(null);
                 }
 
                 @Override
                 public void onClusterServiceClose() {
-                    waitingFuture.onFailure(new NodeClosedException(clusterService.localNode()));
+                    mappingUpdateListener.onFailure(new NodeClosedException(clusterService.localNode()));
                 }
 
                 @Override
                 public void onTimeout(TimeValue timeout) {
-                    waitingFuture.onFailure(
-                        new MapperException("timed out while waiting for a dynamic mapping update"));
+                    mappingUpdateListener.onFailure(new MapperException("timed out while waiting for a dynamic mapping update"));
                 }
-            });
-            waitingFuture.get();
-        };
-        return performOnPrimary(request, primary, updateHelper, threadPool::absoluteTimeInMillis,
-            new ConcreteMappingUpdatePerformer(), waitForMappingUpdate);
+            }), listener, threadPool
+        );
     }
 
-    public static WritePrimaryResult<BulkShardRequest, BulkShardResponse> performOnPrimary(
+    public static void performOnPrimary(
         BulkShardRequest request,
         IndexShard primary,
         UpdateHelper updateHelper,
         LongSupplier nowInMillisSupplier,
         MappingUpdatePerformer mappingUpdater,
-        CheckedRunnable<Exception> waitForMappingUpdate) throws Exception {
-        BulkPrimaryExecutionContext context = new BulkPrimaryExecutionContext(request, primary);
-        return performOnPrimary(context, updateHelper, nowInMillisSupplier, mappingUpdater, waitForMappingUpdate);
+        Consumer<ActionListener<Void>> waitForMappingUpdate,
+        ActionListener<PrimaryResult<BulkShardRequest, BulkShardResponse>> listener,
+        ThreadPool threadPool) {
+        new ActionRunnable<PrimaryResult<BulkShardRequest, BulkShardResponse>>(listener) {
+
+            private final Executor executor = threadPool.executor(ThreadPool.Names.WRITE);
+
+            private final BulkPrimaryExecutionContext context = new BulkPrimaryExecutionContext(request, primary);
+
+            @Override
+            protected void doRun() throws Exception {
+                while (context.hasMoreOperationsToExecute()) {
+                    if (executeBulkItemRequest(context, updateHelper, nowInMillisSupplier, mappingUpdater, waitForMappingUpdate,
+                        ActionListener.wrap(v -> executor.execute(this), this::onRejection)) == false) {
+                        // We are waiting for a mapping update on another thread, that will invoke this action again once its done
+                        // so we just break out here.
+                        return;
+                    }
+                    assert context.isInitial(); // either completed and moved to next or reset
+                }
+                // We're done, there's no more operations to execute so we resolve the wrapped listener
+                finishRequest();
+            }
+
+            @Override
+            public void onRejection(Exception e) {
+                // Fail all operations after a bulk rejection hit an action that waited for a mapping update and finish the request
+                while (context.hasMoreOperationsToExecute()) {
+                    context.setRequestToExecute(context.getCurrent());
+                    final DocWriteRequest<?> docWriteRequest = context.getRequestToExecute();
+                    onComplete(
+                        exceptionToResult(
+                            e, primary, docWriteRequest.opType() == DocWriteRequest.OpType.DELETE, docWriteRequest.version()),
+                        context, null);
+                }
+                finishRequest();
+            }
+
+            private void finishRequest() {
+                ActionListener.completeWith(listener,
+                    () -> new WritePrimaryResult<>(
+                        context.getBulkShardRequest(), context.buildShardResponse(), context.getLocationToSync(), null,
+                        context.getPrimary(), logger));
+            }
+        }.run();
     }
 
-    private static WritePrimaryResult<BulkShardRequest, BulkShardResponse> performOnPrimary(
-        BulkPrimaryExecutionContext context, UpdateHelper updateHelper, LongSupplier nowInMillisSupplier,
-        MappingUpdatePerformer mappingUpdater, CheckedRunnable<Exception> waitForMappingUpdate) throws Exception {
-
-        while (context.hasMoreOperationsToExecute()) {
-            executeBulkItemRequest(context, updateHelper, nowInMillisSupplier, mappingUpdater, waitForMappingUpdate);
-            assert context.isInitial(); // either completed and moved to next or reset
-        }
-        return new WritePrimaryResult<>(context.getBulkShardRequest(), context.buildShardResponse(), context.getLocationToSync(),
-            null, context.getPrimary(), logger);
-    }
-
-    /** Executes bulk item requests and handles request execution exceptions */
-    static void executeBulkItemRequest(BulkPrimaryExecutionContext context, UpdateHelper updateHelper, LongSupplier nowInMillisSupplier,
-                                       MappingUpdatePerformer mappingUpdater, CheckedRunnable<Exception> waitForMappingUpdate)
-        throws Exception {
+    /**
+     * Executes bulk item requests and handles request execution exceptions.
+     * @return {@code true} if request completed on this thread and the listener was invoked, {@code false} if the request triggered
+     *                      a mapping update that will finish and invoke the listener on a different thread
+     */
+    static boolean executeBulkItemRequest(BulkPrimaryExecutionContext context, UpdateHelper updateHelper, LongSupplier nowInMillisSupplier,
+                                       MappingUpdatePerformer mappingUpdater, Consumer<ActionListener<Void>> waitForMappingUpdate,
+                                       ActionListener<Void> itemDoneListener) throws Exception {
         final DocWriteRequest.OpType opType = context.getCurrent().opType();
 
         final UpdateHelper.Result updateResult;
@@ -179,11 +209,12 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
             } catch (Exception failure) {
                 // we may fail translating a update to index or delete operation
                 // we use index result to communicate failure while translating update request
-                final Engine.Result result = new Engine.IndexResult(failure, updateRequest.version(), SequenceNumbers.UNASSIGNED_SEQ_NO);
+                final Engine.Result result =
+                    new Engine.IndexResult(failure, updateRequest.version(), SequenceNumbers.UNASSIGNED_SEQ_NO);
                 context.setRequestToExecute(updateRequest);
                 context.markOperationAsExecuted(result);
                 context.markAsCompleted(context.getExecutionResult());
-                return;
+                return true;
             }
             // execute translated update request
             switch (updateResult.getResponseResult()) {
@@ -201,7 +232,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
                 case NOOP:
                     context.markOperationAsNoOp(updateResult.action());
                     context.markAsCompleted(context.getExecutionResult());
-                    return;
+                    return true;
                 default:
                     throw new IllegalStateException("Illegal update operation " + updateResult.getResponseResult());
             }
@@ -212,59 +243,91 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
 
         assert context.getRequestToExecute() != null; // also checks that we're in TRANSLATED state
 
-        if (context.getRequestToExecute().opType() == DocWriteRequest.OpType.DELETE) {
-            executeDeleteRequestOnPrimary(context, mappingUpdater);
+        final IndexShard primary = context.getPrimary();
+        final long version = context.getRequestToExecute().version();
+        final boolean isDelete = context.getRequestToExecute().opType() == DocWriteRequest.OpType.DELETE;
+        final Engine.Result result;
+        if (isDelete) {
+            final DeleteRequest request = context.getRequestToExecute();
+            result = primary.applyDeleteOperationOnPrimary(version, request.type(), request.id(), request.versionType(),
+                request.ifSeqNo(), request.ifPrimaryTerm());
         } else {
-            executeIndexRequestOnPrimary(context, mappingUpdater);
+            final IndexRequest request = context.getRequestToExecute();
+            result = primary.applyIndexOperationOnPrimary(version, request.versionType(), new SourceToParse(
+                    request.index(), request.type(), request.id(), request.source(), request.getContentType(), request.routing()),
+                request.ifSeqNo(), request.ifPrimaryTerm(), request.getAutoGeneratedTimestamp(), request.isRetry());
         }
+        if (result.getResultType() == Engine.Result.Type.MAPPING_UPDATE_REQUIRED) {
+            mappingUpdater.updateMappings(result.getRequiredMappingUpdate(), primary.shardId(),
+                context.getRequestToExecute().type(),
+                new ActionListener<Void>() {
+                    @Override
+                    public void onResponse(Void v) {
+                        context.markAsRequiringMappingUpdate();
+                        waitForMappingUpdate.accept(
+                            ActionListener.runAfter(new ActionListener<Void>() {
+                                @Override
+                                public void onResponse(Void v) {
+                                    assert context.requiresWaitingForMappingUpdate();
+                                    context.resetForExecutionForRetry();
+                                }
 
-        if (context.requiresWaitingForMappingUpdate()) {
-            try {
-                waitForMappingUpdate.run();
-                context.resetForExecutionForRetry();
-            } catch (Exception e) {
-                context.failOnMappingUpdate(e);
-            }
-            return;
+                                @Override
+                                public void onFailure(Exception e) {
+                                    context.failOnMappingUpdate(e);
+                                }
+                            }, () -> itemDoneListener.onResponse(null))
+                        );
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        onComplete(exceptionToResult(e, primary, isDelete, version), context, updateResult);
+                        // Requesting mapping update failed, so we don't have to wait for a cluster state update
+                        assert context.isInitial();
+                        itemDoneListener.onResponse(null);
+                    }
+                });
+            return false;
+        } else {
+            onComplete(result, context, updateResult);
         }
-
-        assert context.isOperationExecuted();
-
-        if (opType == DocWriteRequest.OpType.UPDATE &&
-            context.getExecutionResult().isFailed() &&
-            isConflictException(context.getExecutionResult().getFailure().getCause())) {
-            final UpdateRequest updateRequest = (UpdateRequest) context.getCurrent();
-            if (context.getRetryCounter() < updateRequest.retryOnConflict()) {
-                context.resetForExecutionForRetry();
-                return;
-            }
-        }
-
-        finalizePrimaryOperationOnCompletion(context, opType, updateResult);
+        return true;
     }
 
-    private static void finalizePrimaryOperationOnCompletion(BulkPrimaryExecutionContext context, DocWriteRequest.OpType opType,
-                                                             UpdateHelper.Result updateResult) {
-        final BulkItemResponse executionResult = context.getExecutionResult();
-        if (opType == DocWriteRequest.OpType.UPDATE) {
-            final UpdateRequest updateRequest = (UpdateRequest) context.getCurrent();
-            context.markAsCompleted(
-                processUpdateResponse(updateRequest, context.getConcreteIndex(), executionResult, updateResult));
-        } else if (executionResult.isFailed()) {
-            final Exception failure = executionResult.getFailure().getCause();
-            final DocWriteRequest docWriteRequest = context.getCurrent();
-            if (TransportShardBulkAction.isConflictException(failure)) {
-                logger.trace(() -> new ParameterizedMessage("{} failed to execute bulk item ({}) {}",
-                    context.getPrimary().shardId(), docWriteRequest.opType().getLowercase(), docWriteRequest), failure);
-            } else {
-                logger.debug(() -> new ParameterizedMessage("{} failed to execute bulk item ({}) {}",
-                    context.getPrimary().shardId(), docWriteRequest.opType().getLowercase(), docWriteRequest), failure);
-            }
+    private static Engine.Result exceptionToResult(Exception e, IndexShard primary, boolean isDelete, long version) {
+        return isDelete ? primary.getFailedDeleteResult(e, version) : primary.getFailedIndexResult(e, version);
+    }
 
-            context.markAsCompleted(executionResult);
-        } else {
-            context.markAsCompleted(executionResult);
+    private static void onComplete(Engine.Result r, BulkPrimaryExecutionContext context, UpdateHelper.Result updateResult) {
+        context.markOperationAsExecuted(r);
+        final DocWriteRequest<?> docWriteRequest = context.getCurrent();
+        final DocWriteRequest.OpType opType = docWriteRequest.opType();
+        final boolean isUpdate = opType == DocWriteRequest.OpType.UPDATE;
+        final BulkItemResponse executionResult = context.getExecutionResult();
+        final boolean isFailed = executionResult.isFailed();
+        if (isUpdate && isFailed && isConflictException(executionResult.getFailure().getCause())
+            && context.getRetryCounter() < ((UpdateRequest) docWriteRequest).retryOnConflict()) {
+            context.resetForExecutionForRetry();
+            return;
         }
+        final BulkItemResponse response;
+        if (isUpdate) {
+            response = processUpdateResponse((UpdateRequest) docWriteRequest, context.getConcreteIndex(), executionResult, updateResult);
+        } else {
+            if (isFailed) {
+                final Exception failure = executionResult.getFailure().getCause();
+                final MessageSupplier messageSupplier = () -> new ParameterizedMessage("{} failed to execute bulk item ({}) {}",
+                    context.getPrimary().shardId(), opType.getLowercase(), docWriteRequest);
+                if (TransportShardBulkAction.isConflictException(failure)) {
+                    logger.trace(messageSupplier, failure);
+                } else {
+                    logger.debug(messageSupplier, failure);
+                }
+            }
+            response = executionResult;
+        }
+        context.markAsCompleted(response);
         assert context.isInitial();
     }
 
@@ -278,7 +341,6 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
     static BulkItemResponse processUpdateResponse(final UpdateRequest updateRequest, final String concreteIndex,
                                                   BulkItemResponse operationResponse,
                                                   final UpdateHelper.Result translate) {
-
         final BulkItemResponse response;
         DocWriteResponse.Result translatedResult = translate.getResponseResult();
         if (operationResponse.isFailed()) {
@@ -438,66 +500,5 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
                 "Mappings are not available on the replica yet, triggered update: " + result.getRequiredMappingUpdate());
         }
         return result;
-    }
-
-    /** Executes index operation on primary shard after updates mapping if dynamic mappings are found */
-    private static void executeIndexRequestOnPrimary(BulkPrimaryExecutionContext context,
-                                             MappingUpdatePerformer mappingUpdater) throws Exception {
-        final IndexRequest request = context.getRequestToExecute();
-        final IndexShard primary = context.getPrimary();
-        final SourceToParse sourceToParse =
-            new SourceToParse(request.index(), request.type(), request.id(), request.source(), request.getContentType(), request.routing());
-        executeOnPrimaryWhileHandlingMappingUpdates(context,
-            () ->
-                primary.applyIndexOperationOnPrimary(request.version(), request.versionType(), sourceToParse,
-                    request.ifSeqNo(), request.ifPrimaryTerm(), request.getAutoGeneratedTimestamp(), request.isRetry()),
-            e -> primary.getFailedIndexResult(e, request.version()),
-            context::markOperationAsExecuted,
-            mapping -> mappingUpdater.updateMappings(mapping, primary.shardId(), request.type()));
-    }
-
-    private static void executeDeleteRequestOnPrimary(BulkPrimaryExecutionContext context,
-                                                      MappingUpdatePerformer mappingUpdater) throws Exception {
-        final DeleteRequest request = context.getRequestToExecute();
-        final IndexShard primary = context.getPrimary();
-        executeOnPrimaryWhileHandlingMappingUpdates(context,
-            () -> primary.applyDeleteOperationOnPrimary(request.version(), request.type(), request.id(), request.versionType(),
-                request.ifSeqNo(), request.ifPrimaryTerm()),
-            e -> primary.getFailedDeleteResult(e, request.version()),
-            context::markOperationAsExecuted,
-            mapping -> mappingUpdater.updateMappings(mapping, primary.shardId(), request.type()));
-    }
-
-    private static <T extends Engine.Result> void executeOnPrimaryWhileHandlingMappingUpdates(
-        BulkPrimaryExecutionContext context, CheckedSupplier<T, IOException> toExecute,
-        Function<Exception, T> exceptionToResult, Consumer<T> onComplete, Consumer<Mapping> mappingUpdater)
-        throws IOException {
-        T result = toExecute.get();
-        if (result.getResultType() == Engine.Result.Type.MAPPING_UPDATE_REQUIRED) {
-            // try to update the mappings and mark the context as needing to try again.
-            try {
-                mappingUpdater.accept(result.getRequiredMappingUpdate());
-                context.markAsRequiringMappingUpdate();
-            } catch (Exception e) {
-                // failure to update the mapping should translate to a failure of specific requests. Other requests
-                // still need to be executed and replicated.
-                onComplete.accept(exceptionToResult.apply(e));
-                return;
-            }
-        } else {
-            onComplete.accept(result);
-        }
-    }
-
-    class ConcreteMappingUpdatePerformer implements MappingUpdatePerformer {
-
-        @Override
-        public void updateMappings(final Mapping update, final ShardId shardId, final String type) {
-            assert update != null;
-            assert shardId != null;
-            // can throw timeout exception when updating mappings or ISE for attempting to
-            // update default mappings which are bubbled up
-            mappingUpdatedAction.updateMappingOnMaster(shardId.getIndex(), type, update);
-        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
@@ -85,13 +85,13 @@ public class TransportResyncReplicationAction extends TransportWriteAction<Resyn
     }
 
     @Override
-    protected WritePrimaryResult<ResyncReplicationRequest, ResyncReplicationResponse> shardOperationOnPrimary(
-        ResyncReplicationRequest request, IndexShard primary) throws Exception {
-        final ResyncReplicationRequest replicaRequest = performOnPrimary(request, primary);
-        return new WritePrimaryResult<>(replicaRequest, new ResyncReplicationResponse(), null, null, primary, logger);
+    protected void shardOperationOnPrimary(ResyncReplicationRequest request, IndexShard primary,
+            ActionListener<PrimaryResult<ResyncReplicationRequest, ResyncReplicationResponse>> listener) {
+        ActionListener.completeWith(listener,
+            () -> new WritePrimaryResult<>(performOnPrimary(request), new ResyncReplicationResponse(), null, null, primary, logger));
     }
 
-    public static ResyncReplicationRequest performOnPrimary(ResyncReplicationRequest request, IndexShard primary) {
+    public static ResyncReplicationRequest performOnPrimary(ResyncReplicationRequest request) {
         return request;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
@@ -103,12 +103,12 @@ public abstract class TransportWriteAction<
     /**
      * Called on the primary with a reference to the primary {@linkplain IndexShard} to modify.
      *
-     * @return the result of the operation on primary, including current translog location and operation response and failure
-     * async refresh is performed on the <code>primary</code> shard according to the <code>Request</code> refresh policy
+     * @param listener listener for the result of the operation on primary, including current translog location and operation response
+     * and failure async refresh is performed on the <code>primary</code> shard according to the <code>Request</code> refresh policy
      */
     @Override
-    protected abstract WritePrimaryResult<ReplicaRequest, Response> shardOperationOnPrimary(
-            Request request, IndexShard primary) throws Exception;
+    protected abstract void shardOperationOnPrimary(
+            Request request, IndexShard primary, ActionListener<PrimaryResult<ReplicaRequest, Response>> listener);
 
     /**
      * Called once per replica with a reference to the replica {@linkplain IndexShard} to modify.

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/FutureUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/FutureUtils.java
@@ -88,17 +88,19 @@ public class FutureUtils {
     public static RuntimeException rethrowExecutionException(ExecutionException e) {
         if (e.getCause() instanceof ElasticsearchException) {
             ElasticsearchException esEx = (ElasticsearchException) e.getCause();
-            Throwable root = esEx.unwrapCause();
-            if (root instanceof ElasticsearchException) {
-                return (ElasticsearchException) root;
-            } else if (root instanceof RuntimeException) {
-                return (RuntimeException) root;
-            }
-            return new UncategorizedExecutionException("Failed execution", root);
+            return unwrapEsException(esEx);
         } else if (e.getCause() instanceof RuntimeException) {
             return (RuntimeException) e.getCause();
         } else {
             return new UncategorizedExecutionException("Failed execution", e);
         }
+    }
+
+    public static RuntimeException unwrapEsException(ElasticsearchException esEx) {
+        Throwable root = esEx.unwrapCause();
+        if (root instanceof ElasticsearchException || root instanceof RuntimeException) {
+            return (RuntimeException) root;
+        }
+        return new UncategorizedExecutionException("Failed execution", root);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncAction.java
@@ -102,10 +102,12 @@ public class GlobalCheckpointSyncAction extends TransportReplicationAction<
     }
 
     @Override
-    protected PrimaryResult<Request, ReplicationResponse> shardOperationOnPrimary(
-            final Request request, final IndexShard indexShard) throws Exception {
-        maybeSyncTranslog(indexShard);
-        return new PrimaryResult<>(request, new ReplicationResponse());
+    protected void shardOperationOnPrimary(Request request, IndexShard indexShard,
+                                           ActionListener<PrimaryResult<Request, ReplicationResponse>> listener) {
+        ActionListener.completeWith(listener, () -> {
+            maybeSyncTranslog(indexShard);
+            return new PrimaryResult<>(request, new ReplicationResponse());
+        });
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncAction.java
@@ -127,14 +127,16 @@ public class RetentionLeaseBackgroundSyncAction extends TransportReplicationActi
     }
 
     @Override
-    protected PrimaryResult<Request, ReplicationResponse> shardOperationOnPrimary(
+    protected void shardOperationOnPrimary(
             final Request request,
-            final IndexShard primary) throws WriteStateException {
-        assert request.waitForActiveShards().equals(ActiveShardCount.NONE) : request.waitForActiveShards();
-        Objects.requireNonNull(request);
-        Objects.requireNonNull(primary);
-        primary.persistRetentionLeases();
-        return new PrimaryResult<>(request, new ReplicationResponse());
+            final IndexShard primary, ActionListener<PrimaryResult<Request, ReplicationResponse>> listener) {
+        ActionListener.completeWith(listener, () -> {
+            assert request.waitForActiveShards().equals(ActiveShardCount.NONE) : request.waitForActiveShards();
+            Objects.requireNonNull(request);
+            Objects.requireNonNull(primary);
+            primary.persistRetentionLeases();
+            return new PrimaryResult<>(request, new ReplicationResponse());
+        });
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
@@ -123,14 +123,15 @@ public class RetentionLeaseSyncAction extends
     }
 
     @Override
-    protected WritePrimaryResult<Request, Response> shardOperationOnPrimary(
-            final Request request,
-            final IndexShard primary) throws WriteStateException {
-        assert request.waitForActiveShards().equals(ActiveShardCount.NONE) : request.waitForActiveShards();
-        Objects.requireNonNull(request);
-        Objects.requireNonNull(primary);
-        primary.persistRetentionLeases();
-        return new WritePrimaryResult<>(request, new Response(), null, null, primary, getLogger());
+    protected void shardOperationOnPrimary(Request request, IndexShard primary,
+            ActionListener<PrimaryResult<Request, Response>> listener) {
+        ActionListener.completeWith(listener, () -> {
+            assert request.waitForActiveShards().equals(ActiveShardCount.NONE) : request.waitForActiveShards();
+            Objects.requireNonNull(request);
+            Objects.requireNonNull(primary);
+            primary.persistRetentionLeases();
+            return new WritePrimaryResult<>(request, new Response(), null, null, primary, getLogger());
+        });
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
@@ -110,7 +110,7 @@ public class IndicesModule extends AbstractModule {
         );
     }
 
-    private Map<String, Mapper.TypeParser> getMappers(List<MapperPlugin> mapperPlugins) {
+    public static Map<String, Mapper.TypeParser> getMappers(List<MapperPlugin> mapperPlugins) {
         Map<String, Mapper.TypeParser> mappers = new LinkedHashMap<>();
 
         // builtin mappers
@@ -168,7 +168,7 @@ public class IndicesModule extends AbstractModule {
         return Collections.unmodifiableMap(builtInMetadataMappers);
     }
 
-    private static Map<String, MetadataFieldMapper.TypeParser> getMetadataMappers(List<MapperPlugin> mapperPlugins) {
+    public static Map<String, MetadataFieldMapper.TypeParser> getMetadataMappers(List<MapperPlugin> mapperPlugins) {
         Map<String, MetadataFieldMapper.TypeParser> metadataMappers = new LinkedHashMap<>();
 
         int i = 0;

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/SplitIndexIT.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/SplitIndexIT.java
@@ -77,7 +77,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
-
 public class SplitIndexIT extends ESIntegTestCase {
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkRejectionIT.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkRejectionIT.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.bulk;
+
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import java.util.Collections;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 2)
+public class BulkRejectionIT extends ESIntegTestCase {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put("thread_pool.write.size", 1)
+            .put("thread_pool.write.queue_size", 1)
+            .build();
+    }
+
+    @Override
+    protected int numberOfReplicas() {
+        return 1;
+    }
+
+    protected int numberOfShards() {
+        return 5;
+    }
+
+    public void testBulkRejectionAfterDynamicMappingUpdate() throws Exception {
+        final String index = "test";
+        assertAcked(prepareCreate(index));
+        ensureGreen();
+        final BulkRequest request1 = new BulkRequest();
+        for (int i = 0; i < 500; ++i) {
+            request1.add(new IndexRequest(index).source(Collections.singletonMap("key" + i, "value" + i)))
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        }
+        // Huge request to keep the write pool busy so that requests waiting on a mapping update in the other bulk request get rejected
+        // by the write pool
+        final BulkRequest request2 = new BulkRequest();
+        for (int i = 0; i < 10_000; ++i) {
+            request2.add(new IndexRequest(index).source(Collections.singletonMap("key", "valuea" + i)))
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        }
+        final ActionFuture<BulkResponse> bulkFuture1 = client().bulk(request1);
+        final ActionFuture<BulkResponse> bulkFuture2 = client().bulk(request2);
+        bulkFuture1.actionGet();
+        bulkFuture2.actionGet();
+        internalCluster().assertSeqNos();
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
@@ -287,11 +287,12 @@ public class ReplicationOperationTests extends ESTestCase {
         final ShardRouting primaryShard = updatedReplicationGroup.getRoutingTable().primaryShard();
         final TestPrimary primary = new TestPrimary(primaryShard, replicationGroup::get) {
             @Override
-            public Result perform(Request request) throws Exception {
-                Result result = super.perform(request);
-                replicationGroup.set(updatedReplicationGroup);
-                logger.debug("--> state after primary operation:\n{}", replicationGroup.get());
-                return result;
+            public void perform(Request request, ActionListener<Result> listener) {
+                super.perform(request, ActionListener.map(listener, result -> {
+                    replicationGroup.set(updatedReplicationGroup);
+                    logger.debug("--> state after primary operation:\n{}", replicationGroup.get());
+                    return result;
+                }));
             }
         };
 
@@ -481,11 +482,11 @@ public class ReplicationOperationTests extends ESTestCase {
         }
 
         @Override
-        public Result perform(Request request) throws Exception {
+        public void perform(Request request, ActionListener<Result> listener) {
             if (request.processedOnPrimary.compareAndSet(false, true) == false) {
                 fail("processed [" + request + "] twice");
             }
-            return new Result(request);
+            listener.onResponse(new Result(request));
         }
 
         static class Result implements ReplicationOperation.PrimaryResult<Request> {

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
@@ -439,12 +439,13 @@ public class TransportReplicationAllPermitsAcquisitionTests extends IndexShardTe
         }
 
         @Override
-        protected PrimaryResult<Request, Response> shardOperationOnPrimary(Request shardRequest, IndexShard shard) throws Exception {
+        protected void shardOperationOnPrimary(Request shardRequest, IndexShard shard,
+                ActionListener<PrimaryResult<Request, Response>> listener) {
             executedOnPrimary.set(true);
             // The TransportReplicationAction.getIndexShard() method is overridden for testing purpose but we double check here
             // that the permit has been acquired on the primary shard
             assertSame(primary, shard);
-            return new PrimaryResult<>(shardRequest, new Response());
+            listener.onResponse(new PrimaryResult<>(shardRequest, new Response()));
         }
 
         @Override
@@ -499,10 +500,11 @@ public class TransportReplicationAllPermitsAcquisitionTests extends IndexShardTe
         }
 
         @Override
-        protected PrimaryResult<Request, Response> shardOperationOnPrimary(Request shardRequest, IndexShard shard) throws Exception {
+        protected void shardOperationOnPrimary(Request shardRequest, IndexShard shard,
+                ActionListener<PrimaryResult<Request, Response>> listener) {
             assertNoBlocks("block must not exist when executing the operation on primary shard: it should have been blocked before");
             assertThat(shard.getActiveOperationsCount(), greaterThan(0));
-            return super.shardOperationOnPrimary(shardRequest, shard);
+            super.shardOperationOnPrimary(shardRequest, shard, listener);
         }
 
         @Override
@@ -545,9 +547,10 @@ public class TransportReplicationAllPermitsAcquisitionTests extends IndexShardTe
         }
 
         @Override
-        protected PrimaryResult<Request, Response> shardOperationOnPrimary(Request shardRequest, IndexShard shard) throws Exception {
+        protected void shardOperationOnPrimary(Request shardRequest, IndexShard shard,
+                ActionListener<PrimaryResult<Request, Response>> listener) {
             assertEquals("All permits must be acquired", 0, shard.getActiveOperationsCount());
-            return super.shardOperationOnPrimary(shardRequest, shard);
+            super.shardOperationOnPrimary(shardRequest, shard, listener);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportWriteActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportWriteActionTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.support.replication;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.action.support.WriteResponse;
@@ -140,14 +141,15 @@ public class TransportWriteActionTests extends ESTestCase {
         TestRequest request = new TestRequest();
         request.setRefreshPolicy(RefreshPolicy.NONE); // The default, but we'll set it anyway just to be explicit
         TestAction testAction = new TestAction();
-        TransportWriteAction.WritePrimaryResult<TestRequest, TestResponse> result =
-                testAction.shardOperationOnPrimary(request, indexShard);
-        CapturingActionListener<TestResponse> listener = new CapturingActionListener<>();
-        result.respond(listener);
-        assertNotNull(listener.response);
-        assertNull(listener.failure);
-        verify(indexShard, never()).refresh(any());
-        verify(indexShard, never()).addRefreshListener(any(), any());
+        testAction.shardOperationOnPrimary(request, indexShard,
+            ActionTestUtils.assertNoFailureListener(result -> {
+                CapturingActionListener<TestResponse> listener = new CapturingActionListener<>();
+                result.respond(listener);
+                assertNotNull(listener.response);
+                assertNull(listener.failure);
+                verify(indexShard, never()).refresh(any());
+                verify(indexShard, never()).addRefreshListener(any(), any());
+            }));
     }
 
     public void testReplicaNoRefreshCall() throws Exception {
@@ -168,15 +170,16 @@ public class TransportWriteActionTests extends ESTestCase {
         TestRequest request = new TestRequest();
         request.setRefreshPolicy(RefreshPolicy.IMMEDIATE);
         TestAction testAction = new TestAction();
-        TransportWriteAction.WritePrimaryResult<TestRequest, TestResponse> result =
-                testAction.shardOperationOnPrimary(request, indexShard);
-        CapturingActionListener<TestResponse> listener = new CapturingActionListener<>();
-        result.respond(listener);
-        assertNotNull(listener.response);
-        assertNull(listener.failure);
-        assertTrue(listener.response.forcedRefresh);
-        verify(indexShard).refresh("refresh_flag_index");
-        verify(indexShard, never()).addRefreshListener(any(), any());
+        testAction.shardOperationOnPrimary(request, indexShard,
+            ActionTestUtils.assertNoFailureListener(result -> {
+                CapturingActionListener<TestResponse> listener = new CapturingActionListener<>();
+                result.respond(listener);
+                assertNotNull(listener.response);
+                assertNull(listener.failure);
+                assertTrue(listener.response.forcedRefresh);
+                verify(indexShard).refresh("refresh_flag_index");
+                verify(indexShard, never()).addRefreshListener(any(), any());
+            }));
     }
 
     public void testReplicaImmediateRefresh() throws Exception {
@@ -198,23 +201,24 @@ public class TransportWriteActionTests extends ESTestCase {
         request.setRefreshPolicy(RefreshPolicy.WAIT_UNTIL);
 
         TestAction testAction = new TestAction();
-        TransportWriteAction.WritePrimaryResult<TestRequest, TestResponse> result =
-                testAction.shardOperationOnPrimary(request, indexShard);
-        CapturingActionListener<TestResponse> listener = new CapturingActionListener<>();
-        result.respond(listener);
-        assertNull(listener.response); // Haven't reallresponded yet
+        testAction.shardOperationOnPrimary(request, indexShard,
+            ActionTestUtils.assertNoFailureListener(result -> {
+                CapturingActionListener<TestResponse> listener = new CapturingActionListener<>();
+                result.respond(listener);
+                assertNull(listener.response); // Haven't really responded yet
 
-        @SuppressWarnings({ "unchecked", "rawtypes" })
-        ArgumentCaptor<Consumer<Boolean>> refreshListener = ArgumentCaptor.forClass((Class) Consumer.class);
-        verify(indexShard, never()).refresh(any());
-        verify(indexShard).addRefreshListener(any(), refreshListener.capture());
+                @SuppressWarnings({"unchecked", "rawtypes"})
+                ArgumentCaptor<Consumer<Boolean>> refreshListener = ArgumentCaptor.forClass((Class) Consumer.class);
+                verify(indexShard, never()).refresh(any());
+                verify(indexShard).addRefreshListener(any(), refreshListener.capture());
 
-        // Now we can fire the listener manually and we'll get a response
-        boolean forcedRefresh = randomBoolean();
-        refreshListener.getValue().accept(forcedRefresh);
-        assertNotNull(listener.response);
-        assertNull(listener.failure);
-        assertEquals(forcedRefresh, listener.response.forcedRefresh);
+                // Now we can fire the listener manually and we'll get a response
+                boolean forcedRefresh = randomBoolean();
+                refreshListener.getValue().accept(forcedRefresh);
+                assertNotNull(listener.response);
+                assertNull(listener.failure);
+                assertEquals(forcedRefresh, listener.response.forcedRefresh);
+            }));
     }
 
     public void testReplicaWaitForRefresh() throws Exception {
@@ -240,12 +244,13 @@ public class TransportWriteActionTests extends ESTestCase {
     public void testDocumentFailureInShardOperationOnPrimary() throws Exception {
         TestRequest request = new TestRequest();
         TestAction testAction = new TestAction(true, true);
-        TransportWriteAction.WritePrimaryResult<TestRequest, TestResponse> writePrimaryResult =
-                testAction.shardOperationOnPrimary(request, indexShard);
-        CapturingActionListener<TestResponse> listener = new CapturingActionListener<>();
-        writePrimaryResult.respond(listener);
-        assertNull(listener.response);
-        assertNotNull(listener.failure);
+        testAction.shardOperationOnPrimary(request, indexShard,
+            ActionTestUtils.assertNoFailureListener(writePrimaryResult -> {
+                CapturingActionListener<TestResponse> listener = new CapturingActionListener<>();
+                writePrimaryResult.respond(listener);
+                assertNull(listener.response);
+                assertNotNull(listener.failure);
+            }));
     }
 
     public void testDocumentFailureInShardOperationOnReplica() throws Exception {
@@ -426,15 +431,15 @@ public class TransportWriteActionTests extends ESTestCase {
         }
 
         @Override
-        protected WritePrimaryResult<TestRequest, TestResponse> shardOperationOnPrimary(
-                TestRequest request, IndexShard primary) throws Exception {
-            final WritePrimaryResult<TestRequest, TestResponse> primaryResult;
-            if (withDocumentFailureOnPrimary) {
-                primaryResult = new WritePrimaryResult<>(request, null, null, new RuntimeException("simulated"), primary, logger);
-            } else {
-                primaryResult = new WritePrimaryResult<>(request, new TestResponse(), location, null, primary, logger);
-            }
-            return primaryResult;
+        protected void shardOperationOnPrimary(
+                TestRequest request, IndexShard primary, ActionListener<PrimaryResult<TestRequest, TestResponse>> listener) {
+            ActionListener.completeWith(listener, () -> {
+                if (withDocumentFailureOnPrimary) {
+                    return new WritePrimaryResult<>(request, null, null, new RuntimeException("simulated"), primary, logger);
+                } else {
+                    return new WritePrimaryResult<>(request, new TestResponse(), location, null, primary, logger);
+                }
+            });
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncActionTests.java
@@ -18,6 +18,7 @@
 package org.elasticsearch.index.seqno;
 
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -113,7 +114,7 @@ public class GlobalCheckpointSyncActionTests extends ESTestCase {
             new IndexNameExpressionResolver());
         final GlobalCheckpointSyncAction.Request primaryRequest = new GlobalCheckpointSyncAction.Request(indexShard.shardId());
         if (randomBoolean()) {
-            action.shardOperationOnPrimary(primaryRequest, indexShard);
+            action.shardOperationOnPrimary(primaryRequest, indexShard, ActionTestUtils.assertNoFailureListener(r -> {}));
         } else {
             action.shardOperationOnReplica(new GlobalCheckpointSyncAction.Request(indexShard.shardId()), indexShard);
         }

--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncActionTests.java
@@ -21,8 +21,9 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.LatchedActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.replication.ReplicationOperation;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
@@ -47,6 +48,7 @@ import org.elasticsearch.transport.TransportService;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.elasticsearch.mock.orig.Mockito.verifyNoMoreInteractions;
@@ -67,6 +69,7 @@ public class RetentionLeaseBackgroundSyncActionTests extends ESTestCase {
     private TransportService transportService;
     private ShardStateAction shardStateAction;
 
+    @Override
     public void setUp() throws Exception {
         super.setUp();
         threadPool = new TestThreadPool(getClass().getName());
@@ -84,6 +87,7 @@ public class RetentionLeaseBackgroundSyncActionTests extends ESTestCase {
         shardStateAction = new ShardStateAction(clusterService, transportService, null, null, threadPool);
     }
 
+    @Override
     public void tearDown() throws Exception {
         try {
             IOUtils.close(transportService, clusterService, transport);
@@ -93,7 +97,7 @@ public class RetentionLeaseBackgroundSyncActionTests extends ESTestCase {
         super.tearDown();
     }
 
-    public void testRetentionLeaseBackgroundSyncActionOnPrimary() throws WriteStateException {
+    public void testRetentionLeaseBackgroundSyncActionOnPrimary() throws InterruptedException {
         final IndicesService indicesService = mock(IndicesService.class);
 
         final Index index = new Index("index", "uuid");
@@ -120,12 +124,15 @@ public class RetentionLeaseBackgroundSyncActionTests extends ESTestCase {
         final RetentionLeaseBackgroundSyncAction.Request request =
                 new RetentionLeaseBackgroundSyncAction.Request(indexShard.shardId(), retentionLeases);
 
-        final ReplicationOperation.PrimaryResult<RetentionLeaseBackgroundSyncAction.Request> result =
-                action.shardOperationOnPrimary(request, indexShard);
-        // the retention leases on the shard should be persisted
-        verify(indexShard).persistRetentionLeases();
-        // we should forward the request containing the current retention leases to the replica
-        assertThat(result.replicaRequest(), sameInstance(request));
+        final CountDownLatch latch = new CountDownLatch(1);
+        action.shardOperationOnPrimary(request, indexShard,
+            new LatchedActionListener<>(ActionTestUtils.assertNoFailureListener(result -> {
+                // the retention leases on the shard should be persisted
+                verify(indexShard).persistRetentionLeases();
+                // we should forward the request containing the current retention leases to the replica
+                assertThat(result.replicaRequest(), sameInstance(request));
+            }), latch));
+        latch.await();
     }
 
     public void testRetentionLeaseBackgroundSyncActionOnReplica() throws WriteStateException {

--- a/test/framework/src/main/java/org/elasticsearch/action/support/ActionTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/action/support/ActionTestUtils.java
@@ -19,8 +19,10 @@
 
 package org.elasticsearch.action.support;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.CheckedConsumer;
 
 import static org.elasticsearch.action.support.PlainActionFuture.newFuture;
 
@@ -33,5 +35,11 @@ public class ActionTestUtils {
         PlainActionFuture<Response> future = newFuture();
         action.execute(request, future);
         return future.actionGet();
+    }
+
+    public static <T> ActionListener<T> assertNoFailureListener(CheckedConsumer<T, Exception> consumer) {
+        return ActionListener.wrap(consumer, e -> {
+            throw new AssertionError(e);
+        });
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
@@ -36,12 +36,14 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.resync.ResyncReplicationRequest;
 import org.elasticsearch.action.resync.ResyncReplicationResponse;
 import org.elasticsearch.action.resync.TransportResyncReplicationAction;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.replication.ReplicatedWriteRequest;
 import org.elasticsearch.action.support.replication.ReplicationOperation;
 import org.elasticsearch.action.support.replication.ReplicationRequest;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
+import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.action.support.replication.TransportReplicationAction.ReplicaResponse;
 import org.elasticsearch.action.support.replication.TransportWriteAction;
 import org.elasticsearch.action.support.replication.TransportWriteActionTestHelper;
@@ -189,14 +191,15 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
                 sync(shardId, retentionLeases, ActionListener.wrap(
                     r -> { },
                     e -> {
-                        throw new AssertionError("failed to backgroun sync retention lease", e);
+                        throw new AssertionError("failed to background sync retention lease", e);
                     }));
             }
         };
 
         protected ReplicationGroup(final IndexMetaData indexMetaData) throws IOException {
             final ShardRouting primaryRouting = this.createShardRouting("s0", true);
-            primary = newShard(primaryRouting, indexMetaData, null, getEngineFactory(primaryRouting), () -> {}, retentionLeaseSyncer);
+            primary = newShard(
+                primaryRouting, indexMetaData, null, getEngineFactory(primaryRouting), () -> {}, retentionLeaseSyncer);
             replicas = new CopyOnWriteArrayList<>();
             this.indexMetaData = indexMetaData;
             updateAllocationIDsOnPrimary();
@@ -252,9 +255,8 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
         private BulkItemResponse executeWriteRequest(
             DocWriteRequest<?> writeRequest, WriteRequest.RefreshPolicy refreshPolicy) throws Exception {
             PlainActionFuture<BulkItemResponse> listener = new PlainActionFuture<>();
-            final ActionListener<BulkShardResponse> wrapBulkListener = ActionListener.wrap(
-                bulkShardResponse -> listener.onResponse(bulkShardResponse.getResponses()[0]),
-                listener::onFailure);
+            final ActionListener<BulkShardResponse> wrapBulkListener =
+                ActionListener.map(listener, bulkShardResponse -> bulkShardResponse.getResponses()[0]);
             BulkItemRequest[] items = new BulkItemRequest[1];
             items[0] = new BulkItemRequest(0, writeRequest);
             BulkShardRequest request = new BulkShardRequest(shardId, refreshPolicy, items);
@@ -307,8 +309,7 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
         }
 
         public synchronized void addReplica(IndexShard replica) throws IOException {
-            assert shardRoutings().stream()
-                .filter(shardRouting -> shardRouting.isSameAllocation(replica.routingEntry())).findFirst().isPresent() == false :
+            assert shardRoutings().stream().anyMatch(shardRouting -> shardRouting.isSameAllocation(replica.routingEntry())) == false :
                 "replica with aId [" + replica.routingEntry().allocationId() + "] already exists";
             replicas.add(replica);
             if (replicationTargets != null) {
@@ -433,7 +434,7 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
         }
 
         public Future<Void> asyncRecoverReplica(
-                final IndexShard replica, final BiFunction<IndexShard, DiscoveryNode, RecoveryTarget> targetSupplier) throws IOException {
+                final IndexShard replica, final BiFunction<IndexShard, DiscoveryNode, RecoveryTarget> targetSupplier) {
             final FutureTask<Void> task = new FutureTask<>(() -> {
                 recoverReplica(replica, targetSupplier);
                 return null;
@@ -531,10 +532,8 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
         }
 
         protected void syncRetentionLeases(ShardId shardId, RetentionLeases leases, ActionListener<ReplicationResponse> listener) {
-            RetentionLeaseSyncAction.Request request = new RetentionLeaseSyncAction.Request(shardId, leases);
-            ActionListener<RetentionLeaseSyncAction.Response> wrappedListener = ActionListener.wrap(
-                r -> listener.onResponse(new ReplicationResponse()), listener::onFailure);
-            new SyncRetentionLeases(request, ReplicationGroup.this, wrappedListener).execute();
+            new SyncRetentionLeases(new RetentionLeaseSyncAction.Request(shardId, leases), this,
+                ActionListener.map(listener, r -> new ReplicationResponse())).execute();
         }
 
         public synchronized RetentionLease addRetentionLease(String id, long retainingSequenceNumber, String source,
@@ -609,17 +608,8 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
         public void execute() {
             try {
                 new ReplicationOperation<>(request, new PrimaryRef(),
-                    new ActionListener<PrimaryResult>() {
-                        @Override
-                        public void onResponse(PrimaryResult result) {
-                            result.respond(listener);
-                        }
-
-                        @Override
-                        public void onFailure(Exception e) {
-                            listener.onFailure(e);
-                        }
-                    }, new ReplicasRef(), logger, opType).execute();
+                    ActionListener.wrap(result -> result.respond(listener), listener::onFailure), new ReplicasRef(), logger, opType
+                ).execute();
             } catch (Exception e) {
                 listener.onFailure(e);
             }
@@ -629,7 +619,7 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
             return replicationTargets.primary;
         }
 
-        protected abstract PrimaryResult performOnPrimary(IndexShard primary, Request request) throws Exception;
+        protected abstract void performOnPrimary(IndexShard primary, Request request, ActionListener<PrimaryResult> listener);
 
         protected abstract void performOnReplica(ReplicaRequest request, IndexShard replica) throws Exception;
 
@@ -646,8 +636,8 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
             }
 
             @Override
-            public PrimaryResult perform(Request request) throws Exception {
-                return performOnPrimary(getPrimaryShard(), request);
+            public void perform(Request request, ActionListener<PrimaryResult> listener) {
+                performOnPrimary(getPrimaryShard(), request, listener);
             }
 
             @Override
@@ -761,10 +751,9 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
         }
 
         @Override
-        protected PrimaryResult performOnPrimary(IndexShard primary, BulkShardRequest request) throws Exception {
-            final TransportWriteAction.WritePrimaryResult<BulkShardRequest, BulkShardResponse>
-                result = executeShardBulkOnPrimary(primary, request);
-            return new PrimaryResult(result.replicaRequest(), result.finalResponseIfSuccessful);
+        protected void performOnPrimary(IndexShard primary, BulkShardRequest request, ActionListener<PrimaryResult> listener) {
+            executeShardBulkOnPrimary(primary, request,
+                ActionListener.map(listener, result -> new PrimaryResult(result.replicaRequest(), result.finalResponseIfSuccessful)));
         }
 
         @Override
@@ -774,8 +763,8 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
         }
     }
 
-    private TransportWriteAction.WritePrimaryResult<BulkShardRequest, BulkShardResponse> executeShardBulkOnPrimary(
-        IndexShard primary, BulkShardRequest request) throws Exception {
+    private void executeShardBulkOnPrimary(IndexShard primary, BulkShardRequest request,
+        ActionListener<TransportWriteAction.WritePrimaryResult<BulkShardRequest, BulkShardResponse>> listener) {
         for (BulkItemRequest itemRequest : request.items()) {
             if (itemRequest.request() instanceof IndexRequest) {
                 ((IndexRequest) itemRequest.request()).process(Version.CURRENT, null, index.getName());
@@ -783,21 +772,27 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
         }
         final PlainActionFuture<Releasable> permitAcquiredFuture = new PlainActionFuture<>();
         primary.acquirePrimaryOperationPermit(permitAcquiredFuture, ThreadPool.Names.SAME, request);
-        final TransportWriteAction.WritePrimaryResult<BulkShardRequest, BulkShardResponse> result;
         try (Releasable ignored = permitAcquiredFuture.actionGet()) {
-            MappingUpdatePerformer noopMappingUpdater = (update, shardId, type) -> { };
-            result = TransportShardBulkAction.performOnPrimary(request, primary, null, System::currentTimeMillis, noopMappingUpdater,
-                null);
+            MappingUpdatePerformer noopMappingUpdater = (update, shardId, type, listener1) -> {};
+            TransportShardBulkAction.performOnPrimary(request, primary, null, System::currentTimeMillis, noopMappingUpdater,
+                null, ActionTestUtils.assertNoFailureListener(result -> {
+                    TransportWriteActionTestHelper.performPostWriteActions(primary, request,
+                        ((TransportWriteAction.WritePrimaryResult<BulkShardRequest, BulkShardResponse>) result).location, logger);
+                    listener.onResponse((TransportWriteAction.WritePrimaryResult<BulkShardRequest, BulkShardResponse>) result);
+                }), threadPool);
+        } catch (Exception e) {
+            listener.onFailure(e);
         }
-        TransportWriteActionTestHelper.performPostWriteActions(primary, request, result.location, logger);
-        return result;
     }
 
-    private <Request extends ReplicatedWriteRequest & DocWriteRequest>
-    BulkShardRequest executeReplicationRequestOnPrimary(IndexShard primary, Request request) throws Exception {
+    private <Request extends ReplicatedWriteRequest & DocWriteRequest> BulkShardRequest executeReplicationRequestOnPrimary(
+            IndexShard primary, Request request) throws Exception {
         final BulkShardRequest bulkShardRequest = new BulkShardRequest(shardId, request.getRefreshPolicy(),
             new BulkItemRequest[]{new BulkItemRequest(0, request)});
-        return executeShardBulkOnPrimary(primary, bulkShardRequest).replicaRequest();
+        final PlainActionFuture<BulkShardRequest> res = new PlainActionFuture<>();
+        executeShardBulkOnPrimary(
+            primary, bulkShardRequest, ActionListener.map(res, TransportReplicationAction.PrimaryResult::replicaRequest));
+        return res.get();
     }
 
     private void executeShardBulkOnReplica(BulkShardRequest request, IndexShard replica, long operationPrimaryTerm,
@@ -860,10 +855,12 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
         }
 
         @Override
-        protected PrimaryResult performOnPrimary(
-                final IndexShard primary, final GlobalCheckpointSyncAction.Request request) throws Exception {
-            primary.sync();
-            return new PrimaryResult(request, new ReplicationResponse());
+        protected void performOnPrimary(IndexShard primary, GlobalCheckpointSyncAction.Request request,
+                ActionListener<PrimaryResult> listener) {
+            ActionListener.completeWith(listener, () -> {
+                primary.sync();
+                return new PrimaryResult(request, new ReplicationResponse());
+            });
         }
 
         @Override
@@ -879,10 +876,12 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
         }
 
         @Override
-        protected PrimaryResult performOnPrimary(IndexShard primary, ResyncReplicationRequest request) throws Exception {
-            final TransportWriteAction.WritePrimaryResult<ResyncReplicationRequest, ResyncReplicationResponse> result =
-                executeResyncOnPrimary(primary, request);
-            return new PrimaryResult(result.replicaRequest(), result.finalResponseIfSuccessful);
+        protected void performOnPrimary(IndexShard primary, ResyncReplicationRequest request, ActionListener<PrimaryResult> listener) {
+            ActionListener.completeWith(listener, () -> {
+                final TransportWriteAction.WritePrimaryResult<ResyncReplicationRequest, ResyncReplicationResponse> result =
+                    executeResyncOnPrimary(primary, request);
+                return new PrimaryResult(result.replicaRequest(), result.finalResponseIfSuccessful);
+            });
         }
 
         @Override
@@ -895,7 +894,7 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
     private TransportWriteAction.WritePrimaryResult<ResyncReplicationRequest, ResyncReplicationResponse> executeResyncOnPrimary(
         IndexShard primary, ResyncReplicationRequest request) throws Exception {
         final TransportWriteAction.WritePrimaryResult<ResyncReplicationRequest, ResyncReplicationResponse> result =
-            new TransportWriteAction.WritePrimaryResult<>(TransportResyncReplicationAction.performOnPrimary(request, primary),
+            new TransportWriteAction.WritePrimaryResult<>(TransportResyncReplicationAction.performOnPrimary(request),
                 new ResyncReplicationResponse(), null, null, primary, logger);
         TransportWriteActionTestHelper.performPostWriteActions(primary, request, result.location, logger);
         return result;
@@ -922,9 +921,12 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
         }
 
         @Override
-        protected PrimaryResult performOnPrimary(IndexShard primary, RetentionLeaseSyncAction.Request request) throws Exception {
-            primary.persistRetentionLeases();
-            return new PrimaryResult(request, new RetentionLeaseSyncAction.Response());
+        protected void performOnPrimary(IndexShard primary, RetentionLeaseSyncAction.Request request,
+                ActionListener<PrimaryResult> listener) {
+            ActionListener.completeWith(listener, () -> {
+                primary.persistRetentionLeases();
+                return new PrimaryResult(request, new RetentionLeaseSyncAction.Response());
+            });
         }
 
         @Override

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/bulk/TransportBulkShardOperationsAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/bulk/TransportBulkShardOperationsAction.java
@@ -61,13 +61,13 @@ public class TransportBulkShardOperationsAction
     }
 
     @Override
-    protected WritePrimaryResult<BulkShardOperationsRequest, BulkShardOperationsResponse> shardOperationOnPrimary(
-            final BulkShardOperationsRequest request, final IndexShard primary) throws Exception {
+    protected void shardOperationOnPrimary(BulkShardOperationsRequest request, IndexShard primary,
+            ActionListener<PrimaryResult<BulkShardOperationsRequest, BulkShardOperationsResponse>> listener) {
         if (logger.isTraceEnabled()) {
             logger.trace("index [{}] on the following primary shard {}", request.getOperations(), primary.routingEntry());
         }
-        return shardOperationOnPrimary(request.shardId(), request.getHistoryUUID(), request.getOperations(),
-            request.getMaxSeqNoOfUpdatesOrDeletes(), primary, logger);
+        ActionListener.completeWith(listener, () -> shardOperationOnPrimary(request.shardId(), request.getHistoryUUID(),
+            request.getOperations(), request.getMaxSeqNoOfUpdatesOrDeletes(), primary, logger));
     }
 
     public static Translog.Operation rewriteOperationWithPrimaryTerm(Translog.Operation operation, long primaryTerm) {

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
@@ -643,20 +643,22 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
         }
 
         @Override
-        protected PrimaryResult performOnPrimary(IndexShard primary, BulkShardOperationsRequest request) throws Exception {
-            final PlainActionFuture<Releasable> permitFuture = new PlainActionFuture<>();
-            primary.acquirePrimaryOperationPermit(permitFuture, ThreadPool.Names.SAME, request);
-            final TransportWriteAction.WritePrimaryResult<BulkShardOperationsRequest, BulkShardOperationsResponse> ccrResult;
-            try (Releasable ignored = permitFuture.get()) {
-                ccrResult = TransportBulkShardOperationsAction.shardOperationOnPrimary(primary.shardId(), request.getHistoryUUID(),
-                    request.getOperations(), request.getMaxSeqNoOfUpdatesOrDeletes(), primary, logger);
-            }
-            return new PrimaryResult(ccrResult.replicaRequest(), ccrResult.finalResponseIfSuccessful) {
-                @Override
-                public void respond(ActionListener<BulkShardOperationsResponse> listener) {
-                    ccrResult.respond(listener);
+        protected void performOnPrimary(IndexShard primary, BulkShardOperationsRequest request, ActionListener<PrimaryResult> listener) {
+            ActionListener.completeWith(listener, () -> {
+                final PlainActionFuture<Releasable> permitFuture = new PlainActionFuture<>();
+                primary.acquirePrimaryOperationPermit(permitFuture, ThreadPool.Names.SAME, request);
+                final TransportWriteAction.WritePrimaryResult<BulkShardOperationsRequest, BulkShardOperationsResponse> ccrResult;
+                try (Releasable ignored = permitFuture.get()) {
+                    ccrResult = TransportBulkShardOperationsAction.shardOperationOnPrimary(primary.shardId(), request.getHistoryUUID(),
+                        request.getOperations(), request.getMaxSeqNoOfUpdatesOrDeletes(), primary, logger);
                 }
-            };
+                return new PrimaryResult(ccrResult.replicaRequest(), ccrResult.finalResponseIfSuccessful) {
+                    @Override
+                    public void respond(ActionListener<BulkShardOperationsResponse> listener) {
+                        ccrResult.respond(listener);
+                    }
+                };
+            });
         }
 
         @Override


### PR DESCRIPTION
This is a dependency of #39504

Motivation:
By refactoring `TransportShardBulkAction#shardOperationOnPrimary` to async, we enable using `DeterministicTaskQueue` based tests to run indexing operations. This was previously impossible since we were blocking on the `write` thread until the `update` thread finished the mapping update.
With this change, the mapping update will trigger a new task in the `write` queue instead.
This change significantly enhances the amount of coverage we get from `SnapshotResiliencyTests` (and other potential future tests) when it comes to tracking down concurrency issues with distributed state machines.

The logical change is effectively all in `TransportShardBulkAction`, the rest of the changes is then simply mechanically moving the caller code and tests to being async and passing the `ActionListener` down.

Since the move to async would've added more parameters to the `private static` steps in this logic, I decided to inline and dry up (between delete and update) the logic as much as I could instead of passing the listener + wait-consumer down through all of them.

-----------------------------

backport of #39793 #41006 #40923 #40940 (the initial PR to `master` was causing test failures that have been resolved in the subsequent PRs in this list, so I squashed them all into one to not break `7.x`)