### PR TITLE
[DOCS] Reword `type` query deprecation note for Asciidoctor migration

### DIFF
--- a/docs/reference/query-dsl/type-query.asciidoc
+++ b/docs/reference/query-dsl/type-query.asciidoc
@@ -1,8 +1,7 @@
 [[query-dsl-type-query]]
 === Type Query
 
-deprecated[7.0.0, Types and the `type` query are deprecated and in the process
-of being removed. See <<removal-of-types>>.]
+deprecated[7.0.0,Types and the `type` query are deprecated and in the process of being removed. See <<removal-of-types>>.]
 
 Filters documents matching the provided document / mapping type.
 

--- a/docs/reference/query-dsl/type-query.asciidoc
+++ b/docs/reference/query-dsl/type-query.asciidoc
@@ -1,7 +1,8 @@
 [[query-dsl-type-query]]
 === Type Query
 
-deprecated[7.0.0, Types are being removed, prefer filtering on a field instead. For more information, please see <<removal-of-types>>.]
+deprecated[7.0.0, Types and the `type` query are deprecated and in the process
+of being removed. See <<removal-of-types>>.]
 
 Filters documents matching the provided document / mapping type.
 


### PR DESCRIPTION
Asciidoctor does not render text following the second comma in `deprecated[]` notes. The current deprecation note is also awkwardly worded.

This rewords the deprecation note to remove commas to prepare for Asciidoctor migration.

Relates to elastic/docs#827