### PR TITLE
[DOCS] Fix Bad Links in Java High-Level Search API Docs for Asciidoctor Migration

### DIFF
--- a/docs/java-rest/high-level/search/search.asciidoc
+++ b/docs/java-rest/high-level/search/search.asciidoc
@@ -431,7 +431,7 @@ include-tagged::{doc-tests-file}[{api}-request-profiling-queries-results]
 <4> Retrieve the profile results for the sub-queries (if any)
 
 The Rest API documentation contains more information about {ref}/_profiling_queries.html[Profiling Queries] with
-a description of the {ref}/_profiling_queries.html#_literal_query_literal_section[query profiling information]
+a description of the {ref}/_profiling_queries.html#profile-query-section[query profiling information]
 
 The `QueryProfileShardResult` also gives access to the profiling information for the Lucene collectors:
 
@@ -445,7 +445,7 @@ include-tagged::{doc-tests-file}[{api}-request-profiling-queries-collectors]
 <4> Retrieve the profile results for the sub-collectors (if any)
 
 The Rest API documentation contains more information about profiling information
-{ref}/_profiling_queries.html#_literal_collectors_literal_section[for Lucene collectors].
+{ref}/_profiling_queries.html#profile-collectors-section[for Lucene collectors].
 
 In a very similar manner to the query tree execution, the `QueryProfileShardResult` objects gives access
 to the detailed aggregations tree execution:

--- a/docs/reference/search/profile.asciidoc
+++ b/docs/reference/search/profile.asciidoc
@@ -221,6 +221,7 @@ sufficient to see that a particular component of a query is slow, and not necess
 the `advance` phase of that query is the cause, for example.
 =======================================
 
+[[profile-query-section]]
 ==== `query` Section
 
 The `query` section contains detailed timing of the query tree executed by Lucene on a particular shard.
@@ -371,6 +372,7 @@ The meaning of the stats are as follows:
     means the `nextDoc()` method was called on two different documents.  This can be used to help judge
     how selective queries are, by comparing counts between different query components.
 
+[[profile-collectors-section]]
 ==== `collectors` Section
 
 The Collectors portion of the response shows high-level execution details. Lucene works by defining a "Collector"


### PR DESCRIPTION
The 6.5 docs for the [Search API of our Java High Level REST Client](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/6.5/java-rest-high-search.html) link to an auto-generated anchor.

This is bad practice generally, but the link breaks in Asciidoctor. This PR:
1. Creates a specified ID for the anchors.
2. Updates the Search API docs to use those new ID anchors.

I plan to backport this to 5.6.

Relates to #41128 and elastic/docs#827.

