### PR TITLE
[ML] fixing test related to #40963 (#41074)

### DIFF
--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameGetAndGetStatsIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameGetAndGetStatsIT.java
@@ -105,7 +105,6 @@ public class DataFrameGetAndGetStatsIT extends DataFrameRestTestCase {
         assertEquals(1, XContentMapValues.extractValue("count", transforms));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/40963")
     @SuppressWarnings("unchecked")
     public void testGetPersistedStatsWithoutTask() throws Exception {
         createPivotReviewsTransform("pivot_stats_1", "pivot_reviews_stats_1", null);
@@ -131,7 +130,6 @@ public class DataFrameGetAndGetStatsIT extends DataFrameRestTestCase {
         for (Map<String, Object> transformStats : transformsStats) {
             Map<String, Object> stat = (Map<String, Object>)transformStats.get("stats");
             assertThat(((Integer)stat.get("documents_processed")), greaterThan(0));
-            assertThat(((Integer)stat.get("search_time_in_ms")), greaterThan(0));
             assertThat(((Integer)stat.get("search_total")), greaterThan(0));
             assertThat(((Integer)stat.get("pages_processed")), greaterThan(0));
         }


### PR DESCRIPTION
This removes the possible zero value check of search_time_in_ms. I have seen this before where the search time is actually recorded as zero. This is OK for this test as we really only care about there being valid statistics. The remain checks are enough to achieve this.

closes #40963

backport of #41074