### PR TITLE
[Backport] put mapping authorization for alias with write-index and multiple read indices (#40834)

### DIFF
--- a/x-pack/plugin/ilm/qa/with-security/src/test/java/org/elasticsearch/xpack/security/PermissionsIT.java
+++ b/x-pack/plugin/ilm/qa/with-security/src/test/java/org/elasticsearch/xpack/security/PermissionsIT.java
@@ -7,9 +7,12 @@ package org.elasticsearch.xpack.security;
 
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
+import org.elasticsearch.client.Node;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
@@ -19,6 +22,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xpack.core.indexlifecycle.DeleteAction;
@@ -26,6 +30,7 @@ import org.elasticsearch.xpack.core.indexlifecycle.LifecycleAction;
 import org.elasticsearch.xpack.core.indexlifecycle.LifecyclePolicy;
 import org.elasticsearch.xpack.core.indexlifecycle.LifecycleSettings;
 import org.elasticsearch.xpack.core.indexlifecycle.Phase;
+import org.elasticsearch.xpack.core.indexlifecycle.RolloverAction;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -36,8 +41,10 @@ import static java.util.Collections.singletonMap;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class PermissionsIT extends ESRestTestCase {
+    private static final String jsonDoc = "{ \"name\" : \"elasticsearch\", \"body\": \"foo bar\" }";
 
     private String deletePolicy = "deletePolicy";
     private Settings indexSettingsWithPolicy;
@@ -74,7 +81,7 @@ public class PermissionsIT extends ESRestTestCase {
             .put("number_of_shards", 1)
             .put("number_of_replicas", 0)
             .build();
-        createNewSingletonPolicy(deletePolicy,"delete", new DeleteAction());
+        createNewSingletonPolicy(client(), deletePolicy,"delete", new DeleteAction());
     }
 
     /**
@@ -126,7 +133,62 @@ public class PermissionsIT extends ESRestTestCase {
         assertOK(client().performRequest(request));
     }
 
-    private void createNewSingletonPolicy(String policy, String phaseName, LifecycleAction action) throws IOException {
+    /**
+     * Tests when the user is limited by alias of an index is able to write to index
+     * which was rolled over by an ILM policy.
+     */
+    public void testWhenUserLimitedByOnlyAliasOfIndexCanWriteToIndexWhichWasRolledoverByILMPolicy()
+            throws IOException, InterruptedException {
+        /*
+         * Setup:
+         * - ILM policy to rollover index when max docs condition is met
+         * - Index template to which the ILM policy applies and create Index
+         * - Create role with just write and manage privileges on alias
+         * - Create user and assign newly created role.
+         */
+        createNewSingletonPolicy(adminClient(), "foo-policy", "hot", new RolloverAction(null, null, 2L));
+        createIndexTemplate("foo-template", "foo-logs-*", "foo_alias", "foo-policy");
+        createIndexAsAdmin("foo-logs-000001", "foo_alias", randomBoolean());
+        createRole("foo_alias_role", "foo_alias");
+        createUser("test_user", "x-pack-test-password", "foo_alias_role");
+
+        // test_user: index docs using alias in the newly created index
+        indexDocs("test_user", "x-pack-test-password", "foo_alias", 2);
+        refresh("foo_alias");
+
+        // wait so the ILM policy triggers rollover action, verify that the new index exists
+        assertThat(awaitBusy(() -> {
+            Request request = new Request("HEAD", "/" + "foo-logs-000002");
+            int status;
+            try {
+                status = adminClient().performRequest(request).getStatusLine().getStatusCode();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            return status == 200;
+        }), is(true));
+
+        // test_user: index docs using alias, now should be able write to new index
+        indexDocs("test_user", "x-pack-test-password", "foo_alias", 1);
+        refresh("foo_alias");
+
+        // verify that the doc has been indexed into new write index
+        awaitBusy(() -> {
+            Request request = new Request("GET", "/foo-logs-000002/_search");
+            Response response;
+            try {
+                response = adminClient().performRequest(request);
+                try (InputStream content = response.getEntity().getContent()) {
+                    Map<String, Object> map = XContentHelper.convertToMap(JsonXContent.jsonXContent, content, false);
+                    return ((Integer) XContentMapValues.extractValue("hits.total", map)) == 1;
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private void createNewSingletonPolicy(RestClient client, String policy, String phaseName, LifecycleAction action) throws IOException {
         Phase phase = new Phase(phaseName, TimeValue.ZERO, singletonMap(action.getWriteableName(), action));
         LifecyclePolicy lifecyclePolicy = new LifecyclePolicy(policy, singletonMap(phase.getName(), phase));
         XContentBuilder builder = jsonBuilder();
@@ -135,13 +197,68 @@ public class PermissionsIT extends ESRestTestCase {
             "{ \"policy\":" + Strings.toString(builder) + "}", ContentType.APPLICATION_JSON);
         Request request = new Request("PUT", "_ilm/policy/" + policy);
         request.setEntity(entity);
-        client().performRequest(request);
+        assertOK(client.performRequest(request));
     }
 
     private void createIndexAsAdmin(String name, Settings settings, String mapping) throws IOException {
         Request request = new Request("PUT", "/" + name);
         request.setJsonEntity("{\n \"settings\": " + Strings.toString(settings)
             + ", \"mappings\" : {" + mapping + "} }");
+        assertOK(adminClient().performRequest(request));
+    }
+
+    private void createIndexAsAdmin(String name, String alias, boolean isWriteIndex) throws IOException {
+        Request request = new Request("PUT", "/" + name);
+        request.setJsonEntity("{ \"aliases\": { \""+alias+"\": {" + ((isWriteIndex) ? "\"is_write_index\" : true" : "")
+            + "} } }");
+        assertOK(adminClient().performRequest(request));
+    }
+
+    private void createIndexTemplate(String name, String pattern, String alias, String policy) throws IOException {
+        Request request = new Request("PUT", "/_template/" + name);
+        request.setJsonEntity("{\n" +
+                "                \"index_patterns\": [\""+pattern+"\"],\n" +
+                "                \"settings\": {\n" +
+                "                   \"number_of_shards\": 1,\n" +
+                "                   \"number_of_replicas\": 0,\n" +
+                "                   \"index.lifecycle.name\": \""+policy+"\",\n" +
+                "                   \"index.lifecycle.rollover_alias\": \""+alias+"\"\n" +
+                "                 }\n" +
+                "              }");
+        assertOK(adminClient().performRequest(request));
+    }
+
+    private void createUser(String name, String password, String role) throws IOException {
+        Request request = new Request("PUT", "/_security/user/" + name);
+        request.setJsonEntity("{ \"password\": \""+password+"\", \"roles\": [ \""+ role+"\"] }");
+        assertOK(adminClient().performRequest(request));
+    }
+
+    private void createRole(String name, String alias) throws IOException {
+        Request request = new Request("PUT", "/_security/role/" + name);
+        request.setJsonEntity("{ \"indices\": [ { \"names\" : [ \""+ alias+"\"], \"privileges\": [ \"write\", \"manage\" ] } ] }");
+        assertOK(adminClient().performRequest(request));
+    }
+
+    private void indexDocs(String user, String passwd, String index, int noOfDocs) throws IOException {
+        RestClientBuilder builder = RestClient.builder(adminClient().getNodes().toArray(new Node[0]));
+        String token = basicAuthHeaderValue(user, new SecureString(passwd.toCharArray()));
+        configureClient(builder, Settings.builder()
+                .put(ThreadContext.PREFIX + ".Authorization", token)
+                .build());
+        builder.setStrictDeprecationMode(true);
+        try (RestClient userClient = builder.build();) {
+
+            for (int cnt = 0; cnt < noOfDocs; cnt++) {
+                Request request = new Request("POST", "/" + index + "/_doc");
+                request.setJsonEntity(jsonDoc);
+                assertOK(userClient.performRequest(request));
+            }
+        }
+    }
+
+    private void refresh(String index) throws IOException {
+        Request request = new Request("POST", "/" + index + "/_refresh");
         assertOK(adminClient().performRequest(request));
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
@@ -246,7 +246,17 @@ class IndicesAndAliasesResolver {
                 Optional<String> foundAlias = aliasMetaData.stream()
                     .map(AliasMetaData::alias)
                     .filter(authorizedIndicesList::contains)
-                    .filter(aliasName -> metaData.getAliasAndIndexLookup().get(aliasName).getIndices().size() == 1)
+                    .filter(aliasName -> {
+                        AliasOrIndex alias = metaData.getAliasAndIndexLookup().get(aliasName);
+                        List<IndexMetaData> indexMetadata = alias.getIndices();
+                        if (indexMetadata.size() == 1) {
+                            return true;
+                        } else {
+                            assert alias instanceof AliasOrIndex.Alias;
+                            IndexMetaData idxMeta = ((AliasOrIndex.Alias) alias).getWriteIndex();
+                            return idxMeta != null && idxMeta.getIndex().getName().equals(concreteIndexName);
+                        }
+                    })
                     .findFirst();
                 resolvedAliasOrIndex = foundAlias.orElse(concreteIndexName);
             } else {


### PR DESCRIPTION
When the same alias points to multiple indices we can write to only one index
with `is_write_index` value `true`. The special handling in case of the put
mapping request(to resolve authorized indices) has a check on indices size
for a concrete index. If multiple indices existed then it marked the request
as unauthorized.

The check has been modified to consider write index flag and only when the
requested index matches with the one with write index alias, the alias is considered
for authorization.

Closes #40831
