### PR TITLE
[DOCS] Specify ID for index property to prepare for Asciidoctor migration

### DIFF
--- a/docs/reference/migration/migrate_5_0/mapping.asciidoc
+++ b/docs/reference/migration/migrate_5_0/mapping.asciidoc
@@ -93,6 +93,7 @@ current timestamp on application side. For `_ttl`, you should either use
 time-based indices when applicable, or cron a delete-by-query with a range
 query on a timestamp field
 
+[[_literal_index_literal_property]]
 ==== `index` property
 
 On all field datatypes (except for the deprecated `string` field), the `index`


### PR DESCRIPTION
In the 5.x version of the Elasticsearch.Net docs, the NEST Breaking Changes page links to an [auto-generated anchor](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/breaking_50_mapping_changes.html#_literal_index_literal_property) in the 5.0 Elasticsearch reference.

This is bad practice generally, but the link breaks in Asciidoctor. This PR adds the anchor to Elasticsearch reference so the Elasticsearch.Net link does not break during Asciidoctor migration.

Relates to #41128 and elastic/docs#827.