### PR TITLE
Limit the number of forks getting Java versions

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -63,7 +63,6 @@ import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
-import java.util.concurrent.ForkJoinPool
 import java.util.concurrent.Future
 import java.util.regex.Matcher
 

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -1,7 +1,7 @@
 elasticsearch     = 8.0.0
 lucene            = 8.1.0-snapshot-e460356abe
 
-bundled_jdk       = 12+33
+bundled_jdk       = 12+33master)
 
 # optional dependencies
 spatial4j         = 0.7

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -1,7 +1,7 @@
 elasticsearch     = 8.0.0
 lucene            = 8.1.0-snapshot-e460356abe
 
-bundled_jdk       = 12+33master)
+bundled_jdk       = 12+33
 
 # optional dependencies
 spatial4j         = 0.7


### PR DESCRIPTION
To reduce configuration time, we fork some threads to compute the Java version for the various configured Javas. However, as the number of JAVA${N}_HOME variable increases, the current implementation creates as many threads as there are such variables, which could be more than the number of physical cores on the machine. It is not likely that we would see benefits to trying to execute all of these once beyond the number of physical cores (maybe simultaneous multi-threading helps though, who knows. Therefore, this commit limits the parallelization here to the number number of physical cores.

Relates #41251, relates #41379