### PR TITLE
Rejection of Port Ranges in module discovery.seed_hosts

### DIFF
--- a/server/src/test/java/org/elasticsearch/discovery/SettingsBasedSeedHostsProviderTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/SettingsBasedSeedHostsProviderTests.java
@@ -74,4 +74,28 @@ public class SettingsBasedSeedHostsProviderTests extends ESTestCase {
             .build(), null).getSeedAddresses(hostsResolver);
         assertTrue(hostsResolver.getResolvedHosts());
     }
+
+    public void testExceptionOnPortRange() {
+        boolean exceptionThrown = false;
+        try {
+            new SettingsBasedSeedHostsProvider(Settings.builder()
+                .putList(SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING.getKey(), "localhost:9200-9300")
+                .build(), null);
+        } catch (IllegalArgumentException e) {
+            exceptionThrown = true;
+        }
+        assertTrue(exceptionThrown);
+    }
+
+    public void testSeedWithoutPortRange() {
+        boolean exceptionThrown = false;
+        try {
+            new SettingsBasedSeedHostsProvider(Settings.builder()
+                .putList(SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING.getKey(), "localhost:9200")
+                .build(), null);
+        } catch (Exception e) {
+            exceptionThrown = true;
+        }
+        assertFalse(exceptionThrown);
+    }
 }


### PR DESCRIPTION
This is meant to resolve Issue#40786. The changes in this pull make it so that the discovery.seed_hosts module will no longer accept ranges of ports rather than a single port or no ports.