### PR TITLE
[ML] Add progress information to checkpoints

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformCheckpointStats.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformCheckpointStats.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.client.dataframe.transforms;
 
 import org.elasticsearch.common.ParseField;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
 
@@ -30,37 +29,44 @@ import java.util.Objects;
 public class DataFrameTransformCheckpointStats {
     public static final ParseField TIMESTAMP_MILLIS = new ParseField("timestamp_millis");
     public static final ParseField TIME_UPPER_BOUND_MILLIS = new ParseField("time_upper_bound_millis");
-
-    public static DataFrameTransformCheckpointStats EMPTY = new DataFrameTransformCheckpointStats(0L, 0L);
+    public static final ParseField TOTAL_DOCS = new ParseField("total_docs");
+    public static final ParseField COMPLETED_DOCS = new ParseField("completed_docs");
+    public static DataFrameTransformCheckpointStats EMPTY = new DataFrameTransformCheckpointStats(0L, 0L, 0L, 0L);
 
     private final long timestampMillis;
     private final long timeUpperBoundMillis;
+    private final long totalDocs;
+    private final long completedDocs;
 
     public static final ConstructingObjectParser<DataFrameTransformCheckpointStats, Void> LENIENT_PARSER = new ConstructingObjectParser<>(
             "data_frame_transform_checkpoint_stats", true, args -> {
                 long timestamp = args[0] == null ? 0L : (Long) args[0];
                 long timeUpperBound = args[1] == null ? 0L : (Long) args[1];
+                long totalDocs = args[2] == null ? 0L : (Long) args[2];
+                long completedDocs = args[3] == null ? 0L : (Long) args[3];
 
-                return new DataFrameTransformCheckpointStats(timestamp, timeUpperBound);
+                return new DataFrameTransformCheckpointStats(timestamp, timeUpperBound, totalDocs, completedDocs);
             });
 
     static {
         LENIENT_PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), TIMESTAMP_MILLIS);
         LENIENT_PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), TIME_UPPER_BOUND_MILLIS);
+        LENIENT_PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), TOTAL_DOCS);
+        LENIENT_PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), COMPLETED_DOCS);
     }
 
     public static DataFrameTransformCheckpointStats fromXContent(XContentParser parser) throws IOException {
         return LENIENT_PARSER.parse(parser, null);
     }
 
