### PR TITLE
Add a rule for task dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -584,6 +584,29 @@ allprojects {
         configurations.findAll { it.isCanBeResolved() }.each { it.resolve() }
       }
   }
+
+  // helper task to print direct dependencies of a single task
+  project.tasks.addRule("Pattern: <taskName>Dependencies") { String taskName ->
+    if (taskName.endsWith("Dependencies") == false) {
+      return
+    }
+    if (project.tasks.findByName(taskName) != null) {
+      return
+    }
+    String realTaskName = taskName.substring(0, taskName.length() - "Dependencies".length())
+    Task realTask = project.tasks.findByName(realTaskName)
+    if (realTask == null) {
+      return
+    }
+    project.tasks.create(taskName, DefaultTask.class) {
+      doLast {
+        println("${realTaskName} dependencies:")
+        for (Task dep : realTask.getTaskDependencies().getDependencies(realTask)) {
+          println("  - ${dep.path}")
+        }
+      }
+    }
+  }
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -598,18 +598,16 @@ allprojects {
     if (realTask == null) {
       return
     }
-    project.tasks.create(taskName, DefaultTask.class) {
+    project.tasks.create(taskName) {
       doLast {
-        println("${realTaskName} dependencies:")
+        println("${realTask.path} dependencies:")
         for (Task dep : realTask.getTaskDependencies().getDependencies(realTask)) {
           println("  - ${dep.path}")
         }
       }
     }
   }
-}
 
-allprojects {
   task checkPart1
   task checkPart2 
   tasks.matching { it.name == "check" }.all { check ->


### PR DESCRIPTION
This commit adds a task rule to print the task dependencies of any task.
It only prints the direct dependencies, but makes debugging missing
dependencies a lot easier.