### PR TITLE
Backport FullClusterRestart tests for 7.0

### DIFF
--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -27,7 +27,6 @@ import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.WarningFailureException;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
-import org.elasticsearch.cluster.metadata.MetaDataIndexStateService;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.Strings;
@@ -40,7 +39,6 @@ import org.elasticsearch.rest.action.document.RestGetAction;
 import org.elasticsearch.rest.action.document.RestIndexAction;
 import org.elasticsearch.rest.action.document.RestUpdateAction;
 import org.elasticsearch.rest.action.search.RestExplainAction;
-
 import org.elasticsearch.test.NotEqualMessageBuilder;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.yaml.ObjectPath;
@@ -49,7 +47,6 @@ import org.junit.Before;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -68,11 +65,8 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 
 /**

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -27,6 +27,7 @@ import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.WarningFailureException;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MetaDataIndexStateService;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.Strings;
@@ -36,8 +37,10 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.rest.action.document.RestBulkAction;
 import org.elasticsearch.rest.action.document.RestGetAction;
+import org.elasticsearch.rest.action.document.RestIndexAction;
 import org.elasticsearch.rest.action.document.RestUpdateAction;
 import org.elasticsearch.rest.action.search.RestExplainAction;
+
 import org.elasticsearch.test.NotEqualMessageBuilder;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.yaml.ObjectPath;
@@ -46,6 +49,7 @@ import org.junit.Before;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -61,12 +65,14 @@ import static java.util.Collections.singletonMap;
 import static org.elasticsearch.cluster.routing.UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING;
 import static org.elasticsearch.cluster.routing.allocation.decider.MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 
 /**
@@ -78,13 +84,18 @@ import static org.hamcrest.Matchers.startsWith;
  */
 public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
     private final boolean supportsLenientBooleans = getOldClusterVersion().before(Version.V_6_0_0_alpha1);
-    private static final Version VERSION_5_1_0_UNRELEASED = Version.fromString("5.1.0");
 
     private String index;
+    private String type;
 
     @Before
     public void setIndex() throws IOException {
         index = getTestName().toLowerCase(Locale.ROOT);
+    }
+
+    @Before
+    public void setType() {
+        type = getOldClusterVersion().before(Version.V_6_7_0) ? "doc" : "_doc";
     }
 
     public void testSearch() throws Exception {
@@ -100,7 +111,9 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             }
             {
                 mappingsAndSettings.startObject("mappings");
-                mappingsAndSettings.startObject("doc");
+                if (isRunningAgainstAncientCluster()) {
+                    mappingsAndSettings.startObject(type);
+                }
                 mappingsAndSettings.startObject("properties");
                 {
                     mappingsAndSettings.startObject("string");
@@ -119,7 +132,9 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                     mappingsAndSettings.endObject();
                 }
                 mappingsAndSettings.endObject();
-                mappingsAndSettings.endObject();
+                if (isRunningAgainstAncientCluster()) {
+                    mappingsAndSettings.endObject();
+                }
                 mappingsAndSettings.endObject();
             }
             mappingsAndSettings.endObject();
@@ -132,17 +147,20 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             count = randomIntBetween(2000, 3000);
             byte[] randomByteArray = new byte[16];
             random().nextBytes(randomByteArray);
-            indexRandomDocuments(count, true, true, i -> {
-                return JsonXContent.contentBuilder().startObject()
-                .field("string", randomAlphaOfLength(10))
-                .field("int", randomInt(100))
-                .field("float", randomFloat())
-                // be sure to create a "proper" boolean (True, False) for the first document so that automapping is correct
-                .field("bool", i > 0 && supportsLenientBooleans ? randomLenientBoolean() : randomBoolean())
-                .field("field.with.dots", randomAlphaOfLength(10))
-                .field("binary", Base64.getEncoder().encodeToString(randomByteArray))
-                .endObject();
-            });
+            indexRandomDocuments(
+                    count,
+                    true,
+                    true,
+                    i -> JsonXContent.contentBuilder().startObject()
+                            .field("string", randomAlphaOfLength(10))
+                            .field("int", randomInt(100))
+                            .field("float", randomFloat())
+                            // be sure to create a "proper" boolean (True, False) for the first document so that automapping is correct
+                            .field("bool", i > 0 && supportsLenientBooleans ? randomLenientBoolean() : randomBoolean())
+                            .field("field.with.dots", randomAlphaOfLength(10))
+                            .field("binary", Base64.getEncoder().encodeToString(randomByteArray))
+                            .endObject()
+            );
             refresh();
         } else {
             count = countOfIndexedRandomDocuments();
@@ -152,7 +170,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         assertBasicSearchWorks(count);
         assertAllSearchWorks(count);
         assertBasicAggregationWorks();
-        assertRealtimeGetWorks();
+        assertRealtimeGetWorks(type);
         assertStoredBinaryFields(count);
     }
 
