### PR TITLE
SQL: Predicate diff takes into account all values

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/capabilities/UnresolvedException.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/capabilities/UnresolvedException.java
@@ -7,16 +7,12 @@ package org.elasticsearch.xpack.sql.capabilities;
 
 import org.elasticsearch.xpack.sql.ServerSqlException;
 
-import java.util.Locale;
-
-import static java.lang.String.format;
-
 /**
  * Thrown when we accidentally attempt to resolve something on on an unresolved entity. Throwing this
  * is always a bug.
  */
 public class UnresolvedException extends ServerSqlException {
     public UnresolvedException(String action, Object target) {
-        super(format(Locale.ROOT, "Invalid call to %s on an unresolved object %s", action, target));
+        super("Invalid call to {} on an unresolved object {}", action, target);
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/Predicates.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/Predicates.java
@@ -97,13 +97,18 @@ public abstract class Predicates {
         return common.isEmpty() ? emptyList() : common;
     }
 
-    public static List<Expression> subtract(List<Expression> from, List<Expression> r) {
-        List<Expression> diff = new ArrayList<>(Math.min(from.size(), r.size()));
-        for (Expression lExp : from) {
-            for (Expression rExp : r) {
-                if (!lExp.semanticEquals(rExp)) {
-                    diff.add(lExp);
+    public static List<Expression> subtract(List<Expression> from, List<Expression> list) {
+        List<Expression> diff = new ArrayList<>(Math.min(from.size(), list.size()));
+        for (Expression f : from) {
+            boolean found = false;
+            for (Expression l : list) {
+                if (f.semanticEquals(l)) {
+                    found = true;
+                    break;
                 }
+            }
+            if (found == false) {
+                diff.add(f);
             }
         }
         return diff.isEmpty() ? emptyList() : diff;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/optimizer/Optimizer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/optimizer/Optimizer.java
@@ -1236,7 +1236,7 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
 
         @Override
         protected Expression rule(Expression e) {
-            if (e instanceof BinaryPredicate) {
+            if (e instanceof And || e instanceof Or) {
                 return simplifyAndOr((BinaryPredicate<?, ?, ?, ?>) e);
             }
             if (e instanceof Not) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/rule/RuleExecutor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/rule/RuleExecutor.java
@@ -38,7 +38,7 @@ public abstract class RuleExecutor<TreeType extends Node<TreeType>> {
 
         boolean reached(int runs) {
             if (runs >= this.runs) {
-                throw new RuleExecutionException("Rule execution limit %d reached", runs);
+                throw new RuleExecutionException("Rule execution limit [{}] reached", runs);
             }
             return false;
         }
@@ -139,7 +139,7 @@ public abstract class RuleExecutor<TreeType extends Node<TreeType>> {
 
         for (Batch batch : batches) {
             int batchRuns = 0;
-            List<Transformation> tfs = new ArrayList<Transformation>();
+            List<Transformation> tfs = new ArrayList<>();
             transformations.put(batch, tfs);
 
             boolean hasChanged = false;


### PR DESCRIPTION
Fix bug in predicate subtraction that caused the evaluation to be
skipped on the first mismatch instead of evaluating the whole list. In
some cases this caused not only an incorrect result but one that kept on
growing causing the engine to bail

Fix #40835