-    public DataFrameTransformCheckpointStats(final long timestampMillis, final long timeUpperBoundMillis) {
+    public DataFrameTransformCheckpointStats(final long timestampMillis,
+                                             final long timeUpperBoundMillis,
+                                             final long totalDocs,
+                                             final long completedDocs) {
         this.timestampMillis = timestampMillis;
         this.timeUpperBoundMillis = timeUpperBoundMillis;
-    }
-
-    public DataFrameTransformCheckpointStats(StreamInput in) throws IOException {
-        this.timestampMillis = in.readLong();
-        this.timeUpperBoundMillis = in.readLong();
+        this.totalDocs = totalDocs;
+        this.completedDocs = completedDocs;
     }
 
     public long getTimestampMillis() {
@@ -71,9 +77,24 @@ public class DataFrameTransformCheckpointStats {
         return timeUpperBoundMillis;
     }
 
+    public long getTotalDocs() {
+        return totalDocs;
+    }
+
+    public long getCompletedDocs() {
+        return completedDocs;
+    }
+
+    public double getPercentageCompleted() {
+        if (completedDocs >= totalDocs) {
+            return 1.0;
+        }
+        return (double)completedDocs/totalDocs;
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hash(timestampMillis, timeUpperBoundMillis);
+        return Objects.hash(timestampMillis, timeUpperBoundMillis, completedDocs, totalDocs);
     }
 
     @Override
@@ -88,6 +109,9 @@ public class DataFrameTransformCheckpointStats {
 
         DataFrameTransformCheckpointStats that = (DataFrameTransformCheckpointStats) other;
 
-        return this.timestampMillis == that.timestampMillis && this.timeUpperBoundMillis == that.timeUpperBoundMillis;
+        return this.timestampMillis == that.timestampMillis
+            && this.timeUpperBoundMillis == that.timeUpperBoundMillis
+            && this.totalDocs == that.totalDocs
+            && this.completedDocs == that.completedDocs;
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformCheckpointStatsTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformCheckpointStatsTests.java
@@ -48,6 +48,8 @@ public class DataFrameTransformCheckpointStatsTests extends ESTestCase {
         builder.startObject();
         builder.field("timestamp_millis", stats.getTimestampMillis());
         builder.field("time_upper_bound_millis", stats.getTimeUpperBoundMillis());
+        builder.field("total_docs", stats.getTotalDocs());
+        builder.field("completed_docs", stats.getCompletedDocs());
         builder.endObject();
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformCheckpointStatsTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformCheckpointStatsTests.java
@@ -38,7 +38,10 @@ public class DataFrameTransformCheckpointStatsTests extends ESTestCase {
     }
 
     public static DataFrameTransformCheckpointStats randomDataFrameTransformCheckpointStats() {
-        return new DataFrameTransformCheckpointStats(randomLongBetween(1, 1_000_000), randomLongBetween(0, 1_000_000));
+        return new DataFrameTransformCheckpointStats(randomLongBetween(1, 1_000_000),
+            randomLongBetween(0, 1_000_000),
+            randomNonNegativeLong(),
+            randomNonNegativeLong());
     }
 
     public static void toXContent(DataFrameTransformCheckpointStats stats, XContentBuilder builder) throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformCheckpointStatsTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformCheckpointStatsTests.java
@@ -31,7 +31,10 @@ public class DataFrameTransformCheckpointStatsTests extends AbstractHlrcXContent
 
     public static DataFrameTransformCheckpointStats fromHlrc(
             org.elasticsearch.client.dataframe.transforms.DataFrameTransformCheckpointStats instance) {
-        return new DataFrameTransformCheckpointStats(instance.getTimestampMillis(), instance.getTimeUpperBoundMillis());
+        return new DataFrameTransformCheckpointStats(instance.getTimestampMillis(),
+            instance.getTimeUpperBoundMillis(),
+            instance.getTotalDocs(),
+            instance.getCompletedDocs());
     }
 
     @Override

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformStateTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformStateTests.java
@@ -87,7 +87,10 @@ public class DataFrameTransformStateTests extends AbstractHlrcXContentTestCase<D
     }
 
     public static DataFrameTransformCheckpointStats randomDataFrameTransformCheckpointStats() {
-        return new DataFrameTransformCheckpointStats(randomNonNegativeLong(), randomNonNegativeLong());
+        return new DataFrameTransformCheckpointStats(randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            randomNonNegativeLong());
     }
 
     public static DataFrameIndexerTransformStats randomStats(String transformId) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameField.java
@@ -39,6 +39,9 @@ public final class DataFrameField {
     public static final ParseField TIME_UPPER_BOUND_MILLIS = new ParseField("time_upper_bound_millis");
     public static final ParseField TIME_UPPER_BOUND = new ParseField("time_upper_bound");
 
+    // Checkpoint information around progress and total docs to import in checkpoint
+    public static final ParseField TOTAL_DOCS = new ParseField("total_docs");
+    public static final ParseField COMPLETED_DOCS = new ParseField("completed_docs");
     // common strings
     public static final String TASK_NAME = "data_frame/transforms";
     public static final String REST_BASE_PATH = "/_data_frame/";

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformCheckpointStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformCheckpointStatsTests.java
@@ -11,10 +11,16 @@ import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
+
 public class DataFrameTransformCheckpointStatsTests extends AbstractSerializingDataFrameTestCase<DataFrameTransformCheckpointStats>
 {
     public static DataFrameTransformCheckpointStats randomDataFrameTransformCheckpointStats() {
-        return new DataFrameTransformCheckpointStats(randomNonNegativeLong(), randomNonNegativeLong());
+        return new DataFrameTransformCheckpointStats(randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            randomNonNegativeLong());
     }
 
     @Override
@@ -32,4 +38,17 @@ public class DataFrameTransformCheckpointStatsTests extends AbstractSerializingD
         return DataFrameTransformCheckpointStats::new;
     }
 
+    public void testPercentageComplete() {
+        DataFrameTransformCheckpointStats stats = new DataFrameTransformCheckpointStats(0L, 0L, 0L, 0L);
+        assertThat(stats.getPercentageCompleted(), equalTo(1.0));
+
+        stats = new DataFrameTransformCheckpointStats(0L, 0L, 100L, 0L);
+        assertThat(stats.getPercentageCompleted(), equalTo(0.0));
+
+        stats = new DataFrameTransformCheckpointStats(0L, 0L, 100L, 50L);
+        assertThat(stats.getPercentageCompleted(), closeTo(0.5, 0.0000001));
+
+        stats = new DataFrameTransformCheckpointStats(0L, 0L, 0L, 50L);
+        assertThat(stats.getPercentageCompleted(), equalTo(1.0));
+    }
 }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportGetDataFrameTransformsStatsAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportGetDataFrameTransformsStatsAction.java
@@ -152,6 +152,7 @@ public class TransportGetDataFrameTransformsStatsAction extends
         }
     }
 
+    // TODO add logic to gather latest stored checkpoint information
     private void collectStatsForTransformsWithoutTasks(Request request,
                                                        Response response,
                                                        ActionListener<Response> listener) {

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/checkpoint/DataFrameTransformsCheckpointService.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/checkpoint/DataFrameTransformsCheckpointService.java
@@ -17,7 +17,6 @@ import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.xpack.core.ClientHelper;
-import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformCheckpointStats;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformCheckpointingInfo;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
 import org.elasticsearch.xpack.dataframe.persistence.DataFrameTransformsConfigManager;

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformCheckpoint.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformCheckpoint.java
@@ -17,7 +17,6 @@ import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.dataframe.DataFrameField;
-import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransform;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformCheckpointStats;
 
 import java.io.IOException;

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformCheckpoint.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformCheckpoint.java
@@ -54,8 +54,6 @@ public class DataFrameTransformCheckpoint implements Writeable, ToXContentObject
     // checkpoint of the indexes (sequence id's)
     public static final ParseField INDICES = new ParseField("indices");
 
-    // Document information to determine progress
-
     private static final String NAME = "data_frame_transform_checkpoint";
 
     private static final ConstructingObjectParser<DataFrameTransformCheckpoint, Void> STRICT_PARSER = createParser(false);
@@ -83,7 +81,7 @@ public class DataFrameTransformCheckpoint implements Writeable, ToXContentObject
                     long totalDocs = args[5] == null ? 0L : (Long) args[5];
                     long completedDocs = args[6] == null ? 0L : (Long) args[6];
 
-                    // ignored, only for internal storage: String docType = (String) args[5];
+                    // ignored, only for internal storage: String docType = (String) args[7];
                     return new DataFrameTransformCheckpoint(id,
                         timestamp,
                         checkpoint,
@@ -121,7 +119,6 @@ public class DataFrameTransformCheckpoint implements Writeable, ToXContentObject
         parser.declareLong(optionalConstructorArg(), DataFrameField.TIME_UPPER_BOUND_MILLIS);
         parser.declareLong(optionalConstructorArg(), TOTAL_DOCS);
         parser.declareLong(optionalConstructorArg(), COMPLETED_DOCS);
-        parser.declareLong(optionalConstructorArg(), DataFrameField.TIME_UPPER_BOUND_MILLIS);
         parser.declareString(optionalConstructorArg(), DataFrameField.INDEX_DOC_TYPE);
 
         return parser;

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
@@ -503,7 +503,8 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
                 },
                 exc -> {
                     logger.error(
-                        "Persisting checkpoint [" + getCheckpointObject().getCheckpoint() + "] for transform [" + transform.getId() + "] failed", exc);
+                        "Persisting checkpoint [" + getCheckpointObject().getCheckpoint() +
+                            "] for transform [" + transform.getId() + "] failed", exc);
                     next.run();
                 }
             );

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/checkpoint/DataFrameTransformCheckpointServiceNodeTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/checkpoint/DataFrameTransformCheckpointServiceNodeTests.java
@@ -132,7 +132,7 @@ public class DataFrameTransformCheckpointServiceNodeTests extends DataFrameSingl
         long timestamp = 1000;
 
         DataFrameTransformCheckpoint checkpoint = new DataFrameTransformCheckpoint(transformId, timestamp, 1L,
-                createCheckPointMap(transformId, 10, 10, 10), null);
+                createCheckPointMap(transformId, 10, 10, 10), null, 0L, 0L);
 
         // create transform
         assertAsync(
@@ -150,7 +150,7 @@ public class DataFrameTransformCheckpointServiceNodeTests extends DataFrameSingl
 
         // add a 2nd checkpoint
         DataFrameTransformCheckpoint checkpoint2 = new DataFrameTransformCheckpoint(transformId, timestamp + 100L, 2L,
-                createCheckPointMap(transformId, 20, 20, 20), null);
+                createCheckPointMap(transformId, 20, 20, 20), null, 0L, 0L);
 
         assertAsync(listener -> transformsConfigManager.putTransformCheckpoint(checkpoint2, listener), true, null, null);
 
