### PR TITLE
SQL: Fix bug with optimization of null related conditionals

### DIFF
--- a/x-pack/plugin/sql/qa/src/main/resources/null.csv-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/null.csv-spec
@@ -61,6 +61,13 @@ c:i
 ;
 
 coalesceMixed
+SELECT COALESCE(null, 123, null, 321);
+
+COALESCE(null, 123, null, 321):i
+123
+;
+
+coalesceMixedWithAlias
 SELECT COALESCE(null, 123, null, 321) AS c;
 
 c:i

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/ConditionalFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/ConditionalFunction.java
@@ -29,6 +29,7 @@ public abstract class ConditionalFunction extends ScalarFunction {
 
     ConditionalFunction(Source source, List<Expression> fields) {
         super(source, fields);
+        setDataType();
     }
 
     @Override
@@ -61,7 +62,6 @@ public abstract class ConditionalFunction extends ScalarFunction {
                         child.dataType().typeName));
                 }
             }
-            dataType = DataTypeConversion.commonType(dataType, child.dataType());
         }
         return TypeResolution.TYPE_RESOLVED;
     }
@@ -69,5 +69,11 @@ public abstract class ConditionalFunction extends ScalarFunction {
     @Override
     public Nullability nullable() {
         return Nullability.UNKNOWN;
+    }
+
+    private void setDataType() {
+        for (Expression exp : children()) {
+            dataType = DataTypeConversion.commonType(dataType, exp.dataType());
+        }
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/ConditionalFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/ConditionalFunction.java
@@ -26,14 +26,20 @@ import static org.elasticsearch.xpack.sql.util.StringUtils.ordinal;
 public abstract class ConditionalFunction extends ScalarFunction {
 
     protected DataType dataType = DataType.NULL;
+    private boolean lazyDataTypeResolution;
 
     ConditionalFunction(Source source, List<Expression> fields) {
         super(source, fields);
-        setDataType();
     }
 
     @Override
     public DataType dataType() {
+        if (lazyDataTypeResolution == false) {
+            for (Expression exp : children()) {
+                dataType = DataTypeConversion.commonType(dataType, exp.dataType());
+            }
+            lazyDataTypeResolution = true;
+        }
         return dataType;
     }
 
@@ -69,11 +75,5 @@ public abstract class ConditionalFunction extends ScalarFunction {
     @Override
     public Nullability nullable() {
         return Nullability.UNKNOWN;
-    }
-
-    private void setDataType() {
-        for (Expression exp : children()) {
-            dataType = DataTypeConversion.commonType(dataType, exp.dataType());
-        }
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/ConditionalFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/ConditionalFunction.java
@@ -25,8 +25,7 @@ import static org.elasticsearch.xpack.sql.util.StringUtils.ordinal;
  */
 public abstract class ConditionalFunction extends ScalarFunction {
 
-    protected DataType dataType = DataType.NULL;
-    private boolean lazyDataTypeResolution;
+    protected DataType dataType = null;
 
     ConditionalFunction(Source source, List<Expression> fields) {
         super(source, fields);
@@ -34,11 +33,11 @@ public abstract class ConditionalFunction extends ScalarFunction {
 
     @Override
     public DataType dataType() {
-        if (lazyDataTypeResolution == false) {
+        if (dataType == null) {
+            dataType = DataType.NULL;
             for (Expression exp : children()) {
                 dataType = DataTypeConversion.commonType(dataType, exp.dataType());
             }
-            lazyDataTypeResolution = true;
         }
         return dataType;
     }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerTests.java
@@ -498,6 +498,7 @@ public class OptimizerTests extends ESTestCase {
                         randomListOfNulls())));
         assertEquals(1, e.children().size());
         assertEquals(TRUE, e.children().get(0));
+        assertEquals(DataType.BOOLEAN, e.dataType());
     }
 
     private List<Expression> randomListOfNulls() {
@@ -511,6 +512,7 @@ public class OptimizerTests extends ESTestCase {
         assertEquals(Coalesce.class, e.getClass());
         assertEquals(1, e.children().size());
         assertEquals(TRUE, e.children().get(0));
+        assertEquals(DataType.BOOLEAN, e.dataType());
     }
 
     public void testSimplifyIfNullNulls() {
@@ -524,11 +526,13 @@ public class OptimizerTests extends ESTestCase {
         assertEquals(IfNull.class, e.getClass());
         assertEquals(1, e.children().size());
         assertEquals(ONE, e.children().get(0));
+        assertEquals(DataType.INTEGER, e.dataType());
 
         e = new SimplifyConditional().rule(new IfNull(EMPTY, ONE, NULL));
         assertEquals(IfNull.class, e.getClass());
         assertEquals(1, e.children().size());
         assertEquals(ONE, e.children().get(0));
+        assertEquals(DataType.INTEGER, e.dataType());
     }
 
     public void testFoldNullNotAppliedOnNullIf() {
@@ -556,6 +560,7 @@ public class OptimizerTests extends ESTestCase {
         assertEquals(2, e.children().size());
         assertEquals(ONE, e.children().get(0));
         assertEquals(TWO, e.children().get(1));
+        assertEquals(DataType.INTEGER, e.dataType());
     }
 
     public void testSimplifyLeastNulls() {
@@ -577,6 +582,7 @@ public class OptimizerTests extends ESTestCase {
         assertEquals(2, e.children().size());
         assertEquals(ONE, e.children().get(0));
         assertEquals(TWO, e.children().get(1));
+        assertEquals(DataType.INTEGER, e.dataType());
     }
     
     public void testConcatFoldingIsNotNull() {


### PR DESCRIPTION
The `SimplifyConditional` rule is removing `NULL` literals from those
functions to simplify their evaluation. This happens in the `Optimizer`
and a new instance of the conditional function is generated. Previously,
the `dataType` was not set properly (defaulted to DataType.NULL) for
those new instances and since the `resolveType()` wasn't called again
it resulted in returning always `null`.

E.g.:
```
SELECT COALESCE(null, 'foo', null, 'bar')

COALESCE(null, 'foo', null, 'bar')
-----------------
null
```

This issue was not visible before because the tests always used an alias
for the conditional function which caused the `resolveType()` to be
called which sets the dataType properly.

E.g.:
```
SELECT COALESCE(null, 'foo', null, 'bar') as c

c
-----------------
foo
```