### PR TITLE
Allow non-exact query types on the root JSON field.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/JsonFieldMapper.java
@@ -315,23 +315,23 @@ public final class JsonFieldMapper extends FieldMapper {
         @Override
         public Query fuzzyQuery(Object value, Fuzziness fuzziness, int prefixLength, int maxExpansions,
                                 boolean transpositions) {
-            throw new UnsupportedOperationException("[fuzzy] queries are not currently supported on [" +
-                CONTENT_TYPE + "] fields.");
+            throw new UnsupportedOperationException("[fuzzy] queries are not currently supported on keyed " +
+                "[" + CONTENT_TYPE + "] fields.");
         }
 
         @Override
         public Query regexpQuery(String value, int flags, int maxDeterminizedStates,
                                  MultiTermQuery.RewriteMethod method, QueryShardContext context) {
-            throw new UnsupportedOperationException("[regexp] queries are not currently supported on [" +
-                CONTENT_TYPE + "] fields.");
+            throw new UnsupportedOperationException("[regexp] queries are not currently supported on keyed " +
+                "[" + CONTENT_TYPE + "] fields.");
         }
 
         @Override
         public Query wildcardQuery(String value,
                                    MultiTermQuery.RewriteMethod method,
                                    QueryShardContext context) {
-            throw new UnsupportedOperationException("[wildcard] queries are not currently supported on [" +
-                CONTENT_TYPE + "] fields.");
+            throw new UnsupportedOperationException("[wildcard] queries are not currently supported on keyed " +
+                "[" + CONTENT_TYPE + "] fields.");
         }
 
         @Override
@@ -515,28 +515,6 @@ public final class JsonFieldMapper extends FieldMapper {
             } else {
                 return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
             }
-        }
-
-        @Override
-        public Query fuzzyQuery(Object value, Fuzziness fuzziness, int prefixLength, int maxExpansions,
-                                boolean transpositions) {
-            throw new UnsupportedOperationException("[fuzzy] queries are not currently supported on [" +
-                CONTENT_TYPE + "] fields.");
-        }
-
-        @Override
-        public Query regexpQuery(String value, int flags, int maxDeterminizedStates,
-                                 MultiTermQuery.RewriteMethod method, QueryShardContext context) {
-            throw new UnsupportedOperationException("[regexp] queries are not currently supported on [" +
-                CONTENT_TYPE + "] fields.");
-        }
-
-        @Override
-        public Query wildcardQuery(String value,
-                                   MultiTermQuery.RewriteMethod method,
-                                   QueryShardContext context) {
-            throw new UnsupportedOperationException("[wildcard] queries are not currently supported on [" +
-                CONTENT_TYPE + "] fields.");
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeyedJsonFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeyedJsonFieldTypeTests.java
@@ -117,7 +117,7 @@ public class KeyedJsonFieldTypeTests extends FieldTypeTestCase {
 
         UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class,
             () -> ft.fuzzyQuery("valuee", Fuzziness.fromEdits(2), 1, 50, true));
-        assertEquals("[fuzzy] queries are not currently supported on [embedded_json] fields.", e.getMessage());
+        assertEquals("[fuzzy] queries are not currently supported on keyed [embedded_json] fields.", e.getMessage());
     }
 
     public void testRangeQuery() {
@@ -151,7 +151,7 @@ public class KeyedJsonFieldTypeTests extends FieldTypeTestCase {
 
         UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class,
             () -> ft.regexpQuery("valu*", 0, 10, null, null));
-        assertEquals("[regexp] queries are not currently supported on [embedded_json] fields.", e.getMessage());
+        assertEquals("[regexp] queries are not currently supported on keyed [embedded_json] fields.", e.getMessage());
     }
 
     public void testWildcardQuery() {
@@ -160,6 +160,6 @@ public class KeyedJsonFieldTypeTests extends FieldTypeTestCase {
 
         UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class,
             () -> ft.wildcardQuery("valu*", null, null));
-        assertEquals("[wildcard] queries are not currently supported on [embedded_json] fields.", e.getMessage());
+        assertEquals("[wildcard] queries are not currently supported on keyed [embedded_json] fields.", e.getMessage());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/RootJsonFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RootJsonFieldTypeTests.java
@@ -21,9 +21,12 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
+import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.RegexpQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TermRangeQuery;
+import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.mapper.JsonFieldMapper.RootJsonFieldType;
@@ -83,9 +86,9 @@ public class RootJsonFieldTypeTests extends FieldTypeTestCase {
         RootJsonFieldType ft = createDefaultFieldType();
         ft.setName("field");
 
-        UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class,
-            () -> ft.fuzzyQuery("valuee", Fuzziness.fromEdits(2), 1, 50, true));
-        assertEquals("[fuzzy] queries are not currently supported on [embedded_json] fields.", e.getMessage());
+        Query expected = new FuzzyQuery(new Term("field", "value"), 2, 1, 50, true);
+        Query actual = ft.fuzzyQuery("value", Fuzziness.fromEdits(2), 1, 50, true);
+        assertEquals(expected, actual);
     }
 
     public void testRangeQuery() {
@@ -107,17 +110,16 @@ public class RootJsonFieldTypeTests extends FieldTypeTestCase {
         RootJsonFieldType ft = createDefaultFieldType();
         ft.setName("field");
 
-        UnsupportedOperationException e  = expectThrows(UnsupportedOperationException.class,
-            () -> ft.regexpQuery("valu*", 0, 10, null, null));
-        assertEquals("[regexp] queries are not currently supported on [embedded_json] fields.", e.getMessage());
+        Query expected = new RegexpQuery(new Term("field", "val.*"));
+        Query actual = ft.regexpQuery("val.*", 0, 10, null, null);
+        assertEquals(expected, actual);
     }
 
     public void testWildcardQuery() {
         RootJsonFieldType ft = createDefaultFieldType();
         ft.setName("field");
 
-        UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class,
-            () -> ft.wildcardQuery("valu*", null, null));
-        assertEquals("[wildcard] queries are not currently supported on [embedded_json] fields.", e.getMessage());
+        Query expected = new WildcardQuery(new Term("field", new BytesRef("valu*")));
+        assertEquals(expected, ft.wildcardQuery("valu*", null, null));
     }
 }


### PR DESCRIPTION
In an earlier iteration of the design, it made sense to disallow these query
types on the root JSON field. It should now it be fine to allow them.