### PR TITLE
Remove the test which is testing java and joda api backport(#41493)

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/rounding/DateTimeUnitTests.java
+++ b/server/src/test/java/org/elasticsearch/common/rounding/DateTimeUnitTests.java
@@ -19,11 +19,6 @@
 package org.elasticsearch.common.rounding;
 
 import org.elasticsearch.test.ESTestCase;
-import org.joda.time.DateTimeZone;
-
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 
 import static org.elasticsearch.common.rounding.DateTimeUnit.DAY_OF_MONTH;
 import static org.elasticsearch.common.rounding.DateTimeUnit.HOUR_OF_DAY;
@@ -33,7 +28,6 @@ import static org.elasticsearch.common.rounding.DateTimeUnit.QUARTER;
 import static org.elasticsearch.common.rounding.DateTimeUnit.SECOND_OF_MINUTE;
 import static org.elasticsearch.common.rounding.DateTimeUnit.WEEK_OF_WEEKYEAR;
 import static org.elasticsearch.common.rounding.DateTimeUnit.YEAR_OF_CENTURY;
-import static org.hamcrest.Matchers.is;
 
 public class DateTimeUnitTests extends ESTestCase {
 
@@ -64,19 +58,5 @@ public class DateTimeUnitTests extends ESTestCase {
 
         assertEquals(8, SECOND_OF_MINUTE.id());
         assertEquals(SECOND_OF_MINUTE, DateTimeUnit.resolve((byte) 8));
-    }
-
-    @AwaitsFix( bugUrl = "https://github.com/elastic/elasticsearch/issues/39617")
-    public void testConversion() {
-        long millis = randomLongBetween(0, Instant.now().toEpochMilli());
-        DateTimeZone zone = randomDateTimeZone();
-        ZoneId zoneId = zone.toTimeZone().toZoneId();
-
-        int offsetSeconds = zoneId.getRules().getOffset(Instant.ofEpochMilli(millis)).getTotalSeconds();
-        long parsedMillisJavaTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), zoneId)
-            .minusSeconds(offsetSeconds).toInstant().toEpochMilli();
-
-        long parsedMillisJodaTime = zone.convertLocalToUTC(millis, true);
-        assertThat(parsedMillisJavaTime, is(parsedMillisJodaTime));
     }
 }


### PR DESCRIPTION
The test is testing the java time API and fails in case it hits daylight saving time changes.
Java time has the right implementation and we don't need to test this.
more details on how the test was affected by the DST change on this comment
closes #39617
backport(#41493)