### PR TITLE
[DOCS] Allow attribute substitution in titleabbrevs for Asciidoctor migration

### DIFF
--- a/docs/reference/data-frames/apis/delete-transform.asciidoc
+++ b/docs/reference/data-frames/apis/delete-transform.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="basic"]
 [[delete-data-frame-transform]]
-=== Delete {dataframe-transforms} API
+=== Delete data frame transforms API
 ++++
-<titleabbrev>Delete {dataframe-transforms}</titleabbrev>
+<titleabbrev>Delete data frame transforms</titleabbrev>
 ++++
 
 Deletes an existing {dataframe-transform}.

--- a/docs/reference/data-frames/apis/delete-transform.asciidoc
+++ b/docs/reference/data-frames/apis/delete-transform.asciidoc
@@ -5,7 +5,7 @@
 
 [subs="attributes"]
 ++++
-<titleabbrev>Delete data frame transforms</titleabbrev>
+<titleabbrev>Delete {dataframe-transforms}</titleabbrev>
 ++++
 
 Deletes an existing {dataframe-transform}.

--- a/docs/reference/data-frames/apis/delete-transform.asciidoc
+++ b/docs/reference/data-frames/apis/delete-transform.asciidoc
@@ -1,7 +1,9 @@
 [role="xpack"]
 [testenv="basic"]
 [[delete-data-frame-transform]]
-=== Delete data frame transforms API
+=== Delete {dataframe-transforms} API
+
+[subs="attributes"]
 ++++
 <titleabbrev>Delete data frame transforms</titleabbrev>
 ++++

--- a/docs/reference/data-frames/apis/get-transform-stats.asciidoc
+++ b/docs/reference/data-frames/apis/get-transform-stats.asciidoc
@@ -5,7 +5,7 @@
 
 [subs="attributes"]
 ++++
-<titleabbrev>Get data frame transform statistics</titleabbrev>
+<titleabbrev>Get {dataframe-transform} statistics</titleabbrev>
 ++++
 
 Retrieves usage information for {dataframe-transforms}.

--- a/docs/reference/data-frames/apis/get-transform-stats.asciidoc
+++ b/docs/reference/data-frames/apis/get-transform-stats.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="basic"]
 [[get-data-frame-transform-stats]]
-=== Get {dataframe-transform} statistics API
+=== Get data frame transform statistics API
 ++++
-<titleabbrev>Get {dataframe-transform} statistics</titleabbrev>
+<titleabbrev>Get data frame transform statistics</titleabbrev>
 ++++
 
 Retrieves usage information for {dataframe-transforms}.

--- a/docs/reference/data-frames/apis/get-transform-stats.asciidoc
+++ b/docs/reference/data-frames/apis/get-transform-stats.asciidoc
@@ -1,7 +1,9 @@
 [role="xpack"]
 [testenv="basic"]
 [[get-data-frame-transform-stats]]
-=== Get data frame transform statistics API
+=== Get {dataframe-transform} statistics API
+
+[subs="attributes"]
 ++++
 <titleabbrev>Get data frame transform statistics</titleabbrev>
 ++++

--- a/docs/reference/data-frames/apis/get-transform.asciidoc
+++ b/docs/reference/data-frames/apis/get-transform.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="basic"]
 [[get-data-frame-transform]]
-=== Get {dataframe-transforms} API
+=== Get data frame transforms API
 ++++
-<titleabbrev>Get {dataframe-transforms}</titleabbrev>
+<titleabbrev>Get data frame transforms</titleabbrev>
 ++++
 
 Retrieves configuration information for {dataframe-transforms}.

--- a/docs/reference/data-frames/apis/get-transform.asciidoc
+++ b/docs/reference/data-frames/apis/get-transform.asciidoc
@@ -5,7 +5,7 @@
 
 [subs="attributes"]
 ++++
-<titleabbrev>Get data frame transforms</titleabbrev>
+<titleabbrev>Get {dataframe-transforms}</titleabbrev>
 ++++
 
 Retrieves configuration information for {dataframe-transforms}.

--- a/docs/reference/data-frames/apis/get-transform.asciidoc
+++ b/docs/reference/data-frames/apis/get-transform.asciidoc
@@ -1,7 +1,9 @@
 [role="xpack"]
 [testenv="basic"]
 [[get-data-frame-transform]]
