### PR TITLE
[DOCS] Specify ID for string field replacement section of 5.0 breaking changes

### DIFF
--- a/docs/reference/migration/migrate_5_0/mapping.asciidoc
+++ b/docs/reference/migration/migrate_5_0/mapping.asciidoc
@@ -1,6 +1,7 @@
 [[breaking_50_mapping_changes]]
 === Mapping changes
 
+[[_literal_string_literal_fields_replaced_by_literal_text_literal_literal_keyword_literal_fields]]
 ==== `string` fields replaced by `text`/`keyword` fields
 
 The `string` field datatype has been replaced by the `text` field for full


### PR DESCRIPTION
In the 5.x version of the Elasticsearch.Net docs, the NEST Breaking Changes page links to an [auto-generated anchor](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/breaking_50_mapping_changes.html#_literal_string_literal_fields_replaced_by_literal_text_literal_literal_keyword_literal_fields) in the 5.6 Elasticsearch reference.

This is bad practice generally, but the link breaks in Asciidoctor. This PR adds the anchor to Elasticsearch reference so the Elasticsearch.Net link does not break during Asciidoctor migration.

Relates to #41128 and elastic/docs#827.