### PR TITLE
Update community client and integration docs

### DIFF
--- a/docs/community-clients/index.asciidoc
+++ b/docs/community-clients/index.asciidoc
@@ -146,12 +146,6 @@ Also see the {client}/php-api/current/index.html[official Elasticsearch PHP clie
 
 Also see the {client}/python-api/current/index.html[official Elasticsearch Python client].
 
-* http://github.com/rhec/pyelasticsearch[pyelasticsearch]:
-  Python client.
-
-* http://github.com/aparo/pyes[pyes]:
-  Python client.
-
 [[r]]
 == R
 

--- a/docs/community-clients/index.asciidoc
+++ b/docs/community-clients/index.asciidoc
@@ -13,14 +13,12 @@ a number of clients that have been contributed by the community for various lang
 * <<coldfusion>>
 * <<erlang>>
 * <<go>>
-* <<groovy>>
 * <<haskell>>
 * <<java>>
 * <<javascript>>
 * <<kotlin>>
 * <<lua>>
 * <<dotnet>>
-* <<ocaml>>
 * <<perl>>
 * <<php>>
 * <<python>>
@@ -55,19 +53,11 @@ a number of clients that have been contributed by the community for various lang
 * https://www.forgebox.io/view/cbelasticsearch[cbElasticSearch]
   Native ColdFusion (CFML) support for the ColdBox MVC Platform which provides you with a fluent search interface for Elasticsearch, in addition to a CacheBox Cache provider and a Logbox Appender for logging.
 
-The following project appears to be abandoned:
-
-* https://github.com/jasonfill/ColdFusion-ElasticSearch-Client[ColdFusion-Elasticsearch-Client]
-  ColdFusion client for Elasticsearch
-
 [[erlang]]
 == Erlang
 
 * http://github.com/tsloughter/erlastic_search[erlastic_search]:
   Erlang client using HTTP.
-
-* https://github.com/dieswaytoofast/erlasticsearch[erlasticsearch]:
-  Erlang client using Thrift.
 
 * https://github.com/datahogs/tirexs[Tirexs]:
   An https://github.com/elixir-lang/elixir[Elixir] based API/DSL, inspired by
@@ -78,11 +68,10 @@ The following project appears to be abandoned:
 [[go]]
 == Go
 
+Also see the {client}/go-api/current/index.html[official Elasticsearch Go client].
+
 * https://github.com/mattbaird/elastigo[elastigo]:
   Go client.
-
-* https://github.com/belogik/goes[goes]:
-  Go lib.
 
 * https://github.com/olivere/elastic[elastic]:
   Elasticsearch client for Google Go.
@@ -90,11 +79,6 @@ The following project appears to be abandoned:
 * https://github.com/softctrl/elk[elk]
   Golang lib for Elasticsearch client.
 
-
-[[groovy]]
-== Groovy
-
-See the {client}/groovy-api/current/index.html[official Elasticsearch Groovy client].
 
 [[haskell]]
 == Haskell
@@ -117,19 +101,6 @@ Also see the {client}/java-api/current/index.html[official Elasticsearch Java cl
 
 Also see the {client}/javascript-api/current/index.html[official Elasticsearch JavaScript client].
 
-* https://github.com/fullscale/elastic.js[Elastic.js]:
-  A JavaScript implementation of the Elasticsearch Query DSL and Core API.
-
-* https://github.com/printercu/elastics[elastics]: Simple tiny client that just works
-
-* https://github.com/roundscope/ember-data-elasticsearch-kit[ember-data-elasticsearch-kit]:
-  An ember-data kit for both pushing and querying objects to Elasticsearch cluster
-
-The following project appears to be abandoned:
-
-* https://github.com/ramv/node-elastical[node-elastical]:
-  Node.js client for the Elasticsearch REST API
-
 [[kotlin]]
 == Kotlin
 
@@ -149,17 +120,6 @@ The following project appears to be abandoned:
 == .NET
 
 Also see the {client}/net-api/current/index.html[official Elasticsearch .NET client].
-
-* https://github.com/Yegoroff/PlainElastic.Net[PlainElastic.Net]:
-  .NET client.
-
-[[ocaml]]
-== OCaml
-
-The following project appears to be abandoned:
-
-* https://github.com/tovbinm/ocaml-elasticsearch[ocaml-elasticsearch]:
-  OCaml client for Elasticsearch
 
 [[perl]]
 == Perl
@@ -189,22 +149,8 @@ Also see the {client}/python-api/current/index.html[official Elasticsearch Pytho
 * http://github.com/rhec/pyelasticsearch[pyelasticsearch]:
   Python client.
 
-* https://github.com/eriky/ESClient[ESClient]:
-  A lightweight and easy to use Python client for Elasticsearch.
-
-* https://github.com/mozilla/elasticutils/[elasticutils]:
-  A friendly chainable Elasticsearch interface for Python.
-
 * http://github.com/aparo/pyes[pyes]:
   Python client.
-
-The following projects appear to be abandoned:
-
-* https://github.com/humangeo/rawes[rawes]:
-  Python low level client.
-
-* http://intridea.github.io/surfiki-refine-elasticsearch/[Surfiki Refine]:
-  Python Map-Reduce engine targeting Elasticsearch indices.
 
 [[r]]
 == R
@@ -218,18 +164,10 @@ The following projects appear to be abandoned:
 * https://github.com/UptakeOpenSource/uptasticsearch[uptasticsearch]:
   An R client tailored to data science workflows.
 
-The following projects appear to be abandoned:
-
-* https://github.com/Tomesch/elasticsearch[elasticsearch]
-  R client for Elasticsearch
-
 [[ruby]]
 == Ruby
 
 Also see the {client}/ruby-api/current/index.html[official Elasticsearch Ruby client].
-
-* https://github.com/PoseBiz/stretcher[stretcher]:
-  Ruby client.
 
 * https://github.com/printercu/elastics-rb[elastics]:
   Tiny client with built-in zero-downtime migrations and ActiveRecord integration.
@@ -242,14 +180,6 @@ Also see the {client}/ruby-api/current/index.html[official Elasticsearch Ruby cl
 
 * https://github.com/artsy/estella[Estella]:
   Make your Ruby models searchable
-
-The following projects appear to be abandoned:
-
-* https://github.com/wireframe/elastic_searchable/[elastic_searchable]:
-  Ruby client + Rails integration.
-
-* https://github.com/ddnexus/flex[Flex]:
-  Ruby Client.
 
 [[rust]]
 == Rust
@@ -275,15 +205,6 @@ The following projects appear to be abandoned:
 * https://github.com/SumoLogic/elasticsearch-client[elasticsearch-client]:
   Scala DSL that uses the REST API. Akka and AWS helpers included.
 
-The following projects appear to be abandoned:
-
-* https://github.com/scalastuff/esclient[esclient]:
-  Thin Scala client.
-
-* https://github.com/bsadeh/scalastic[scalastic]:
-  Scala client.
-
-
 [[smalltalk]]
 == Smalltalk
 
@@ -293,9 +214,8 @@ The following projects appear to be abandoned:
 * http://ss3.gemstone.com/ss/Elasticsearch.html[Elasticsearch] -
   Smalltalk client for Elasticsearch
 
-
 [[vertx]]
 == Vert.x
 
-* https://github.com/goodow/realtime-search[realtime-search]:
-  Elasticsearch module for Vert.x
+* https://github.com/reactiverse/elasticsearch-client[elasticsearch-client]:
+  An Elasticsearch client for Eclipse Vert.x

--- a/docs/plugins/integrations.asciidoc
+++ b/docs/plugins/integrations.asciidoc
@@ -72,6 +72,9 @@ releases 2.0 and later do not support rivers.
 * https://github.com/dadoonet/fscrawler[FS Crawler]:
   The File System (FS) crawler allows to index documents (PDF, Open Office...) from your local file system and over SSH. (by David Pilato)
 
+* https://github.com/senacor/elasticsearch-evolution[Elasticsearch Evolution]:
+  A library to migrate elasticsearch mappings.
+
 [float]
 [[deployment]]
 === Deployment
@@ -132,6 +135,27 @@ releases 2.0 and later do not support rivers.
 * https://github.com/twitter/storehaus[Twitter Storehaus]:
   Thin asynchronous Scala client for Storehaus.
 
+* https://zeebe.io[Zeebe]:
+  An Elasticsearch exporter acts as a bridge between Zeebe and Elasticsearch
+
+* https://pulsar.apache.org/docs/en/io-elasticsearch[Apache Pulsar]:
+  The Elasticsearch Sink Connector is used to pull messages from Pulsar topics
+  and persist the messages to a index.
+
+* https://micronaut-projects.github.io/micronaut-elasticsearch/latest/guide/index.html[Micronaut Elasticsearch Integration]:
+  Integration of Micronaut with Elasticsearch
+
+* https://docs.streampipes.org/docs/user-guide-introduction[StreamPipes]:
+  StreamPipes is a framework that enables users to work with data streams allowing to store data in Elasticsearch.
+
+* https://metamodel.apache.org/[Apache MetaModel]:
+  Providing a common interface for discovery, exploration of metadata and querying of different types of data sources.
+
+* https://jooby.org/doc/elasticsearch/[Jooby Framework]:
+  Scalable, fast and modular micro web framework for Java.
+
+* https://micrometer.io[Micrometer]:
+  Vendor-neutral application metrics facade. Think SLF4j, but for metrics.
 
 [float]
 [[hadoop-integrations]]
@@ -143,6 +167,12 @@ releases 2.0 and later do not support rivers.
 * link:/guide/en/elasticsearch/hadoop/current/[es-hadoop]: Elasticsearch real-time
   search and analytics natively integrated with Hadoop. Supports Map/Reduce,
   Cascading, Apache Hive, Apache Pig, Apache Spark and Apache Storm.
+
+[float]
+==== Supported by the community:
+
+* https://github.com/criteo/garmadon[Garmadon]:
+  Garmadon is a solution for Hadoop Cluster realtime introspection.
 
 
 [float]


### PR DESCRIPTION
Added integrations for a couple of frameworks.

Removed community clients where the last commit was more than three
years ago. Also added the official go client link and removed the
official groovy client, as it is outdated.

