### PR TITLE
Add next_execution to SLM policy metadata

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/snapshotlifecycle/SnapshotLifecyclePolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/snapshotlifecycle/SnapshotLifecyclePolicy.java
@@ -113,6 +113,11 @@ public class SnapshotLifecyclePolicy extends AbstractDiffable<SnapshotLifecycleP
         return this.configuration;
     }
 
+    public long calculateNextExecution() {
+        final Cron schedule = new Cron(this.schedule);
+        return schedule.getNextValidTimeAfter(System.currentTimeMillis());
+    }
+
     public ActionRequestValidationException validate() {
         ActionRequestValidationException err = new ActionRequestValidationException();
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/snapshotlifecycle/SnapshotLifecyclePolicyItem.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/snapshotlifecycle/SnapshotLifecyclePolicyItem.java
@@ -112,15 +112,18 @@ public class SnapshotLifecyclePolicyItem implements ToXContentFragment, Writeabl
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(policy.getId());
-        builder.field("version", version);
-        builder.timeField("modified_date_millis", "modified_date", modifiedDate);
-        builder.field("policy", policy);
+        builder.field(SnapshotLifecyclePolicyMetadata.VERSION.getPreferredName(), version);
+        builder.timeField(SnapshotLifecyclePolicyMetadata.MODIFIED_DATE_MILLIS.getPreferredName(),
+            SnapshotLifecyclePolicyMetadata.MODIFIED_DATE.getPreferredName(), modifiedDate);
+        builder.field(SnapshotLifecyclePolicyMetadata.POLICY.getPreferredName(), policy);
         if (lastSuccess != null) {
-            builder.field("last_success", lastSuccess);
+            builder.field(SnapshotLifecyclePolicyMetadata.LAST_SUCCESS.getPreferredName(), lastSuccess);
         }
         if (lastFailure != null) {
-            builder.field("last_failure", lastFailure);
+            builder.field(SnapshotLifecyclePolicyMetadata.LAST_FAILURE.getPreferredName(), lastFailure);
         }
+        builder.timeField(SnapshotLifecyclePolicyMetadata.NEXT_EXECUTION_MILLIS.getPreferredName(),
+            SnapshotLifecyclePolicyMetadata.NEXT_EXECUTION.getPreferredName(), policy.calculateNextExecution());
         builder.endObject();
         return builder;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/snapshotlifecycle/SnapshotLifecyclePolicyMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/snapshotlifecycle/SnapshotLifecyclePolicyMetadata.java
@@ -53,11 +53,11 @@ public class SnapshotLifecyclePolicyMetadata extends AbstractDiffable<SnapshotLi
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<SnapshotLifecyclePolicyMetadata, String> PARSER =
-        new ConstructingObjectParser<>("snapshot_policy_metadata", true,
+        new ConstructingObjectParser<>("snapshot_policy_metadata",
             a -> {
                 SnapshotLifecyclePolicy policy = (SnapshotLifecyclePolicy) a[0];
-                SnapshotInvocationRecord lastSuccess = (SnapshotInvocationRecord) a[5];
-                SnapshotInvocationRecord lastFailure = (SnapshotInvocationRecord) a[6];
+                SnapshotInvocationRecord lastSuccess = (SnapshotInvocationRecord) a[4];
+                SnapshotInvocationRecord lastFailure = (SnapshotInvocationRecord) a[5];
 
                 return builder()
                     .setPolicy(policy)
@@ -170,7 +170,6 @@ public class SnapshotLifecyclePolicyMetadata extends AbstractDiffable<SnapshotLi
         if (Objects.nonNull(lastFailure)) {
             builder.field(LAST_FAILURE.getPreferredName(), lastFailure);
         }
-        builder.timeField(NEXT_EXECUTION_MILLIS.getPreferredName(), NEXT_EXECUTION.getPreferredName(), policy.calculateNextExecution());
         builder.endObject();
         return builder;
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/snapshotlifecycle/SnapshotLifecyclePolicyMetadataTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/snapshotlifecycle/SnapshotLifecyclePolicyMetadataTests.java
@@ -47,7 +47,7 @@ public class SnapshotLifecyclePolicyMetadataTests extends AbstractSerializingTes
 
     @Override
     protected SnapshotLifecyclePolicyMetadata mutateInstance(SnapshotLifecyclePolicyMetadata instance) throws IOException {
-        switch (between(0, 4)) {
+        switch (between(0, 5)) {
             case 0:
                 return SnapshotLifecyclePolicyMetadata.builder(instance)
                     .setPolicy(randomValueOtherThan(instance.getPolicy(), () -> createRandomPolicy(randomAlphaOfLength(10))))
@@ -58,14 +58,18 @@ public class SnapshotLifecyclePolicyMetadataTests extends AbstractSerializingTes
                     .build();
             case 2:
                 return SnapshotLifecyclePolicyMetadata.builder(instance)
-                    .setHeaders(randomValueOtherThan(instance.getHeaders(), SnapshotLifecyclePolicyMetadataTests::randomHeaders))
+                    .setModifiedDate(randomValueOtherThan(instance.getModifiedDate(), ESTestCase::randomNonNegativeLong))
                     .build();
             case 3:
+                return SnapshotLifecyclePolicyMetadata.builder(instance)
+                    .setHeaders(randomValueOtherThan(instance.getHeaders(), SnapshotLifecyclePolicyMetadataTests::randomHeaders))
+                    .build();
+            case 4:
                 return SnapshotLifecyclePolicyMetadata.builder(instance)
                     .setLastSuccess(randomValueOtherThan(instance.getLastSuccess(),
                         SnapshotInvocationRecordTests::randomSnapshotInvocationRecord))
                     .build();
-            case 4:
+            case 5:
                 return SnapshotLifecyclePolicyMetadata.builder(instance)
                     .setLastFailure(randomValueOtherThan(instance.getLastFailure(),
                         SnapshotInvocationRecordTests::randomSnapshotInvocationRecord))

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/snapshotlifecycle/SnapshotLifecyclePolicyTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/snapshotlifecycle/SnapshotLifecyclePolicyTests.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.startsWith;
 
@@ -44,10 +45,8 @@ public class SnapshotLifecyclePolicyTests extends AbstractSerializingTestCase<Sn
     }
 
     public void testNextExecutionTime() {
-        // I don't know of a way to schedule something so far into the future that it won't fail
-        // when we reach that time and the test is run, so I settled for a less strict test
-        SnapshotLifecyclePolicy p = new SnapshotLifecyclePolicy("id", "name", "*/30 * * * * ?", "repo", Collections.emptyMap());
-        assertThat(p.calculateNextExecution(), greaterThan(System.currentTimeMillis()));
+        SnapshotLifecyclePolicy p = new SnapshotLifecyclePolicy("id", "name", "0 1 2 3 4 ? 2099", "repo", Collections.emptyMap());
+        assertThat(p.calculateNextExecution(), equalTo(4078864860000L));
     }
 
     public void testValidation() {

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/snapshotlifecycle/SnapshotLifecyclePolicyTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/snapshotlifecycle/SnapshotLifecyclePolicyTests.java
@@ -43,6 +43,13 @@ public class SnapshotLifecyclePolicyTests extends AbstractSerializingTestCase<Sn
         assertThat(p.generateSnapshotName(context), startsWith("name-2019-03-15.21:09:00-"));
     }
 
+    public void testNextExecutionTime() {
+        // I don't know of a way to schedule something so far into the future that it won't fail
+        // when we reach that time and the test is run, so I settled for a less strict test
+        SnapshotLifecyclePolicy p = new SnapshotLifecyclePolicy("id", "name", "*/30 * * * * ?", "repo", Collections.emptyMap());
+        assertThat(p.calculateNextExecution(), greaterThan(System.currentTimeMillis()));
+    }
+
     public void testValidation() {
         SnapshotLifecyclePolicy policy = new SnapshotLifecyclePolicy("a,b", "<my, snapshot-{now/M}>",
             "* * * * * L", "  ", Collections.emptyMap());


### PR DESCRIPTION
This adds the next time a snapshot lifecycle policy will be executed when
retriving a policy's metadata, for example:

```json
GET /_ilm/snapshot?human
{
  "production" : {
    "version" : 1,
    "modified_date" : "2019-04-15T21:16:21.865Z",
    "modified_date_millis" : 1555362981865,
    "policy" : {
      "name" : "<production-snap-{now/d}>",
      "schedule" : "*/30 * * * * ?",
      "repository" : "repo",
      "config" : {
        "indices" : [
          "foo-*",
          "important"
        ],
        "ignore_unavailable" : true,
        "include_global_state" : false
      }
    },
    "next_execution" : "2019-04-15T21:16:30.000Z",
    "next_execution_millis" : 1555362990000
  },
  "other" : {
    "version" : 1,
    "modified_date" : "2019-04-15T21:12:19.959Z",
    "modified_date_millis" : 1555362739959,
    "policy" : {
      "name" : "<other-snap-{now/d}>",
      "schedule" : "0 30 2 * * ?",
      "repository" : "repo",
      "config" : {
        "indices" : [
          "other"
        ],
        "ignore_unavailable" : false,
        "include_global_state" : true
      }
    },
    "next_execution" : "2019-04-16T02:30:00.000Z",
    "next_execution_millis" : 1555381800000
  }
}
```

Relates to #38461
