### PR TITLE
SQL: Allow locally executed queries with count(*)

### DIFF
--- a/docs/changelog/41531.yaml
+++ b/docs/changelog/41531.yaml
@@ -1,0 +1,6 @@
+pr: 41531
+summary: Allow locally executed queries with count(*)
+area: SQL
+type: enhancement
+issues:
+ - 37051

--- a/x-pack/plugin/sql/qa/src/main/resources/agg.sql-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/agg.sql-spec
@@ -246,6 +246,32 @@ SELECT gender, COUNT(last_name) ln, COUNT(distinct last_name) dln, COUNT(first_n
 aggCountWithHavingAndWhere
 SELECT COUNT(last_name) c, COUNT(DISTINCT last_name) distinct_names, gender FROM test_emp WHERE salary > 65000 GROUP BY gender HAVING distinct_names > 10 ORDER BY gender;
 
+// Local COUNT(*)
+selectLiteralWithHavingNotMatching
+SELECT 123 HAVING COUNT(*) > 1;
+selectLiteralWithHavingMatching
+SELECT 123 HAVING COUNT(*) >= 1;
+selectLiteralAndCountWithHavingNotMatching
+SELECT 123, COUNT(*) HAVING COUNT(*) > 1;
+selectLiteralAndCountWithHavingMatching
+SELECT 123, COUNT(*) HAVING COUNT(*) >= 1;
+selectLiteralAndCount
+SELECT 123, COUNT(*);
+selectLiteralAndCountAlias
+SELECT 123, COUNT(*) c;
+selectLiteralAndCountAliasWithHavingNotMatching
+SELECT 123, COUNT(*) c HAVING COUNT(*) > 1;
+selectLiteralAndCountAliasWithHavingMatching
+SELECT 123, COUNT(*) c HAVING COUNT(*) >= 1;
+selectLiteralAndCountAliasWithHavingAliasNotMatching
+SELECT 123, COUNT(*) c HAVING c > 1;
+selectLiteralAndCountAliasWithHavingAliasMatching
+SELECT 123, COUNT(*) c HAVING c >= 1;
+selectLiteralAndCountAliasWithHavingAliasNotMatchingArithmetics
+SELECT 123, COUNT(*) c HAVING c + 1 > 2;
+selectLiteralAndCountAliasWithHavingAliasMatchingArithmetics
+SELECT 123, COUNT(*) c HAVING c + 1 = 2;
+
 // MIN
 aggMinImplicit
 // tag::min

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
@@ -633,6 +633,21 @@ public class VerifierErrorMessagesTests extends ESTestCase {
                 error("SELECT MAX(int) FROM test WHERE MAX(int) > 10 GROUP BY bool"));
     }
 
+    public void testCountInWhere() {
+        assertEquals("1:33: Cannot use WHERE filtering on aggregate function [COUNT(*)], use HAVING instead",
+                error("SELECT COUNT(*) FROM test WHERE COUNT(*) > 10"));
+    }
+
+    public void testCountAliasInWhere() {
+        assertEquals("1:8: Cannot use WHERE filtering on aggregate function [COUNT(*)], use HAVING instead",
+                error("SELECT COUNT(*) c FROM test WHERE c > 10"));
+    }
+    
+    public void testCountInWhereInLocalQuery() {
+        assertEquals("1:18: Cannot use WHERE filtering on aggregate function [COUNT(*)], use HAVING instead",
+                error("SELECT 123 WHERE COUNT(*) > 10"));
+    }
+
     public void testHistogramInFilter() {
         assertEquals("1:63: Cannot filter on grouping function [HISTOGRAM(date, INTERVAL 1 MONTH)], use its argument instead",
                 error("SELECT HISTOGRAM(date, INTERVAL 1 MONTH) AS h FROM test WHERE "


### PR DESCRIPTION
This PR adds functionality that allows locally executed queries with COUNT(*). For example `select 1 having count(*) > 0;` In these scenarios `count(*)` should always return a size of `1`.

Fixes https://github.com/elastic/elasticsearch/issues/37051.