### PR TITLE
[DRAFT] Rebase keyed JSON ordinals to start from zero.

### DIFF
--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasChildQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasChildQueryBuilder.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.AtomicOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
+import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalMap;
 import org.elasticsearch.index.fielddata.plain.SortedSetDVOrdinalsIndexFieldData;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
@@ -395,7 +396,8 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
 
             AtomicOrdinalsFieldData atomicOrdinalsFieldData = indexParentChildFieldData.load(
                 reader.getContext().leaves().get(0));
-            return atomicOrdinalsFieldData.getOrdinalMap();
+            GlobalOrdinalMap ordinalMap = atomicOrdinalsFieldData.getOrdinalMap();
+            return ordinalMap != null ? ordinalMap.getWrappedMap() : null;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/AtomicOrdinalsFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/AtomicOrdinalsFieldData.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.fielddata;
 
+import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.SortedSetDocValues;
 
 /**
@@ -31,5 +32,11 @@ public interface AtomicOrdinalsFieldData extends AtomicFieldData {
      * Return the ordinals values for the current atomic reader.
      */
     SortedSetDocValues getOrdinalsValues();
+
+    /**
+     * Returns the underlying {@link OrdinalMap} for this fielddata
+     * or null if global ordinals are not needed (constant value or single segment).
+     */
+    OrdinalMap getOrdinalMap();
 
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/AtomicOrdinalsFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/AtomicOrdinalsFieldData.java
@@ -19,8 +19,8 @@
 
 package org.elasticsearch.index.fielddata;
 
-import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.SortedSetDocValues;
+import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalMap;
 
 /**
  * Specialization of {@link AtomicFieldData} for data that is indexed with
@@ -34,9 +34,9 @@ public interface AtomicOrdinalsFieldData extends AtomicFieldData {
     SortedSetDocValues getOrdinalsValues();
 
     /**
-     * Returns the underlying {@link OrdinalMap} for this fielddata
+     * Returns the underlying {@link GlobalOrdinalMap} for this fielddata
      * or null if global ordinals are not needed (constant value or single segment).
      */
-    OrdinalMap getOrdinalMap();
+    GlobalOrdinalMap getOrdinalMap();
 
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/IndexOrdinalsFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/IndexOrdinalsFieldData.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.fielddata;
 
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.OrdinalMap;
 
 
 /**
@@ -41,10 +40,4 @@ public interface IndexOrdinalsFieldData extends IndexFieldData.Global<AtomicOrdi
      */
     @Override
     IndexOrdinalsFieldData localGlobalDirect(DirectoryReader indexReader) throws Exception;
