### PR TITLE
fix FullClusterRestart tests now that 7.0.0 can be an "oldCluster"

### DIFF
--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -820,6 +820,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             shouldHaveTranslog = Booleans.parseBoolean(loadInfoDocument("should_have_translog"));
         }
 
+        refresh();
         // Count the documents in the index to make sure we have as many as we put there
         Request countRequest = new Request("GET", "/" + index + "/_search");
         countRequest.addParameter("size", "0");

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -21,11 +21,7 @@ package org.elasticsearch.upgrades;
 
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.Version;
-import org.elasticsearch.client.Request;
-import org.elasticsearch.client.Response;
-import org.elasticsearch.client.ResponseException;
-import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.WarningFailureException;
+import org.elasticsearch.client.*;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.CheckedFunction;
@@ -36,7 +32,6 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.rest.action.document.RestBulkAction;
 import org.elasticsearch.rest.action.document.RestGetAction;
-import org.elasticsearch.rest.action.document.RestUpdateAction;
 import org.elasticsearch.rest.action.search.RestExplainAction;
 import org.elasticsearch.test.NotEqualMessageBuilder;
 import org.elasticsearch.test.rest.ESRestTestCase;
@@ -44,30 +39,16 @@ import org.elasticsearch.test.rest.yaml.ObjectPath;
 import org.junit.Before;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
