### PR TITLE
Introduce aliases version

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -313,6 +313,7 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
             sb.append(": v[").append(indexMetaData.getVersion())
                     .append("], mv[").append(indexMetaData.getMappingVersion())
                     .append("], sv[").append(indexMetaData.getSettingsVersion())
+                    .append("], av[").append(indexMetaData.getAliasesVersion())
                     .append("]\n");
             for (int shard = 0; shard < indexMetaData.getNumberOfShards(); shard++) {
                 sb.append(TAB).append(TAB).append(shard).append(": ");

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -714,7 +714,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
             if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
                 aliasesVersion = in.readVLong();
             } else {
-                aliasesVersion = 1;
+                aliasesVersion = 0;
             }
             state = State.fromId(in.readByte());
             settings = Settings.readSettingsFromStream(in);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -260,6 +260,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
     static final String KEY_VERSION = "version";
     static final String KEY_MAPPING_VERSION = "mapping_version";
     static final String KEY_SETTINGS_VERSION = "settings_version";
+    static final String KEY_ALIASES_VERSION = "aliases_version";
     static final String KEY_ROUTING_NUM_SHARDS = "routing_num_shards";
     static final String KEY_SETTINGS = "settings";
     static final String KEY_STATE = "state";
@@ -282,6 +283,8 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
     private final long mappingVersion;
 
     private final long settingsVersion;
+    
+    private final long aliasesVersion;
 
     private final long[] primaryTerms;
 
@@ -310,15 +313,31 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
     private final ActiveShardCount waitForActiveShards;
     private final ImmutableOpenMap<String, RolloverInfo> rolloverInfos;
 
