### PR TITLE
Disable composePull only if it exists

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -142,4 +142,4 @@ assemble.dependsOn "buildDockerImage"
 // We build the images used in compose locally, but the pull command insists on using a repository
 // thus we must disable it to prevent it from doing so. 
 // Everything will still be pulled since we will build the local images on a pull
-composePull.enabled = false
+tasks.matching { name == "composePull" }.all { enabled = false }


### PR DESCRIPTION
The task will not be created when docker is not available.

