### PR TITLE
Rebase keyed JSON ordinals to start from zero.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
@@ -424,8 +424,8 @@ public final class JsonFieldMapper extends FieldMapper {
 
         @Override
         public OrdinalMap getOrdinalMap() {
-            throw new UnsupportedOperationException("Keyed JSON field data does not allow access to the" +
-                " underlying ordinal map.");
+            throw new UnsupportedOperationException("The keyed JSON field data for field ["
+                + delegate.getFieldName() + "] does not allow access to the underlying ordinal map.");
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
@@ -362,6 +362,9 @@ public final class JsonFieldMapper extends FieldMapper {
      * filters out values whose prefix doesn't match the requested key. Loading and caching
      * is fully delegated to the wrapped field data, so that different {@link KeyedJsonIndexFieldData}
      * for the same JSON field share the same global ordinals.
+     *
+     * Because of the code-level complexity it would introduce, it is currently not possible
+     * to retrieve the underlying global ordinals map through {@link #getOrdinalMap()}.
      */
     public static class KeyedJsonIndexFieldData implements IndexOrdinalsFieldData {
         private final String key;
@@ -421,7 +424,8 @@ public final class JsonFieldMapper extends FieldMapper {
 
         @Override
         public OrdinalMap getOrdinalMap() {
-            return delegate.getOrdinalMap();
+            throw new UnsupportedOperationException("Keyed JSON field data does not allow access to the" +
+                " underlying ordinal map.");
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldParser.java
@@ -37,7 +37,7 @@ import java.util.List;
  * and produces a pair of indexable fields for each leaf value.
  */
 public class JsonFieldParser {
-    private static final String SEPARATOR = "\0";
+    static final String SEPARATOR = "\0";
     private static final byte SEPARATOR_BYTE = '\0';
 
     private final String rootFieldName;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
@@ -262,21 +262,26 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory<Values
                 assert maxOrd != -1;
                 final double ratio = maxOrd / ((double) context.searcher().getIndexReader().numDocs());
 
+                assert valuesSource instanceof ValuesSource.Bytes.WithOrdinals;
+                ValuesSource.Bytes.WithOrdinals ordinalsValuesSource = (ValuesSource.Bytes.WithOrdinals) valuesSource;
+
                 if (factories == AggregatorFactories.EMPTY &&
                         includeExclude == null &&
                         Aggregator.descendsFromBucketAggregator(parent) == false &&
+                        ordinalsValuesSource.supportsGlobalOrdinalsMapping() &&
                         // we use the static COLLECT_SEGMENT_ORDS to allow tests to force specific optimizations
                         (COLLECT_SEGMENT_ORDS!= null ? COLLECT_SEGMENT_ORDS.booleanValue() : ratio <= 0.5 && maxOrd <= 2048)) {
                     /**
                      * We can use the low cardinality execution mode iff this aggregator:
                      *  - has no sub-aggregator AND
                      *  - is not a child of a bucket aggregator AND
+                     *  - has a values source that can map from segment to global ordinals
                      *  - At least we reduce the number of global ordinals look-ups by half (ration <= 0.5) AND
                      *  - the maximum global ordinal is less than 2048 (LOW_CARDINALITY has additional memory usage,
                      *  which directly linked to maxOrd, so we need to limit).
                      */
                     return new GlobalOrdinalsStringTermsAggregator.LowCardinality(name, factories,
-                            (ValuesSource.Bytes.WithOrdinals) valuesSource, order, format, bucketCountThresholds, context, parent, false,
+                            ordinalsValuesSource, order, format, bucketCountThresholds, context, parent, false,
                             subAggCollectMode, showTermDocCountError, pipelineAggregators, metaData);
 
                 }
@@ -301,7 +306,7 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory<Values
                          remapGlobalOrds = false;
                     }
                 }
-                return new GlobalOrdinalsStringTermsAggregator(name, factories, (ValuesSource.Bytes.WithOrdinals) valuesSource, order,
+                return new GlobalOrdinalsStringTermsAggregator(name, factories, ordinalsValuesSource, order,
                         format, bucketCountThresholds, filter, context, parent, remapGlobalOrds, subAggCollectMode, showTermDocCountError,
                         pipelineAggregators, metaData);
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
@@ -114,7 +114,7 @@ public abstract class ValuesSource {
 
             /**
              * Whether this values source is able to provide a mapping between global and segment ordinals,
-             * by returning the underlying {@link OrdinalMap}. If this method returnns false, then calling
+             * by returning the underlying {@link OrdinalMap}. If this method returns false, then calling
              * {@link #globalOrdinalsMapping} will result in an {@link UnsupportedOperationException}.
              */
             public boolean supportsGlobalOrdinalsMapping() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
@@ -42,6 +42,7 @@ import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortingBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortingNumericDoubleValues;
+import org.elasticsearch.index.mapper.JsonFieldMapper;
 import org.elasticsearch.script.AggregationScript;
 import org.elasticsearch.search.aggregations.support.ValuesSource.WithScript.BytesValues;
 import org.elasticsearch.search.aggregations.support.values.ScriptBytesValues;
@@ -111,6 +112,15 @@ public abstract class ValuesSource {
             public abstract SortedSetDocValues globalOrdinalsValues(LeafReaderContext context)
                     throws IOException;
 
+            /**
+             * Whether this values source is able to provide a mapping between global and segment ordinals,
+             * by returning the underlying {@link OrdinalMap}. If this method returnns false, then calling
+             * {@link #globalOrdinalsMapping} will result in an {@link UnsupportedOperationException}.
+             */
+            public boolean supportsGlobalOrdinalsMapping() {
+                return true;
+            }
+
             /** Returns a mapping from segment ordinals to global ordinals. */
             public abstract LongUnaryOperator globalOrdinalsMapping(LeafReaderContext context)
                     throws IOException;
@@ -151,6 +161,11 @@ public abstract class ValuesSource {
                     final IndexOrdinalsFieldData global = indexFieldData.loadGlobal((DirectoryReader)context.parent.reader());
                     final AtomicOrdinalsFieldData atomicFieldData = global.load(context);
                     return atomicFieldData.getOrdinalsValues();
+                }
+
+                @Override
+                public boolean supportsGlobalOrdinalsMapping() {
+                    return (indexFieldData instanceof JsonFieldMapper.KeyedJsonIndexFieldData) == false;
                 }
 
                 @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeyedJsonAtomicFieldDataTests.java
@@ -30,7 +30,6 @@ import org.junit.Before;
 import java.io.IOException;
 
 import static org.apache.lucene.index.SortedSetDocValues.NO_MORE_ORDS;
-import static org.hamcrest.Matchers.containsString;
 
 public class KeyedJsonAtomicFieldDataTests extends ESTestCase {
     private AtomicOrdinalsFieldData delegate;
@@ -130,32 +129,29 @@ public class KeyedJsonAtomicFieldDataTests extends ESTestCase {
 
         int retrievedOrds = 0;
         for (long ord = docValues.nextOrd(); ord != NO_MORE_ORDS; ord = docValues.nextOrd()) {
-            assertTrue(30 <= ord && ord < 40);
+            assertTrue(0 <= ord && ord < 10);
             retrievedOrds++;
 
-            BytesRef prefixedTerm = delegate.getOrdinalsValues().lookupOrd(ord);
-            BytesRef key = JsonFieldParser.extractKey(prefixedTerm);
-            assertEquals("banana", key.utf8ToString());
+            BytesRef expectedValue = new BytesRef("value" + (ord + 30));
+            BytesRef actualValue = docValues.lookupOrd(ord);
+            assertEquals(expectedValue, actualValue);
         }
 
         assertEquals(10, retrievedOrds);
     }
 
     public void testLookupOrd() throws IOException {
-        AtomicOrdinalsFieldData fieldData = new KeyedJsonAtomicFieldData("apple", delegate);
-        SortedSetDocValues docValues = fieldData.getOrdinalsValues();
+        AtomicOrdinalsFieldData appleFieldData = new KeyedJsonAtomicFieldData("apple", delegate);
+        SortedSetDocValues appleDocValues = appleFieldData.getOrdinalsValues();
+        assertEquals(new BytesRef("value0"), appleDocValues.lookupOrd(0));
 
-        BytesRef expectedValue = new BytesRef("value0");
-        BytesRef value = docValues.lookupOrd(0);
-        assertEquals(0, expectedValue.compareTo(value));
-    }
+        AtomicOrdinalsFieldData cantaloupeFieldData = new KeyedJsonAtomicFieldData("cantaloupe", delegate);
+        SortedSetDocValues cantaloupeDocValues = cantaloupeFieldData.getOrdinalsValues();
+        assertEquals(new BytesRef("value40"), cantaloupeDocValues.lookupOrd(0));
 
-    public void testLookupInvalidOrd() {
-        AtomicOrdinalsFieldData fieldData = new KeyedJsonAtomicFieldData("apple", delegate);
-        SortedSetDocValues docValues = fieldData.getOrdinalsValues();
-
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> docValues.lookupOrd(42));
-        assertThat(e.getMessage(), containsString("The provided ordinal [42] is outside the valid range."));
+        AtomicOrdinalsFieldData cucumberFieldData = new KeyedJsonAtomicFieldData("cucumber", delegate);
+        SortedSetDocValues cucumberDocValues = cucumberFieldData.getOrdinalsValues();
+        assertEquals(new BytesRef("value41"), cucumberDocValues.lookupOrd(0));
     }
 
     private static class MockAtomicOrdinalsFieldData extends AbstractAtomicOrdinalsFieldData {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsIT.java
@@ -1184,6 +1184,24 @@ public class StringTermsIT extends AbstractTermsTestCase {
         }
     }
 
+    public void testKeyedJsonFieldWithMinDocCount() {
+        TermsAggregationBuilder priorityAgg = terms("terms")
+            .field(JSON_FIELD_NAME + ".priority")
+            .collectMode(randomFrom(SubAggCollectionMode.values()))
+            .executionHint(randomExecutionHint())
+            .minDocCount(0);
+
+        SearchResponse priorityResponse = client().prepareSearch("idx")
+            .addAggregation(priorityAgg)
+            .get();
+        assertSearchResponse(priorityResponse);
+
+        Terms priorityTerms = priorityResponse.getAggregations().get("terms");
+        assertThat(priorityTerms, notNullValue());
+        assertThat(priorityTerms.getName(), equalTo("terms"));
+        assertThat(priorityTerms.getBuckets().size(), equalTo(1));
+    }
+
     public void testOtherDocCount() {
         testOtherDocCount(SINGLE_VALUED_FIELD_NAME, MULTI_VALUED_FIELD_NAME);
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityIT.java
@@ -126,6 +126,9 @@ public class CardinalityIT extends ESIntegTestCase {
                     .startObject("d_values")
                         .field("type", "double")
                     .endObject()
+                    .startObject("json_values")
+                        .field("type", "embedded_json")
+                    .endObject()
                     .endObject().endObject().endObject()).get();
 
         numDocs = randomIntBetween(2, 100);
@@ -140,6 +143,10 @@ public class CardinalityIT extends ESIntegTestCase {
                         .array("l_values", new int[] {i * 2, i * 2 + 1})
                         .field("d_value", i)
                         .array("d_values", new double[]{i * 2, i * 2 + 1})
+                        .startObject("json_values")
+                            .field("first", i)
+                            .field("second", i / 2)
+                        .endObject()
                     .endObject());
         }
         indexRandom(true, builders);
@@ -299,6 +306,40 @@ public class CardinalityIT extends ESIntegTestCase {
         assertThat(count, notNullValue());
         assertThat(count.getName(), equalTo("cardinality"));
         assertCount(count, numDocs * 2);
+    }
+
+    public void testJsonField() {
+        SearchResponse response = client().prepareSearch("idx")
+            .addAggregation(cardinality("cardinality")
+                .precisionThreshold(precisionThreshold)
+                .field("json_values"))
+            .get();
+
+        assertSearchResponse(response);
+        Cardinality count = response.getAggregations().get("cardinality");
+        assertCount(count, numDocs);
+    }
+
+    public void testKeyedJsonField() {
+        SearchResponse firstResponse = client().prepareSearch("idx")
+            .addAggregation(cardinality("cardinality")
+                .precisionThreshold(precisionThreshold)
+                .field("json_values.first"))
+            .get();
+        assertSearchResponse(firstResponse);
+
+        Cardinality firstCount = firstResponse.getAggregations().get("cardinality");
+        assertCount(firstCount, numDocs);
+
+        SearchResponse secondResponse = client().prepareSearch("idx")
+            .addAggregation(cardinality("cardinality")
+                .precisionThreshold(precisionThreshold)
+                .field("json_values.second"))
+            .get();
+        assertSearchResponse(secondResponse);
+
+        Cardinality secondCount = secondResponse.getAggregations().get("cardinality");
+        assertCount(secondCount, (numDocs + 1) / 2);
     }
 
     public void testSingleValuedStringScript() throws Exception {

--- a/server/src/test/java/org/elasticsearch/search/sort/FieldSortIT.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/FieldSortIT.java
@@ -1832,9 +1832,15 @@ public class FieldSortIT extends ESIntegTestCase {
         response = client().prepareSearch("test")
             .addSort("json_field.key", SortOrder.DESC)
             .get();
-
         assertSearchResponse(response);
         assertHitCount(response, 3);
         assertOrderedSearchHits(response, "2", "1", "3");
+
+        response = client().prepareSearch("test")
+            .addSort(new FieldSortBuilder("json_field.key").order(SortOrder.DESC).missing("Z"))
+            .get();
+        assertSearchResponse(response);
+        assertHitCount(response, 3);
+        assertOrderedSearchHits(response, "3", "2", "1");
     }
 }


### PR DESCRIPTION
This PR updates `KeyedJsonAtomicFieldData` to always return ordinals in the
range `[0, (maxOrd - minOrd)]`, which is necessary for certain aggregations and
sorting options to be supported.

As discussed in #41220, I opted not to support
`KeyedIndexFieldData#getOrdinalMap`, as it would add substantial complexity.
The one place this affects is the 'low cardinality' optimization for terms
aggregations, which now needs to be disabled for keyed JSON fields.

It was fairly difficult to incorporate this change, and I have a couple
follow-up refactors in mind to help simplify the global ordinals code. (I will
likely wait until this feature branch is merged though before opening PRs on
master).