-=== Get data frame transforms API
+=== Get {dataframe-transforms} API
+
+[subs="attributes"]
 ++++
 <titleabbrev>Get data frame transforms</titleabbrev>
 ++++

--- a/docs/reference/data-frames/apis/preview-transform.asciidoc
+++ b/docs/reference/data-frames/apis/preview-transform.asciidoc
@@ -1,7 +1,9 @@
 [role="xpack"]
 [testenv="basic"]
 [[preview-data-frame-transform]]
-=== Preview data frame transforms API
+=== Preview {dataframe-transforms} API
+
+[subs="attributes"]
 ++++
 <titleabbrev>Preview data frame transforms</titleabbrev>
 ++++

--- a/docs/reference/data-frames/apis/preview-transform.asciidoc
+++ b/docs/reference/data-frames/apis/preview-transform.asciidoc
@@ -5,7 +5,7 @@
 
 [subs="attributes"]
 ++++
-<titleabbrev>Preview data frame transforms</titleabbrev>
+<titleabbrev>Preview {dataframe-transforms}</titleabbrev>
 ++++
 
 Previews a {dataframe-transform}.

--- a/docs/reference/data-frames/apis/preview-transform.asciidoc
+++ b/docs/reference/data-frames/apis/preview-transform.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="basic"]
 [[preview-data-frame-transform]]
-=== Preview {dataframe-transforms} API
+=== Preview data frame transforms API
 ++++
-<titleabbrev>Preview {dataframe-transforms}</titleabbrev>
+<titleabbrev>Preview data frame transforms</titleabbrev>
 ++++
 
 Previews a {dataframe-transform}.

--- a/docs/reference/data-frames/apis/put-transform.asciidoc
+++ b/docs/reference/data-frames/apis/put-transform.asciidoc
@@ -5,7 +5,7 @@
 
 [subs="attributes"]
 ++++
-<titleabbrev>Create data frame transforms</titleabbrev>
+<titleabbrev>Create {dataframe-transforms}</titleabbrev>
 ++++
 
 Instantiates a {dataframe-transform}.

--- a/docs/reference/data-frames/apis/put-transform.asciidoc
+++ b/docs/reference/data-frames/apis/put-transform.asciidoc
@@ -1,7 +1,9 @@
 [role="xpack"]
 [testenv="basic"]
 [[put-data-frame-transform]]
-=== Create data frame transforms API
+=== Create {dataframe-transforms} API
+
+[subs="attributes"]
 ++++
 <titleabbrev>Create data frame transforms</titleabbrev>
 ++++

--- a/docs/reference/data-frames/apis/put-transform.asciidoc
+++ b/docs/reference/data-frames/apis/put-transform.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="basic"]
 [[put-data-frame-transform]]
-=== Create {dataframe-transforms} API
+=== Create data frame transforms API
 ++++
-<titleabbrev>Create {dataframe-transforms}</titleabbrev>
+<titleabbrev>Create data frame transforms</titleabbrev>
 ++++
 
 Instantiates a {dataframe-transform}.

--- a/docs/reference/data-frames/apis/start-transform.asciidoc
+++ b/docs/reference/data-frames/apis/start-transform.asciidoc
@@ -5,7 +5,7 @@
 
 [subs="attributes"]
 ++++
-<titleabbrev>Start data frame transforms</titleabbrev>
+<titleabbrev>Start {dataframe-transforms}</titleabbrev>
 ++++
 
 Starts one or more {dataframe-transforms}.

--- a/docs/reference/data-frames/apis/start-transform.asciidoc
+++ b/docs/reference/data-frames/apis/start-transform.asciidoc
@@ -1,7 +1,9 @@
 [role="xpack"]
 [testenv="basic"]
 [[start-data-frame-transform]]
-=== Start data frame transforms API
+=== Start {dataframe-transforms} API
+
+[subs="attributes"]
 ++++
 <titleabbrev>Start data frame transforms</titleabbrev>
 ++++

--- a/docs/reference/data-frames/apis/start-transform.asciidoc
+++ b/docs/reference/data-frames/apis/start-transform.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="basic"]
 [[start-data-frame-transform]]
