### PR TITLE
Fix some documentation urls in rest-api-spec (backport #40618)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_pipeline.json
@@ -1,6 +1,6 @@
 {
   "ingest.delete_pipeline": {
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html",
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html",
     "methods": [ "DELETE" ],
     "url": {
       "path": "/_ingest/pipeline/{id}",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.get_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.get_pipeline.json
@@ -1,6 +1,6 @@
 {
   "ingest.get_pipeline": {
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html",
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html",
     "methods": [ "GET" ],
     "url": {
       "path": "/_ingest/pipeline/{id}",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.processor_grok.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.processor_grok.json
@@ -1,6 +1,6 @@
 {
   "ingest.processor_grok": {
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html",
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/grok-processor.html#grok-processor-rest-get",
     "methods": [ "GET" ],
     "url": {
       "path": "/_ingest/processor/grok",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_pipeline.json
@@ -1,6 +1,6 @@
 {
   "ingest.put_pipeline": {
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html",
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-pipeline-api.html",
     "methods": [ "PUT" ],
     "url": {
       "path": "/_ingest/pipeline/{id}",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.simulate.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.simulate.json
@@ -1,6 +1,6 @@
 {
   "ingest.simulate": {
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html",
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html",
     "methods": [ "GET", "POST" ],
     "url": {
       "path": "/_ingest/pipeline/_simulate",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.delete.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.delete.json
@@ -1,6 +1,6 @@
 {
   "xpack.license.delete": {
-    "documentation": "https://www.elastic.co/guide/en/x-pack/current/license-management.html",
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/6.7/delete-license.html",
     "methods": ["DELETE"],
     "url": {
       "path": "/_xpack/license",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.get.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.get.json
@@ -1,6 +1,6 @@
 {
   "xpack.license.get": {
-    "documentation": "https://www.elastic.co/guide/en/x-pack/current/license-management.html",
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/6.7/get-license.html",
     "methods": ["GET"],
     "url": {
       "path": "/_xpack/license",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.get_basic_status.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.get_basic_status.json
@@ -1,6 +1,6 @@
 {
   "xpack.license.get_basic_status": {
-    "documentation": "https://www.elastic.co/guide/en/x-pack/current/license-management.html",
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/6.7/get-trial-status.html",
     "methods": ["GET"],
     "url": {
       "path": "/_xpack/license/basic_status",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.get_trial_status.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.get_trial_status.json
@@ -1,6 +1,6 @@
 {
   "xpack.license.get_trial_status": {
-    "documentation": "https://www.elastic.co/guide/en/x-pack/current/license-management.html",
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/6.7/get-basic-status.html",
     "methods": ["GET"],
     "url": {
       "path": "/_xpack/license/trial_status",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.post.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.post.json
@@ -1,6 +1,6 @@
 {
   "xpack.license.post": {
-    "documentation": "https://www.elastic.co/guide/en/x-pack/current/license-management.html",
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/6.7/update-license.html",
     "methods": ["PUT", "POST"],
     "url": {
       "path": "/_xpack/license",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.post_start_basic.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.post_start_basic.json
@@ -1,6 +1,6 @@
 {
   "xpack.license.post_start_basic": {
-    "documentation": "https://www.elastic.co/guide/en/x-pack/current/license-management.html",
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/6.7/start-basic.html",
     "methods": ["POST"],
     "url": {
       "path": "/_xpack/license/start_basic",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.post_start_trial.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.license.post_start_trial.json
@@ -1,6 +1,6 @@
 {
   "xpack.license.post_start_trial": {
-    "documentation": "https://www.elastic.co/guide/en/x-pack/current/license-management.html",
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/6.7/start-trial.html",
     "methods": ["POST"],
     "url": {
       "path": "/_xpack/license/start_trial",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.migration.deprecations.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.migration.deprecations.json
@@ -1,6 +1,6 @@
 {
   "xpack.migration.deprecations": {
-    "documentation": "http://www.elastic.co/guide/en/migration/current/migration-api-deprecation.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/6.7/migration-api-deprecation.html",
     "methods": [ "GET" ],
     "url": {
       "path": "/{index}/_xpack/migration/deprecations",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.ml.find_file_structure.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.ml.find_file_structure.json
@@ -1,6 +1,6 @@
 {
   "xpack.ml.find_file_structure": {
-    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-file-structure.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/6.7/ml-find-file-structure.html",
     "methods": [ "POST" ],
     "url": {
       "path": "/_xpack/ml/find_file_structure",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.monitoring.bulk.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.monitoring.bulk.json
@@ -1,6 +1,6 @@
 {
   "xpack.monitoring.bulk": {
-    "documentation": "http://www.elastic.co/guide/en/monitoring/current/appendix-api-bulk.html",
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/6.7/es-monitoring.html",
     "methods": ["POST", "PUT"],
     "url": {
       "path": "/_xpack/monitoring/_bulk",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.security.get_user_privileges.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.security.get_user_privileges.json
@@ -1,6 +1,6 @@
 {
   "xpack.security.get_user_privileges": {
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user-privileges.html",
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/6.7/security-api-get-privileges.html",
     "methods": [ "GET" ],
     "url": {
       "path": "/_xpack/security/user/_privileges",


### PR DESCRIPTION
Fixes some documentation urls in the rest-api-spec. Some of these URLs
pointed to 404s and a few others pointed to deprecated documentation
when we have better documentation now. I'm not consistent about `master`
vs `current` because we're not consistent in other places and I think we
should solve all of those at once with something a little more
automatic.
