### PR TITLE
[DOCS] Fix delimited blocks for Asciidoctor migration

### DIFF
--- a/docs/reference/upgrade/cluster_restart.asciidoc
+++ b/docs/reference/upgrade/cluster_restart.asciidoc
@@ -46,6 +46,7 @@ include::remove-xpack.asciidoc[]
 +
 --
 include::upgrade-node.asciidoc[]
+--
 +
 --
 include::set-paths-tip.asciidoc[]

--- a/docs/reference/upgrade/cluster_restart.asciidoc
+++ b/docs/reference/upgrade/cluster_restart.asciidoc
@@ -46,6 +46,8 @@ include::remove-xpack.asciidoc[]
 +
 --
 include::upgrade-node.asciidoc[]
++
+--
 include::set-paths-tip.asciidoc[]
 --
 

--- a/docs/reference/upgrade/upgrade-node.asciidoc
+++ b/docs/reference/upgrade/upgrade-node.asciidoc
@@ -18,12 +18,10 @@ To upgrade using a zip or compressed tarball:
    data directory. If you are not using an external `data` directory, copy
    your old data directory over to the new installation. +
 +
---
 IMPORTANT: If you use {monitor-features}, re-use the data directory when you upgrade
 {es}. Monitoring identifies unique {es} nodes by using the persistent UUID, which
 is stored in the data directory.
 
---
 
 .. Set `path.logs` in `config/elasticsearch.yml` to point to the location
    where you want to store your logs. If you do not specify this setting,


### PR DESCRIPTION
In Asciidoctor, these delimited block resets the nested ordered list (changing `d` to `a` and `6` to `1`). This fixes those breaking changes.

### Asciidoctor output before changes
<img width="794" alt="asciidoctor-before" src="https://user-images.githubusercontent.com/40268737/56814311-ead16b00-680c-11e9-9362-bb2a524023e1.png">

### Asciidoctor output after changes
<img width="770" alt="asciidoctor-after" src="https://user-images.githubusercontent.com/40268737/56814323-f0c74c00-680c-11e9-965b-c42508ef8e54.png">

### AsciiDoc output after changes
<img width="757" alt="asciidoc-output" src="https://user-images.githubusercontent.com/40268737/56814333-f6249680-680c-11e9-96c2-e46ba9e256a8.png">