@@ -180,35 +180,35 @@ public class DataFrameTransformCheckpointServiceNodeTests extends DataFrameSingl
                 true, null, null);
 
         DataFrameTransformCheckpoint checkpoint = new DataFrameTransformCheckpoint(transformId, timestamp, 1L,
-                createCheckPointMap(transformId, 10, 10, 10), null);
+                createCheckPointMap(transformId, 10, 10, 10), null, 1000L, 500L);
 
         assertAsync(listener -> transformsConfigManager.putTransformCheckpoint(checkpoint, listener), true, null, null);
 
         DataFrameTransformCheckpoint checkpoint2 = new DataFrameTransformCheckpoint(transformId, timestamp + 100L, 2L,
-                createCheckPointMap(transformId, 20, 20, 20), null);
+                createCheckPointMap(transformId, 20, 20, 20), null, 100L, 0L);
 
         assertAsync(listener -> transformsConfigManager.putTransformCheckpoint(checkpoint2, listener), true, null, null);
 
         mockClientForCheckpointing.setShardStats(createShardStats(createCheckPointMap(transformId, 20, 20, 20)));
         DataFrameTransformCheckpointingInfo checkpointInfo = new DataFrameTransformCheckpointingInfo(
-                new DataFrameTransformCheckpointStats(timestamp, 0L),
-                new DataFrameTransformCheckpointStats(timestamp + 100L, 0L),
+            new DataFrameTransformCheckpointStats(timestamp, 0L, 1000L, 500L),
+            new DataFrameTransformCheckpointStats(timestamp + 100L, 0L, 100L, 0L),
                 30L);
 
         assertAsync(listener -> transformsCheckpointService.getCheckpointStats(transformId, 1, 2, listener), checkpointInfo, null, null);
 
         mockClientForCheckpointing.setShardStats(createShardStats(createCheckPointMap(transformId, 10, 50, 33)));
         checkpointInfo = new DataFrameTransformCheckpointingInfo(
-                new DataFrameTransformCheckpointStats(timestamp, 0L),
-                new DataFrameTransformCheckpointStats(timestamp + 100L, 0L),
-                63L);
+            new DataFrameTransformCheckpointStats(timestamp, 0L, 1000L, 500L),
+            new DataFrameTransformCheckpointStats(timestamp + 100L, 0L, 100L, 0L),
+            63L);
         assertAsync(listener -> transformsCheckpointService.getCheckpointStats(transformId, 1, 2, listener), checkpointInfo, null, null);
 
         // same as current
         mockClientForCheckpointing.setShardStats(createShardStats(createCheckPointMap(transformId, 10, 10, 10)));
         checkpointInfo = new DataFrameTransformCheckpointingInfo(
-                new DataFrameTransformCheckpointStats(timestamp, 0L),
-                new DataFrameTransformCheckpointStats(timestamp + 100L, 0L),
+            new DataFrameTransformCheckpointStats(timestamp, 0L, 1000L, 500L),
+            new DataFrameTransformCheckpointStats(timestamp + 100L, 0L, 100L, 0L),
                 0L);
         assertAsync(listener -> transformsCheckpointService.getCheckpointStats(transformId, 1, 2, listener), checkpointInfo, null, null);
     }

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformCheckpointTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformCheckpointTests.java
@@ -25,7 +25,7 @@ public class DataFrameTransformCheckpointTests extends AbstractSerializingDataFr
 
     public static DataFrameTransformCheckpoint randomDataFrameTransformCheckpoints() {
         return new DataFrameTransformCheckpoint(randomAlphaOfLengthBetween(1, 10), randomNonNegativeLong(), randomNonNegativeLong(),
-                randomCheckpointsByIndex(), randomNonNegativeLong());
+                randomCheckpointsByIndex(), randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong());
     }
 
     @Override
