### PR TITLE
ProfileScorer should propagate `setMinCompetitiveScore`. (#40958)

### DIFF
--- a/docs/reference/search/profile.asciidoc
+++ b/docs/reference/search/profile.asciidoc
@@ -82,7 +82,9 @@ This will yield the following result:
                           "compute_max_score": 0,
                           "compute_max_score_count": 0,
                           "shallow_advance": 0,
-                          "shallow_advance_count": 0
+                          "shallow_advance_count": 0,
+                          "set_min_competitive_score": 0,
+                          "set_min_competitive_score_count": 0
                        },
                        "children": [
                           {
@@ -105,7 +107,9 @@ This will yield the following result:
                                 "compute_max_score": 0,
                                 "compute_max_score_count": 0,
                                 "shallow_advance": 0,
-                                "shallow_advance_count": 0
+                                "shallow_advance_count": 0,
+                                "set_min_competitive_score": 0,
+                                "set_min_competitive_score_count": 0
                              }
                           },
                           {
@@ -128,7 +132,9 @@ This will yield the following result:
                                 "compute_max_score": 0,
                                 "compute_max_score_count": 0,
                                 "shallow_advance": 0,
-                                "shallow_advance_count": 0
+                                "shallow_advance_count": 0,
+                                "set_min_competitive_score": 0,
+                                "set_min_competitive_score_count": 0
                              }
                           }
                        ]
@@ -311,7 +317,9 @@ The `breakdown` component lists detailed timing statistics about low-level Lucen
    "compute_max_score": 0,
    "compute_max_score_count": 0,
    "shallow_advance": 0,
-   "shallow_advance_count": 0
+   "shallow_advance_count": 0,
+   "set_min_competitive_score": 0,
+   "set_min_competitive_score_count": 0
 }
 --------------------------------------------------
 // TESTRESPONSE[s/^/{\n"took": $body.took,\n"timed_out": $body.timed_out,\n"_shards": $body._shards,\n"hits": $body.hits,\n"profile": {\n"shards": [ {\n"id": "$body.$_path",\n"searches": [{\n"query": [{\n"type": "BooleanQuery",\n"description": "message:some message:number",\n"time_in_nanos": $body.$_path,/]
@@ -575,7 +583,9 @@ And the response:
                               "compute_max_score": 0,
                               "compute_max_score_count": 0,
                               "shallow_advance": 0,
-                              "shallow_advance_count": 0
+                              "shallow_advance_count": 0,
+                              "set_min_competitive_score": 0,
+                              "set_min_competitive_score_count": 0
                            }
                         },
                         {
@@ -598,7 +608,9 @@ And the response:
                               "compute_max_score": 0,
                               "compute_max_score_count": 0,
                               "shallow_advance": 0,
-                              "shallow_advance_count": 0
+                              "shallow_advance_count": 0,
+                              "set_min_competitive_score": 0,
+                              "set_min_competitive_score_count": 0
                            }
                         }
                      ],