-=== Start {dataframe-transforms} API
+=== Start data frame transforms API
 ++++
-<titleabbrev>Start {dataframe-transforms}</titleabbrev>
+<titleabbrev>Start data frame transforms</titleabbrev>
 ++++
 
 Starts one or more {dataframe-transforms}.

--- a/docs/reference/data-frames/apis/stop-transform.asciidoc
+++ b/docs/reference/data-frames/apis/stop-transform.asciidoc
@@ -1,7 +1,9 @@
 [role="xpack"]
 [testenv="basic"]
 [[stop-data-frame-transform]]
-=== Stop data frame transforms API
+=== Stop {dataframe-transforms} API
+
+[subs="attributes"]
 ++++
 <titleabbrev>Stop data frame transforms</titleabbrev>
 ++++

--- a/docs/reference/data-frames/apis/stop-transform.asciidoc
+++ b/docs/reference/data-frames/apis/stop-transform.asciidoc
@@ -5,7 +5,7 @@
 
 [subs="attributes"]
 ++++
-<titleabbrev>Stop data frame transforms</titleabbrev>
+<titleabbrev>Stop {dataframe-transforms}</titleabbrev>
 ++++
 
 Stops one or more {dataframe-transforms}.

--- a/docs/reference/data-frames/apis/stop-transform.asciidoc
+++ b/docs/reference/data-frames/apis/stop-transform.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="basic"]
 [[stop-data-frame-transform]]
-=== Stop {dataframe-transforms} API
+=== Stop data frame transforms API
 ++++
-<titleabbrev>Stop {dataframe-transforms}</titleabbrev>
+<titleabbrev>Stop data frame transforms</titleabbrev>
 ++++
 
 Stops one or more {dataframe-transforms}.

--- a/docs/reference/ilm/apis/get-status.asciidoc
+++ b/docs/reference/ilm/apis/get-status.asciidoc
@@ -5,7 +5,7 @@
 
 [subs="attributes"]
 ++++
-<titleabbrev>Get index lifecycle management status</titleabbrev>
+<titleabbrev>Get {ilm} status</titleabbrev>
 ++++
 
 Retrieves the current {ilm} ({ilm-init}) status.

--- a/docs/reference/ilm/apis/get-status.asciidoc
+++ b/docs/reference/ilm/apis/get-status.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="basic"]
 [[ilm-get-status]]
-=== Get {ilm} status API
+=== Get index lifecycle management status API
 ++++
-<titleabbrev>Get {ilm} status</titleabbrev>
+<titleabbrev>Get index lifecycle management status</titleabbrev>
 ++++
 
 Retrieves the current {ilm} ({ilm-init}) status.

--- a/docs/reference/ilm/apis/get-status.asciidoc
+++ b/docs/reference/ilm/apis/get-status.asciidoc
@@ -1,7 +1,9 @@
 [role="xpack"]
 [testenv="basic"]
 [[ilm-get-status]]
-=== Get index lifecycle management status API
+=== Get {ilm} status API
+
+[subs="attributes"]
 ++++
 <titleabbrev>Get index lifecycle management status</titleabbrev>
 ++++

--- a/docs/reference/ilm/apis/start.asciidoc
+++ b/docs/reference/ilm/apis/start.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="basic"]
 [[ilm-start]]
-=== Start {ilm} API
+=== Start index lifecycle management API
 ++++
-<titleabbrev>Start {ilm}</titleabbrev>
+<titleabbrev>Start index lifecycle management</titleabbrev>
 ++++
 
 Start the {ilm} ({ilm-init}) plugin.

--- a/docs/reference/ilm/apis/start.asciidoc
+++ b/docs/reference/ilm/apis/start.asciidoc
@@ -1,7 +1,9 @@
 [role="xpack"]
 [testenv="basic"]
 [[ilm-start]]
-=== Start index lifecycle management API
+=== Start {ilm} API
+
+[subs="attributes"]
 ++++
 <titleabbrev>Start index lifecycle management</titleabbrev>
 ++++

