### PR TITLE
SQL: Allow current_date/time/timestamp to be also used as a function escape pattern

### DIFF
--- a/x-pack/plugin/sql/src/main/antlr/SqlBase.g4
+++ b/x-pack/plugin/sql/src/main/antlr/SqlBase.g4
@@ -226,9 +226,9 @@ primaryExpression
     ;
 
 builtinDateTimeFunction
-    : name=CURRENT_TIMESTAMP ('(' precision=INTEGER_VALUE? ')')?
-    | name=CURRENT_DATE ('(' ')')?
-    | name=CURRENT_TIME ('(' precision=INTEGER_VALUE? ')')?
+    : name=CURRENT_TIMESTAMP
+    | name=CURRENT_DATE
+    | name=CURRENT_TIME
     ;
 
 castExpression
@@ -340,7 +340,7 @@ string
 // http://developer.mimer.se/validator/sql-reserved-words.tml
 nonReserved
     : ANALYZE | ANALYZED 
-    | CATALOGS | COLUMNS
+    | CATALOGS | COLUMNS | CURRENT_DATE | CURRENT_TIME | CURRENT_TIMESTAMP
     | DAY | DEBUG  
     | EXECUTABLE | EXPLAIN 
     | FIRST | FORMAT | FULL | FUNCTIONS

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentDateTime.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentDateTime.java
@@ -7,13 +7,14 @@
 package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
 import org.elasticsearch.xpack.sql.expression.Expression;
-import org.elasticsearch.xpack.sql.expression.Foldables;
 import org.elasticsearch.xpack.sql.session.Configuration;
 import org.elasticsearch.xpack.sql.tree.NodeInfo;
 import org.elasticsearch.xpack.sql.tree.Source;
 import org.elasticsearch.xpack.sql.type.DataType;
 
 import java.time.ZonedDateTime;
