### PR TITLE
Add enrich processor and enrich source meta field mapper.

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichPolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichPolicy.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  */
 public final class EnrichPolicy implements Writeable, ToXContentFragment {
 
-    static final String EXACT_MATCH_TYPE = "exact_match";
+    public static final String EXACT_MATCH_TYPE = "exact_match";
     public static final String[] SUPPORTED_POLICY_TYPES = new String[]{EXACT_MATCH_TYPE};
 
     static final ParseField TYPE = new ParseField("type");

--- a/x-pack/plugin/enrich/build.gradle
+++ b/x-pack/plugin/enrich/build.gradle
@@ -20,5 +20,6 @@ run {
     plugin xpackModule('core')
 }
 
-// No tests yet:
-integTest.enabled = false
+integTestCluster {
+    plugin xpackModule('core')
+}

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPlugin.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPlugin.java
@@ -6,22 +6,32 @@
 package org.elasticsearch.xpack.enrich;
 
 import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.plugins.IngestPlugin;
+import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class EnrichPlugin extends Plugin implements IngestPlugin {
+public class EnrichPlugin extends Plugin implements IngestPlugin, MapperPlugin {
 
     @Override
-    public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {
-        return Collections.emptyMap();
+    public Map<String, MetadataFieldMapper.TypeParser> getMetadataMappers() {
+        return Collections.singletonMap(EnrichSourceFieldMapper.NAME, new EnrichSourceFieldMapper.TypeParser());
+    }
+
+    @Override
+    public Map<String, Processor.Factory> getProcessors(final Processor.Parameters parameters) {
+        final ClusterService clusterService = parameters.ingestService.getClusterService();
+        return Collections.singletonMap(EnrichProcessorFactory.TYPE,
+            new EnrichProcessorFactory(clusterService::state, parameters.localShardSearcher));
     }
 
     @Override

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichProcessorFactory.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichProcessorFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.enrich;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.ingest.ConfigurationUtils;
+import org.elasticsearch.ingest.Processor;
+import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+final class EnrichProcessorFactory implements Processor.Factory {
+
+    static final String TYPE = "enrich";
+
+    private final Function<String, EnrichPolicy> policyLookup;
+    private final Function<String, Engine.Searcher> searchProvider;
+
+    EnrichProcessorFactory(Supplier<ClusterState> clusterStateSupplier,
+                           Function<String, Engine.Searcher> searchProvider) {
+        this.policyLookup = policyName -> {
+            ClusterState clusterState = clusterStateSupplier.get();
+            return EnrichStore.getPolicy(policyName, clusterState);
+        };
+        this.searchProvider = searchProvider;
+    }
+
+    @Override
+    public Processor create(Map<String, Processor.Factory> processorFactories, String tag, Map<String, Object> config) throws Exception {
+        String policyName = ConfigurationUtils.readStringProperty(TYPE, tag, config, "policy_name");
+        EnrichPolicy policy = policyLookup.apply(policyName);
+        if (policy == null) {
+            throw new IllegalArgumentException("policy [" + policyName + "] does not exists");
+        }
+
+        String key = ConfigurationUtils.readStringProperty(TYPE, tag, config, "key", policy.getEnrichKey());
+        boolean ignoreKeyMissing = ConfigurationUtils.readBooleanProperty(TYPE, tag, config, "key_ignore_missing", false);
+
+        final List<EnrichSpecification> specifications;
+        final List<Map<?, ?>> specificationConfig = ConfigurationUtils.readList(TYPE, tag, config, "values");
+        specifications = specificationConfig.stream()
+            .map(entry -> new EnrichSpecification((String) entry.get("source"), (String) entry.get("target")))
+            .collect(Collectors.toList());
+
+        switch (policy.getType()) {
+            case EnrichPolicy.EXACT_MATCH_TYPE:
+                return new ExactMatchProcessor(tag, policyLookup, searchProvider, policyName, key, ignoreKeyMissing, specifications);
+            default:
+                throw new IllegalArgumentException("unsupported policy type [" + policy.getType() + "]");
+        }
+    }
+
+    static final class EnrichSpecification {
+
+        final String sourceField;
+        final String targetField;
+
+        EnrichSpecification(String sourceField, String targetField) {
+            this.sourceField = sourceField;
+            this.targetField = targetField;
+        }
+    }
+
+}

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichSourceFieldMapper.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichSourceFieldMapper.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.enrich;
+
+import org.apache.lucene.document.BinaryDocValuesField;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.DocValuesFieldExistsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.fielddata.AtomicFieldData;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.IndexFieldDataCache;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.MetadataFieldMapper;
+import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.QueryShardException;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.MultiValueMode;
+
+import java.io.IOException;
+import java.time.ZoneId;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.DeprecationHandler.THROW_UNSUPPORTED_OPERATION;
+import static org.elasticsearch.common.xcontent.NamedXContentRegistry.EMPTY;
+
+/**
+ * A metadata fieldmapper that stores the source of a document as binary doc values.
+ * This is a trade off for faster read performance in exchange for higher disk usage compared
+ * to {@link org.elasticsearch.index.mapper.SourceFieldMapper}.
+ *
+ * This metadata field mapper is internal and meant to be only used by the enrich plugin.
+ */
+public final class EnrichSourceFieldMapper extends MetadataFieldMapper {
+
+    static final String NAME = "_enrich_source";
+
+    private static final MappedFieldType DEFAULT = new FieldType();
+    private static final boolean DEFAULT_ENABLED = false;
+
+    static class FieldType extends MappedFieldType {
+
+        FieldType() {
+            setName(NAME);
+            setIndexOptions(IndexOptions.NONE);
+            setStored(false);
+            setHasDocValues(true);
+            setDocValuesType(DocValuesType.BINARY);
+        }
+
+        FieldType(MappedFieldType ref) {
+            super(ref);
+        }
+
+        @Override
+        public MappedFieldType clone() {
+            return new FieldType(this);
+        }
+
+        @Override
+        public String typeName() {
+            return NAME;
+        }
+
+        @Override
+        public DocValueFormat docValueFormat(String format, ZoneId timeZone) {
+            return DocValueFormat.BINARY;
+        }
+
+        @Override
+        public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
+            failIfNoDocValues();
+            return new EnrichSourceIndexFieldData.Builder();
+        }
+
+        @Override
+        public Query existsQuery(QueryShardContext context) {
+            failIfNoDocValues();
+            return new DocValuesFieldExistsQuery(name());
+        }
+
+        @Override
+        public Query termQuery(Object value, QueryShardContext context) {
+            throw new QueryShardException(context, "[" + NAME + "] does not support searching");
+        }
+
+    }
+
+    // This exists only to make sure that we can retrieve the source of documents from enrich indices via
+    // the search api using doc value fields. This is useful for debugging purposes.
+    static final class EnrichSourceIndexFieldData extends DocValuesIndexFieldData
+        implements IndexFieldData<EnrichSourceIndexFieldData.AtomicFD> {
+
+        EnrichSourceIndexFieldData(Index index, String fieldName) {
+            super(index, fieldName);
+        }
+
+        @Override
+        public SortField sortField(@Nullable Object missingValue, MultiValueMode sortMode,
+                                   XFieldComparatorSource.Nested nested, boolean reverse) {
+            throw new IllegalArgumentException("can't sort on binary field");
+        }
+
+        @Override
+        public AtomicFD load(LeafReaderContext context) {
+            try {
+                return new AtomicFD(DocValues.getBinary(context.reader(), fieldName));
+            } catch (IOException e) {
+                throw new IllegalStateException("Cannot load doc values", e);
+            }
+        }
+
+        @Override
+        public AtomicFD loadDirect(LeafReaderContext context) throws Exception {
+            return load(context);
+        }
+
+        static class Builder implements IndexFieldData.Builder {
+
+            @Override
+            public IndexFieldData<?> build(IndexSettings indexSettings, MappedFieldType fieldType, IndexFieldDataCache cache,
+                                           CircuitBreakerService breakerService, MapperService mapperService) {
+                // Ignore breaker
+                final String fieldName = fieldType.name();
+                return new EnrichSourceIndexFieldData(indexSettings.getIndex(), fieldName);
+            }
+
+        }
+
+        static final class AtomicFD implements AtomicFieldData {
+
+            private final BinaryDocValues values;
+
+            AtomicFD(BinaryDocValues values) {
+                super();
+                this.values = values;
+            }
+
+            @Override
+            public long ramBytesUsed() {
+                return 0; // not exposed by Lucene
+            }
+
+            @Override
+            public Collection<Accountable> getChildResources() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public SortedBinaryDocValues getBytesValues() {
+                return new SortedBinaryDocValues() {
+
+                    @Override
+                    public boolean advanceExact(int doc) throws IOException {
+                        return values.advanceExact(doc);
+                    }
+
+                    @Override
+                    public int docValueCount() {
+                        return 1;
+                    }
+
+                    @Override
+                    public BytesRef nextValue() throws IOException {
+                        return values.binaryValue();
+                    }
+
+                };
+            }
+
+            @Override
+            public ScriptDocValues<BytesRef> getScriptValues() {
+                return new ScriptDocValues.BytesRefs(getBytesValues());
+            }
+
+            @Override
+            public void close() {
+                // no-op
+            }
+
+        }
+    }
+
+    static final class TypeParser implements MetadataFieldMapper.TypeParser {
+        @Override
+        public MetadataFieldMapper.Builder<?, ?> parse(String name,
+                                                       Map<String, Object> node,
+                                                       ParserContext parserContext) throws MapperParsingException {
+            Builder builder = new Builder();
+            for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
+                Map.Entry<String, Object> entry = iterator.next();
+                if ("enabled".equals(entry.getKey())) {
+                    builder.setEnabled(XContentMapValues.nodeBooleanValue(entry.getValue(), name + ".enabled"));
+                    iterator.remove();
+                }
+            }
+            return builder;
+        }
+
+        @Override
+        public MetadataFieldMapper getDefault(MappedFieldType fieldType, ParserContext parserContext) {
+            Settings indexSettings = parserContext.mapperService().getIndexSettings().getSettings();
+            return new EnrichSourceFieldMapper(indexSettings, DEFAULT, DEFAULT.clone(), false);
+        }
+
+    }
+
+    static final class Builder extends MetadataFieldMapper.Builder<Builder, EnrichSourceFieldMapper> {
+
+        private boolean enabled = false;
+
+        Builder() {
+            super(NAME, DEFAULT, DEFAULT.clone());
+        }
+
+        void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        @Override
+        public EnrichSourceFieldMapper build(BuilderContext context) {
+            setupFieldType(context);
+            return new EnrichSourceFieldMapper(context.indexSettings(), fieldType, defaultFieldType, enabled);
+        }
+    }
+
+    private EnrichSourceFieldMapper(Settings indexSettings, MappedFieldType fieldType, MappedFieldType defaultFieldType, boolean enabled) {
+        super(NAME, fieldType, defaultFieldType, indexSettings);
+        this.enabled = enabled;
+    }
+
+    private final boolean enabled;
+
+    @Override
+    public void preParse(ParseContext context) throws IOException {
+        super.parse(context);
+    }
+
+    @Override
+    public void parse(ParseContext context) throws IOException {
+        // nothing to do here, we will call it in pre parse
+    }
+
+    @Override
+    protected void parseCreateField(ParseContext context, List<IndexableField> fields) throws IOException {
+        BytesReference source = context.sourceToParse().source();
+        if (enabled && source != null) {
+            XContentType contentType = context.sourceToParse().getXContentType();
+            fields.add(createEnrichSourceField(fieldType.name(), source, contentType));
+        }
+    }
+
+    @Override
+    protected String contentType() {
+        return NAME;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        boolean includeDefaults = params.paramAsBoolean("include_defaults", false);
+
+        builder.startObject(contentType());
+        if (includeDefaults || enabled != DEFAULT_ENABLED) {
+            builder.field("enabled", enabled);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    protected void doMerge(Mapper mergeWith) {
+        EnrichSourceFieldMapper sourceMergeWith = (EnrichSourceFieldMapper) mergeWith;
+        if (this.enabled != sourceMergeWith.enabled) {
+            throw new IllegalArgumentException("Cannot update enabled setting for [_enrich_source]");
+        }
+    }
+
+    static IndexableField createEnrichSourceField(String name, BytesReference source, XContentType contentType) throws IOException {
+        // if current source is not in smile then convert it to smile for optimal storage:
+        if (contentType != XContentType.SMILE) {
+            try (XContentParser parser = XContentHelper.createParser(EMPTY, THROW_UNSUPPORTED_OPERATION, source, contentType)) {
+                try (BytesStreamOutput out = new BytesStreamOutput()) {
+                    XContentBuilder builder = XContentFactory.contentBuilder(XContentType.SMILE, out);
+                    builder.copyCurrentStructure(parser);
+                    builder.flush();
+                    source = out.bytes();
+                }
+            }
+        }
+
+        return new BinaryDocValuesField(name, source.toBytesRef());
+    }
+}

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichSourceFieldMapper.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichSourceFieldMapper.java
@@ -292,12 +292,11 @@ public final class EnrichSourceFieldMapper extends MetadataFieldMapper {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         boolean includeDefaults = params.paramAsBoolean("include_defaults", false);
-
-        builder.startObject(contentType());
         if (includeDefaults || enabled != DEFAULT_ENABLED) {
+            builder.startObject(contentType());
             builder.field("enabled", enabled);
+            builder.endObject();
         }
-        builder.endObject();
         return builder;
     }
 

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/ExactMatchProcessor.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/ExactMatchProcessor.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.enrich;
+
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.ingest.AbstractProcessor;
+import org.elasticsearch.ingest.IngestDocument;
+import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+final class ExactMatchProcessor extends AbstractProcessor {
+
+    private final Function<String, EnrichPolicy> policyLookup;
+    private final Function<String, Engine.Searcher> searchProvider;
+
+    private final String policyName;
+    private final String key;
+    private final boolean ignoreKeyMissing;
+    private final List<EnrichProcessorFactory.EnrichSpecification> specifications;
+
+    ExactMatchProcessor(String tag,
+                        Function<String, EnrichPolicy> policyLookup,
+                        Function<String, Engine.Searcher> searchProvider, String policyName,
+                        String key,
+                        boolean ignoreKeyMissing,
+                        List<EnrichProcessorFactory.EnrichSpecification> specifications) {
+        super(tag);
+        this.policyLookup = policyLookup;
+        this.searchProvider = searchProvider;
+        this.policyName = policyName;
+        this.key = key;
+        this.ignoreKeyMissing = ignoreKeyMissing;
+        this.specifications = specifications;
+    }
+
+    @Override
+    public IngestDocument execute(IngestDocument ingestDocument) throws Exception {
+        final EnrichPolicy policy = policyLookup.apply(policyName);
+        if (policy == null) {
+            throw new IllegalArgumentException("policy [" + policyName + "] does not exists");
+        }
+
+        final String value = ingestDocument.getFieldValue(key, String.class, ignoreKeyMissing);
+        if (value == null) {
+            return ingestDocument;
+        }
+
+        // TODO: re-use the engine searcher between enriching documents from the same write request
+        try (Engine.Searcher engineSearcher = searchProvider.apply(policy.getIndexPattern())) {
+            if (engineSearcher.getDirectoryReader().leaves().size() != 1) {
+                throw new IllegalStateException("enrich index must have exactly a single segment");
+            }
+
+            final LeafReader leafReader = engineSearcher.getDirectoryReader().leaves().get(0).reader();
+            final Terms terms = leafReader.terms(policy.getEnrichKey());
+            if (terms == null) {
+                return ingestDocument;
+            }
+
+            final TermsEnum tenum = terms.iterator();
+            if (tenum.seekExact(new BytesRef(value))) {
+                PostingsEnum penum = tenum.postings(null, PostingsEnum.NONE);
+                final int docId = penum.nextDoc();
+                assert docId != PostingsEnum.NO_MORE_DOCS : "no matching doc id for [" + key + "]";
+                assert penum.nextDoc() == PostingsEnum.NO_MORE_DOCS : "more than one doc id matching for [" + key + "]";
+
+                BinaryDocValues enrichSourceField = leafReader.getBinaryDocValues(EnrichSourceFieldMapper.NAME);
+                assert enrichSourceField != null : "enrich source field is missing";
+
+                boolean exact = enrichSourceField.advanceExact(docId);
+                assert exact : "doc id [" + docId + "] doesn't have binary doc values";
+
+                final BytesReference encoded = new BytesArray(enrichSourceField.binaryValue());
+                final Map<String, Object> decoded =
+                    XContentHelper.convertToMap(encoded, false, XContentType.SMILE).v2();
+                for (EnrichProcessorFactory.EnrichSpecification specification : specifications) {
+                    Object enrichValue = decoded.get(specification.sourceField);
+                    ingestDocument.setFieldValue(specification.targetField, enrichValue);
+                }
+            }
+        }
+        return ingestDocument;
+    }
+
+    @Override
+    public String getType() {
+        return EnrichProcessorFactory.TYPE;
+    }
+
+    String getPolicyName() {
+        return policyName;
+    }
+
+    String getKey() {
+        return key;
+    }
+
+    boolean isIgnoreKeyMissing() {
+        return ignoreKeyMissing;
+    }
+
+    List<EnrichProcessorFactory.EnrichSpecification> getSpecifications() {
+        return specifications;
+    }
+}

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichIT.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichIT.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+*/
+package org.elasticsearch.xpack.enrich;
+
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.test.rest.yaml.ObjectPath;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Base64;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class EnrichIT extends ESRestTestCase {
+
+    // TODO: replace this with a more complete test that uses enrich apis to create a policy and with the enrich processor
+    public void testEnrichSourceMapping() throws Exception {
+//        String mapping = "\"dynamic\": false,\"_source\": {\"enabled\": false},\"_enrich_source\": {\"enabled\": false}";
+        String mapping = "\"_source\": {\"enabled\": false},\"_enrich_source\": {\"enabled\": true}";
+        createIndex("enrich", Settings.EMPTY, mapping);
+
+        Request indexRequest = new Request("PUT", "/enrich/_doc/elastic.co");
+        indexRequest.setJsonEntity("{\"globalRank\": 25, \"tldRank\": 7, \"tld\": \"co\"}");
+        assertOK(client().performRequest(indexRequest));
+
+        Request refreshRequest = new Request("POST", "/enrich/_refresh");
+        assertOK(client().performRequest(refreshRequest));
+
+        Request searchRequest = new Request("GET", "/enrich/_search");
+        searchRequest.setJsonEntity("{\"docvalue_fields\": [{\"field\": \"_enrich_source\"}]}");
+        Map<String, ?> response = toMap(client().performRequest(searchRequest));
+        logger.info("RSP={}", response);
+        String enrichSource = ObjectPath.evaluate(response, "hits.hits.0.fields._enrich_source.0");
+        assertThat(enrichSource, notNullValue());
+
+        try (InputStream in = new ByteArrayInputStream(Base64.getDecoder().decode(enrichSource))) {
+            Map<String, Object> map = XContentHelper.convertToMap(XContentType.SMILE.xContent(), in, false);
+            assertThat(map.size(), equalTo(3));
+            assertThat(map.get("globalRank"), equalTo(25));
+            assertThat(map.get("tldRank"), equalTo(7));
+            assertThat(map.get("tld"), equalTo("co"));
+        }
+    }
+
+    @Override
+    protected boolean preserveClusterUponCompletion() {
+        return true;
+    }
+
+    private static Map<String, Object> toMap(Response response) throws IOException {
+        return toMap(EntityUtils.toString(response.getEntity()));
+    }
+
+    private static Map<String, Object> toMap(String response) {
+        return XContentHelper.convertToMap(JsonXContent.jsonXContent, response, false);
+    }
+
+}

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichProcessorFactoryTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichProcessorFactoryTests.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.enrich;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
+import org.elasticsearch.xpack.enrich.EnrichProcessorFactory.EnrichSpecification;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class EnrichProcessorFactoryTests extends ESTestCase {
+
+    public void testCreateProcessorInstance() throws Exception {
+        List<String> enrichValues = List.of("globalRank", "tldRank", "tld");
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.EXACT_MATCH_TYPE, null, "source_index", "my_key", enrichValues, "schedule");
+        EnrichProcessorFactory factory = new EnrichProcessorFactory(createClusterStateSupplier("majestic", policy), null);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("policy_name", "majestic");
+        config.put("key", "host");
+        boolean keyIgnoreMissing = randomBoolean();
+        if (keyIgnoreMissing || randomBoolean()) {
+            config.put("key_ignore_missing", keyIgnoreMissing);
+        }
+
+        int numRandomValues = randomIntBetween(1, 8);
+        List<Tuple<String, String>> randomValues = new ArrayList<>(numRandomValues);
+        for (int i = 0; i < numRandomValues; i++) {
+            randomValues.add(new Tuple<>(randomFrom(enrichValues), randomAlphaOfLength(4)));
+        }
+
+        List<Map<String, Object>> valuesConfig = new ArrayList<>(numRandomValues);
+        for (Tuple<String, String> tuple : randomValues) {
+            valuesConfig.add(Map.of("source", tuple.v1(), "target", tuple.v2()));
+        }
+        config.put("values", valuesConfig);
+
+        ExactMatchProcessor result = (ExactMatchProcessor) factory.create(Collections.emptyMap(), "_tag", config);
+        assertThat(result, notNullValue());
+        assertThat(result.getPolicyName(), equalTo("majestic"));
+        assertThat(result.getKey(), equalTo("host"));
+        assertThat(result.isIgnoreKeyMissing(), is(keyIgnoreMissing));
+        assertThat(result.getSpecifications().size(), equalTo(numRandomValues));
+        for (int i = 0; i < numRandomValues; i++) {
+            EnrichSpecification actual = result.getSpecifications().get(i);
+            Tuple<String, String> expected = randomValues.get(i);
+            assertThat(actual.sourceField, equalTo(expected.v1()));
+            assertThat(actual.targetField, equalTo(expected.v2()));
+        }
+    }
+
+    public void testPolicyDoesNotExist() {
+        List<String> enrichValues = List.of("globalRank", "tldRank", "tld");
+        EnrichProcessorFactory factory = new EnrichProcessorFactory(createClusterStateSupplier(), null);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("policy_name", "majestic");
+        config.put("key", "host");
+        boolean keyIgnoreMissing = randomBoolean();
+        if (keyIgnoreMissing || randomBoolean()) {
+            config.put("key_ignore_missing", keyIgnoreMissing);
+        }
+
+        int numRandomValues = randomIntBetween(1, 8);
+        List<Tuple<String, String>> randomValues = new ArrayList<>(numRandomValues);
+        for (int i = 0; i < numRandomValues; i++) {
+            randomValues.add(new Tuple<>(randomFrom(enrichValues), randomAlphaOfLength(4)));
+        }
+
+        List<Map<String, Object>> valuesConfig = new ArrayList<>(numRandomValues);
+        for (Tuple<String, String> tuple : randomValues) {
+            valuesConfig.add(Map.of("source", tuple.v1(), "target", tuple.v2()));
+        }
+        config.put("values", valuesConfig);
+
+        Exception e = expectThrows(IllegalArgumentException.class, () -> factory.create(Collections.emptyMap(), "_tag", config));
+        assertThat(e.getMessage(), equalTo("policy [majestic] does not exists"));
+    }
+
+    public void testPolicyNameMissing() {
+        List<String> enrichValues = List.of("globalRank", "tldRank", "tld");
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.EXACT_MATCH_TYPE, null, "source_index", "my_key", enrichValues, "schedule");
+        EnrichProcessorFactory factory = new EnrichProcessorFactory(createClusterStateSupplier("_name", policy), null);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("key", "host");
+        boolean keyIgnoreMissing = randomBoolean();
+        if (keyIgnoreMissing || randomBoolean()) {
+            config.put("key_ignore_missing", keyIgnoreMissing);
+        }
+
+        int numRandomValues = randomIntBetween(1, 8);
+        List<Tuple<String, String>> randomValues = new ArrayList<>(numRandomValues);
+        for (int i = 0; i < numRandomValues; i++) {
+            randomValues.add(new Tuple<>(randomFrom(enrichValues), randomAlphaOfLength(4)));
+        }
+
+        List<Map<String, Object>> valuesConfig = new ArrayList<>(numRandomValues);
+        for (Tuple<String, String> tuple : randomValues) {
+            valuesConfig.add(Map.of("source", tuple.v1(), "target", tuple.v2()));
+        }
+        config.put("values", valuesConfig);
+
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> factory.create(Collections.emptyMap(), "_tag", config));
+        assertThat(e.getMessage(), equalTo("[policy_name] required property is missing"));
+    }
+
+    public void testUnsupportedPolicy() {
+        List<String> enrichValues = List.of("globalRank", "tldRank", "tld");
+        EnrichPolicy policy = new EnrichPolicy("unsupported", null, "source_index", "my_key", enrichValues, "schedule");
+        EnrichProcessorFactory factory = new EnrichProcessorFactory(createClusterStateSupplier("majestic", policy), null);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("policy_name", "majestic");
+        config.put("key", "host");
+        boolean keyIgnoreMissing = randomBoolean();
+        if (keyIgnoreMissing || randomBoolean()) {
+            config.put("key_ignore_missing", keyIgnoreMissing);
+        }
+
+        int numRandomValues = randomIntBetween(1, 8);
+        List<Tuple<String, String>> randomValues = new ArrayList<>(numRandomValues);
+        for (int i = 0; i < numRandomValues; i++) {
+            randomValues.add(new Tuple<>(randomFrom(enrichValues), randomAlphaOfLength(4)));
+        }
+
+        List<Map<String, Object>> valuesConfig = new ArrayList<>(numRandomValues);
+        for (Tuple<String, String> tuple : randomValues) {
+            valuesConfig.add(Map.of("source", tuple.v1(), "target", tuple.v2()));
+        }
+        config.put("values", valuesConfig);
+
+        Exception e = expectThrows(IllegalArgumentException.class, () -> factory.create(Collections.emptyMap(), "_tag", config));
+        assertThat(e.getMessage(), equalTo("unsupported policy type [unsupported]"));
+    }
+
+    private static Supplier<ClusterState> createClusterStateSupplier(String policyName, EnrichPolicy policy) {
+        EnrichMetadata enrichMetadata = new EnrichMetadata(Map.of(policyName, policy));
+        ClusterState state = ClusterState.builder(new ClusterName("_name"))
+            .metaData(MetaData.builder().putCustom(EnrichMetadata.TYPE, enrichMetadata).build())
+            .build();
+        return () -> state;
+    }
+
+    private static Supplier<ClusterState> createClusterStateSupplier() {
+        EnrichMetadata enrichMetadata = new EnrichMetadata(Map.of());
+        ClusterState state = ClusterState.builder(new ClusterName("_name"))
+            .metaData(MetaData.builder().putCustom(EnrichMetadata.TYPE, enrichMetadata).build())
+            .build();
+        return () -> state;
+    }
+
+}

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichSourceFieldMapperTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichSourceFieldMapperTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.enrich;
+
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.LeafReader;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+public class EnrichSourceFieldMapperTests extends ESSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return List.of(EnrichPlugin.class);
+    }
+
+    public void testEnrichFieldMapper() throws Exception {
+        String mapping = "{\"_source\": {\"enabled\": false},\"_enrich_source\": {\"enabled\": true}, \"dynamic\": false}";
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest("enrich");
+        createIndexRequest.mapping("_doc", mapping, XContentType.JSON);
+        client().admin().indices().create(createIndexRequest).actionGet();
+
+        IndexRequest indexRequest = new IndexRequest("enrich");
+        indexRequest.source("{\"globalRank\": 25, \"tldRank\": 7, \"tld\": \"co\"}", XContentType.JSON);
+        indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        client().index(indexRequest).actionGet();
+
+        Index index = getInstanceFromNode(ClusterService.class).state().metaData().index("enrich").getIndex();
+        IndicesService indicesServices = getInstanceFromNode(IndicesService.class);
+        IndexService indexService = indicesServices.indexService(index);
+        IndexShard indexShard = indexService.getShard(0);
+        try (Engine.Searcher searcher = indexShard.acquireSearcher(getClass().getSimpleName())) {
+            LeafReader leafReader = searcher.getDirectoryReader().leaves().get(0).reader();
+            BinaryDocValues binaryDocValues = leafReader.getBinaryDocValues(EnrichSourceFieldMapper.NAME);
+            assertThat(binaryDocValues, notNullValue());
+            assertThat(binaryDocValues.advanceExact(0), is(true));
+            Map<String, Object> result = XContentHelper.convertToMap(
+                new BytesArray(binaryDocValues.binaryValue()), false, XContentType.SMILE).v2();
+            assertThat(result.size(), equalTo(3));
+            assertThat(result.get("globalRank"), equalTo(25));
+            assertThat(result.get("tldRank"), equalTo(7));
+            assertThat(result.get("tld"), equalTo("co"));
+        }
+    }
+
+    public void testDisabled() throws Exception {
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest("enrich");
+        if (randomBoolean()) {
+            String mapping = "{\"_source\": {\"enabled\": false},\"_enrich_source\": {\"enabled\": false}, \"dynamic\": false}";
+            createIndexRequest.mapping("_doc", mapping, XContentType.JSON);
+        }
+        client().admin().indices().create(createIndexRequest).actionGet();
+
+        IndexRequest indexRequest = new IndexRequest("enrich");
+        indexRequest.source("{\"globalRank\": 25, \"tldRank\": 7, \"tld\": \"co\"}", XContentType.JSON);
+        indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        client().index(indexRequest).actionGet();
+
+        Index index = getInstanceFromNode(ClusterService.class).state().metaData().index("enrich").getIndex();
+        IndicesService indicesServices = getInstanceFromNode(IndicesService.class);
+        IndexService indexService = indicesServices.indexService(index);
+        IndexShard indexShard = indexService.getShard(0);
+        try (Engine.Searcher searcher = indexShard.acquireSearcher(getClass().getSimpleName())) {
+            LeafReader leafReader = searcher.getDirectoryReader().leaves().get(0).reader();
+            BinaryDocValues binaryDocValues = leafReader.getBinaryDocValues(EnrichSourceFieldMapper.NAME);
+            assertThat(binaryDocValues, nullValue());
+        }
+    }
+
+}

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/ExactMatchProcessorTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/ExactMatchProcessorTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.enrich;
+
+import org.apache.lucene.analysis.MockAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.store.Directory;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.VersionType;
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.ingest.IngestDocument;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
+import org.elasticsearch.xpack.enrich.EnrichProcessorFactory.EnrichSpecification;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class ExactMatchProcessorTests extends ESTestCase {
+
+    public void testBasics() throws Exception {
+        try (Directory directory = newDirectory()) {
+            IndexWriterConfig iwConfig = new IndexWriterConfig(new MockAnalyzer(random()));
+            iwConfig.setMergePolicy(NoMergePolicy.INSTANCE);
+            try (IndexWriter indexWriter = new IndexWriter(directory, iwConfig)) {
+                indexWriter.addDocument(createEnrichDocument("google.com", Map.of("globalRank", 1, "tldRank", 1, "tld", "com")));
+                indexWriter.addDocument(createEnrichDocument("elastic.co", Map.of("globalRank", 451, "tldRank",23, "tld", "co")));
+                indexWriter.addDocument(createEnrichDocument("bbc.co.uk", Map.of("globalRank", 45, "tldRank", 14, "tld", "co.uk")));
+                indexWriter.addDocument(createEnrichDocument("eops.nl", Map.of("globalRank", 4567, "tldRank", 80, "tld", "nl")));
+                indexWriter.commit();
+
+                EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.EXACT_MATCH_TYPE, null, "majestic_index", "key", List.of(), "schedule");
+                Function<String, EnrichPolicy> policyLookup = policyName -> policy;
+
+                try (IndexReader indexReader = DirectoryReader.open(directory)) {
+                    IndexSearcher indexSearcher = new IndexSearcher(indexReader);
+                    Function<String, Engine.Searcher> searchProvider = index -> new Engine.Searcher("_enrich", indexSearcher, indexReader);
+
+                    ExactMatchProcessor processor =
+                        new ExactMatchProcessor("_tag", policyLookup, searchProvider, "_name", "domain", false,
+                            List.of(new EnrichSpecification("tldRank", "tld_rank"), new EnrichSpecification("tld", "tld")));
+
+                    IngestDocument ingestDocument = new IngestDocument("_index", "_type", "_id", "_routing", 1L, VersionType.INTERNAL,
+                        Map.of("domain", "elastic.co"));
+                    assertThat(processor.execute(ingestDocument), notNullValue());
+                    assertThat(ingestDocument.getFieldValue("tld_rank", Integer.class), equalTo(23));
+                    assertThat(ingestDocument.getFieldValue("tld", String.class), equalTo("co"));
+                }
+
+                try (IndexReader indexReader = DirectoryReader.open(directory)) {
+                    IndexSearcher indexSearcher = new IndexSearcher(indexReader);
+                    Function<String, Engine.Searcher> searchProvider = index -> new Engine.Searcher("_enrich", indexSearcher, indexReader);
+
+                    ExactMatchProcessor processor =
+                        new ExactMatchProcessor("_tag", policyLookup, searchProvider, "_name", "domain", false,
+                            List.of(new EnrichSpecification("tldRank", "tld_rank"), new EnrichSpecification("tld", "tld")));
+
+                    IngestDocument ingestDocument = new IngestDocument("_index", "_type", "_id", "_routing", 1L, VersionType.INTERNAL,
+                        Map.of("domain", "eops.nl"));
+                    assertThat(processor.execute(ingestDocument), notNullValue());
+                    assertThat(ingestDocument.getFieldValue("tld_rank", Integer.class), equalTo(80));
+                    assertThat(ingestDocument.getFieldValue("tld", String.class), equalTo("nl"));
+                }
+            }
+        }
+    }
+
+    private Document createEnrichDocument(String key, Map<String, ?> decorateValues) throws IOException {
+        XContentType contentType = randomFrom(XContentType.values());
+
+        BytesReference decorateContent;
+        try (XContentBuilder builder = XContentBuilder.builder(contentType.xContent())) {
+            builder.map(decorateValues);
+            builder.flush();
+            ByteArrayOutputStream outputStream = (ByteArrayOutputStream) builder.getOutputStream();
+            decorateContent = new BytesArray(outputStream.toByteArray());
+        }
+        Document document = new Document();
+        document.add(new StringField("key", key, Field.Store.NO));
+        document.add(EnrichSourceFieldMapper.createEnrichSourceField(EnrichSourceFieldMapper.NAME, decorateContent, contentType));
+        return document;
+    }
+
+}