--- a/docs/reference/ilm/apis/start.asciidoc
+++ b/docs/reference/ilm/apis/start.asciidoc
@@ -5,7 +5,7 @@
 
 [subs="attributes"]
 ++++
-<titleabbrev>Start index lifecycle management</titleabbrev>
+<titleabbrev>Start {ilm}</titleabbrev>
 ++++
 
 Start the {ilm} ({ilm-init}) plugin.

--- a/docs/reference/ilm/apis/stop.asciidoc
+++ b/docs/reference/ilm/apis/stop.asciidoc
@@ -5,7 +5,7 @@
 
 [subs="attributes"]
 ++++
-<titleabbrev>Stop index lifecycle management</titleabbrev>
+<titleabbrev>Stop {ilm}</titleabbrev>
 ++++
 
 Stop the {ilm} ({ilm-init}) plugin.

--- a/docs/reference/ilm/apis/stop.asciidoc
+++ b/docs/reference/ilm/apis/stop.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="basic"]
 [[ilm-stop]]
-=== Stop {ilm} API
+=== Stop index lifecycle management API
 ++++
-<titleabbrev>Stop {ilm}</titleabbrev>
+<titleabbrev>Stop index lifecycle management</titleabbrev>
 ++++
 
 Stop the {ilm} ({ilm-init}) plugin.

--- a/docs/reference/ilm/apis/stop.asciidoc
+++ b/docs/reference/ilm/apis/stop.asciidoc
@@ -1,7 +1,9 @@
 [role="xpack"]
 [testenv="basic"]
 [[ilm-stop]]
-=== Stop index lifecycle management API
+=== Stop {ilm} API
+
+[subs="attributes"]
 ++++
 <titleabbrev>Stop index lifecycle management</titleabbrev>
 ++++

--- a/docs/reference/ml/apis/delete-datafeed.asciidoc
+++ b/docs/reference/ml/apis/delete-datafeed.asciidoc
@@ -5,7 +5,7 @@
 
 [subs="attributes"]
 ++++
-<titleabbrev>Delete datafeeds</titleabbrev>
+<titleabbrev>Delete {dfeeds}</titleabbrev>
 ++++
 
 Deletes an existing {dfeed}.

--- a/docs/reference/ml/apis/delete-datafeed.asciidoc
+++ b/docs/reference/ml/apis/delete-datafeed.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-delete-datafeed]]
-=== Delete {dfeeds} API
+=== Delete datafeeds API
 ++++
-<titleabbrev>Delete {dfeeds}</titleabbrev>
+<titleabbrev>Delete datafeeds</titleabbrev>
 ++++
 
 Deletes an existing {dfeed}.

--- a/docs/reference/ml/apis/delete-datafeed.asciidoc
+++ b/docs/reference/ml/apis/delete-datafeed.asciidoc
@@ -1,7 +1,9 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-delete-datafeed]]
-=== Delete datafeeds API
+=== Delete {dfeeds} API
+
+[subs="attributes"]
 ++++
 <titleabbrev>Delete datafeeds</titleabbrev>
 ++++

--- a/docs/reference/ml/apis/get-datafeed-stats.asciidoc
+++ b/docs/reference/ml/apis/get-datafeed-stats.asciidoc
@@ -1,7 +1,9 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-get-datafeed-stats]]
-=== Get datafeed statistics API
+=== Get {dfeed} statistics API
+
+[subs="attributes"]
 ++++
 <titleabbrev>Get datafeed statistics</titleabbrev>
 ++++

--- a/docs/reference/ml/apis/get-datafeed-stats.asciidoc
+++ b/docs/reference/ml/apis/get-datafeed-stats.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-get-datafeed-stats]]
-=== Get {dfeed} statistics API
+=== Get datafeed statistics API
 ++++
-<titleabbrev>Get {dfeed} statistics</titleabbrev>
+<titleabbrev>Get datafeed statistics</titleabbrev>
 ++++
 
 Retrieves usage information for {dfeeds}.

--- a/docs/reference/ml/apis/get-datafeed-stats.asciidoc
+++ b/docs/reference/ml/apis/get-datafeed-stats.asciidoc
@@ -5,7 +5,7 @@
 
 [subs="attributes"]
 ++++