@@ -58,13 +58,15 @@ public class DataFrameTransformCheckpointTests extends AbstractSerializingDataFr
         String id = randomAlphaOfLengthBetween(1, 10);
         long timestamp = randomNonNegativeLong();
         long checkpoint = randomNonNegativeLong();
+        long numDocs = randomNonNegativeLong();
+        long completedDocs = randomLongBetween(0L, numDocs);
         Map<String, long[]> checkpointsByIndex = randomCheckpointsByIndex();
         Map<String, long[]> otherCheckpointsByIndex = new TreeMap<>(checkpointsByIndex);
         otherCheckpointsByIndex.put(randomAlphaOfLengthBetween(1, 10), new long[] { 1, 2, 3 });
         long timeUpperBound = randomNonNegativeLong();
 
         DataFrameTransformCheckpoint dataFrameTransformCheckpoints = new DataFrameTransformCheckpoint(id, timestamp, checkpoint,
-                checkpointsByIndex, timeUpperBound);
+                checkpointsByIndex, timeUpperBound, numDocs, completedDocs);
 
         // same
         assertTrue(dataFrameTransformCheckpoints.matches(dataFrameTransformCheckpoints));
@@ -76,25 +78,57 @@ public class DataFrameTransformCheckpointTests extends AbstractSerializingDataFr
 
         // other id
         assertFalse(dataFrameTransformCheckpoints
-                .matches(new DataFrameTransformCheckpoint(id + "-1", timestamp, checkpoint, checkpointsByIndex, timeUpperBound)));
+                .matches(new DataFrameTransformCheckpoint(id + "-1",
+                    timestamp,
+                    checkpoint,
+                    checkpointsByIndex,
+                    timeUpperBound,
+                    numDocs,
+                    completedDocs)));
         // other timestamp
         assertTrue(dataFrameTransformCheckpoints
-                .matches(new DataFrameTransformCheckpoint(id, (timestamp / 2) + 1, checkpoint, checkpointsByIndex, timeUpperBound)));
+                .matches(new DataFrameTransformCheckpoint(id,
+                    (timestamp / 2) + 1,
+                    checkpoint,
+                    checkpointsByIndex,
+                    timeUpperBound,
+                    numDocs,
+                    completedDocs)));
         // other checkpoint
         assertTrue(dataFrameTransformCheckpoints
-                .matches(new DataFrameTransformCheckpoint(id, timestamp, (checkpoint / 2) + 1, checkpointsByIndex, timeUpperBound)));
+                .matches(new DataFrameTransformCheckpoint(id,
+                    timestamp,
+                    (checkpoint / 2) + 1,
+                    checkpointsByIndex,
+                    timeUpperBound,
+                    numDocs,
+                    completedDocs)));
         // other index checkpoints
         assertFalse(dataFrameTransformCheckpoints
-                .matches(new DataFrameTransformCheckpoint(id, timestamp, checkpoint, otherCheckpointsByIndex, timeUpperBound)));
+                .matches(new DataFrameTransformCheckpoint(id,
+                    timestamp,
+                    checkpoint,
+                    otherCheckpointsByIndex,
+                    timeUpperBound,
+                    numDocs,
+                    completedDocs)));
         // other time upper bound
         assertTrue(dataFrameTransformCheckpoints
-                .matches(new DataFrameTransformCheckpoint(id, timestamp, checkpoint, checkpointsByIndex, (timeUpperBound / 2) + 1)));
+                .matches(new DataFrameTransformCheckpoint(id,
+                    timestamp,
+                    checkpoint,
+                    checkpointsByIndex,
+                    (timeUpperBound / 2) + 1,
+                    numDocs,
+                    completedDocs)));
     }
 
     public void testGetBehind() {
         String id = randomAlphaOfLengthBetween(1, 10);
         long timestamp = randomNonNegativeLong();
 
+        long numDocs = randomNonNegativeLong();
+        long completedDocs = randomLongBetween(0L, numDocs);
         TreeMap<String, long[]> checkpointsByIndexOld = new TreeMap<>();
         TreeMap<String, long[]> checkpointsByIndexNew = new TreeMap<>();
 
@@ -120,13 +154,13 @@ public class DataFrameTransformCheckpointTests extends AbstractSerializingDataFr
         long checkpoint = randomLongBetween(10, 100);
 
         DataFrameTransformCheckpoint checkpointOld = new DataFrameTransformCheckpoint(
-                id, timestamp, checkpoint, checkpointsByIndexOld, 0L);
+                id, timestamp, checkpoint, checkpointsByIndexOld, 0L, numDocs, completedDocs);
         DataFrameTransformCheckpoint checkpointTransientNew = new DataFrameTransformCheckpoint(
-                id, timestamp, -1L, checkpointsByIndexNew, 0L);
+                id, timestamp, -1L, checkpointsByIndexNew, 0L, numDocs, completedDocs);
         DataFrameTransformCheckpoint checkpointNew = new DataFrameTransformCheckpoint(
-                id, timestamp, checkpoint + 1, checkpointsByIndexNew, 0L);
+                id, timestamp, checkpoint + 1, checkpointsByIndexNew, 0L, numDocs, completedDocs);
         DataFrameTransformCheckpoint checkpointOlderButNewerShardsCheckpoint = new DataFrameTransformCheckpoint(
-                id, timestamp, checkpoint - 1, checkpointsByIndexNew, 0L);
+                id, timestamp, checkpoint - 1, checkpointsByIndexNew, 0L, numDocs, completedDocs);
 
         assertEquals(indices * shards * 10L, DataFrameTransformCheckpoint.getBehind(checkpointOld, checkpointTransientNew));
         assertEquals(indices * shards * 10L, DataFrameTransformCheckpoint.getBehind(checkpointOld, checkpointNew));

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_stats.yml
@@ -59,6 +59,7 @@ teardown:
   - match: { transforms.0.stats.search_time_in_ms: 0 }
   - match: { transforms.0.stats.search_total: 0 }
   - match: { transforms.0.stats.search_failures: 0 }
+  - is_true: transforms.0.checkpointing
 
 ---
 "Test get transform stats on missing transform":


### PR DESCRIPTION
Checkpoints record the current information in an indexing run. It seems natural for them to also include the progress and total docs being searched for a given run. 

Alternative designs considered:
* **Include current run stats in indexer stats**. This was not chosen as it conflated "current" statistics and "overall" statistics.
* **Add new ephemeral/current run indexer stats object**. This has some complexity to it. If we did this, we would store a new stats object for each checkpoint, and an overall stats object. Additionally, do we keep each "ephemeral" or "checkpoint stat" indexer stats object? If so, why do we even have the overall stats object?
    * This design could potentially work if we "reset" the stats on each checkpoint and store stats not only for each transform, but for each checkpoint for each transform. This may cause an explosion in the amount of statistical docs we store.


I added a TODO around returning current checkpoint information for transforms without tasks. This seems necessary to me once we start allowing `_stop` to kill the task. We should include checkpoint stats in the transform stats call even if there is not a task. The transform could have been stopped in the middle of a checkpoint, and having a rough estimate of how far it got would be useful information.