--- a/server/src/main/java/org/elasticsearch/search/profile/query/ProfileScorer.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/query/ProfileScorer.java
@@ -39,9 +39,9 @@ final class ProfileScorer extends Scorer {
     private final Scorer scorer;
     private ProfileWeight profileWeight;
 
-    private final Timer scoreTimer, nextDocTimer, advanceTimer, matchTimer, shallowAdvanceTimer, computeMaxScoreTimer;
+    private final Timer scoreTimer, nextDocTimer, advanceTimer, matchTimer, shallowAdvanceTimer, computeMaxScoreTimer,
+        setMinCompetitiveScoreTimer;
     private final boolean isConstantScoreQuery;
-
 
     ProfileScorer(ProfileWeight w, Scorer scorer, QueryProfileBreakdown profile) throws IOException {
         super(w);
@@ -53,6 +53,7 @@ final class ProfileScorer extends Scorer {
         matchTimer = profile.getTimer(QueryTimingType.MATCH);
         shallowAdvanceTimer = profile.getTimer(QueryTimingType.SHALLOW_ADVANCE);
         computeMaxScoreTimer = profile.getTimer(QueryTimingType.COMPUTE_MAX_SCORE);
+        setMinCompetitiveScoreTimer = profile.getTimer(QueryTimingType.SET_MIN_COMPETITIVE_SCORE);
         ProfileScorer profileScorer = null;
         if (w.getQuery() instanceof ConstantScoreQuery && scorer instanceof ProfileScorer) {
             //Case when we have a totalHits query and it is not cached
@@ -217,6 +218,16 @@ final class ProfileScorer extends Scorer {
             return scorer.getMaxScore(upTo);
         } finally {
             computeMaxScoreTimer.stop();
+        }
+    }
+
+    @Override
+    public void setMinCompetitiveScore(float minScore) throws IOException {
+        setMinCompetitiveScoreTimer.start();
+        try {
+            scorer.setMinCompetitiveScore(minScore);
+        } finally {
+            setMinCompetitiveScoreTimer.stop();
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/profile/query/QueryTimingType.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/query/QueryTimingType.java
@@ -29,7 +29,8 @@ public enum QueryTimingType {
     MATCH,
     SCORE,
     SHALLOW_ADVANCE,
-    COMPUTE_MAX_SCORE;
+    COMPUTE_MAX_SCORE,
+    SET_MIN_COMPETITIVE_SCORE;
 
     @Override
     public String toString() {

--- a/server/src/test/java/org/elasticsearch/search/profile/query/ProfileScorerTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/query/ProfileScorerTests.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.profile.query;
+
+import org.apache.lucene.index.MultiReader;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+public class ProfileScorerTests extends ESTestCase {
+
+    private static class FakeScorer extends Scorer {
+
+        public float maxScore, minCompetitiveScore;
+
+        protected FakeScorer(Weight weight) {
+            super(weight);
+        }
+
+        @Override
+        public DocIdSetIterator iterator() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public float getMaxScore(int upTo) throws IOException {
+            return maxScore;
+        }
+
+        @Override
+        public float score() throws IOException {
+            return 1f;
+        }
+
+        @Override
+        public int docID() {
+            throw new UnsupportedOperationException();
+        }
+        
+        @Override
+        public void setMinCompetitiveScore(float minScore) {
+            this.minCompetitiveScore = minScore;
+        }
+    }
+
+    public void testPropagateMinCompetitiveScore() throws IOException {
+        Query query = new MatchAllDocsQuery();
+        Weight weight = query.createWeight(new IndexSearcher(new MultiReader()), ScoreMode.TOP_SCORES, 1f);
+        FakeScorer fakeScorer = new FakeScorer(weight);
+        QueryProfileBreakdown profile = new QueryProfileBreakdown();
+        ProfileWeight profileWeight = new ProfileWeight(query, weight, profile);
+        ProfileScorer profileScorer = new ProfileScorer(profileWeight, fakeScorer, profile);
+        profileScorer.setMinCompetitiveScore(0.42f);
+        assertEquals(0.42f, fakeScorer.minCompetitiveScore, 0f);
+    }
+
+    public void testPropagateMaxScore() throws IOException {
+        Query query = new MatchAllDocsQuery();
+        Weight weight = query.createWeight(new IndexSearcher(new MultiReader()), ScoreMode.TOP_SCORES, 1f);
+        FakeScorer fakeScorer = new FakeScorer(weight);
+        QueryProfileBreakdown profile = new QueryProfileBreakdown();
+        ProfileWeight profileWeight = new ProfileWeight(query, weight, profile);
+        ProfileScorer profileScorer = new ProfileScorer(profileWeight, fakeScorer, profile);
+        profileScorer.setMinCompetitiveScore(0.42f);
+        fakeScorer.maxScore = 42f;
+        assertEquals(42f, profileScorer.getMaxScore(DocIdSetIterator.NO_MORE_DOCS), 0f);
+    }
+}


### PR DESCRIPTION
Currently enabling profiling disables top-hits optimizations, which is
unfortunate: it would be nice to be able to notice the difference in method
counts and timings depending on whether total hit counts are requested.
