### PR TITLE
[DOCS] Remove inline callouts for Asciidoctor migration

### DIFF
--- a/docs/reference/sql/functions/conditional.asciidoc
+++ b/docs/reference/sql/functions/conditional.asciidoc
@@ -229,7 +229,10 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[ifNullReturnSecond]
 .Synopsis:
 [source, sql]
 ----
-IIF(expression<1>, expression<2>, [expression<3>])
+IIF(
+    expression,   <1>
+    expression,   <2>
+    [expression]) <3>
 ----
 
 *Input*:


### PR DESCRIPTION
Removes inline callouts from the [IFF SQL function](https://www.elastic.co/guide/en/elasticsearch/reference/master/sql-functions-conditional.html#sql-functions-conditional-iif) documentation. These callouts were added with #41420. This change helps prepare Elasticsearch docs for Asciidoctor migration.

Per https://asciidoctor.org/docs/user-manual/#callouts, AsciiDoctor enforces this requirement: "The callout number (at the target) must be placed at the end of the line."

Relates to #41128