### PR TITLE
Drop inline callouts from SQL conditional docs

### DIFF
--- a/docs/reference/sql/functions/conditional.asciidoc
+++ b/docs/reference/sql/functions/conditional.asciidoc
@@ -11,7 +11,10 @@ Functions that return one of their arguments by evaluating in an if-else manner.
 .Synopsis:
 [source, sql]
 ----
-COALESCE(expression<1>, expression<2>, ...)
+COALESCE(
+    expression, <1>
+    expression, <2>
+    ...)
 ----
 
 *Input*:
@@ -51,7 +54,10 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[coalesceReturnNull]
 .Synopsis:
 [source, sql]
 ----
-GREATEST(expression<1>, expression<2>, ...)
+GREATEST(
+    expression, <1>
+    expression, <2>
+    ...)
 ----
 
 *Input*:
@@ -92,7 +98,9 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[greatestReturnNull]
 .Synopsis:
 [source, sql]
 ----
-IFNULL(expression<1>, expression<2>)
+IFNULL(
+    expression, <1>
+    expression) <2>
 ----
 
 *Input*:
@@ -129,7 +137,9 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[ifNullReturnSecond]
 .Synopsis:
 [source, sql]
 ----
-ISNULL(expression<1>, expression<2>)
+ISNULL(
+    expression, <1>
+    expression) <2>
 ----
 
 *Input*:
@@ -166,7 +176,10 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[isNullReturnSecond]
 .Synopsis:
 [source, sql]
 ----
-LEAST(expression<1>, expression<2>, ...)
+LEAST(
+    expression, <1>
+    expression, <2>
+    ...)
 ----
 
 *Input*:
@@ -208,7 +221,9 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[leastReturnNull]
 .Synopsis:
 [source, sql]
 ----
-NULLIF(expression<1>, expression<2>)
+NULLIF(
+    expression, <1>
+    expression) <2>
 ----
 
 *Input*:
@@ -243,7 +258,9 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[nullIfReturnNull]
 .Synopsis:
 [source, sql]
 ----
-NVL(expression<1>, expression<2>)
+NVL(
+    expression, <1>
+    expression) <2>
 ----
 
 *Input*:


### PR DESCRIPTION
Drops "inline callouts" from the docs for SQL conditionals because they
aren't supported by Asciidoctor.

Relates to #41128
