### PR TITLE
[DOCS] Move block delimiter and anchor in 'Configuring Security' for Asciidoctor migration

### DIFF
--- a/x-pack/docs/en/security/configuring-es.asciidoc
+++ b/x-pack/docs/en/security/configuring-es.asciidoc
@@ -82,12 +82,13 @@ user API.
 ** <<configuring-kerberos-realm,Configure a Kerberos realm>>.
 
 . Set up roles and users to control access to {es}.
++
+--
 For example, to grant _John Doe_ full access to all indices that match
 the pattern `events*` and enable him to create visualizations and dashboards
 for those indices in {kib}, you could create an `events_admin` role
 and assign the role to a new `johndoe` user.
-+
---
+
 [source,shell]
 ----------------------------------------------------------
 curl -XPOST -u elastic 'localhost:9200/_security/role/events_admin' -H "Content-Type: application/json" -d '{
@@ -113,8 +114,7 @@ curl -XPOST -u elastic 'localhost:9200/_security/user/johndoe' -H "Content-Type:
 // NOTCONSOLE
 --
 
-[[enable-auditing]]
-. Enable auditing to keep track of attempted and successful interactions with
+. [[enable-auditing]]Enable auditing to keep track of attempted and successful interactions with
   your {es} cluster:
 +
 --


### PR DESCRIPTION
On the [Configuring security in Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-security.html) page, the placement of a block delimiter and the `[[enable-auditing]]` anchor breaks the ordered list count at item 9.

This fixes that break to prepare for the Asciidoctor migration.

Relates to elastic/docs#827

### Asciidoctor before changes
<img width="748" alt="Asciidoctor-before" src="https://user-images.githubusercontent.com/40268737/56832511-3a7a5b80-683a-11e9-86ef-12f062d30d98.png">

### Asciidoctor after changes
<img width="749" alt="Asciidoctor-after" src="https://user-images.githubusercontent.com/40268737/56832504-377f6b00-683a-11e9-9669-77a70956ace6.png">

### AsciiDoc after changes
<img width="747" alt="AsciiDoc-after" src="https://user-images.githubusercontent.com/40268737/56832499-351d1100-683a-11e9-838c-74283bd36948.png">
