### PR TITLE
[DOCS] Add space to fix Asciidoctor output

### DIFF
--- a/x-pack/plugin/sql/qa/src/main/resources/docs/docs.csv-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/docs/docs.csv-spec
@@ -607,7 +607,7 @@ M              |57
 groupByAndAggExpression
 // tag::groupByAndAggExpression
 schema::g:s|salary:i
-SELECT gender AS g, ROUND((MIN(salary) / 100)) AS salary FROM emp GROUP BY gender;
+SELECT gender AS g, ROUND( (MIN(salary) / 100) ) AS salary FROM emp GROUP BY gender;
 
        g       |    salary     
 ---------------+---------------


### PR DESCRIPTION
Asciidoctor outputs `((MIN(salary) / 100))` as `<indexterm><primary>MIN(salary) / 100</primary></indexterm>`. This adds whitespace to correct the output in preparation for the Asciidoctor migration.

Relates to elastic/docs#827 and #41128.