### PR TITLE
Set region 5.6.4

### DIFF
--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -305,6 +305,13 @@ class S3Repository extends BlobStoreRepository {
 
         AmazonS3 client = s3Service.client(metadata.settings());
         String region = InternalAwsS3Service.getRegion(metadata.settings(), settings);
+
+        try {
+            client.setRegion(Region.getRegion(Regions.fromName(region)));
+        } catch (Exception e) { // todo real exception
+           logger.warn("Unable to set S3 region to [{}]. Continuing without region explicitly set", region)
+        }
+
         blobStore = new S3BlobStore(settings, client,
                 bucket, region, serverSideEncryption, bufferSize, cannedACL, storageClass);
 

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -306,10 +306,13 @@ class S3Repository extends BlobStoreRepository {
         AmazonS3 client = s3Service.client(metadata.settings());
         String region = InternalAwsS3Service.getRegion(metadata.settings(), settings);
 
+        String regionEndpoint = String.format("s3.%s.amazonaws.com", region);
+
         try {
-            client.setRegion(Region.getRegion(Regions.fromName(region)));
-        } catch (Exception e) { // todo real exception
-           logger.warn("Unable to set S3 region to [{}]. Continuing without region explicitly set", region)
+            logger.debug("Setting client region endpoint to [{}]", regionEndpoint);
+            client.setEndpoint(regionEndpoint);
+        } catch (IllegalArgumentException e) {
+           logger.warn("Unable to set S3 region endpoint to [{}]. Continuing without region endpoint explicitly set", regionEndpoint);
         }
 
         blobStore = new S3BlobStore(settings, client,


### PR DESCRIPTION
**Do not merge**

SigV4 is currently supported in all AWS regions while SigV2 is only supported in regions launched
prior to Jan 2014. S3 will stop accepting requests signed using SigV2 in all regions on June 24, 2019, any requests signed using SigV2 made after this time will fail.

For any AWS SDK released prior to May 2016, it's possible to force usage of SigV4 via a [command line flag](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version)

With this flag turned on, however, creation of an S3 repository fails with: 

```
com.amazonaws.AmazonClientException: Signature Version 4 requires knowing the region 
of the bucket you're trying to access. You can configure a region by calling
    AmazonS3Client.setRegion(Region) or AmazonS3Client.setEndpoint(String) 
    with a region-specific endpoint such as "s3-us-west-2.amazonaws.com".
```

It seems necessary to explicitly set the S3 endpoint before repository creation can succeed. 