### PR TITLE
[DOCS] Remove inline callouts in SQL Command docs for Asciidoctor migration

### DIFF
--- a/docs/reference/sql/language/syntax/commands/describe-table.asciidoc
+++ b/docs/reference/sql/language/syntax/commands/describe-table.asciidoc
@@ -8,7 +8,7 @@
 ----
 DESCRIBE
     [table identifier | <1>
-    [LIKE pattern]] <2>
+    [LIKE pattern]]     <2>
 ----
 
 <1> single table identifier or double quoted es multi index
@@ -20,7 +20,7 @@ or
 ----
 DESC 
     [table identifier | <1>
-    [LIKE pattern]] <2>
+    [LIKE pattern]]     <2>
 ----
 
 <1> single table identifier or double quoted es multi index

--- a/docs/reference/sql/language/syntax/commands/describe-table.asciidoc
+++ b/docs/reference/sql/language/syntax/commands/describe-table.asciidoc
@@ -6,7 +6,9 @@
 .Synopsis
 [source, sql]
 ----
-DESCRIBE [table identifier<1> | [LIKE pattern<2>]]
+DESCRIBE
+    [table identifier | <1>
+    [LIKE pattern]] <2>
 ----
 
 <1> single table identifier or double quoted es multi index
@@ -16,7 +18,9 @@ or
 
 [source, sql]
 ----
-DESC [table identifier<1>|[LIKE pattern<2>]]
+DESC 
+    [table identifier | <1>
+    [LIKE pattern]] <2>
 ----
 
 <1> single table identifier or double quoted es multi index

--- a/docs/reference/sql/language/syntax/commands/show-columns.asciidoc
+++ b/docs/reference/sql/language/syntax/commands/show-columns.asciidoc
@@ -6,7 +6,9 @@
 .Synopsis
 [source, sql]
 ----
-SHOW COLUMNS [ FROM | IN ]? [ table identifier<1> | [ LIKE pattern<2> ] ]
+SHOW COLUMNS [ FROM | IN ]?
+    [table identifier | <1>
+    [LIKE pattern] ] <2>
 ----
 
 <1> single table identifier or double quoted es multi index

--- a/docs/reference/sql/language/syntax/commands/show-columns.asciidoc
+++ b/docs/reference/sql/language/syntax/commands/show-columns.asciidoc
@@ -8,7 +8,7 @@
 ----
 SHOW COLUMNS [ FROM | IN ]?
     [table identifier | <1>
-    [LIKE pattern] ] <2>
+    [LIKE pattern] ]    <2>
 ----
 
 <1> single table identifier or double quoted es multi index

--- a/docs/reference/sql/language/syntax/commands/show-functions.asciidoc
+++ b/docs/reference/sql/language/syntax/commands/show-functions.asciidoc
@@ -6,7 +6,7 @@
 .Synopsis
 [source, sql]
 ----
-SHOW FUNCTIONS [LIKE pattern?]?<1>
+SHOW FUNCTIONS [LIKE pattern?]? <1>
 ----
 
 <1> SQL match pattern

--- a/docs/reference/sql/language/syntax/commands/show-functions.asciidoc
+++ b/docs/reference/sql/language/syntax/commands/show-functions.asciidoc
@@ -6,7 +6,7 @@
 .Synopsis
 [source, sql]
 ----
-SHOW FUNCTIONS [ LIKE pattern<1>? ]?
+SHOW FUNCTIONS [LIKE pattern?]?<1>
 ----
 
 <1> SQL match pattern

--- a/docs/reference/sql/language/syntax/commands/show-tables.asciidoc
+++ b/docs/reference/sql/language/syntax/commands/show-tables.asciidoc
@@ -8,7 +8,7 @@
 ----
 SHOW TABLES
     [table identifier | <1>
-    [LIKE pattern ]]? <2>
+    [LIKE pattern ]]?   <2>
 ----
 
 <1> single table identifier or double quoted es multi index

--- a/docs/reference/sql/language/syntax/commands/show-tables.asciidoc
+++ b/docs/reference/sql/language/syntax/commands/show-tables.asciidoc
@@ -6,7 +6,9 @@
 .Synopsis
 [source, sql]
 ----
-SHOW TABLES [ table identifier<1> | [ LIKE pattern<2> ] ]?
+SHOW TABLES
+    [table identifier | <1>
+    [LIKE pattern ]]? <2>
 ----
 
 <1> single table identifier or double quoted es multi index


### PR DESCRIPTION
Removes inline callouts from the [SQL Commands](https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-commands.html) documentation. This change helps prepare Elasticsearch docs for Asciidoctor migration.

Per https://asciidoctor.org/docs/user-manual/#callouts, AsciiDoctor enforces this requirement: "The callout number (at the target) must be placed at the end of the line."

Relates to #41128

## Before / After Rendering
### DESCRIBE TABLE
**Before**
<img width="775" alt="describe-before" src="https://user-images.githubusercontent.com/40268737/56246914-12c80e00-6058-11e9-8eb2-07aa7837c9d1.png">

**After**
<img width="771" alt="Screen Shot 2019-04-17 at 6 29 15 AM" src="https://user-images.githubusercontent.com/40268737/56291460-287e1780-60da-11e9-8d09-1acae41f4e29.png">


### SHOW COLUMNS
**Before**
<img width="772" alt="show-columns-before" src="https://user-images.githubusercontent.com/40268737/56246987-40ad5280-6058-11e9-8e88-bea13d664821.png">

**After**
<img width="777" alt="Screen Shot 2019-04-17 at 6 29 52 AM" src="https://user-images.githubusercontent.com/40268737/56291495-3d5aab00-60da-11e9-98a7-d5098a394add.png">

### SHOW FUNCTIONS
**Before**
<img width="769" alt="show-functions-before" src="https://user-images.githubusercontent.com/40268737/56247025-5cb0f400-6058-11e9-9bdd-249609f1b633.png">

**After**
<img width="775" alt="Screen Shot 2019-04-17 at 6 37 20 AM" src="https://user-images.githubusercontent.com/40268737/56292057-4ac46500-60db-11e9-8c19-f8beae152f6b.png">


### SHOW TABLES
**Before**
<img width="757" alt="show-tables-before" src="https://user-images.githubusercontent.com/40268737/56247063-79e5c280-6058-11e9-8214-a00a922d9a80.png">

**After**
<img width="783" alt="Screen Shot 2019-04-17 at 6 31 28 AM" src="https://user-images.githubusercontent.com/40268737/56291632-772bb180-60da-11e9-8a91-348226c03188.png">

