### PR TITLE
Highlight the use of single-node discovery in docker docs

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -62,6 +62,9 @@ ifeval::["{release-state}"!="unreleased"]
 docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" {docker-image}
 --------------------------------------------
 
+Note the use of <<single-node-discovery,single-node discovery>> that allows bypassing
+the <<bootstrap-checks,bootstrap checks>> in a single-node development cluster.
+
 endif::[]
 
 [[docker-cli-run-prod-mode]]


### PR DESCRIPTION
Relates to https://discuss.elastic.co/t/es-7-and-docker-single-node-cluster/176585