### PR TITLE
[POC] proof of concept: current and total statistics with the ability to ca…

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameIndexerTransformStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameIndexerTransformStats.java
@@ -114,8 +114,8 @@ public class DataFrameIndexerTransformStats extends IndexerJobStats {
      *
      * @return The id of document the where the transform stats are persisted
      */
-    public static String documentId(String transformId) {
-        return NAME + "-" + transformId;
+    public static String documentId(String transformId, boolean total) {
+        return NAME + "-" + transformId + (total ? "-total" : "-current");
     }
 
     @Nullable

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformState.java
@@ -35,6 +35,7 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
 
     private final DataFrameTransformTaskState taskState;
     private final IndexerState indexerState;
+    private final long totalDocsCurrentRun;
     private final long checkpoint;
 
     @Nullable
@@ -87,11 +88,13 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
     public DataFrameTransformState(DataFrameTransformTaskState taskState,
                                    IndexerState indexerState,
                                    @Nullable Map<String, Object> position,
+                                   long totalDocsCurrentRun,
                                    long checkpoint,
                                    @Nullable String reason) {
         this.taskState = taskState;
         this.indexerState = indexerState;
         this.currentPosition = position == null ? null : Collections.unmodifiableSortedMap(new TreeMap<>(position));
+        this.totalDocsCurrentRun = totalDocsCurrentRun;
         this.checkpoint = checkpoint;
         this.reason = reason;
     }
@@ -114,6 +117,10 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
 
     public Map<String, Object> getPosition() {
         return currentPosition;
+    }
+
+    public long getTotalDocsCurrentRun() {
+        return totalDocsCurrentRun;
     }
 
     public long getCheckpoint() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/IndexerJobStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/IndexerJobStats.java
@@ -71,6 +71,19 @@ public abstract class IndexerJobStats implements ToXContentObject, Writeable {
         }
     }
 
+    public void reset() {
+        numPages = 0;
+        numInputDocuments = 0;
+        numOuputDocuments = 0;
+        numInvocations = 0;
+        indexTime = 0;
+        searchTime = 0;
+        indexTotal = 0;
+        searchTotal = 0;
+        indexFailures = 0;
+        searchFailures = 0;
+    }
+
     public long getNumPages() {
         return numPages;
     }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
@@ -67,7 +67,7 @@ public class DataFrameTransformPersistentTasksExecutor extends PersistentTasksEx
             logger.warn("Tried to start failed transform [" + params.getId() + "] failure reason: " + transformState.getReason());
             return;
         }
-        transformsConfigManager.getTransformStats(params.getId(), ActionListener.wrap(
+        transformsConfigManager.getTransformStats(params.getId(), true, ActionListener.wrap(
             stats -> {
                 // Initialize with the previously recorded stats
                 buildTask.initializePreviousStats(stats);


### PR DESCRIPTION
**Proof of concept: This is not supposed to work, but only showing an idea**

Alternative solution to #41121

Demonstrates storage of current and total statistics:

- current total docs count is stored in the task state
- total statistics store the stats for the overall life time of the data frame
- current stats store the stats for the current run of the indexer
- progress can be calculated using current stats and the current total docs 

I haven't looked into implementing `_stats`, but it should be straight forward