-<titleabbrev>Get datafeed statistics</titleabbrev>
+<titleabbrev>Get {dfeed} statistics</titleabbrev>
 ++++
 
 Retrieves usage information for {dfeeds}.

--- a/docs/reference/ml/apis/get-datafeed.asciidoc
+++ b/docs/reference/ml/apis/get-datafeed.asciidoc
@@ -1,7 +1,9 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-get-datafeed]]
-=== Get datafeeds API
+=== Get {dfeeds} API
+
+[subs="attributes"]
 ++++
 <titleabbrev>Get datafeeds</titleabbrev>
 ++++

--- a/docs/reference/ml/apis/get-datafeed.asciidoc
+++ b/docs/reference/ml/apis/get-datafeed.asciidoc
@@ -2,11 +2,8 @@
 [testenv="platinum"]
 [[ml-get-datafeed]]
 === Get {dfeeds} API
-<<<<<<< HEAD
 
 [subs="attributes"]
-=======
->>>>>>> parent of 98f130257a7... [DOCS] Replace attributes in titleabbrevs for Asciidoctor migration
 ++++
 <titleabbrev>Get {dfeeds}</titleabbrev>
 ++++

--- a/docs/reference/ml/apis/get-datafeed.asciidoc
+++ b/docs/reference/ml/apis/get-datafeed.asciidoc
@@ -2,10 +2,13 @@
 [testenv="platinum"]
 [[ml-get-datafeed]]
 === Get {dfeeds} API
+<<<<<<< HEAD
 
 [subs="attributes"]
+=======
+>>>>>>> parent of 98f130257a7... [DOCS] Replace attributes in titleabbrevs for Asciidoctor migration
 ++++
-<titleabbrev>Get datafeeds</titleabbrev>
+<titleabbrev>Get {dfeeds}</titleabbrev>
 ++++
 
 Retrieves configuration information for {dfeeds}.

--- a/docs/reference/ml/apis/get-datafeed.asciidoc
+++ b/docs/reference/ml/apis/get-datafeed.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-get-datafeed]]
-=== Get {dfeeds} API
+=== Get datafeeds API
 ++++
-<titleabbrev>Get {dfeeds}</titleabbrev>
+<titleabbrev>Get datafeeds</titleabbrev>
 ++++
 
 Retrieves configuration information for {dfeeds}.

--- a/docs/reference/ml/apis/get-ml-info.asciidoc
+++ b/docs/reference/ml/apis/get-ml-info.asciidoc
@@ -2,6 +2,8 @@
 [testenv="platinum"]
 [[get-ml-info]]
 === Get machine learning info API
+
+[subs="attributes"]
 ++++
 <titleabbrev>Get machine learning info</titleabbrev>
 ++++

--- a/docs/reference/ml/apis/get-ml-info.asciidoc
+++ b/docs/reference/ml/apis/get-ml-info.asciidoc
@@ -3,7 +3,7 @@
 [[get-ml-info]]
 === Get machine learning info API
 ++++
-<titleabbrev>Get {ml} info</titleabbrev>
+<titleabbrev>Get machine learning info</titleabbrev>
 ++++
 
 Returns defaults and limits used by machine learning.

--- a/docs/reference/ml/apis/get-ml-info.asciidoc
+++ b/docs/reference/ml/apis/get-ml-info.asciidoc
@@ -5,7 +5,7 @@
 
 [subs="attributes"]
 ++++
-<titleabbrev>Get machine learning info</titleabbrev>
+<titleabbrev>Get {ml} info</titleabbrev>
 ++++
 
 Returns defaults and limits used by machine learning.

--- a/docs/reference/ml/apis/preview-datafeed.asciidoc
+++ b/docs/reference/ml/apis/preview-datafeed.asciidoc
@@ -1,7 +1,9 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-preview-datafeed]]
-=== Preview datafeeds API
+=== Preview {dfeeds} API
+
+[subs="attributes"]
 ++++
 <titleabbrev>Preview datafeeds</titleabbrev>
 ++++

--- a/docs/reference/ml/apis/preview-datafeed.asciidoc
+++ b/docs/reference/ml/apis/preview-datafeed.asciidoc
@@ -5,7 +5,7 @@
 
 [subs="attributes"]
 ++++
