### PR TITLE
[DOCS] Remove title abbreviations for Asciidoctor migration

### DIFF
--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -1,8 +1,5 @@
 [[release-highlights]]
-= {es} Release highlights
-++++
-<titleabbrev>Release highlights</titleabbrev>
-++++
+= Release highlights
 
 [partintro]
 --


### PR DESCRIPTION
Per asciidoctor/asciidoctor#3132, title abbreviations don't currently work with `[partintro]` styling in Asciidoctor.

This removes a title abbreviation from the [Elasticsearch Release Highlights page](https://www.elastic.co/guide/en/elasticsearch/reference/current/release-highlights.html). As a side effect, the h1 title of the page will change from `Elasticsearch Release highlights` to `Release highlights`.

Relates to #41128

### Before / After Images

**Before**
<img width="763" alt="Screen Shot 2019-04-18 at 3 08 13 PM" src="https://user-images.githubusercontent.com/40268737/56394433-3e7bfd00-61ec-11e9-9d88-a15a7435f2c0.png">

**After**
<img width="767" alt="Screen Shot 2019-04-18 at 3 09 35 PM" src="https://user-images.githubusercontent.com/40268737/56394446-463ba180-61ec-11e9-993f-37c3d50e991d.png">
