### PR TITLE
Docs: Specify two IDs in migration docs

### DIFF
--- a/docs/reference/migration/migrate_7_0/cluster.asciidoc
+++ b/docs/reference/migration/migrate_7_0/cluster.asciidoc
@@ -10,6 +10,7 @@
 // end::notable-breaking-changes[]
 
 [float]
+[[_literal_literal_is_no_longer_allowed_in_cluster_name]]
 ==== `:` is no longer allowed in cluster name
 
 Due to cross-cluster search using `:` to separate a cluster and index name,

--- a/docs/reference/migration/migrate_7_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_7_0/indices.asciidoc
@@ -15,6 +15,7 @@ Previous versions of Elasticsearch defaulted to creating five shards per index.
 Starting with 7.0.0, the default is now one shard per index.
 
 [float]
+[[_literal_literal_is_no_longer_allowed_in_index_name]]
 ==== `:` is no longer allowed in index name
 
 Due to cross-cluster search using `:` to separate a cluster and index name,


### PR DESCRIPTION
We link to these migraiton docs but we don't specify the id. This
isn't great practice in general and is preventing us from migrating to
Asciidoctor because it generates ids in a slightly different way.