-<titleabbrev>Preview datafeeds</titleabbrev>
+<titleabbrev>Preview {dfeeds}</titleabbrev>
 ++++
 
 Previews a {dfeed}.

--- a/docs/reference/ml/apis/preview-datafeed.asciidoc
+++ b/docs/reference/ml/apis/preview-datafeed.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-preview-datafeed]]
-=== Preview {dfeeds} API
+=== Preview datafeeds API
 ++++
-<titleabbrev>Preview {dfeeds}</titleabbrev>
+<titleabbrev>Preview datafeeds</titleabbrev>
 ++++
 
 Previews a {dfeed}.

--- a/docs/reference/ml/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/apis/put-datafeed.asciidoc
@@ -1,7 +1,9 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-put-datafeed]]
-=== Create datafeeds API
+=== Create {dfeeds} API
+
+[subs="attributes"]
 ++++
 <titleabbrev>Create datafeeds</titleabbrev>
 ++++

--- a/docs/reference/ml/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/apis/put-datafeed.asciidoc
@@ -5,7 +5,7 @@
 
 [subs="attributes"]
 ++++
-<titleabbrev>Create datafeeds</titleabbrev>
+<titleabbrev>Create {dfeeds}</titleabbrev>
 ++++
 
 Instantiates a {dfeed}.

--- a/docs/reference/ml/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/apis/put-datafeed.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-put-datafeed]]
-=== Create {dfeeds} API
+=== Create datafeeds API
 ++++
-<titleabbrev>Create {dfeeds}</titleabbrev>
+<titleabbrev>Create datafeeds</titleabbrev>
 ++++
 
 Instantiates a {dfeed}.

--- a/docs/reference/ml/apis/start-datafeed.asciidoc
+++ b/docs/reference/ml/apis/start-datafeed.asciidoc
@@ -5,7 +5,7 @@
 
 [subs="attributes"]
 ++++
-<titleabbrev>Start datafeeds</titleabbrev>
+<titleabbrev>Start {dfeeds}</titleabbrev>
 ++++
 
 Starts one or more {dfeeds}.

--- a/docs/reference/ml/apis/start-datafeed.asciidoc
+++ b/docs/reference/ml/apis/start-datafeed.asciidoc
@@ -1,7 +1,9 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-start-datafeed]]
-=== Start datafeeds API
+=== Start {dfeeds} API
+
+[subs="attributes"]
 ++++
 <titleabbrev>Start datafeeds</titleabbrev>
 ++++

--- a/docs/reference/ml/apis/start-datafeed.asciidoc
+++ b/docs/reference/ml/apis/start-datafeed.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-start-datafeed]]
-=== Start {dfeeds} API
+=== Start datafeeds API
 ++++
-<titleabbrev>Start {dfeeds}</titleabbrev>
+<titleabbrev>Start datafeeds</titleabbrev>
 ++++
 
 Starts one or more {dfeeds}.

--- a/docs/reference/ml/apis/stop-datafeed.asciidoc
+++ b/docs/reference/ml/apis/stop-datafeed.asciidoc
@@ -1,7 +1,9 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-stop-datafeed]]
-=== Stop datafeeds API
+=== Stop {dfeeds} API
+
+[subs="attributes"]
 ++++
 <titleabbrev>Stop datafeeds</titleabbrev>
 ++++

--- a/docs/reference/ml/apis/stop-datafeed.asciidoc
+++ b/docs/reference/ml/apis/stop-datafeed.asciidoc
@@ -5,7 +5,7 @@
 
 [subs="attributes"]
 ++++
-<titleabbrev>Stop datafeeds</titleabbrev>
+<titleabbrev>Stop {dfeeds}</titleabbrev>
 ++++
 
 Stops one or more {dfeeds}.

--- a/docs/reference/ml/apis/stop-datafeed.asciidoc
+++ b/docs/reference/ml/apis/stop-datafeed.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-stop-datafeed]]
-=== Stop {dfeeds} API
+=== Stop datafeeds API
 ++++
-<titleabbrev>Stop {dfeeds}</titleabbrev>
+<titleabbrev>Stop datafeeds</titleabbrev>
 ++++
 
 Stops one or more {dfeeds}.

