### PR TITLE
[DOCS] Replace nested open block for Asciidoctor migration

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -47,17 +47,15 @@ specific index module:
 `index.shard.check_on_startup`::
 
 Whether or not shards should be checked for corruption before opening. When
-corruption is detected, it will prevent the shard from being opened. Accepts:
-+
-[cols="<,<"]
-|===
-|`false` |(default) Don't check for corruption when opening a shard.
-|`checksum` |Check for physical corruption.
-|`true` |Check for both physical and logical corruption. This is much more
+corruption is detected, it will prevent the shard from being opened.
+Accepts:
+`false`::: (default) Don't check for corruption when opening a shard.
+`checksum`::: Check for physical corruption.
+`true`::: Check for both physical and logical corruption. This is much more
 expensive in terms of CPU and memory usage.
-|===
 +
-WARNING: Expert only. Checking shards may take a lot of time on large indices.
+WARNING: Expert only. Checking shards may take a lot of time on large
+indices.
 
 [[index-codec]] `index.codec`::
 

--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -45,26 +45,19 @@ specific index module:
     part of the cluster.
 
 `index.shard.check_on_startup`::
-+
---
+
 Whether or not shards should be checked for corruption before opening. When
 corruption is detected, it will prevent the shard from being opened. Accepts:
-
-`false`::
-
-    (default) Don't check for corruption when opening a shard.
-
-`checksum`::
-
-    Check for physical corruption.
-
-`true`::
-
-    Check for both physical and logical corruption. This is much more
-    expensive in terms of CPU and memory usage.
-
++
+[cols="<,<"]
+|===
+|`false` |(default) Don't check for corruption when opening a shard.
+|`checksum` |Check for physical corruption.
+|`true` |Check for both physical and logical corruption. This is much more
+expensive in terms of CPU and memory usage.
+|===
++
 WARNING: Expert only. Checking shards may take a lot of time on large indices.
---
 
 [[index-codec]] `index.codec`::
 


### PR DESCRIPTION
Per https://github.com/asciidoctor/asciidoctor/issues/1121, Asciidoctor does not currently allow nested open blocks. This removes the nested open block from the [Index modules](https://www.elastic.co/guide/en/elasticsearch/reference/master/index-modules.html) page and replaces it with a table.

This prevents the following error:
`INFO:build_docs:asciidoctor: ERROR: illegal block content outside of partintro block`

Relates to #41128