### PR TITLE
[DOCS] Fix code snippet delimiters in Rank Eval API docs for Asciidoctor migration

### DIFF
--- a/docs/reference/search/rank-eval.asciidoc
+++ b/docs/reference/search/rank-eval.asciidoc
@@ -44,7 +44,7 @@ GET /my_index/_rank_eval
       "mean_reciprocal_rank": { ... } <3>
    }
 }
-------------------------------
+-----------------------------
 // NOTCONSOLE
 
 <1> a set of typical search requests, together with their provided ratings
@@ -77,7 +77,7 @@ The request section contains several search requests typical to your application
             ]
         }
     ]
-------------------------------
+-----------------------------
 // NOTCONSOLE
 
 <1> the search requests id, used to group result details later 


### PR DESCRIPTION
Per https://asciidoctor.org/docs/user-manual/#changed-syntax, "the length of start and end delimiter lines [of code snippets] must match exactly."

This prevents the following errors:
```
INFO:build_docs:asciidoctor: WARNING: search/rank-eval.asciidoc: line 47: MIGRATION: code block end doesn't match start
INFO:build_docs:asciidoctor: WARNING: search/rank-eval.asciidoc: line 80: MIGRATION: code block end doesn't match start
```

Relates to #41128