### PR TITLE
Fix: added missing skip

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/30_copy_settings.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/30_copy_settings.yml
@@ -1,7 +1,7 @@
 ---
 "Copy settings during split index":
   - skip:
-    features: [arbitrary_key]
+      features: [arbitrary_key]
 
   - do:
       nodes.info:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/30_copy_settings.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/30_copy_settings.yml
@@ -1,5 +1,7 @@
 ---
 "Copy settings during split index":
+  - skip:
+    features: [arbitrary_key]
 
   - do:
       nodes.info:


### PR DESCRIPTION
In `indices.split/30_copy_settings.yml` we are using the `arbitrary_key` feature, but it is not declared inside the skip list.

Related: https://github.com/elastic/elasticsearch/pull/40052
/cc @elastic/es-clients 