### PR TITLE
Fixing missing link on session_token

### DIFF
--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -94,10 +94,10 @@ settings belong in the `elasticsearch.yml` file.
 
     An S3 secret key. The `access_key` setting must also be specified.
 
-`session_token`::
+`session_token` ({ref}/secure-settings.html[Secure])::
 
     An S3 session token. The `access_key` and `secret_key` settings must also be
-    specified. (Secure)
+    specified.
 
 `endpoint`::
 


### PR DESCRIPTION
session_token was missing a "secure link"

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
