### PR TITLE
Upgrade hamcrest to 2.1

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -37,7 +37,7 @@ httpcore          = 4.4.11
 httpasyncclient   = 4.1.4
 commonslogging    = 1.1.3
 commonscodec      = 1.11
-hamcrest          = 1.3
+hamcrest          = 2.1
 securemock        = 1.2
 mocksocket        = 1.2
 

--- a/client/rest-high-level/build.gradle
+++ b/client/rest-high-level/build.gradle
@@ -61,7 +61,6 @@ dependencies {
   testCompile "org.elasticsearch.test:framework:${version}"
   testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
   testCompile "junit:junit:${versions.junit}"
-  testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
   //this is needed to make RestHighLevelClientTests#testApiNamingConventions work from IDEs
   testCompile "org.elasticsearch:rest-api-spec:${version}"
   // Needed for serialization tests: 

--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -47,7 +47,7 @@ dependencies {
   testCompile "org.elasticsearch.client:test:${version}"
   testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
   testCompile "junit:junit:${versions.junit}"
-  testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
+  testCompile "org.hamcrest:hamcrest:${versions.hamcrest}"
   testCompile "org.elasticsearch:securemock:${versions.securemock}"
   testCompile "org.elasticsearch:mocksocket:${versions.mocksocket}"
 }

--- a/client/sniffer/build.gradle
+++ b/client/sniffer/build.gradle
@@ -45,7 +45,6 @@ dependencies {
   testCompile "org.elasticsearch.client:test:${version}"
   testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
   testCompile "junit:junit:${versions.junit}"
-  testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
   testCompile "org.elasticsearch:securemock:${versions.securemock}"
   testCompile "org.elasticsearch:mocksocket:${versions.mocksocket}"
 }

--- a/client/test/build.gradle
+++ b/client/test/build.gradle
@@ -27,7 +27,7 @@ dependencies {
   compile "org.apache.httpcomponents:httpcore:${versions.httpcore}"
   compile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
   compile "junit:junit:${versions.junit}"
-  compile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
+  compile "org.hamcrest:hamcrest:${versions.hamcrest}"
 }
 
 forbiddenApisMain {

--- a/client/transport/build.gradle
+++ b/client/transport/build.gradle
@@ -32,7 +32,7 @@ dependencies {
   compile "org.elasticsearch.plugin:rank-eval-client:${version}"
   testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
   testCompile "junit:junit:${versions.junit}"
-  testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
+  testCompile "org.hamcrest:hamcrest:${versions.hamcrest}"
 }
 
 dependencyLicenses {

--- a/distribution/tools/launchers/build.gradle
+++ b/distribution/tools/launchers/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     compile parent.project('java-version-checker')
     testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
     testCompile "junit:junit:${versions.junit}"
-    testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
+    testCompile "org.hamcrest:hamcrest:${versions.hamcrest}"
 }
 
 archivesBaseName = 'elasticsearch-launchers'

--- a/libs/core/build.gradle
+++ b/libs/core/build.gradle
@@ -34,7 +34,7 @@ publishing {
 dependencies {
     testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
     testCompile "junit:junit:${versions.junit}"
-    testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
+    testCompile "org.hamcrest:hamcrest:${versions.hamcrest}"
 
     if (isEclipse == false || project.path == ":libs:core-tests") {
         testCompile("org.elasticsearch.test:framework:${version}") {

--- a/libs/nio/build.gradle
+++ b/libs/nio/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 
   testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
   testCompile "junit:junit:${versions.junit}"
-  testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
+  testCompile "org.hamcrest:hamcrest:${versions.hamcrest}"
 
   if (isEclipse == false || project.path == ":libs:nio-tests") {
       testCompile("org.elasticsearch.test:framework:${version}") {

--- a/libs/secure-sm/build.gradle
+++ b/libs/secure-sm/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 
     testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
     testCompile "junit:junit:${versions.junit}"
-    testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
+    testCompile "org.hamcrest:hamcrest:${versions.hamcrest}"
 
     if (isEclipse == false || project.path == ":libs:secure-sm-tests") {
         testCompile("org.elasticsearch.test:framework:${version}") {

--- a/libs/ssl-config/build.gradle
+++ b/libs/ssl-config/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 
     testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
     testCompile "junit:junit:${versions.junit}"
-    testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
+    testCompile "org.hamcrest:hamcrest:${versions.hamcrest}"
 }
 
 if (isEclipse) {

--- a/libs/x-content/build.gradle
+++ b/libs/x-content/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 
     testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
     testCompile "junit:junit:${versions.junit}"
-    testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
+    testCompile "org.hamcrest:hamcrest:${versions.hamcrest}"
 
     if (isEclipse == false || project.path == ":libs:x-content-tests") {
         testCompile("org.elasticsearch.test:framework:${version}") {

--- a/qa/vagrant/build.gradle
+++ b/qa/vagrant/build.gradle
@@ -26,8 +26,7 @@ plugins {
 
 dependencies {
   compile "junit:junit:${versions.junit}"
-  compile "org.hamcrest:hamcrest-core:${versions.hamcrest}"
-  compile "org.hamcrest:hamcrest-library:${versions.hamcrest}"
+  compile "org.hamcrest:hamcrest:${versions.hamcrest}"
   compile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
 
   compile "org.apache.httpcomponents:httpcore:${versions.httpcore}"

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/util/FileMatcher.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/util/FileMatcher.java
@@ -30,11 +30,10 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.util.Objects;
 import java.util.Set;
 
+import static java.nio.file.attribute.PosixFilePermissions.fromString;
 import static org.elasticsearch.packaging.util.FileUtils.getBasicFileAttributes;
 import static org.elasticsearch.packaging.util.FileUtils.getFileOwner;
 import static org.elasticsearch.packaging.util.FileUtils.getPosixFileAttributes;
-
-import static java.nio.file.attribute.PosixFilePermissions.fromString;
 
 /**
  * Asserts that a file at a path matches its status as Directory/File, and its owner. If on a posix system, also matches the permission

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -52,15 +52,7 @@ thirdPartyAudit.ignoreMissingClasses (
   'javax.servlet.ServletContextListener',
   'org.apache.avalon.framework.logger.Logger',
   'org.apache.log.Hierarchy',
-  'org.apache.log.Logger',
-   // we intentionally exclude the ant tasks because people were depending on them from their tests!!!!!!!
-  'org.apache.tools.ant.BuildException',
-  'org.apache.tools.ant.DirectoryScanner',
-  'org.apache.tools.ant.Task',
-  'org.apache.tools.ant.types.FileSet',
-  'org.easymock.EasyMock',
-  'org.easymock.IArgumentMatcher',
-  'org.jmock.core.Constraint'
+  'org.apache.log.Logger'
 )
 
 test {

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -25,7 +25,7 @@ dependencies {
   compile "org.elasticsearch:elasticsearch-cli:${version}"
   compile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
   compile "junit:junit:${versions.junit}"
-  compile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
+  compile "org.hamcrest:hamcrest:${versions.hamcrest}"
   compile "org.apache.lucene:lucene-test-framework:${versions.lucene}"
   compile "org.apache.lucene:lucene-codecs:${versions.lucene}"
   compile "commons-logging:commons-logging:${versions.commonslogging}"

--- a/x-pack/plugin/security/cli/build.gradle
+++ b/x-pack/plugin/security/cli/build.gradle
@@ -11,9 +11,6 @@ dependencies {
     compile "org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}"
     compile "org.bouncycastle:bcprov-jdk15on:${versions.bouncycastle}"
     testImplementation 'com.google.jimfs:jimfs:1.1'
-    testCompile "junit:junit:${versions.junit}"
-    testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
-    testCompile 'org.elasticsearch:securemock:1.2'
     testCompile "org.elasticsearch.test:framework:${version}"
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
 }

--- a/x-pack/transport-client/build.gradle
+++ b/x-pack/transport-client/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     compile "org.elasticsearch.client:transport:${version}"
     testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
     testCompile "junit:junit:${versions.junit}"
-    testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
+    testCompile "org.hamcrest:hamcrest:${versions.hamcrest}"
 }
 
 dependencyLicenses.enabled = false


### PR DESCRIPTION
hamcrest has some improvements in newer versions, like FileMatchers
that make assertions regarding file exists cleaner. This commit upgrades
to the latest version of hamcrest so we can start using new and improved
matchers.