### PR TITLE
Strengthen typing in sorted differences

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Reconfigurator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Reconfigurator.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.util.set.Sets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -123,8 +124,8 @@ public class Reconfigurator {
         final Set<String> liveInConfigIds = new TreeSet<>(currentConfig.getNodeIds());
         liveInConfigIds.retainAll(liveNodeIds);
 
-        final Set<String> inConfigNotLiveIds = Sets.unmodifiableSortedDifference(currentConfig.getNodeIds(), liveInConfigIds);
-        final Set<String> nonRetiredInConfigNotLiveIds = new TreeSet<>(inConfigNotLiveIds);
+        final SortedSet<String> inConfigNotLiveIds = Sets.unmodifiableSortedDifference(currentConfig.getNodeIds(), liveInConfigIds);
+        final SortedSet<String> nonRetiredInConfigNotLiveIds = new TreeSet<>(inConfigNotLiveIds);
         nonRetiredInConfigNotLiveIds.removeAll(retiredNodeIds);
 
         final Set<String> nonRetiredInConfigLiveIds = new TreeSet<>(liveInConfigIds);
@@ -141,7 +142,7 @@ public class Reconfigurator {
             nonRetiredInConfigLiveMasterIds = Collections.emptySet();
         }
 
-        final Set<String> nonRetiredLiveNotInConfigIds = Sets.sortedDifference(liveNodeIds, currentConfig.getNodeIds());
+        final SortedSet<String> nonRetiredLiveNotInConfigIds = Sets.sortedDifference(liveNodeIds, currentConfig.getNodeIds());
         nonRetiredLiveNotInConfigIds.removeAll(retiredNodeIds);
 
         /*

--- a/server/src/main/java/org/elasticsearch/common/util/set/Sets.java
+++ b/server/src/main/java/org/elasticsearch/common/util/set/Sets.java
@@ -112,7 +112,7 @@ public final class Sets {
      * @param <T>   the type of the elements of the sets
      * @return the unmodifiable sorted relative complement of the left set with respect to the right set
      */
-    public static <T> Set<T> unmodifiableSortedDifference(final Set<T> left, final Set<T> right) {
+    public static <T> SortedSet<T> unmodifiableSortedDifference(final Set<T> left, final Set<T> right) {
         Objects.requireNonNull(left);
         Objects.requireNonNull(right);
         return left.stream().filter(k -> right.contains(k) == false).collect(toUnmodifiableSortedSet());
@@ -135,11 +135,11 @@ public final class Sets {
      * @param <T> the type of the input elements
      * @return an unmodifiable set where the underlying set is sorted
      */
-    public static <T> Collector<T, SortedSet<T>, Set<T>> toUnmodifiableSortedSet() {
+    public static <T> Collector<T, SortedSet<T>, SortedSet<T>> toUnmodifiableSortedSet() {
         return new UnmodifiableSortedSetCollector<>();
     }
 
-    abstract static class AbstractSortedSetCollector<T, R extends Set<T>> implements Collector<T, SortedSet<T>, R> {
+    abstract static class AbstractSortedSetCollector<T> implements Collector<T, SortedSet<T>, SortedSet<T>> {
 
         @Override
         public Supplier<SortedSet<T>> supplier() {
@@ -159,13 +159,13 @@ public final class Sets {
             };
         }
 
-        public abstract Function<SortedSet<T>, R> finisher();
+        public abstract Function<SortedSet<T>, SortedSet<T>> finisher();
 
         public abstract Set<Characteristics> characteristics();
 
     }
 
-    private static class SortedSetCollector<T> extends AbstractSortedSetCollector<T, SortedSet<T>> {
+    private static class SortedSetCollector<T> extends AbstractSortedSetCollector<T> {
 
         @Override
         public Function<SortedSet<T>, SortedSet<T>> finisher() {
@@ -182,11 +182,11 @@ public final class Sets {
 
     }
 
-    private static class UnmodifiableSortedSetCollector<T> extends AbstractSortedSetCollector<T, Set<T>> {
+    private static class UnmodifiableSortedSetCollector<T> extends AbstractSortedSetCollector<T> {
 
         @Override
-        public Function<SortedSet<T>, Set<T>> finisher() {
-            return Collections::unmodifiableSet;
+        public Function<SortedSet<T>, SortedSet<T>> finisher() {
+            return Collections::unmodifiableSortedSet;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingAction.java
@@ -50,6 +50,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
@@ -116,7 +117,7 @@ public class RestGetMappingAction extends BaseRestHandler {
                     }
                 }
 
-                final Set<String> difference = Sets.sortedDifference(Arrays.stream(types).collect(Collectors.toSet()), typeNames);
+                final SortedSet<String> difference = Sets.sortedDifference(Arrays.stream(types).collect(Collectors.toSet()), typeNames);
 
                 // now remove requested aliases that contain wildcards that are simple matches
                 final List<String> matches = new ArrayList<>();

--- a/server/src/test/java/org/elasticsearch/common/util/set/SetsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/set/SetsTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.test.ESTestCase;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -54,11 +55,11 @@ public class SetsTests extends ESTestCase {
     }
 
     private void runSortedDifferenceTest(
-        final BiFunction<Set<Integer>, Set<Integer>, Set<Integer>> sortedDifference,
+        final BiFunction<Set<Integer>, Set<Integer>, SortedSet<Integer>> sortedDifference,
         final Consumer<Set<Integer>> asserter) {
         final int endExclusive = randomIntBetween(0, 256);
         final Tuple<Set<Integer>, Set<Integer>> sets = randomSets(endExclusive);
-        final Set<Integer> difference = sortedDifference.apply(sets.v1(), sets.v2());
+        final SortedSet<Integer> difference = sortedDifference.apply(sets.v1(), sets.v2());
         assertDifference(endExclusive, sets, difference);
         final Iterator<Integer> it = difference.iterator();
         if (it.hasNext()) {


### PR DESCRIPTION
We have some convenience methods for computing modifiable and unmodifiable sorted differences. The unmodifiable sorted difference method was not typed to return a SortedSet. This commit addresses that by using the new method Collections#unmodifiableSortedSet so that we can return a SortedSet here too.
