### PR TITLE
Preserve java 8 class format for in build tools

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -84,10 +84,8 @@ sourceSets {
   }
 }
 compileMinimumRuntimeGroovy {
-  // We can't use BuildPlugin here, so read from file
-  String minimumRuntimeVersion = file('src/main/resources/minimumRuntimeVersion').text.trim()
-  targetCompatibility = minimumRuntimeVersion
-  sourceCompatibility = minimumRuntimeVersion
+  targetCompatibility = 8
+  sourceCompatibility = 8
 }
 dependencies {
   if (project.ext.has("isEclipse") == false || project.ext.isEclipse == false) {


### PR DESCRIPTION
Keep the minimum compatability classes at the same version for a bit
longer.

