### PR TITLE
Unmute TestClustersPluginIT.testMultiNode

### DIFF
--- a/buildSrc/src/test/java/org/elasticsearch/gradle/testclusters/TestClustersPluginIT.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/testclusters/TestClustersPluginIT.java
@@ -21,7 +21,6 @@ package org.elasticsearch.gradle.testclusters;
 import org.elasticsearch.gradle.test.GradleIntegrationTestCase;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
-import org.junit.Ignore;
 
 import java.util.Arrays;
 
@@ -151,7 +150,6 @@ public class TestClustersPluginIT extends GradleIntegrationTestCase {
         );
     }
 
-    @Ignore // https://github.com/elastic/elasticsearch/issues/41256
     public void testMultiNode() {
         BuildResult result = getTestClustersRunner(":multiNode").build();
         assertTaskSuccessful(result, ":multiNode");


### PR DESCRIPTION
The failure doesn't reproduced, tried running the test for half a day
including on the failing CI woker image and with the entire suite and it
doesn't reproduce.

Closes #41256 Will keep under observation.