### PR TITLE
Fix multi-node parsing in voting config exclusions REST API

### DIFF
--- a/modules/transport-netty4/src/test/java/org/elasticsearch/rest/discovery/Zen2RestApiIT.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/rest/discovery/Zen2RestApiIT.java
@@ -160,4 +160,18 @@ public class Zen2RestApiIT extends ESNetty4IntegTestCase {
             );
         }
     }
+
+    public void testRemoveTwoNodesAtOnce() throws Exception {
+        internalCluster().setBootstrapMasterNodeIndex(2);
+        List<String> nodes = internalCluster().startNodes(3);
+        ensureStableCluster(3);
+        RestClient restClient = getRestClient();
+        Response response = restClient.performRequest(new Request("POST", "/_cluster/voting_config_exclusions/" +
+            nodes.get(2) + "," + nodes.get(0)));
+        assertThat(response.getStatusLine().getStatusCode(), is(200));
+        assertThat(response.getEntity().getContentLength(), is(0L));
+        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(nodes.get(0)));
+        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(nodes.get(2)));
+        ensureStableCluster(1);
+    }
 }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestAddVotingConfigExclusionAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestAddVotingConfigExclusionAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.rest.action.admin.cluster;
 import org.elasticsearch.action.admin.cluster.configuration.AddVotingConfigExclusionsRequest;
 import org.elasticsearch.action.admin.cluster.configuration.AddVotingConfigExclusionsAction;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -58,7 +59,7 @@ public class RestAddVotingConfigExclusionAction extends BaseRestHandler {
     AddVotingConfigExclusionsRequest resolveVotingConfigExclusionsRequest(final RestRequest request) {
         String nodeName = request.param("node_name");
         return new AddVotingConfigExclusionsRequest(
-            nodeName.split(","),
+            Strings.splitStringByCommaToArray(nodeName),
             TimeValue.parseTimeValue(request.param("timeout"), DEFAULT_TIMEOUT, getClass().getSimpleName() + ".timeout")
         );
     }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestAddVotingConfigExclusionAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestAddVotingConfigExclusionAction.java
@@ -47,9 +47,10 @@ public class RestAddVotingConfigExclusionAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
+        AddVotingConfigExclusionsRequest votingConfigExclusionsRequest = resolveVotingConfigExclusionsRequest(request);
         return channel -> client.execute(
             AddVotingConfigExclusionsAction.INSTANCE,
-            resolveVotingConfigExclusionsRequest(request),
+            votingConfigExclusionsRequest,
             new RestToXContentListener<>(channel)
         );
     }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestAddVotingConfigExclusionAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestAddVotingConfigExclusionAction.java
@@ -47,15 +47,18 @@ public class RestAddVotingConfigExclusionAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
-        String nodeName = request.param("node_name");
-        AddVotingConfigExclusionsRequest votingConfigExclusionsRequest = new AddVotingConfigExclusionsRequest(
-            new String[]{nodeName},
-            TimeValue.parseTimeValue(request.param("timeout"), DEFAULT_TIMEOUT, getClass().getSimpleName() + ".timeout")
-        );
         return channel -> client.execute(
             AddVotingConfigExclusionsAction.INSTANCE,
-            votingConfigExclusionsRequest,
+            resolveVotingConfigExclusionsRequest(request),
             new RestToXContentListener<>(channel)
+        );
+    }
+
+    AddVotingConfigExclusionsRequest resolveVotingConfigExclusionsRequest(final RestRequest request) {
+        String nodeName = request.param("node_name");
+        return new AddVotingConfigExclusionsRequest(
+            nodeName.split(","),
+            TimeValue.parseTimeValue(request.param("timeout"), DEFAULT_TIMEOUT, getClass().getSimpleName() + ".timeout")
         );
     }
 }

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/cluster/RestAddVotingConfigExclusionActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/cluster/RestAddVotingConfigExclusionActionTests.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.admin.cluster;
+
+import org.elasticsearch.action.admin.cluster.configuration.AddVotingConfigExclusionsRequest;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.test.rest.FakeRestRequest;
+import org.elasticsearch.test.rest.RestActionTestCase;
+import org.junit.Before;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class RestAddVotingConfigExclusionActionTests extends RestActionTestCase {
+
+    private RestAddVotingConfigExclusionAction action;
+
+    @Before
+    public void setupAction() {
+        action = new RestAddVotingConfigExclusionAction(Settings.EMPTY, controller());
+    }
+
+    public void testResolveVotingConfigExclusionsRequest() {
+        Map<String, String> params = new HashMap<>();
+        params.put("node_name", "node-1,node-2,node-3");
+        RestRequest deprecatedRequest = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(RestRequest.Method.PUT)
+            .withPath("/_cluster/voting_config_exclusions")
+            .withParams(params)
+            .build();
+
+        AddVotingConfigExclusionsRequest addVotingConfigExclusionsRequest = action.resolveVotingConfigExclusionsRequest(deprecatedRequest);
+        String[] expected = {"node-1","node-2", "node-3"};
+        assertArrayEquals(expected, addVotingConfigExclusionsRequest.getNodeDescriptions());
+    }
+}


### PR DESCRIPTION
Fix #41587 
This PR split the `node_name` parameter before it is processed by `resolveNodes`
