### PR TITLE
[DOCS] Fixes deprecation notice in pagerduty action

### DIFF
--- a/x-pack/docs/en/watcher/actions/pagerduty.asciidoc
+++ b/x-pack/docs/en/watcher/actions/pagerduty.asciidoc
@@ -155,7 +155,7 @@ must specify an account name and integration key, (see {ref}/secure-settings.htm
 bin/elasticsearch-keystore add xpack.notification.pagerduty.account.my_pagerduty_account.secure_service_api_key
 --------------------------------------------------
 
-deprecated[7.0.0, Storing the service api key in the YAML file or via cluster update settings is still supported, but the keystore setting should be used]
+deprecated[7.0.0, "Storing the service api key in the YAML file or via cluster update settings is still supported, but the keystore setting should be used."]
 
 You can also specify defaults for the <<pagerduty-event-trigger-incident-attributes, 
 PagerDuty event attributes>>:

--- a/x-pack/docs/en/watcher/actions/pagerduty.asciidoc
+++ b/x-pack/docs/en/watcher/actions/pagerduty.asciidoc
@@ -155,7 +155,7 @@ must specify an account name and integration key, (see {ref}/secure-settings.htm
 bin/elasticsearch-keystore add xpack.notification.pagerduty.account.my_pagerduty_account.secure_service_api_key
 --------------------------------------------------
 
-deprecated[Storing the service api key in the YAML file or via cluster update settings is still supported, but the keystore setting should be used]
+deprecated[7.0.0, Storing the service api key in the YAML file or via cluster update settings is still supported, but the keystore setting should be used]
 
 You can also specify defaults for the <<pagerduty-event-trigger-incident-attributes, 
 PagerDuty event attributes>>:


### PR DESCRIPTION
The documentation for the Watcher pagerduty action (https://www.elastic.co/guide/en/elastic-stack-overview/master/actions-pagerduty.html) contains a deprecation notice in 7.0 and later:

![image](https://user-images.githubusercontent.com/26471269/56389803-59944000-61df-11e9-9fad-3676a05bd2a0.png)

As seen above, it's missing the version details about when the behaviour was deprecated. This PR fixes that omission.