--- a/docs/reference/ml/apis/update-datafeed.asciidoc
+++ b/docs/reference/ml/apis/update-datafeed.asciidoc
@@ -5,7 +5,7 @@
 
 [subs="attributes"]
 ++++
-<titleabbrev>Update datafeeds</titleabbrev>
+<titleabbrev>Update {dfeeds}</titleabbrev>
 ++++
 
 Updates certain properties of a {dfeed}.

--- a/docs/reference/ml/apis/update-datafeed.asciidoc
+++ b/docs/reference/ml/apis/update-datafeed.asciidoc
@@ -1,7 +1,9 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-update-datafeed]]
-=== Update datafeeds API
+=== Update {dfeeds} API
+
+[subs="attributes"]
 ++++
 <titleabbrev>Update datafeeds</titleabbrev>
 ++++

--- a/docs/reference/ml/apis/update-datafeed.asciidoc
+++ b/docs/reference/ml/apis/update-datafeed.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-update-datafeed]]
-=== Update {dfeeds} API
+=== Update datafeeds API
 ++++
-<titleabbrev>Update {dfeeds}</titleabbrev>
+<titleabbrev>Update datafeeds</titleabbrev>
 ++++
 
 Updates certain properties of a {dfeed}.

--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -1,7 +1,9 @@
 [role="xpack"]
 [testenv="gold"]
 [[configuring-metricbeat]]
-=== Collecting Elasticsearch monitoring data with Metricbeat
+=== Collecting {es} monitoring data with {metricbeat}
+
+[subs="attributes"]
 ++++
 <titleabbrev>Collecting monitoring data with Metricbeat</titleabbrev>
 ++++

--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -5,7 +5,7 @@
 
 [subs="attributes"]
 ++++
-<titleabbrev>Collecting monitoring data with Metricbeat</titleabbrev>
+<titleabbrev>Collecting monitoring data with {metricbeat}</titleabbrev>
 ++++
 
 In 6.5 and later, you can use {metricbeat} to collect data about {es} 

--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="gold"]
 [[configuring-metricbeat]]
-=== Collecting {es} monitoring data with {metricbeat}
+=== Collecting Elasticsearch monitoring data with Metricbeat
 ++++
-<titleabbrev>Collecting monitoring data with {metricbeat}</titleabbrev>
+<titleabbrev>Collecting monitoring data with Metricbeat</titleabbrev>
 ++++
 
 In 6.5 and later, you can use {metricbeat} to collect data about {es} 

--- a/docs/reference/settings/notification-settings.asciidoc
+++ b/docs/reference/settings/notification-settings.asciidoc
@@ -1,6 +1,8 @@
 [role="xpack"]
 [[notification-settings]]
-=== Watcher settings in Elasticsearch
+=== {watcher} settings in Elasticsearch
+
+[subs="attributes"]
 ++++
 <titleabbrev>Watcher settings</titleabbrev>
 ++++

--- a/docs/reference/settings/notification-settings.asciidoc
+++ b/docs/reference/settings/notification-settings.asciidoc
@@ -4,7 +4,7 @@
 
 [subs="attributes"]
 ++++
-<titleabbrev>Watcher settings</titleabbrev>
+<titleabbrev>{watcher} settings</titleabbrev>
 ++++
 
 You configure {watcher} settings to set up {watcher} and send notifications via

--- a/docs/reference/settings/notification-settings.asciidoc
+++ b/docs/reference/settings/notification-settings.asciidoc
@@ -1,8 +1,8 @@
 [role="xpack"]
 [[notification-settings]]
-=== {watcher} settings in Elasticsearch
+=== Watcher settings in Elasticsearch
 ++++
-<titleabbrev>{watcher} settings</titleabbrev>
+<titleabbrev>Watcher settings</titleabbrev>
 ++++
 
 You configure {watcher} settings to set up {watcher} and send notifications via


### PR DESCRIPTION
By default, Asciidoctor does not expand attributes included in `<titleabbrev>` tags. This Adds the `[subs="attributes"]` to `<titleabbrev>` tags containing attributes in preparation for the Asciidoctor migration

Relates to /elastic/docs#827 and #41128.