### PR TITLE
Make sure to apply eager_global_ordinals for keyed JSON fields.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.collect.CopyOnWriteHashMap;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.regex.Regex;
 
 import java.util.Collection;
@@ -204,7 +205,16 @@ class FieldTypeLookup implements Iterable<MappedFieldType> {
 
     @Override
     public Iterator<MappedFieldType> iterator() {
-        return fullNameToFieldType.values().iterator();
+        Iterator<MappedFieldType> concreteFieldTypes = fullNameToFieldType.values().iterator();
+
+        if (fullNameToJsonMapper.isEmpty()) {
+            return concreteFieldTypes;
+        } else {
+            Iterator<MappedFieldType> keyedJsonFieldTypes = fullNameToJsonMapper.values().stream()
+                .<MappedFieldType>map(mapper -> mapper.keyedFieldType(""))
+                .iterator();
+            return Iterators.concat(concreteFieldTypes, keyedJsonFieldTypes);
+        }
     }
 
     // Visible for testing.

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
@@ -31,10 +31,13 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import static java.util.Collections.emptyList;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class FieldTypeLookupTests extends ESTestCase {
@@ -243,6 +246,22 @@ public class FieldTypeLookupTests extends ESTestCase {
 
         assertTrue(names.contains("bar"));
         assertTrue(names.contains("barometer"));
+    }
+
+    public void testFieldTypeIterator() {
+        MockFieldMapper mapper = new MockFieldMapper("foo");
+        JsonFieldMapper jsonMapper = createJsonMapper("object1.object2.field");
+
+        FieldTypeLookup lookup = new FieldTypeLookup()
+            .copyAndAddAll("type", newList(mapper, jsonMapper), emptyList());
+
+        Set<String> fieldNames = new HashSet<>();
+        for (MappedFieldType fieldType : lookup) {
+            fieldNames.add(fieldType.name());
+        }
+
+        assertThat(fieldNames, containsInAnyOrder(
+            mapper.name(), jsonMapper.name(), jsonMapper.keyedFieldName()));
     }
 
     public void testIteratorImmutable() {


### PR DESCRIPTION
The index warmer iterates through all field types when determining the fields
for which global ordinals should be loaded. Previously, keyed JSON field types
were not returned from `FieldTypeLookup#iterator`, so their `eager_global_ordinals`
setting would be ignored. This PR fixes the issue by including keyed JSON fields
in `FieldTypeLookup#iterator`.