### PR TITLE
[DOCS] Move beta[] tag for Asciidoctor migration

### DIFF
--- a/docs/reference/setup/install.asciidoc
+++ b/docs/reference/setup/install.asciidoc
@@ -46,9 +46,7 @@ Elasticsearch website or from our RPM repository.
 
 `msi`::
 
-beta[]
-+
-The `msi` package is suitable for installation on Windows 64-bit systems with at least
+beta[] The `msi` package is suitable for installation on Windows 64-bit systems with at least
 .NET 4.5 framework installed, and is the easiest choice for getting started with
 Elasticsearch on Windows. MSIs may be downloaded from the Elasticsearch website.
 +


### PR DESCRIPTION
For the [Installing Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html) page, Asciidoctor does not render the `beta[]` tag on it's own line. This moves the tag so it renders.

Relates to elastic/docs#827

### Asciidoctor before changes
<img width="762" alt="Screen Shot 2019-04-26 at 2 28 52 PM" src="https://user-images.githubusercontent.com/40268737/56828613-adcaa000-682f-11e9-92e8-6de52a0d0dff.png">

### Asciidoctor after changes
<img width="753" alt="Asciidoctor-after" src="https://user-images.githubusercontent.com/40268737/56828554-883d9680-682f-11e9-8901-18ca5747add1.png">

### AsciiDoc after changes
<img width="765" alt="Screen Shot 2019-04-26 at 2 36 29 PM" src="https://user-images.githubusercontent.com/40268737/56829047-b5d70f80-6830-11e9-87f2-4ce3b74fca1b.png">