### PR TITLE
[DOCS] Specify ID to prepare for Asciidoctor migration

### DIFF
--- a/docs/reference/migration/migrate_6_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_6_0/indices.asciidoc
@@ -1,6 +1,7 @@
 [[breaking_60_indices_changes]]
 === Indices changes
 
+[[_index_templates_use_literal_index_patterns_literal_instead_of_literal_template_literal]]
 ==== Index templates use `index_patterns` instead of `template`
 
 Previously templates expressed the indices that they should match using a glob


### PR DESCRIPTION
From 5.6 to 6.5, a snippet on the [Deprecation info APIs ](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/migration-api-deprecation.html) page contained a link with an autogenerated anchor to a [6.0 Breaking Change](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/breaking_60_indices_changes.html#_index_templates_use_literal_index_patterns_literal_instead_of_literal_template_literal) page.

This is bad practice generally, but the link breaks in Asciidoctor. This PR adds the anchor to so the link does not break during Asciidoctor migration.

Relates to #41128 and elastic/docs#827.