### PR TITLE
[ML] Adds progress reporting for transforms (#41278)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformProgress.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformProgress.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.dataframe.transforms;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.util.Objects;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+public class DataFrameTransformProgress {
+
+    public static final ParseField TOTAL_DOCS = new ParseField("total_docs");
+    public static final ParseField DOCS_REMAINING = new ParseField("docs_remaining");
+    public static final ParseField PERCENT_COMPLETE = new ParseField("percent_complete");
+
+    public static final ConstructingObjectParser<DataFrameTransformProgress, Void> PARSER = new ConstructingObjectParser<>(
+        "data_frame_transform_progress",
+        true,
+        a -> new DataFrameTransformProgress((Long) a[0], (Long)a[1], (Double)a[2]));
+
+    static {
+        PARSER.declareLong(constructorArg(), TOTAL_DOCS);
+        PARSER.declareLong(optionalConstructorArg(), DOCS_REMAINING);
+        PARSER.declareDouble(optionalConstructorArg(), PERCENT_COMPLETE);
+    }
+
+    public static DataFrameTransformProgress fromXContent(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+
+    private final long totalDocs;
+    private final long remainingDocs;
+    private final double percentComplete;
+
+    public DataFrameTransformProgress(long totalDocs, Long remainingDocs, double percentComplete) {
+        this.totalDocs = totalDocs;
+        this.remainingDocs = remainingDocs == null ? totalDocs : remainingDocs;
+        this.percentComplete = percentComplete;
+    }
+
+    public double getPercentComplete() {
+        return percentComplete;
+    }
+
+    public long getTotalDocs() {
+        return totalDocs;
+    }
+
+    public long getRemainingDocs() {
+        return remainingDocs;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (other == null || other.getClass() != getClass()) {
+            return false;
+        }
+
+        DataFrameTransformProgress that = (DataFrameTransformProgress) other;
+        return Objects.equals(this.remainingDocs, that.remainingDocs)
+            && Objects.equals(this.totalDocs, that.totalDocs)
+            && Objects.equals(this.percentComplete, that.percentComplete);
+    }
+
+    @Override
+    public int hashCode(){
+        return Objects.hash(remainingDocs, totalDocs, percentComplete);
+    }
+}

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformState.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformState.java
@@ -23,16 +23,14 @@ import org.elasticsearch.client.core.IndexerState;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
-import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.ObjectParser.ValueType;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
@@ -44,33 +42,25 @@ public class DataFrameTransformState {
     private static final ParseField CURRENT_POSITION = new ParseField("current_position");
     private static final ParseField CHECKPOINT = new ParseField("checkpoint");
     private static final ParseField REASON = new ParseField("reason");
+    private static final ParseField PROGRESS = new ParseField("progress");
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<DataFrameTransformState, Void> PARSER =
             new ConstructingObjectParser<>("data_frame_transform_state", true,
                     args -> new DataFrameTransformState((DataFrameTransformTaskState) args[0],
                         (IndexerState) args[1],
-                        (HashMap<String, Object>) args[2],
+                        (Map<String, Object>) args[2],
                         (long) args[3],
-                        (String) args[4]));
+                        (String) args[4],
+                        (DataFrameTransformProgress) args[5]));
 
     static {
-        PARSER.declareField(constructorArg(),
-            p -> DataFrameTransformTaskState.fromString(p.text()),
-            TASK_STATE,
-            ObjectParser.ValueType.STRING);
-        PARSER.declareField(constructorArg(), p -> IndexerState.fromString(p.text()), INDEXER_STATE, ObjectParser.ValueType.STRING);
-        PARSER.declareField(optionalConstructorArg(), p -> {
-            if (p.currentToken() == XContentParser.Token.START_OBJECT) {
-                return p.map();
-            }
-            if (p.currentToken() == XContentParser.Token.VALUE_NULL) {
-                return null;
-            }
-            throw new IllegalArgumentException("Unsupported token [" + p.currentToken() + "]");
-        }, CURRENT_POSITION, ObjectParser.ValueType.VALUE_OBJECT_ARRAY);
+        PARSER.declareField(constructorArg(), p -> DataFrameTransformTaskState.fromString(p.text()), TASK_STATE, ValueType.STRING);
+        PARSER.declareField(constructorArg(), p -> IndexerState.fromString(p.text()), INDEXER_STATE, ValueType.STRING);
+        PARSER.declareField(optionalConstructorArg(), (p, c) -> p.mapOrdered(), CURRENT_POSITION, ValueType.OBJECT);
         PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), CHECKPOINT);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), REASON);
