### PR TITLE
[DOCS] Remove delimited block for Asciidoctor migration

### DIFF
--- a/docs/reference/upgrade/upgrade-node.asciidoc
+++ b/docs/reference/upgrade/upgrade-node.asciidoc
@@ -18,12 +18,10 @@ To upgrade using a zip or compressed tarball:
    data directory. If you are not using an external `data` directory, copy
    your old data directory over to the new installation. +
 +
---
 IMPORTANT: If you use {monitor-features}, re-use the data directory when you upgrade
 {es}. Monitoring identifies unique {es} nodes by using the persistent UUID, which
 is stored in the data directory.
 
---
 
 .. Set `path.logs` in `config/elasticsearch.yml` to point to the location
    where you want to store your logs. If you do not specify this setting,


### PR DESCRIPTION
In Asciidoctor, this delimited block resets the nested ordered list (changing `d` to `a`). This removes the block, which wasn't needed anyway.

### Before/After Images in Asciidoctor

**Before**
<img width="766" alt="asciidoctor-before" src="https://user-images.githubusercontent.com/40268737/56811967-ef475500-6807-11e9-8007-6aeb69ea84ae.png">

**After**
<img width="701" alt="asciidoctor-after" src="https://user-images.githubusercontent.com/40268737/56811974-f3737280-6807-11e9-9d44-77754927d20e.png">