### PR TITLE
Docs: Rework close ml section

### DIFF
--- a/docs/reference/upgrade/close-ml.asciidoc
+++ b/docs/reference/upgrade/close-ml.asciidoc
@@ -25,18 +25,16 @@ it puts increased load on the cluster.
 prevent new jobs from opening by using the
 <<ml-set-upgrade-mode,set upgrade mode API>>:
 +
---
 [source,js]
 --------------------------------------------------
 POST _ml/set_upgrade_mode?enabled=true
 --------------------------------------------------
 // CONSOLE
-
++
 When you disable upgrade mode, the jobs resume using the last model
 state that was automatically saved. This option avoids the overhead of managing
 active jobs during the upgrade and is faster than explicitly stopping {dfeeds}
 and closing jobs.
---
 
 * {stack-ov}/stopping-ml.html[Stop all {dfeeds} and close all jobs]. This option
 saves the model state at the time of closure. When you reopen the jobs after the


### PR DESCRIPTION
Reworks the close ml section to work properly in Asciidoctor. It
renders a little funny in AsciiDoc but AsciiDoc is on its way out
anyway....

Relates to #41128