@@ -168,7 +186,9 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             }
             {
                 mappingsAndSettings.startObject("mappings");
-                mappingsAndSettings.startObject("doc");
+                if (isRunningAgainstAncientCluster()) {
+                    mappingsAndSettings.startObject(type);
+                }
                 mappingsAndSettings.startObject("properties");
                 {
                     mappingsAndSettings.startObject("field");
@@ -176,7 +196,9 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                     mappingsAndSettings.endObject();
                 }
                 mappingsAndSettings.endObject();
-                mappingsAndSettings.endObject();
+                if (isRunningAgainstAncientCluster()) {
+                    mappingsAndSettings.endObject();
+                }
                 mappingsAndSettings.endObject();
             }
             mappingsAndSettings.endObject();
@@ -187,11 +209,8 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             client().performRequest(createIndex);
 
             int numDocs = randomIntBetween(2000, 3000);
-            indexRandomDocuments(numDocs, true, false, i -> {
-                return JsonXContent.contentBuilder().startObject()
-                    .field("field", "value")
-                    .endObject();
-            });
+            indexRandomDocuments(
+                    numDocs, true, false, i -> JsonXContent.contentBuilder().startObject().field("field", "value").endObject());
             logger.info("Refreshing [{}]", index);
             client().performRequest(new Request("POST", "/" + index + "/_refresh"));
         } else {
@@ -200,7 +219,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             logger.debug("--> creating [{}] replicas for index [{}]", numReplicas, index);
             Request setNumberOfReplicas = new Request("PUT", "/" + index + "/_settings");
             setNumberOfReplicas.setJsonEntity("{ \"index\": { \"number_of_replicas\" : " + numReplicas + " }}");
-            Response response = client().performRequest(setNumberOfReplicas);
+            client().performRequest(setNumberOfReplicas);
 
             ensureGreenLongWait(index);
 
@@ -218,76 +237,6 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                 counts.add(hits);
             }
             assertEquals("All nodes should have a consistent number of documents", 1, counts.size());
