### PR TITLE
remove path from rest-api-spec

### DIFF
--- a/plugins/examples/rest-handler/src/test/resources/rest-api-spec/api/cat.example.json
+++ b/plugins/examples/rest-handler/src/test/resources/rest-api-spec/api/cat.example.json
@@ -3,7 +3,6 @@
     "documentation": "",
     "methods": ["GET"],
     "url": {
-      "path": "/_cat/example",
       "paths": ["/_cat/example"],
       "parts": {},
       "params": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/bulk.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/bulk.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html",
     "methods": ["POST", "PUT"],
     "url": {
-      "path": "/_bulk",
       "paths": ["/_bulk", "/{index}/_bulk", "/{index}/{type}/_bulk"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cat/aliases",
       "paths": ["/_cat/aliases", "/_cat/aliases/{name}"],
       "parts": {
         "name": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cat/allocation",
       "paths": ["/_cat/allocation", "/_cat/allocation/{node_id}"],
       "parts": {
         "node_id": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.count.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cat/count",
       "paths": ["/_cat/count", "/_cat/count/{index}"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.fielddata.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.fielddata.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cat/fielddata",
       "paths": ["/_cat/fielddata", "/_cat/fielddata/{fields}"],
       "parts": {
         "fields": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.health.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.health.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cat/health",
       "paths": ["/_cat/health"],
       "parts": {
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.help.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.help.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cat",
       "paths": ["/_cat"],
       "parts": {
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cat/indices",
       "paths": ["/_cat/indices", "/_cat/indices/{index}"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.master.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.master.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cat/master",
       "paths": ["/_cat/master"],
       "parts": {
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodeattrs.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodeattrs.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cat/nodeattrs",
       "paths": ["/_cat/nodeattrs"],
       "parts": {
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cat/nodes",
       "paths": ["/_cat/nodes"],
       "parts": {
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.pending_tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.pending_tasks.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cat/pending_tasks",
       "paths": ["/_cat/pending_tasks"],
       "parts": {
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.plugins.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.plugins.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cat/plugins",
       "paths": ["/_cat/plugins"],
       "params": {
         "format": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cat/recovery",
       "paths": ["/_cat/recovery", "/_cat/recovery/{index}"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.repositories.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.repositories.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cat/repositories",
       "paths": ["/_cat/repositories"],
       "parts": {
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cat/segments",
       "paths": ["/_cat/segments", "/_cat/segments/{index}"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cat/shards",
       "paths": ["/_cat/shards", "/_cat/shards/{index}"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cat/snapshots",
       "paths": [
         "/_cat/snapshots",
         "/_cat/snapshots/{repository}"],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.tasks.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cat/tasks",
       "paths": ["/_cat/tasks"],
       "parts": {
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.templates.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.templates.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cat/templates",
       "paths": ["/_cat/templates", "/_cat/templates/{name}"],
       "parts": {
         "name": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cat/thread_pool",
       "paths": ["/_cat/thread_pool","/_cat/thread_pool/{thread_pool_patterns}"],
       "parts": {
         "thread_pool_patterns": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/clear_scroll.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/clear_scroll.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html",
     "methods": ["DELETE"],
     "url": {
-      "path": "/_search/scroll",
       "paths": [ "/_search/scroll"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.allocation_explain.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.allocation_explain.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html",
     "methods": ["GET", "POST"],
     "url": {
-      "path": "/_cluster/allocation/explain",
       "paths": ["/_cluster/allocation/explain"],
       "parts": {},
       "params": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_settings.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cluster/settings",
       "paths": ["/_cluster/settings"],
       "parts": {},
       "params": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cluster/health",
       "paths": ["/_cluster/health", "/_cluster/health/{index}"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.pending_tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.pending_tasks.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cluster/pending_tasks",
       "paths": ["/_cluster/pending_tasks"],
       "parts": {
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_settings.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html",
     "methods": ["PUT"],
     "url": {
-      "path": "/_cluster/settings",
       "paths": ["/_cluster/settings"],
       "parts": {},
       "params": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.remote_info.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.remote_info.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_remote/info",
       "paths": ["/_remote/info"],
       "params": {}
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.reroute.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.reroute.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html",
     "methods": ["POST"],
     "url": {
-      "path": "/_cluster/reroute",
       "paths": ["/_cluster/reroute"],
       "parts": {
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cluster/state",
       "paths": [
         "/_cluster/state",
         "/_cluster/state/{metric}",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.stats.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_cluster/stats",
       "paths": ["/_cluster/stats", "/_cluster/stats/nodes/{node_id}"],
       "parts": {
         "node_id": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html",
     "methods": ["POST", "GET"],
     "url": {
-      "path": "/_count",
       "paths": ["/_count", "/{index}/_count"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html",
     "methods": ["PUT","POST"],
     "url": {
-      "path": "/{index}/_create/{id}",
       "paths": ["/{index}/_create/{id}"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html",
     "methods": ["DELETE"],
     "url": {
-      "path": "/{index}/_doc/{id}",
       "paths": ["/{index}/_doc/{id}"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html",
     "methods": ["POST"],
     "url": {
-      "path": "/{index}/_delete_by_query",
       "paths": ["/{index}/_delete_by_query"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query_rethrottle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query_rethrottle.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html",
     "methods": ["POST"],
     "url": {
-      "path": "/_delete_by_query/{task_id}/_rethrottle",
       "paths": ["/_delete_by_query/{task_id}/_rethrottle"],
       "parts": {
         "task_id": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_script.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_script.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html",
     "methods": ["DELETE"],
     "url": {
-      "path": "/_scripts/{id}",
       "paths": [ "/_scripts/{id}" ],
       "parts": {
         "id": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/exists.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/exists.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html",
     "methods": ["HEAD"],
     "url": {
-      "path": "/{index}/_doc/{id}",
       "paths": ["/{index}/_doc/{id}"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/exists_source.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/exists_source.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html",
     "methods": ["HEAD"],
     "url": {
-      "path": "/{index}/_source/{id}",
       "paths": ["/{index}/_source/{id}"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/explain.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/explain.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html",
     "methods": ["GET", "POST"],
     "url": {
-      "path": "/{index}/_explain/{id}",
       "paths": ["/{index}/_explain/{id}"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/field_caps.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/field_caps.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html",
     "methods": ["GET", "POST"],
     "url": {
-      "path": "/_field_caps",
       "paths": [
         "/_field_caps",
         "/{index}/_field_caps"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html",
     "methods": ["GET"],
     "url": {
-      "path": "/{index}/_doc/{id}",
       "paths": ["/{index}/_doc/{id}"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get_script.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get_script.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_scripts/{id}",
       "paths": [ "/_scripts/{id}" ],
       "parts": {
         "id": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get_source.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get_source.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html",
     "methods": ["GET"],
     "url": {
-      "path": "/{index}/_source/{id}",
       "paths": ["/{index}/_source/{id}"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html",
     "methods": ["POST", "PUT"],
     "url": {
-      "path": "/{index}/_doc",
       "paths": ["/{index}/_doc/{id}", "/{index}/_doc"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.analyze.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.analyze.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html",
     "methods": ["GET", "POST"],
     "url": {
-      "path": "/_analyze",
       "paths": ["/_analyze", "/{index}/_analyze"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clear_cache.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clear_cache.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html",
     "methods": ["POST"],
     "url": {
-      "path": "/_cache/clear",
       "paths": ["/_cache/clear", "/{index}/_cache/clear"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.close.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.close.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html",
     "methods": ["POST"],
     "url": {
-      "path": "/{index}/_close",
       "paths": ["/{index}/_close"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html",
     "methods": ["PUT"],
     "url": {
-      "path": "/{index}",
       "paths": ["/{index}"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html",
     "methods": ["DELETE"],
     "url": {
-      "path": "/{index}",
       "paths": ["/{index}"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_alias.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html",
     "methods": ["DELETE"],
     "url": {
-      "path": "/{index}/_alias/{name}",
       "paths": ["/{index}/_alias/{name}", "/{index}/_aliases/{name}"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_template.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
     "methods": ["DELETE"],
     "url": {
-      "path": "/_template/{name}",
       "paths": ["/_template/{name}"],
       "parts": {
         "name": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html",
     "methods": [ "HEAD" ],
     "url": {
-      "path": "/{index}",
       "paths": [ "/{index}" ],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_alias.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html",
     "methods": ["HEAD"],
     "url": {
-      "path": "/_alias/{name}",
       "paths": ["/_alias/{name}", "/{index}/_alias/{name}"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_template.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
     "methods": ["HEAD"],
     "url": {
-      "path": "/_template/{name}",
       "paths": [ "/_template/{name}" ],
       "parts": {
         "name": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_type.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_type.json
@@ -7,7 +7,6 @@
       "description" : "Types are being removed from elasticsearch and therefor this API is on the way out. Read more here: https://www.elastic.co/guide/en/elasticsearch/reference/master/removal-of-types.html"
     },
     "url": {
-      "path": "/{index}/_mapping/{type}",
       "paths": ["/{index}/_mapping/{type}"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.flush.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.flush.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html",
     "methods": ["POST", "GET"],
     "url": {
-      "path": "/_flush",
       "paths": ["/_flush", "/{index}/_flush"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.flush_synced.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.flush_synced.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush.html",
     "methods": ["POST", "GET"],
     "url": {
-      "path": "/_flush/synced",
       "paths": [
         "/_flush/synced",
         "/{index}/_flush/synced"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html",
     "methods": ["POST"],
     "url": {
-      "path": "/_forcemerge",
       "paths": ["/_forcemerge", "/{index}/_forcemerge"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
@@ -3,7 +3,6 @@
     "documentation":"http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html",
     "methods":[ "GET" ],
     "url":{
-      "path":"/{index}",
       "paths":[ "/{index}" ],
       "parts":{
         "index":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_alias.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_alias/",
       "paths": [ "/_alias", "/_alias/{name}", "/{index}/_alias/{name}", "/{index}/_alias"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_mapping/field/{fields}",
       "paths": ["/_mapping/field/{fields}", "/{index}/_mapping/field/{fields}"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_mapping.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_mapping",
       "paths": ["/_mapping", "/{index}/_mapping"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_settings.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_settings",
       "paths": ["/_settings", "/{index}/_settings", "/{index}/_settings/{name}", "/_settings/{name}"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_template/{name}",
       "paths": [
         "/_template",
         "/_template/{name}"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_upgrade.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_upgrade.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_upgrade",
       "paths": ["/_upgrade", "/{index}/_upgrade"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.open.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.open.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html",
     "methods": ["POST"],
     "url": {
-      "path": "/{index}/_open",
       "paths": ["/{index}/_open"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_alias.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html",
     "methods": ["PUT", "POST"],
     "url": {
-      "path": "/{index}/_alias/{name}",
       "paths": ["/{index}/_alias/{name}", "/{index}/_aliases/{name}"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_mapping.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html",
     "methods": ["PUT", "POST"],
     "url": {
-      "path": "{index}/_mapping",
       "paths": ["{index}/_mapping"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_settings.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html",
     "methods": ["PUT"],
     "url": {
-      "path": "/_settings",
       "paths": ["/_settings", "/{index}/_settings"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
     "methods": ["PUT", "POST"],
     "url": {
-      "path": "/_template/{name}",
       "paths": ["/_template/{name}"],
       "parts": {
         "name": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.recovery.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.recovery.json
@@ -3,7 +3,6 @@
         "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html",
         "methods": ["GET"],
         "url": {
-            "path": "/_recovery",
             "paths": ["/_recovery", "/{index}/_recovery"],
             "parts": {
                 "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.refresh.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.refresh.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html",
     "methods": ["POST", "GET"],
     "url": {
-      "path": "/_refresh",
       "paths": ["/_refresh", "/{index}/_refresh"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html",
     "methods": ["POST"],
     "url": {
-      "path": "/{alias}/_rollover",
       "paths": ["/{alias}/_rollover", "/{alias}/_rollover/{new_index}"],
       "parts": {
         "alias": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.segments.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_segments",
       "paths": ["/_segments", "/{index}/_segments"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shard_stores.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shard_stores.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_shard_stores",
       "paths": ["/_shard_stores", "/{index}/_shard_stores"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shrink.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shrink.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html",
     "methods": ["PUT", "POST"],
     "url": {
-      "path": "/{index}/_shrink/{target}",
       "paths": ["/{index}/_shrink/{target}"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.split.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.split.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html",
     "methods": ["PUT", "POST"],
     "url": {
-      "path": "/{index}/_split/{target}",
       "paths": ["/{index}/_split/{target}"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.stats.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_stats",
       "paths": [
         "/_stats",
         "/_stats/{metric}",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.update_aliases.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.update_aliases.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html",
     "methods": ["POST"],
     "url": {
-      "path": "/_aliases",
       "paths": ["/_aliases"],
       "parts": {
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.upgrade.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.upgrade.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html",
     "methods": ["POST"],
     "url": {
-      "path": "/_upgrade",
       "paths": ["/_upgrade", "/{index}/_upgrade"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.validate_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.validate_query.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html",
     "methods": ["GET", "POST"],
     "url": {
-      "path": "/_validate/query",
       "paths": ["/_validate/query", "/{index}/_validate/query"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/info.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/info.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/",
     "methods": ["GET"],
     "url": {
-      "path": "/",
       "paths": ["/"],
       "parts": {
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_pipeline.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html",
     "methods": [ "DELETE" ],
     "url": {
-      "path": "/_ingest/pipeline/{id}",
       "paths": [ "/_ingest/pipeline/{id}" ],
       "parts": {
         "id": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.get_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.get_pipeline.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_ingest/pipeline/{id}",
       "paths": [ "/_ingest/pipeline", "/_ingest/pipeline/{id}" ],
       "parts": {
         "id": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.processor_grok.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.processor_grok.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/grok-processor.html#grok-processor-rest-get",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_ingest/processor/grok",
       "paths": ["/_ingest/processor/grok"],
       "parts": {
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_pipeline.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-pipeline-api.html",
     "methods": [ "PUT" ],
     "url": {
-      "path": "/_ingest/pipeline/{id}",
       "paths": [ "/_ingest/pipeline/{id}" ],
       "parts": {
         "id": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.simulate.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.simulate.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html",
     "methods": [ "GET", "POST" ],
     "url": {
-      "path": "/_ingest/pipeline/_simulate",
       "paths": [ "/_ingest/pipeline/_simulate", "/_ingest/pipeline/{id}/_simulate" ],
       "parts": {
         "id": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/mget.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/mget.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html",
     "methods": ["GET", "POST"],
     "url": {
-      "path": "/_mget",
       "paths": ["/_mget", "/{index}/_mget"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html",
     "methods": ["GET", "POST"],
     "url": {
-      "path": "/_msearch",
       "paths": ["/_msearch", "/{index}/_msearch"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/msearch_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/msearch_template.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html",
     "methods": ["GET", "POST"],
     "url": {
-      "path": "/_msearch/template",
       "paths": ["/_msearch/template", "/{index}/_msearch/template"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/mtermvectors.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/mtermvectors.json
@@ -3,7 +3,6 @@
     "documentation" : "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html",
     "methods" : ["GET", "POST"],
     "url" : {
-      "path" : "/_mtermvectors",
       "paths" : ["/_mtermvectors", "/{index}/_mtermvectors"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.hot_threads.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.hot_threads.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_nodes/hot_threads",
       "paths": ["/_nodes/hot_threads",  "/_nodes/{node_id}/hot_threads"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.info.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.info.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_nodes",
       "paths": ["/_nodes", "/_nodes/{node_id}", "/_nodes/{metric}", "/_nodes/{node_id}/{metric}"],
       "parts": {
         "node_id": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.reload_secure_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.reload_secure_settings.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings",
     "methods": ["POST"],
     "url": {
-      "path": "/_nodes/reload_secure_settings",
       "paths": ["/_nodes/reload_secure_settings", "/_nodes/{node_id}/reload_secure_settings"],
       "parts": {
         "node_id": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.stats.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_nodes/stats",
       "paths": [
         "/_nodes/stats",
         "/_nodes/{node_id}/stats",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.usage.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.usage.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_nodes/usage",
       "paths": [
         "/_nodes/usage",
         "/_nodes/{node_id}/usage",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ping.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/",
     "methods": ["HEAD"],
     "url": {
-      "path": "/",
       "paths": ["/"],
       "parts": {
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/put_script.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/put_script.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html",
     "methods": ["PUT", "POST"],
     "url": {
-      "path": "/_scripts/{id}",
       "paths": [ "/_scripts/{id}", "/_scripts/{id}/{context}" ],
       "parts": {
         "id": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rank_eval.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rank_eval.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html",
     "methods": ["GET", "POST"],
     "url": {
-      "path": "/_rank_eval",
       "paths": ["/_rank_eval", "/{index}/_rank_eval"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html",
     "methods": ["POST"],
     "url": {
-      "path": "/_reindex",
       "paths": ["/_reindex"],
       "parts": {},
       "params": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex_rethrottle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex_rethrottle.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html",
     "methods": ["POST"],
     "url": {
-      "path": "/_reindex/{task_id}/_rethrottle",
       "paths": ["/_reindex/{task_id}/_rethrottle"],
       "parts": {
         "task_id": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/render_search_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/render_search_template.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html",
     "methods": ["GET", "POST"],
     "url": {
-      "path": "/_render/template",
       "paths": [ "/_render/template", "/_render/template/{id}" ],
       "parts": {
         "id": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/scripts_painless_context.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/scripts_painless_context.json
@@ -2,7 +2,6 @@
   "scripts_painless_context": {
     "methods": ["GET"],
     "url": {
-      "path": "/_scripts/painless/_context",
       "paths": ["/_scripts/painless/_context"],
       "parts": {
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/scripts_painless_execute.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/scripts_painless_execute.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html",
     "methods": ["GET", "POST"],
     "url": {
-      "path": "/_scripts/painless/_execute",
       "paths": ["/_scripts/painless/_execute"],
       "parts": {
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/scroll.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/scroll.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-scroll.html",
     "methods": ["GET", "POST"],
     "url": {
-      "path": "/_search/scroll",
       "paths": ["/_search/scroll"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html",
     "methods": ["GET", "POST"],
     "url": {
-      "path": "/_search",
       "paths": ["/_search", "/{index}/_search"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_shards.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_shards.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html",
     "methods": ["GET", "POST"],
     "url": {
-      "path": "/{index}/_search_shards",
       "paths": ["/_search_shards", "/{index}/_search_shards"],
       "parts": {
         "index": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html",
     "methods": ["GET", "POST"],
     "url": {
-      "path": "/_search/template",
       "paths": ["/_search/template", "/{index}/_search/template"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
     "methods": ["PUT", "POST"],
     "url": {
-      "path": "/_snapshot/{repository}/{snapshot}",
       "paths": ["/_snapshot/{repository}/{snapshot}"],
       "parts": {
         "repository": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create_repository.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
     "methods": ["PUT", "POST"],
     "url": {
-      "path": "/_snapshot/{repository}",
       "paths": ["/_snapshot/{repository}"],
       "parts": {
         "repository": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
     "methods": ["DELETE"],
     "url": {
-      "path": "/_snapshot/{repository}/{snapshot}",
       "paths": ["/_snapshot/{repository}/{snapshot}"],
       "parts": {
         "repository": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete_repository.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
     "methods": ["DELETE"],
     "url": {
-      "path": "/_snapshot/{repository}",
       "paths": ["/_snapshot/{repository}"],
       "parts": {
         "repository": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_snapshot/{repository}/{snapshot}",
       "paths": ["/_snapshot/{repository}/{snapshot}"],
       "parts": {
         "repository": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get_repository.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_snapshot",
       "paths": ["/_snapshot", "/_snapshot/{repository}"],
       "parts": {
         "repository": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.restore.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.restore.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
     "methods": ["POST"],
     "url": {
-      "path": "/_snapshot/{repository}/{snapshot}/_restore",
       "paths": ["/_snapshot/{repository}/{snapshot}/_restore"],
       "parts": {
         "repository": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.status.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.status.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_snapshot/_status",
       "paths": ["/_snapshot/_status", "/_snapshot/{repository}/_status", "/_snapshot/{repository}/{snapshot}/_status"],
       "parts": {
         "repository": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.verify_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.verify_repository.json
@@ -3,7 +3,6 @@
         "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
         "methods": ["POST"],
         "url": {
-            "path": "/_snapshot/{repository}/_verify",
             "paths": ["/_snapshot/{repository}/_verify"],
             "parts": {
                 "repository": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.cancel.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.cancel.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html",
     "methods": ["POST"],
     "url": {
-      "path": "/_tasks",
       "paths": ["/_tasks/_cancel", "/_tasks/{task_id}/_cancel"],
       "parts": {
         "task_id": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.get.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_tasks/{task_id}",
       "paths": ["/_tasks/{task_id}"],
       "parts": {
         "task_id": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_tasks",
       "paths": ["/_tasks"],
       "parts": {},
       "params": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/termvectors.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/termvectors.json
@@ -3,7 +3,6 @@
     "documentation" : "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html",
     "methods" : ["GET", "POST"],
     "url" : {
-      "path" : "/{index}/_termvectors/{id}",
       "paths" : ["/{index}/_termvectors/{id}", "/{index}/_termvectors"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html",
     "methods": ["POST"],
     "url": {
-      "path": "/{index}/_update/{id}",
       "paths": ["/{index}/_update/{id}"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html",
     "methods": ["POST"],
     "url": {
-      "path": "/{index}/_update_by_query",
       "paths": ["/{index}/_update_by_query"],
       "deprecated_paths" : [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query_rethrottle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query_rethrottle.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html",
     "methods": ["POST"],
     "url": {
-      "path": "/_update_by_query/{task_id}/_rethrottle",
       "paths": ["/_update_by_query/{task_id}/_rethrottle"],
       "parts": {
         "task_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.delete_auto_follow_pattern.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.delete_auto_follow_pattern.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-delete-auto-follow-pattern.html",
     "methods": [ "DELETE" ],
     "url": {
-      "path": "/_ccr/auto_follow/{name}",
       "paths": [ "/_ccr/auto_follow/{name}" ],
       "parts": {
         "name": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.follow.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.follow.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-follow.html",
     "methods": [ "PUT" ],
     "url": {
-      "path": "/{index}/_ccr/follow",
       "paths": [ "/{index}/_ccr/follow" ],
       "parts": {
         "index": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.follow_info.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.follow_info.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-info.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/{index}/_ccr/info",
       "paths": [ "/{index}/_ccr/info" ],
       "parts": {
         "index": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.follow_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.follow_stats.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-stats.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/{index}/_ccr/stats",
       "paths": [ "/{index}/_ccr/stats" ],
       "parts": {
         "index": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.forget_follower.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.forget_follower.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current",
     "methods": [ "POST" ],
     "url": {
-      "path": "/{index}/_ccr/forget_follower",
       "paths": [ "/{index}/_ccr/forget_follower" ],
       "parts": {
         "index": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.get_auto_follow_pattern.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.get_auto_follow_pattern.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-auto-follow-pattern.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_ccr/auto_follow/{name}",
       "paths": [ "/_ccr/auto_follow", "/_ccr/auto_follow/{name}" ],
       "parts": {
         "name": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.pause_follow.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.pause_follow.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-pause-follow.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/{index}/_ccr/pause_follow",
       "paths": [ "/{index}/_ccr/pause_follow" ],
       "parts": {
         "index": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.put_auto_follow_pattern.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.put_auto_follow_pattern.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-auto-follow-pattern.html",
     "methods": [ "PUT" ],
     "url": {
-      "path": "/_ccr/auto_follow/{name}",
       "paths": [ "/_ccr/auto_follow/{name}" ],
       "parts": {
         "name": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.resume_follow.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.resume_follow.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-resume-follow.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/{index}/_ccr/resume_follow",
       "paths": [ "/{index}/_ccr/resume_follow" ],
       "parts": {
         "index": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.stats.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-stats.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_ccr/stats",
       "paths": [ "/_ccr/stats" ],
       "parts": {},
       "body": null

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.unfollow.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.unfollow.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current",
     "methods": [ "POST" ],
     "url": {
-      "path": "/{index}/_ccr/unfollow",
       "paths": [ "/{index}/_ccr/unfollow" ],
       "parts": {
         "index": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.delete_data_frame_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.delete_data_frame_transform.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-data-frame-transform.html",
     "methods": [ "DELETE" ],
     "url": {
-      "path": "/_data_frame/transforms/{transform_id}",
       "paths": [
         "/_data_frame/transforms/{transform_id}"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.get_data_frame_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.get_data_frame_transform.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-data-frame-transform.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_data_frame/transforms/{transform_id}",
       "paths": [ "/_data_frame/transforms/{transform_id}", "/_data_frame/transforms"],
       "parts": {
         "transform_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.get_data_frame_transform_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.get_data_frame_transform_stats.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-data-frame-transform-stats.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_data_frame/transforms/{transform_id}/_stats",
       "paths": [ "/_data_frame/transforms/{transform_id}/_stats" ],
       "parts": {
         "transform_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.preview_data_frame_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.preview_data_frame_transform.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/preview-data-frame-transform.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_data_frame/transforms/_preview",
       "paths": [ "/_data_frame/transforms/_preview" ]
     },
     "body": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.put_data_frame_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.put_data_frame_transform.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-data-frame-transform.html",
     "methods": [ "PUT" ],
     "url": {
-      "path": "/_data_frame/transforms/{transform_id}",
       "paths": [ "/_data_frame/transforms/{transform_id}" ],
       "parts": {
         "transform_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.start_data_frame_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.start_data_frame_transform.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/start-data-frame-transform.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_data_frame/transforms/{transform_id}/_start",
       "paths": [ "/_data_frame/transforms/{transform_id}/_start" ],
       "parts": {
         "transform_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.stop_data_frame_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.stop_data_frame_transform.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-data-frame-transform.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_data_frame/transforms/{transform_id}/_stop",
       "paths": [ "/_data_frame/transforms/{transform_id}/_stop" ],
       "parts": {
         "transform_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/graph.explore.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/graph.explore.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html",
     "methods": ["GET", "POST"],
     "url": {
-      "path": "/{index}/_graph/explore",
       "paths": ["/{index}/_graph/explore"],
       "deprecated_paths" : [
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.delete_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.delete_lifecycle.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-delete-lifecycle.html",
     "methods": [ "DELETE" ],
     "url": {
-      "path": "/_ilm/policy/{policy}",
       "paths": ["/_ilm/policy/{policy}"],
       "parts": {
         "policy": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.explain_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.explain_lifecycle.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/{index}/_ilm/explain",
       "paths": ["/{index}/_ilm/explain"],
       "parts": {
         "index": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.get_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.get_lifecycle.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_ilm/policy/{policy}",
       "paths": ["/_ilm/policy/{policy}", "/_ilm/policy"],
       "parts": {
         "policy": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.get_status.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.get_status.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-status.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_ilm/status",
       "paths": ["/_ilm/status"],
       "parts": {},
       "params": {}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.move_to_step.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.move_to_step.json
@@ -4,7 +4,6 @@
     "description": "Triggers execution of a specific step in the lifecycle policy. Since this action is designed to only be run in emergency situations, clients should not implement this API",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_ilm/move/{index}",
       "paths": ["/_ilm/move/{index}"],
       "parts": {
         "index": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.put_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.put_lifecycle.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html",
     "methods": [ "PUT" ],
     "url": {
-      "path": "/_ilm/policy/{policy}",
       "paths": ["/_ilm/policy/{policy}"],
       "parts": {
         "policy": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.remove_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.remove_policy.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-remove-policy.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/{index}/_ilm/remove",
       "paths": ["/{index}/_ilm/remove"],
       "parts": {
         "index": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.retry.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.retry.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-retry-policy.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/{index}/_ilm/retry",
       "paths": ["/{index}/_ilm/retry"],
       "parts": {
         "index": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.start.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.start.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-start.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_ilm/start",
       "paths": ["/_ilm/start"],
       "parts": {},
       "params": {}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.stop.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.stop.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-stop.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_ilm/stop",
       "paths": ["/_ilm/stop"],
       "parts": {},
       "params": {}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.freeze.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.freeze.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/frozen.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/{index}/_freeze",
       "paths": [
         "/{index}/_freeze"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.unfreeze.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.unfreeze.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/frozen.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/{index}/_unfreeze",
       "paths": [ "/{index}/_unfreeze" ],
       "parts": {
         "index": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/license.delete.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/license.delete.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-license.html",
     "methods": ["DELETE"],
     "url": {
-      "path": "/_license",
       "paths": ["/_license"],
       "parts" : {}
     },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/license.get.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/license.get.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-license.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_license",
       "paths": ["/_license"],
       "parts" : {
       },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/license.get_basic_status.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/license.get_basic_status.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-basic-status.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_license/basic_status",
       "paths": ["/_license/basic_status"],
       "parts" : {
       },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/license.get_trial_status.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/license.get_trial_status.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trial-status.html",
     "methods": ["GET"],
     "url": {
-      "path": "/_license/trial_status",
       "paths": ["/_license/trial_status"],
       "parts" : {
       },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/license.post.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/license.post.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/update-license.html",
     "methods": ["PUT", "POST"],
     "url": {
-      "path": "/_license",
       "paths": ["/_license"],
       "parts" : {
       },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/license.post_start_basic.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/license.post_start_basic.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/start-basic.html",
     "methods": ["POST"],
     "url": {
-      "path": "/_license/start_basic",
       "paths": ["/_license/start_basic"],
       "parts" : {
       },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/license.post_start_trial.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/license.post_start_trial.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trial.html",
     "methods": ["POST"],
     "url": {
-      "path": "/_license/start_trial",
       "paths": ["/_license/start_trial"],
       "parts" : {
       },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/migration.deprecations.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/migration.deprecations.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-deprecation.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/{index}/_migration/deprecations",
       "paths": ["/_migration/deprecations", "/{index}/_migration/deprecations"],
       "parts": {
         "index": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.close_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.close_job.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_ml/anomaly_detectors/{job_id}/_close",
       "paths": [ "/_ml/anomaly_detectors/{job_id}/_close" ],
       "parts": {
         "job_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_calendar.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_calendar.json
@@ -2,7 +2,6 @@
   "ml.delete_calendar": {
     "methods": [ "DELETE" ],
     "url": {
-      "path": "/_ml/calendars/{calendar_id}",
       "paths": [ "/_ml/calendars/{calendar_id}" ],
       "parts": {
         "calendar_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_calendar_event.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_calendar_event.json
@@ -2,7 +2,6 @@
   "ml.delete_calendar_event": {
     "methods": [ "DELETE" ],
     "url": {
-      "path": "/_ml/calendars/{calendar_id}/events/{event_id}",
       "paths": [ "/_ml/calendars/{calendar_id}/events/{event_id}" ],
       "parts": {
         "calendar_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_calendar_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_calendar_job.json
@@ -2,7 +2,6 @@
   "ml.delete_calendar_job": {
     "methods": [ "DELETE" ],
     "url": {
-      "path": "/_ml/calendars/{calendar_id}/jobs/{job_id}",
       "paths": [ "/_ml/calendars/{calendar_id}/jobs/{job_id}" ],
       "parts": {
         "calendar_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_datafeed.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_datafeed.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html",
     "methods": [ "DELETE" ],
     "url": {
-      "path": "/_ml/datafeeds/{datafeed_id}",
       "paths": [ "/_ml/datafeeds/{datafeed_id}" ],
       "parts": {
         "datafeed_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_expired_data.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_expired_data.json
@@ -2,7 +2,6 @@
   "ml.delete_expired_data": {
     "methods": [ "DELETE" ],
     "url": {
-      "path": "/_ml/_delete_expired_data",
       "paths": [ "/_ml/_delete_expired_data" ],
       "parts": {}
     },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_filter.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_filter.json
@@ -2,7 +2,6 @@
   "ml.delete_filter": {
     "methods": [ "DELETE" ],
     "url": {
-      "path": "/_ml/filters/{filter_id}",
       "paths": [ "/_ml/filters/{filter_id}" ],
       "parts": {
         "filter_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_forecast.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_forecast.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html",
     "methods": [ "DELETE" ],
     "url": {
-      "path": "/_ml/anomaly_detectors/{job_id}/_forecast/{forecast_id}",
       "paths": [
         "/_ml/anomaly_detectors/{job_id}/_forecast",
         "/_ml/anomaly_detectors/{job_id}/_forecast/{forecast_id}"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_job.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html",
     "methods": [ "DELETE" ],
     "url": {
-      "path": "/_ml/anomaly_detectors/{job_id}",
       "paths": [ "/_ml/anomaly_detectors/{job_id}" ],
       "parts": {
         "job_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_model_snapshot.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_model_snapshot.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html",
     "methods": [ "DELETE" ],
     "url": {
-      "path": "/_ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}",
       "paths": [ "/_ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}" ],
       "parts": {
         "job_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.find_file_structure.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.find_file_structure.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-find-file-structure.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_ml/find_file_structure",
       "paths": [ "/_ml/find_file_structure" ],
       "params": {
         "lines_to_sample": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.flush_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.flush_job.json
@@ -5,7 +5,6 @@
       "POST"
     ],
     "url": {
-      "path": "/_ml/anomaly_detectors/{job_id}/_flush",
       "paths": [
         "/_ml/anomaly_detectors/{job_id}/_flush"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.forecast.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.forecast.json
@@ -2,7 +2,6 @@
   "ml.forecast": {
     "methods": [ "POST" ],
     "url": {
-      "path": "/_ml/anomaly_detectors/{job_id}/_forecast",
       "paths": [ "/_ml/anomaly_detectors/{job_id}/_forecast" ],
       "parts": {
         "job_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_buckets.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_buckets.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html",
     "methods": [ "GET", "POST" ],
     "url": {
-      "path": "/_ml/anomaly_detectors/{job_id}/results/buckets/{timestamp}",
       "paths": [
         "/_ml/anomaly_detectors/{job_id}/results/buckets/{timestamp}",
         "/_ml/anomaly_detectors/{job_id}/results/buckets"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_calendar_events.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_calendar_events.json
@@ -2,7 +2,6 @@
   "ml.get_calendar_events": {
     "methods": [ "GET" ],
     "url": {
-      "path": "/_ml/calendars/{calendar_id}/events",
       "paths": [
         "/_ml/calendars/{calendar_id}/events"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_calendars.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_calendars.json
@@ -2,7 +2,6 @@
   "ml.get_calendars": {
     "methods": [ "GET", "POST" ],
     "url": {
-      "path": "/_ml/calendars/{calendar_id}",
       "paths": [
         "/_ml/calendars",
         "/_ml/calendars/{calendar_id}"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_categories.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_categories.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html",
     "methods": [ "GET", "POST" ],
     "url": {
-      "path": "/_ml/anomaly_detectors/{job_id}/results/categories/{category_id}",
       "paths": [
         "/_ml/anomaly_detectors/{job_id}/results/categories/{category_id}",
         "/_ml/anomaly_detectors/{job_id}/results/categories/"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeed_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeed_stats.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html",
     "methods": [ "GET"],
     "url": {
-      "path": "/_ml/datafeeds/{datafeed_id}/_stats",
       "paths": [
         "/_ml/datafeeds/{datafeed_id}/_stats",
         "/_ml/datafeeds/_stats"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeeds.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeeds.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html",
     "methods": [ "GET"],
     "url": {
-      "path": "/_ml/datafeeds/{datafeed_id}",
       "paths": [
         "/_ml/datafeeds/{datafeed_id}",
         "/_ml/datafeeds"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_filters.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_filters.json
@@ -2,7 +2,6 @@
   "ml.get_filters": {
     "methods": [ "GET" ],
     "url": {
-      "path": "/_ml/filters/{filter_id}",
       "paths": [ "/_ml/filters", "/_ml/filters/{filter_id}" ],
       "parts": {
         "filter_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_influencers.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_influencers.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html",
     "methods": [ "GET", "POST" ],
     "url": {
-      "path": "/_ml/anomaly_detectors/{job_id}/results/influencers",
       "paths": [ "/_ml/anomaly_detectors/{job_id}/results/influencers" ],
       "parts": {
         "job_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_job_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_job_stats.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html",
     "methods": [ "GET"],
     "url": {
-      "path": "/_ml/anomaly_detectors/{job_id}/_stats",
       "paths": [
         "/_ml/anomaly_detectors/_stats",
         "/_ml/anomaly_detectors/{job_id}/_stats"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_jobs.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_jobs.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html",
     "methods": [ "GET"],
     "url": {
-      "path": "/_ml/anomaly_detectors/{job_id}",
       "paths": [
         "/_ml/anomaly_detectors/{job_id}",
         "/_ml/anomaly_detectors"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_model_snapshots.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_model_snapshots.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html",
     "methods": [ "GET", "POST" ],
     "url": {
-      "path": "/_ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}",
       "paths": [
         "/_ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}",
         "/_ml/anomaly_detectors/{job_id}/model_snapshots"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_overall_buckets.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_overall_buckets.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html",
     "methods": [ "GET", "POST" ],
     "url": {
-      "path": "/_ml/anomaly_detectors/{job_id}/results/overall_buckets",
       "paths": [
         "/_ml/anomaly_detectors/{job_id}/results/overall_buckets"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_records.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_records.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html",
     "methods": ["GET", "POST"],
     "url": {
-      "path": "/_ml/anomaly_detectors/{job_id}/results/records",
       "paths": [
         "/_ml/anomaly_detectors/{job_id}/results/records"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.info.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.info.json
@@ -2,7 +2,6 @@
   "ml.info": {
     "methods": [ "GET" ],
     "url": {
-      "path": "/_ml/info",
       "paths": [ "/_ml/info" ],
       "parts": {},
       "body": null

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.open_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.open_job.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_ml/anomaly_detectors/{job_id}/_open",
       "paths": [ "/_ml/anomaly_detectors/{job_id}/_open" ],
       "parts": {
         "job_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.post_calendar_events.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.post_calendar_events.json
@@ -2,7 +2,6 @@
   "ml.post_calendar_events": {
     "methods": [ "POST" ],
     "url": {
-      "path": "/_ml/calendars/{calendar_id}/events",
       "paths": [ "/_ml/calendars/{calendar_id}/events" ],
       "parts": {
         "calendar_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.post_data.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.post_data.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_ml/anomaly_detectors/{job_id}/_data",
       "paths": [ "/_ml/anomaly_detectors/{job_id}/_data" ],
       "parts": {
         "job_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.preview_datafeed.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.preview_datafeed.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_ml/datafeeds/{datafeed_id}/_preview",
       "paths": [ "/_ml/datafeeds/{datafeed_id}/_preview" ],
       "parts": {
         "datafeed_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_calendar.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_calendar.json
@@ -2,7 +2,6 @@
   "ml.put_calendar": {
     "methods": [ "PUT" ],
     "url": {
-      "path": "/_ml/calendars/{calendar_id}",
       "paths": [ "/_ml/calendars/{calendar_id}" ],
       "parts": {
         "calendar_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_calendar_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_calendar_job.json
@@ -2,7 +2,6 @@
   "ml.put_calendar_job": {
     "methods": [ "PUT" ],
     "url": {
-      "path": "/_ml/calendars/{calendar_id}/jobs/{job_id}",
       "paths": [ "/_ml/calendars/{calendar_id}/jobs/{job_id}" ],
       "parts": {
         "calendar_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_datafeed.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_datafeed.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html",
     "methods": [ "PUT" ],
     "url": {
-      "path": "/_ml/datafeeds/{datafeed_id}",
       "paths": [ "/_ml/datafeeds/{datafeed_id}" ],
       "parts": {
         "datafeed_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_filter.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_filter.json
@@ -2,7 +2,6 @@
   "ml.put_filter": {
     "methods": [ "PUT" ],
     "url": {
-      "path": "/_ml/filters/{filter_id}",
       "paths": [ "/_ml/filters/{filter_id}" ],
       "parts": {
         "filter_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_job.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html",
     "methods": [ "PUT" ],
     "url": {
-      "path": "/_ml/anomaly_detectors/{job_id}",
       "paths": [ "/_ml/anomaly_detectors/{job_id}" ],
       "parts": {
         "job_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.revert_model_snapshot.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.revert_model_snapshot.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}/_revert",
       "paths": [ "/_ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}/_revert" ],
       "parts": {
         "job_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.set_upgrade_mode.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.set_upgrade_mode.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-set-upgrade-mode.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_ml/set_upgrade_mode",
       "paths": [ "/_ml/set_upgrade_mode" ],
       "params": {
         "enabled": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.start_datafeed.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.start_datafeed.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_ml/datafeeds/{datafeed_id}/_start",
       "paths": [ "/_ml/datafeeds/{datafeed_id}/_start" ],
       "parts": {
         "datafeed_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.stop_datafeed.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.stop_datafeed.json
@@ -5,7 +5,6 @@
       "POST"
     ],
     "url": {
-      "path": "/_ml/datafeeds/{datafeed_id}/_stop",
       "paths": [
         "/_ml/datafeeds/{datafeed_id}/_stop"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_datafeed.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_datafeed.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_ml/datafeeds/{datafeed_id}/_update",
       "paths": [ "/_ml/datafeeds/{datafeed_id}/_update" ],
       "parts": {
         "datafeed_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_filter.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_filter.json
@@ -2,7 +2,6 @@
   "ml.update_filter": {
     "methods": [ "POST" ],
     "url": {
-      "path": "/_ml/filters/{filter_id}/_update",
       "paths": [ "/_ml/filters/{filter_id}/_update" ],
       "parts": {
         "filter_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_job.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_ml/anomaly_detectors/{job_id}/_update",
       "paths": [ "/_ml/anomaly_detectors/{job_id}/_update" ],
       "parts": {
         "job_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_model_snapshot.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_model_snapshot.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}/_update",
       "paths": [ "/_ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}/_update" ],
       "parts": {
         "job_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.validate.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.validate.json
@@ -2,7 +2,6 @@
   "ml.validate": {
     "methods": [ "POST" ],
     "url": {
-      "path": "/_ml/anomaly_detectors/_validate",
       "paths": [ "/_ml/anomaly_detectors/_validate" ],
       "params": {}
     },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.validate_detector.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.validate_detector.json
@@ -2,7 +2,6 @@
   "ml.validate_detector": {
     "methods": [ "POST" ],
     "url": {
-      "path": "/_ml/anomaly_detectors/_validate/detector",
       "paths": [ "/_ml/anomaly_detectors/_validate/detector" ],
       "params": {}
     },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/monitoring.bulk.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/monitoring.bulk.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/es-monitoring.html",
     "methods": ["POST", "PUT"],
     "url": {
-      "path": "/_monitoring/bulk",
       "paths": ["/_monitoring/bulk"],
       "deprecated_paths" : [
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.delete_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.delete_job.json
@@ -3,7 +3,6 @@
     "documentation": "",
     "methods": [ "DELETE" ],
     "url": {
-      "path": "/_rollup/job/{id}",
       "paths": [ "/_rollup/job/{id}" ],
       "parts": {
         "id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.get_jobs.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.get_jobs.json
@@ -3,7 +3,6 @@
     "documentation": "",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_rollup/job/{id}",
       "paths": [ "/_rollup/job/{id}", "/_rollup/job/" ],
       "parts": {
         "id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.get_rollup_caps.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.get_rollup_caps.json
@@ -3,7 +3,6 @@
     "documentation": "",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_rollup/data/{id}",
       "paths": [ "/_rollup/data/{id}", "/_rollup/data/" ],
       "parts": {
         "id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.get_rollup_index_caps.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.get_rollup_index_caps.json
@@ -3,7 +3,6 @@
     "documentation": "",
     "methods": [ "GET" ],
     "url": {
-      "path": "/{index}/_rollup/data",
       "paths": [ "/{index}/_rollup/data" ],
       "parts": {
         "index": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.put_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.put_job.json
@@ -3,7 +3,6 @@
     "documentation": "",
     "methods": [ "PUT" ],
     "url": {
-      "path": "/_rollup/job/{id}",
       "paths": [ "/_rollup/job/{id}" ],
       "parts": {
         "id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup_search.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup_search.json
@@ -3,7 +3,6 @@
     "documentation": "",
     "methods": [ "GET", "POST" ],
     "url": {
-      "path": "/{index}/_rollup_search",
       "paths": [ "{index}/_rollup_search"],
       "deprecated_paths" : [
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.start_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.start_job.json
@@ -3,7 +3,6 @@
     "documentation": "",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_rollup/job/{id}/_start",
       "paths": [ "/_rollup/job/{id}/_start" ],
       "parts": {
         "id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.stop_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.stop_job.json
@@ -3,7 +3,6 @@
     "documentation": "",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_rollup/job/{id}/_stop",
       "paths": [ "/_rollup/job/{id}/_stop" ],
       "parts": {
         "id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.authenticate.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.authenticate.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_security/_authenticate",
       "paths": [
         "/_security/_authenticate"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.change_password.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.change_password.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-change-password.html",
     "methods": [ "PUT", "POST" ],
     "url": {
-      "path": "/_security/user/{username}/_password",
       "paths": [
         "/_security/user/{username}/_password",
         "/_security/user/_password"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_cached_realms.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_cached_realms.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-cache.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_security/realm/{realms}/_clear_cache",
       "paths": [
         "/_security/realm/{realms}/_clear_cache"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_cached_roles.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_cached_roles.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-role-cache.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_security/role/{name}/_clear_cache",
       "paths": [
         "/_security/role/{name}/_clear_cache"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.create_api_key.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.create_api_key.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html",
     "methods": [ "PUT", "POST" ],
     "url": {
-      "path": "/_security/api_key",
       "paths": [ "/_security/api_key" ],
       "parts": {},
       "params": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_privileges.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_privileges.json
@@ -3,7 +3,6 @@
     "documentation": "TODO",
     "methods": [ "DELETE" ],
     "url": {
-      "path": "/_security/privilege/{application}/{name}",
       "paths": [
         "/_security/privilege/{application}/{name}"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_role.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_role.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html",
     "methods": [ "DELETE" ],
     "url": {
-      "path": "/_security/role/{name}",
       "paths": [
         "/_security/role/{name}"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_role_mapping.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_role_mapping.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role-mapping.html",
     "methods": [ "DELETE" ],
     "url": {
-      "path": "/_security/role_mapping/{name}",
       "paths": [
         "/_security/role_mapping/{name}"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_user.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_user.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-user.html",
     "methods": [ "DELETE" ],
     "url": {
-      "path": "/_security/user/{username}",
       "paths": [
         "/_security/user/{username}"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.disable_user.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.disable_user.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-disable-user.html",
     "methods": [ "PUT", "POST" ],
     "url": {
-      "path": "/_security/user/{username}/_disable",
       "paths": [
         "/_security/user/{username}/_disable"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.enable_user.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.enable_user.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-enable-user.html",
     "methods": [ "PUT", "POST" ],
     "url": {
-      "path": "/_security/user/{username}/_enable",
       "paths": [
         "/_security/user/{username}/_enable"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_api_key.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_api_key.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_security/api_key",
       "paths": [ "/_security/api_key" ],
       "parts": {},
       "params": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_privileges.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_privileges.json
@@ -3,7 +3,6 @@
     "documentation": "TODO",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_security/privilege/{application}/{name}",
       "paths": [
         "/_security/privilege",
         "/_security/privilege/{application}",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_role.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_role.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_security/role/{name}",
       "paths": [
         "/_security/role/{name}",
         "/_security/role"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_role_mapping.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_role_mapping.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_security/role_mapping/{name}",
       "paths": [
         "/_security/role_mapping/{name}",
         "/_security/role_mapping"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_token.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_token.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_security/oauth2/token",
       "paths": [
         "/_security/oauth2/token"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_user.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_user.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_security/user/{username}",
       "paths": [
         "/_security/user/{username}",
         "/_security/user"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_user_privileges.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_user_privileges.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-privileges.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_security/user/_privileges",
       "paths": [
         "/_security/user/_privileges"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.has_privileges.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.has_privileges.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html",
     "methods": [ "GET", "POST" ],
     "url": {
-      "path": "/_security/user/_has_privileges",
       "paths": [
         "/_security/user/_has_privileges",
         "/_security/user/{user}/_has_privileges"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.invalidate_api_key.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.invalidate_api_key.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html",
     "methods": [ "DELETE" ],
     "url": {
-      "path": "/_security/api_key",
       "paths": [ "/_security/api_key" ],
       "parts": {}
     },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.invalidate_token.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.invalidate_token.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-token.html",
     "methods": [ "DELETE" ],
     "url": {
-      "path": "/_security/oauth2/token",
       "paths": [
         "/_security/oauth2/token"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_privileges.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_privileges.json
@@ -3,7 +3,6 @@
     "documentation": "TODO",
     "methods": [ "PUT", "POST" ],
     "url": {
-      "path": "/_security/privilege/",
       "paths": [
         "/_security/privilege/"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_role.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_role.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html",
     "methods": [ "PUT", "POST" ],
     "url": {
-      "path": "/_security/role/{name}",
       "paths": [
         "/_security/role/{name}"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_role_mapping.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_role_mapping.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html",
     "methods": [ "PUT", "POST" ],
     "url": {
-      "path": "/_security/role_mapping/{name}",
       "paths": [
         "/_security/role_mapping/{name}"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_user.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_user.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html",
     "methods": [ "PUT", "POST" ],
     "url": {
-      "path": "/_security/user/{username}",
       "paths": [
         "/_security/user/{username}"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/sql.clear_cursor.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/sql.clear_cursor.json
@@ -3,7 +3,6 @@
     "documentation": "Clear SQL cursor",
     "methods": [ "POST"],
     "url": {
-      "path": "/_sql/close",
       "paths": [ "/_sql/close" ],
       "parts": {}
     },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/sql.query.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/sql.query.json
@@ -3,7 +3,6 @@
       "documentation": "Execute SQL",
       "methods": [ "POST", "GET" ],
       "url": {
-        "path": "/_sql",
         "paths": [ "/_sql" ],
         "parts": {},
         "params": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/sql.translate.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/sql.translate.json
@@ -3,7 +3,6 @@
       "documentation": "Translate SQL into Elasticsearch queries",
       "methods": [ "POST", "GET" ],
       "url": {
-        "path": "/_sql/translate",
         "paths": [ "/_sql/translate" ],
         "parts": {},
         "params": {}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ssl.certificates.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ssl.certificates.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-ssl.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_ssl/certificates",
       "paths": [
         "/_ssl/certificates"
       ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.ack_watch.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.ack_watch.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html",
     "methods": [ "PUT", "POST" ],
     "url": {
-      "path": "/_watcher/watch/{watch_id}/_ack",
       "paths": [ "/_watcher/watch/{watch_id}/_ack", "/_watcher/watch/{watch_id}/_ack/{action_id}"],
       "parts": {
         "watch_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.activate_watch.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.activate_watch.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-activate-watch.html",
     "methods": [ "PUT", "POST" ],
     "url": {
-      "path": "/_watcher/watch/{watch_id}/_activate",
       "paths": [ "/_watcher/watch/{watch_id}/_activate" ],
       "parts": {
         "watch_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.deactivate_watch.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.deactivate_watch.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-deactivate-watch.html",
     "methods": [ "PUT", "POST" ],
     "url": {
-      "path": "/_watcher/watch/{watch_id}/_deactivate",
       "paths": [ "/_watcher/watch/{watch_id}/_deactivate" ],
       "parts": {
         "watch_id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.delete_watch.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.delete_watch.json
@@ -4,7 +4,6 @@
 
     "methods": [ "DELETE" ],
     "url": {
-      "path": "/_watcher/watch/{id}",
       "paths": [ "/_watcher/watch/{id}" ],
       "parts": {
         "id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.execute_watch.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.execute_watch.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html",
     "methods": [ "PUT", "POST" ],
     "url": {
-      "path": "/_watcher/watch/{id}/_execute",
       "paths": [ "/_watcher/watch/{id}/_execute", "/_watcher/watch/_execute" ],
       "parts": {
         "id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.get_watch.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.get_watch.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_watcher/watch/{id}",
       "paths": [ "/_watcher/watch/{id}" ],
       "parts": {
         "id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.put_watch.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.put_watch.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html",
     "methods": [ "PUT", "POST" ],
     "url": {
-      "path": "/_watcher/watch/{id}",
       "paths": [ "/_watcher/watch/{id}" ],
       "parts": {
         "id": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.start.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.start.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_watcher/_start",
       "paths": [ "/_watcher/_start" ],
       "parts": {
       },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.stats.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_watcher/stats",
       "paths": [ "/_watcher/stats", "/_watcher/stats/{metric}" ],
       "parts": {
         "metric": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.stop.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.stop.json
@@ -3,7 +3,6 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_watcher/_stop",
       "paths": [ "/_watcher/_stop" ],
       "parts": {
       },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.info.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.info.json
@@ -3,7 +3,6 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_xpack",
       "paths": [ "/_xpack" ],
       "parts": {},
       "params": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.usage.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.usage.json
@@ -3,7 +3,6 @@
     "documentation": "Retrieve information about xpack features usage",
     "methods": [ "GET" ],
     "url": {
-      "path": "/_xpack/usage",
       "paths": [ "/_xpack/usage" ],
       "parts": {},
       "params": {


### PR DESCRIPTION
AFAIK `path` in the `rest-api-spec` is superfluous and neither any of the client codebases nor the java rest spec parser uses this field 


cc: @elastic/es-clients.
Also: @polyfractal @clintongormley 

Anyone remember the purpose of this field? 
