### PR TITLE
[DOCS] Deprecates transport settings

### DIFF
--- a/docs/reference/migration/migrate_7_1.asciidoc
+++ b/docs/reference/migration/migrate_7_1.asciidoc
@@ -17,3 +17,53 @@ coming[7.1.0]
 //tag::notable-breaking-changes[]
 
 // end::notable-breaking-changes[]
+
+[float]
+[[breaking_71_http_changes]]
+=== HTTP changes
+
+[float]
+==== Deprecation of old HTTP settings
+
+The `http.tcp_no_delay` setting is deprecated in 7.1. It is replaced by
+`http.tcp.no_delay`.
+
+[float]
+[[breaking_71_network_changes]]
+=== Network changes
+
+[float]
+==== Deprecation of old network settings
+
+The `network.tcp.connect_timeout` setting is deprecated in 7.1. This setting
+was a fallback setting for `transport.connect_timeout`. To change the default
+connection timeout for client connections, modify `transport.connect_timeout`.
+
+[float]
+[[breaking_71_transport_changes]]
+=== Transport changes
+
+//tag::notable-breaking-changes[]
+[float]
+==== Deprecation of old transport settings
+
+The following settings are deprecated in 7.1. Each setting has a replacement
+setting that was introduced in 6.7.
+
+- `transport.tcp.port` is replaced by `transport.port`
+- `transport.tcp.compress` is replaced by `transport.compress`
+- `transport.tcp.connect_timeout` is replaced by `transport.connect_timeout`
+- `transport.tcp_no_delay` is replaced by `transport.tcp.no_delay`
+- `transport.profiles.profile_name.tcp_no_delay` is replaced by
+`transport.profiles.profile_name.tcp.no_delay`
+- `transport.profiles.profile_name.tcp_keep_alive` is replaced by
+`transport.profiles.profile_name.tcp.keep_alive`
+- `transport.profiles.profile_name.reuse_address` is replaced by
+`transport.profiles.profile_name.tcp.reuse_address`
+- `transport.profiles.profile_name.send_buffer_size` is replaced by `transport.profiles.profile_name.tcp.send_buffer_size`
+- `transport.profiles.profile_name.receive_buffer_size` is replaced by `transport.profiles.profile_name.tcp.receive_buffer_size`
+
+// end::notable-breaking-changes[]
+
+
+


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/40918

This PR adds information about the deprecated HTTP, network, and transport settings to the 7.x Elasticsearch Reference.