-        }
-    }
-
-    /**
-     * Search on an alias that contains illegal characters that would prevent it from being created after 5.1.0. It should still be
-     * search-able though.
-     */
-    public void testAliasWithBadName() throws Exception {
-        assumeTrue("Can only test bad alias name if old cluster is on 5.1.0 or before",
-            getOldClusterVersion().before(VERSION_5_1_0_UNRELEASED));
-
-        int count;
-        if (isRunningAgainstOldCluster()) {
-            XContentBuilder mappingsAndSettings = jsonBuilder();
-            mappingsAndSettings.startObject();
-            {
-                mappingsAndSettings.startObject("settings");
-                mappingsAndSettings.field("number_of_shards", 1);
-                mappingsAndSettings.field("number_of_replicas", 0);
-                mappingsAndSettings.endObject();
-            }
-            {
-                mappingsAndSettings.startObject("mappings");
-                mappingsAndSettings.startObject("doc");
-                mappingsAndSettings.startObject("properties");
-                {
-                    mappingsAndSettings.startObject("key");
-                    mappingsAndSettings.field("type", "keyword");
-                    mappingsAndSettings.endObject();
-                }
-                mappingsAndSettings.endObject();
-                mappingsAndSettings.endObject();
-                mappingsAndSettings.endObject();
-            }
-            mappingsAndSettings.endObject();
-            Request createIndex = new Request("PUT", "/" + index);
-            createIndex.setJsonEntity(Strings.toString(mappingsAndSettings));
-            client().performRequest(createIndex);
-
-            String aliasName = "%23" + index; // %23 == #
-            client().performRequest(new Request("PUT", "/" + index + "/_alias/" + aliasName));
-            Response response = client().performRequest(new Request("HEAD", "/" + index + "/_alias/" + aliasName));
-            assertEquals(200, response.getStatusLine().getStatusCode());
-
-            count = randomIntBetween(32, 128);
-            indexRandomDocuments(count, true, true, i -> {
-                return JsonXContent.contentBuilder().startObject()
-                    .field("key", "value")
-                    .endObject();
-            });
-            refresh();
-        } else {
-            count = countOfIndexedRandomDocuments();
-        }
-
-        Request request = new Request("GET", "/_cluster/state");
-        request.addParameter("metric", "metadata");
-        logger.error("clusterState=" + entityAsMap(client().performRequest(request)));
-        // We can read from the alias just like we can read from the index.
-        String aliasName = "%23" + index; // %23 == #
-        Map<String, Object> searchRsp = entityAsMap(client().performRequest(new Request("GET", "/" + aliasName + "/_search")));
-        int totalHits = extractTotalHits(searchRsp);
-        assertEquals(count, totalHits);
-        if (isRunningAgainstOldCluster() == false) {
-            // We can remove the alias.
-            Response response = client().performRequest(new Request("DELETE", "/" + index + "/_alias/" + aliasName));
-            assertEquals(200, response.getStatusLine().getStatusCode());
-            // and check that it is gone:
-            response = client().performRequest(new Request("HEAD", "/" + index + "/_alias/" + aliasName));
-            assertEquals(404, response.getStatusLine().getStatusCode());
         }
     }
 
@@ -344,16 +293,32 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             mappingsAndSettings.startObject();
             {
                 mappingsAndSettings.startObject("mappings");
-                mappingsAndSettings.startObject("doc");
-                mappingsAndSettings.startObject("properties");
                 {
-                    mappingsAndSettings.startObject("field");
-                    mappingsAndSettings.field("type", "text");
+                    if (isRunningAgainstAncientCluster()) {
+                        mappingsAndSettings.startObject(type);
+                    }
+                    mappingsAndSettings.startObject("properties");
+                    {
+                        mappingsAndSettings.startObject("field");
+                        {
+                            mappingsAndSettings.field("type", "text");
+                        }
+                        mappingsAndSettings.endObject();
+                    }
                     mappingsAndSettings.endObject();
+                    if (isRunningAgainstAncientCluster()) {
+                        mappingsAndSettings.endObject();
+                    }
                 }
                 mappingsAndSettings.endObject();
-                mappingsAndSettings.endObject();
-                mappingsAndSettings.endObject();
+                if (isRunningAgainstAncientCluster() == false) {
+                    // the default number of shards is now one so we have to set the number of shards to be more than one explicitly
+                    mappingsAndSettings.startObject("settings");
+                    {
+                        mappingsAndSettings.field("index.number_of_shards", 5);
+                    }
+                    mappingsAndSettings.endObject();
+                }
             }
             mappingsAndSettings.endObject();
 
@@ -363,11 +328,8 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             client().performRequest(createIndex);
 
             numDocs = randomIntBetween(512, 1024);
-            indexRandomDocuments(numDocs, true, true, i -> {
-                return JsonXContent.contentBuilder().startObject()
-                    .field("field", "value")
-                    .endObject();
-            });
+            indexRandomDocuments(
+                    numDocs, true, true, i -> JsonXContent.contentBuilder().startObject().field("field", "value").endObject());
 
             ensureGreen(index); // wait for source index to be available on both nodes before starting shrink
 
@@ -376,7 +338,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             client().performRequest(updateSettingsRequest);
 
             Request shrinkIndexRequest = new Request("PUT", "/" + index + "/_shrink/" + shrunkenIndex);
