### PR TITLE
[DOCS] Fix ID for Asciidoctor migration

### DIFF
--- a/docs/reference/setup/stopping.asciidoc
+++ b/docs/reference/setup/stopping.asciidoc
@@ -36,8 +36,8 @@ $ cat /tmp/elasticsearch-pid && echo
 $ kill -SIGTERM 15516
 --------------------------------------------------
 
-[[fatal-errors]
 [float]
+[[fatal-errors]]
 === Stopping on Fatal Errors
 
 During the life of the Elasticsearch virtual machine, certain fatal errors could arise that put the


### PR DESCRIPTION
In Asciidoctor, this ID renders literally as `[[fatal-errors]`. This fixes the ID.

Relates to /elastic/docs/#827 and #41128.