### PR TITLE
Remove search analyzers from DocumentFieldMappers

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
@@ -34,8 +34,6 @@ public final class DocumentFieldMappers implements Iterable<Mapper> {
     private final Map<String, Mapper> fieldMappers;
 
     private final FieldNameAnalyzer indexAnalyzer;
-    private final FieldNameAnalyzer searchAnalyzer;
-    private final FieldNameAnalyzer searchQuoteAnalyzer;
 
     private static void put(Map<String, Analyzer> analyzers, String key, Analyzer value, Analyzer defaultValue) {
         if (value == null) {
@@ -67,8 +65,6 @@ public final class DocumentFieldMappers implements Iterable<Mapper> {
 
         this.fieldMappers = Collections.unmodifiableMap(fieldMappers);
         this.indexAnalyzer = new FieldNameAnalyzer(indexAnalyzers);
-        this.searchAnalyzer = new FieldNameAnalyzer(searchAnalyzers);
-        this.searchQuoteAnalyzer = new FieldNameAnalyzer(searchQuoteAnalyzers);
     }
 
     /**
@@ -89,18 +85,7 @@ public final class DocumentFieldMappers implements Iterable<Mapper> {
         return this.indexAnalyzer;
     }
 
-    /**
-     * A smart analyzer used for searching that takes into account specific analyzers configured
-     * per {@link FieldMapper}.
-     */
-    public Analyzer searchAnalyzer() {
-        return this.searchAnalyzer;
-    }
-
-    public Analyzer searchQuoteAnalyzer() {
-        return this.searchQuoteAnalyzer;
-    }
-
+    @Override
     public Iterator<Mapper> iterator() {
         return fieldMappers.values().iterator();
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentFieldMapperTests.java
@@ -147,12 +147,8 @@ public class DocumentFieldMapperTests extends LuceneTestCase {
             defaultSearchQuote);
 
         assertAnalyzes(documentFieldMappers.indexAnalyzer(), "field1", "index");
-        assertAnalyzes(documentFieldMappers.searchAnalyzer(), "field1", "search");
-        assertAnalyzes(documentFieldMappers.searchQuoteAnalyzer(), "field1", "search_quote");
 
         assertAnalyzes(documentFieldMappers.indexAnalyzer(), "field2", "default_index");
-        assertAnalyzes(documentFieldMappers.searchAnalyzer(), "field2", "default_search");
-        assertAnalyzes(documentFieldMappers.searchQuoteAnalyzer(), "field2", "default_search_quote");
     }
 
     private void assertAnalyzes(Analyzer analyzer, String field, String output) throws IOException {


### PR DESCRIPTION
These references seem to be unused except for tests and should be removed to
keep the places we store analyzers limited.
