### PR TITLE
[DOCS] Fix code snippet delimiter in Split Index docs for Asciidoctor migration

### DIFF
--- a/docs/reference/indices/split-index.asciidoc
+++ b/docs/reference/indices/split-index.asciidoc
@@ -92,7 +92,7 @@ PUT my_source_index
     "index.number_of_shards" : 1
   }
 }
--------------------------------------------------
+--------------------------------------------------
 // CONSOLE
 
 In order to split an index, the index must be marked as read-only,


### PR DESCRIPTION
Per https://asciidoctor.org/docs/user-manual/#changed-syntax, "the length of start and end delimiter lines [of code snippets] must match exactly."

This prevents the following error:
`INFO:build_docs:asciidoctor: WARNING:  indices/split-index.asciidoc: line 95: MIGRATION: code block end doesn't match start`

Relates to #41128