### PR TITLE
[6.7] [Monitoring] Add `usage` mapping for `monitoring-kibana` index (#40899)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/exporter/MonitoringTemplateUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/exporter/MonitoringTemplateUtils.java
@@ -29,7 +29,7 @@ public final class MonitoringTemplateUtils {
      * <p>
      * It may be possible for this to diverge between templates and pipelines, but for now they're the same.
      */
-    public static final int LAST_UPDATED_VERSION = Version.V_6_5_3.id;
+    public static final int LAST_UPDATED_VERSION = Version.V_6_7_2.id;
 
     /**
      * Current version of templates used in their name to differentiate from breaking changes (separate from product version).

--- a/x-pack/plugin/core/src/main/resources/monitoring-alerts.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-alerts.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [ ".monitoring-alerts-${monitoring.template.version}" ],
-  "version": 6050399,
+  "version": 6070299,
   "settings": {
     "index": {
       "number_of_shards": 1,

--- a/x-pack/plugin/core/src/main/resources/monitoring-beats.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-beats.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [ ".monitoring-beats-${monitoring.template.version}-*" ],
-  "version": 6050399,
+  "version": 6070299,
   "settings": {
     "index.number_of_shards": 1,
     "index.number_of_replicas": 0,

--- a/x-pack/plugin/core/src/main/resources/monitoring-es.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-es.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [ ".monitoring-es-${monitoring.template.version}-*" ],
-  "version": 6050399,
+  "version": 6070299,
   "settings": {
     "index.number_of_shards": 1,
     "index.number_of_replicas": 0,

--- a/x-pack/plugin/core/src/main/resources/monitoring-kibana.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-kibana.json
@@ -50,6 +50,13 @@
         },
         "kibana_stats": {
           "properties": {
+            "usage": {
+              "properties": {
+                "index": {
+                  "type": "keyword"
+                }
+              }
+            },
             "kibana": {
               "properties": {
                 "uuid": {

--- a/x-pack/plugin/core/src/main/resources/monitoring-kibana.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-kibana.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [ ".monitoring-kibana-${monitoring.template.version}-*" ],
-  "version": 6050399,
+  "version": 6070299,
   "settings": {
     "index.number_of_shards": 1,
     "index.number_of_replicas": 0,

--- a/x-pack/plugin/core/src/main/resources/monitoring-logstash.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-logstash.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [ ".monitoring-logstash-${monitoring.template.version}-*" ],
-  "version": 6050399,
+  "version": 6070299,
   "settings": {
     "index.number_of_shards": 1,
     "index.number_of_replicas": 0,


### PR DESCRIPTION
Backports the following commits to 6.7:

- Add `usage` mapping for `monitoring-kibana` index (#40899 / #41601)