### PR TITLE
Move primary term from replicas proxy to repl op

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
@@ -115,8 +115,8 @@ public class TransportVerifyShardBeforeCloseAction extends TransportReplicationA
     }
 
     @Override
-    protected ReplicationOperation.Replicas<ShardRequest> newReplicasProxy(final long primaryTerm) {
-        return new VerifyShardBeforeCloseActionReplicasProxy(primaryTerm);
+    protected ReplicationOperation.Replicas<ShardRequest> newReplicasProxy() {
+        return new VerifyShardBeforeCloseActionReplicasProxy();
     }
 
     /**
@@ -125,13 +125,9 @@ public class TransportVerifyShardBeforeCloseAction extends TransportReplicationA
      * or reopened in an unverified state with potential non flushed translog operations.
      */
     class VerifyShardBeforeCloseActionReplicasProxy extends ReplicasProxy {
-
-        VerifyShardBeforeCloseActionReplicasProxy(final long primaryTerm) {
-            super(primaryTerm);
-        }
-
         @Override
-        public void markShardCopyAsStaleIfNeeded(final ShardId shardId, final String allocationId, final ActionListener<Void> listener) {
+        public void markShardCopyAsStaleIfNeeded(final ShardId shardId, final String allocationId, final long primaryTerm,
+                                                 final ActionListener<Void> listener) {
             shardStateAction.remoteShardFailed(shardId, allocationId, primaryTerm, true, "mark copy as stale", null, listener);
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
@@ -68,8 +68,8 @@ public class TransportResyncReplicationAction extends TransportWriteAction<Resyn
     }
 
     @Override
-    protected ReplicationOperation.Replicas newReplicasProxy(long primaryTerm) {
-        return new ResyncActionReplicasProxy(primaryTerm);
+    protected ReplicationOperation.Replicas newReplicasProxy() {
+        return new ResyncActionReplicasProxy();
     }
 
     @Override
@@ -96,9 +96,10 @@ public class TransportResyncReplicationAction extends TransportWriteAction<Resyn
     }
 
     @Override
-    protected WriteReplicaResult shardOperationOnReplica(ResyncReplicationRequest request, IndexShard replica) throws Exception {
+    protected WriteReplicaResult<ResyncReplicationRequest> shardOperationOnReplica(ResyncReplicationRequest request,
+                                                                                   IndexShard replica) throws Exception {
         Translog.Location location = performOnReplica(request, replica);
-        return new WriteReplicaResult(request, location, null, replica, logger);
+        return new WriteReplicaResult<>(request, location, null, replica, logger);
     }
 
     public static Translog.Location performOnReplica(ResyncReplicationRequest request, IndexShard replica) throws Exception {
@@ -174,12 +175,9 @@ public class TransportResyncReplicationAction extends TransportWriteAction<Resyn
      */
     class ResyncActionReplicasProxy extends ReplicasProxy {
 
-        ResyncActionReplicasProxy(long primaryTerm) {
-            super(primaryTerm);
-        }
-
         @Override
-        public void failShardIfNeeded(ShardRouting replica, String message, Exception exception, ActionListener<Void> listener) {
+        public void failShardIfNeeded(ShardRouting replica, long primaryTerm, String message, Exception exception,
+                                      ActionListener<Void> listener) {
             shardStateAction.remoteShardFailed(
                 replica.shardId(), replica.allocationId().getId(), primaryTerm, false, message, exception, listener);
         }

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
@@ -71,7 +71,10 @@ public class ReplicationOperation<
     private final Primary<Request, ReplicaRequest, PrimaryResultT> primary;
     private final Replicas<ReplicaRequest> replicasProxy;
     private final AtomicBoolean finished = new AtomicBoolean();
-    protected final ActionListener<PrimaryResultT> resultListener;
+    private final long primaryTerm;
+
+    // exposed for tests
+    final ActionListener<PrimaryResultT> resultListener;
 
     private volatile PrimaryResultT primaryResult = null;
 
@@ -80,13 +83,14 @@ public class ReplicationOperation<
     public ReplicationOperation(Request request, Primary<Request, ReplicaRequest, PrimaryResultT> primary,
                                 ActionListener<PrimaryResultT> listener,
                                 Replicas<ReplicaRequest> replicas,
-                                Logger logger, String opType) {
+                                Logger logger, String opType, long primaryTerm) {
         this.replicasProxy = replicas;
         this.primary = primary;
         this.resultListener = listener;
         this.logger = logger;
         this.request = request;
         this.opType = opType;
+        this.primaryTerm = primaryTerm;
     }
 
     public void execute() throws Exception {
@@ -137,7 +141,7 @@ public class ReplicationOperation<
         // if inSyncAllocationIds contains allocation ids of shards that don't exist in RoutingTable, mark copies as stale
         for (String allocationId : replicationGroup.getUnavailableInSyncShards()) {
             pendingActions.incrementAndGet();
-            replicasProxy.markShardCopyAsStaleIfNeeded(replicaRequest.shardId(), allocationId,
+            replicasProxy.markShardCopyAsStaleIfNeeded(replicaRequest.shardId(), allocationId, primaryTerm,
                 ActionListener.wrap(r -> decPendingAndFinishIfNeeded(), ReplicationOperation.this::onNoLongerPrimary));
         }
     }
@@ -165,44 +169,45 @@ public class ReplicationOperation<
 
         totalShards.incrementAndGet();
         pendingActions.incrementAndGet();
-        replicasProxy.performOn(shard, replicaRequest, globalCheckpoint, maxSeqNoOfUpdatesOrDeletes, new ActionListener<ReplicaResponse>() {
-            @Override
-            public void onResponse(ReplicaResponse response) {
-                successfulShards.incrementAndGet();
-                try {
-                    primary.updateLocalCheckpointForShard(shard.allocationId().getId(), response.localCheckpoint());
-                    primary.updateGlobalCheckpointForShard(shard.allocationId().getId(), response.globalCheckpoint());
-                } catch (final AlreadyClosedException e) {
-                    // okay, the index was deleted or this shard was never activated after a relocation; fall through and finish normally
-                } catch (final Exception e) {
-                    // fail the primary but fall through and let the rest of operation processing complete
-                    final String message = String.format(Locale.ROOT, "primary failed updating local checkpoint for replica %s", shard);
-                    primary.failShard(message, e);
+        replicasProxy.performOn(shard, replicaRequest, primaryTerm, globalCheckpoint, maxSeqNoOfUpdatesOrDeletes,
+            new ActionListener<>() {
+                @Override
+                public void onResponse(ReplicaResponse response) {
+                    successfulShards.incrementAndGet();
+                    try {
+                        primary.updateLocalCheckpointForShard(shard.allocationId().getId(), response.localCheckpoint());
+                        primary.updateGlobalCheckpointForShard(shard.allocationId().getId(), response.globalCheckpoint());
+                    } catch (final AlreadyClosedException e) {
+                        // the index was deleted or this shard was never activated after a relocation; fall through and finish normally
+                    } catch (final Exception e) {
+                        // fail the primary but fall through and let the rest of operation processing complete
+                        final String message = String.format(Locale.ROOT, "primary failed updating local checkpoint for replica %s", shard);
+                        primary.failShard(message, e);
+                    }
+                    decPendingAndFinishIfNeeded();
                 }
-                decPendingAndFinishIfNeeded();
-            }
 
-            @Override
-            public void onFailure(Exception replicaException) {
-                logger.trace(() -> new ParameterizedMessage(
-                    "[{}] failure while performing [{}] on replica {}, request [{}]",
-                    shard.shardId(), opType, shard, replicaRequest), replicaException);
-                // Only report "critical" exceptions - TODO: Reach out to the master node to get the latest shard state then report.
-                if (TransportActions.isShardNotAvailableException(replicaException) == false) {
-                    RestStatus restStatus = ExceptionsHelper.status(replicaException);
-                    shardReplicaFailures.add(new ReplicationResponse.ShardInfo.Failure(
-                        shard.shardId(), shard.currentNodeId(), replicaException, restStatus, false));
+                @Override
+                public void onFailure(Exception replicaException) {
+                    logger.trace(() -> new ParameterizedMessage(
+                        "[{}] failure while performing [{}] on replica {}, request [{}]",
+                        shard.shardId(), opType, shard, replicaRequest), replicaException);
+                    // Only report "critical" exceptions - TODO: Reach out to the master node to get the latest shard state then report.
+                    if (TransportActions.isShardNotAvailableException(replicaException) == false) {
+                        RestStatus restStatus = ExceptionsHelper.status(replicaException);
+                        shardReplicaFailures.add(new ReplicationResponse.ShardInfo.Failure(
+                            shard.shardId(), shard.currentNodeId(), replicaException, restStatus, false));
+                    }
+                    String message = String.format(Locale.ROOT, "failed to perform %s on replica %s", opType, shard);
+                    replicasProxy.failShardIfNeeded(shard, primaryTerm, message, replicaException,
+                        ActionListener.wrap(r -> decPendingAndFinishIfNeeded(), ReplicationOperation.this::onNoLongerPrimary));
                 }
-                String message = String.format(Locale.ROOT, "failed to perform %s on replica %s", opType, shard);
-                replicasProxy.failShardIfNeeded(shard, message, replicaException,
-                    ActionListener.wrap(r -> decPendingAndFinishIfNeeded(), ReplicationOperation.this::onNoLongerPrimary));
-            }
 
-            @Override
-            public String toString() {
-                return "[" + replicaRequest + "][" + shard + "]";
-            }
-        });
+                @Override
+                public String toString() {
+                    return "[" + replicaRequest + "][" + shard + "]";
+                }
+            });
     }
 
     private void onNoLongerPrimary(Exception failure) {
@@ -373,25 +378,27 @@ public class ReplicationOperation<
          *
          * @param replica                    the shard this request should be executed on
          * @param replicaRequest             the operation to perform
+         * @param primaryTerm                the primary term
          * @param globalCheckpoint           the global checkpoint on the primary
          * @param maxSeqNoOfUpdatesOrDeletes the max seq_no of updates (index operations overwriting Lucene) or deletes on primary
          *                                   after this replication was executed on it.
          * @param listener                   callback for handling the response or failure
          */
-        void performOn(ShardRouting replica, RequestT replicaRequest, long globalCheckpoint,
-                       long maxSeqNoOfUpdatesOrDeletes, ActionListener<ReplicaResponse> listener);
+        void performOn(ShardRouting replica, RequestT replicaRequest,
+                       long primaryTerm, long globalCheckpoint, long maxSeqNoOfUpdatesOrDeletes, ActionListener<ReplicaResponse> listener);
 
         /**
          * Fail the specified shard if needed, removing it from the current set
          * of active shards. Whether a failure is needed is left up to the
          * implementation.
          *
-         * @param replica   shard to fail
-         * @param message   a (short) description of the reason
-         * @param exception the original exception which caused the ReplicationOperation to request the shard to be failed
-         * @param listener  a listener that will be notified when the failing shard has been removed from the in-sync set
+         * @param replica      shard to fail
+         * @param primaryTerm  the primary term
+         * @param message      a (short) description of the reason
+         * @param exception    the original exception which caused the ReplicationOperation to request the shard to be failed
+         * @param listener     a listener that will be notified when the failing shard has been removed from the in-sync set
          */
-        void failShardIfNeeded(ShardRouting replica, String message, Exception exception, ActionListener<Void> listener);
+        void failShardIfNeeded(ShardRouting replica, long primaryTerm, String message, Exception exception, ActionListener<Void> listener);
 
         /**
          * Marks shard copy as stale if needed, removing its allocation id from
@@ -400,9 +407,10 @@ public class ReplicationOperation<
          *
          * @param shardId      shard id
          * @param allocationId allocation id to remove from the set of in-sync allocation ids
+         * @param primaryTerm  the primary term
          * @param listener     a listener that will be notified when the failing shard has been removed from the in-sync set
          */
-        void markShardCopyAsStaleIfNeeded(ShardId shardId, String allocationId, ActionListener<Void> listener);
+        void markShardCopyAsStaleIfNeeded(ShardId shardId, String allocationId, long primaryTerm, ActionListener<Void> listener);
     }
 
     /**
@@ -427,11 +435,11 @@ public class ReplicationOperation<
     }
 
     public static class RetryOnPrimaryException extends ElasticsearchException {
-        public RetryOnPrimaryException(ShardId shardId, String msg) {
+        RetryOnPrimaryException(ShardId shardId, String msg) {
             this(shardId, msg, null);
         }
 
-        public RetryOnPrimaryException(ShardId shardId, String msg, Throwable cause) {
+        RetryOnPrimaryException(ShardId shardId, String msg, Throwable cause) {
             super(msg, cause);
             setShard(shardId);
         }

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
@@ -96,8 +96,8 @@ public abstract class TransportWriteAction<
     }
 
     @Override
-    protected ReplicationOperation.Replicas newReplicasProxy(long primaryTerm) {
-        return new WriteActionReplicasProxy(primaryTerm);
+    protected ReplicationOperation.Replicas<ReplicaRequest> newReplicasProxy() {
+        return new WriteActionReplicasProxy();
     }
 
     /**
@@ -371,12 +371,9 @@ public abstract class TransportWriteAction<
      */
     class WriteActionReplicasProxy extends ReplicasProxy {
 
-        WriteActionReplicasProxy(long primaryTerm) {
-            super(primaryTerm);
-        }
-
         @Override
-        public void failShardIfNeeded(ShardRouting replica, String message, Exception exception, ActionListener<Void> listener) {
+        public void failShardIfNeeded(ShardRouting replica, long primaryTerm, String message, Exception exception,
+                                      ActionListener<Void> listener) {
             if (TransportActions.isShardNotAvailableException(exception) == false) {
                 logger.warn(new ParameterizedMessage("[{}] {}", replica.shardId(), message), exception);
             }
@@ -385,7 +382,7 @@ public abstract class TransportWriteAction<
         }
 
         @Override
-        public void markShardCopyAsStaleIfNeeded(ShardId shardId, String allocationId, ActionListener<Void> listener) {
+        public void markShardCopyAsStaleIfNeeded(ShardId shardId, String allocationId, long primaryTerm, ActionListener<Void> listener) {
             shardStateAction.remoteShardFailed(shardId, allocationId, primaryTerm, true, "mark copy as stale", null, listener);
         }
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseActionTests.java
@@ -139,7 +139,7 @@ public class TransportVerifyShardBeforeCloseActionTests extends ESTestCase {
         final TaskId taskId = new TaskId("_node_id", randomNonNegativeLong());
         final TransportVerifyShardBeforeCloseAction.ShardRequest request =
             new TransportVerifyShardBeforeCloseAction.ShardRequest(indexShard.shardId(), clusterBlock, taskId);
-        final PlainActionFuture res = PlainActionFuture.newFuture();
+        final PlainActionFuture<Void> res = PlainActionFuture.newFuture();
         action.shardOperationOnPrimary(request, indexShard, ActionListener.wrap(
             r -> {
                 assertNotNull(r);
@@ -228,10 +228,10 @@ public class TransportVerifyShardBeforeCloseActionTests extends ESTestCase {
         TaskId taskId = new TaskId(clusterService.localNode().getId(), 0L);
         TransportVerifyShardBeforeCloseAction.ShardRequest request =
             new TransportVerifyShardBeforeCloseAction.ShardRequest(shardId, clusterBlock, taskId);
-        ReplicationOperation.Replicas<TransportVerifyShardBeforeCloseAction.ShardRequest> proxy = action.newReplicasProxy(primaryTerm);
+        ReplicationOperation.Replicas<TransportVerifyShardBeforeCloseAction.ShardRequest> proxy = action.newReplicasProxy();
         ReplicationOperation<TransportVerifyShardBeforeCloseAction.ShardRequest,
-            TransportVerifyShardBeforeCloseAction.ShardRequest, PrimaryResult> operation =
-            new ReplicationOperation<>(request, createPrimary(primaryRouting, replicationGroup), listener, proxy, logger, "test");
+            TransportVerifyShardBeforeCloseAction.ShardRequest, PrimaryResult> operation = new ReplicationOperation<>(
+                request, createPrimary(primaryRouting, replicationGroup), listener, proxy, logger, "test", primaryTerm);
         operation.execute();
 
         final CapturingTransport.CapturedRequest[] capturedRequests = transport.getCapturedRequestsAndClear();
@@ -268,53 +268,50 @@ public class TransportVerifyShardBeforeCloseActionTests extends ESTestCase {
         TransportVerifyShardBeforeCloseAction.ShardRequest,
         PrimaryResult>
             createPrimary(final ShardRouting primary, final ReplicationGroup replicationGroup) {
-                return new ReplicationOperation.Primary<
-                    TransportVerifyShardBeforeCloseAction.ShardRequest,
-                    TransportVerifyShardBeforeCloseAction.ShardRequest,
-                    PrimaryResult>() {
-                        @Override
-                        public ShardRouting routingEntry() {
-                            return primary;
-                        }
+                return new ReplicationOperation.Primary<>() {
+                    @Override
+                    public ShardRouting routingEntry() {
+                        return primary;
+                    }
 
-                        @Override
-                        public ReplicationGroup getReplicationGroup() {
-                            return replicationGroup;
-                        }
+                    @Override
+                    public ReplicationGroup getReplicationGroup() {
+                        return replicationGroup;
+                    }
 
-                        @Override
-                        public void perform(
-                                TransportVerifyShardBeforeCloseAction.ShardRequest request, ActionListener<PrimaryResult> listener) {
-                            listener.onResponse(new PrimaryResult(request));
-                        }
+                    @Override
+                    public void perform(
+                        TransportVerifyShardBeforeCloseAction.ShardRequest request, ActionListener<PrimaryResult> listener) {
+                        listener.onResponse(new PrimaryResult(request));
+                    }
 
-                        @Override
-                        public void failShard(String message, Exception exception) {
+                    @Override
+                    public void failShard(String message, Exception exception) {
 
-                        }
+                    }
 
-                        @Override
-                        public void updateLocalCheckpointForShard(String allocationId, long checkpoint) {
-                        }
+                    @Override
+                    public void updateLocalCheckpointForShard(String allocationId, long checkpoint) {
+                    }
 
-                        @Override
-                        public void updateGlobalCheckpointForShard(String allocationId, long globalCheckpoint) {
-                        }
+                    @Override
+                    public void updateGlobalCheckpointForShard(String allocationId, long globalCheckpoint) {
+                    }
 
-                        @Override
-                        public long localCheckpoint() {
-                            return 0;
-                        }
+                    @Override
+                    public long localCheckpoint() {
+                        return 0;
+                    }
 
-                        @Override
-                        public long globalCheckpoint() {
-                            return 0;
-                        }
+                    @Override
+                    public long globalCheckpoint() {
+                        return 0;
+                    }
 
-                        @Override
-                        public long maxSeqNoOfUpdatesOrDeletes() {
-                            return 0;
-                        }
+                    @Override
+                    public long maxSeqNoOfUpdatesOrDeletes() {
+                        return 0;
+                    }
                 };
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
@@ -608,8 +608,8 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
         public void execute() {
             try {
                 new ReplicationOperation<>(request, new PrimaryRef(),
-                    ActionListener.wrap(result -> result.respond(listener), listener::onFailure), new ReplicasRef(), logger, opType
-                ).execute();
+                    ActionListener.wrap(result -> result.respond(listener), listener::onFailure), new ReplicasRef(), logger, opType,
+                    primaryTerm).execute();
             } catch (Exception e) {
                 listener.onFailure(e);
             }
@@ -678,6 +678,7 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
             public void performOn(
                 final ShardRouting replicaRouting,
                 final ReplicaRequest request,
+                final long primaryTerm,
                 final long globalCheckpoint,
                 final long maxSeqNoOfUpdatesOrDeletes,
                 final ActionListener<ReplicationOperation.ReplicaResponse> listener) {
@@ -700,12 +701,14 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
             }
 
             @Override
-            public void failShardIfNeeded(ShardRouting replica, String message, Exception exception, ActionListener<Void> listener) {
+            public void failShardIfNeeded(ShardRouting replica, long primaryTerm, String message, Exception exception,
+                                          ActionListener<Void> listener) {
                 throw new UnsupportedOperationException("failing shard " + replica + " isn't supported. failure: " + message, exception);
             }
 
             @Override
-            public void markShardCopyAsStaleIfNeeded(ShardId shardId, String allocationId, ActionListener<Void> listener) {
+            public void markShardCopyAsStaleIfNeeded(ShardId shardId, String allocationId, long primaryTerm,
+                                                     ActionListener<Void> listener) {
                 throw new UnsupportedOperationException("can't mark " + shardId  + ", aid [" + allocationId + "] as stale");
             }
         }


### PR DESCRIPTION
A small refactoring that removes the primaryTerm field from ReplicasProxy and
instead passes it directly in to the methods that need it.