### PR TITLE
[DOCS] Explicitly set section IDs for Asciidoctor migration

### DIFF
--- a/docs/reference/how-to/search-speed.asciidoc
+++ b/docs/reference/how-to/search-speed.asciidoc
@@ -419,6 +419,7 @@ indexes 2-shingles and is automatically leveraged by query parsers to run phrase
 queries that don't have a slop. If your use-case involves running lots of phrase
 queries, this can speed up queries significantly.
 
+[[faster-prefix-queries]]
 === Faster prefix queries with `index_prefixes`
 
 The <<text,`text`>> field has an <<index-phrases,`index_prefixes`>> option that

--- a/docs/reference/how-to/search-speed.asciidoc
+++ b/docs/reference/how-to/search-speed.asciidoc
@@ -411,6 +411,7 @@ Some caveats to the Profile API are that:
  - given the added overhead, the resulting took times are not reliable indicators of actual took time, but can be used comparatively between clauses for relative timing differences
  - the Profile API is best for exploring possible reasons behind the most costly clauses of a query but isn't intended for accurately measuring absolute timings of each clause 
 
+[[faster-phrase-queries]]
 === Faster phrase queries with `index_phrases`
 
 The <<text,`text`>> field has an <<index-phrases,`index_phrases`>> option that

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -594,3 +594,7 @@ formation module>>.
 === {xpack} settings in {es}
 
 include::{asciidoc-dir}/../../shared/settings.asciidoc[]
+
+[role="exclude",id="_faster_phrase_queries_with_literal_index_phrases_literal"]
+
+See <<faster-phrase-queries>>.

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -598,3 +598,7 @@ include::{asciidoc-dir}/../../shared/settings.asciidoc[]
 [role="exclude",id="_faster_phrase_queries_with_literal_index_phrases_literal"]
 
 See <<faster-phrase-queries>>.
+
+[role="exclude",id="_faster_prefix_queries_with_literal_index_prefixes_literal.html"]
+
+See <<faster-prefix-queries>>.


### PR DESCRIPTION
The following page URLs contain autogenerated IDs:
- https://www.elastic.co/guide/en/elasticsearch/reference/master/_faster_phrase_queries_with_literal_index_phrases_literal.html (`_faster_phrase_queries_with_literal_index_phrases_literal`)
- https://www.elastic.co/guide/en/elasticsearch/reference/master/_faster_prefix_queries_with_literal_index_prefixes_literal.html (`_faster_prefix_queries_with_literal_index_prefixes_literal`)

 With the Asciidoctor migration, these IDs would change and result in broken links.

This explicitly sets the IDs so the page URLs are stable during Asciidoctor migration. It also adds a redirect for any users that have bookmarked the old URLs.

I plan to backport this to 7.0. Relates to #41128 and elastic/docs#827.