+        PARSER.declareField(optionalConstructorArg(), DataFrameTransformProgress::fromXContent, PROGRESS, ValueType.OBJECT);
     }
 
     public static DataFrameTransformState fromXContent(XContentParser parser) throws IOException {
@@ -80,19 +70,22 @@ public class DataFrameTransformState {
     private final DataFrameTransformTaskState taskState;
     private final IndexerState indexerState;
     private final long checkpoint;
-    private final SortedMap<String, Object> currentPosition;
+    private final Map<String, Object> currentPosition;
     private final String reason;
+    private final DataFrameTransformProgress progress;
 
     public DataFrameTransformState(DataFrameTransformTaskState taskState,
                                    IndexerState indexerState,
                                    @Nullable Map<String, Object> position,
                                    long checkpoint,
-                                   @Nullable String reason) {
+                                   @Nullable String reason,
+                                   @Nullable DataFrameTransformProgress progress) {
         this.taskState = taskState;
         this.indexerState = indexerState;
-        this.currentPosition = position == null ? null : Collections.unmodifiableSortedMap(new TreeMap<>(position));
+        this.currentPosition = position == null ? null : Collections.unmodifiableMap(new LinkedHashMap<>(position));
         this.checkpoint = checkpoint;
         this.reason = reason;
+        this.progress = progress;
     }
 
     public IndexerState getIndexerState() {
@@ -117,6 +110,11 @@ public class DataFrameTransformState {
         return reason;
     }
 
+    @Nullable
+    public DataFrameTransformProgress getProgress() {
+        return progress;
+    }
+
     @Override
     public boolean equals(Object other) {
         if (this == other) {
@@ -132,13 +130,14 @@ public class DataFrameTransformState {
         return Objects.equals(this.taskState, that.taskState) &&
             Objects.equals(this.indexerState, that.indexerState) &&
             Objects.equals(this.currentPosition, that.currentPosition) &&
+            Objects.equals(this.progress, that.progress) &&
             this.checkpoint == that.checkpoint &&
             Objects.equals(this.reason, that.reason);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(taskState, indexerState, currentPosition, checkpoint, reason);
+        return Objects.hash(taskState, indexerState, currentPosition, checkpoint, reason, progress);
     }
 
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformStateAndStats.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformStateAndStats.java
@@ -57,7 +57,7 @@ public class DataFrameTransformStateAndStats {
     private final DataFrameTransformCheckpointingInfo checkpointingInfo;
 
     public DataFrameTransformStateAndStats(String id, DataFrameTransformState state, DataFrameIndexerTransformStats stats,
-            DataFrameTransformCheckpointingInfo checkpointingInfo) {
+                                           DataFrameTransformCheckpointingInfo checkpointingInfo) {
         this.id = id;
         this.transformState = state;
         this.transformStats = stats;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/DataFrameTransformIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/DataFrameTransformIT.java
@@ -71,6 +71,7 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
@@ -360,6 +361,10 @@ public class DataFrameTransformIT extends ESRestHighLevelClientTestCase {
             assertEquals(DataFrameTransformTaskState.STARTED, stateAndStats.getTransformState().getTaskState());
             assertEquals(null, stateAndStats.getTransformState().getReason());
             assertNotEquals(zeroIndexerStats, stateAndStats.getTransformStats());
+            assertNotNull(stateAndStats.getTransformState().getProgress());
+            assertThat(stateAndStats.getTransformState().getProgress().getPercentComplete(), equalTo(100.0));
+            assertThat(stateAndStats.getTransformState().getProgress().getTotalDocs(), greaterThan(0L));
+            assertThat(stateAndStats.getTransformState().getProgress().getRemainingDocs(), equalTo(0L));
         });
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformProgressTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformProgressTests.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.dataframe.transforms;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+import static org.elasticsearch.test.AbstractXContentTestCase.xContentTester;
+
+public class DataFrameTransformProgressTests extends ESTestCase {
+
+    public void testFromXContent() throws IOException {
+        xContentTester(this::createParser,
+            DataFrameTransformProgressTests::randomInstance,
+            DataFrameTransformProgressTests::toXContent,
+            DataFrameTransformProgress::fromXContent)
+           .supportsUnknownFields(true)
+           .randomFieldsExcludeFilter(field -> field.startsWith("state"))
+           .test();
+    }
+
+    public static DataFrameTransformProgress randomInstance() {
+        long totalDocs = randomNonNegativeLong();
+        Long docsRemaining = randomBoolean() ? null : randomLongBetween(0, totalDocs);
+        double percentComplete = totalDocs == 0 ? 1.0 : docsRemaining == null ? 0.0 : 100.0*(double)(totalDocs - docsRemaining)/totalDocs;
+        return new DataFrameTransformProgress(totalDocs, docsRemaining, percentComplete);
+    }
+
+    public static void toXContent(DataFrameTransformProgress progress, XContentBuilder builder) throws IOException {
+        builder.startObject();
+        builder.field(DataFrameTransformProgress.TOTAL_DOCS.getPreferredName(), progress.getTotalDocs());
+        builder.field(DataFrameTransformProgress.DOCS_REMAINING.getPreferredName(), progress.getRemainingDocs());
+        builder.field(DataFrameTransformProgress.PERCENT_COMPLETE.getPreferredName(), progress.getPercentComplete());
+        builder.endObject();
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformStateAndStatsTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformStateAndStatsTests.java
@@ -40,9 +40,9 @@ public class DataFrameTransformStateAndStatsTests extends ESTestCase {
 
     public static DataFrameTransformStateAndStats randomInstance() {
         return new DataFrameTransformStateAndStats(randomAlphaOfLength(10),
-                DataFrameTransformStateTests.randomDataFrameTransformState(),
-                DataFrameIndexerTransformStatsTests.randomStats(),
-                DataFrameTransformCheckpointingInfoTests.randomDataFrameTransformCheckpointingInfo());
+            DataFrameTransformStateTests.randomDataFrameTransformState(),
+            DataFrameIndexerTransformStatsTests.randomStats(),
+            DataFrameTransformCheckpointingInfoTests.randomDataFrameTransformCheckpointingInfo());
     }
 
     public static void toXContent(DataFrameTransformStateAndStats stateAndStats, XContentBuilder builder) throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformStateTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformStateTests.java
@@ -24,7 +24,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.elasticsearch.test.AbstractXContentTestCase.xContentTester;
@@ -46,7 +46,8 @@ public class DataFrameTransformStateTests extends ESTestCase {
             randomFrom(IndexerState.values()),
             randomPositionMap(),
             randomLongBetween(0,10),
-            randomBoolean() ? null : randomAlphaOfLength(10));
+            randomBoolean() ? null : randomAlphaOfLength(10),
+            randomBoolean() ? null : DataFrameTransformProgressTests.randomInstance());
     }
 
     public static void toXContent(DataFrameTransformState state, XContentBuilder builder) throws IOException {
@@ -60,6 +61,10 @@ public class DataFrameTransformStateTests extends ESTestCase {
         if (state.getReason() != null) {
             builder.field("reason", state.getReason());
         }
+        if (state.getProgress() != null) {
+            builder.field("progress");
+            DataFrameTransformProgressTests.toXContent(state.getProgress(), builder);
+        }
         builder.endObject();
     }
 
@@ -68,7 +73,7 @@ public class DataFrameTransformStateTests extends ESTestCase {
             return null;
         }
         int numFields = randomIntBetween(1, 5);
-        Map<String, Object> position = new HashMap<>();
+        Map<String, Object> position = new LinkedHashMap<>();
         for (int i = 0; i < numFields; i++) {
             Object value;
             if (randomBoolean()) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformProgressTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformProgressTests.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.dataframe.transforms.hlrc;
+
+import org.elasticsearch.client.AbstractResponseTestCase;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformProgress;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class DataFrameTransformProgressTests extends AbstractResponseTestCase<
+        DataFrameTransformProgress,
+        org.elasticsearch.client.dataframe.transforms.DataFrameTransformProgress> {
+
+    public static DataFrameTransformProgress fromHlrc(
+            org.elasticsearch.client.dataframe.transforms.DataFrameTransformProgress instance) {
+        if (instance == null) {
+            return null;
+        }
+        return new DataFrameTransformProgress(instance.getTotalDocs(), instance.getRemainingDocs());
+    }
+
+    @Override
+    protected DataFrameTransformProgress createServerTestInstance() {
+        return DataFrameTransformStateTests.randomDataFrameTransformProgress();
+    }
+
+    @Override
+    protected org.elasticsearch.client.dataframe.transforms.DataFrameTransformProgress doParseToClientInstance(XContentParser parser) {
+        return org.elasticsearch.client.dataframe.transforms.DataFrameTransformProgress.fromXContent(parser);
+    }
+
+    @Override
+    protected void assertInstances(DataFrameTransformProgress serverTestInstance,
+                                   org.elasticsearch.client.dataframe.transforms.DataFrameTransformProgress clientInstance) {
+        assertThat(serverTestInstance.getTotalDocs(), equalTo(clientInstance.getTotalDocs()));
+        assertThat(serverTestInstance.getRemainingDocs(), equalTo(clientInstance.getRemainingDocs()));
+        assertThat(serverTestInstance.getPercentComplete(), equalTo(clientInstance.getPercentComplete()));
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformStateTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformStateTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.client.AbstractHlrcXContentTestCase;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerTransformStats;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformCheckpointStats;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformCheckpointingInfo;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformProgress;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformState;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformStateAndStats;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformTaskState;
@@ -40,7 +41,7 @@ public class DataFrameTransformStateTests extends AbstractHlrcXContentTestCase<D
     public static DataFrameTransformState fromHlrc(org.elasticsearch.client.dataframe.transforms.DataFrameTransformState instance) {
         return new DataFrameTransformState(DataFrameTransformTaskState.fromString(instance.getTaskState().value()),
                 IndexerState.fromString(instance.getIndexerState().value()), instance.getPosition(), instance.getCheckpoint(),
-                instance.getReason());
+                instance.getReason(), DataFrameTransformProgressTests.fromHlrc(instance.getProgress()));
     }
 
     @Override
@@ -90,6 +91,12 @@ public class DataFrameTransformStateTests extends AbstractHlrcXContentTestCase<D
         return new DataFrameTransformCheckpointStats(randomNonNegativeLong(), randomNonNegativeLong());
     }
 
+    public static DataFrameTransformProgress randomDataFrameTransformProgress() {
+        long totalDocs = randomNonNegativeLong();
+        Long remainingDocs = randomBoolean() ? null : randomLongBetween(0, totalDocs);
+        return new DataFrameTransformProgress(totalDocs, remainingDocs);
+    }
+
     public static DataFrameIndexerTransformStats randomStats(String transformId) {
         return new DataFrameIndexerTransformStats(transformId, randomLongBetween(10L, 10000L),
             randomLongBetween(0L, 10000L), randomLongBetween(0L, 10000L), randomLongBetween(0L, 10000L), randomLongBetween(0L, 10000L),
@@ -102,7 +109,8 @@ public class DataFrameTransformStateTests extends AbstractHlrcXContentTestCase<D
             randomFrom(IndexerState.values()),
             randomPosition(),
             randomLongBetween(0,10),
-            randomBoolean() ? null : randomAlphaOfLength(10));
+            randomBoolean() ? null : randomAlphaOfLength(10),
+            randomBoolean() ? null : randomDataFrameTransformProgress());
     }
 
     private static Map<String, Object> randomPosition() {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/DataFrameTransformDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/DataFrameTransformDocumentationIT.java
@@ -40,6 +40,7 @@ import org.elasticsearch.client.dataframe.StopDataFrameTransformRequest;
 import org.elasticsearch.client.dataframe.StopDataFrameTransformResponse;
 import org.elasticsearch.client.dataframe.transforms.DataFrameIndexerTransformStats;
 import org.elasticsearch.client.dataframe.transforms.DataFrameTransformConfig;
+import org.elasticsearch.client.dataframe.transforms.DataFrameTransformProgress;
 import org.elasticsearch.client.dataframe.transforms.DataFrameTransformStateAndStats;
 import org.elasticsearch.client.dataframe.transforms.DataFrameTransformTaskState;
 import org.elasticsearch.client.dataframe.transforms.DestConfig;
@@ -465,18 +466,21 @@ public class DataFrameTransformDocumentationIT extends ESRestHighLevelClientTest
 
             // tag::get-data-frame-transform-stats-response
             DataFrameTransformStateAndStats stateAndStats =
-                    response.getTransformsStateAndStats().get(0);   // <1>
+                response.getTransformsStateAndStats().get(0);   // <1>
             DataFrameTransformTaskState taskState =
                 stateAndStats.getTransformState().getTaskState(); // <2>
             IndexerState indexerState =
-                    stateAndStats.getTransformState().getIndexerState();  // <3>
+                stateAndStats.getTransformState().getIndexerState();  // <3>
             DataFrameIndexerTransformStats transformStats =
-                    stateAndStats.getTransformStats();              // <4>
+                stateAndStats.getTransformStats();              // <4>
+            DataFrameTransformProgress progress =
+                stateAndStats.getTransformState().getProgress(); // <5>
             // end::get-data-frame-transform-stats-response
 
             assertEquals(IndexerState.STOPPED, indexerState);
             assertEquals(DataFrameTransformTaskState.STOPPED, taskState);
             assertNotNull(transformStats);
+            assertNull(progress);
         }
         {
             // tag::get-data-frame-transform-stats-execute-listener

--- a/docs/java-rest/high-level/dataframe/get_data_frame_stats.asciidoc
+++ b/docs/java-rest/high-level/dataframe/get_data_frame_stats.asciidoc
@@ -37,4 +37,6 @@ include-tagged::{doc-tests-file}[{api}-response]
 <1> The response contains a list of `DataFrameTransformStateAndStats` objects
 <2> The running state of the transform task e.g `started`
 <3> The running state of the transform indexer e.g `started`, `indexing`, etc.
-<4> The transform progress statistics recording the number of documents indexed etc
+<4> The overall transform statistics recording the number of documents indexed etc.
+<5> The progress of the current run in the transform. Supplies the number of docs left until the next checkpoint
+and the total number of docs expected.

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformProgress.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformProgress.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.dataframe.transforms;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+public class DataFrameTransformProgress implements Writeable, ToXContentObject {
+
+    private static final ParseField TOTAL_DOCS = new ParseField("total_docs");
+    private static final ParseField DOCS_REMAINING = new ParseField("docs_remaining");
+    private static final String PERCENT_COMPLETE = "percent_complete";
+
+    public static final ConstructingObjectParser<DataFrameTransformProgress, Void> PARSER = new ConstructingObjectParser<>(
+        "data_frame_transform_progress",
+        true,
+        a -> new DataFrameTransformProgress((Long) a[0], (Long)a[1]));
+
+    static {
+        PARSER.declareLong(constructorArg(), TOTAL_DOCS);
+        PARSER.declareLong(optionalConstructorArg(), DOCS_REMAINING);
+    }
+
+    private final long totalDocs;
+    private long remainingDocs;
+
+    public DataFrameTransformProgress(long totalDocs, Long remainingDocs) {
+        if (totalDocs < 0) {
+            throw new IllegalArgumentException("[total_docs] must be >0.");
+        }
+        this.totalDocs = totalDocs;
+        if (remainingDocs != null && remainingDocs < 0) {
+            throw new IllegalArgumentException("[docs_remaining] must be >0.");
+        }
+        this.remainingDocs = remainingDocs == null ? totalDocs : remainingDocs;
+    }
+
+    public DataFrameTransformProgress(DataFrameTransformProgress otherProgress) {
+        this.totalDocs = otherProgress.totalDocs;
+        this.remainingDocs = otherProgress.remainingDocs;
+    }
+
+    public DataFrameTransformProgress(StreamInput in) throws IOException {
+        this.totalDocs = in.readLong();
+        this.remainingDocs = in.readLong();
+    }
+
+    public Double getPercentComplete() {
+        if (totalDocs == 0) {
+            return 100.0;
+        }
+        long docsRead = totalDocs - remainingDocs;
+        if (docsRead < 0) {
+            return 100.0;
+        }
+        return 100.0*(double)docsRead/totalDocs;
+    }
+
+    public long getTotalDocs() {
+        return totalDocs;
+    }
+
+    public long getRemainingDocs() {
+        return remainingDocs;
+    }
+
+    public void resetRemainingDocs() {
+        this.remainingDocs = totalDocs;
+    }
+
+    public void docsProcessed(long docsProcessed) {
+        assert docsProcessed >= 0;
+        if (docsProcessed > remainingDocs) {
+            remainingDocs = 0;
+        } else {
+            remainingDocs -= docsProcessed;
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (other == null || other.getClass() != getClass()) {
+            return false;
+        }
+
+        DataFrameTransformProgress that = (DataFrameTransformProgress) other;
+        return Objects.equals(this.remainingDocs, that.remainingDocs) && Objects.equals(this.totalDocs, that.totalDocs);
+    }
+
+    @Override
+    public int hashCode(){
+        return Objects.hash(remainingDocs, totalDocs);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeLong(totalDocs);
+        out.writeLong(remainingDocs);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(TOTAL_DOCS.getPreferredName(), totalDocs);
+        builder.field(DOCS_REMAINING.getPreferredName(), remainingDocs);
+        builder.field(PERCENT_COMPLETE, getPercentComplete());
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this, true, true);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformState.java
@@ -12,7 +12,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
-import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.ObjectParser.ValueType;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.persistent.PersistentTaskState;
@@ -22,10 +22,9 @@ import org.elasticsearch.xpack.core.indexing.IndexerState;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
@@ -35,10 +34,11 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
 
     private final DataFrameTransformTaskState taskState;
     private final IndexerState indexerState;
+    private final DataFrameTransformProgress progress;
     private final long checkpoint;
 
     @Nullable
-    private final SortedMap<String, Object> currentPosition;
+    private final Map<String, Object> currentPosition;
     @Nullable
     private final String reason;
 
@@ -47,6 +47,7 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
     private static final ParseField CURRENT_POSITION = new ParseField("current_position");
     private static final ParseField CHECKPOINT = new ParseField("checkpoint");
     private static final ParseField REASON = new ParseField("reason");
+    private static final ParseField PROGRESS = new ParseField("progress");
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<DataFrameTransformState, Void> PARSER = new ConstructingObjectParser<>(NAME,
@@ -55,53 +56,40 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
                 (IndexerState) args[1],
                 (Map<String, Object>) args[2],
                 (long) args[3],
-                (String) args[4]));
+                (String) args[4],
+                (DataFrameTransformProgress) args[5]));
 
     static {
-        PARSER.declareField(constructorArg(), p -> {
-            if (p.currentToken() == XContentParser.Token.VALUE_STRING) {
-                return DataFrameTransformTaskState.fromString(p.text());
-            }
-            throw new IllegalArgumentException("Unsupported token [" + p.currentToken() + "]");
-        }, TASK_STATE, ObjectParser.ValueType.STRING);
-        PARSER.declareField(constructorArg(), p -> {
-            if (p.currentToken() == XContentParser.Token.VALUE_STRING) {
-                return IndexerState.fromString(p.text());
-            }
-            throw new IllegalArgumentException("Unsupported token [" + p.currentToken() + "]");
-
-        }, INDEXER_STATE, ObjectParser.ValueType.STRING);
-        PARSER.declareField(optionalConstructorArg(), p -> {
-            if (p.currentToken() == XContentParser.Token.START_OBJECT) {
-                return p.map();
-            }
-            if (p.currentToken() == XContentParser.Token.VALUE_NULL) {
-                return null;
-            }
-            throw new IllegalArgumentException("Unsupported token [" + p.currentToken() + "]");
-        }, CURRENT_POSITION, ObjectParser.ValueType.VALUE_OBJECT_ARRAY);
+        PARSER.declareField(constructorArg(), p -> DataFrameTransformTaskState.fromString(p.text()), TASK_STATE, ValueType.STRING);
+        PARSER.declareField(constructorArg(), p -> IndexerState.fromString(p.text()), INDEXER_STATE, ValueType.STRING);
+        PARSER.declareField(optionalConstructorArg(), XContentParser::mapOrdered, CURRENT_POSITION, ValueType.OBJECT);
         PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), CHECKPOINT);
         PARSER.declareString(optionalConstructorArg(), REASON);
+        PARSER.declareField(optionalConstructorArg(), DataFrameTransformProgress.PARSER::apply, PROGRESS, ValueType.OBJECT);
     }
 
     public DataFrameTransformState(DataFrameTransformTaskState taskState,
                                    IndexerState indexerState,
                                    @Nullable Map<String, Object> position,
                                    long checkpoint,
-                                   @Nullable String reason) {
+                                   @Nullable String reason,
+                                   @Nullable DataFrameTransformProgress progress) {
         this.taskState = taskState;
         this.indexerState = indexerState;
-        this.currentPosition = position == null ? null : Collections.unmodifiableSortedMap(new TreeMap<>(position));
+        this.currentPosition = position == null ? null : Collections.unmodifiableMap(new LinkedHashMap<>(position));
         this.checkpoint = checkpoint;
         this.reason = reason;
+        this.progress = progress;
     }
 
     public DataFrameTransformState(StreamInput in) throws IOException {
         taskState = DataFrameTransformTaskState.fromStream(in);
         indexerState = IndexerState.fromStream(in);
-        currentPosition = in.readBoolean() ? Collections.unmodifiableSortedMap(new TreeMap<>(in.readMap())) : null;
+        Map<String, Object> position = in.readMap();
+        currentPosition = position == null ? null : Collections.unmodifiableMap(position);
         checkpoint = in.readLong();
         reason = in.readOptionalString();
+        progress = in.readOptionalWriteable(DataFrameTransformProgress::new);
     }
 
     public DataFrameTransformTaskState getTaskState() {
@@ -118,6 +106,10 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
 
     public long getCheckpoint() {
         return checkpoint;
+    }
+
+    public DataFrameTransformProgress getProgress() {
+        return progress;
     }
 
     /**
@@ -153,6 +145,9 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
         if (reason != null) {
             builder.field(REASON.getPreferredName(), reason);
         }
+        if (progress != null) {
+            builder.field(PROGRESS.getPreferredName(), progress);
+        }
         builder.endObject();
         return builder;
     }
@@ -166,12 +161,10 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
     public void writeTo(StreamOutput out) throws IOException {
         taskState.writeTo(out);
         indexerState.writeTo(out);
-        out.writeBoolean(currentPosition != null);
-        if (currentPosition != null) {
-            out.writeMap(currentPosition);
-        }
+        out.writeMap(currentPosition);
         out.writeLong(checkpoint);
         out.writeOptionalString(reason);
+        out.writeOptionalWriteable(progress);
     }
 
     @Override
@@ -190,12 +183,13 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
             Objects.equals(this.indexerState, that.indexerState) &&
             Objects.equals(this.currentPosition, that.currentPosition) &&
             this.checkpoint == that.checkpoint &&
-            Objects.equals(this.reason, that.reason);
+            Objects.equals(this.reason, that.reason) &&
+            Objects.equals(this.progress, that.progress);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(taskState, indexerState, currentPosition, checkpoint, reason);
+        return Objects.hash(taskState, indexerState, currentPosition, checkpoint, reason, progress);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformStateAndStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformStateAndStats.java
@@ -53,7 +53,7 @@ public class DataFrameTransformStateAndStats implements Writeable, ToXContentObj
 
     public static DataFrameTransformStateAndStats initialStateAndStats(String id, DataFrameIndexerTransformStats indexerTransformStats) {
         return new DataFrameTransformStateAndStats(id,
-            new DataFrameTransformState(DataFrameTransformTaskState.STOPPED, IndexerState.STOPPED, null, 0L, null),
+            new DataFrameTransformState(DataFrameTransformTaskState.STOPPED, IndexerState.STOPPED, null, 0L, null, null),
             indexerTransformStats,
             DataFrameTransformCheckpointingInfo.EMPTY);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/SingleGroupSource.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/SingleGroupSource.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.core.dataframe.transforms.pivot;
 
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -115,5 +116,10 @@ public abstract class SingleGroupSource implements Writeable, ToXContentObject {
     @Override
     public int hashCode() {
         return Objects.hash(field);
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this, true, true);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/utils/ExceptionsHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/utils/ExceptionsHelper.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.dataframe.utils;
+
+/**
+ * Collection of methods to aid in creating and checking for exceptions.
+ */
+public class ExceptionsHelper {
+    /**
+     * A more REST-friendly Object.requireNonNull()
+     */
+    public static <T> T requireNonNull(T obj, String paramName) {
+        if (obj == null) {
+            throw new IllegalArgumentException("[" + paramName + "] must not be null.");
+        }
+        return obj;
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformProgressTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformProgressTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.dataframe.transforms;
+
+import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
+
+public class DataFrameTransformProgressTests extends AbstractSerializingDataFrameTestCase<DataFrameTransformProgress> {
+    public static DataFrameTransformProgress randomDataFrameTransformProgress() {
+        long totalDocs = randomNonNegativeLong();
+        return new DataFrameTransformProgress(totalDocs, randomBoolean() ? null : randomLongBetween(0, totalDocs));
+    }
+
+    @Override
+    protected DataFrameTransformProgress doParseInstance(XContentParser parser) throws IOException {
+        return DataFrameTransformProgress.PARSER.apply(parser, null);
+    }
+
+    @Override
+    protected DataFrameTransformProgress createTestInstance() {
+        return randomDataFrameTransformProgress();
+    }
+
+    @Override
+    protected Reader<DataFrameTransformProgress> instanceReader() {
+        return DataFrameTransformProgress::new;
+    }
+
+    public void testPercentComplete() {
+        DataFrameTransformProgress progress = new DataFrameTransformProgress(0L, 100L);
+        assertThat(progress.getPercentComplete(), equalTo(100.0));
+
+        progress = new DataFrameTransformProgress(100L, 0L);
+        assertThat(progress.getPercentComplete(), equalTo(100.0));
+
+        progress = new DataFrameTransformProgress(100L, 10000L);
+        assertThat(progress.getPercentComplete(), equalTo(100.0));
+
+        progress = new DataFrameTransformProgress(100L, null);
+        assertThat(progress.getPercentComplete(), equalTo(0.0));
+
+        progress = new DataFrameTransformProgress(100L, 50L);
+        assertThat(progress.getPercentComplete(), closeTo(50.0, 0.000001));
+    }
+
+    public void testConstructor() {
+        IllegalArgumentException ex =
+            expectThrows(IllegalArgumentException.class, () -> new DataFrameTransformProgress(-1, null));
+        assertThat(ex.getMessage(), equalTo("[total_docs] must be >0."));
+
+        ex = expectThrows(IllegalArgumentException.class, () -> new DataFrameTransformProgress(1L, -1L));
+        assertThat(ex.getMessage(), equalTo("[docs_remaining] must be >0."));
+    }
+
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformStateTests.java
@@ -16,6 +16,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Predicate;
 
+import static org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformProgressTests.randomDataFrameTransformProgress;
+
 public class DataFrameTransformStateTests extends AbstractSerializingTestCase<DataFrameTransformState> {
 
     public static DataFrameTransformState randomDataFrameTransformState() {
@@ -23,7 +25,8 @@ public class DataFrameTransformStateTests extends AbstractSerializingTestCase<Da
             randomFrom(IndexerState.values()),
             randomPosition(),
             randomLongBetween(0,10),
-            randomBoolean() ? null : randomAlphaOfLength(10));
+            randomBoolean() ? null : randomAlphaOfLength(10),
+            randomBoolean() ? null : randomDataFrameTransformProgress());
     }
 
     @Override

--- a/x-pack/plugin/data-frame/qa/single-node-tests/build.gradle
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/build.gradle
@@ -2,7 +2,8 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile "org.elasticsearch.plugin:x-pack-core:${version}"
+  testCompile project(path: xpackModule('core'), configuration: 'default')
+  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
   testCompile project(path: xpackModule('data-frame'), configuration: 'runtime')
 }
 

--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameGetAndGetStatsIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameGetAndGetStatsIT.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
 public class DataFrameGetAndGetStatsIT extends DataFrameRestTestCase {
@@ -83,6 +84,19 @@ public class DataFrameGetAndGetStatsIT extends DataFrameRestTestCase {
         stats = entityAsMap(client().performRequest(getRequest));
         assertEquals(2, XContentMapValues.extractValue("count", stats));
 
+        List<Map<String, Object>> transformsStats = (List<Map<String, Object>>)XContentMapValues.extractValue("transforms", stats);
+        // Verify that both transforms have valid stats
+        for (Map<String, Object> transformStats : transformsStats) {
+            Map<String, Object> stat = (Map<String, Object>)transformStats.get("stats");
+            assertThat("documents_processed is not > 0.", ((Integer)stat.get("documents_processed")), greaterThan(0));
+            assertThat("search_total is not > 0.", ((Integer)stat.get("search_total")), greaterThan(0));
+            assertThat("pages_processed is not > 0.", ((Integer)stat.get("pages_processed")), greaterThan(0));
+            Map<String, Object> progress = (Map<String, Object>)XContentMapValues.extractValue("state.progress", transformStats);
+            assertThat("total_docs is not 1000", progress.get("total_docs"), equalTo(1000));
+            assertThat("docs_remaining is not 0", progress.get("docs_remaining"), equalTo(0));
+            assertThat("percent_complete is not 100.0", progress.get("percent_complete"), equalTo(100.0));
+        }
+
         // only pivot_1
         getRequest = createRequestWithAuth("GET", DATAFRAME_ENDPOINT + "pivot_1/_stats", authHeader);
         stats = entityAsMap(client().performRequest(getRequest));
@@ -132,6 +146,34 @@ public class DataFrameGetAndGetStatsIT extends DataFrameRestTestCase {
             assertThat(((Integer)stat.get("documents_processed")), greaterThan(0));
             assertThat(((Integer)stat.get("search_total")), greaterThan(0));
             assertThat(((Integer)stat.get("pages_processed")), greaterThan(0));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testGetProgressStatsWithPivotQuery() throws Exception {
+        String transformId = "simpleStatsPivotWithQuery";
+        String dataFrameIndex = "pivot_stats_reviews_user_id_above_20";
+        String query = "\"match\": {\"user_id\": \"user_26\"}";
+        createPivotReviewsTransform(transformId, dataFrameIndex, query);
+        startAndWaitForTransform(transformId, dataFrameIndex);
+
+        // Alternate testing between admin and lowly user, as both should be able to get the configs and stats
+        String authHeader = randomFrom(BASIC_AUTH_VALUE_DATA_FRAME_USER, BASIC_AUTH_VALUE_DATA_FRAME_ADMIN);
+
+        Request getRequest = createRequestWithAuth("GET", DATAFRAME_ENDPOINT + "simpleStatsPivotWithQuery/_stats", authHeader);
+        Map<String, Object> stats = entityAsMap(client().performRequest(getRequest));
+        assertEquals(1, XContentMapValues.extractValue("count", stats));
+        List<Map<String, Object>> transformsStats = (List<Map<String, Object>>)XContentMapValues.extractValue("transforms", stats);
+        // Verify that the transform has stats and the total docs process matches the expected
+        for (Map<String, Object> transformStats : transformsStats) {
+            Map<String, Object> stat = (Map<String, Object>)transformStats.get("stats");
+            assertThat("documents_processed is not > 0.", ((Integer)stat.get("documents_processed")), greaterThan(0));
+            assertThat("search_total is not > 0.", ((Integer)stat.get("search_total")), greaterThan(0));
+            assertThat("pages_processed is not > 0.", ((Integer)stat.get("pages_processed")), greaterThan(0));
+            Map<String, Object> progress = (Map<String, Object>)XContentMapValues.extractValue("state.progress", transformStats);
+            assertThat("total_docs is not 37", progress.get("total_docs"), equalTo(37));
+            assertThat("docs_remaining is not 0", progress.get("docs_remaining"), equalTo(0));
+            assertThat("percent_complete is not 100.0", progress.get("percent_complete"), equalTo(100.0));
         }
     }
 }

--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameTransformProgressIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameTransformProgressIT.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.dataframe.integration;
+
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.network.NetworkModule;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.SecuritySettingsSourceField;
+import org.elasticsearch.transport.Netty4Plugin;
+import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
+import org.elasticsearch.xpack.core.XPackClientPlugin;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformProgress;
+import org.elasticsearch.xpack.core.dataframe.transforms.DestConfig;
+import org.elasticsearch.xpack.core.dataframe.transforms.QueryConfig;
+import org.elasticsearch.xpack.core.dataframe.transforms.SourceConfig;
+import org.elasticsearch.xpack.core.dataframe.transforms.pivot.AggregationConfig;
+import org.elasticsearch.xpack.core.dataframe.transforms.pivot.GroupConfig;
+import org.elasticsearch.xpack.core.dataframe.transforms.pivot.HistogramGroupSource;
+import org.elasticsearch.xpack.core.dataframe.transforms.pivot.PivotConfig;
+import org.elasticsearch.xpack.core.security.SecurityField;
+import org.elasticsearch.xpack.dataframe.transforms.TransformProgressGatherer;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.xpack.dataframe.integration.DataFrameRestTestCase.REVIEWS_INDEX_NAME;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class DataFrameTransformProgressIT extends ESIntegTestCase {
+
+    protected void createReviewsIndex() throws Exception {
+        final int numDocs = 1000;
+
+        // create mapping
+        try (XContentBuilder builder = jsonBuilder()) {
+            builder.startObject();
+            {
+                builder.startObject("properties")
+                    .startObject("timestamp")
+                    .field("type", "date")
+                    .endObject()
+                    .startObject("user_id")
+                    .field("type", "keyword")
+                    .endObject()
+                    .startObject("count")
+                    .field("type", "integer")
+                    .endObject()
+                    .startObject("business_id")
+                    .field("type", "keyword")
+                    .endObject()
+                    .startObject("stars")
+                    .field("type", "integer")
+                    .endObject()
+                    .endObject();
+            }
+            builder.endObject();
+            CreateIndexResponse response = client().admin()
+                .indices()
+                .prepareCreate(REVIEWS_INDEX_NAME)
+                .addMapping("_doc", builder)
+                .get();
+            assertThat(response.isAcknowledged(), is(true));
+        }
+
+        // create index
+        BulkRequestBuilder bulk = client().prepareBulk(REVIEWS_INDEX_NAME, "_doc");
+        int day = 10;
+        for (int i = 0; i < numDocs; i++) {
+            long user = i % 28;
+            int stars = (i + 20) % 5;
+            long business = (i + 100) % 50;
+            int hour = 10 + (i % 13);
+            int min = 10 + (i % 49);
+            int sec = 10 + (i % 49);
+
+            String date_string = "2017-01-" + day + "T" + hour + ":" + min + ":" + sec + "Z";
+
+            StringBuilder sourceBuilder = new StringBuilder();
+            sourceBuilder.append("{\"user_id\":\"")
+                .append("user_")
+                .append(user)
+                .append("\",\"count\":")
+                .append(i)
+                .append(",\"business_id\":\"")
+                .append("business_")
+                .append(business)
+                .append("\",\"stars\":")
+                .append(stars)
+                .append(",\"timestamp\":\"")
+                .append(date_string)
+                .append("\"}");
+            bulk.add(new IndexRequest().source(sourceBuilder.toString(), XContentType.JSON));
+
+            if (i % 50 == 0) {
+                BulkResponse response = client().bulk(bulk.request()).get();
+                assertThat(response.buildFailureMessage(), response.hasFailures(), is(false));
+                bulk = client().prepareBulk(REVIEWS_INDEX_NAME, "_doc");
+                day += 1;
+            }
+        }
+        client().bulk(bulk.request()).get();
+        client().admin().indices().prepareRefresh(REVIEWS_INDEX_NAME).get();
+    }
+
+    public void testGetProgress() throws Exception {
+        createReviewsIndex();
+        SourceConfig sourceConfig = new SourceConfig(REVIEWS_INDEX_NAME);
+        DestConfig destConfig = new DestConfig("unnecessary");
+        GroupConfig histgramGroupConfig = new GroupConfig(Collections.emptyMap(),
+            Collections.singletonMap("every_50", new HistogramGroupSource("count", 50.0)));
+        AggregatorFactories.Builder aggs = new AggregatorFactories.Builder();
+        aggs.addAggregator(AggregationBuilders.avg("avg_rating").field("stars"));
+        AggregationConfig aggregationConfig = new AggregationConfig(Collections.emptyMap(), aggs);
+        PivotConfig pivotConfig = new PivotConfig(histgramGroupConfig, aggregationConfig);
+        DataFrameTransformConfig config = new DataFrameTransformConfig("get_progress_transform",
+            sourceConfig,
+            destConfig,
+            null,
+            pivotConfig);
+
+        PlainActionFuture<DataFrameTransformProgress> progressFuture = new PlainActionFuture<>();
+        TransformProgressGatherer.getInitialProgress(client(), config, progressFuture);
+
+        DataFrameTransformProgress progress = progressFuture.get();
+
+        assertThat(progress.getTotalDocs(), equalTo(1000L));
+        assertThat(progress.getRemainingDocs(), equalTo(1000L));
+        assertThat(progress.getPercentComplete(), equalTo(0.0));
+
+
+        QueryConfig queryConfig = new QueryConfig(Collections.emptyMap(), QueryBuilders.termQuery("user_id", "user_26"));
+        pivotConfig = new PivotConfig(histgramGroupConfig, aggregationConfig);
+        sourceConfig = new SourceConfig(new String[]{REVIEWS_INDEX_NAME}, queryConfig);
+        config = new DataFrameTransformConfig("get_progress_transform",
+            sourceConfig,
+            destConfig,
+            null,
+            pivotConfig);
+
+
+        progressFuture = new PlainActionFuture<>();
+
+        TransformProgressGatherer.getInitialProgress(client(), config, progressFuture);
+        progress = progressFuture.get();
+
+        assertThat(progress.getTotalDocs(), equalTo(35L));
+        assertThat(progress.getRemainingDocs(), equalTo(35L));
+        assertThat(progress.getPercentComplete(), equalTo(0.0));
+
+        client().admin().indices().prepareDelete(REVIEWS_INDEX_NAME).get();
+    }
+
+    @Override
+    protected Settings externalClusterClientSettings() {
+        Settings.Builder builder = Settings.builder();
+        builder.put(NetworkModule.TRANSPORT_TYPE_KEY, SecurityField.NAME4);
+        builder.put(SecurityField.USER_SETTING.getKey(), "x_pack_rest_user:" +  SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING);
+        return builder.build();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(LocalStateCompositeXPackPlugin.class, Netty4Plugin.class);
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> transportClientPlugins() {
+        return Arrays.asList(XPackClientPlugin.class, Netty4Plugin.class);
+    }
+}

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.LatchedActionListener;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.persistent.AllocatedPersistentTask;
@@ -19,21 +20,31 @@ import org.elasticsearch.persistent.PersistentTasksExecutor;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.dataframe.DataFrameField;
+import org.elasticsearch.xpack.core.dataframe.DataFrameMessages;
+import org.elasticsearch.xpack.core.dataframe.action.StartDataFrameTransformTaskAction;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerTransformStats;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransform;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformState;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformTaskState;
+import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.core.scheduler.SchedulerEngine;
 import org.elasticsearch.xpack.dataframe.DataFrame;
 import org.elasticsearch.xpack.dataframe.checkpoint.DataFrameTransformsCheckpointService;
 import org.elasticsearch.xpack.dataframe.notifications.DataFrameAuditor;
 import org.elasticsearch.xpack.dataframe.persistence.DataFrameTransformsConfigManager;
+import org.elasticsearch.xpack.dataframe.transforms.pivot.SchemaUtil;
 
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public class DataFrameTransformPersistentTasksExecutor extends PersistentTasksExecutor<DataFrameTransform> {
 
     private static final Logger logger = LogManager.getLogger(DataFrameTransformPersistentTasksExecutor.class);
 
+    // The amount of time we wait for the cluster state to respond when being marked as failed
+    private static final int MARK_AS_FAILED_TIMEOUT_SEC = 90;
     private final Client client;
     private final DataFrameTransformsConfigManager transformsConfigManager;
     private final DataFrameTransformsCheckpointService dataFrameTransformsCheckpointService;
@@ -58,36 +69,116 @@ public class DataFrameTransformPersistentTasksExecutor extends PersistentTasksEx
 
     @Override
     protected void nodeOperation(AllocatedPersistentTask task, @Nullable DataFrameTransform params, PersistentTaskState state) {
-        DataFrameTransformTask buildTask = (DataFrameTransformTask) task;
-        SchedulerEngine.Job schedulerJob = new SchedulerEngine.Job(
-                DataFrameTransformTask.SCHEDULE_NAME + "_" + params.getId(), next());
-        DataFrameTransformState transformState = (DataFrameTransformState) state;
-        if (transformState != null && transformState.getTaskState() == DataFrameTransformTaskState.FAILED) {
-            logger.warn("Tried to start failed transform [" + params.getId() + "] failure reason: " + transformState.getReason());
-            return;
-        }
-        transformsConfigManager.getTransformStats(params.getId(), ActionListener.wrap(
+        final String transformId = params.getId();
+        final DataFrameTransformTask buildTask = (DataFrameTransformTask) task;
+        final SchedulerEngine.Job schedulerJob = new SchedulerEngine.Job(DataFrameTransformTask.SCHEDULE_NAME + "_" + transformId,
+            next());
+        final DataFrameTransformState transformState = (DataFrameTransformState) state;
+
+        final DataFrameTransformTask.ClientDataFrameIndexerBuilder indexerBuilder =
+            new DataFrameTransformTask.ClientDataFrameIndexerBuilder()
+                .setAuditor(auditor)
+                .setClient(client)
+                .setIndexerState(transformState == null ? IndexerState.STOPPED : transformState.getIndexerState())
+                .setInitialPosition(transformState == null ? null : transformState.getPosition())
+                // If the state is `null` that means this is a "first run". We can safely assume the
+                // task will attempt to gather the initial progress information
+                // if we have state, this may indicate the previous execution node crashed, so we should attempt to retrieve
+                // the progress from state to keep an accurate measurement of our progress
+                .setProgress(transformState == null ? null : transformState.getProgress())
+                .setTransformsCheckpointService(dataFrameTransformsCheckpointService)
+                .setTransformsConfigManager(transformsConfigManager)
+                .setTransformId(transformId);
+
+        ActionListener<StartDataFrameTransformTaskAction.Response> startTaskListener = ActionListener.wrap(
+            response -> logger.info("Successfully completed and scheduled task in node operation"),
+            failure -> logger.error("Failed to start task ["+ transformId +"] in node operation", failure)
+        );
+
+        // <3> Set the previous stats (if they exist), initialize the indexer, start the task (If it is STOPPED)
+        // Since we don't create the task until `_start` is called, if we see that the task state is stopped, attempt to start
+        // Schedule execution regardless
+        ActionListener<DataFrameIndexerTransformStats> transformStatsActionListener = ActionListener.wrap(
             stats -> {
-                // Initialize with the previously recorded stats
-                buildTask.initializePreviousStats(stats);
-                scheduleTask(buildTask, schedulerJob, params.getId());
+                indexerBuilder.setInitialStats(stats);
+                buildTask.initializeIndexer(indexerBuilder);
+                scheduleAndStartTask(buildTask, schedulerJob, startTaskListener);
             },
             error -> {
                 if (error instanceof ResourceNotFoundException == false) {
                     logger.error("Unable to load previously persisted statistics for transform [" + params.getId() + "]", error);
                 }
-                scheduleTask(buildTask, schedulerJob, params.getId());
+                indexerBuilder.setInitialStats(new DataFrameIndexerTransformStats(transformId));
+                buildTask.initializeIndexer(indexerBuilder);
+                scheduleAndStartTask(buildTask, schedulerJob, startTaskListener);
             }
-        ));
+        );
+
+        // <2> set fieldmappings for the indexer, get the previous stats (if they exist)
+        ActionListener<Map<String, String>> getFieldMappingsListener = ActionListener.wrap(
+            fieldMappings -> {
+                indexerBuilder.setFieldMappings(fieldMappings);
+                transformsConfigManager.getTransformStats(transformId, transformStatsActionListener);
+            },
+            error -> {
+                String msg = DataFrameMessages.getMessage(DataFrameMessages.DATA_FRAME_UNABLE_TO_GATHER_FIELD_MAPPINGS,
+                    indexerBuilder.getTransformConfig().getDestination().getIndex());
+                logger.error(msg, error);
+                markAsFailed(buildTask, msg);
+            }
+        );
+
+        // <1> Validate the transform, assigning it to the indexer, and get the field mappings
+        ActionListener<DataFrameTransformConfig> getTransformConfigListener = ActionListener.wrap(
+            config -> {
+                if (config.isValid()) {
+                    indexerBuilder.setTransformConfig(config);
+                    SchemaUtil.getDestinationFieldMappings(client, config.getDestination().getIndex(), getFieldMappingsListener);
+                } else {
+                    markAsFailed(buildTask,
+                        DataFrameMessages.getMessage(DataFrameMessages.DATA_FRAME_TRANSFORM_CONFIGURATION_INVALID, transformId));
+                }
+            },
+            error -> {
+                String msg = DataFrameMessages.getMessage(DataFrameMessages.FAILED_TO_LOAD_TRANSFORM_CONFIGURATION, transformId);
+                logger.error(msg, error);
+                markAsFailed(buildTask, msg);
+            }
+        );
+        // <0> Get the transform config
+        transformsConfigManager.getTransformConfiguration(transformId, getTransformConfigListener);
     }
 
-    private void scheduleTask(DataFrameTransformTask buildTask, SchedulerEngine.Job schedulerJob, String id) {
+    private void markAsFailed(DataFrameTransformTask task, String reason) {
+        CountDownLatch latch = new CountDownLatch(1);
+
+        task.markAsFailed(reason, new LatchedActionListener<>(ActionListener.wrap(
+            nil -> {},
+            failure -> logger.error("Failed to set task [" + task.getTransformId() +"] to failed", failure)
+        ), latch));
+        try {
+            latch.await(MARK_AS_FAILED_TIMEOUT_SEC, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            logger.error("Timeout waiting for task [" + task.getTransformId() + "] to be marked as failed in cluster state", e);
+        }
+    }
+
+    private void scheduleAndStartTask(DataFrameTransformTask buildTask,
+                                      SchedulerEngine.Job schedulerJob,
+                                      ActionListener<StartDataFrameTransformTaskAction.Response> listener) {
         // Note that while the task is added to the scheduler here, the internal state will prevent
         // it from doing any work until the task is "started" via the StartTransform api
         schedulerEngine.register(buildTask);
         schedulerEngine.add(schedulerJob);
-
-        logger.info("Data frame transform [" + id + "] created.");
+        logger.info("Data frame transform [{}] created.", buildTask.getTransformId());
+        // If we are stopped, and it is an initial run, this means we have never been started,
+        // attempt to start the task
+        if (buildTask.getState().getTaskState().equals(DataFrameTransformTaskState.STOPPED) && buildTask.isInitialRun()) {
+            buildTask.start(listener);
+        } else {
+            logger.debug("No need to start task. Its current state is: {}", buildTask.getState().getIndexerState());
+            listener.onResponse(new StartDataFrameTransformTaskAction.Response(true));
+        }
     }
 
     static SchedulerEngine.Schedule next() {
@@ -100,7 +191,6 @@ public class DataFrameTransformPersistentTasksExecutor extends PersistentTasksEx
     protected AllocatedPersistentTask createTask(long id, String type, String action, TaskId parentTaskId,
             PersistentTasksCustomMetaData.PersistentTask<DataFrameTransform> persistentTask, Map<String, String> headers) {
         return new DataFrameTransformTask(id, type, action, parentTaskId, persistentTask.getParams(),
-            (DataFrameTransformState) persistentTask.getState(), client, transformsConfigManager,
-            dataFrameTransformsCheckpointService, schedulerEngine, auditor, threadPool, headers);
+            (DataFrameTransformState) persistentTask.getState(), schedulerEngine, auditor, threadPool, headers);
     }
 }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/TransformProgressGatherer.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/TransformProgressGatherer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.dataframe.transforms;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchAction;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformProgress;
+
+/**
+ * Utility class to gather the progress information for a given config and its cursor position
+ */
+public final class TransformProgressGatherer {
+
+    /**
+     * This gathers the total docs given the config and search
+     *
+     * TODO: Support checkpointing logic to restrict the query
+     * @param progressListener The listener to alert on completion
+     */
+    public static void getInitialProgress(Client client,
+                                          DataFrameTransformConfig config,
+                                          ActionListener<DataFrameTransformProgress> progressListener) {
+        SearchRequest request = client.prepareSearch(config.getSource().getIndex())
+            .setSize(0)
+            .setAllowPartialSearchResults(false)
+            .setTrackTotalHits(true)
+            .setQuery(config.getSource().getQueryConfig().getQuery())
+            .request();
+
+        ActionListener<SearchResponse> searchResponseActionListener = ActionListener.wrap(
+            searchResponse -> {
+                progressListener.onResponse(new DataFrameTransformProgress(searchResponse.getHits().getTotalHits().value, null));
+            },
+            progressListener::onFailure
+        );
+        ClientHelper.executeWithHeadersAsync(config.getHeaders(),
+            ClientHelper.DATA_FRAME_ORIGIN,
+            client,
+            SearchAction.INSTANCE,
+            request,
+            searchResponseActionListener);
+    }
+
+}

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexerTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexerTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerTransformStats;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfigTests;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformProgress;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.dataframe.notifications.DataFrameAuditor;
 import org.elasticsearch.xpack.dataframe.transforms.pivot.Pivot;
@@ -92,6 +93,11 @@ public class DataFrameIndexerTests extends ESTestCase {
         @Override
         protected Map<String, String> getFieldMappings() {
             return fieldMappings;
+        }
+
+        @Override
+        protected DataFrameTransformProgress getProgress() {
+            return null;
         }
 
         @Override

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_stats.yml
@@ -34,6 +34,7 @@ teardown:
   - do:
       data_frame.stop_data_frame_transform:
         transform_id: "airline-transform-stats"
+        wait_for_completion: true
 
   - do:
       data_frame.delete_data_frame_transform:
@@ -197,6 +198,7 @@ teardown:
   - match: { transforms.0.id: "airline-transform-stats-dos" }
   - match: { transforms.0.state.indexer_state: "stopped" }
   - match: { transforms.0.state.checkpoint: 0 }
+  - is_false: transforms.0.state.progress
   - match: { transforms.0.stats.pages_processed: 0 }
   - match: { transforms.0.stats.documents_processed: 0 }
   - match: { transforms.0.stats.documents_indexed: 0 }


### PR DESCRIPTION
This admittedly large PR adds progress reporting to data frame transforms. The majority of the size is due to refactoring cause by yak-shaving[0] :(. 

## Design decisions

* I opted to put the progress reporting into its own object (so we can add more fields as we desire in the future), and put it directly under the State object. I kept it separated from the checkpoint information just for simplicity's sake as the two pieces of information (checkpoint status and progress) are two separate pieces of information. 
* Also, due to yak-shaving, much refactoring was done in this PR. All the refactoring done in this PR would have to be done eventually when we cancel the task on `_stop` and I needed part of it for gathering progress information when the ES Node executes the task. 
* I am now having the task automatically start when the node executor kicks it off. This is part of the yak-shaving refactoring. It makes sense that if `_start` creates the task (and the executor sees that it is a new task) that it should automatically start without having to call `start()` on the allocated task on the node.
* Progress information is now stored in the state, gathering the "remaining docs" via a query could require a very costly query. Specifically range queries against terms are very expensive.
* Total number of docs is a simple enough query.

## Considerations

* This is a "good enough" progress reporting. No guarantees are made as the index could be updated so that the cursor actually hits more or fewer docs than initially gathered. 

## Future work
* Have the total docs query take checkpointing into account. Right now, it only utilizes the dataframe source query. As new checkpoints are executed, the query will have to change to give an accurate count of the total docs expected to be processed in that checkpoint.

[0] https://en.wiktionary.org/wiki/yak_shaving

Backport of #41278