### PR TITLE
[DOCS] Fix code snippet delimiter in Docker install docs for Asciidoctor migration

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -82,7 +82,7 @@ The `vm.max_map_count` setting should be set permanently in `/etc/sysctl.conf`:
 --------------------------------------------
 $ grep vm.max_map_count /etc/sysctl.conf
 vm.max_map_count=262144
-----------------------------------
+--------------------------------------------
 
 To apply the setting on a live system type: `sysctl -w vm.max_map_count=262144`
 --


### PR DESCRIPTION
Per https://asciidoctor.org/docs/user-manual/#changed-syntax, "the length of start and end delimiter lines [of code snippets] must match exactly."

This prevents the following error:
`INFO:build_docs:asciidoctor: WARNING: setup/install/docker.asciidoc: line 85: MIGRATION: code block end doesn't match start`

Relates to #41128