### PR TITLE
Docs: Drop inline callouts from two SQL pages

### DIFF
--- a/docs/reference/sql/functions/string.asciidoc
+++ b/docs/reference/sql/functions/string.asciidoc
@@ -11,7 +11,7 @@ Functions for performing string manipulation.
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-ASCII(string_exp<1>)
+ASCII(string_exp) <1>
 --------------------------------------------------
 
 *Input*:
@@ -35,7 +35,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[stringAscii]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-BIT_LENGTH(string_exp<1>)
+BIT_LENGTH(string_exp) <1>
 --------------------------------------------------
 *Input*:
 
@@ -58,7 +58,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[stringBitLength]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-CHAR(code<1>)
+CHAR(code) <1>
 --------------------------------------------------
 *Input*:
 
@@ -81,7 +81,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[stringChar]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-CHAR_LENGTH(string_exp<1>)
+CHAR_LENGTH(string_exp) <1>
 --------------------------------------------------
 *Input*:
 
@@ -104,7 +104,9 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[stringCharLength]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-CONCAT(string_exp1<1>,string_exp2<2>)
+CONCAT(
+    string_exp1, <1>
+    string_exp2) <2>
 --------------------------------------------------
 *Input*:
 
@@ -128,7 +130,11 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[stringConcat]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-INSERT(source<1>, start<2>, length<3>, replacement<4>)
+INSERT(
+    source,      <1>
+    start,       <2>
+    length,      <3>
+    replacement) <4>
 --------------------------------------------------
 *Input*:
 
@@ -154,7 +160,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[stringInsert]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-LCASE(string_exp<1>)
+LCASE(string_exp) <1>
 --------------------------------------------------
 *Input*:
 
@@ -177,7 +183,9 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[stringLCase]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-LEFT(string_exp<1>, count<2>)
+LEFT(
+    string_exp, <1>
+    count)      <2>
 --------------------------------------------------
 *Input*:
 
@@ -201,7 +209,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[stringLeft]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-LENGTH(string_exp<1>)
+LENGTH(string_exp) <1>
 --------------------------------------------------
 *Input*:
 
@@ -224,7 +232,11 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[stringLength]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-LOCATE(pattern<1>, source<2>[, start]<3>)
+LOCATE(
+    pattern, <1>
+    source   <2>
+    [, start]<3>
+)
 --------------------------------------------------
 *Input*:
 
@@ -254,7 +266,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[stringLocateWithStart]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-LTRIM(string_exp<1>)
+LTRIM(string_exp) <1>
 --------------------------------------------------
 *Input*:
 
@@ -277,7 +289,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[stringLTrim]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-OCTET_LENGTH(string_exp<1>)
+OCTET_LENGTH(string_exp) <1>
 --------------------------------------------------
 *Input*:
 
@@ -300,7 +312,9 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[stringOctetLength]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-POSITION(string_exp1<1>, string_exp2<2>)
+POSITION(
+    string_exp1, <1>
+    string_exp2) <2>
 --------------------------------------------------
 *Input*:
 
@@ -324,7 +338,9 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[stringPosition]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-REPEAT(string_exp<1>, count<2>)
+REPEAT(
+    string_exp, <1>
+    count)      <2>
 --------------------------------------------------
 *Input*:
 
@@ -348,7 +364,10 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[stringRepeat]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-REPLACE(source<1>, pattern<2>, replacement<3>)
+REPLACE(
+    source,      <1>
+    pattern,     <2>
+    replacement) <3>
 --------------------------------------------------
 *Input*:
 
@@ -373,7 +392,9 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[stringReplace]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-RIGHT(string_exp<1>, count<2>)
+RIGHT(
+    string_exp, <1>
+    count)      <2>
 --------------------------------------------------
 *Input*:
 
@@ -397,7 +418,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[stringRight]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-RTRIM(string_exp<1>)
+RTRIM(string_exp) <1>
 --------------------------------------------------
 *Input*:
 
@@ -420,7 +441,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[stringRTrim]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-SPACE(count<1>)
+SPACE(count) <1>
 --------------------------------------------------
 *Input*:
 
@@ -443,7 +464,10 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[stringSpace]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-SUBSTRING(source<1>, start<2>, length<3>)
+SUBSTRING(
+    source, <1>
+    start,  <2>
+    length) <3>
 --------------------------------------------------
 *Input*:
 
@@ -468,7 +492,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[stringSubString]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-UCASE(string_exp<1>)
+UCASE(string_exp) <1>
 --------------------------------------------------
 *Input*:
 

--- a/docs/reference/sql/functions/type-conversion.asciidoc
+++ b/docs/reference/sql/functions/type-conversion.asciidoc
@@ -11,7 +11,9 @@ Functions for converting an expression of one data type to another.
 .Synopsis:
 [source, sql]
 ----
-CAST(expression<1> AS data_type<2>)
+CAST(
+    expression <1>
+ AS data_type) <2>
 ----
 
 <1> Expression to cast
@@ -50,7 +52,9 @@ To obtain an {es} `float`, perform casting to its SQL equivalent, `real` type.
 .Synopsis:
 [source, sql]
 ----
-CONVERT(expression<1>, data_type<2>)
+CONVERT(
+    expression, <1>
+    data_type)  <2>
 ----
 
 <1> Expression to convert


### PR DESCRIPTION
Drops inline callouts from the docs for SQL's string and type-conversion
functions because they are not compatible with Asciidoctor.
