### PR TITLE
Fix Repository Base Path Matching in Azure ITs (#41457)

### DIFF
--- a/plugins/repository-azure/qa/microsoft-azure-storage/src/test/resources/rest-api-spec/test/repository_azure/10_repository.yml
+++ b/plugins/repository-azure/qa/microsoft-azure-storage/src/test/resources/rest-api-spec/test/repository_azure/10_repository.yml
@@ -23,7 +23,7 @@ setup:
 
   - match: { repository.settings.container: ${container} }
   - match: { repository.settings.client : "integration_test" }
-  - match: { repository.settings.base_path : ${base_path} }
+  - match: { repository.settings.base_path : "${base_path}" }
 
   # Index documents
   - do:


### PR DESCRIPTION
* Added quotes so that "regexy" base paths like `7.0` that we use on CI
don't break matching
* closes #41405

backport of #41457