### PR TITLE
Fix error applying `ignore_malformed` to boolean values

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.index.mapper;
 
+import com.fasterxml.jackson.core.JsonParseException;
+
 import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FloatPoint;
@@ -1042,7 +1044,7 @@ public class NumberFieldMapper extends FieldMapper {
         } else {
             try {
                 numericValue = fieldType().type.parse(parser, coerce.value());
-            } catch (IllegalArgumentException e) {
+            } catch (IllegalArgumentException | JsonParseException e) {
                 if (ignoreMalformed.value()) {
                     context.addIgnoredField(fieldType.name());
                     return;

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1045,7 +1045,7 @@ public class NumberFieldMapper extends FieldMapper {
             try {
                 numericValue = fieldType().type.parse(parser, coerce.value());
             } catch (IllegalArgumentException | JsonParseException e) {
-                if (ignoreMalformed.value()) {
+                if (ignoreMalformed.value() && parser.currentToken().isValue()) {
                     context.addIgnoredField(fieldType.name());
                     return;
                 } else {

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
@@ -20,12 +20,12 @@
 package org.elasticsearch.index.mapper;
 
 import com.carrotsearch.randomizedtesting.annotations.Timeout;
+
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
@@ -220,38 +220,36 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
 
     public void testIgnoreMalformed() throws Exception {
         for (String type : TYPES) {
-            Object malformedValue = randomBoolean() ? "a" : false;
-            String mapping = Strings.toString(jsonBuilder().startObject().startObject("type").startObject("properties")
-                    .startObject("field").field("type", type).endObject().endObject().endObject().endObject());
+            for (Object malformedValue : new Object[] { "a", Boolean.FALSE }) {
+                String mapping = Strings.toString(jsonBuilder().startObject().startObject("type").startObject("properties")
+                        .startObject("field").field("type", type).endObject().endObject().endObject().endObject());
 
-            DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+                DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
 
-            assertEquals(mapping, mapper.mappingSource().toString());
+                assertEquals(mapping, mapper.mappingSource().toString());
 
-            ThrowingRunnable runnable = () -> mapper.parse(new SourceToParse("test", "type", "1",
-                    BytesReference.bytes(jsonBuilder().startObject().field("field", malformedValue).endObject()),
-                    XContentType.JSON));
-            MapperParsingException e = expectThrows(MapperParsingException.class, runnable);
-            if (malformedValue instanceof String) {
-                assertThat(e.getCause().getMessage(), containsString("For input string: \"a\""));
-            } else {
-                assertThat(e.getCause().getMessage(), containsString("Current token"));
-                assertThat(e.getCause().getMessage(), containsString("not numeric, can not use numeric value accessors")); 
+                ThrowingRunnable runnable = () -> mapper.parse(new SourceToParse("test", "type", "1",
+                        BytesReference.bytes(jsonBuilder().startObject().field("field", malformedValue).endObject()), XContentType.JSON));
+                MapperParsingException e = expectThrows(MapperParsingException.class, runnable);
+                if (malformedValue instanceof String) {
+                    assertThat(e.getCause().getMessage(), containsString("For input string: \"a\""));
+                } else {
+                    assertThat(e.getCause().getMessage(), containsString("Current token"));
+                    assertThat(e.getCause().getMessage(), containsString("not numeric, can not use numeric value accessors"));
+                }
+
+                mapping = Strings.toString(jsonBuilder().startObject().startObject("type").startObject("properties").startObject("field")
+                        .field("type", type).field("ignore_malformed", true).endObject().endObject().endObject().endObject());
+
+                DocumentMapper mapper2 = parser.parse("type", new CompressedXContent(mapping));
+
+                ParsedDocument doc = mapper2.parse(new SourceToParse("test", "type", "1",
+                        BytesReference.bytes(jsonBuilder().startObject().field("field", malformedValue).endObject()), XContentType.JSON));
+
+                IndexableField[] fields = doc.rootDoc().getFields("field");
+                assertEquals(0, fields.length);
+                assertArrayEquals(new String[] { "field" }, doc.rootDoc().getValues("_ignored"));
             }
-
-            mapping = Strings
-                    .toString(jsonBuilder().startObject().startObject("type").startObject("properties").startObject("field")
-                            .field("type", type).field("ignore_malformed", true).endObject().endObject().endObject().endObject());
-
-            DocumentMapper mapper2 = parser.parse("type", new CompressedXContent(mapping));
-
-            ParsedDocument doc = mapper2.parse(new SourceToParse("test", "type", "1",
-                    BytesReference.bytes(jsonBuilder().startObject().field("field", malformedValue).endObject()),
-                    XContentType.JSON));
-
-            IndexableField[] fields = doc.rootDoc().getFields("field");
-            assertEquals(0, fields.length);
-            assertArrayEquals(new String[] { "field" }, doc.rootDoc().getValues("_ignored"));
         }
     }
 


### PR DESCRIPTION
The `ignore_malformed` option currently works on numeric fields only when the
bad value isn't a string value but not if it is a boolean. In this case we get a
parsing error from the xContent parser which we need to catch in addition to the
field mapper.

Closes #11498