-    private IndexMetaData(Index index, long version, long mappingVersion, long settingsVersion, long[] primaryTerms, State state,
-                          int numberOfShards, int numberOfReplicas, Settings settings,
-                          ImmutableOpenMap<String, MappingMetaData> mappings, ImmutableOpenMap<String, AliasMetaData> aliases,
-                          ImmutableOpenMap<String, DiffableStringMap> customData, ImmutableOpenIntMap<Set<String>> inSyncAllocationIds,
-                          DiscoveryNodeFilters requireFilters, DiscoveryNodeFilters initialRecoveryFilters,
-                          DiscoveryNodeFilters includeFilters, DiscoveryNodeFilters excludeFilters,
-                          Version indexCreatedVersion, Version indexUpgradedVersion,
-                          int routingNumShards, int routingPartitionSize, ActiveShardCount waitForActiveShards,
-                          ImmutableOpenMap<String, RolloverInfo> rolloverInfos) {
+    private IndexMetaData(
+            final Index index,
+            final long version,
+            final long mappingVersion,
+            final long settingsVersion,
+            final long aliasesVersion,
+            final long[] primaryTerms,
+            final State state,
+            final int numberOfShards,
+            final int numberOfReplicas,
+            final Settings settings,
+            final ImmutableOpenMap<String, MappingMetaData> mappings,
+            final ImmutableOpenMap<String, AliasMetaData> aliases,
+            final ImmutableOpenMap<String, DiffableStringMap> customData,
+            final ImmutableOpenIntMap<Set<String>> inSyncAllocationIds,
+            final DiscoveryNodeFilters requireFilters,
+            final DiscoveryNodeFilters initialRecoveryFilters,
+            final DiscoveryNodeFilters includeFilters,
+            final DiscoveryNodeFilters excludeFilters,
+            final Version indexCreatedVersion,
+            final Version indexUpgradedVersion,
+            final int routingNumShards,
+            final int routingPartitionSize,
+            final ActiveShardCount waitForActiveShards,
+            final ImmutableOpenMap<String, RolloverInfo> rolloverInfos) {
 
         this.index = index;
         this.version = version;
@@ -326,6 +345,8 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
         this.mappingVersion = mappingVersion;
         assert settingsVersion >= 0 : settingsVersion;
         this.settingsVersion = settingsVersion;
+        assert aliasesVersion >= 0 : aliasesVersion;
+        this.aliasesVersion = aliasesVersion;
         this.primaryTerms = primaryTerms;
         assert primaryTerms.length == numberOfShards;
         this.state = state;
@@ -381,6 +402,10 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
 
     public long getSettingsVersion() {
         return settingsVersion;
+    }
+
+    public long getAliasesVersion() {
+        return aliasesVersion;
     }
 
     /**
@@ -652,6 +677,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
         private final long version;
         private final long mappingVersion;
         private final long settingsVersion;
+        private final long aliasesVersion;
         private final long[] primaryTerms;
         private final State state;
         private final Settings settings;
@@ -666,6 +692,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
             version = after.version;
             mappingVersion = after.mappingVersion;
             settingsVersion = after.settingsVersion;
+            aliasesVersion = after.aliasesVersion;
             routingNumShards = after.routingNumShards;
             state = after.state;
             settings = after.settings;
@@ -684,6 +711,11 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
             version = in.readLong();
             mappingVersion = in.readVLong();
             settingsVersion = in.readVLong();
+            if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+                aliasesVersion = in.readVLong();
+            } else {
+                aliasesVersion = 1;
+            }
             state = State.fromId(in.readByte());
             settings = Settings.readSettingsFromStream(in);
             primaryTerms = in.readVLongArray();
@@ -706,6 +738,9 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
             out.writeLong(version);
             out.writeVLong(mappingVersion);
             out.writeVLong(settingsVersion);
+            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+                out.writeVLong(aliasesVersion);
+            }
             out.writeByte(state.id);
             Settings.writeSettingsToStream(settings, out);
             out.writeVLongArray(primaryTerms);
@@ -722,6 +757,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
             builder.version(version);
             builder.mappingVersion(mappingVersion);
             builder.settingsVersion(settingsVersion);
+            builder.aliasesVersion(aliasesVersion);
             builder.setRoutingNumShards(routingNumShards);
             builder.state(state);
             builder.settings(settings);
@@ -740,6 +776,9 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
         builder.version(in.readLong());
         builder.mappingVersion(in.readVLong());
         builder.settingsVersion(in.readVLong());
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            builder.aliasesVersion(in.readVLong());
+        }
         builder.setRoutingNumShards(in.readInt());
         builder.state(State.fromId(in.readByte()));
         builder.settings(readSettingsFromStream(in));
@@ -779,6 +818,9 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
         out.writeLong(version);
         out.writeVLong(mappingVersion);
         out.writeVLong(settingsVersion);
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            out.writeVLong(aliasesVersion);
+        }
         out.writeInt(routingNumShards);
         out.writeByte(state.id());
         writeSettingsToStream(settings, out);
@@ -822,6 +864,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
         private long version = 1;
         private long mappingVersion = 1;
         private long settingsVersion = 1;
+        private long aliasesVersion = 1;
         private long[] primaryTerms = null;
         private Settings settings = Settings.Builder.EMPTY_SETTINGS;
         private final ImmutableOpenMap.Builder<String, MappingMetaData> mappings;
@@ -846,6 +889,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
             this.version = indexMetaData.version;
             this.mappingVersion = indexMetaData.mappingVersion;
             this.settingsVersion = indexMetaData.settingsVersion;
+            this.aliasesVersion = indexMetaData.aliasesVersion;
             this.settings = indexMetaData.getSettings();
             this.primaryTerms = indexMetaData.primaryTerms.clone();
             this.mappings = ImmutableOpenMap.builder(indexMetaData.mappings);
@@ -994,20 +1038,29 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
             return mappingVersion;
         }
 
-        public long settingsVersion() {
-            return settingsVersion;
-        }
-
         public Builder mappingVersion(final long mappingVersion) {
             this.mappingVersion = mappingVersion;
             return this;
         }
-
+        
+        public long settingsVersion() {
+            return settingsVersion;
+        }
+        
         public Builder settingsVersion(final long settingsVersion) {
             this.settingsVersion = settingsVersion;
             return this;
         }
-
+        
+        public long aliasesVersion() {
+            return aliasesVersion;
+        }
+        
+        public Builder aliasesVersion(final long aliasesVersion) {
+            this.aliasesVersion = aliasesVersion;
+            return this;
+        }
+        
         /**
          * returns the primary term for the given shard.
          * See {@link IndexMetaData#primaryTerm(int)} for more information.
@@ -1136,11 +1189,31 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
 
             final String uuid = settings.get(SETTING_INDEX_UUID, INDEX_UUID_NA_VALUE);
 
-            return new IndexMetaData(new Index(index, uuid), version, mappingVersion, settingsVersion, primaryTerms, state,
-                numberOfShards, numberOfReplicas, tmpSettings, mappings.build(), tmpAliases.build(), customMetaData.build(),
-                filledInSyncAllocationIds.build(), requireFilters, initialRecoveryFilters, includeFilters, excludeFilters,
-                indexCreatedVersion, indexUpgradedVersion, getRoutingNumShards(), routingPartitionSize, waitForActiveShards,
-                rolloverInfos.build());
+            return new IndexMetaData(
+                    new Index(index, uuid),
+                    version,
+                    mappingVersion,
+                    settingsVersion,
+                    aliasesVersion,
+                    primaryTerms,
+                    state,
+                    numberOfShards,
+                    numberOfReplicas,
+                    tmpSettings,
+                    mappings.build(),
+                    tmpAliases.build(),
+                    customMetaData.build(),
+                    filledInSyncAllocationIds.build(),
+                    requireFilters,
+                    initialRecoveryFilters,
+                    includeFilters,
+                    excludeFilters,
+                    indexCreatedVersion,
+                    indexUpgradedVersion,
+                    getRoutingNumShards(),
+                    routingPartitionSize,
+                    waitForActiveShards,
+                    rolloverInfos.build());
         }
 
         public static void toXContent(IndexMetaData indexMetaData, XContentBuilder builder, ToXContent.Params params) throws IOException {
@@ -1149,6 +1222,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
             builder.field(KEY_VERSION, indexMetaData.getVersion());
             builder.field(KEY_MAPPING_VERSION, indexMetaData.getMappingVersion());
             builder.field(KEY_SETTINGS_VERSION, indexMetaData.getSettingsVersion());
+            builder.field(KEY_ALIASES_VERSION, indexMetaData.getAliasesVersion());
             builder.field(KEY_ROUTING_NUM_SHARDS, indexMetaData.getRoutingNumShards());
             builder.field(KEY_STATE, indexMetaData.getState().toString().toLowerCase(Locale.ENGLISH));
 
@@ -1223,6 +1297,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
             }
             boolean mappingVersion = false;
             boolean settingsVersion = false;
+            boolean aliasesVersion = false;
             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                 if (token == XContentParser.Token.FIELD_NAME) {
                     currentFieldName = parser.currentName();
@@ -1321,6 +1396,9 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
                     } else if (KEY_SETTINGS_VERSION.equals(currentFieldName)) {
                         settingsVersion = true;
                         builder.settingsVersion(parser.longValue());
+                    } else if (KEY_ALIASES_VERSION.equals(currentFieldName)) {
+                        aliasesVersion = true;
+                        builder.aliasesVersion(parser.longValue());
                     } else if (KEY_ROUTING_NUM_SHARDS.equals(currentFieldName)) {
                         builder.setRoutingNumShards(parser.intValue());
                     } else {
@@ -1335,6 +1413,9 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
             }
             if (Assertions.ENABLED && Version.indexCreated(builder.settings).onOrAfter(Version.V_6_5_0)) {
                 assert settingsVersion : "settings version should be present for indices created on or after 6.5.0";
+            }
+            if (Assertions.ENABLED && Version.indexCreated(builder.settings).onOrAfter(Version.V_8_0_0)) {
+                assert aliasesVersion : "aliases version should be present for indices created on or after 8.0.0";
             }
             return builder.build();
         }

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -308,7 +308,9 @@ public class RestoreService implements ClusterStateApplier {
                                 indexMdBuilder.mappingVersion(
                                         Math.max(snapshotIndexMetaData.getMappingVersion(), 1 + currentIndexMetaData.getMappingVersion()));
                                 indexMdBuilder.settingsVersion(
-                                        Math.max(snapshotIndexMetaData.getSettingsVersion(), 1 + currentIndexMetaData.getSettingsVersion()));
+                                        Math.max(
+                                                snapshotIndexMetaData.getSettingsVersion(),
+                                                1 + currentIndexMetaData.getSettingsVersion()));
                                 indexMdBuilder.aliasesVersion(
                                         Math.max(snapshotIndexMetaData.getAliasesVersion(), 1 + currentIndexMetaData.getAliasesVersion()));
 

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -301,13 +301,16 @@ public class RestoreService implements ClusterStateApplier {
                             } else {
                                 validateExistingIndex(currentIndexMetaData, snapshotIndexMetaData, renamedIndexName, partial);
                                 // Index exists and it's closed - open it in metadata and start recovery
-                                IndexMetaData.Builder indexMdBuilder = IndexMetaData.builder(snapshotIndexMetaData)
-                                                                                    .state(IndexMetaData.State.OPEN);
-                                indexMdBuilder.version(Math.max(snapshotIndexMetaData.getVersion(), currentIndexMetaData.getVersion() + 1));
-                                indexMdBuilder.mappingVersion(Math.max(snapshotIndexMetaData.getMappingVersion(),
-                                                                        currentIndexMetaData.getMappingVersion() + 1));
-                                indexMdBuilder.settingsVersion(Math.max(snapshotIndexMetaData.getSettingsVersion(),
-                                                                        currentIndexMetaData.getSettingsVersion() + 1));
+                                IndexMetaData.Builder indexMdBuilder =
+                                        IndexMetaData.builder(snapshotIndexMetaData).state(IndexMetaData.State.OPEN);
+                                indexMdBuilder.version(
+                                        Math.max(snapshotIndexMetaData.getVersion(), 1 + currentIndexMetaData.getVersion()));
+                                indexMdBuilder.mappingVersion(
+                                        Math.max(snapshotIndexMetaData.getMappingVersion(), 1 + currentIndexMetaData.getMappingVersion()));
+                                indexMdBuilder.settingsVersion(
+                                        Math.max(snapshotIndexMetaData.getSettingsVersion(), 1 + currentIndexMetaData.getSettingsVersion()));
+                                indexMdBuilder.aliasesVersion(
+                                        Math.max(snapshotIndexMetaData.getAliasesVersion(), 1 + currentIndexMetaData.getAliasesVersion()));
 
                                 for (int shard = 0; shard < snapshotIndexMetaData.getNumberOfShards(); shard++) {
                                     indexMdBuilder.primaryTerm(shard,

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesServiceTests.java
@@ -23,14 +23,17 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 import static java.util.Collections.singletonList;
@@ -74,6 +77,7 @@ public class MetaDataIndexAliasesServiceTests extends ESTestCase {
         assertNotNull(alias);
         assertTrue(alias.isAlias());
         assertThat(alias.getIndices(), contains(after.metaData().index(index)));
+        assertAliasesVersionIncreased(index, before, after);
 
         // Remove the alias from it while adding another one
         before = after;
@@ -85,12 +89,102 @@ public class MetaDataIndexAliasesServiceTests extends ESTestCase {
         assertNotNull(alias);
         assertTrue(alias.isAlias());
         assertThat(alias.getIndices(), contains(after.metaData().index(index)));
+        assertAliasesVersionIncreased(index, before, after);
 
         // Now just remove on its own
         before = after;
         after = service.innerExecute(before, singletonList(new AliasAction.Remove(index, "test_2")));
         assertNull(after.metaData().getAliasAndIndexLookup().get("test"));
         assertNull(after.metaData().getAliasAndIndexLookup().get("test_2"));
+        assertAliasesVersionIncreased(index, before, after);
+    }
+
+    public void testMultipleIndices() {
+        final var length = randomIntBetween(2, 8);
+        final var indices = new HashSet<String>(length);
+        var before = ClusterState.builder(ClusterName.DEFAULT).build();
+        final var addActions = new ArrayList<AliasAction>(length);
+        for (int i = 0; i < length; i++) {
+            final String index = randomValueOtherThanMany(v -> indices.add(v) == false, () -> randomAlphaOfLength(8));
+            before = createIndex(before, index);
+            addActions.add(new AliasAction.Add(index, "alias-" + index, null, null, null, null));
+        }
+        final var afterAddingAliasesToAll = service.innerExecute(before, addActions);
+        assertAliasesVersionIncreased(indices.toArray(new String[0]), before, afterAddingAliasesToAll);
+
+        // now add some aliases randomly
+        final var randomIndices = new HashSet<String>(length);
+        final var randomAddActions = new ArrayList<AliasAction>(length);
+        for (var index : indices) {
+            if (randomBoolean()) {
+                randomAddActions.add(new AliasAction.Add(index, "random-alias-" + index, null, null, null, null));
+                randomIndices.add(index);
+            }
+        }
+        final var afterAddingRandomAliases = service.innerExecute(afterAddingAliasesToAll, randomAddActions);
+        assertAliasesVersionIncreased(randomIndices.toArray(new String[0]), afterAddingAliasesToAll, afterAddingRandomAliases);
+        assertAliasesVersionUnchanged(
+                Sets.difference(indices, randomIndices).toArray(new String[0]),
+                afterAddingAliasesToAll,
+                afterAddingRandomAliases);
+    }
+
+    public void testChangingWriteAliasStateIncreasesAliasesVersion() {
+        final String index = randomAlphaOfLength(8);
+        final ClusterState before = createIndex(ClusterState.builder(ClusterName.DEFAULT).build(), index);
+
+        final ClusterState afterAddWriteAlias =
+                service.innerExecute(before, singletonList(new AliasAction.Add(index, "test", null, null, null, true)));
+        assertAliasesVersionIncreased(index, before, afterAddWriteAlias);
+
+        final ClusterState afterChangeWriteAliasToNonWriteAlias =
+                service.innerExecute(afterAddWriteAlias, singletonList(new AliasAction.Add(index, "test", null, null, null, false)));
+        assertAliasesVersionIncreased(index, afterAddWriteAlias, afterChangeWriteAliasToNonWriteAlias);
+
+        final ClusterState afterChangeNonWriteAliasToWriteAlias =
+                service.innerExecute(
+                        afterChangeWriteAliasToNonWriteAlias,
+                        singletonList(new AliasAction.Add(index, "test", null, null, null, true)));
+        assertAliasesVersionIncreased(index, afterChangeWriteAliasToNonWriteAlias, afterChangeNonWriteAliasToWriteAlias);
+    }
+
+    public void testAddingAliasMoreThanOnceShouldOnlyIncreaseAliasesVersionByOne() {
+        final String index = randomAlphaOfLength(8);
+        final ClusterState before = createIndex(ClusterState.builder(ClusterName.DEFAULT).build(), index);
+
+        // add an alias to the index multiple times
+        final int length = randomIntBetween(2, 8);
+        final var addActions = new ArrayList<AliasAction>(length);
+        for (int i = 0; i < length; i++) {
+            addActions.add(new AliasAction.Add(index, "test", null, null, null, null));
+        }
+        final ClusterState afterAddingAliases = service.innerExecute(before, addActions);
+
+        assertAliasesVersionIncreased(index, before, afterAddingAliases);
+    }
+
+    public void testAliasesVersionUnchangedWhenActionsAreIdempotent() {
+        final String index = randomAlphaOfLength(8);
+        final ClusterState before = createIndex(ClusterState.builder(ClusterName.DEFAULT).build(), index);
+
+        // add some aliases to the index
+        final int length = randomIntBetween(1, 8);
+        final var aliasNames = new HashSet<String>();
+        final var addActions = new ArrayList<AliasAction>(length);
+        for (int i = 0; i < length; i++) {
+            final String aliasName = randomValueOtherThanMany(v -> aliasNames.add(v) == false, () -> randomAlphaOfLength(8));
+            addActions.add(new AliasAction.Add(index, aliasName, null, null, null, null));
+        }
+        final ClusterState afterAddingAlias = service.innerExecute(before, addActions);
+
+        // now perform a remove and add for each alias which is idempotent, the resulting aliases are unchanged
+        final var removeAndAddActions = new ArrayList<AliasAction>(2 * length);
+        for (final var aliasName : aliasNames) {
+            removeAndAddActions.add(new AliasAction.Remove(index, aliasName));
+            removeAndAddActions.add(new AliasAction.Add(index, aliasName, null, null, null, null));
+        }
+        final ClusterState afterRemoveAndAddAlias = service.innerExecute(afterAddingAlias, removeAndAddActions);
+        assertAliasesVersionUnchanged(index, afterAddingAlias, afterRemoveAndAddAlias);
     }
 
     public void testSwapIndexWithAlias() {
@@ -106,6 +200,7 @@ public class MetaDataIndexAliasesServiceTests extends ESTestCase {
         assertNotNull(alias);
         assertTrue(alias.isAlias());
         assertThat(alias.getIndices(), contains(after.metaData().index("test_2")));
+        assertAliasesVersionIncreased("test_2", before, after);
     }
 
     public void testAddAliasToRemovedIndex() {
@@ -137,18 +232,21 @@ public class MetaDataIndexAliasesServiceTests extends ESTestCase {
             new AliasAction.Add("test", "alias", null, null, null, false)));
         assertFalse(after.metaData().index("test").getAliases().get("alias").writeIndex());
         assertNull(((AliasOrIndex.Alias) after.metaData().getAliasAndIndexLookup().get("alias")).getWriteIndex());
+        assertAliasesVersionIncreased("test", before, after);
 
         after = service.innerExecute(before, Arrays.asList(
             new AliasAction.Add("test", "alias", null, null, null, null)));
         assertNull(after.metaData().index("test").getAliases().get("alias").writeIndex());
         assertThat(((AliasOrIndex.Alias) after.metaData().getAliasAndIndexLookup().get("alias")).getWriteIndex(),
             equalTo(after.metaData().index("test")));
+        assertAliasesVersionIncreased("test", before, after);
 
         after = service.innerExecute(before, Arrays.asList(
             new AliasAction.Add("test", "alias", null, null, null, true)));
         assertTrue(after.metaData().index("test").getAliases().get("alias").writeIndex());
         assertThat(((AliasOrIndex.Alias) after.metaData().getAliasAndIndexLookup().get("alias")).getWriteIndex(),
             equalTo(after.metaData().index("test")));
+        assertAliasesVersionIncreased("test", before, after);
     }
 
     public void testAddWriteOnlyWithExistingWriteIndex() {
@@ -165,6 +263,8 @@ public class MetaDataIndexAliasesServiceTests extends ESTestCase {
         assertNull(after.metaData().index("test").getAliases().get("alias").writeIndex());
         assertThat(((AliasOrIndex.Alias) after.metaData().getAliasAndIndexLookup().get("alias")).getWriteIndex(),
             equalTo(after.metaData().index("test2")));
+        assertAliasesVersionIncreased("test", before, after);
+        assertAliasesVersionUnchanged("test2", before, after);
 
         Exception exception = expectThrows(IllegalStateException.class, () -> service.innerExecute(before, Arrays.asList(
             new AliasAction.Add("test", "alias", null, null, null, true))));
@@ -191,6 +291,8 @@ public class MetaDataIndexAliasesServiceTests extends ESTestCase {
         assertTrue(after.metaData().index("test2").getAliases().get("alias").writeIndex());
         assertThat(((AliasOrIndex.Alias) after.metaData().getAliasAndIndexLookup().get("alias")).getWriteIndex(),
             equalTo(after.metaData().index("test2")));
+        assertAliasesVersionIncreased("test", before, after);
+        assertAliasesVersionIncreased("test2", before, after);
     }
 
     public void testAddWriteOnlyWithExistingNonWriteIndices() {
@@ -212,7 +314,9 @@ public class MetaDataIndexAliasesServiceTests extends ESTestCase {
         assertTrue(after.metaData().index("test3").getAliases().get("alias").writeIndex());
         assertThat(((AliasOrIndex.Alias) after.metaData().getAliasAndIndexLookup().get("alias")).getWriteIndex(),
             equalTo(after.metaData().index("test3")));
-
+        assertAliasesVersionUnchanged("test", before, after);
+        assertAliasesVersionUnchanged("test2", before, after);
+        assertAliasesVersionIncreased("test3", before, after);
     }
 
     public void testAddWriteOnlyWithIndexRemoved() {
@@ -233,6 +337,7 @@ public class MetaDataIndexAliasesServiceTests extends ESTestCase {
         assertNull(after.metaData().index("test2").getAliases().get("alias").writeIndex());
         assertThat(((AliasOrIndex.Alias) after.metaData().getAliasAndIndexLookup().get("alias")).getWriteIndex(),
             equalTo(after.metaData().index("test2")));
+        assertAliasesVersionUnchanged("test2", before, after);
     }
 
     public void testAddWriteOnlyValidatesAgainstMetaDataBuilder() {
@@ -260,4 +365,29 @@ public class MetaDataIndexAliasesServiceTests extends ESTestCase {
                 .metaData(MetaData.builder(state.metaData()).put(indexMetaData, false))
                 .build();
     }
+
+    private void assertAliasesVersionUnchanged(final String index, final ClusterState before, final ClusterState after) {
+        assertAliasesVersionUnchanged(new String[]{index}, before, after);
+    }
+
+    private void assertAliasesVersionUnchanged(final String[] indices, final ClusterState before, final ClusterState after) {
+        for (final var index : indices) {
+            final long expected = before.metaData().index(index).getAliasesVersion();
+            final long actual = after.metaData().index(index).getAliasesVersion();
+            assertThat("index metadata aliases version mismatch", actual, equalTo(expected));
+        }
+    }
+
+    private void assertAliasesVersionIncreased(final String index, final ClusterState before, final ClusterState after) {
+        assertAliasesVersionIncreased(new String[]{index}, before, after);
+    }
+
+    private void assertAliasesVersionIncreased(final String[] indices, final ClusterState before, final ClusterState after) {
+        for (final var index : indices) {
+            final long expected = 1 + before.metaData().index(index).getAliasesVersion();
+            final long actual = after.metaData().index(index).getAliasesVersion();
+            assertThat("index metadata aliases version mismatch", actual, equalTo(expected));
+        }
+    }
+
 }


### PR DESCRIPTION
This commit introduces aliases versions to index metadata. This will be useful in CCR when we replicate aliases.

Relates #41396
