### PR TITLE
Add no-parallel for older branches

### DIFF
--- a/.ci/java-versions.properties
+++ b/.ci/java-versions.properties
@@ -7,4 +7,4 @@
 ES_BUILD_JAVA=openjdk12
 ES_RUNTIME_JAVA=java8
 GRADLE_TASK=build
-
+GRADLE_EXTRA_ARGS=--no-parallel


### PR DESCRIPTION
elasticsearc-ci/1 now runs in parallel, so we need to  explicitly disable it for older branches that don't support it. 