-            if (getOldClusterVersion().onOrAfter(Version.V_6_4_0)) {
+            if (getOldClusterVersion().onOrAfter(Version.V_6_4_0) && getOldClusterVersion().before(Version.V_7_0_0)) {
                 shrinkIndexRequest.addParameter("copy_settings", "true");
             }
             shrinkIndexRequest.setJsonEntity("{\"settings\": {\"index.number_of_shards\": 1}}");
@@ -414,16 +376,30 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             mappingsAndSettings.startObject();
             {
                 mappingsAndSettings.startObject("mappings");
-                mappingsAndSettings.startObject("doc");
-                mappingsAndSettings.startObject("properties");
                 {
-                    mappingsAndSettings.startObject("field");
-                    mappingsAndSettings.field("type", "text");
+                    if (isRunningAgainstAncientCluster()) {
+                        mappingsAndSettings.startObject(type);
+                    }
+                    mappingsAndSettings.startObject("properties");
+                    {
+                        mappingsAndSettings.startObject("field");
+                        {
+                            mappingsAndSettings.field("type", "text");
+                        }
+                        mappingsAndSettings.endObject();
+                    }
                     mappingsAndSettings.endObject();
+                    if (isRunningAgainstAncientCluster()) {
+                        mappingsAndSettings.endObject();
+                    }
                 }
                 mappingsAndSettings.endObject();
-                mappingsAndSettings.endObject();
-                mappingsAndSettings.endObject();
+                if (isRunningAgainstAncientCluster() == false) {
+                    // the default number of shards is now one so we have to set the number of shards to be more than one explicitly
+                    mappingsAndSettings.startObject("settings");
+                    mappingsAndSettings.field("index.number_of_shards", 5);
+                    mappingsAndSettings.endObject();
+                }
             }
             mappingsAndSettings.endObject();
 
@@ -433,11 +409,12 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             client().performRequest(createIndex);
 
             numDocs = randomIntBetween(512, 1024);
-            indexRandomDocuments(numDocs, true, true, i -> {
-                return JsonXContent.contentBuilder().startObject()
-                    .field("field", "value")
-                    .endObject();
-            });
+            indexRandomDocuments(
+                    numDocs,
+                    true,
+                    true,
+                    i -> JsonXContent.contentBuilder().startObject().field("field", "value").endObject()
+            );
         } else {
             ensureGreen(index); // wait for source index to be available on both nodes before starting shrink
 
@@ -504,7 +481,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             bulk.append("{\"index\":{}}\n");
             bulk.append("{\"test\":\"test\"}\n");
         }
-        Request bulkRequest = new Request("POST", "/" + index + "_write/doc/_bulk");
+        Request bulkRequest = new Request("POST", "/" + index + "_write/" + type + "/_bulk");
         bulkRequest.setJsonEntity(bulk.toString());
         bulkRequest.addParameter("refresh", "");
         bulkRequest.setOptions(expectWarnings(RestBulkAction.TYPES_DEPRECATION_MESSAGE));
@@ -627,7 +604,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         assertTotalHits(termsCount, boolTerms);
     }
 
