### PR TITLE
[DOCS] Fixes callout for Asciidoctor migration

### DIFF
--- a/docs/reference/aggregations/bucket/daterange-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/daterange-aggregation.asciidoc
@@ -278,7 +278,7 @@ POST /sales/_search?size=0
                "time_zone": "CET",
                "ranges": [
                   { "to": "2016/02/01" }, <1>
-                  { "from": "2016/02/01", "to" : "now/d" <2>},
+                  { "from": "2016/02/01", "to" : "now/d" }, <2>
                   { "from": "now/d" }
               ]
           }


### PR DESCRIPTION
Per https://asciidoctor.org/docs/user-manual/#callouts, AsciiDoctor enforces this requirement: "The callout number (at the target) must be placed at the end of the line."

Otherwise, you get errors like this:

INFO:build_docs:/out/html_docs/index.xml:31050: element callout: validity error : Syntax of value for attribute arearefs of callout is not valid
INFO:build_docs:<callout arearefs="">
INFO:build_docs:     

Related to https://github.com/elastic/elasticsearch/issues/41128