+import static java.util.Collections.*;
 import static org.elasticsearch.cluster.routing.UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING;
 import static org.elasticsearch.cluster.routing.allocation.decider.MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.*;
 
 /**
  * Tests to run before and after a full cluster restart. This is run twice,
@@ -100,7 +81,9 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             }
             {
                 mappingsAndSettings.startObject("mappings");
-                mappingsAndSettings.startObject("doc");
+                if(getOldClusterVersion().before(Version.V_7_0_0)) {
+                    mappingsAndSettings.startObject("doc");
+                }
                 mappingsAndSettings.startObject("properties");
                 {
                     mappingsAndSettings.startObject("string");
@@ -119,14 +102,18 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                     mappingsAndSettings.endObject();
                 }
                 mappingsAndSettings.endObject();
-                mappingsAndSettings.endObject();
+                if(getOldClusterVersion().before(Version.V_7_0_0)) {
+                    mappingsAndSettings.endObject();
+                }
                 mappingsAndSettings.endObject();
             }
             mappingsAndSettings.endObject();
 
             Request createIndex = new Request("PUT", "/" + index);
             createIndex.setJsonEntity(Strings.toString(mappingsAndSettings));
-            createIndex.setOptions(allowTypesRemovalWarnings());
+            if(getOldClusterVersion().onOrAfter(Version.V_6_7_0) && getOldClusterVersion().before(Version.V_7_0_0)){
+                createIndex.addParameter(INCLUDE_TYPE_NAME_PARAMETER, "true");
+            }
             client().performRequest(createIndex);
 
             count = randomIntBetween(2000, 3000);
@@ -168,7 +155,9 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             }
             {
                 mappingsAndSettings.startObject("mappings");
-                mappingsAndSettings.startObject("doc");
+                if(getOldClusterVersion().before(Version.V_7_0_0)) {
+                    mappingsAndSettings.startObject("doc");
+                }
                 mappingsAndSettings.startObject("properties");
                 {
                     mappingsAndSettings.startObject("field");
@@ -176,14 +165,18 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                     mappingsAndSettings.endObject();
                 }
                 mappingsAndSettings.endObject();
-                mappingsAndSettings.endObject();
+                if(getOldClusterVersion().before(Version.V_7_0_0)) {
+                    mappingsAndSettings.endObject();
+                }
                 mappingsAndSettings.endObject();
             }
             mappingsAndSettings.endObject();
 
             Request createIndex = new Request("PUT", "/" + index);
             createIndex.setJsonEntity(Strings.toString(mappingsAndSettings));
-            createIndex.setOptions(allowTypesRemovalWarnings());
+            if(getOldClusterVersion().onOrAfter(Version.V_6_7_0) && getOldClusterVersion().before(Version.V_7_0_0)){
+                createIndex.addParameter(INCLUDE_TYPE_NAME_PARAMETER, "true");
+            }
             client().performRequest(createIndex);
 
             int numDocs = randomIntBetween(2000, 3000);
@@ -241,7 +234,9 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             }
             {
                 mappingsAndSettings.startObject("mappings");
-                mappingsAndSettings.startObject("doc");
+                if(getOldClusterVersion().before(Version.V_7_0_0)) {
+                    mappingsAndSettings.startObject("doc");
+                }
                 mappingsAndSettings.startObject("properties");
                 {
                     mappingsAndSettings.startObject("key");
@@ -249,12 +244,17 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                     mappingsAndSettings.endObject();
                 }
                 mappingsAndSettings.endObject();
-                mappingsAndSettings.endObject();
+                if(getOldClusterVersion().before(Version.V_7_0_0)) {
+                    mappingsAndSettings.endObject();
+                }
                 mappingsAndSettings.endObject();
             }
             mappingsAndSettings.endObject();
             Request createIndex = new Request("PUT", "/" + index);
             createIndex.setJsonEntity(Strings.toString(mappingsAndSettings));
+            if(getOldClusterVersion().onOrAfter(Version.V_6_7_0) && getOldClusterVersion().before(Version.V_7_0_0)){
+                createIndex.addParameter(INCLUDE_TYPE_NAME_PARAMETER, "true");
+            }
             client().performRequest(createIndex);
 
             String aliasName = "%23" + index; // %23 == #
@@ -343,8 +343,14 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             XContentBuilder mappingsAndSettings = jsonBuilder();
             mappingsAndSettings.startObject();
             {
+                mappingsAndSettings.startObject("settings");
+                mappingsAndSettings.field("number_of_shards", 2);
+                mappingsAndSettings.endObject();
+
                 mappingsAndSettings.startObject("mappings");
-                mappingsAndSettings.startObject("doc");
+                if(getOldClusterVersion().before(Version.V_7_0_0)) {
+                    mappingsAndSettings.startObject("doc");
+                }
                 mappingsAndSettings.startObject("properties");
                 {
                     mappingsAndSettings.startObject("field");
@@ -352,14 +358,18 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                     mappingsAndSettings.endObject();
                 }
                 mappingsAndSettings.endObject();
-                mappingsAndSettings.endObject();
+                if(getOldClusterVersion().before(Version.V_7_0_0)) {
+                    mappingsAndSettings.endObject();
+                }
                 mappingsAndSettings.endObject();
             }
             mappingsAndSettings.endObject();
 
             Request createIndex = new Request("PUT", "/" + index);
             createIndex.setJsonEntity(Strings.toString(mappingsAndSettings));
-            createIndex.setOptions(allowTypesRemovalWarnings());
+            if(getOldClusterVersion().onOrAfter(Version.V_6_7_0) && getOldClusterVersion().before(Version.V_7_0_0)){
+                createIndex.addParameter(INCLUDE_TYPE_NAME_PARAMETER, "true");
+            }
             client().performRequest(createIndex);
 
             numDocs = randomIntBetween(512, 1024);
@@ -376,7 +386,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             client().performRequest(updateSettingsRequest);
 
             Request shrinkIndexRequest = new Request("PUT", "/" + index + "/_shrink/" + shrunkenIndex);
-            if (getOldClusterVersion().onOrAfter(Version.V_6_4_0)) {
+            if (getOldClusterVersion().onOrAfter(Version.V_6_4_0) && getOldClusterVersion().before(Version.V_7_0_0)) {
                 shrinkIndexRequest.addParameter("copy_settings", "true");
             }
             shrinkIndexRequest.setJsonEntity("{\"settings\": {\"index.number_of_shards\": 1}}");
@@ -390,7 +400,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         Map<?, ?> response = entityAsMap(client().performRequest(new Request("GET", "/" + index + "/_search")));
         assertNoFailures(response);
         int totalShards = (int) XContentMapValues.extractValue("_shards.total", response);
-        assertThat(totalShards, greaterThan(1));
+        assertThat(totalShards, greaterThanOrEqualTo(1));
         int successfulShards = (int) XContentMapValues.extractValue("_shards.successful", response);
         assertEquals(totalShards, successfulShards);
         int totalHits = extractTotalHits(response);
@@ -414,7 +424,9 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             mappingsAndSettings.startObject();
             {
                 mappingsAndSettings.startObject("mappings");
-                mappingsAndSettings.startObject("doc");
+                if(getOldClusterVersion().before(Version.V_7_0_0)) {
+                    mappingsAndSettings.startObject("doc");
+                }
                 mappingsAndSettings.startObject("properties");
                 {
                     mappingsAndSettings.startObject("field");
@@ -422,14 +434,18 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                     mappingsAndSettings.endObject();
                 }
                 mappingsAndSettings.endObject();
-                mappingsAndSettings.endObject();
+                if(getOldClusterVersion().before(Version.V_7_0_0)) {
+                    mappingsAndSettings.endObject();
+                }
                 mappingsAndSettings.endObject();
             }
             mappingsAndSettings.endObject();
 
             Request createIndex = new Request("PUT", "/" + index);
             createIndex.setJsonEntity(Strings.toString(mappingsAndSettings));
-            createIndex.setOptions(allowTypesRemovalWarnings());
+            if(getOldClusterVersion().onOrAfter(Version.V_6_7_0) && getOldClusterVersion().before(Version.V_7_0_0)){
+                createIndex.addParameter(INCLUDE_TYPE_NAME_PARAMETER, "true");
+            }
             client().performRequest(createIndex);
 
             numDocs = randomIntBetween(512, 1024);
@@ -457,7 +473,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         Map<?, ?> response = entityAsMap(client().performRequest(new Request("GET", "/" + index + "/_search")));
         assertNoFailures(response);
         int totalShards = (int) XContentMapValues.extractValue("_shards.total", response);
-        assertThat(totalShards, greaterThan(1));
+        assertThat(totalShards, greaterThanOrEqualTo(1));
         int successfulShards = (int) XContentMapValues.extractValue("_shards.successful", response);
         assertEquals(totalShards, successfulShards);
         int totalHits = extractTotalHits(response);
@@ -488,6 +504,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
      * </ol>
      */
     public void testRollover() throws IOException {
+       // String type =
         if (isRunningAgainstOldCluster()) {
             Request createIndex = new Request("PUT", "/" + index + "-000001");
             createIndex.setJsonEntity("{"
@@ -504,18 +521,19 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             bulk.append("{\"index\":{}}\n");
             bulk.append("{\"test\":\"test\"}\n");
         }
-        Request bulkRequest = new Request("POST", "/" + index + "_write/doc/_bulk");
+        Request bulkRequest = isRunningAgainstOldCluster() && getOldClusterVersion().before(Version.V_7_0_0) ?
+            new Request("POST", "/" + index + "_write/doc/_bulk") :
+            new Request("POST", "/" + index + "_write/_bulk") ;
         bulkRequest.setJsonEntity(bulk.toString());
         bulkRequest.addParameter("refresh", "");
-        bulkRequest.setOptions(expectWarnings(RestBulkAction.TYPES_DEPRECATION_MESSAGE));
         assertThat(EntityUtils.toString(client().performRequest(bulkRequest).getEntity()), containsString("\"errors\":false"));
 
         if (isRunningAgainstOldCluster()) {
             Request rolloverRequest = new Request("POST", "/" + index + "_write/_rollover");
-            rolloverRequest.setOptions(allowTypesRemovalWarnings());
             rolloverRequest.setJsonEntity("{"
                     + "  \"conditions\": {"
                     + "    \"max_docs\": 5"
+                    + "  }"
                     + "  }"
                     + "}");
             client().performRequest(rolloverRequest);
@@ -585,9 +603,11 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         String type = (String) bestHit.get("_type");
         String id = (String) bestHit.get("_id");
 
-        Request explainRequest = new Request("GET", "/" + index + "/" + type + "/" + id + "/_explain");
+        Request explainRequest = isRunningAgainstOldCluster() && getOldClusterVersion().before(Version.V_7_0_0) ?
+            new Request("GET", "/" + index + "/" + type + "/" + id + "/_explain") :
+            new Request("GET", "/" + index + "/_explain/" + id);
+
         explainRequest.setJsonEntity("{ \"query\": { \"match_all\" : {} }}");
-        explainRequest.setOptions(expectWarnings(RestExplainAction.TYPES_DEPRECATION_MESSAGE));
         String explanation = toStr(client().performRequest(explainRequest));
         assertFalse("Could not find payload boost in explanation\n" + explanation, explanation.contains("payloadBoost"));
 
@@ -628,6 +648,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
     }
 
     void assertRealtimeGetWorks() throws IOException {
+        String type = isRunningAgainstOldCluster() && getOldClusterVersion().before(Version.V_7_0_0) ? "doc" : "_doc";
         Request disableAutoRefresh = new Request("PUT", "/" + index + "/_settings");
         disableAutoRefresh.setJsonEntity("{ \"index\": { \"refresh_interval\" : -1 }}");
         client().performRequest(disableAutoRefresh);
@@ -638,13 +659,13 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         Map<?, ?> hit = (Map<?, ?>) ((List<?>)(XContentMapValues.extractValue("hits.hits", searchResponse))).get(0);
         String docId = (String) hit.get("_id");
 
-        Request updateRequest = new Request("POST", "/" + index + "/doc/" + docId + "/_update");
-        updateRequest.setOptions(expectWarnings(RestUpdateAction.TYPES_DEPRECATION_MESSAGE));
+        Request updateRequest = isRunningAgainstOldCluster() && getOldClusterVersion().before(Version.V_7_0_0) ?
+            new Request("POST", "/" + index + "/" + type + "/" + docId + "/_update") :
+            new Request("POST", "/" + index + "/_update/" + docId);
         updateRequest.setJsonEntity("{ \"doc\" : { \"foo\": \"bar\"}}");
         client().performRequest(updateRequest);
 
-        Request getRequest = new Request("GET", "/" + index + "/doc/" + docId);
-        getRequest.setOptions(expectWarnings(RestGetAction.TYPES_DEPRECATION_MESSAGE));
+        Request getRequest = new Request("GET", "/" + index + "/" + type + "/" + docId);
         Map<String, Object> getRsp = entityAsMap(client().performRequest(getRequest));
         Map<?, ?> source = (Map<?, ?>) getRsp.get("_source");
         assertTrue("doc does not contain 'foo' key: " + source, source.containsKey("foo"));
@@ -698,7 +719,8 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
      * Tests that a single document survives. Super basic smoke test.
      */
     public void testSingleDoc() throws IOException {
-        String docLocation = "/" + index + "/doc/1";
+        String type = isRunningAgainstOldCluster() && getOldClusterVersion().before(Version.V_7_0_0) ? "doc" : "_doc";
+        String docLocation = "/" + index + "/" + type + "/1";
         String doc = "{\"test\": \"test\"}";
 
         if (isRunningAgainstOldCluster()) {
@@ -707,9 +729,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             client().performRequest(createDoc);
         }
 
-
         Request request = new Request("GET", docLocation);
-        request.setOptions(expectWarnings(RestGetAction.TYPES_DEPRECATION_MESSAGE));
         assertThat(toStr(client().performRequest(request)), containsString(doc));
     }
 
@@ -888,13 +908,16 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         }
         templateBuilder.endObject();
         templateBuilder.startObject("mappings"); {
-            templateBuilder.startObject("doc"); {
-                templateBuilder.startObject("_source"); {
-                    templateBuilder.field("enabled", true);
-                }
-                templateBuilder.endObject();
+            if(isRunningAgainstOldCluster() && getOldClusterVersion().before(Version.V_7_0_0)) {
+                templateBuilder.startObject("doc");
+            }
+            templateBuilder.startObject("_source"); {
+                templateBuilder.field("enabled", true);
             }
             templateBuilder.endObject();
+            if(isRunningAgainstOldCluster() && getOldClusterVersion().before(Version.V_7_0_0)) {
+                templateBuilder.endObject();
+            }
         }
         templateBuilder.endObject();
         templateBuilder.startObject("aliases"); {
@@ -914,13 +937,10 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         Request createTemplateRequest = new Request("PUT", "/_template/test_template");
         createTemplateRequest.setJsonEntity(Strings.toString(templateBuilder));
 
-        // In 7.0, type names are no longer expected by default in put index template requests.
-        // We therefore use the deprecated typed APIs when running against the current version.
-        if (isRunningAgainstOldCluster() == false) {
+        if (isRunningAgainstOldCluster() && getOldClusterVersion().onOrAfter(Version.V_6_7_0) &&
+            getOldClusterVersion().before(Version.V_7_0_0)) {
             createTemplateRequest.addParameter(INCLUDE_TYPE_NAME_PARAMETER, "true");
         }
-        createTemplateRequest.setOptions(allowTypesRemovalWarnings());
-
         client().performRequest(createTemplateRequest);
 
         if (isRunningAgainstOldCluster()) {
@@ -991,6 +1011,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
     }
 
     public void testSoftDeletes() throws Exception {
+        String type = isRunningAgainstOldCluster() && getOldClusterVersion().before(Version.V_7_0_0) ? "doc" : "_doc";
         if (isRunningAgainstOldCluster()) {
             XContentBuilder mappingsAndSettings = jsonBuilder();
             mappingsAndSettings.startObject();
@@ -1010,7 +1031,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             int numDocs = between(10, 100);
             for (int i = 0; i < numDocs; i++) {
                 String doc = Strings.toString(JsonXContent.contentBuilder().startObject().field("field", "v1").endObject());
-                Request request = new Request("POST", "/" + index + "/doc/" + i);
+                Request request = new Request("POST", "/" + index + "/" + type + "/" + i);
                 request.setJsonEntity(doc);
                 client().performRequest(request);
                 if (rarely()) {
@@ -1019,15 +1040,16 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             }
             client().performRequest(new Request("POST", "/" + index + "/_flush"));
             int liveDocs = numDocs;
+            refresh();
             assertTotalHits(liveDocs, entityAsMap(client().performRequest(new Request("GET", "/" + index + "/_search"))));
             for (int i = 0; i < numDocs; i++) {
                 if (randomBoolean()) {
                     String doc = Strings.toString(JsonXContent.contentBuilder().startObject().field("field", "v2").endObject());
-                    Request request = new Request("POST", "/" + index + "/doc/" + i);
+                    Request request = new Request("POST", "/" + index + "/" + type + "/" + i);
                     request.setJsonEntity(doc);
                     client().performRequest(request);
                 } else if (randomBoolean()) {
-                    client().performRequest(new Request("DELETE", "/" + index + "/doc/" + i));
+                    client().performRequest(new Request("DELETE", "/" + index + "/" + type + "/" + i));
                     liveDocs--;
                 }
             }
@@ -1097,10 +1119,12 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             bulk.append("{\"index\":{\"_id\":\"").append(count + i).append("\"}}\n");
             bulk.append("{\"test\":\"test\"}\n");
         }
-        Request writeToRestoredRequest = new Request("POST", "/restored_" + index + "/doc/_bulk");
+
+        Request writeToRestoredRequest = isRunningAgainstOldCluster() && getOldClusterVersion().before(Version.V_7_0_0) ?
+            new Request("POST", "/restored_" + index + "/doc/_bulk") :
+            new Request("POST", "/restored_" + index + "/_bulk");
         writeToRestoredRequest.addParameter("refresh", "true");
         writeToRestoredRequest.setJsonEntity(bulk.toString());
-        writeToRestoredRequest.setOptions(expectWarnings(RestBulkAction.TYPES_DEPRECATION_MESSAGE));
         assertThat(EntityUtils.toString(client().performRequest(writeToRestoredRequest).getEntity()), containsString("\"errors\":false"));
 
         // And count to make sure the add worked
@@ -1124,12 +1148,10 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         // Check that the template was restored successfully
         Request getTemplateRequest = new Request("GET", "/_template/test_template");
 
-        // In 7.0, type names are no longer returned by default in get index template requests.
-        // We therefore use the deprecated typed APIs when running against the current version.
-        if (isRunningAgainstOldCluster() == false) {
+        if (isRunningAgainstOldCluster() && getOldClusterVersion().onOrAfter(Version.V_6_7_0) &&
+            getOldClusterVersion().before(Version.V_7_0_0)) {
             getTemplateRequest.addParameter(INCLUDE_TYPE_NAME_PARAMETER, "true");
         }
-        getTemplateRequest.setOptions(allowTypesRemovalWarnings());
 
         Map<String, Object> getTemplateResponse = entityAsMap(client().performRequest(getTemplateRequest));
         Map<String, Object> expectedTemplate = new HashMap<>();
@@ -1139,7 +1161,12 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             expectedTemplate.put("index_patterns", singletonList("evil_*"));
         }
         expectedTemplate.put("settings", singletonMap("index", singletonMap("number_of_shards", "1")));
-        expectedTemplate.put("mappings", singletonMap("doc", singletonMap("_source", singletonMap("enabled", true))));
+        if (isRunningAgainstOldCluster() && getOldClusterVersion().onOrAfter(Version.V_6_7_0) &&
+            getOldClusterVersion().before(Version.V_7_0_0)) {
+            expectedTemplate.put("mappings", singletonMap("doc", singletonMap("_source", singletonMap("enabled", true))));
+        } else {
+            expectedTemplate.put("mappings", singletonMap("_source", singletonMap("enabled", true)));
+        }
         expectedTemplate.put("order", 0);
         Map<String, Object> aliases = new HashMap<>();
         aliases.put("alias1", emptyMap());
@@ -1158,9 +1185,10 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
     private void indexRandomDocuments(int count, boolean flushAllowed, boolean saveInfo,
                                       CheckedFunction<Integer, XContentBuilder, IOException> docSupplier) throws IOException {
         logger.info("Indexing {} random documents", count);
+        String type = isRunningAgainstOldCluster() && getOldClusterVersion().before(Version.V_7_0_0) ? "doc" : "_doc";
         for (int i = 0; i < count; i++) {
             logger.debug("Indexing document [{}]", i);
-            Request createDocument = new Request("POST", "/" + index + "/doc/" + i);
+            Request createDocument = new Request("POST", "/" + index + "/" + type + "/" + i);
             createDocument.setJsonEntity(Strings.toString(docSupplier.apply(i)));
             client().performRequest(createDocument);
             if (rarely()) {
@@ -1180,21 +1208,22 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         return Integer.parseInt(loadInfoDocument("count"));
     }
 
-    private void saveInfoDocument(String type, String value) throws IOException {
+    private void saveInfoDocument(String infoType, String value) throws IOException {
+        String type = isRunningAgainstOldCluster() && getOldClusterVersion().before(Version.V_7_0_0) ? "doc" : "_doc";
         XContentBuilder infoDoc = JsonXContent.contentBuilder().startObject();
         infoDoc.field("value", value);
         infoDoc.endObject();
         // Only create the first version so we know how many documents are created when the index is first created
-        Request request = new Request("PUT", "/info/doc/" + index + "_" + type);
+        Request request = new Request("PUT", "/info/" + type + "/" + index + "_" + infoType);
         request.addParameter("op_type", "create");
         request.setJsonEntity(Strings.toString(infoDoc));
         client().performRequest(request);
     }
 
-    private String loadInfoDocument(String type) throws IOException {
-        Request request = new Request("GET", "/info/doc/" + index + "_" + type);
+    private String loadInfoDocument(String infoType) throws IOException {
+        String type = isRunningAgainstOldCluster() && getOldClusterVersion().before(Version.V_7_0_0) ? "doc" : "_doc";
+        Request request = new Request("GET", "/info/" + type + "/" + index + "_" + infoType);
         request.addParameter("filter_path", "_source");
-        request.setOptions(expectWarnings(RestGetAction.TYPES_DEPRECATION_MESSAGE));
         String doc = toStr(client().performRequest(request));
         Matcher m = Pattern.compile("\"value\":\"(.+)\"").matcher(doc);
         assertTrue(doc, m.find());

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -359,7 +359,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             mappingsAndSettings.startObject();
             {
                 mappingsAndSettings.startObject("settings");
-                mappingsAndSettings.field("number_of_shards", 2);
+                mappingsAndSettings.field("number_of_shards", 5);
                 mappingsAndSettings.endObject();
 
                 mappingsAndSettings.startObject("mappings");

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -1179,7 +1179,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             expectedTemplate.put("index_patterns", singletonList("evil_*"));
         }
         expectedTemplate.put("settings", singletonMap("index", singletonMap("number_of_shards", "1")));
-        if (tookOnVersion.before(Version.V_7_0_0)) {
+        if (isRunningAgainstOldCluster() && getOldClusterVersion().before(Version.V_7_0_0)) {
             expectedTemplate.put("mappings", singletonMap("doc", singletonMap("_source", singletonMap("enabled", true))));
         } else {
             expectedTemplate.put("mappings", singletonMap("_source", singletonMap("enabled", true)));

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -549,6 +549,10 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                     + "    \"max_docs\": 5"
                     + "  }"
                     + "}");
+            if (isRunningAgainstOldCluster() && getOldClusterVersion().onOrAfter(Version.V_6_7_0) &&
+                getOldClusterVersion().before(Version.V_7_0_0)) {
+                rolloverRequest.addParameter(INCLUDE_TYPE_NAME_PARAMETER, "true");
+            }
             client().performRequest(rolloverRequest);
 
             assertThat(EntityUtils.toString(client().performRequest(new Request("GET", "/_cat/indices?v")).getEntity()),

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -519,7 +519,6 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
      * </ol>
      */
     public void testRollover() throws IOException {
-       // String type =
         if (isRunningAgainstOldCluster()) {
             Request createIndex = new Request("PUT", "/" + index + "-000001");
             createIndex.setJsonEntity("{"
@@ -548,7 +547,6 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             rolloverRequest.setJsonEntity("{"
                     + "  \"conditions\": {"
                     + "    \"max_docs\": 5"
-                    + "  }"
                     + "  }"
                     + "}");
             client().performRequest(rolloverRequest);

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -1177,8 +1177,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             expectedTemplate.put("index_patterns", singletonList("evil_*"));
         }
         expectedTemplate.put("settings", singletonMap("index", singletonMap("number_of_shards", "1")));
-        if (isRunningAgainstOldCluster() && getOldClusterVersion().onOrAfter(Version.V_6_7_0) &&
-            getOldClusterVersion().before(Version.V_7_0_0)) {
+        if (tookOnVersion.before(Version.V_7_0_0)) {
             expectedTemplate.put("mappings", singletonMap("doc", singletonMap("_source", singletonMap("enabled", true))));
         } else {
             expectedTemplate.put("mappings", singletonMap("_source", singletonMap("enabled", true)));


### PR DESCRIPTION
Now that 7.0.0 can be an "old" cluster the following needs to be updated:

* Needs a refresh() in addition to _flush :https://github.com/elastic/elasticsearch/pull/27000
* A single shard is not always the case for the old cluster.
(greaterThan --> greaterThanOrEqualTo)
* More then 1 shard is explicitly needed to shrink down to 1 shard 
* Disallow a type name in the mapping with out a special flag
(include_type_name) : https://github.com/elastic/elasticsearch/pull/37285
* Only require include_type_name for 6.7, not 7.0.0
* Fix expectations for template mappings from a snapshot.

This commit favors using the non-deprecrated and typeless APIs if the
"old" cluster is 7.0.0 or greater, and thus all of the relevant expected
depreciations are removed. 

closes: #41222
