### PR TITLE
[DOCS] Escape commas in deprecated[] for Asciidoctor migration

### DIFF
--- a/docs/reference/mapping/params/boost.asciidoc
+++ b/docs/reference/mapping/params/boost.asciidoc
@@ -64,7 +64,7 @@ POST _search
 // CONSOLE
 
 
-deprecated[5.0.0, index time boost is deprecated.  Instead, the field mapping boost is applied at query time. For indices created before 5.0.0 the boost will still be applied at index time.]
+deprecated[5.0.0, "Index time boost is deprecated.  Instead, the field mapping boost is applied at query time. For indices created before 5.0.0, the boost will still be applied at index time."]
 [WARNING]
 .Why index time boosting is a bad idea
 ==================================================


### PR DESCRIPTION
Asciidoctor does not render text following the second comma in `deprecated[]` macros. This escapes the text in the `deprecated[]` macro in preparation for the Asciidoctor migration.

Quotes will be included in the existing AsciiDoc output, but I don't think that's too disruptive. It'll also be removed after the Asciidoctor migration is complete.

Relates to elastic/docs#827