### PR TITLE
Change SLM endpoint from /_ilm/* to /_slm/*

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/snapshotlifecycle/action/DeleteSnapshotLifecycleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/snapshotlifecycle/action/DeleteSnapshotLifecycleAction.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 
 public class DeleteSnapshotLifecycleAction extends Action<DeleteSnapshotLifecycleAction.Response> {
     public static final DeleteSnapshotLifecycleAction INSTANCE = new DeleteSnapshotLifecycleAction();
-    public static final String NAME = "cluster:admin/ilm/snapshot/delete";
+    public static final String NAME = "cluster:admin/slm/delete";
 
     protected DeleteSnapshotLifecycleAction() {
         super(NAME);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/snapshotlifecycle/action/ExecuteSnapshotLifecycleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/snapshotlifecycle/action/ExecuteSnapshotLifecycleAction.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  */
 public class ExecuteSnapshotLifecycleAction extends Action<ExecuteSnapshotLifecycleAction.Response> {
     public static final ExecuteSnapshotLifecycleAction INSTANCE = new ExecuteSnapshotLifecycleAction();
-    public static final String NAME = "cluster:admin/ilm/snapshot/execute";
+    public static final String NAME = "cluster:admin/slm/execute";
 
     protected ExecuteSnapshotLifecycleAction() {
         super(NAME);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/snapshotlifecycle/action/GetSnapshotLifecycleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/snapshotlifecycle/action/GetSnapshotLifecycleAction.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 
 public class GetSnapshotLifecycleAction extends Action<GetSnapshotLifecycleAction.Response> {
     public static final GetSnapshotLifecycleAction INSTANCE = new GetSnapshotLifecycleAction();
-    public static final String NAME = "cluster:admin/ilm/snapshot/get";
+    public static final String NAME = "cluster:admin/slm/get";
 
     protected GetSnapshotLifecycleAction() {
         super(NAME);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/snapshotlifecycle/action/PutSnapshotLifecycleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/snapshotlifecycle/action/PutSnapshotLifecycleAction.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 
 public class PutSnapshotLifecycleAction extends Action<PutSnapshotLifecycleAction.Response> {
     public static final PutSnapshotLifecycleAction INSTANCE = new PutSnapshotLifecycleAction();
-    public static final String NAME = "cluster:admin/ilm/snapshot/put";
+    public static final String NAME = "cluster:admin/slm/put";
 
     protected PutSnapshotLifecycleAction() {
         super(NAME);

--- a/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/snapshotlifecycle/SnapshotLifecycleIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/snapshotlifecycle/SnapshotLifecycleIT.java
@@ -44,7 +44,7 @@ public class SnapshotLifecycleIT extends ESRestTestCase {
         SnapshotLifecyclePolicy policy = new SnapshotLifecyclePolicy("test-policy", "snap",
             "*/1 * * * * ?", "missing-repo", Collections.emptyMap());
 
-        Request putLifecycle = new Request("PUT", "/_ilm/snapshot/test-policy");
+        Request putLifecycle = new Request("PUT", "/_slm/policy/test-policy");
         XContentBuilder lifecycleBuilder = JsonXContent.contentBuilder();
         policy.toXContent(lifecycleBuilder, ToXContent.EMPTY_PARAMS);
         putLifecycle.setJsonEntity(Strings.toString(lifecycleBuilder));
@@ -86,7 +86,7 @@ public class SnapshotLifecycleIT extends ESRestTestCase {
             assertThat((List<String>)snapResponse.get("indices"), equalTo(Collections.singletonList(indexName)));
 
             // Check that the last success date was written to the cluster state
-            Request getReq = new Request("GET", "/_ilm/snapshot/" + policyName);
+            Request getReq = new Request("GET", "/_slm/policy/" + policyName);
             Response policyMetadata = client().performRequest(getReq);
             Map<String, Object> policyResponseMap;
             try (InputStream is = policyMetadata.getEntity().getContent()) {
@@ -105,7 +105,7 @@ public class SnapshotLifecycleIT extends ESRestTestCase {
             assertThat(lastSnapshotName, startsWith("snap-"));
         });
 
-        Request delReq = new Request("DELETE", "/_ilm/snapshot/" + policyName);
+        Request delReq = new Request("DELETE", "/_slm/policy/" + policyName);
         assertOK(client().performRequest(delReq));
 
         // It's possible there could have been a snapshot in progress when the
@@ -127,7 +127,7 @@ public class SnapshotLifecycleIT extends ESRestTestCase {
 
         assertBusy(() -> {
             // Check that the failure is written to the cluster state
-            Request getReq = new Request("GET", "/_ilm/snapshot/" + policyName);
+            Request getReq = new Request("GET", "/_slm/policy/" + policyName);
             Response policyMetadata = client().performRequest(getReq);
             try (InputStream is = policyMetadata.getEntity().getContent()) {
                 Map<String, Object> responseMap = XContentHelper.convertToMap(XContentType.JSON.xContent(), is, true);
@@ -151,7 +151,7 @@ public class SnapshotLifecycleIT extends ESRestTestCase {
             }
         });
 
-        Request delReq = new Request("DELETE", "/_ilm/snapshot/" + policyName);
+        Request delReq = new Request("DELETE", "/_slm/policy/" + policyName);
         assertOK(client().performRequest(delReq));
     }
 
@@ -171,11 +171,11 @@ public class SnapshotLifecycleIT extends ESRestTestCase {
         createSnapshotPolicy(policyName, "snap", "1 2 3 4 5 ?", repoId, indexName, true);
 
         ResponseException badResp = expectThrows(ResponseException.class,
-            () -> client().performRequest(new Request("PUT", "/_ilm/snapshot/" + policyName + "-bad/_execute")));
+            () -> client().performRequest(new Request("PUT", "/_slm/policy/" + policyName + "-bad/_execute")));
         assertThat(EntityUtils.toString(badResp.getResponse().getEntity()),
             containsString("no such snapshot lifecycle policy [" + policyName + "-bad]"));
 
-        Response goodResp = client().performRequest(new Request("PUT", "/_ilm/snapshot/" + policyName + "/_execute"));
+        Response goodResp = client().performRequest(new Request("PUT", "/_slm/policy/" + policyName + "/_execute"));
 
         try (XContentParser parser = JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY,
             DeprecationHandler.THROW_UNSUPPORTED_OPERATION, EntityUtils.toByteArray(goodResp.getEntity()))) {
@@ -196,7 +196,7 @@ public class SnapshotLifecycleIT extends ESRestTestCase {
             });
         }
 
-        Request delReq = new Request("DELETE", "/_ilm/snapshot/" + policyName);
+        Request delReq = new Request("DELETE", "/_slm/policy/" + policyName);
         assertOK(client().performRequest(delReq));
 
         // It's possible there could have been a snapshot in progress when the
@@ -213,7 +213,7 @@ public class SnapshotLifecycleIT extends ESRestTestCase {
         snapConfig.put("ignore_unavailable", ignoreUnavailable);
         SnapshotLifecyclePolicy policy = new SnapshotLifecyclePolicy(policyName, snapshotNamePattern, schedule, repoId, snapConfig);
 
-        Request putLifecycle = new Request("PUT", "/_ilm/snapshot/" + policyName);
+        Request putLifecycle = new Request("PUT", "/_slm/policy/" + policyName);
         XContentBuilder lifecycleBuilder = JsonXContent.contentBuilder();
         policy.toXContent(lifecycleBuilder, ToXContent.EMPTY_PARAMS);
         putLifecycle.setJsonEntity(Strings.toString(lifecycleBuilder));

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/snapshotlifecycle/action/RestDeleteSnapshotLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/snapshotlifecycle/action/RestDeleteSnapshotLifecycleAction.java
@@ -18,12 +18,12 @@ public class RestDeleteSnapshotLifecycleAction extends BaseRestHandler {
 
     public RestDeleteSnapshotLifecycleAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.DELETE, "/_ilm/snapshot/{name}", this);
+        controller.registerHandler(RestRequest.Method.DELETE, "/_slm/policy/{name}", this);
     }
 
     @Override
     public String getName() {
-        return "ilm_delete_snapshot_lifecycle";
+        return "slm_delete_lifecycle";
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/snapshotlifecycle/action/RestExecuteSnapshotLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/snapshotlifecycle/action/RestExecuteSnapshotLifecycleAction.java
@@ -20,12 +20,12 @@ public class RestExecuteSnapshotLifecycleAction extends BaseRestHandler {
 
     public RestExecuteSnapshotLifecycleAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.PUT, "/_ilm/snapshot/{name}/_execute", this);
+        controller.registerHandler(RestRequest.Method.PUT, "/_slm/policy/{name}/_execute", this);
     }
 
     @Override
     public String getName() {
-        return "ilm_execute_snapshot_lifecycle";
+        return "slm_execute_lifecycle";
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/snapshotlifecycle/action/RestGetSnapshotLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/snapshotlifecycle/action/RestGetSnapshotLifecycleAction.java
@@ -19,13 +19,13 @@ public class RestGetSnapshotLifecycleAction extends BaseRestHandler {
 
     public RestGetSnapshotLifecycleAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.GET, "/_ilm/snapshot", this);
-        controller.registerHandler(RestRequest.Method.GET, "/_ilm/snapshot/{name}", this);
+        controller.registerHandler(RestRequest.Method.GET, "/_slm/policy", this);
+        controller.registerHandler(RestRequest.Method.GET, "/_slm/policy/{name}", this);
     }
 
     @Override
     public String getName() {
-        return "ilm_get_snapshot_lifecycle";
+        return "slm_get_lifecycle";
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/snapshotlifecycle/action/RestPutSnapshotLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/snapshotlifecycle/action/RestPutSnapshotLifecycleAction.java
@@ -21,12 +21,12 @@ public class RestPutSnapshotLifecycleAction extends BaseRestHandler {
 
     public RestPutSnapshotLifecycleAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.PUT, "/_ilm/snapshot/{name}", this);
+        controller.registerHandler(RestRequest.Method.PUT, "/_slm/policy/{name}", this);
     }
 
     @Override
     public String getName() {
-        return "ilm_put_snapshot_lifecycle";
+        return "slm_put_lifecycle";
     }
 
     @Override


### PR DESCRIPTION
This commit changes the endpoint for snapshot lifecycle management from:

```
GET /_ilm/snapshot/<policy>
```

to:

```
GET /_slm/policy/<policy>
```

It mimics the ILM path only using `slm` instead of `ilm`.

Relates to #38461