+
+import static org.elasticsearch.xpack.sql.util.DateUtils.getNanoPrecision;
 
 public class CurrentDateTime extends CurrentFunction<ZonedDateTime> {
 
@@ -34,13 +35,6 @@ public class CurrentDateTime extends CurrentFunction<ZonedDateTime> {
     }
 
     static ZonedDateTime nanoPrecision(ZonedDateTime zdt, Expression precisionExpression) {
-        int precision = precisionExpression != null ? Foldables.intValueOf(precisionExpression) : 3;
-        int nano = zdt.getNano();
-        if (precision >= 0 && precision < 10) {
-            // remove the remainder
-            nano = nano - nano % (int) Math.pow(10, (9 - precision));
-            return zdt.withNano(nano);
-        }
-        return zdt;
+        return zdt.withNano(getNanoPrecision(precisionExpression, zdt.getNano()));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentTime.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentTime.java
@@ -7,13 +7,14 @@
 package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
 import org.elasticsearch.xpack.sql.expression.Expression;
-import org.elasticsearch.xpack.sql.expression.Foldables;
 import org.elasticsearch.xpack.sql.session.Configuration;
 import org.elasticsearch.xpack.sql.tree.NodeInfo;
 import org.elasticsearch.xpack.sql.tree.Source;
 import org.elasticsearch.xpack.sql.type.DataType;
 
 import java.time.OffsetTime;
+
+import static org.elasticsearch.xpack.sql.util.DateUtils.getNanoPrecision;
 
 public class CurrentTime extends CurrentFunction<OffsetTime> {
 
@@ -35,13 +36,7 @@ public class CurrentTime extends CurrentFunction<OffsetTime> {
     }
 
     static OffsetTime nanoPrecision(OffsetTime ot, Expression precisionExpression) {
-        int precision = precisionExpression != null ? Foldables.intValueOf(precisionExpression) : 3;
-        int nano = ot.getNano();
-        if (precision >= 0 && precision < 10) {
-            // remove the remainder
-            nano = nano - nano % (int) Math.pow(10, (9 - precision));
-            return ot.withNano(nano);
-        }
-        return ot;
+        return ot.withNano(getNanoPrecision(precisionExpression, ot.getNano()));
     }
+
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/ExpressionBuilder.java
@@ -109,7 +109,6 @@ import org.elasticsearch.xpack.sql.parser.SqlBaseParser.ValueExpressionDefaultCo
 import org.elasticsearch.xpack.sql.proto.SqlTypedParamValue;
 import org.elasticsearch.xpack.sql.tree.Source;
 import org.elasticsearch.xpack.sql.type.DataType;
-import org.elasticsearch.xpack.sql.type.DataTypeConversion;
 import org.elasticsearch.xpack.sql.type.DataTypes;
 import org.elasticsearch.xpack.sql.util.StringUtils;
 
@@ -431,30 +430,15 @@ abstract class ExpressionBuilder extends IdentifierBuilder {
         // maps CURRENT_XXX to its respective function e.g: CURRENT_TIMESTAMP()
         // since the functions need access to the Configuration, the parser only registers the definition and not the actual function
         Source source = source(ctx);
-        Literal p = null;
-
-        if (ctx.precision != null) {
-            try {
-                Source pSource = source(ctx.precision);
-                short safeShort = DataTypeConversion.safeToShort(StringUtils.parseLong(ctx.precision.getText()));
-                if (safeShort > 9 || safeShort < 0) {
-                    throw new ParsingException(pSource, "Precision needs to be between [0-9], received [{}]", safeShort);
-                }
-                p = Literal.of(pSource, Short.valueOf(safeShort));
-            } catch (SqlIllegalArgumentException siae) {
-                throw new ParsingException(source, siae.getMessage());
-            }
-        }
-        
         String functionName = ctx.name.getText();
 
         switch (ctx.name.getType()) {
             case SqlBaseLexer.CURRENT_TIMESTAMP:
-                return new UnresolvedFunction(source, functionName, ResolutionType.STANDARD, p != null ? singletonList(p) : emptyList());
+                return new UnresolvedFunction(source, functionName, ResolutionType.STANDARD, emptyList());
             case SqlBaseLexer.CURRENT_DATE:
                 return new UnresolvedFunction(source, functionName, ResolutionType.STANDARD, emptyList());
             case SqlBaseLexer.CURRENT_TIME:
-                return new UnresolvedFunction(source, functionName, ResolutionType.STANDARD, p != null ? singletonList(p) : emptyList());
+                return new UnresolvedFunction(source, functionName, ResolutionType.STANDARD, emptyList());
             default:
                 throw new ParsingException(source, "Unknown function [{}]", functionName);
         }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlBaseParser.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/SqlBaseParser.java
@@ -1,13 +1,27 @@
 // ANTLR GENERATED CODE: DO NOT EDIT
 package org.elasticsearch.xpack.sql.parser;
-import org.antlr.v4.runtime.atn.*;
+
+import org.antlr.v4.runtime.FailedPredicateException;
+import org.antlr.v4.runtime.NoViableAltException;
+import org.antlr.v4.runtime.Parser;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.RuleContext;
+import org.antlr.v4.runtime.RuntimeMetaData;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.TokenStream;
+import org.antlr.v4.runtime.Vocabulary;
+import org.antlr.v4.runtime.VocabularyImpl;
+import org.antlr.v4.runtime.atn.ATN;
+import org.antlr.v4.runtime.atn.ATNDeserializer;
+import org.antlr.v4.runtime.atn.ParserATNSimulator;
+import org.antlr.v4.runtime.atn.PredictionContextCache;
 import org.antlr.v4.runtime.dfa.DFA;
-import org.antlr.v4.runtime.*;
-import org.antlr.v4.runtime.misc.*;
-import org.antlr.v4.runtime.tree.*;
+import org.antlr.v4.runtime.tree.ParseTreeListener;
+import org.antlr.v4.runtime.tree.ParseTreeVisitor;
+import org.antlr.v4.runtime.tree.TerminalNode;
+
 import java.util.List;
-import java.util.Iterator;
-import java.util.ArrayList;
 
 @SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast"})
 class SqlBaseParser extends Parser {
@@ -768,6 +782,9 @@ class SqlBaseParser extends Parser {
         case ANALYZED:
         case CATALOGS:
         case COLUMNS:
+        case CURRENT_DATE:
+        case CURRENT_TIME:
+        case CURRENT_TIMESTAMP:
         case DAY:
         case DEBUG:
         case EXECUTABLE:
@@ -844,6 +861,9 @@ class SqlBaseParser extends Parser {
         case ANALYZED:
         case CATALOGS:
         case COLUMNS:
+        case CURRENT_DATE:
+        case CURRENT_TIME:
+        case CURRENT_TIMESTAMP:
         case DAY:
         case DEBUG:
         case EXECUTABLE:
@@ -914,6 +934,9 @@ class SqlBaseParser extends Parser {
         case ANALYZED:
         case CATALOGS:
         case COLUMNS:
+        case CURRENT_DATE:
+        case CURRENT_TIME:
+        case CURRENT_TIMESTAMP:
         case DAY:
         case DEBUG:
         case EXECUTABLE:
@@ -1087,6 +1110,9 @@ class SqlBaseParser extends Parser {
         case ANALYZED:
         case CATALOGS:
         case COLUMNS:
+        case CURRENT_DATE:
+        case CURRENT_TIME:
+        case CURRENT_TIMESTAMP:
         case DAY:
         case DEBUG:
         case EXECUTABLE:
@@ -4241,7 +4267,7 @@ class SqlBaseParser extends Parser {
         _prevctx = _localctx;
         setState(577);
         _la = _input.LA(1);
-        if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ANALYZE) | (1L << ANALYZED) | (1L << CATALOGS) | (1L << COLUMNS) | (1L << DAY) | (1L << DEBUG) | (1L << EXECUTABLE) | (1L << EXPLAIN) | (1L << FIRST) | (1L << FORMAT) | (1L << FULL) | (1L << FUNCTIONS) | (1L << GRAPHVIZ) | (1L << HOUR) | (1L << INTERVAL) | (1L << LAST) | (1L << LIMIT) | (1L << MAPPED) | (1L << MINUTE) | (1L << MONTH))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (OPTIMIZED - 64)) | (1L << (PARSED - 64)) | (1L << (PHYSICAL - 64)) | (1L << (PLAN - 64)) | (1L << (RLIKE - 64)) | (1L << (QUERY - 64)) | (1L << (SCHEMAS - 64)) | (1L << (SECOND - 64)) | (1L << (SHOW - 64)) | (1L << (SYS - 64)) | (1L << (TABLES - 64)) | (1L << (TEXT - 64)) | (1L << (TYPE - 64)) | (1L << (TYPES - 64)) | (1L << (VERIFY - 64)) | (1L << (YEAR - 64)) | (1L << (IDENTIFIER - 64)) | (1L << (DIGIT_IDENTIFIER - 64)) | (1L << (QUOTED_IDENTIFIER - 64)) | (1L << (BACKQUOTED_IDENTIFIER - 64)))) != 0)) {
+        if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ANALYZE) | (1L << ANALYZED) | (1L << CATALOGS) | (1L << COLUMNS) | (1L << CURRENT_DATE) | (1L << CURRENT_TIME) | (1L << CURRENT_TIMESTAMP) | (1L << DAY) | (1L << DEBUG) | (1L << EXECUTABLE) | (1L << EXPLAIN) | (1L << FIRST) | (1L << FORMAT) | (1L << FULL) | (1L << FUNCTIONS) | (1L << GRAPHVIZ) | (1L << HOUR) | (1L << INTERVAL) | (1L << LAST) | (1L << LIMIT) | (1L << MAPPED) | (1L << MINUTE) | (1L << MONTH))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (OPTIMIZED - 64)) | (1L << (PARSED - 64)) | (1L << (PHYSICAL - 64)) | (1L << (PLAN - 64)) | (1L << (RLIKE - 64)) | (1L << (QUERY - 64)) | (1L << (SCHEMAS - 64)) | (1L << (SECOND - 64)) | (1L << (SHOW - 64)) | (1L << (SYS - 64)) | (1L << (TABLES - 64)) | (1L << (TEXT - 64)) | (1L << (TYPE - 64)) | (1L << (TYPES - 64)) | (1L << (VERIFY - 64)) | (1L << (YEAR - 64)) | (1L << (IDENTIFIER - 64)) | (1L << (DIGIT_IDENTIFIER - 64)) | (1L << (QUOTED_IDENTIFIER - 64)) | (1L << (BACKQUOTED_IDENTIFIER - 64)))) != 0)) {
           {
           setState(574);
           qualifiedName();
@@ -4339,9 +4365,7 @@ class SqlBaseParser extends Parser {
 
   public static class BuiltinDateTimeFunctionContext extends ParserRuleContext {
     public Token name;
-    public Token precision;
     public TerminalNode CURRENT_TIMESTAMP() { return getToken(SqlBaseParser.CURRENT_TIMESTAMP, 0); }
-    public TerminalNode INTEGER_VALUE() { return getToken(SqlBaseParser.INTEGER_VALUE, 0); }
     public TerminalNode CURRENT_DATE() { return getToken(SqlBaseParser.CURRENT_DATE, 0); }
     public TerminalNode CURRENT_TIME() { return getToken(SqlBaseParser.CURRENT_TIME, 0); }
     public BuiltinDateTimeFunctionContext(ParserRuleContext parent, int invokingState) {
@@ -4366,83 +4390,28 @@ class SqlBaseParser extends Parser {
   public final BuiltinDateTimeFunctionContext builtinDateTimeFunction() throws RecognitionException {
     BuiltinDateTimeFunctionContext _localctx = new BuiltinDateTimeFunctionContext(_ctx, getState());
     enterRule(_localctx, 62, RULE_builtinDateTimeFunction);
-    int _la;
     try {
-      setState(621);
+      setState(603);
       switch (_input.LA(1)) {
       case CURRENT_TIMESTAMP:
         enterOuterAlt(_localctx, 1);
         {
         setState(600);
         ((BuiltinDateTimeFunctionContext)_localctx).name = match(CURRENT_TIMESTAMP);
-        setState(606);
-        _errHandler.sync(this);
-        switch ( getInterpreter().adaptivePredict(_input,82,_ctx) ) {
-        case 1:
-          {
-          setState(601);
-          match(T__0);
-          setState(603);
-          _la = _input.LA(1);
-          if (_la==INTEGER_VALUE) {
-            {
-            setState(602);
-            ((BuiltinDateTimeFunctionContext)_localctx).precision = match(INTEGER_VALUE);
-            }
-          }
-
-          setState(605);
-          match(T__1);
-          }
-          break;
-        }
         }
         break;
       case CURRENT_DATE:
         enterOuterAlt(_localctx, 2);
         {
-        setState(608);
+        setState(601);
         ((BuiltinDateTimeFunctionContext)_localctx).name = match(CURRENT_DATE);
-        setState(611);
-        _errHandler.sync(this);
-        switch ( getInterpreter().adaptivePredict(_input,83,_ctx) ) {
-        case 1:
-          {
-          setState(609);
-          match(T__0);
-          setState(610);
-          match(T__1);
-          }
-          break;
-        }
         }
         break;
       case CURRENT_TIME:
         enterOuterAlt(_localctx, 3);
         {
-        setState(613);
+        setState(602);
         ((BuiltinDateTimeFunctionContext)_localctx).name = match(CURRENT_TIME);
-        setState(619);
-        _errHandler.sync(this);
-        switch ( getInterpreter().adaptivePredict(_input,85,_ctx) ) {
-        case 1:
-          {
-          setState(614);
-          match(T__0);
-          setState(616);
-          _la = _input.LA(1);
-          if (_la==INTEGER_VALUE) {
-            {
-            setState(615);
-            ((BuiltinDateTimeFunctionContext)_localctx).precision = match(INTEGER_VALUE);
-            }
-          }
-
-          setState(618);
-          match(T__1);
-          }
-          break;
-        }
         }
         break;
       default:
@@ -4492,42 +4461,42 @@ class SqlBaseParser extends Parser {
     CastExpressionContext _localctx = new CastExpressionContext(_ctx, getState());
     enterRule(_localctx, 64, RULE_castExpression);
     try {
-      setState(633);
+      setState(615);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,87,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,82,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(623);
+        setState(605);
         castTemplate();
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(624);
+        setState(606);
         match(FUNCTION_ESC);
-        setState(625);
+        setState(607);
         castTemplate();
-        setState(626);
+        setState(608);
         match(ESC_END);
         }
         break;
       case 3:
         enterOuterAlt(_localctx, 3);
         {
-        setState(628);
+        setState(610);
         convertTemplate();
         }
         break;
       case 4:
         enterOuterAlt(_localctx, 4);
         {
-        setState(629);
+        setState(611);
         match(FUNCTION_ESC);
-        setState(630);
+        setState(612);
         convertTemplate();
-        setState(631);
+        setState(613);
         match(ESC_END);
         }
         break;
@@ -4578,17 +4547,17 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(635);
+      setState(617);
       match(CAST);
-      setState(636);
+      setState(618);
       match(T__0);
-      setState(637);
+      setState(619);
       expression();
-      setState(638);
+      setState(620);
       match(AS);
-      setState(639);
+      setState(621);
       dataType();
-      setState(640);
+      setState(622);
       match(T__1);
       }
     }
@@ -4636,17 +4605,17 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(642);
+      setState(624);
       match(CONVERT);
-      setState(643);
+      setState(625);
       match(T__0);
-      setState(644);
+      setState(626);
       expression();
-      setState(645);
+      setState(627);
       match(T__2);
-      setState(646);
+      setState(628);
       dataType();
-      setState(647);
+      setState(629);
       match(T__1);
       }
     }
@@ -4690,23 +4659,23 @@ class SqlBaseParser extends Parser {
     ExtractExpressionContext _localctx = new ExtractExpressionContext(_ctx, getState());
     enterRule(_localctx, 70, RULE_extractExpression);
     try {
-      setState(654);
+      setState(636);
       switch (_input.LA(1)) {
       case EXTRACT:
         enterOuterAlt(_localctx, 1);
         {
-        setState(649);
+        setState(631);
         extractTemplate();
         }
         break;
       case FUNCTION_ESC:
         enterOuterAlt(_localctx, 2);
         {
-        setState(650);
+        setState(632);
         match(FUNCTION_ESC);
-        setState(651);
+        setState(633);
         extractTemplate();
-        setState(652);
+        setState(634);
         match(ESC_END);
         }
         break;
@@ -4760,17 +4729,17 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(656);
+      setState(638);
       match(EXTRACT);
-      setState(657);
+      setState(639);
       match(T__0);
-      setState(658);
+      setState(640);
       ((ExtractTemplateContext)_localctx).field = identifier();
-      setState(659);
+      setState(641);
       match(FROM);
-      setState(660);
+      setState(642);
       valueExpression(0);
-      setState(661);
+      setState(643);
       match(T__1);
       }
     }
@@ -4813,12 +4782,15 @@ class SqlBaseParser extends Parser {
     FunctionExpressionContext _localctx = new FunctionExpressionContext(_ctx, getState());
     enterRule(_localctx, 74, RULE_functionExpression);
     try {
-      setState(668);
+      setState(650);
       switch (_input.LA(1)) {
       case ANALYZE:
       case ANALYZED:
       case CATALOGS:
       case COLUMNS:
+      case CURRENT_DATE:
+      case CURRENT_TIME:
+      case CURRENT_TIMESTAMP:
       case DAY:
       case DEBUG:
       case EXECUTABLE:
@@ -4859,18 +4831,18 @@ class SqlBaseParser extends Parser {
       case BACKQUOTED_IDENTIFIER:
         enterOuterAlt(_localctx, 1);
         {
-        setState(663);
+        setState(645);
         functionTemplate();
         }
         break;
       case FUNCTION_ESC:
         enterOuterAlt(_localctx, 2);
         {
-        setState(664);
+        setState(646);
         match(FUNCTION_ESC);
-        setState(665);
+        setState(647);
         functionTemplate();
-        setState(666);
+        setState(648);
         match(ESC_END);
         }
         break;
@@ -4928,45 +4900,45 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(670);
+      setState(652);
       functionName();
-      setState(671);
+      setState(653);
       match(T__0);
-      setState(683);
+      setState(665);
       _la = _input.LA(1);
       if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << T__0) | (1L << ALL) | (1L << ANALYZE) | (1L << ANALYZED) | (1L << CAST) | (1L << CATALOGS) | (1L << COLUMNS) | (1L << CONVERT) | (1L << CURRENT_DATE) | (1L << CURRENT_TIME) | (1L << CURRENT_TIMESTAMP) | (1L << DAY) | (1L << DEBUG) | (1L << DISTINCT) | (1L << EXECUTABLE) | (1L << EXISTS) | (1L << EXPLAIN) | (1L << EXTRACT) | (1L << FALSE) | (1L << FIRST) | (1L << FORMAT) | (1L << FULL) | (1L << FUNCTIONS) | (1L << GRAPHVIZ) | (1L << HOUR) | (1L << INTERVAL) | (1L << LAST) | (1L << LEFT) | (1L << LIMIT) | (1L << MAPPED) | (1L << MATCH) | (1L << MINUTE) | (1L << MONTH) | (1L << NOT) | (1L << NULL))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (OPTIMIZED - 64)) | (1L << (PARSED - 64)) | (1L << (PHYSICAL - 64)) | (1L << (PLAN - 64)) | (1L << (RIGHT - 64)) | (1L << (RLIKE - 64)) | (1L << (QUERY - 64)) | (1L << (SCHEMAS - 64)) | (1L << (SECOND - 64)) | (1L << (SHOW - 64)) | (1L << (SYS - 64)) | (1L << (TABLES - 64)) | (1L << (TEXT - 64)) | (1L << (TRUE - 64)) | (1L << (TYPE - 64)) | (1L << (TYPES - 64)) | (1L << (VERIFY - 64)) | (1L << (YEAR - 64)) | (1L << (FUNCTION_ESC - 64)) | (1L << (DATE_ESC - 64)) | (1L << (TIME_ESC - 64)) | (1L << (TIMESTAMP_ESC - 64)) | (1L << (GUID_ESC - 64)) | (1L << (PLUS - 64)) | (1L << (MINUS - 64)) | (1L << (ASTERISK - 64)) | (1L << (PARAM - 64)) | (1L << (STRING - 64)) | (1L << (INTEGER_VALUE - 64)) | (1L << (DECIMAL_VALUE - 64)) | (1L << (IDENTIFIER - 64)) | (1L << (DIGIT_IDENTIFIER - 64)) | (1L << (QUOTED_IDENTIFIER - 64)) | (1L << (BACKQUOTED_IDENTIFIER - 64)))) != 0)) {
         {
-        setState(673);
+        setState(655);
         _la = _input.LA(1);
         if (_la==ALL || _la==DISTINCT) {
           {
-          setState(672);
+          setState(654);
           setQuantifier();
           }
         }
 
-        setState(675);
+        setState(657);
         expression();
-        setState(680);
+        setState(662);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==T__2) {
           {
           {
-          setState(676);
+          setState(658);
           match(T__2);
-          setState(677);
+          setState(659);
           expression();
           }
           }
-          setState(682);
+          setState(664);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
         }
       }
 
-      setState(685);
+      setState(667);
       match(T__1);
       }
     }
@@ -5010,19 +4982,19 @@ class SqlBaseParser extends Parser {
     FunctionNameContext _localctx = new FunctionNameContext(_ctx, getState());
     enterRule(_localctx, 78, RULE_functionName);
     try {
-      setState(690);
+      setState(672);
       switch (_input.LA(1)) {
       case LEFT:
         enterOuterAlt(_localctx, 1);
         {
-        setState(687);
+        setState(669);
         match(LEFT);
         }
         break;
       case RIGHT:
         enterOuterAlt(_localctx, 2);
         {
-        setState(688);
+        setState(670);
         match(RIGHT);
         }
         break;
@@ -5030,6 +5002,9 @@ class SqlBaseParser extends Parser {
       case ANALYZED:
       case CATALOGS:
       case COLUMNS:
+      case CURRENT_DATE:
+      case CURRENT_TIME:
+      case CURRENT_TIMESTAMP:
       case DAY:
       case DEBUG:
       case EXECUTABLE:
@@ -5068,7 +5043,7 @@ class SqlBaseParser extends Parser {
       case BACKQUOTED_IDENTIFIER:
         enterOuterAlt(_localctx, 3);
         {
-        setState(689);
+        setState(671);
         identifier();
         }
         break;
@@ -5299,13 +5274,13 @@ class SqlBaseParser extends Parser {
     enterRule(_localctx, 80, RULE_constant);
     try {
       int _alt;
-      setState(718);
+      setState(700);
       switch (_input.LA(1)) {
       case NULL:
         _localctx = new NullLiteralContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(692);
+        setState(674);
         match(NULL);
         }
         break;
@@ -5313,7 +5288,7 @@ class SqlBaseParser extends Parser {
         _localctx = new IntervalLiteralContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(693);
+        setState(675);
         interval();
         }
         break;
@@ -5322,7 +5297,7 @@ class SqlBaseParser extends Parser {
         _localctx = new NumericLiteralContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(694);
+        setState(676);
         number();
         }
         break;
@@ -5331,7 +5306,7 @@ class SqlBaseParser extends Parser {
         _localctx = new BooleanLiteralContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(695);
+        setState(677);
         booleanValue();
         }
         break;
@@ -5339,7 +5314,7 @@ class SqlBaseParser extends Parser {
         _localctx = new StringLiteralContext(_localctx);
         enterOuterAlt(_localctx, 5);
         {
-        setState(697); 
+        setState(679); 
         _errHandler.sync(this);
         _alt = 1;
         do {
@@ -5347,7 +5322,7 @@ class SqlBaseParser extends Parser {
           case 1:
             {
             {
-            setState(696);
+            setState(678);
             match(STRING);
             }
             }
@@ -5355,9 +5330,9 @@ class SqlBaseParser extends Parser {
           default:
             throw new NoViableAltException(this);
           }
-          setState(699); 
+          setState(681); 
           _errHandler.sync(this);
-          _alt = getInterpreter().adaptivePredict(_input,94,_ctx);
+          _alt = getInterpreter().adaptivePredict(_input,89,_ctx);
         } while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER );
         }
         break;
@@ -5365,7 +5340,7 @@ class SqlBaseParser extends Parser {
         _localctx = new ParamLiteralContext(_localctx);
         enterOuterAlt(_localctx, 6);
         {
-        setState(701);
+        setState(683);
         match(PARAM);
         }
         break;
@@ -5373,11 +5348,11 @@ class SqlBaseParser extends Parser {
         _localctx = new DateEscapedLiteralContext(_localctx);
         enterOuterAlt(_localctx, 7);
         {
-        setState(702);
+        setState(684);
         match(DATE_ESC);
-        setState(703);
+        setState(685);
         string();
-        setState(704);
+        setState(686);
         match(ESC_END);
         }
         break;
@@ -5385,11 +5360,11 @@ class SqlBaseParser extends Parser {
         _localctx = new TimeEscapedLiteralContext(_localctx);
         enterOuterAlt(_localctx, 8);
         {
-        setState(706);
+        setState(688);
         match(TIME_ESC);
-        setState(707);
+        setState(689);
         string();
-        setState(708);
+        setState(690);
         match(ESC_END);
         }
         break;
@@ -5397,11 +5372,11 @@ class SqlBaseParser extends Parser {
         _localctx = new TimestampEscapedLiteralContext(_localctx);
         enterOuterAlt(_localctx, 9);
         {
-        setState(710);
+        setState(692);
         match(TIMESTAMP_ESC);
-        setState(711);
+        setState(693);
         string();
-        setState(712);
+        setState(694);
         match(ESC_END);
         }
         break;
@@ -5409,11 +5384,11 @@ class SqlBaseParser extends Parser {
         _localctx = new GuidEscapedLiteralContext(_localctx);
         enterOuterAlt(_localctx, 10);
         {
-        setState(714);
+        setState(696);
         match(GUID_ESC);
-        setState(715);
+        setState(697);
         string();
-        setState(716);
+        setState(698);
         match(ESC_END);
         }
         break;
@@ -5466,7 +5441,7 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(720);
+      setState(702);
       _la = _input.LA(1);
       if ( !(((((_la - 101)) & ~0x3f) == 0 && ((1L << (_la - 101)) & ((1L << (EQ - 101)) | (1L << (NULLEQ - 101)) | (1L << (NEQ - 101)) | (1L << (LT - 101)) | (1L << (LTE - 101)) | (1L << (GT - 101)) | (1L << (GTE - 101)))) != 0)) ) {
       _errHandler.recoverInline(this);
@@ -5515,7 +5490,7 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(722);
+      setState(704);
       _la = _input.LA(1);
       if ( !(_la==FALSE || _la==TRUE) ) {
       _errHandler.recoverInline(this);
@@ -5583,13 +5558,13 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(724);
+      setState(706);
       match(INTERVAL);
-      setState(726);
+      setState(708);
       _la = _input.LA(1);
       if (_la==PLUS || _la==MINUS) {
         {
-        setState(725);
+        setState(707);
         ((IntervalContext)_localctx).sign = _input.LT(1);
         _la = _input.LA(1);
         if ( !(_la==PLUS || _la==MINUS) ) {
@@ -5600,35 +5575,35 @@ class SqlBaseParser extends Parser {
         }
       }
 
-      setState(730);
+      setState(712);
       switch (_input.LA(1)) {
       case INTEGER_VALUE:
       case DECIMAL_VALUE:
         {
-        setState(728);
+        setState(710);
         ((IntervalContext)_localctx).valueNumeric = number();
         }
         break;
       case PARAM:
       case STRING:
         {
-        setState(729);
+        setState(711);
         ((IntervalContext)_localctx).valuePattern = string();
         }
         break;
       default:
         throw new NoViableAltException(this);
       }
-      setState(732);
+      setState(714);
       ((IntervalContext)_localctx).leading = intervalField();
-      setState(735);
+      setState(717);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,98,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,93,_ctx) ) {
       case 1:
         {
-        setState(733);
+        setState(715);
         match(TO);
-        setState(734);
+        setState(716);
         ((IntervalContext)_localctx).trailing = intervalField();
         }
         break;
@@ -5685,7 +5660,7 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(737);
+      setState(719);
       _la = _input.LA(1);
       if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << DAY) | (1L << DAYS) | (1L << HOUR) | (1L << HOURS) | (1L << MINUTE) | (1L << MINUTES) | (1L << MONTH) | (1L << MONTHS))) != 0) || ((((_la - 75)) & ~0x3f) == 0 && ((1L << (_la - 75)) & ((1L << (SECOND - 75)) | (1L << (SECONDS - 75)) | (1L << (YEAR - 75)) | (1L << (YEARS - 75)))) != 0)) ) {
       _errHandler.recoverInline(this);
@@ -5743,7 +5718,7 @@ class SqlBaseParser extends Parser {
       _localctx = new PrimitiveDataTypeContext(_localctx);
       enterOuterAlt(_localctx, 1);
       {
-      setState(739);
+      setState(721);
       identifier();
       }
     }
@@ -5795,25 +5770,25 @@ class SqlBaseParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(746);
+      setState(728);
       _errHandler.sync(this);
-      _alt = getInterpreter().adaptivePredict(_input,99,_ctx);
+      _alt = getInterpreter().adaptivePredict(_input,94,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
         if ( _alt==1 ) {
           {
           {
-          setState(741);
+          setState(723);
           identifier();
-          setState(742);
+          setState(724);
           match(DOT);
           }
           } 
         }
-        setState(748);
+        setState(730);
         _errHandler.sync(this);
-        _alt = getInterpreter().adaptivePredict(_input,99,_ctx);
+        _alt = getInterpreter().adaptivePredict(_input,94,_ctx);
       }
-      setState(749);
+      setState(731);
       identifier();
       }
     }
@@ -5858,13 +5833,13 @@ class SqlBaseParser extends Parser {
     IdentifierContext _localctx = new IdentifierContext(_ctx, getState());
     enterRule(_localctx, 94, RULE_identifier);
     try {
-      setState(753);
+      setState(735);
       switch (_input.LA(1)) {
       case QUOTED_IDENTIFIER:
       case BACKQUOTED_IDENTIFIER:
         enterOuterAlt(_localctx, 1);
         {
-        setState(751);
+        setState(733);
         quoteIdentifier();
         }
         break;
@@ -5872,6 +5847,9 @@ class SqlBaseParser extends Parser {
       case ANALYZED:
       case CATALOGS:
       case COLUMNS:
+      case CURRENT_DATE:
+      case CURRENT_TIME:
+      case CURRENT_TIMESTAMP:
       case DAY:
       case DEBUG:
       case EXECUTABLE:
@@ -5908,7 +5886,7 @@ class SqlBaseParser extends Parser {
       case DIGIT_IDENTIFIER:
         enterOuterAlt(_localctx, 2);
         {
-        setState(752);
+        setState(734);
         unquoteIdentifier();
         }
         break;
@@ -5961,43 +5939,43 @@ class SqlBaseParser extends Parser {
     enterRule(_localctx, 96, RULE_tableIdentifier);
     int _la;
     try {
-      setState(767);
+      setState(749);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,103,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,98,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(758);
+        setState(740);
         _la = _input.LA(1);
-        if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ANALYZE) | (1L << ANALYZED) | (1L << CATALOGS) | (1L << COLUMNS) | (1L << DAY) | (1L << DEBUG) | (1L << EXECUTABLE) | (1L << EXPLAIN) | (1L << FIRST) | (1L << FORMAT) | (1L << FULL) | (1L << FUNCTIONS) | (1L << GRAPHVIZ) | (1L << HOUR) | (1L << INTERVAL) | (1L << LAST) | (1L << LIMIT) | (1L << MAPPED) | (1L << MINUTE) | (1L << MONTH))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (OPTIMIZED - 64)) | (1L << (PARSED - 64)) | (1L << (PHYSICAL - 64)) | (1L << (PLAN - 64)) | (1L << (RLIKE - 64)) | (1L << (QUERY - 64)) | (1L << (SCHEMAS - 64)) | (1L << (SECOND - 64)) | (1L << (SHOW - 64)) | (1L << (SYS - 64)) | (1L << (TABLES - 64)) | (1L << (TEXT - 64)) | (1L << (TYPE - 64)) | (1L << (TYPES - 64)) | (1L << (VERIFY - 64)) | (1L << (YEAR - 64)) | (1L << (IDENTIFIER - 64)) | (1L << (DIGIT_IDENTIFIER - 64)) | (1L << (QUOTED_IDENTIFIER - 64)) | (1L << (BACKQUOTED_IDENTIFIER - 64)))) != 0)) {
+        if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ANALYZE) | (1L << ANALYZED) | (1L << CATALOGS) | (1L << COLUMNS) | (1L << CURRENT_DATE) | (1L << CURRENT_TIME) | (1L << CURRENT_TIMESTAMP) | (1L << DAY) | (1L << DEBUG) | (1L << EXECUTABLE) | (1L << EXPLAIN) | (1L << FIRST) | (1L << FORMAT) | (1L << FULL) | (1L << FUNCTIONS) | (1L << GRAPHVIZ) | (1L << HOUR) | (1L << INTERVAL) | (1L << LAST) | (1L << LIMIT) | (1L << MAPPED) | (1L << MINUTE) | (1L << MONTH))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (OPTIMIZED - 64)) | (1L << (PARSED - 64)) | (1L << (PHYSICAL - 64)) | (1L << (PLAN - 64)) | (1L << (RLIKE - 64)) | (1L << (QUERY - 64)) | (1L << (SCHEMAS - 64)) | (1L << (SECOND - 64)) | (1L << (SHOW - 64)) | (1L << (SYS - 64)) | (1L << (TABLES - 64)) | (1L << (TEXT - 64)) | (1L << (TYPE - 64)) | (1L << (TYPES - 64)) | (1L << (VERIFY - 64)) | (1L << (YEAR - 64)) | (1L << (IDENTIFIER - 64)) | (1L << (DIGIT_IDENTIFIER - 64)) | (1L << (QUOTED_IDENTIFIER - 64)) | (1L << (BACKQUOTED_IDENTIFIER - 64)))) != 0)) {
           {
-          setState(755);
+          setState(737);
           ((TableIdentifierContext)_localctx).catalog = identifier();
-          setState(756);
+          setState(738);
           match(T__3);
           }
         }
 
-        setState(760);
+        setState(742);
         match(TABLE_IDENTIFIER);
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(764);
+        setState(746);
         _errHandler.sync(this);
-        switch ( getInterpreter().adaptivePredict(_input,102,_ctx) ) {
+        switch ( getInterpreter().adaptivePredict(_input,97,_ctx) ) {
         case 1:
           {
-          setState(761);
+          setState(743);
           ((TableIdentifierContext)_localctx).catalog = identifier();
-          setState(762);
+          setState(744);
           match(T__3);
           }
           break;
         }
-        setState(766);
+        setState(748);
         ((TableIdentifierContext)_localctx).name = identifier();
         }
         break;
@@ -6064,13 +6042,13 @@ class SqlBaseParser extends Parser {
     QuoteIdentifierContext _localctx = new QuoteIdentifierContext(_ctx, getState());
     enterRule(_localctx, 98, RULE_quoteIdentifier);
     try {
-      setState(771);
+      setState(753);
       switch (_input.LA(1)) {
       case QUOTED_IDENTIFIER:
         _localctx = new QuotedIdentifierContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(769);
+        setState(751);
         match(QUOTED_IDENTIFIER);
         }
         break;
@@ -6078,7 +6056,7 @@ class SqlBaseParser extends Parser {
         _localctx = new BackQuotedIdentifierContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(770);
+        setState(752);
         match(BACKQUOTED_IDENTIFIER);
         }
         break;
@@ -6150,13 +6128,13 @@ class SqlBaseParser extends Parser {
     UnquoteIdentifierContext _localctx = new UnquoteIdentifierContext(_ctx, getState());
     enterRule(_localctx, 100, RULE_unquoteIdentifier);
     try {
-      setState(776);
+      setState(758);
       switch (_input.LA(1)) {
       case IDENTIFIER:
         _localctx = new UnquotedIdentifierContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(773);
+        setState(755);
         match(IDENTIFIER);
         }
         break;
@@ -6164,6 +6142,9 @@ class SqlBaseParser extends Parser {
       case ANALYZED:
       case CATALOGS:
       case COLUMNS:
+      case CURRENT_DATE:
+      case CURRENT_TIME:
+      case CURRENT_TIMESTAMP:
       case DAY:
       case DEBUG:
       case EXECUTABLE:
@@ -6199,7 +6180,7 @@ class SqlBaseParser extends Parser {
         _localctx = new UnquotedIdentifierContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(774);
+        setState(756);
         nonReserved();
         }
         break;
@@ -6207,7 +6188,7 @@ class SqlBaseParser extends Parser {
         _localctx = new DigitIdentifierContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(775);
+        setState(757);
         match(DIGIT_IDENTIFIER);
         }
         break;
@@ -6276,13 +6257,13 @@ class SqlBaseParser extends Parser {
     NumberContext _localctx = new NumberContext(_ctx, getState());
     enterRule(_localctx, 102, RULE_number);
     try {
-      setState(780);
+      setState(762);
       switch (_input.LA(1)) {
       case DECIMAL_VALUE:
         _localctx = new DecimalLiteralContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(778);
+        setState(760);
         match(DECIMAL_VALUE);
         }
         break;
@@ -6290,7 +6271,7 @@ class SqlBaseParser extends Parser {
         _localctx = new IntegerLiteralContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(779);
+        setState(761);
         match(INTEGER_VALUE);
         }
         break;
@@ -6338,7 +6319,7 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(782);
+      setState(764);
       _la = _input.LA(1);
       if ( !(_la==PARAM || _la==STRING) ) {
       _errHandler.recoverInline(this);
@@ -6363,6 +6344,9 @@ class SqlBaseParser extends Parser {
     public TerminalNode ANALYZED() { return getToken(SqlBaseParser.ANALYZED, 0); }
     public TerminalNode CATALOGS() { return getToken(SqlBaseParser.CATALOGS, 0); }
     public TerminalNode COLUMNS() { return getToken(SqlBaseParser.COLUMNS, 0); }
+    public TerminalNode CURRENT_DATE() { return getToken(SqlBaseParser.CURRENT_DATE, 0); }
+    public TerminalNode CURRENT_TIME() { return getToken(SqlBaseParser.CURRENT_TIME, 0); }
+    public TerminalNode CURRENT_TIMESTAMP() { return getToken(SqlBaseParser.CURRENT_TIMESTAMP, 0); }
     public TerminalNode DAY() { return getToken(SqlBaseParser.DAY, 0); }
     public TerminalNode DEBUG() { return getToken(SqlBaseParser.DEBUG, 0); }
     public TerminalNode EXECUTABLE() { return getToken(SqlBaseParser.EXECUTABLE, 0); }
@@ -6421,9 +6405,9 @@ class SqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(784);
+      setState(766);
       _la = _input.LA(1);
-      if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ANALYZE) | (1L << ANALYZED) | (1L << CATALOGS) | (1L << COLUMNS) | (1L << DAY) | (1L << DEBUG) | (1L << EXECUTABLE) | (1L << EXPLAIN) | (1L << FIRST) | (1L << FORMAT) | (1L << FULL) | (1L << FUNCTIONS) | (1L << GRAPHVIZ) | (1L << HOUR) | (1L << INTERVAL) | (1L << LAST) | (1L << LIMIT) | (1L << MAPPED) | (1L << MINUTE) | (1L << MONTH))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (OPTIMIZED - 64)) | (1L << (PARSED - 64)) | (1L << (PHYSICAL - 64)) | (1L << (PLAN - 64)) | (1L << (RLIKE - 64)) | (1L << (QUERY - 64)) | (1L << (SCHEMAS - 64)) | (1L << (SECOND - 64)) | (1L << (SHOW - 64)) | (1L << (SYS - 64)) | (1L << (TABLES - 64)) | (1L << (TEXT - 64)) | (1L << (TYPE - 64)) | (1L << (TYPES - 64)) | (1L << (VERIFY - 64)) | (1L << (YEAR - 64)))) != 0)) ) {
+      if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ANALYZE) | (1L << ANALYZED) | (1L << CATALOGS) | (1L << COLUMNS) | (1L << CURRENT_DATE) | (1L << CURRENT_TIME) | (1L << CURRENT_TIMESTAMP) | (1L << DAY) | (1L << DEBUG) | (1L << EXECUTABLE) | (1L << EXPLAIN) | (1L << FIRST) | (1L << FORMAT) | (1L << FULL) | (1L << FUNCTIONS) | (1L << GRAPHVIZ) | (1L << HOUR) | (1L << INTERVAL) | (1L << LAST) | (1L << LIMIT) | (1L << MAPPED) | (1L << MINUTE) | (1L << MONTH))) != 0) || ((((_la - 64)) & ~0x3f) == 0 && ((1L << (_la - 64)) & ((1L << (OPTIMIZED - 64)) | (1L << (PARSED - 64)) | (1L << (PHYSICAL - 64)) | (1L << (PLAN - 64)) | (1L << (RLIKE - 64)) | (1L << (QUERY - 64)) | (1L << (SCHEMAS - 64)) | (1L << (SECOND - 64)) | (1L << (SHOW - 64)) | (1L << (SYS - 64)) | (1L << (TABLES - 64)) | (1L << (TEXT - 64)) | (1L << (TYPE - 64)) | (1L << (TYPES - 64)) | (1L << (VERIFY - 64)) | (1L << (YEAR - 64)))) != 0)) ) {
       _errHandler.recoverInline(this);
       } else {
         consume();
@@ -6481,7 +6465,7 @@ class SqlBaseParser extends Parser {
   }
 
   public static final String _serializedATN =
-    "\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3\u0083\u0315\4\2\t"+
+    "\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3\u0083\u0303\4\2\t"+
     "\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13"+
     "\t\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22"+
     "\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31\t\31"+
@@ -6528,115 +6512,114 @@ class SqlBaseParser extends Parser {
     "\n\37\3\37\3\37\3\37\3\37\3\37\3\37\3\37\3\37\3\37\3\37\7\37\u0237\n\37"+
     "\f\37\16\37\u023a\13\37\3 \3 \3 \3 \3 \3 \3 \3 \5 \u0244\n \3 \3 \3 \3"+
     " \3 \3 \3 \3 \3 \3 \3 \5 \u0251\n \3 \3 \3 \7 \u0256\n \f \16 \u0259\13"+
-    " \3!\3!\3!\5!\u025e\n!\3!\5!\u0261\n!\3!\3!\3!\5!\u0266\n!\3!\3!\3!\5"+
-    "!\u026b\n!\3!\5!\u026e\n!\5!\u0270\n!\3\"\3\"\3\"\3\"\3\"\3\"\3\"\3\""+
-    "\3\"\3\"\5\"\u027c\n\"\3#\3#\3#\3#\3#\3#\3#\3$\3$\3$\3$\3$\3$\3$\3%\3"+
-    "%\3%\3%\3%\5%\u0291\n%\3&\3&\3&\3&\3&\3&\3&\3\'\3\'\3\'\3\'\3\'\5\'\u029f"+
-    "\n\'\3(\3(\3(\5(\u02a4\n(\3(\3(\3(\7(\u02a9\n(\f(\16(\u02ac\13(\5(\u02ae"+
-    "\n(\3(\3(\3)\3)\3)\5)\u02b5\n)\3*\3*\3*\3*\3*\6*\u02bc\n*\r*\16*\u02bd"+
-    "\3*\3*\3*\3*\3*\3*\3*\3*\3*\3*\3*\3*\3*\3*\3*\3*\3*\5*\u02d1\n*\3+\3+"+
-    "\3,\3,\3-\3-\5-\u02d9\n-\3-\3-\5-\u02dd\n-\3-\3-\3-\5-\u02e2\n-\3.\3."+
-    "\3/\3/\3\60\3\60\3\60\7\60\u02eb\n\60\f\60\16\60\u02ee\13\60\3\60\3\60"+
-    "\3\61\3\61\5\61\u02f4\n\61\3\62\3\62\3\62\5\62\u02f9\n\62\3\62\3\62\3"+
-    "\62\3\62\5\62\u02ff\n\62\3\62\5\62\u0302\n\62\3\63\3\63\5\63\u0306\n\63"+
-    "\3\64\3\64\3\64\5\64\u030b\n\64\3\65\3\65\5\65\u030f\n\65\3\66\3\66\3"+
-    "\67\3\67\3\67\2\5.<>8\2\4\6\b\n\f\16\20\22\24\26\30\32\34\36 \"$&(*,."+
-    "\60\62\64\668:<>@BDFHJLNPRTVXZ\\^`bdfhjl\2\22\b\2\7\7\t\t\37\37\67\67"+
-    "BBFF\4\2))TT\4\2\t\tBB\4\2&&..\3\2\33\34\3\2no\4\2\7\7xx\4\2\r\r\33\33"+
-    "\4\2$$\63\63\4\2\7\7\35\35\3\2pr\3\2gm\4\2##UU\7\2\30\31,-9<MN]^\3\2v"+
-    "w\30\2\b\t\22\23\30\30\32\32\37\37!!$%\'),,\60\60\63\63\66\6799;;BBFH"+
-    "JMPQSTWXZZ]]\u0376\2n\3\2\2\2\4q\3\2\2\2\6\u00d9\3\2\2\2\b\u00e4\3\2\2"+
-    "\2\n\u00e8\3\2\2\2\f\u00fd\3\2\2\2\16\u0104\3\2\2\2\20\u0106\3\2\2\2\22"+
-    "\u010e\3\2\2\2\24\u012a\3\2\2\2\26\u0134\3\2\2\2\30\u013e\3\2\2\2\32\u014d"+
-    "\3\2\2\2\34\u014f\3\2\2\2\36\u0155\3\2\2\2 \u0157\3\2\2\2\"\u015e\3\2"+
-    "\2\2$\u0170\3\2\2\2&\u0181\3\2\2\2(\u0191\3\2\2\2*\u01ac\3\2\2\2,\u01ae"+
-    "\3\2\2\2.\u01cf\3\2\2\2\60\u01e0\3\2\2\2\62\u01e3\3\2\2\2\64\u0215\3\2"+
-    "\2\2\66\u0217\3\2\2\28\u021a\3\2\2\2:\u0224\3\2\2\2<\u022a\3\2\2\2>\u0250"+
-    "\3\2\2\2@\u026f\3\2\2\2B\u027b\3\2\2\2D\u027d\3\2\2\2F\u0284\3\2\2\2H"+
-    "\u0290\3\2\2\2J\u0292\3\2\2\2L\u029e\3\2\2\2N\u02a0\3\2\2\2P\u02b4\3\2"+
-    "\2\2R\u02d0\3\2\2\2T\u02d2\3\2\2\2V\u02d4\3\2\2\2X\u02d6\3\2\2\2Z\u02e3"+
-    "\3\2\2\2\\\u02e5\3\2\2\2^\u02ec\3\2\2\2`\u02f3\3\2\2\2b\u0301\3\2\2\2"+
-    "d\u0305\3\2\2\2f\u030a\3\2\2\2h\u030e\3\2\2\2j\u0310\3\2\2\2l\u0312\3"+
-    "\2\2\2no\5\6\4\2op\7\2\2\3p\3\3\2\2\2qr\5,\27\2rs\7\2\2\3s\5\3\2\2\2t"+
-    "\u00da\5\b\5\2u\u0083\7!\2\2v\177\7\3\2\2wx\7H\2\2x~\t\2\2\2yz\7%\2\2"+
-    "z~\t\3\2\2{|\7Z\2\2|~\5V,\2}w\3\2\2\2}y\3\2\2\2}{\3\2\2\2~\u0081\3\2\2"+
-    "\2\177}\3\2\2\2\177\u0080\3\2\2\2\u0080\u0082\3\2\2\2\u0081\177\3\2\2"+
-    "\2\u0082\u0084\7\4\2\2\u0083v\3\2\2\2\u0083\u0084\3\2\2\2\u0084\u0085"+
-    "\3\2\2\2\u0085\u00da\5\6\4\2\u0086\u0092\7\32\2\2\u0087\u008e\7\3\2\2"+
-    "\u0088\u0089\7H\2\2\u0089\u008d\t\4\2\2\u008a\u008b\7%\2\2\u008b\u008d"+
-    "\t\3\2\2\u008c\u0088\3\2\2\2\u008c\u008a\3\2\2\2\u008d\u0090\3\2\2\2\u008e"+
-    "\u008c\3\2\2\2\u008e\u008f\3\2\2\2\u008f\u0091\3\2\2\2\u0090\u008e\3\2"+
-    "\2\2\u0091\u0093\7\4\2\2\u0092\u0087\3\2\2\2\u0092\u0093\3\2\2\2\u0093"+
-    "\u0094\3\2\2\2\u0094\u00da\5\6\4\2\u0095\u0096\7P\2\2\u0096\u0099\7S\2"+
-    "\2\u0097\u009a\5\66\34\2\u0098\u009a\5b\62\2\u0099\u0097\3\2\2\2\u0099"+
-    "\u0098\3\2\2\2\u0099\u009a\3\2\2\2\u009a\u00da\3\2\2\2\u009b\u009c\7P"+
-    "\2\2\u009c\u009d\7\23\2\2\u009d\u00a0\t\5\2\2\u009e\u00a1\5\66\34\2\u009f"+
-    "\u00a1\5b\62\2\u00a0\u009e\3\2\2\2\u00a0\u009f\3\2\2\2\u00a1\u00da\3\2"+
-    "\2\2\u00a2\u00a5\t\6\2\2\u00a3\u00a6\5\66\34\2\u00a4\u00a6\5b\62\2\u00a5"+
-    "\u00a3\3\2\2\2\u00a5\u00a4\3\2\2\2\u00a6\u00da\3\2\2\2\u00a7\u00a8\7P"+
-    "\2\2\u00a8\u00aa\7(\2\2\u00a9\u00ab\5\66\34\2\u00aa\u00a9\3\2\2\2\u00aa"+
-    "\u00ab\3\2\2\2\u00ab\u00da\3\2\2\2\u00ac\u00ad\7P\2\2\u00ad\u00da\7L\2"+
-    "\2\u00ae\u00af\7Q\2\2\u00af\u00b2\7S\2\2\u00b0\u00b1\7\21\2\2\u00b1\u00b3"+
-    "\5\66\34\2\u00b2\u00b0\3\2\2\2\u00b2\u00b3\3\2\2\2\u00b3\u00b6\3\2\2\2"+
-    "\u00b4\u00b7\5\66\34\2\u00b5\u00b7\5b\62\2\u00b6\u00b4\3\2\2\2\u00b6\u00b5"+
-    "\3\2\2\2\u00b6\u00b7\3\2\2\2\u00b7\u00c1\3\2\2\2\u00b8\u00b9\7W\2\2\u00b9"+
-    "\u00be\5j\66\2\u00ba\u00bb\7\5\2\2\u00bb\u00bd\5j\66\2\u00bc\u00ba\3\2"+
-    "\2\2\u00bd\u00c0\3\2\2\2\u00be\u00bc\3\2\2\2\u00be\u00bf\3\2\2\2\u00bf"+
-    "\u00c2\3\2\2\2\u00c0\u00be\3\2\2\2\u00c1\u00b8\3\2\2\2\u00c1\u00c2\3\2"+
-    "\2\2\u00c2\u00da\3\2\2\2\u00c3\u00c4\7Q\2\2\u00c4\u00c7\7\23\2\2\u00c5"+
-    "\u00c6\7\21\2\2\u00c6\u00c8\5j\66\2\u00c7\u00c5\3\2\2\2\u00c7\u00c8\3"+
-    "\2\2\2\u00c8\u00cc\3\2\2\2\u00c9\u00ca\7R\2\2\u00ca\u00cd\5\66\34\2\u00cb"+
-    "\u00cd\5b\62\2\u00cc\u00c9\3\2\2\2\u00cc\u00cb\3\2\2\2\u00cc\u00cd\3\2"+
-    "\2\2\u00cd\u00cf\3\2\2\2\u00ce\u00d0\5\66\34\2\u00cf\u00ce\3\2\2\2\u00cf"+
-    "\u00d0\3\2\2\2\u00d0\u00da\3\2\2\2\u00d1\u00d2\7Q\2\2\u00d2\u00d7\7X\2"+
-    "\2\u00d3\u00d5\t\7\2\2\u00d4\u00d3\3\2\2\2\u00d4\u00d5\3\2\2\2\u00d5\u00d6"+
-    "\3\2\2\2\u00d6\u00d8\5h\65\2\u00d7\u00d4\3\2\2\2\u00d7\u00d8\3\2\2\2\u00d8"+
-    "\u00da\3\2\2\2\u00d9t\3\2\2\2\u00d9u\3\2\2\2\u00d9\u0086\3\2\2\2\u00d9"+
-    "\u0095\3\2\2\2\u00d9\u009b\3\2\2\2\u00d9\u00a2\3\2\2\2\u00d9\u00a7\3\2"+
-    "\2\2\u00d9\u00ac\3\2\2\2\u00d9\u00ae\3\2\2\2\u00d9\u00c3\3\2\2\2\u00d9"+
-    "\u00d1\3\2\2\2\u00da\7\3\2\2\2\u00db\u00dc\7\\\2\2\u00dc\u00e1\5\34\17"+
-    "\2\u00dd\u00de\7\5\2\2\u00de\u00e0\5\34\17\2\u00df\u00dd\3\2\2\2\u00e0"+
-    "\u00e3\3\2\2\2\u00e1\u00df\3\2\2\2\u00e1\u00e2\3\2\2\2\u00e2\u00e5\3\2"+
-    "\2\2\u00e3\u00e1\3\2\2\2\u00e4\u00db\3\2\2\2\u00e4\u00e5\3\2\2\2\u00e5"+
-    "\u00e6\3\2\2\2\u00e6\u00e7\5\n\6\2\u00e7\t\3\2\2\2\u00e8\u00f3\5\16\b"+
-    "\2\u00e9\u00ea\7D\2\2\u00ea\u00eb\7\17\2\2\u00eb\u00f0\5\20\t\2\u00ec"+
-    "\u00ed\7\5\2\2\u00ed\u00ef\5\20\t\2\u00ee\u00ec\3\2\2\2\u00ef\u00f2\3"+
-    "\2\2\2\u00f0\u00ee\3\2\2\2\u00f0\u00f1\3\2\2\2\u00f1\u00f4\3\2\2\2\u00f2"+
-    "\u00f0\3\2\2\2\u00f3\u00e9\3\2\2\2\u00f3\u00f4\3\2\2\2\u00f4\u00f6\3\2"+
-    "\2\2\u00f5\u00f7\5\f\7\2\u00f6\u00f5\3\2\2\2\u00f6\u00f7\3\2\2\2\u00f7"+
-    "\13\3\2\2\2\u00f8\u00f9\7\66\2\2\u00f9\u00fe\t\b\2\2\u00fa\u00fb\7a\2"+
-    "\2\u00fb\u00fc\t\b\2\2\u00fc\u00fe\7f\2\2\u00fd\u00f8\3\2\2\2\u00fd\u00fa"+
-    "\3\2\2\2\u00fe\r\3\2\2\2\u00ff\u0105\5\22\n\2\u0100\u0101\7\3\2\2\u0101"+
-    "\u0102\5\n\6\2\u0102\u0103\7\4\2\2\u0103\u0105\3\2\2\2\u0104\u00ff\3\2"+
-    "\2\2\u0104\u0100\3\2\2\2\u0105\17\3\2\2\2\u0106\u0108\5,\27\2\u0107\u0109"+
-    "\t\t\2\2\u0108\u0107\3\2\2\2\u0108\u0109\3\2\2\2\u0109\u010c\3\2\2\2\u010a"+
-    "\u010b\7@\2\2\u010b\u010d\t\n\2\2\u010c\u010a\3\2\2\2\u010c\u010d\3\2"+
-    "\2\2\u010d\21\3\2\2\2\u010e\u0110\7O\2\2\u010f\u0111\5\36\20\2\u0110\u010f"+
-    "\3\2\2\2\u0110\u0111\3\2\2\2\u0111\u0112\3\2\2\2\u0112\u0117\5 \21\2\u0113"+
-    "\u0114\7\5\2\2\u0114\u0116\5 \21\2\u0115\u0113\3\2\2\2\u0116\u0119\3\2"+
-    "\2\2\u0117\u0115\3\2\2\2\u0117\u0118\3\2\2\2\u0118\u011b\3\2\2\2\u0119"+
-    "\u0117\3\2\2\2\u011a\u011c\5\24\13\2\u011b\u011a\3\2\2\2\u011b\u011c\3"+
-    "\2\2\2\u011c\u011f\3\2\2\2\u011d\u011e\7[\2\2\u011e\u0120\5.\30\2\u011f"+
-    "\u011d\3\2\2\2\u011f\u0120\3\2\2\2\u0120\u0124\3\2\2\2\u0121\u0122\7*"+
-    "\2\2\u0122\u0123\7\17\2\2\u0123\u0125\5\26\f\2\u0124\u0121\3\2\2\2\u0124"+
-    "\u0125\3\2\2\2\u0125\u0128\3\2\2\2\u0126\u0127\7+\2\2\u0127\u0129\5.\30"+
-    "\2\u0128\u0126\3\2\2\2\u0128\u0129\3\2\2\2\u0129\23\3\2\2\2\u012a\u012b"+
-    "\7&\2\2\u012b\u0130\5\"\22\2\u012c\u012d\7\5\2\2\u012d\u012f\5\"\22\2"+
-    "\u012e\u012c\3\2\2\2\u012f\u0132\3\2\2\2\u0130\u012e\3\2\2\2\u0130\u0131"+
-    "\3\2\2\2\u0131\25\3\2\2\2\u0132\u0130\3\2\2\2\u0133\u0135\5\36\20\2\u0134"+
-    "\u0133\3\2\2\2\u0134\u0135\3\2\2\2\u0135\u0136\3\2\2\2\u0136\u013b\5\30"+
-    "\r\2\u0137\u0138\7\5\2\2\u0138\u013a\5\30\r\2\u0139\u0137\3\2\2\2\u013a"+
-    "\u013d\3\2\2\2\u013b\u0139\3\2\2\2\u013b\u013c\3\2\2\2\u013c\27\3\2\2"+
-    "\2\u013d\u013b\3\2\2\2\u013e\u013f\5\32\16\2\u013f\31\3\2\2\2\u0140\u0149"+
-    "\7\3\2\2\u0141\u0146\5,\27\2\u0142\u0143\7\5\2\2\u0143\u0145\5,\27\2\u0144"+
-    "\u0142\3\2\2\2\u0145\u0148\3\2\2\2\u0146\u0144\3\2\2\2\u0146\u0147\3\2"+
-    "\2\2\u0147\u014a\3\2\2\2\u0148\u0146\3\2\2\2\u0149\u0141\3\2\2\2\u0149"+
-    "\u014a\3\2\2\2\u014a\u014b\3\2\2\2\u014b\u014e\7\4\2\2\u014c\u014e\5,"+
-    "\27\2\u014d\u0140\3\2\2\2\u014d\u014c\3\2\2\2\u014e\33\3\2\2\2\u014f\u0150"+
-    "\5`\61\2\u0150\u0151\7\f\2\2\u0151\u0152\7\3\2\2\u0152\u0153\5\n\6\2\u0153"+
-    "\u0154\7\4\2\2\u0154\35\3\2\2\2\u0155\u0156\t\13\2\2\u0156\37\3\2\2\2"+
-    "\u0157\u015c\5,\27\2\u0158\u015a\7\f\2\2\u0159\u0158\3\2\2\2\u0159\u015a"+
-    "\3\2\2\2\u015a\u015b\3\2\2\2\u015b\u015d\5`\61\2\u015c\u0159\3\2\2\2\u015c"+
+    " \3!\3!\3!\5!\u025e\n!\3\"\3\"\3\"\3\"\3\"\3\"\3\"\3\"\3\"\3\"\5\"\u026a"+
+    "\n\"\3#\3#\3#\3#\3#\3#\3#\3$\3$\3$\3$\3$\3$\3$\3%\3%\3%\3%\3%\5%\u027f"+
+    "\n%\3&\3&\3&\3&\3&\3&\3&\3\'\3\'\3\'\3\'\3\'\5\'\u028d\n\'\3(\3(\3(\5"+
+    "(\u0292\n(\3(\3(\3(\7(\u0297\n(\f(\16(\u029a\13(\5(\u029c\n(\3(\3(\3)"+
+    "\3)\3)\5)\u02a3\n)\3*\3*\3*\3*\3*\6*\u02aa\n*\r*\16*\u02ab\3*\3*\3*\3"+
+    "*\3*\3*\3*\3*\3*\3*\3*\3*\3*\3*\3*\3*\3*\5*\u02bf\n*\3+\3+\3,\3,\3-\3"+
+    "-\5-\u02c7\n-\3-\3-\5-\u02cb\n-\3-\3-\3-\5-\u02d0\n-\3.\3.\3/\3/\3\60"+
+    "\3\60\3\60\7\60\u02d9\n\60\f\60\16\60\u02dc\13\60\3\60\3\60\3\61\3\61"+
+    "\5\61\u02e2\n\61\3\62\3\62\3\62\5\62\u02e7\n\62\3\62\3\62\3\62\3\62\5"+
+    "\62\u02ed\n\62\3\62\5\62\u02f0\n\62\3\63\3\63\5\63\u02f4\n\63\3\64\3\64"+
+    "\3\64\5\64\u02f9\n\64\3\65\3\65\5\65\u02fd\n\65\3\66\3\66\3\67\3\67\3"+
+    "\67\2\5.<>8\2\4\6\b\n\f\16\20\22\24\26\30\32\34\36 \"$&(*,.\60\62\64\66"+
+    "8:<>@BDFHJLNPRTVXZ\\^`bdfhjl\2\22\b\2\7\7\t\t\37\37\67\67BBFF\4\2))TT"+
+    "\4\2\t\tBB\4\2&&..\3\2\33\34\3\2no\4\2\7\7xx\4\2\r\r\33\33\4\2$$\63\63"+
+    "\4\2\7\7\35\35\3\2pr\3\2gm\4\2##UU\7\2\30\31,-9<MN]^\3\2vw\30\2\b\t\22"+
+    "\23\25\30\32\32\37\37!!$%\'),,\60\60\63\63\66\6799;;BBFHJMPQSTWXZZ]]\u035f"+
+    "\2n\3\2\2\2\4q\3\2\2\2\6\u00d9\3\2\2\2\b\u00e4\3\2\2\2\n\u00e8\3\2\2\2"+
+    "\f\u00fd\3\2\2\2\16\u0104\3\2\2\2\20\u0106\3\2\2\2\22\u010e\3\2\2\2\24"+
+    "\u012a\3\2\2\2\26\u0134\3\2\2\2\30\u013e\3\2\2\2\32\u014d\3\2\2\2\34\u014f"+
+    "\3\2\2\2\36\u0155\3\2\2\2 \u0157\3\2\2\2\"\u015e\3\2\2\2$\u0170\3\2\2"+
+    "\2&\u0181\3\2\2\2(\u0191\3\2\2\2*\u01ac\3\2\2\2,\u01ae\3\2\2\2.\u01cf"+
+    "\3\2\2\2\60\u01e0\3\2\2\2\62\u01e3\3\2\2\2\64\u0215\3\2\2\2\66\u0217\3"+
+    "\2\2\28\u021a\3\2\2\2:\u0224\3\2\2\2<\u022a\3\2\2\2>\u0250\3\2\2\2@\u025d"+
+    "\3\2\2\2B\u0269\3\2\2\2D\u026b\3\2\2\2F\u0272\3\2\2\2H\u027e\3\2\2\2J"+
+    "\u0280\3\2\2\2L\u028c\3\2\2\2N\u028e\3\2\2\2P\u02a2\3\2\2\2R\u02be\3\2"+
+    "\2\2T\u02c0\3\2\2\2V\u02c2\3\2\2\2X\u02c4\3\2\2\2Z\u02d1\3\2\2\2\\\u02d3"+
+    "\3\2\2\2^\u02da\3\2\2\2`\u02e1\3\2\2\2b\u02ef\3\2\2\2d\u02f3\3\2\2\2f"+
+    "\u02f8\3\2\2\2h\u02fc\3\2\2\2j\u02fe\3\2\2\2l\u0300\3\2\2\2no\5\6\4\2"+
+    "op\7\2\2\3p\3\3\2\2\2qr\5,\27\2rs\7\2\2\3s\5\3\2\2\2t\u00da\5\b\5\2u\u0083"+
+    "\7!\2\2v\177\7\3\2\2wx\7H\2\2x~\t\2\2\2yz\7%\2\2z~\t\3\2\2{|\7Z\2\2|~"+
+    "\5V,\2}w\3\2\2\2}y\3\2\2\2}{\3\2\2\2~\u0081\3\2\2\2\177}\3\2\2\2\177\u0080"+
+    "\3\2\2\2\u0080\u0082\3\2\2\2\u0081\177\3\2\2\2\u0082\u0084\7\4\2\2\u0083"+
+    "v\3\2\2\2\u0083\u0084\3\2\2\2\u0084\u0085\3\2\2\2\u0085\u00da\5\6\4\2"+
+    "\u0086\u0092\7\32\2\2\u0087\u008e\7\3\2\2\u0088\u0089\7H\2\2\u0089\u008d"+
+    "\t\4\2\2\u008a\u008b\7%\2\2\u008b\u008d\t\3\2\2\u008c\u0088\3\2\2\2\u008c"+
+    "\u008a\3\2\2\2\u008d\u0090\3\2\2\2\u008e\u008c\3\2\2\2\u008e\u008f\3\2"+
+    "\2\2\u008f\u0091\3\2\2\2\u0090\u008e\3\2\2\2\u0091\u0093\7\4\2\2\u0092"+
+    "\u0087\3\2\2\2\u0092\u0093\3\2\2\2\u0093\u0094\3\2\2\2\u0094\u00da\5\6"+
+    "\4\2\u0095\u0096\7P\2\2\u0096\u0099\7S\2\2\u0097\u009a\5\66\34\2\u0098"+
+    "\u009a\5b\62\2\u0099\u0097\3\2\2\2\u0099\u0098\3\2\2\2\u0099\u009a\3\2"+
+    "\2\2\u009a\u00da\3\2\2\2\u009b\u009c\7P\2\2\u009c\u009d\7\23\2\2\u009d"+
+    "\u00a0\t\5\2\2\u009e\u00a1\5\66\34\2\u009f\u00a1\5b\62\2\u00a0\u009e\3"+
+    "\2\2\2\u00a0\u009f\3\2\2\2\u00a1\u00da\3\2\2\2\u00a2\u00a5\t\6\2\2\u00a3"+
+    "\u00a6\5\66\34\2\u00a4\u00a6\5b\62\2\u00a5\u00a3\3\2\2\2\u00a5\u00a4\3"+
+    "\2\2\2\u00a6\u00da\3\2\2\2\u00a7\u00a8\7P\2\2\u00a8\u00aa\7(\2\2\u00a9"+
+    "\u00ab\5\66\34\2\u00aa\u00a9\3\2\2\2\u00aa\u00ab\3\2\2\2\u00ab\u00da\3"+
+    "\2\2\2\u00ac\u00ad\7P\2\2\u00ad\u00da\7L\2\2\u00ae\u00af\7Q\2\2\u00af"+
+    "\u00b2\7S\2\2\u00b0\u00b1\7\21\2\2\u00b1\u00b3\5\66\34\2\u00b2\u00b0\3"+
+    "\2\2\2\u00b2\u00b3\3\2\2\2\u00b3\u00b6\3\2\2\2\u00b4\u00b7\5\66\34\2\u00b5"+
+    "\u00b7\5b\62\2\u00b6\u00b4\3\2\2\2\u00b6\u00b5\3\2\2\2\u00b6\u00b7\3\2"+
+    "\2\2\u00b7\u00c1\3\2\2\2\u00b8\u00b9\7W\2\2\u00b9\u00be\5j\66\2\u00ba"+
+    "\u00bb\7\5\2\2\u00bb\u00bd\5j\66\2\u00bc\u00ba\3\2\2\2\u00bd\u00c0\3\2"+
+    "\2\2\u00be\u00bc\3\2\2\2\u00be\u00bf\3\2\2\2\u00bf\u00c2\3\2\2\2\u00c0"+
+    "\u00be\3\2\2\2\u00c1\u00b8\3\2\2\2\u00c1\u00c2\3\2\2\2\u00c2\u00da\3\2"+
+    "\2\2\u00c3\u00c4\7Q\2\2\u00c4\u00c7\7\23\2\2\u00c5\u00c6\7\21\2\2\u00c6"+
+    "\u00c8\5j\66\2\u00c7\u00c5\3\2\2\2\u00c7\u00c8\3\2\2\2\u00c8\u00cc\3\2"+
+    "\2\2\u00c9\u00ca\7R\2\2\u00ca\u00cd\5\66\34\2\u00cb\u00cd\5b\62\2\u00cc"+
+    "\u00c9\3\2\2\2\u00cc\u00cb\3\2\2\2\u00cc\u00cd\3\2\2\2\u00cd\u00cf\3\2"+
+    "\2\2\u00ce\u00d0\5\66\34\2\u00cf\u00ce\3\2\2\2\u00cf\u00d0\3\2\2\2\u00d0"+
+    "\u00da\3\2\2\2\u00d1\u00d2\7Q\2\2\u00d2\u00d7\7X\2\2\u00d3\u00d5\t\7\2"+
+    "\2\u00d4\u00d3\3\2\2\2\u00d4\u00d5\3\2\2\2\u00d5\u00d6\3\2\2\2\u00d6\u00d8"+
+    "\5h\65\2\u00d7\u00d4\3\2\2\2\u00d7\u00d8\3\2\2\2\u00d8\u00da\3\2\2\2\u00d9"+
+    "t\3\2\2\2\u00d9u\3\2\2\2\u00d9\u0086\3\2\2\2\u00d9\u0095\3\2\2\2\u00d9"+
+    "\u009b\3\2\2\2\u00d9\u00a2\3\2\2\2\u00d9\u00a7\3\2\2\2\u00d9\u00ac\3\2"+
+    "\2\2\u00d9\u00ae\3\2\2\2\u00d9\u00c3\3\2\2\2\u00d9\u00d1\3\2\2\2\u00da"+
+    "\7\3\2\2\2\u00db\u00dc\7\\\2\2\u00dc\u00e1\5\34\17\2\u00dd\u00de\7\5\2"+
+    "\2\u00de\u00e0\5\34\17\2\u00df\u00dd\3\2\2\2\u00e0\u00e3\3\2\2\2\u00e1"+
+    "\u00df\3\2\2\2\u00e1\u00e2\3\2\2\2\u00e2\u00e5\3\2\2\2\u00e3\u00e1\3\2"+
+    "\2\2\u00e4\u00db\3\2\2\2\u00e4\u00e5\3\2\2\2\u00e5\u00e6\3\2\2\2\u00e6"+
+    "\u00e7\5\n\6\2\u00e7\t\3\2\2\2\u00e8\u00f3\5\16\b\2\u00e9\u00ea\7D\2\2"+
+    "\u00ea\u00eb\7\17\2\2\u00eb\u00f0\5\20\t\2\u00ec\u00ed\7\5\2\2\u00ed\u00ef"+
+    "\5\20\t\2\u00ee\u00ec\3\2\2\2\u00ef\u00f2\3\2\2\2\u00f0\u00ee\3\2\2\2"+
+    "\u00f0\u00f1\3\2\2\2\u00f1\u00f4\3\2\2\2\u00f2\u00f0\3\2\2\2\u00f3\u00e9"+
+    "\3\2\2\2\u00f3\u00f4\3\2\2\2\u00f4\u00f6\3\2\2\2\u00f5\u00f7\5\f\7\2\u00f6"+
+    "\u00f5\3\2\2\2\u00f6\u00f7\3\2\2\2\u00f7\13\3\2\2\2\u00f8\u00f9\7\66\2"+
+    "\2\u00f9\u00fe\t\b\2\2\u00fa\u00fb\7a\2\2\u00fb\u00fc\t\b\2\2\u00fc\u00fe"+
+    "\7f\2\2\u00fd\u00f8\3\2\2\2\u00fd\u00fa\3\2\2\2\u00fe\r\3\2\2\2\u00ff"+
+    "\u0105\5\22\n\2\u0100\u0101\7\3\2\2\u0101\u0102\5\n\6\2\u0102\u0103\7"+
+    "\4\2\2\u0103\u0105\3\2\2\2\u0104\u00ff\3\2\2\2\u0104\u0100\3\2\2\2\u0105"+
+    "\17\3\2\2\2\u0106\u0108\5,\27\2\u0107\u0109\t\t\2\2\u0108\u0107\3\2\2"+
+    "\2\u0108\u0109\3\2\2\2\u0109\u010c\3\2\2\2\u010a\u010b\7@\2\2\u010b\u010d"+
+    "\t\n\2\2\u010c\u010a\3\2\2\2\u010c\u010d\3\2\2\2\u010d\21\3\2\2\2\u010e"+
+    "\u0110\7O\2\2\u010f\u0111\5\36\20\2\u0110\u010f\3\2\2\2\u0110\u0111\3"+
+    "\2\2\2\u0111\u0112\3\2\2\2\u0112\u0117\5 \21\2\u0113\u0114\7\5\2\2\u0114"+
+    "\u0116\5 \21\2\u0115\u0113\3\2\2\2\u0116\u0119\3\2\2\2\u0117\u0115\3\2"+
+    "\2\2\u0117\u0118\3\2\2\2\u0118\u011b\3\2\2\2\u0119\u0117\3\2\2\2\u011a"+
+    "\u011c\5\24\13\2\u011b\u011a\3\2\2\2\u011b\u011c\3\2\2\2\u011c\u011f\3"+
+    "\2\2\2\u011d\u011e\7[\2\2\u011e\u0120\5.\30\2\u011f\u011d\3\2\2\2\u011f"+
+    "\u0120\3\2\2\2\u0120\u0124\3\2\2\2\u0121\u0122\7*\2\2\u0122\u0123\7\17"+
+    "\2\2\u0123\u0125\5\26\f\2\u0124\u0121\3\2\2\2\u0124\u0125\3\2\2\2\u0125"+
+    "\u0128\3\2\2\2\u0126\u0127\7+\2\2\u0127\u0129\5.\30\2\u0128\u0126\3\2"+
+    "\2\2\u0128\u0129\3\2\2\2\u0129\23\3\2\2\2\u012a\u012b\7&\2\2\u012b\u0130"+
+    "\5\"\22\2\u012c\u012d\7\5\2\2\u012d\u012f\5\"\22\2\u012e\u012c\3\2\2\2"+
+    "\u012f\u0132\3\2\2\2\u0130\u012e\3\2\2\2\u0130\u0131\3\2\2\2\u0131\25"+
+    "\3\2\2\2\u0132\u0130\3\2\2\2\u0133\u0135\5\36\20\2\u0134\u0133\3\2\2\2"+
+    "\u0134\u0135\3\2\2\2\u0135\u0136\3\2\2\2\u0136\u013b\5\30\r\2\u0137\u0138"+
+    "\7\5\2\2\u0138\u013a\5\30\r\2\u0139\u0137\3\2\2\2\u013a\u013d\3\2\2\2"+
+    "\u013b\u0139\3\2\2\2\u013b\u013c\3\2\2\2\u013c\27\3\2\2\2\u013d\u013b"+
+    "\3\2\2\2\u013e\u013f\5\32\16\2\u013f\31\3\2\2\2\u0140\u0149\7\3\2\2\u0141"+
+    "\u0146\5,\27\2\u0142\u0143\7\5\2\2\u0143\u0145\5,\27\2\u0144\u0142\3\2"+
+    "\2\2\u0145\u0148\3\2\2\2\u0146\u0144\3\2\2\2\u0146\u0147\3\2\2\2\u0147"+
+    "\u014a\3\2\2\2\u0148\u0146\3\2\2\2\u0149\u0141\3\2\2\2\u0149\u014a\3\2"+
+    "\2\2\u014a\u014b\3\2\2\2\u014b\u014e\7\4\2\2\u014c\u014e\5,\27\2\u014d"+
+    "\u0140\3\2\2\2\u014d\u014c\3\2\2\2\u014e\33\3\2\2\2\u014f\u0150\5`\61"+
+    "\2\u0150\u0151\7\f\2\2\u0151\u0152\7\3\2\2\u0152\u0153\5\n\6\2\u0153\u0154"+
+    "\7\4\2\2\u0154\35\3\2\2\2\u0155\u0156\t\13\2\2\u0156\37\3\2\2\2\u0157"+
+    "\u015c\5,\27\2\u0158\u015a\7\f\2\2\u0159\u0158\3\2\2\2\u0159\u015a\3\2"+
+    "\2\2\u015a\u015b\3\2\2\2\u015b\u015d\5`\61\2\u015c\u0159\3\2\2\2\u015c"+
     "\u015d\3\2\2\2\u015d!\3\2\2\2\u015e\u0162\5*\26\2\u015f\u0161\5$\23\2"+
     "\u0160\u015f\3\2\2\2\u0161\u0164\3\2\2\2\u0162\u0160\3\2\2\2\u0162\u0163"+
     "\3\2\2\2\u0163#\3\2\2\2\u0164\u0162\3\2\2\2\u0165\u0166\5&\24\2\u0166"+
@@ -6723,77 +6706,70 @@ class SqlBaseParser extends Parser {
     "\u024b\3\2\2\2\u0250\u024c\3\2\2\2\u0251\u0257\3\2\2\2\u0252\u0253\f\13"+
     "\2\2\u0253\u0254\7s\2\2\u0254\u0256\5\\/\2\u0255\u0252\3\2\2\2\u0256\u0259"+
     "\3\2\2\2\u0257\u0255\3\2\2\2\u0257\u0258\3\2\2\2\u0258?\3\2\2\2\u0259"+
-    "\u0257\3\2\2\2\u025a\u0260\7\27\2\2\u025b\u025d\7\3\2\2\u025c\u025e\7"+
-    "x\2\2\u025d\u025c\3\2\2\2\u025d\u025e\3\2\2\2\u025e\u025f\3\2\2\2\u025f"+
-    "\u0261\7\4\2\2\u0260\u025b\3\2\2\2\u0260\u0261\3\2\2\2\u0261\u0270\3\2"+
-    "\2\2\u0262\u0265\7\25\2\2\u0263\u0264\7\3\2\2\u0264\u0266\7\4\2\2\u0265"+
-    "\u0263\3\2\2\2\u0265\u0266\3\2\2\2\u0266\u0270\3\2\2\2\u0267\u026d\7\26"+
-    "\2\2\u0268\u026a\7\3\2\2\u0269\u026b\7x\2\2\u026a\u0269\3\2\2\2\u026a"+
-    "\u026b\3\2\2\2\u026b\u026c\3\2\2\2\u026c\u026e\7\4\2\2\u026d\u0268\3\2"+
-    "\2\2\u026d\u026e\3\2\2\2\u026e\u0270\3\2\2\2\u026f\u025a\3\2\2\2\u026f"+
-    "\u0262\3\2\2\2\u026f\u0267\3\2\2\2\u0270A\3\2\2\2\u0271\u027c\5D#\2\u0272"+
-    "\u0273\7`\2\2\u0273\u0274\5D#\2\u0274\u0275\7f\2\2\u0275\u027c\3\2\2\2"+
-    "\u0276\u027c\5F$\2\u0277\u0278\7`\2\2\u0278\u0279\5F$\2\u0279\u027a\7"+
-    "f\2\2\u027a\u027c\3\2\2\2\u027b\u0271\3\2\2\2\u027b\u0272\3\2\2\2\u027b"+
-    "\u0276\3\2\2\2\u027b\u0277\3\2\2\2\u027cC\3\2\2\2\u027d\u027e\7\20\2\2"+
-    "\u027e\u027f\7\3\2\2\u027f\u0280\5,\27\2\u0280\u0281\7\f\2\2\u0281\u0282"+
-    "\5\\/\2\u0282\u0283\7\4\2\2\u0283E\3\2\2\2\u0284\u0285\7\24\2\2\u0285"+
-    "\u0286\7\3\2\2\u0286\u0287\5,\27\2\u0287\u0288\7\5\2\2\u0288\u0289\5\\"+
-    "/\2\u0289\u028a\7\4\2\2\u028aG\3\2\2\2\u028b\u0291\5J&\2\u028c\u028d\7"+
-    "`\2\2\u028d\u028e\5J&\2\u028e\u028f\7f\2\2\u028f\u0291\3\2\2\2\u0290\u028b"+
-    "\3\2\2\2\u0290\u028c\3\2\2\2\u0291I\3\2\2\2\u0292\u0293\7\"\2\2\u0293"+
-    "\u0294\7\3\2\2\u0294\u0295\5`\61\2\u0295\u0296\7&\2\2\u0296\u0297\5<\37"+
-    "\2\u0297\u0298\7\4\2\2\u0298K\3\2\2\2\u0299\u029f\5N(\2\u029a\u029b\7"+
-    "`\2\2\u029b\u029c\5N(\2\u029c\u029d\7f\2\2\u029d\u029f\3\2\2\2\u029e\u0299"+
-    "\3\2\2\2\u029e\u029a\3\2\2\2\u029fM\3\2\2\2\u02a0\u02a1\5P)\2\u02a1\u02ad"+
-    "\7\3\2\2\u02a2\u02a4\5\36\20\2\u02a3\u02a2\3\2\2\2\u02a3\u02a4\3\2\2\2"+
-    "\u02a4\u02a5\3\2\2\2\u02a5\u02aa\5,\27\2\u02a6\u02a7\7\5\2\2\u02a7\u02a9"+
-    "\5,\27\2\u02a8\u02a6\3\2\2\2\u02a9\u02ac\3\2\2\2\u02aa\u02a8\3\2\2\2\u02aa"+
-    "\u02ab\3\2\2\2\u02ab\u02ae\3\2\2\2\u02ac\u02aa\3\2\2\2\u02ad\u02a3\3\2"+
-    "\2\2\u02ad\u02ae\3\2\2\2\u02ae\u02af\3\2\2\2\u02af\u02b0\7\4\2\2\u02b0"+
-    "O\3\2\2\2\u02b1\u02b5\7\64\2\2\u02b2\u02b5\7I\2\2\u02b3\u02b5\5`\61\2"+
-    "\u02b4\u02b1\3\2\2\2\u02b4\u02b2\3\2\2\2\u02b4\u02b3\3\2\2\2\u02b5Q\3"+
-    "\2\2\2\u02b6\u02d1\7?\2\2\u02b7\u02d1\5X-\2\u02b8\u02d1\5h\65\2\u02b9"+
-    "\u02d1\5V,\2\u02ba\u02bc\7w\2\2\u02bb\u02ba\3\2\2\2\u02bc\u02bd\3\2\2"+
-    "\2\u02bd\u02bb\3\2\2\2\u02bd\u02be\3\2\2\2\u02be\u02d1\3\2\2\2\u02bf\u02d1"+
-    "\7v\2\2\u02c0\u02c1\7b\2\2\u02c1\u02c2\5j\66\2\u02c2\u02c3\7f\2\2\u02c3"+
-    "\u02d1\3\2\2\2\u02c4\u02c5\7c\2\2\u02c5\u02c6\5j\66\2\u02c6\u02c7\7f\2"+
-    "\2\u02c7\u02d1\3\2\2\2\u02c8\u02c9\7d\2\2\u02c9\u02ca\5j\66\2\u02ca\u02cb"+
-    "\7f\2\2\u02cb\u02d1\3\2\2\2\u02cc\u02cd\7e\2\2\u02cd\u02ce\5j\66\2\u02ce"+
-    "\u02cf\7f\2\2\u02cf\u02d1\3\2\2\2\u02d0\u02b6\3\2\2\2\u02d0\u02b7\3\2"+
-    "\2\2\u02d0\u02b8\3\2\2\2\u02d0\u02b9\3\2\2\2\u02d0\u02bb\3\2\2\2\u02d0"+
-    "\u02bf\3\2\2\2\u02d0\u02c0\3\2\2\2\u02d0\u02c4\3\2\2\2\u02d0\u02c8\3\2"+
-    "\2\2\u02d0\u02cc\3\2\2\2\u02d1S\3\2\2\2\u02d2\u02d3\t\r\2\2\u02d3U\3\2"+
-    "\2\2\u02d4\u02d5\t\16\2\2\u02d5W\3\2\2\2\u02d6\u02d8\7\60\2\2\u02d7\u02d9"+
-    "\t\7\2\2\u02d8\u02d7\3\2\2\2\u02d8\u02d9\3\2\2\2\u02d9\u02dc\3\2\2\2\u02da"+
-    "\u02dd\5h\65\2\u02db\u02dd\5j\66\2\u02dc\u02da\3\2\2\2\u02dc\u02db\3\2"+
-    "\2\2\u02dd\u02de\3\2\2\2\u02de\u02e1\5Z.\2\u02df\u02e0\7V\2\2\u02e0\u02e2"+
-    "\5Z.\2\u02e1\u02df\3\2\2\2\u02e1\u02e2\3\2\2\2\u02e2Y\3\2\2\2\u02e3\u02e4"+
-    "\t\17\2\2\u02e4[\3\2\2\2\u02e5\u02e6\5`\61\2\u02e6]\3\2\2\2\u02e7\u02e8"+
-    "\5`\61\2\u02e8\u02e9\7u\2\2\u02e9\u02eb\3\2\2\2\u02ea\u02e7\3\2\2\2\u02eb"+
-    "\u02ee\3\2\2\2\u02ec\u02ea\3\2\2\2\u02ec\u02ed\3\2\2\2\u02ed\u02ef\3\2"+
-    "\2\2\u02ee\u02ec\3\2\2\2\u02ef\u02f0\5`\61\2\u02f0_\3\2\2\2\u02f1\u02f4"+
-    "\5d\63\2\u02f2\u02f4\5f\64\2\u02f3\u02f1\3\2\2\2\u02f3\u02f2\3\2\2\2\u02f4"+
-    "a\3\2\2\2\u02f5\u02f6\5`\61\2\u02f6\u02f7\7\6\2\2\u02f7\u02f9\3\2\2\2"+
-    "\u02f8\u02f5\3\2\2\2\u02f8\u02f9\3\2\2\2\u02f9\u02fa\3\2\2\2\u02fa\u0302"+
-    "\7|\2\2\u02fb\u02fc\5`\61\2\u02fc\u02fd\7\6\2\2\u02fd\u02ff\3\2\2\2\u02fe"+
-    "\u02fb\3\2\2\2\u02fe\u02ff\3\2\2\2\u02ff\u0300\3\2\2\2\u0300\u0302\5`"+
-    "\61\2\u0301\u02f8\3\2\2\2\u0301\u02fe\3\2\2\2\u0302c\3\2\2\2\u0303\u0306"+
-    "\7}\2\2\u0304\u0306\7~\2\2\u0305\u0303\3\2\2\2\u0305\u0304\3\2\2\2\u0306"+
-    "e\3\2\2\2\u0307\u030b\7z\2\2\u0308\u030b\5l\67\2\u0309\u030b\7{\2\2\u030a"+
-    "\u0307\3\2\2\2\u030a\u0308\3\2\2\2\u030a\u0309\3\2\2\2\u030bg\3\2\2\2"+
-    "\u030c\u030f\7y\2\2\u030d\u030f\7x\2\2\u030e\u030c\3\2\2\2\u030e\u030d"+
-    "\3\2\2\2\u030fi\3\2\2\2\u0310\u0311\t\20\2\2\u0311k\3\2\2\2\u0312\u0313"+
-    "\t\21\2\2\u0313m\3\2\2\2m}\177\u0083\u008c\u008e\u0092\u0099\u00a0\u00a5"+
-    "\u00aa\u00b2\u00b6\u00be\u00c1\u00c7\u00cc\u00cf\u00d4\u00d7\u00d9\u00e1"+
-    "\u00e4\u00f0\u00f3\u00f6\u00fd\u0104\u0108\u010c\u0110\u0117\u011b\u011f"+
-    "\u0124\u0128\u0130\u0134\u013b\u0146\u0149\u014d\u0159\u015c\u0162\u0169"+
-    "\u0170\u0173\u0177\u017b\u017f\u0181\u018c\u0191\u0195\u0198\u019e\u01a1"+
-    "\u01a7\u01aa\u01ac\u01cf\u01d7\u01d9\u01e0\u01e5\u01e8\u01f0\u01f9\u01ff"+
-    "\u0207\u020c\u0212\u0215\u021c\u0224\u022a\u0236\u0238\u0243\u0250\u0257"+
-    "\u025d\u0260\u0265\u026a\u026d\u026f\u027b\u0290\u029e\u02a3\u02aa\u02ad"+
-    "\u02b4\u02bd\u02d0\u02d8\u02dc\u02e1\u02ec\u02f3\u02f8\u02fe\u0301\u0305"+
-    "\u030a\u030e";
+    "\u0257\3\2\2\2\u025a\u025e\7\27\2\2\u025b\u025e\7\25\2\2\u025c\u025e\7"+
+    "\26\2\2\u025d\u025a\3\2\2\2\u025d\u025b\3\2\2\2\u025d\u025c\3\2\2\2\u025e"+
+    "A\3\2\2\2\u025f\u026a\5D#\2\u0260\u0261\7`\2\2\u0261\u0262\5D#\2\u0262"+
+    "\u0263\7f\2\2\u0263\u026a\3\2\2\2\u0264\u026a\5F$\2\u0265\u0266\7`\2\2"+
+    "\u0266\u0267\5F$\2\u0267\u0268\7f\2\2\u0268\u026a\3\2\2\2\u0269\u025f"+
+    "\3\2\2\2\u0269\u0260\3\2\2\2\u0269\u0264\3\2\2\2\u0269\u0265\3\2\2\2\u026a"+
+    "C\3\2\2\2\u026b\u026c\7\20\2\2\u026c\u026d\7\3\2\2\u026d\u026e\5,\27\2"+
+    "\u026e\u026f\7\f\2\2\u026f\u0270\5\\/\2\u0270\u0271\7\4\2\2\u0271E\3\2"+
+    "\2\2\u0272\u0273\7\24\2\2\u0273\u0274\7\3\2\2\u0274\u0275\5,\27\2\u0275"+
+    "\u0276\7\5\2\2\u0276\u0277\5\\/\2\u0277\u0278\7\4\2\2\u0278G\3\2\2\2\u0279"+
+    "\u027f\5J&\2\u027a\u027b\7`\2\2\u027b\u027c\5J&\2\u027c\u027d\7f\2\2\u027d"+
+    "\u027f\3\2\2\2\u027e\u0279\3\2\2\2\u027e\u027a\3\2\2\2\u027fI\3\2\2\2"+
+    "\u0280\u0281\7\"\2\2\u0281\u0282\7\3\2\2\u0282\u0283\5`\61\2\u0283\u0284"+
+    "\7&\2\2\u0284\u0285\5<\37\2\u0285\u0286\7\4\2\2\u0286K\3\2\2\2\u0287\u028d"+
+    "\5N(\2\u0288\u0289\7`\2\2\u0289\u028a\5N(\2\u028a\u028b\7f\2\2\u028b\u028d"+
+    "\3\2\2\2\u028c\u0287\3\2\2\2\u028c\u0288\3\2\2\2\u028dM\3\2\2\2\u028e"+
+    "\u028f\5P)\2\u028f\u029b\7\3\2\2\u0290\u0292\5\36\20\2\u0291\u0290\3\2"+
+    "\2\2\u0291\u0292\3\2\2\2\u0292\u0293\3\2\2\2\u0293\u0298\5,\27\2\u0294"+
+    "\u0295\7\5\2\2\u0295\u0297\5,\27\2\u0296\u0294\3\2\2\2\u0297\u029a\3\2"+
+    "\2\2\u0298\u0296\3\2\2\2\u0298\u0299\3\2\2\2\u0299\u029c\3\2\2\2\u029a"+
+    "\u0298\3\2\2\2\u029b\u0291\3\2\2\2\u029b\u029c\3\2\2\2\u029c\u029d\3\2"+
+    "\2\2\u029d\u029e\7\4\2\2\u029eO\3\2\2\2\u029f\u02a3\7\64\2\2\u02a0\u02a3"+
+    "\7I\2\2\u02a1\u02a3\5`\61\2\u02a2\u029f\3\2\2\2\u02a2\u02a0\3\2\2\2\u02a2"+
+    "\u02a1\3\2\2\2\u02a3Q\3\2\2\2\u02a4\u02bf\7?\2\2\u02a5\u02bf\5X-\2\u02a6"+
+    "\u02bf\5h\65\2\u02a7\u02bf\5V,\2\u02a8\u02aa\7w\2\2\u02a9\u02a8\3\2\2"+
+    "\2\u02aa\u02ab\3\2\2\2\u02ab\u02a9\3\2\2\2\u02ab\u02ac\3\2\2\2\u02ac\u02bf"+
+    "\3\2\2\2\u02ad\u02bf\7v\2\2\u02ae\u02af\7b\2\2\u02af\u02b0\5j\66\2\u02b0"+
+    "\u02b1\7f\2\2\u02b1\u02bf\3\2\2\2\u02b2\u02b3\7c\2\2\u02b3\u02b4\5j\66"+
+    "\2\u02b4\u02b5\7f\2\2\u02b5\u02bf\3\2\2\2\u02b6\u02b7\7d\2\2\u02b7\u02b8"+
+    "\5j\66\2\u02b8\u02b9\7f\2\2\u02b9\u02bf\3\2\2\2\u02ba\u02bb\7e\2\2\u02bb"+
+    "\u02bc\5j\66\2\u02bc\u02bd\7f\2\2\u02bd\u02bf\3\2\2\2\u02be\u02a4\3\2"+
+    "\2\2\u02be\u02a5\3\2\2\2\u02be\u02a6\3\2\2\2\u02be\u02a7\3\2\2\2\u02be"+
+    "\u02a9\3\2\2\2\u02be\u02ad\3\2\2\2\u02be\u02ae\3\2\2\2\u02be\u02b2\3\2"+
+    "\2\2\u02be\u02b6\3\2\2\2\u02be\u02ba\3\2\2\2\u02bfS\3\2\2\2\u02c0\u02c1"+
+    "\t\r\2\2\u02c1U\3\2\2\2\u02c2\u02c3\t\16\2\2\u02c3W\3\2\2\2\u02c4\u02c6"+
+    "\7\60\2\2\u02c5\u02c7\t\7\2\2\u02c6\u02c5\3\2\2\2\u02c6\u02c7\3\2\2\2"+
+    "\u02c7\u02ca\3\2\2\2\u02c8\u02cb\5h\65\2\u02c9\u02cb\5j\66\2\u02ca\u02c8"+
+    "\3\2\2\2\u02ca\u02c9\3\2\2\2\u02cb\u02cc\3\2\2\2\u02cc\u02cf\5Z.\2\u02cd"+
+    "\u02ce\7V\2\2\u02ce\u02d0\5Z.\2\u02cf\u02cd\3\2\2\2\u02cf\u02d0\3\2\2"+
+    "\2\u02d0Y\3\2\2\2\u02d1\u02d2\t\17\2\2\u02d2[\3\2\2\2\u02d3\u02d4\5`\61"+
+    "\2\u02d4]\3\2\2\2\u02d5\u02d6\5`\61\2\u02d6\u02d7\7u\2\2\u02d7\u02d9\3"+
+    "\2\2\2\u02d8\u02d5\3\2\2\2\u02d9\u02dc\3\2\2\2\u02da\u02d8\3\2\2\2\u02da"+
+    "\u02db\3\2\2\2\u02db\u02dd\3\2\2\2\u02dc\u02da\3\2\2\2\u02dd\u02de\5`"+
+    "\61\2\u02de_\3\2\2\2\u02df\u02e2\5d\63\2\u02e0\u02e2\5f\64\2\u02e1\u02df"+
+    "\3\2\2\2\u02e1\u02e0\3\2\2\2\u02e2a\3\2\2\2\u02e3\u02e4\5`\61\2\u02e4"+
+    "\u02e5\7\6\2\2\u02e5\u02e7\3\2\2\2\u02e6\u02e3\3\2\2\2\u02e6\u02e7\3\2"+
+    "\2\2\u02e7\u02e8\3\2\2\2\u02e8\u02f0\7|\2\2\u02e9\u02ea\5`\61\2\u02ea"+
+    "\u02eb\7\6\2\2\u02eb\u02ed\3\2\2\2\u02ec\u02e9\3\2\2\2\u02ec\u02ed\3\2"+
+    "\2\2\u02ed\u02ee\3\2\2\2\u02ee\u02f0\5`\61\2\u02ef\u02e6\3\2\2\2\u02ef"+
+    "\u02ec\3\2\2\2\u02f0c\3\2\2\2\u02f1\u02f4\7}\2\2\u02f2\u02f4\7~\2\2\u02f3"+
+    "\u02f1\3\2\2\2\u02f3\u02f2\3\2\2\2\u02f4e\3\2\2\2\u02f5\u02f9\7z\2\2\u02f6"+
+    "\u02f9\5l\67\2\u02f7\u02f9\7{\2\2\u02f8\u02f5\3\2\2\2\u02f8\u02f6\3\2"+
+    "\2\2\u02f8\u02f7\3\2\2\2\u02f9g\3\2\2\2\u02fa\u02fd\7y\2\2\u02fb\u02fd"+
+    "\7x\2\2\u02fc\u02fa\3\2\2\2\u02fc\u02fb\3\2\2\2\u02fdi\3\2\2\2\u02fe\u02ff"+
+    "\t\20\2\2\u02ffk\3\2\2\2\u0300\u0301\t\21\2\2\u0301m\3\2\2\2h}\177\u0083"+
+    "\u008c\u008e\u0092\u0099\u00a0\u00a5\u00aa\u00b2\u00b6\u00be\u00c1\u00c7"+
+    "\u00cc\u00cf\u00d4\u00d7\u00d9\u00e1\u00e4\u00f0\u00f3\u00f6\u00fd\u0104"+
+    "\u0108\u010c\u0110\u0117\u011b\u011f\u0124\u0128\u0130\u0134\u013b\u0146"+
+    "\u0149\u014d\u0159\u015c\u0162\u0169\u0170\u0173\u0177\u017b\u017f\u0181"+
+    "\u018c\u0191\u0195\u0198\u019e\u01a1\u01a7\u01aa\u01ac\u01cf\u01d7\u01d9"+
+    "\u01e0\u01e5\u01e8\u01f0\u01f9\u01ff\u0207\u020c\u0212\u0215\u021c\u0224"+
+    "\u022a\u0236\u0238\u0243\u0250\u0257\u025d\u0269\u027e\u028c\u0291\u0298"+
+    "\u029b\u02a2\u02ab\u02be\u02c6\u02ca\u02cf\u02da\u02e1\u02e6\u02ec\u02ef"+
+    "\u02f3\u02f8\u02fc";
   public static final ATN _ATN =
     new ATNDeserializer().deserialize(_serializedATN.toCharArray());
   static {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/util/DateUtils.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/util/DateUtils.java
@@ -40,6 +40,7 @@ public final class DateUtils {
         .toFormatter().withZone(UTC);
 
     private static final DateFormatter UTC_DATE_TIME_FORMATTER = DateFormatter.forPattern("date_optional_time").withZone(UTC);
+    private static final int DEFAULT_PRECISION_FOR_CURRENT_FUNCTIONS = 3;
 
     private DateUtils() {}
 
@@ -128,7 +129,7 @@ public final class DateUtils {
     }
 
     public static int getNanoPrecision(Expression precisionExpression, int nano) {
-        int precision = 3;
+        int precision = DEFAULT_PRECISION_FOR_CURRENT_FUNCTIONS;
 
         if (precisionExpression != null) {
             try {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentDateTimeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentDateTimeTests.java
@@ -6,11 +6,21 @@
 
 package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.TestUtils;
+import org.elasticsearch.xpack.sql.analysis.analyzer.Analyzer;
+import org.elasticsearch.xpack.sql.analysis.analyzer.Verifier;
+import org.elasticsearch.xpack.sql.analysis.index.EsIndex;
+import org.elasticsearch.xpack.sql.analysis.index.IndexResolution;
 import org.elasticsearch.xpack.sql.expression.Expression;
 import org.elasticsearch.xpack.sql.expression.Literal;
+import org.elasticsearch.xpack.sql.expression.function.FunctionRegistry;
+import org.elasticsearch.xpack.sql.parser.ParsingException;
+import org.elasticsearch.xpack.sql.parser.SqlParser;
 import org.elasticsearch.xpack.sql.session.Configuration;
+import org.elasticsearch.xpack.sql.stats.Metrics;
 import org.elasticsearch.xpack.sql.tree.AbstractNodeTestCase;
+import org.elasticsearch.xpack.sql.type.TypesTests;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -22,7 +32,7 @@ import static org.elasticsearch.xpack.sql.tree.Source.EMPTY;
 public class CurrentDateTimeTests extends AbstractNodeTestCase<CurrentDateTime, Expression> {
 
     public static CurrentDateTime randomCurrentDateTime() {
-        return new CurrentDateTime(EMPTY, Literal.of(EMPTY, randomInt(10)), TestUtils.randomConfiguration());
+        return new CurrentDateTime(EMPTY, Literal.of(EMPTY, randomInt(9) + 1), TestUtils.randomConfiguration());
     }
 
     @Override
@@ -39,8 +49,8 @@ public class CurrentDateTimeTests extends AbstractNodeTestCase<CurrentDateTime, 
     protected CurrentDateTime mutate(CurrentDateTime instance) {
         ZonedDateTime now = instance.configuration().now();
         ZoneId mutatedZoneId = randomValueOtherThanMany(o -> Objects.equals(now.getOffset(), o.getRules().getOffset(now.toInstant())),
-                () -> randomZone());
-        return new CurrentDateTime(instance.source(), Literal.of(EMPTY, randomInt(10)), TestUtils.randomConfiguration(mutatedZoneId));
+            ESTestCase::randomZone);
+        return new CurrentDateTime(instance.source(), Literal.of(EMPTY, randomInt(9) + 1), TestUtils.randomConfiguration(mutatedZoneId));
     }
 
     @Override
@@ -74,5 +84,20 @@ public class CurrentDateTimeTests extends AbstractNodeTestCase<CurrentDateTime, 
         
         ZonedDateTime zdt = ZonedDateTime.parse("2019-02-26T12:34:56.123456789Z");
         assertEquals(123_000_000, CurrentDateTime.nanoPrecision(zdt, null).getNano());
+    }
+
+    public void testInvalidPrecision() {
+        SqlParser parser = new SqlParser();
+        IndexResolution indexResolution = IndexResolution.valid(new EsIndex("test",
+            TypesTests.loadMapping("mapping-multi-field-with-nested.json")));
+
+        Analyzer analyzer = new Analyzer(TestUtils.TEST_CFG, new FunctionRegistry(), indexResolution, new Verifier(new Metrics()));
+        ParsingException e = expectThrows(ParsingException.class, () ->
+            analyzer.analyze(parser.createStatement("SELECT CURRENT_TIMESTAMP(100000000000000)"), true));
+        assertEquals("line 1:27: invalid precision; [100000000000000] out of [integer] range", e.getMessage());
+
+        e = expectThrows(ParsingException.class, () ->
+            analyzer.analyze(parser.createStatement("SELECT CURRENT_TIMESTAMP(100)"), true));
+        assertEquals("line 1:27: precision needs to be between [0-9], received [100]", e.getMessage());
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentDateTimeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentDateTimeTests.java
@@ -32,7 +32,7 @@ import static org.elasticsearch.xpack.sql.tree.Source.EMPTY;
 public class CurrentDateTimeTests extends AbstractNodeTestCase<CurrentDateTime, Expression> {
 
     public static CurrentDateTime randomCurrentDateTime() {
-        return new CurrentDateTime(EMPTY, Literal.of(EMPTY, randomInt(9) + 1), TestUtils.randomConfiguration());
+        return new CurrentDateTime(EMPTY, Literal.of(EMPTY, randomInt(9)), TestUtils.randomConfiguration());
     }
 
     @Override
@@ -50,7 +50,7 @@ public class CurrentDateTimeTests extends AbstractNodeTestCase<CurrentDateTime, 
         ZonedDateTime now = instance.configuration().now();
         ZoneId mutatedZoneId = randomValueOtherThanMany(o -> Objects.equals(now.getOffset(), o.getRules().getOffset(now.toInstant())),
             ESTestCase::randomZone);
-        return new CurrentDateTime(instance.source(), Literal.of(EMPTY, randomInt(9) + 1), TestUtils.randomConfiguration(mutatedZoneId));
+        return new CurrentDateTime(instance.source(), Literal.of(EMPTY, randomInt(9)), TestUtils.randomConfiguration(mutatedZoneId));
     }
 
     @Override

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentTimeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentTimeTests.java
@@ -33,7 +33,7 @@ import static org.elasticsearch.xpack.sql.tree.Source.EMPTY;
 public class CurrentTimeTests extends AbstractNodeTestCase<CurrentTime, Expression> {
 
     public static CurrentTime randomCurrentTime() {
-        return new CurrentTime(EMPTY, Literal.of(EMPTY, randomInt(9) + 1), TestUtils.randomConfiguration());
+        return new CurrentTime(EMPTY, Literal.of(EMPTY, randomInt(9)), TestUtils.randomConfiguration());
     }
 
     @Override
@@ -51,7 +51,7 @@ public class CurrentTimeTests extends AbstractNodeTestCase<CurrentTime, Expressi
         ZonedDateTime now = instance.configuration().now();
         ZoneId mutatedZoneId = randomValueOtherThanMany(o -> Objects.equals(now.getOffset(), o.getRules().getOffset(now.toInstant())),
             ESTestCase::randomZone);
-        return new CurrentTime(instance.source(), Literal.of(EMPTY, randomInt(9) + 1), TestUtils.randomConfiguration(mutatedZoneId));
+        return new CurrentTime(instance.source(), Literal.of(EMPTY, randomInt(9)), TestUtils.randomConfiguration(mutatedZoneId));
     }
 
     @Override

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentTimeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentTimeTests.java
@@ -6,11 +6,21 @@
 
 package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.TestUtils;
+import org.elasticsearch.xpack.sql.analysis.analyzer.Analyzer;
+import org.elasticsearch.xpack.sql.analysis.analyzer.Verifier;
+import org.elasticsearch.xpack.sql.analysis.index.EsIndex;
+import org.elasticsearch.xpack.sql.analysis.index.IndexResolution;
 import org.elasticsearch.xpack.sql.expression.Expression;
 import org.elasticsearch.xpack.sql.expression.Literal;
+import org.elasticsearch.xpack.sql.expression.function.FunctionRegistry;
+import org.elasticsearch.xpack.sql.parser.ParsingException;
+import org.elasticsearch.xpack.sql.parser.SqlParser;
 import org.elasticsearch.xpack.sql.session.Configuration;
+import org.elasticsearch.xpack.sql.stats.Metrics;
 import org.elasticsearch.xpack.sql.tree.AbstractNodeTestCase;
+import org.elasticsearch.xpack.sql.type.TypesTests;
 
 import java.time.OffsetTime;
 import java.time.ZoneId;
@@ -23,7 +33,7 @@ import static org.elasticsearch.xpack.sql.tree.Source.EMPTY;
 public class CurrentTimeTests extends AbstractNodeTestCase<CurrentTime, Expression> {
 
     public static CurrentTime randomCurrentTime() {
-        return new CurrentTime(EMPTY, Literal.of(EMPTY, randomInt(10)), TestUtils.randomConfiguration());
+        return new CurrentTime(EMPTY, Literal.of(EMPTY, randomInt(9) + 1), TestUtils.randomConfiguration());
     }
 
     @Override
@@ -40,8 +50,8 @@ public class CurrentTimeTests extends AbstractNodeTestCase<CurrentTime, Expressi
     protected CurrentTime mutate(CurrentTime instance) {
         ZonedDateTime now = instance.configuration().now();
         ZoneId mutatedZoneId = randomValueOtherThanMany(o -> Objects.equals(now.getOffset(), o.getRules().getOffset(now.toInstant())),
-                () -> randomZone());
-        return new CurrentTime(instance.source(), Literal.of(EMPTY, randomInt(10)), TestUtils.randomConfiguration(mutatedZoneId));
+            ESTestCase::randomZone);
+        return new CurrentTime(instance.source(), Literal.of(EMPTY, randomInt(9) + 1), TestUtils.randomConfiguration(mutatedZoneId));
     }
 
     @Override
@@ -75,5 +85,20 @@ public class CurrentTimeTests extends AbstractNodeTestCase<CurrentTime, Expressi
 
         OffsetTime ot = OffsetTime.parse("12:34:56.123456789Z");
         assertEquals(123_000_000, CurrentTime.nanoPrecision(ot, null).getNano());
+    }
+
+    public void testInvalidPrecision() {
+        SqlParser parser = new SqlParser();
+        IndexResolution indexResolution = IndexResolution.valid(new EsIndex("test",
+            TypesTests.loadMapping("mapping-multi-field-with-nested.json")));
+
+        Analyzer analyzer = new Analyzer(TestUtils.TEST_CFG, new FunctionRegistry(), indexResolution, new Verifier(new Metrics()));
+        ParsingException e = expectThrows(ParsingException.class, () ->
+            analyzer.analyze(parser.createStatement("SELECT CURRENT_TIME(100000000000000)"), true));
+        assertEquals("line 1:22: invalid precision; [100000000000000] out of [integer] range", e.getMessage());
+
+        e = expectThrows(ParsingException.class, () ->
+            analyzer.analyze(parser.createStatement("SELECT CURRENT_TIME(100)"), true));
+        assertEquals("line 1:22: precision needs to be between [0-9], received [100]", e.getMessage());
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/parser/EscapedFunctionsTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/parser/EscapedFunctionsTests.java
@@ -226,6 +226,29 @@ public class EscapedFunctionsTests extends ESTestCase {
         assertEquals("line 1:8: Invalid GUID, too short", ex.getMessage());
     }
 
+    public void testCurrentTimestampAsEscapedExpression() {
+        Expression expr = parser.createExpression("{fn CURRENT_TIMESTAMP(2)}");
+        assertEquals(UnresolvedFunction.class, expr.getClass());
+        UnresolvedFunction ur = (UnresolvedFunction) expr;
+        assertEquals("{fn CURRENT_TIMESTAMP(2)}", ur.sourceText());
+        assertEquals(1, ur.children().size());
+    }
+
+    public void testCurrentDateAsEscapedExpression() {
+        Expression expr = parser.createExpression("{fn CURRENT_DATE()}");
+        assertEquals(UnresolvedFunction.class, expr.getClass());
+        UnresolvedFunction ur = (UnresolvedFunction) expr;
+        assertEquals("{fn CURRENT_DATE()}", ur.sourceText());
+        assertEquals(0, ur.children().size());
+    }
+
+    public void testCurrentTimeAsEscapedExpression() {
+        Expression expr = parser.createExpression("{fn CURRENT_TIME(2)}");
+        assertEquals(UnresolvedFunction.class, expr.getClass());
+        UnresolvedFunction ur = (UnresolvedFunction) expr;
+        assertEquals("{fn CURRENT_TIME(2)}", ur.sourceText());
+        assertEquals(1, ur.children().size());
+    }
 
     public void testLimit() {
         Limit limit = limit(10);

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/parser/ExpressionTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/parser/ExpressionTests.java
@@ -398,12 +398,7 @@ public class ExpressionTests extends ESTestCase {
         assertEquals(1, ur.children().size());
         Expression child = ur.children().get(0);
         assertEquals(Literal.class, child.getClass());
-        assertEquals(Short.valueOf((short) 4), child.fold());
-    }
-
-    public void testCurrentTimestampInvalidPrecision() {
-        ParsingException ex = expectThrows(ParsingException.class, () -> parser.createExpression("CURRENT_TIMESTAMP(100)"));
-        assertEquals("line 1:20: Precision needs to be between [0-9], received [100]", ex.getMessage());
+        assertEquals(4, child.fold());
     }
 
     public void testCurrentDate() {
@@ -438,12 +433,7 @@ public class ExpressionTests extends ESTestCase {
         assertEquals(1, ur.children().size());
         Expression child = ur.children().get(0);
         assertEquals(Literal.class, child.getClass());
-        assertEquals(Short.valueOf((short) 7), child.fold());
-    }
-
-    public void testCurrentTimeInvalidPrecision() {
-        ParsingException ex = expectThrows(ParsingException.class, () -> parser.createExpression("CURRENT_TIME(100)"));
-        assertEquals("line 1:15: Precision needs to be between [0-9], received [100]", ex.getMessage());
+        assertEquals(7, child.fold());
     }
 
     public void testSourceKeyword() {


### PR DESCRIPTION
CURRENT_DATE/CURRENT_TIME/CURRENT_TIMESTAMP can be used as SQL keywords
(without parentheses) and therefore there is a special rule in the
grammar to accommodate this.

Previously, this rule was also catching the parenthesised version of those functions too, 
not allowing the `{fn <functionName>()}` to be used. E.g.:
`{fn current_time(2)}` or `{fn current_timestamp()}`

Now, the grammar rule catches only the keyword versions and all the parenthesised
versions go through the normal function resolution. As a consequence the validation
of the precision is moved from the parser lever (`ExpressionBuilder`) to the function
implementations.

Fixes: #41240