### PR TITLE
SQL: Tweak pattern matching in SYS TABLES

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/CommandBuilder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/CommandBuilder.java
@@ -144,35 +144,31 @@ abstract class CommandBuilder extends LogicalPlanBuilder {
     public SysTables visitSysTables(SysTablesContext ctx) {
         List<IndexType> types = new ArrayList<>();
         boolean legacyTableType = false;
-        boolean allTypes = false;
         for (StringContext string : ctx.string()) {
             String value = string(string);
             if (value != null && value.isEmpty() == false) {
                 // check special ODBC wildcard case
                 if (value.equals(StringUtils.SQL_WILDCARD) && ctx.string().size() == 1) {
+                    // treat % as null
                     // https://docs.microsoft.com/en-us/sql/odbc/reference/develop-app/value-list-arguments
-                    allTypes = true;
                 }
-                else {
-                    // special case for legacy apps (like msquery) that always asks for 'TABLE'
-                    // which we manually map to all concrete tables supported
-                    if (value.toUpperCase(Locale.ROOT).equals("TABLE")) {
-                        legacyTableType = true;
-                        types.add(IndexType.INDEX);
-                    } else {
-                        IndexType type = IndexType.from(value);
-                        types.add(type);
-                    }
+                // special case for legacy apps (like msquery) that always asks for 'TABLE'
+                // which we manually map to all concrete tables supported
+                else if (value.toUpperCase(Locale.ROOT).equals("TABLE")) {
+                    legacyTableType = true;
+                    types.add(IndexType.INDEX);
+                } else {
+                    IndexType type = IndexType.from(value);
+                    types.add(type);
                 }
             }
         }
 
         // if the ODBC enumeration is specified, skip validation
-        EnumSet<IndexType> set = types.isEmpty() ? EnumSet.noneOf(IndexType.class) : EnumSet.copyOf(types);
+        EnumSet<IndexType> set = types.isEmpty() ? null : EnumSet.copyOf(types);
         TableIdentifier ti = visitTableIdentifier(ctx.tableIdent);
         String index = ti != null ? ti.qualifiedIndex() : null;
-        return new SysTables(source(ctx), visitLikePattern(ctx.clusterLike), index, visitLikePattern(ctx.tableLike), allTypes,
-                set, legacyTableType);
+        return new SysTables(source(ctx), visitLikePattern(ctx.clusterLike), index, visitLikePattern(ctx.tableLike), set, legacyTableType);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTablesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTablesTests.java
@@ -54,7 +54,19 @@ public class SysTablesTests extends ESTestCase {
     //
     // catalog enumeration
     //
-    public void testSysTablesCatalogEnumeration() throws Exception {
+    public void testSysTablesCatalogEnumerationWithEmptyType() throws Exception {
+        executeCommand("SYS TABLES CATALOG LIKE '%' LIKE '' TYPE ''", r -> {
+            assertEquals(1, r.size());
+            assertEquals(CLUSTER_NAME, r.column(0));
+            // everything else should be null
+            for (int i = 1; i < 10; i++) {
+                assertNull(r.column(i));
+            }
+        }, index);
+    }
+
+    // when types are null, consider them equivalent to '' for compatibility reasons
+    public void testSysTablesCatalogNoTypes() throws Exception {
         executeCommand("SYS TABLES CATALOG LIKE '%' LIKE ''", r -> {
             assertEquals(1, r.size());
             assertEquals(CLUSTER_NAME, r.column(0));
@@ -70,11 +82,8 @@ public class SysTablesTests extends ESTestCase {
     //
     public void testSysTablesTypesEnumerationWoString() throws Exception {
         executeCommand("SYS TABLES CATALOG LIKE '' LIKE '' ", r -> {
-            assertEquals(2, r.size());
-            assertEquals("BASE TABLE", r.column(3));
-            assertTrue(r.advanceRow());
-            assertEquals("VIEW", r.column(3));
-        }, new IndexInfo[0]);
+            assertEquals(0, r.size());
+        }, alias, index);
     }
 
     public void testSysTablesEnumerateTypes() throws Exception {
@@ -113,6 +122,13 @@ public class SysTablesTests extends ESTestCase {
             assertFalse(r.hasCurrentRow());
         });
     }
+
+    public void testSysTablesEmptyTable() throws Exception {
+        executeCommand("SYS TABLES CATALOG LIKE '%' LIKE '' TYPE '%'", r -> {
+            assertEquals(0, r.size());
+        }, index, alias);
+    }
+
 
     public void testSysTablesNoTypes() throws Exception {
         executeCommand("SYS TABLES", r -> {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTablesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTablesTests.java
@@ -65,6 +65,17 @@ public class SysTablesTests extends ESTestCase {
         }, index);
     }
 
+    public void testSysTablesCatalogAllTypes() throws Exception {
+        executeCommand("SYS TABLES CATALOG LIKE '%' LIKE '' TYPE '%'", r -> {
+            assertEquals(1, r.size());
+            assertEquals(CLUSTER_NAME, r.column(0));
+            // everything else should be null
+            for (int i = 1; i < 10; i++) {
+                assertNull(r.column(i));
+            }
+        }, new IndexInfo[0]);
+    }
+
     // when types are null, consider them equivalent to '' for compatibility reasons
     public void testSysTablesCatalogNoTypes() throws Exception {
         executeCommand("SYS TABLES CATALOG LIKE '%' LIKE ''", r -> {
@@ -77,17 +88,14 @@ public class SysTablesTests extends ESTestCase {
         }, index);
     }
 
+
     //
     // table types enumeration
     //
+
+    // missing type means pattern
     public void testSysTablesTypesEnumerationWoString() throws Exception {
         executeCommand("SYS TABLES CATALOG LIKE '' LIKE '' ", r -> {
-            assertEquals(0, r.size());
-        }, alias, index);
-    }
-
-    public void testSysTablesEnumerateTypes() throws Exception {
-        executeCommand("SYS TABLES CATALOG LIKE '' LIKE '' TYPE '%'", r -> {
             assertEquals(2, r.size());
             assertEquals("BASE TABLE", r.column(3));
             assertTrue(r.advanceRow());
@@ -116,19 +124,19 @@ public class SysTablesTests extends ESTestCase {
         }, new IndexInfo[0]);
     }
 
+    // when a type is specified, apply filtering
+    public void testSysTablesTypesEnumerationAllCatalogsAndSpecifiedView() throws Exception {
+        executeCommand("SYS TABLES CATALOG LIKE '%' LIKE '' TYPE 'VIEW'", r -> {
+            assertEquals(0, r.size());
+        }, new IndexInfo[0]);
+    }
+
     public void testSysTablesDifferentCatalog() throws Exception {
         executeCommand("SYS TABLES CATALOG LIKE 'foo'", r -> {
             assertEquals(0, r.size());
             assertFalse(r.hasCurrentRow());
         });
     }
-
-    public void testSysTablesEmptyTable() throws Exception {
-        executeCommand("SYS TABLES CATALOG LIKE '%' LIKE '' TYPE '%'", r -> {
-            assertEquals(0, r.size());
-        }, index, alias);
-    }
-
 
     public void testSysTablesNoTypes() throws Exception {
         executeCommand("SYS TABLES", r -> {
@@ -275,6 +283,12 @@ public class SysTablesTests extends ESTestCase {
         executeCommand("SYS TABLES CATALOG LIKE '%' LIKE 'test' TYPE 'VIEW'", r -> {
             assertEquals(1, r.size());
             assertEquals("alias", r.column(2));
+        }, alias);
+    }
+
+    public void testSysTablesWithEmptyCatalogOnlyAliases() throws Exception {
+        executeCommand("SYS TABLES CATALOG LIKE '' LIKE 'test' TYPE 'VIEW'", r -> {
+            assertEquals(0, r.size());
         }, alias);
     }
 


### PR DESCRIPTION
Yet another improvement to SYS TABLES on differentiating between table
types specified as '%' and '' while maintaining legacy support for null

Fix #40775