-    void assertRealtimeGetWorks() throws IOException {
+    void assertRealtimeGetWorks(final String typeName) throws IOException {
         Request disableAutoRefresh = new Request("PUT", "/" + index + "/_settings");
         disableAutoRefresh.setJsonEntity("{ \"index\": { \"refresh_interval\" : -1 }}");
         client().performRequest(disableAutoRefresh);
@@ -638,13 +615,15 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         Map<?, ?> hit = (Map<?, ?>) ((List<?>)(XContentMapValues.extractValue("hits.hits", searchResponse))).get(0);
         String docId = (String) hit.get("_id");
 
-        Request updateRequest = new Request("POST", "/" + index + "/doc/" + docId + "/_update");
+        Request updateRequest = new Request("POST", "/" + index + "/" + typeName + "/" + docId + "/_update");
         updateRequest.setOptions(expectWarnings(RestUpdateAction.TYPES_DEPRECATION_MESSAGE));
         updateRequest.setJsonEntity("{ \"doc\" : { \"foo\": \"bar\"}}");
         client().performRequest(updateRequest);
 
-        Request getRequest = new Request("GET", "/" + index + "/doc/" + docId);
-        getRequest.setOptions(expectWarnings(RestGetAction.TYPES_DEPRECATION_MESSAGE));
+        Request getRequest = new Request("GET", "/" + index + "/" + typeName + "/" + docId);
+        if (getOldClusterVersion().before(Version.V_6_7_0)) {
+            getRequest.setOptions(expectWarnings(RestGetAction.TYPES_DEPRECATION_MESSAGE));
+        }
         Map<String, Object> getRsp = entityAsMap(client().performRequest(getRequest));
         Map<?, ?> source = (Map<?, ?>) getRsp.get("_source");
         assertTrue("doc does not contain 'foo' key: " + source, source.containsKey("foo"));
@@ -683,7 +662,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
 
     void assertTotalHits(int expectedTotalHits, Map<?, ?> response) {
         int actualTotalHits = extractTotalHits(response);
-        assertEquals(expectedTotalHits, actualTotalHits);
+        assertEquals(response.toString(), expectedTotalHits, actualTotalHits);
     }
 
     int extractTotalHits(Map<?, ?> response) {
@@ -698,7 +677,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
      * Tests that a single document survives. Super basic smoke test.
      */
     public void testSingleDoc() throws IOException {
-        String docLocation = "/" + index + "/doc/1";
+        String docLocation = "/" + index + "/" + type + "/1";
         String doc = "{\"test\": \"test\"}";
 
         if (isRunningAgainstOldCluster()) {
@@ -709,7 +688,9 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
 
 
         Request request = new Request("GET", docLocation);
-        request.setOptions(expectWarnings(RestGetAction.TYPES_DEPRECATION_MESSAGE));
+        if (getOldClusterVersion().before(Version.V_6_7_0)) {
+            request.setOptions(expectWarnings(RestGetAction.TYPES_DEPRECATION_MESSAGE));
+        }
         assertThat(toStr(client().performRequest(request)), containsString(doc));
     }
 
@@ -773,8 +754,12 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             }
             if (shouldHaveTranslog) {
                 // Update a few documents so we are sure to have a translog
-                indexRandomDocuments(count / 10, false /* Flushing here would invalidate the whole thing....*/, false,
-                    i -> jsonBuilder().startObject().field("field", "value").endObject());
+                indexRandomDocuments(
+                        count / 10,
+                        false, // flushing here would invalidate the whole thing
+                        false,
+                        i -> jsonBuilder().startObject().field("field", "value").endObject()
+                );
             }
             saveInfoDocument("should_have_translog", Boolean.toString(shouldHaveTranslog));
         } else {
@@ -785,6 +770,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         // Count the documents in the index to make sure we have as many as we put there
         Request countRequest = new Request("GET", "/" + index + "/_search");
         countRequest.addParameter("size", "0");
+        refresh();
         Map<String, Object> countResponse = entityAsMap(client().performRequest(countRequest));
         assertTotalHits(count, countResponse);
 
@@ -888,13 +874,19 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         }
         templateBuilder.endObject();
         templateBuilder.startObject("mappings"); {
-            templateBuilder.startObject("doc"); {
-                templateBuilder.startObject("_source"); {
+            if (isRunningAgainstAncientCluster()) {
+                templateBuilder.startObject(type);
+            }
+            {
+                templateBuilder.startObject("_source");
+                {
                     templateBuilder.field("enabled", true);
                 }
                 templateBuilder.endObject();
             }
-            templateBuilder.endObject();
+            if (isRunningAgainstAncientCluster()) {
+                templateBuilder.endObject();
+            }
         }
         templateBuilder.endObject();
         templateBuilder.startObject("aliases"); {
@@ -913,12 +905,6 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         templateBuilder.endObject().endObject();
         Request createTemplateRequest = new Request("PUT", "/_template/test_template");
         createTemplateRequest.setJsonEntity(Strings.toString(templateBuilder));
-
-        // In 7.0, type names are no longer expected by default in put index template requests.
-        // We therefore use the deprecated typed APIs when running against the current version.
-        if (isRunningAgainstOldCluster() == false) {
-            createTemplateRequest.addParameter(INCLUDE_TYPE_NAME_PARAMETER, "true");
-        }
         createTemplateRequest.setOptions(allowTypesRemovalWarnings());
 
         client().performRequest(createTemplateRequest);
@@ -1010,12 +996,13 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             int numDocs = between(10, 100);
             for (int i = 0; i < numDocs; i++) {
                 String doc = Strings.toString(JsonXContent.contentBuilder().startObject().field("field", "v1").endObject());
-                Request request = new Request("POST", "/" + index + "/doc/" + i);
+                Request request = new Request("POST", "/" + index + "/" + type + "/" + i);
+                if (isRunningAgainstAncientCluster() == false) {
+                    request.setOptions(expectWarnings(RestIndexAction.TYPES_DEPRECATION_MESSAGE));
+                }
                 request.setJsonEntity(doc);
                 client().performRequest(request);
-                if (rarely()) {
-                    refresh();
-                }
+                refresh();
             }
             client().performRequest(new Request("POST", "/" + index + "/_flush"));
             int liveDocs = numDocs;
@@ -1023,11 +1010,11 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             for (int i = 0; i < numDocs; i++) {
                 if (randomBoolean()) {
                     String doc = Strings.toString(JsonXContent.contentBuilder().startObject().field("field", "v2").endObject());
-                    Request request = new Request("POST", "/" + index + "/doc/" + i);
+                    Request request = new Request("POST", "/" + index + "/" + type + "/" + i);
                     request.setJsonEntity(doc);
                     client().performRequest(request);
                 } else if (randomBoolean()) {
-                    client().performRequest(new Request("DELETE", "/" + index + "/doc/" + i));
+                    client().performRequest(new Request("DELETE", "/" + index + "/" + type + "/" + i));
                     liveDocs--;
                 }
             }
@@ -1040,7 +1027,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         }
     }
 
-    private void checkSnapshot(String snapshotName, int count, Version tookOnVersion) throws IOException {
+    private void checkSnapshot(final String snapshotName, final int count, final Version tookOnVersion) throws IOException {
         // Check the snapshot metadata, especially the version
         Request listSnapshotRequest = new Request("GET", "/_snapshot/repo/" + snapshotName);
         Map<String, Object> listSnapshotResponse = entityAsMap(client().performRequest(listSnapshotRequest));
@@ -1097,7 +1084,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             bulk.append("{\"index\":{\"_id\":\"").append(count + i).append("\"}}\n");
             bulk.append("{\"test\":\"test\"}\n");
         }
-        Request writeToRestoredRequest = new Request("POST", "/restored_" + index + "/doc/_bulk");
+        Request writeToRestoredRequest = new Request("POST", "/restored_" + index + "/" + type + "/_bulk");
         writeToRestoredRequest.addParameter("refresh", "true");
         writeToRestoredRequest.setJsonEntity(bulk.toString());
         writeToRestoredRequest.setOptions(expectWarnings(RestBulkAction.TYPES_DEPRECATION_MESSAGE));
@@ -1123,12 +1110,6 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
 
         // Check that the template was restored successfully
         Request getTemplateRequest = new Request("GET", "/_template/test_template");
-
-        // In 7.0, type names are no longer returned by default in get index template requests.
-        // We therefore use the deprecated typed APIs when running against the current version.
-        if (isRunningAgainstOldCluster() == false) {
-            getTemplateRequest.addParameter(INCLUDE_TYPE_NAME_PARAMETER, "true");
-        }
         getTemplateRequest.setOptions(allowTypesRemovalWarnings());
 
         Map<String, Object> getTemplateResponse = entityAsMap(client().performRequest(getTemplateRequest));
@@ -1139,7 +1120,14 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             expectedTemplate.put("index_patterns", singletonList("evil_*"));
         }
         expectedTemplate.put("settings", singletonMap("index", singletonMap("number_of_shards", "1")));
-        expectedTemplate.put("mappings", singletonMap("doc", singletonMap("_source", singletonMap("enabled", true))));
+        // We don't have the type in the response starting with 7.0, but we won't have it on old cluster after upgrade
+        // either so look at the response to figure out the correct assertions
+        if (isTypeInTemplateResponse(getTemplateResponse)) {
+            expectedTemplate.put("mappings", singletonMap(type, singletonMap("_source", singletonMap("enabled", true))));
+        } else {
+            expectedTemplate.put("mappings", singletonMap("_source", singletonMap("enabled", true)));
+        }
+
         expectedTemplate.put("order", 0);
         Map<String, Object> aliases = new HashMap<>();
         aliases.put("alias1", emptyMap());
@@ -1149,18 +1137,33 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         if (false == expectedTemplate.equals(getTemplateResponse)) {
             NotEqualMessageBuilder builder = new NotEqualMessageBuilder();
             builder.compareMaps(getTemplateResponse, expectedTemplate);
+            logger.info("expected: {}\nactual:{}", expectedTemplate, getTemplateResponse);
             fail("template doesn't match:\n" + builder.toString());
         }
     }
 
+    @SuppressWarnings("unchecked")
+    private boolean isTypeInTemplateResponse(Map<String, Object> getTemplateResponse) {
+        return ( (Map<String, Object>) (
+            (Map<String, Object>) getTemplateResponse.getOrDefault("test_template", emptyMap())
+        ).get("mappings")).get("_source") == null;
+    }
+
     // TODO tests for upgrades after shrink. We've had trouble with shrink in the past.
 
-    private void indexRandomDocuments(int count, boolean flushAllowed, boolean saveInfo,
-                                      CheckedFunction<Integer, XContentBuilder, IOException> docSupplier) throws IOException {
+    private void indexRandomDocuments(
+            final int count,
+            final boolean flushAllowed,
+            final boolean saveInfo,
+            final CheckedFunction<Integer, XContentBuilder, IOException> docSupplier)
+            throws IOException {
         logger.info("Indexing {} random documents", count);
         for (int i = 0; i < count; i++) {
             logger.debug("Indexing document [{}]", i);
-            Request createDocument = new Request("POST", "/" + index + "/doc/" + i);
+            Request createDocument = new Request("POST", "/" + index + "/" + type + "/" + i);
+            if (isRunningAgainstAncientCluster() == false) {
+                createDocument.setOptions(expectWarnings(RestBulkAction.TYPES_DEPRECATION_MESSAGE));
+            }
             createDocument.setJsonEntity(Strings.toString(docSupplier.apply(i)));
             client().performRequest(createDocument);
             if (rarely()) {
@@ -1185,16 +1188,21 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         infoDoc.field("value", value);
         infoDoc.endObject();
         // Only create the first version so we know how many documents are created when the index is first created
-        Request request = new Request("PUT", "/info/doc/" + index + "_" + type);
+        Request request = new Request("PUT", "/info/" + this.type + "/" + index + "_" + type);
         request.addParameter("op_type", "create");
         request.setJsonEntity(Strings.toString(infoDoc));
+        if (isRunningAgainstAncientCluster() == false) {
+            request.setOptions(expectWarnings(RestIndexAction.TYPES_DEPRECATION_MESSAGE));
+        }
         client().performRequest(request);
     }
 
     private String loadInfoDocument(String type) throws IOException {
-        Request request = new Request("GET", "/info/doc/" + index + "_" + type);
+        Request request = new Request("GET", "/info/" + this.type + "/" + index + "_" + type);
         request.addParameter("filter_path", "_source");
-        request.setOptions(expectWarnings(RestGetAction.TYPES_DEPRECATION_MESSAGE));
+        if (getOldClusterVersion().before(Version.V_6_7_0)) {
+            request.setOptions(expectWarnings(RestGetAction.TYPES_DEPRECATION_MESSAGE));
+        }
         String doc = toStr(client().performRequest(request));
         Matcher m = Pattern.compile("\"value\":\"(.+)\"").matcher(doc);
         assertTrue(doc, m.find());

--- a/test/framework/src/main/java/org/elasticsearch/upgrades/AbstractFullClusterRestartTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/upgrades/AbstractFullClusterRestartTestCase.java
@@ -63,6 +63,14 @@ public abstract class AbstractFullClusterRestartTestCase extends ESRestTestCase 
 
     private final Version oldClusterVersion = Version.fromString(System.getProperty("tests.old_cluster_version"));
 
+    /**
+     * @return true if test is running against an old cluster before that last major, in this case
+     * when System.getProperty("tests.is_old_cluster" == true) and oldClusterVersion is before {@link Version#V_7_0_0}
+     */
+    protected final boolean isRunningAgainstAncientCluster() {
+        return isRunningAgainstOldCluster() && oldClusterVersion.before(Version.V_7_0_0);
+    }
+
     public final Version getOldClusterVersion() {
         return oldClusterVersion;
     }


### PR DESCRIPTION
This commit is copy of the applicable changes pulled from the 7.x branch.
The only non-applicable change (i.e. not included here) is from #39499 since
that is 7.1+

related: #38514
replaces: #41224