### PR DESCRIPTION
The enrich processor uses a field value from the document being
enriched and uses that to do a lookup in the locally allocated
enrich index shard. If there is a match then retrieves the source
of the enrich document from the enrich source field. This is a special
binary doc values field. The document being enriched then gets values
from the enrich document based on the configured decorate fields.

The policy contains the information what field in the enrich index
to query and what fields are available to decorate a document being
enriched with.

The enrich processor has the following configuration options:
* `policy_name` - the name of the policy this processor should use
* `enrich_key_field` - the field in the document being enriched that holds to lookup value
* `enrich_key_field_ignore_missing` - Whether to allow the key field to be missing
* `enrich_values` - a list of fields to decorate the document being enriched with.
                    Each entry holds a source field and a target field.
                    The source field indicates what decorate field to use that is available in the policy.
                    The target field controls the field name to use in the document being enriched.
                    The source and target fields can be the same.

Example pipeline config:

```
{
   "processors": [
      {
         "policy_name": "my_policy",
         "key": "host_name",
         "values": [
            {
              "source": "globalRank",
              "target": "global_rank"
            }
         ]
      }
   ]
}
```

In the above example documents are being enriched with a global rank value.
For each document that has match in the enrich index based on its host_name field,
the document gets an global rank field value, which is fetched from the `globalRank`
field in the enrich index and saved as `global_rank` in the document being enriched.

The enrich source field mapper is an internal field mapper meant to be
used by enrich exclusively.

Relates to #32789

I will open this PR as draft, because I will split this PR in two smaller PRs. One PR around the enrich processor and one pr around the enrich source field mapper. I think this will make the reviewing easier.

cc: @jakelandis @hub-cap @jbaiera @jpountz 