### PR TITLE
fix the packer cache script

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -138,3 +138,8 @@ for (final boolean oss : [false, true]) {
 
 assemble.dependsOn "buildOssDockerImage"
 assemble.dependsOn "buildDockerImage"
+
+// We build the images used in compose locally, but the pull command insists on using a repository
+// thus we mmust disable it to prevent it from doing so. 
+// Everything will still be pulled since we will build the local images on a pull
+composePull.enabled = false

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -140,6 +140,6 @@ assemble.dependsOn "buildOssDockerImage"
 assemble.dependsOn "buildDockerImage"
 
 // We build the images used in compose locally, but the pull command insists on using a repository
-// thus we mmust disable it to prevent it from doing so. 
+// thus we must disable it to prevent it from doing so. 
 // Everything will still be pulled since we will build the local images on a pull
 composePull.enabled = false


### PR DESCRIPTION
This PR disabled the explicit pull since it seems this always tries to
work with a registry.
Functionality will not be affected since we will still build the images
on pull.

