### PR TITLE
[DOCS] Fix callout for Asciidoctor migration

### DIFF
--- a/docs/reference/query-dsl/script-score-query.asciidoc
+++ b/docs/reference/query-dsl/script-score-query.asciidoc
@@ -96,7 +96,7 @@ cosine similarity between a given query vector and document vectors.
         "match_all": {}
       },
       "script": {
-        "source": "cosineSimilarity(params.query_vector, doc['my_dense_vector']) + 1.0" <1>,
+        "source": "cosineSimilarity(params.query_vector, doc['my_dense_vector']) + 1.0", <1>
         "params": {
           "query_vector": [4, 3.4, -0.2]  <2>
         }


### PR DESCRIPTION
Per https://asciidoctor.org/docs/user-manual/#callouts, AsciiDoctor enforces this requirement: "The callout number (at the target) must be placed at the end of the line."

This prevents the following error: 
`INFO:build_docs:asciidoctor: WARNING: query-dsl/script-score-query.asciidoc: line 109: no callout found for <1>`

Relates to #41128