### PR TITLE
Switch run task to use real distro

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -99,9 +99,8 @@ class PluginBuildPlugin extends BuildPlugin {
 
             project.tasks.run.dependsOn(project.tasks.bundlePlugin)
             if (isModule) {
-                project.tasks.run.clusterConfig.module(project)
                 project.tasks.run.clusterConfig.distribution = System.getProperty(
-                        'run.distribution', 'integ-test-zip'
+                        'run.distribution', isXPackModule ? 'default' : 'oss'
                 )
             } else {
                 project.tasks.run.clusterConfig.plugin(project.path)

--- a/x-pack/plugin/ccr/build.gradle
+++ b/x-pack/plugin/ccr/build.gradle
@@ -59,10 +59,6 @@ dependencyLicenses {
     ignoreSha 'x-pack-core'
 }
 
-run {
-    plugin xpackModule('core')
-}
-
 testingConventions.naming {
     IT {
         baseClass "org.elasticsearch.xpack.CcrIntegTestCase"

--- a/x-pack/plugin/data-frame/build.gradle
+++ b/x-pack/plugin/data-frame/build.gradle
@@ -15,10 +15,6 @@ dependencies {
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
-run {
-    plugin xpackModule('core')
-}
-
 // xpack modules are installed in real clusters as the meta plugin, so
 // installing them as individual plugins for integ tests doesn't make sense,
 // so we disable integ tests

--- a/x-pack/plugin/deprecation/build.gradle
+++ b/x-pack/plugin/deprecation/build.gradle
@@ -13,8 +13,4 @@ dependencies {
     compileOnly "org.elasticsearch.plugin:x-pack-core:${version}"
 }
 
-run {
-    plugin xpackModule('core')
-}
-
 integTest.enabled = false

--- a/x-pack/plugin/graph/build.gradle
+++ b/x-pack/plugin/graph/build.gradle
@@ -24,8 +24,4 @@ gradle.projectsEvaluated {
             .each { check.dependsOn it.check }
 }
 
-run {
-    plugin xpackModule('core')
-}
-
 integTest.enabled = false

--- a/x-pack/plugin/ilm/build.gradle
+++ b/x-pack/plugin/ilm/build.gradle
@@ -29,6 +29,3 @@ gradle.projectsEvaluated {
 
 integTest.enabled = false
 
-run {
-    plugin xpackModule('core')
-}

--- a/x-pack/plugin/logstash/build.gradle
+++ b/x-pack/plugin/logstash/build.gradle
@@ -15,8 +15,4 @@ dependencies {
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
-run {
-    plugin xpackModule('core')
-}
-
 integTest.enabled = false

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -81,10 +81,6 @@ project.afterEvaluate {
     }
 }
 
-run {
-    plugin xpackModule('core')
-}
-
 // xpack modules are installed in real clusters as the meta plugin, so
 // installing them as individual plugins for integ tests doesn't make sense,
 // so we disable integ tests

--- a/x-pack/plugin/monitoring/build.gradle
+++ b/x-pack/plugin/monitoring/build.gradle
@@ -45,10 +45,6 @@ dependencyLicenses {
     mapping from: /commons-.*/, to: 'commons' // pulled in by rest client
 }
 
-run {
-    plugin xpackModule('core')
-}
-
 // xpack modules are installed in real clusters as the meta plugin, so
 // installing them as individual plugins for integ tests doesn't make sense,
 // so we disable integ tests

--- a/x-pack/plugin/rollup/build.gradle
+++ b/x-pack/plugin/rollup/build.gradle
@@ -21,8 +21,4 @@ dependencies {
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
-run {
-    plugin xpackModule('core')
-}
-
 integTest.enabled = false

--- a/x-pack/plugin/security/build.gradle
+++ b/x-pack/plugin/security/build.gradle
@@ -301,10 +301,6 @@ thirdPartyAudit.ignoreMissingClasses(
 )
 
 
-run {
-    plugin xpackModule('core')
-}
-
 test {
     /*
      * We have to disable setting the number of available processors as tests in the same JVM randomize processors and will step on each

--- a/x-pack/plugin/watcher/build.gradle
+++ b/x-pack/plugin/watcher/build.gradle
@@ -69,10 +69,6 @@ thirdPartyAudit {
     )
 }
 
-run {
-    plugin xpackModule('core')
-}
-
 test {
     /*
      * We have to disable setting the number of available processors as tests in the same JVM randomize processors and will step on each


### PR DESCRIPTION
The run task is supposed to run elasticsearch with the given plugin or
module. However, for modules, this is most realistic if using the full
distribution. This commit changes the run setup to use the default or
oss as appropriate.