-
-    /**
-     * Returns the underlying {@link OrdinalMap} for this fielddata
-     * or null if global ordinals are not needed (constant value or single segment).
-     */
-    OrdinalMap getOrdinalMap();
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalMap.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalMap.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.fielddata.ordinals;
+
+import org.apache.lucene.index.OrdinalMap;
+import org.apache.lucene.util.LongValues;
+
+public interface GlobalOrdinalMap {
+
+    /**
+     * Given a segment number, return a {@link LongValues} instance that maps
+     * segment ordinals to global ordinals.
+     */
+    LongValues getGlobalOrds(int segmentIndex);
+
+    /**
+     * Returns the total number of unique terms in global ord space.
+     */
+    long getValueCount();
+
+    OrdinalMap getWrappedMap();
+
+    static GlobalOrdinalMap create(OrdinalMap ordinalMap) {
+        return new OrdinalMapWrapper(ordinalMap);
+    }
+
+    class OrdinalMapWrapper implements GlobalOrdinalMap {
+        private final OrdinalMap ordinalMap;
+
+        private OrdinalMapWrapper(OrdinalMap ordinalMap) {
+            this.ordinalMap = ordinalMap;
+        }
+
+        /**
+         * Given a segment number, return a {@link LongValues} instance that maps
+         * segment ordinals to global ordinals.
+         */
+        public LongValues getGlobalOrds(int segmentIndex) {
+            return ordinalMap.getGlobalOrds(segmentIndex);
+        }
+
+        /**
+         * Returns the total number of unique terms in global ord space.
+         */
+        public long getValueCount() {
+            return ordinalMap.getValueCount();
+        }
+
+        public OrdinalMap getWrappedMap() {
+            return ordinalMap;
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
@@ -93,7 +93,7 @@ public enum GlobalOrdinalsBuilder {
                 }
 
                 @Override
-                public OrdinalMap getOrdinalMap() {
+                public GlobalOrdinalMap getOrdinalMap() {
                     return null;
                 }
 

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
@@ -93,6 +93,11 @@ public enum GlobalOrdinalsBuilder {
                 }
 
                 @Override
+                public OrdinalMap getOrdinalMap() {
+                    return null;
+                }
+
+                @Override
                 public long ramBytesUsed() {
                     return 0;
                 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
@@ -143,8 +143,8 @@ public class GlobalOrdinalsIndexFieldData extends AbstractIndexComponent impleme
         }
 
         @Override
-        public OrdinalMap getOrdinalMap() {
-            return ordinalMap;
+        public GlobalOrdinalMap getOrdinalMap() {
+            return GlobalOrdinalMap.create(ordinalMap);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/RebasedGlobalOrdinalMap.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/RebasedGlobalOrdinalMap.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.fielddata.ordinals;
+
+import org.apache.lucene.index.OrdinalMap;
+import org.apache.lucene.util.LongValues;
+
+public class RebasedGlobalOrdinalMap implements GlobalOrdinalMap {
+
+    private final GlobalOrdinalMap delegate;
+    private final long minOrd;
+    private final long maxOrd;
+
+    public RebasedGlobalOrdinalMap(GlobalOrdinalMap delegate,
+                                   long minOrd,
+                                   long maxOrd) {
+        this.delegate = delegate;
+        this.minOrd = minOrd;
+        this.maxOrd = maxOrd;
+    }
+
+    @Override
+    public LongValues getGlobalOrds(int segmentIndex) {
+        LongValues globalOrds = delegate.getGlobalOrds(segmentIndex);
+        return new RebasedLongValues(globalOrds, minOrd, maxOrd);
+    }
+
+    @Override
+    public long getValueCount() {
+        return maxOrd - minOrd;
+    }
+
+    @Override
+    public OrdinalMap getWrappedMap() {
+        throw new IllegalArgumentException();
+    }
+
+    private static class RebasedLongValues extends LongValues {
+
+        private final LongValues delegate;
+        private final long minOrd;
+        private final long maxOrd;
+
+        RebasedLongValues(LongValues delegate,
+                          long minOrd,
+                          long maxOrd) {
+            this.delegate = delegate;
+            this.minOrd = minOrd;
+            this.maxOrd = maxOrd;
+        }
+
+        @Override
+        public long get(long index) {
+            assert index <= maxOrd;
+            return delegate.get(index) - minOrd;
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/RebasedGlobalOrdinalMap.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/RebasedGlobalOrdinalMap.java
@@ -30,6 +30,7 @@ public class RebasedGlobalOrdinalMap implements GlobalOrdinalMap {
     public RebasedGlobalOrdinalMap(GlobalOrdinalMap delegate,
                                    long minOrd,
                                    long maxOrd) {
+        assert minOrd >= 0 && maxOrd >= 0;
         this.delegate = delegate;
         this.minOrd = minOrd;
         this.maxOrd = maxOrd;

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractAtomicOrdinalsFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractAtomicOrdinalsFieldData.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.fielddata.plain;
 
 import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.index.fielddata.AtomicOrdinalsFieldData;
@@ -74,6 +75,11 @@ public abstract class AbstractAtomicOrdinalsFieldData implements AtomicOrdinalsF
             @Override
             public SortedSetDocValues getOrdinalsValues() {
                 return DocValues.emptySortedSet();
+            }
+
+            @Override
+            public OrdinalMap getOrdinalMap() {
+                return null;
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractAtomicOrdinalsFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractAtomicOrdinalsFieldData.java
@@ -20,13 +20,13 @@
 package org.elasticsearch.index.fielddata.plain;
 
 import org.apache.lucene.index.DocValues;
-import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.index.fielddata.AtomicOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalMap;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -78,7 +78,7 @@ public abstract class AbstractAtomicOrdinalsFieldData implements AtomicOrdinalsF
             }
 
             @Override
-            public OrdinalMap getOrdinalMap() {
+            public GlobalOrdinalMap getOrdinalMap() {
                 return null;
             }
         };

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexOrdinalsFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexOrdinalsFieldData.java
@@ -22,7 +22,6 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.FilteredTermsEnum;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.util.BytesRef;
@@ -51,11 +50,6 @@ public abstract class AbstractIndexOrdinalsFieldData extends AbstractIndexFieldD
         this.minFrequency = minFrequency;
         this.maxFrequency = maxFrequency;
         this.minSegmentSize = minSegmentSize;
-    }
-
-    @Override
-    public OrdinalMap getOrdinalMap() {
-        return null;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/ConstantIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/ConstantIndexFieldData.java
@@ -22,7 +22,6 @@ package org.elasticsearch.index.fielddata.plain;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.search.SortField;
@@ -36,6 +35,7 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
+import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalMap;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.TextFieldMapper;
@@ -122,7 +122,7 @@ public class ConstantIndexFieldData extends AbstractIndexOrdinalsFieldData {
         }
 
         @Override
-        public OrdinalMap getOrdinalMap() {
+        public GlobalOrdinalMap getOrdinalMap() {
             return null;
         }
 

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/ConstantIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/ConstantIndexFieldData.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.fielddata.plain;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.search.SortField;
@@ -118,6 +119,11 @@ public class ConstantIndexFieldData extends AbstractIndexOrdinalsFieldData {
                 }
             };
             return (SortedSetDocValues) DocValues.singleton(sortedValues);
+        }
+
+        @Override
+        public OrdinalMap getOrdinalMap() {
+            return null;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesAtomicFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesAtomicFieldData.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.index.fielddata.plain;
 
+import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.Accountables;
@@ -70,6 +71,11 @@ public class PagedBytesAtomicFieldData extends AbstractAtomicOrdinalsFieldData {
     @Override
     public SortedSetDocValues getOrdinalsValues() {
         return ordinals.ordinals(new ValuesHolder(bytes, termOrdToBytesOffset));
+    }
+
+    @Override
+    public OrdinalMap getOrdinalMap() {
+        return null;
     }
 
     private static class ValuesHolder implements Ordinals.ValuesHolder {

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesAtomicFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/PagedBytesAtomicFieldData.java
@@ -18,13 +18,13 @@
  */
 package org.elasticsearch.index.fielddata.plain;
 
-import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.Accountables;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.PagedBytes;
 import org.apache.lucene.util.packed.PackedLongValues;
+import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalMap;
 import org.elasticsearch.index.fielddata.ordinals.Ordinals;
 
 import java.util.ArrayList;
@@ -74,7 +74,7 @@ public class PagedBytesAtomicFieldData extends AbstractAtomicOrdinalsFieldData {
     }
 
     @Override
-    public OrdinalMap getOrdinalMap() {
+    public GlobalOrdinalMap getOrdinalMap() {
         return null;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVBytesAtomicFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVBytesAtomicFieldData.java
@@ -21,11 +21,11 @@ package org.elasticsearch.index.fielddata.plain;
 
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.index.fielddata.AtomicFieldData;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalMap;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -57,7 +57,7 @@ public final class SortedSetDVBytesAtomicFieldData extends AbstractAtomicOrdinal
     }
 
     @Override
-    public OrdinalMap getOrdinalMap() {
+    public GlobalOrdinalMap getOrdinalMap() {
         return null;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVBytesAtomicFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVBytesAtomicFieldData.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.fielddata.plain;
 
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.index.fielddata.AtomicFieldData;
@@ -53,6 +54,11 @@ public final class SortedSetDVBytesAtomicFieldData extends AbstractAtomicOrdinal
         } catch (IOException e) {
             throw new IllegalStateException("cannot load docvalues", e);
         }
+    }
+
+    @Override
+    public OrdinalMap getOrdinalMap() {
+        return null;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVOrdinalsIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVOrdinalsIndexFieldData.java
@@ -23,7 +23,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedSetSelector;
@@ -128,10 +127,5 @@ public class SortedSetDVOrdinalsIndexFieldData extends DocValuesIndexFieldData i
     @Override
     public IndexOrdinalsFieldData localGlobalDirect(DirectoryReader indexReader) throws Exception {
         return GlobalOrdinalsBuilder.build(indexReader, this, indexSettings, breakerService, logger, scriptFunction);
-    }
-
-    @Override
-    public OrdinalMap getOrdinalMap() {
-        return null;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
@@ -25,7 +25,6 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.MultiTermQuery;
@@ -417,11 +416,6 @@ public final class JsonFieldMapper extends FieldMapper {
         public IndexOrdinalsFieldData localGlobalDirect(DirectoryReader indexReader) throws Exception {
             IndexOrdinalsFieldData fieldData = delegate.localGlobalDirect(indexReader);
             return new KeyedJsonIndexFieldData(key, fieldData);
-        }
-
-        @Override
-        public OrdinalMap getOrdinalMap() {
-            return delegate.getOrdinalMap();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldData.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.DocValues;
-import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BytesRef;
@@ -29,6 +28,7 @@ import org.elasticsearch.index.fielddata.AtomicOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalMap;
 import org.elasticsearch.index.fielddata.plain.AbstractAtomicOrdinalsFieldData;
 
 import java.io.IOException;
@@ -83,7 +83,7 @@ public class KeyedJsonAtomicFieldData implements AtomicOrdinalsFieldData {
     }
 
     @Override
-    public OrdinalMap getOrdinalMap() {
+    public GlobalOrdinalMap getOrdinalMap() {
         return delegate.getOrdinalMap();
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldData.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BytesRef;
@@ -79,6 +80,11 @@ public class KeyedJsonAtomicFieldData implements AtomicOrdinalsFieldData {
         }
 
         return new KeyedJsonDocValues(keyBytes, values, minOrd, maxOrd);
+    }
+
+    @Override
+    public OrdinalMap getOrdinalMap() {
+        return delegate.getOrdinalMap();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
@@ -22,7 +22,6 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.search.IndexSearcher;
@@ -42,6 +41,7 @@ import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortingBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortingNumericDoubleValues;
+import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalMap;
 import org.elasticsearch.script.AggregationScript;
 import org.elasticsearch.search.aggregations.support.ValuesSource.WithScript.BytesValues;
 import org.elasticsearch.search.aggregations.support.values.ScriptBytesValues;
@@ -154,10 +154,10 @@ public abstract class ValuesSource {
                 }
 
                 @Override
-                public LongUnaryOperator globalOrdinalsMapping(LeafReaderContext context) throws IOException {
+                public LongUnaryOperator globalOrdinalsMapping(LeafReaderContext context) {
                     final IndexOrdinalsFieldData global = indexFieldData.loadGlobal((DirectoryReader)context.parent.reader());
                     final AtomicOrdinalsFieldData atomicFieldData = global.load(context);
-                    final OrdinalMap map = atomicFieldData.getOrdinalMap();
+                    final GlobalOrdinalMap map = atomicFieldData.getOrdinalMap();
 
                     if (map == null) {
                         // segments and global ordinals are the same

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
@@ -156,7 +156,9 @@ public abstract class ValuesSource {
                 @Override
                 public LongUnaryOperator globalOrdinalsMapping(LeafReaderContext context) throws IOException {
                     final IndexOrdinalsFieldData global = indexFieldData.loadGlobal((DirectoryReader)context.parent.reader());
-                    final OrdinalMap map = global.getOrdinalMap();
+                    final AtomicOrdinalsFieldData atomicFieldData = global.load(context);
+                    final OrdinalMap map = atomicFieldData.getOrdinalMap();
+
                     if (map == null) {
                         // segments and global ordinals are the same
                         return LongUnaryOperator.identity();

--- a/server/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTestCase.java
@@ -461,13 +461,14 @@ public abstract class AbstractStringFieldDataTestCase extends AbstractFieldDataI
         refreshReader();
         IndexOrdinalsFieldData ifd = getForField("string", "value", hasDocValues());
         IndexOrdinalsFieldData globalOrdinals = ifd.loadGlobal(topLevelReader);
-        assertNotNull(globalOrdinals.getOrdinalMap());
         assertThat(topLevelReader.leaves().size(), equalTo(3));
 
         // First segment
         assertThat(globalOrdinals, instanceOf(GlobalOrdinalsIndexFieldData.class));
         LeafReaderContext leaf = topLevelReader.leaves().get(0);
         AtomicOrdinalsFieldData afd = globalOrdinals.load(leaf);
+        assertNotNull(afd.getOrdinalMap());
+
         SortedSetDocValues values = afd.getOrdinalsValues();
         assertTrue(values.advanceExact(0));
         long ord = values.nextOrd();
@@ -589,7 +590,8 @@ public abstract class AbstractStringFieldDataTestCase extends AbstractFieldDataI
         refreshReader();
         IndexOrdinalsFieldData ifd = getForField("string", "value", hasDocValues());
         IndexOrdinalsFieldData globalOrdinals = ifd.loadGlobal(topLevelReader);
-        assertNotNull(globalOrdinals.getOrdinalMap());
+        AtomicOrdinalsFieldData afd = globalOrdinals.load(topLevelReader.getContext().leaves().get(0));
+        assertNotNull(afd.getOrdinalMap());
         assertThat(ifd.loadGlobal(topLevelReader), sameInstance(globalOrdinals));
         // 3 b/c 1 segment level caches and 1 top level cache
         // in case of doc values, we don't cache atomic FD, so only the top-level cache is there

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldDataTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.fielddata.AbstractSortedSetDocValues;
@@ -170,6 +171,11 @@ public class KeyedJsonAtomicFieldDataTests extends ESTestCase {
         @Override
         public SortedSetDocValues getOrdinalsValues() {
             return docValues;
+        }
+
+        @Override
+        public OrdinalMap getOrdinalMap() {
+            return null;
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldDataTests.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.fielddata.AbstractSortedSetDocValues;
 import org.elasticsearch.index.fielddata.AtomicOrdinalsFieldData;
+import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalMap;
 import org.elasticsearch.index.fielddata.plain.AbstractAtomicOrdinalsFieldData;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
@@ -174,7 +174,7 @@ public class KeyedJsonAtomicFieldDataTests extends ESTestCase {
         }
 
         @Override
-        public OrdinalMap getOrdinalMap() {
+        public GlobalOrdinalMap getOrdinalMap() {
             return null;
         }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldDataTests.java
@@ -114,18 +114,18 @@ public class KeyedJsonAtomicFieldDataTests extends ESTestCase {
     }
 
     public void testAdvanceExact() throws IOException {
-        AtomicOrdinalsFieldData avocadoFieldData = new KeyedJsonAtomicFieldData("avocado", delegate);
+        AtomicOrdinalsFieldData avocadoFieldData = KeyedJsonAtomicFieldData.create("avocado", delegate, false);
         assertFalse(avocadoFieldData.getOrdinalsValues().advanceExact(0));
 
-        AtomicOrdinalsFieldData bananaFieldData = new KeyedJsonAtomicFieldData("banana", delegate);
+        AtomicOrdinalsFieldData bananaFieldData = KeyedJsonAtomicFieldData.create("banana", delegate, false);
         assertTrue(bananaFieldData.getOrdinalsValues().advanceExact(0));
 
-        AtomicOrdinalsFieldData nonexistentFieldData = new KeyedJsonAtomicFieldData("berry", delegate);
+        AtomicOrdinalsFieldData nonexistentFieldData = KeyedJsonAtomicFieldData.create("berry", delegate, false);
         assertFalse(nonexistentFieldData.getOrdinalsValues().advanceExact(0));
     }
 
     public void testNextOrd() throws IOException {
-        AtomicOrdinalsFieldData fieldData = new KeyedJsonAtomicFieldData("banana", delegate);
+        AtomicOrdinalsFieldData fieldData = KeyedJsonAtomicFieldData.create("banana", delegate, false);
         SortedSetDocValues docValues = fieldData.getOrdinalsValues();
         docValues.advanceExact(0);
 
@@ -143,7 +143,7 @@ public class KeyedJsonAtomicFieldDataTests extends ESTestCase {
     }
 
     public void testLookupOrd() throws IOException {
-        AtomicOrdinalsFieldData fieldData = new KeyedJsonAtomicFieldData("apple", delegate);
+        AtomicOrdinalsFieldData fieldData = KeyedJsonAtomicFieldData.create("apple", delegate, false);
         SortedSetDocValues docValues = fieldData.getOrdinalsValues();
 
         BytesRef expectedValue = new BytesRef("value0");
@@ -152,7 +152,7 @@ public class KeyedJsonAtomicFieldDataTests extends ESTestCase {
     }
 
     public void testLookupInvalidOrd() {
-        AtomicOrdinalsFieldData fieldData = new KeyedJsonAtomicFieldData("apple", delegate);
+        AtomicOrdinalsFieldData fieldData = KeyedJsonAtomicFieldData.create("apple", delegate, false);
         SortedSetDocValues docValues = fieldData.getOrdinalsValues();
 
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> docValues.lookupOrd(42));

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsIT.java
@@ -1184,6 +1184,24 @@ public class StringTermsIT extends AbstractTermsTestCase {
         }
     }
 
+    public void testKeyedJsonFieldWithMinDocCount() {
+        TermsAggregationBuilder priorityAgg = terms("terms")
+            .field(JSON_FIELD_NAME + ".priority")
+            .collectMode(randomFrom(SubAggCollectionMode.values()))
+            .executionHint(randomExecutionHint())
+            .minDocCount(0);
+
+        SearchResponse priorityResponse = client().prepareSearch("idx")
+            .addAggregation(priorityAgg)
+            .get();
+        assertSearchResponse(priorityResponse);
+
+        Terms priorityTerms = priorityResponse.getAggregations().get("terms");
+        assertThat(priorityTerms, notNullValue());
+        assertThat(priorityTerms.getName(), equalTo("terms"));
+        assertThat(priorityTerms.getBuckets().size(), equalTo(1));
+    }
+
     public void testOtherDocCount() {
         testOtherDocCount(SINGLE_VALUED_FIELD_NAME, MULTI_VALUED_FIELD_NAME);
     }

--- a/server/src/test/java/org/elasticsearch/search/sort/FieldSortIT.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/FieldSortIT.java
@@ -1836,5 +1836,19 @@ public class FieldSortIT extends ESIntegTestCase {
         assertSearchResponse(response);
         assertHitCount(response, 3);
         assertOrderedSearchHits(response, "2", "1", "3");
+
+        response = client().prepareSearch("test")
+            .addSort(new FieldSortBuilder("json_field.key").order(SortOrder.DESC).missing("Z"))
+            .get();
+        assertSearchResponse(response);
+        assertHitCount(response, 3);
+        assertOrderedSearchHits(response, "3", "2", "1");
+
+        response = client().prepareSearch("test")
+            .addSort(new FieldSortBuilder("json_field.key").order(SortOrder.DESC).missing("Z"))
+            .get();
+        assertSearchResponse(response);
+        assertHitCount(response, 3);
+        assertOrderedSearchHits(response, "3", "2", "1");
     }
 }


### PR DESCRIPTION
I opened this PR to give a sense of the difficulties involved in rebasing keyed JSON ordinals to lie in the range `[0, (maxOrd - minOrd)]`. It's not intended as an actual proposed change, as it has some hacky elements and is not well-tested.

The main complexity comes from the fact that in addition to rebasing the atomic field data, the underlying `OrdinalMap` must be rebased as well. There are two main issues:
- With the current class structure, the ordinal map is accessed through `IndexOrdinalsFieldData`. So in order to rebase it, the min and max ords would need to be available from this top-level index field data. However, at this level, there is not an easy way to lookup global ords in order to compute the min and max. It might seem like it should be easy to lookup global ords, as all the right information is available in `GlobalOrdinalsFieldData`. But the index field data could instead be of the form of `SortedSetDVOrdinalsIndexFieldData`, where it is harder to add such a method. Instead of doing a large refactor to address that issue, this PR pushes the method `getOrdinalMap` down into `AtomicOrdinalsFieldData`, where the min and max ords are readily available.
- For a particular segment, `OrdinalMap` translates from global to segment ordinals. We always rebase global ordinals, but there is a question of whether segment ordinals should be rebased as well. The implementation of `getOrdinalMap` is certainly simplest if the segment ordinals are not rebased, since it doesn't need to keep track of the min ords for each segment. However, it adds some complexity in that only sometimes rebase the keyed JSON ordinals. This PR explores that approach, and adds a flag `rebaseOrdinals` to `KeyedJsonDocValues`.

I was hoping to get your thoughts on whether this approach is worth pursuing. To me it feels quite complicated and I'm wondering if we should consider a simpler compromise. For example, we could still rebase, but disallow the underlying `OrdinalMap` from being accessed for keyed JSON fields (and turn off the optimizations that rely on it being available).

I am also still fairly new to this area of the code, so I wanted to check if I was misunderstanding something and accidentally overcomplicating the approach.

Relates to https://github.com/elastic/elasticsearch/pull/40069#issuecomment-477797499.
