### PR TITLE
Remove pending deletions workaround

### DIFF
--- a/plugins/store-smb/src/main/java/org/elasticsearch/index/store/SmbDirectoryWrapper.java
+++ b/plugins/store-smb/src/main/java/org/elasticsearch/index/store/SmbDirectoryWrapper.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.nio.channels.Channels;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
-import java.util.Set;
 
 /**
  * This class is used to wrap an existing {@link org.apache.lucene.store.FSDirectory} so that
@@ -79,11 +78,5 @@ public final class SmbDirectoryWrapper extends FilterDirectory {
                     },
                     CHUNK_SIZE);
         }
-    }
-
-    // temporary override until LUCENE-8735 is integrated
-    @Override
-    public Set<String> getPendingDeletions() throws IOException {
-        return in.getPendingDeletions();
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/shard/LocalShardSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/LocalShardSnapshot.java
@@ -33,7 +33,6 @@ import org.elasticsearch.index.store.Store;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 final class LocalShardSnapshot implements Closeable {
@@ -116,12 +115,6 @@ final class LocalShardSnapshot implements Closeable {
             @Override
             public void close() throws IOException {
                 throw new UnsupportedOperationException("nobody should close this directory wrapper");
-            }
-
-            // temporary override until LUCENE-8735 is integrated
-            @Override
-            public Set<String> getPendingDeletions() throws IOException {
-                return in.getPendingDeletions();
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
@@ -259,12 +259,6 @@ final class StoreRecovery {
                 assert index.getFileDetails(dest).recovered() == l : index.getFileDetails(dest).toString();
             }
         }
-
-        // temporary override until LUCENE-8735 is integrated
-        @Override
-        public Set<String> getPendingDeletions() throws IOException {
-            return in.getPendingDeletions();
-        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/store/ByteSizeCachingDirectory.java
+++ b/server/src/main/java/org/elasticsearch/index/store/ByteSizeCachingDirectory.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.NoSuchFileException;
-import java.util.Set;
 
 final class ByteSizeCachingDirectory extends FilterDirectory {
 
@@ -179,11 +178,5 @@ final class ByteSizeCachingDirectory extends FilterDirectory {
                 modCount++;
             }
         }
-    }
-
-    // temporary override until LUCENE-8735 is integrated
-    @Override
-    public Set<String> getPendingDeletions() throws IOException {
-        return in.getPendingDeletions();
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -760,13 +760,6 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         public String toString() {
             return "store(" + in.toString() + ")";
         }
-
-        @Override
-        public Set<String> getPendingDeletions() throws IOException {
-            // FilterDirectory.getPendingDeletions does not delegate, working around it here.
-            // to be removed once fixed in FilterDirectory.
-            return unwrap(this).getPendingDeletions();
-        }
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -1457,12 +1457,6 @@ public class IndexShardTests extends IndexShardTestCase {
                     return super.listAll();
                 }
             }
-
-            // temporary override until LUCENE-8735 is integrated
-            @Override
-            public Set<String> getPendingDeletions() throws IOException {
-                return in.getPendingDeletions();
-            }
         };
 
         try (Store store = createStore(shardId, new IndexSettings(metaData, Settings.EMPTY), directory)) {

--- a/server/src/test/java/org/elasticsearch/index/store/ByteSizeCachingDirectoryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/ByteSizeCachingDirectoryTests.java
@@ -28,7 +28,6 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
-import java.util.Set;
 
 @LuceneTestCase.SuppressFileSystems("ExtrasFS")
 public class ByteSizeCachingDirectoryTests extends ESTestCase {
@@ -45,12 +44,6 @@ public class ByteSizeCachingDirectoryTests extends ESTestCase {
         public long fileLength(String name) throws IOException {
             numFileLengthCalls++;
             return super.fileLength(name);
-        }
-
-        // temporary override until LUCENE-8735 is integrated
-        @Override
-        public Set<String> getPendingDeletions() throws IOException {
-            return in.getPendingDeletions();
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/store/MockFSDirectoryService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/store/MockFSDirectoryService.java
@@ -54,7 +54,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Random;
-import java.util.Set;
 
 public class MockFSDirectoryService extends FsDirectoryService {
 
@@ -178,12 +177,6 @@ public class MockFSDirectoryService extends FsDirectoryService {
             if (crash) {
                 super.crash();
             }
-        }
-
-        // temporary override until LUCENE-8735 is integrated
-        @Override
-        public Set<String> getPendingDeletions() throws IOException {
-            return in.getPendingDeletions();
         }
     }
 


### PR DESCRIPTION
The recent upgrade to lucene 8.1.0 included the fix for LUCENE-8735
(pending deletions did not delegate). Removed the temporary workaround
for this.

Follow up to #40345
