### PR TITLE
Simplify Snapshot Resiliency Test (#40930)

### DIFF
--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -47,7 +47,6 @@ import org.elasticsearch.action.admin.indices.delete.DeleteIndexAction;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.admin.indices.delete.TransportDeleteIndexAction;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingAction;
-import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.action.admin.indices.mapping.put.TransportPutMappingAction;
 import org.elasticsearch.action.admin.indices.shards.IndicesShardStoresAction;
 import org.elasticsearch.action.admin.indices.shards.TransportIndicesShardStoresAction;
@@ -260,29 +259,24 @@ public class SnapshotResiliencyTests extends ESTestCase {
                                             )));
                                     }));
                                 final AtomicInteger countdown = new AtomicInteger(documents);
-                                masterNode.client.admin().indices().putMapping(
-                                    new PutMappingRequest(index).type("_doc").source("foo", "type=text"),
-                                    assertNoFailureListener(r -> {
-                                            for (int i = 0; i < documents; ++i) {
-                                                masterNode.client.bulk(
-                                                    new BulkRequest().add(new IndexRequest(index).source(
-                                                        Collections.singletonMap("foo", "bar" + i)))
-                                                        .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE),
-                                                    assertNoFailureListener(
-                                                        bulkResponse -> {
-                                                            assertFalse(
-                                                                "Failures in bulkresponse: " + bulkResponse.buildFailureMessage(),
-                                                                bulkResponse.hasFailures());
-                                                            if (countdown.decrementAndGet() == 0) {
-                                                                afterIndexing.run();
-                                                            }
-                                                        }));
-                                            }
-                                            if (documents == 0) {
-                                                afterIndexing.run();
-                                            }
-                                        }
-                                    ));
+                                for (int i = 0; i < documents; ++i) {
+                                    masterNode.client.bulk(
+                                        new BulkRequest().add(new IndexRequest(index).source(
+                                            Collections.singletonMap("foo", "bar" + i)))
+                                            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE),
+                                        assertNoFailureListener(
+                                            bulkResponse -> {
+                                                assertFalse(
+                                                    "Failures in bulkresponse: " + bulkResponse.buildFailureMessage(),
+                                                    bulkResponse.hasFailures());
+                                                if (countdown.decrementAndGet() == 0) {
+                                                    afterIndexing.run();
+                                                }
+                                            }));
+                                }
+                                if (documents == 0) {
+                                    afterIndexing.run();
+                                }
                             }))));
         runUntil(documentCountVerified::get, TimeUnit.MINUTES.toMillis(5L));
         assertTrue(createdSnapshot.get());


### PR DESCRIPTION
* Thanks to #39793 dynamic mapping updates don't contain blocking operations anymore so we don't have to manually put the mapping in this test and can keep it a little simpler

backport of #40930 