### PR TITLE
[DOCS] Standardize docs for `url` setting

### DIFF
--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -281,10 +281,10 @@ The `type` setting must be set to `ldap`. In addition to the
 `url`::
 One or more LDAP URLs in the `ldap[s]://<server>:<port>` format. Required.
 +
-To provide a single URL, use the `ldap` protocol: `ldap://server1:636`. To
-provide multiple URLs, use the `ldaps` protocol with an array syntax:
-`["ldaps://server1:636", "ldaps://server2:636" ]`. You can't mix the `ldap` and
-`ldaps` URL protocols.
+To provide multiple URLs, use a YAML array (`["ldap://server1:636", "ldap://server2:636"]`)
+or comma-separated string (`"ldap://server1:636, ldap://server2:636"`).
++
+While both are supported, you can't mix the `ldap` and `ldaps` protocols.
 
 `load_balance.type`::
 The behavior to use when there are multiple LDAP URLs defined. For supported
@@ -554,10 +554,10 @@ One or more LDAP URLs in the `ldap[s]://<server>:<port>` format. Defaults to
 `ldap://<domain_name>:389`. This setting is required when connecting using
 SSL/TLS or when using a custom port.
 +
-To provide a single URL, use the `ldap` protocol: `ldap://server1:389`. To
-provide multiple URLs, use the `ldaps` protocol with an array syntax:
-`["ldaps://server1:389", "ldaps://server2:389" ]`. You can't mix the `ldap` and
-`ldaps` URL protocols.
+To provide multiple URLs, use a YAML array (`["ldap://server1:636", "ldap://server2:636"]`)
+or comma-separated string (`"ldap://server1:636, ldap://server2:636"`).
++
+While both are supported, you can't mix the `ldap` and `ldaps` protocols.
 +
 If no URL is provided, {es} uses a default of `ldap://<domain_name>:389`. This
 default uses the `domain_name` setting value and assumes an unencrypted

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -278,10 +278,13 @@ Defaults to `true`.
 The `type` setting must be set to `ldap`. In addition to the 
 <<ref-realm-settings>>, you can specify the following settings: 
 
-`url`:: Specifies one or more LDAP URLs in the format  
-`ldap[s]://<server>:<port>`. Multiple URLs can be defined using a comma 
-separated value or array syntax: `[ "ldaps://server1:636", "ldaps://server2:636" ]`. 
-`ldaps` and `ldap` URL protocols cannot be mixed in the same realm. Required.
+`url`::
+One or more LDAP URLs in the `ldap[s]://<server>:<port>` format. Required.
++
+To provide a single URL, use the `ldap` protocol: `ldap://server1:636`. To
+provide multiple URLs, use the `ldaps` protocol with an array syntax:
+`["ldaps://server1:636", "ldaps://server2:636" ]`. You can't mix the `ldap` and
+`ldaps` URL protocols.
 
 `load_balance.type`::
 The behavior to use when there are multiple LDAP URLs defined. For supported
@@ -547,11 +550,18 @@ The `type` setting must be set to `active_directory`. In addition to the
 the following settings: 
 
 `url`::
-An LDAP URL of the form `ldap[s]://<server>:<port>`. {es} attempts to 
-authenticate against this URL. If the URL is not specified, it is derived from 
-the `domain_name` setting and assumes an unencrypted connection to port 389. 
-Defaults to `ldap://<domain_name>:389`. This setting is required when connecting 
-using SSL/TLS or when using a custom port.
+One or more LDAP URLs in the `ldap[s]://<server>:<port>` format. Defaults to
+`ldap://<domain_name>:389`. This setting is required when connecting using
+SSL/TLS or when using a custom port.
++
+To provide a single URL, use the `ldap` protocol: `ldap://server1:389`. To
+provide multiple URLs, use the `ldaps` protocol with an array syntax:
+`["ldaps://server1:389", "ldaps://server2:389" ]`. You can't mix the `ldap` and
+`ldaps` URL protocols.
++
+If no URL is provided, {es} uses a default of `ldap://<domain_name>:389`. This
+default uses the `domain_name` setting value and assumes an unencrypted
+connection to port 389. 
 
 `load_balance.type`::
 The behavior to use when there are multiple LDAP URLs defined. For supported


### PR DESCRIPTION
- Updates `url` Active Directory realm setting to indicate you can provide multiple URLs
- Standardizes wording for `url` setting in LDAP and Active Directory realms

Resolves #32830
