### PR TITLE
Docs: change "_security" to "security"

### DIFF
--- a/x-pack/docs/en/rest-api/security/get-users.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-users.asciidoc
@@ -10,9 +10,9 @@ Retrieves information about users in the native realm.
 
 ==== Request
 
-`GET /_security/user` +
+`GET /security/user` +
 
-`GET /_security/user/<username>` 
+`GET /security/user/<username>` 
 
 ==== Description
 
@@ -34,12 +34,12 @@ To use this API, you must have at least the `manage_security` cluster privilege.
 
 ==== Examples
 
-To retrieve a native user, submit a GET request to the `/_security/user/<username>`
+To retrieve a native user, submit a GET request to the `/security/user/<username>`
 endpoint:
 
 [source,js]
 --------------------------------------------------
-GET /_security/user/jacknich
+GET /security/user/jacknich
 --------------------------------------------------
 // CONSOLE
 // TEST[setup:jacknich_user]


### PR DESCRIPTION
Today I tested reading a user on Elasticsearch version 7.0.0 using the publicly released binary. I noted that [past docs](https://www.elastic.co/guide/en/elasticsearch/reference/6.7/security-api-get-user.html) state the path to the security API is `security`, but [current docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html) state it's `_security`. I tested both, and found that `security` is still the correct one.

This PR updates the docs to continue to reflect the path to the security API.