### PR TITLE
Add `manage_slm` and `read_slm` cluster privileges

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilege.java
@@ -15,10 +15,13 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.xpack.core.indexlifecycle.action.GetLifecycleAction;
 import org.elasticsearch.xpack.core.indexlifecycle.action.GetStatusAction;
+import org.elasticsearch.xpack.core.indexlifecycle.action.StartILMAction;
+import org.elasticsearch.xpack.core.indexlifecycle.action.StopILMAction;
 import org.elasticsearch.xpack.core.security.action.token.InvalidateTokenAction;
 import org.elasticsearch.xpack.core.security.action.token.RefreshTokenAction;
 import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesAction;
 import org.elasticsearch.xpack.core.security.support.Automatons;
+import org.elasticsearch.xpack.core.snapshotlifecycle.action.GetSnapshotLifecycleAction;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -60,6 +63,9 @@ public final class ClusterPrivilege extends Privilege {
     private static final Automaton READ_CCR_AUTOMATON = patterns(ClusterStateAction.NAME, HasPrivilegesAction.NAME);
     private static final Automaton MANAGE_ILM_AUTOMATON = patterns("cluster:admin/ilm/*");
     private static final Automaton READ_ILM_AUTOMATON = patterns(GetLifecycleAction.NAME, GetStatusAction.NAME);
+    private static final Automaton MANAGE_SLM_AUTOMATON =
+        patterns("cluster:admin/slm/*", StartILMAction.NAME, StopILMAction.NAME, GetStatusAction.NAME);
+    private static final Automaton READ_SLM_AUTOMATON = patterns(GetSnapshotLifecycleAction.NAME, GetStatusAction.NAME);
 
     public static final ClusterPrivilege NONE =                  new ClusterPrivilege("none",                Automatons.EMPTY);
     public static final ClusterPrivilege ALL =                   new ClusterPrivilege("all",                 ALL_CLUSTER_AUTOMATON);
@@ -90,6 +96,8 @@ public final class ClusterPrivilege extends Privilege {
     public static final ClusterPrivilege CREATE_SNAPSHOT =       new ClusterPrivilege("create_snapshot", CREATE_SNAPSHOT_AUTOMATON);
     public static final ClusterPrivilege MANAGE_ILM =            new ClusterPrivilege("manage_ilm", MANAGE_ILM_AUTOMATON);
     public static final ClusterPrivilege READ_ILM =              new ClusterPrivilege("read_ilm", READ_ILM_AUTOMATON);
+    public static final ClusterPrivilege MANAGE_SLM =            new ClusterPrivilege("manage_slm", MANAGE_SLM_AUTOMATON);
+    public static final ClusterPrivilege READ_SLM =              new ClusterPrivilege("read_slm", READ_SLM_AUTOMATON);
 
     public static final Predicate<String> ACTION_MATCHER = ClusterPrivilege.ALL.predicate();
 
@@ -119,6 +127,8 @@ public final class ClusterPrivilege extends Privilege {
             .put("create_snapshot", CREATE_SNAPSHOT)
             .put("manage_ilm", MANAGE_ILM)
             .put("read_ilm", READ_ILM)
+            .put("manage_slm", MANAGE_SLM)
+            .put("read_slm", READ_SLM)
             .immutableMap();
 
     private static final ConcurrentHashMap<Set<String>, ClusterPrivilege> CACHE = new ConcurrentHashMap<>();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/PrivilegeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/PrivilegeTests.java
@@ -204,4 +204,32 @@ public class PrivilegeTests extends ESTestCase {
             assertThat(predicate.test("indices:admin/whatever"), is(false));
         }
     }
+
+    public void testSlmPriviledges() {
+        {
+            Predicate<String> predicate = ClusterPrivilege.MANAGE_SLM.predicate();
+            // check cluster actions
+            assertThat(predicate.test("cluster:admin/slm/delete"), is(true));
+            assertThat(predicate.test("cluster:admin/slm/put"), is(true));
+            assertThat(predicate.test("cluster:admin/slm/get"), is(true));
+            assertThat(predicate.test("cluster:admin/ilm/start"), is(true));
+            assertThat(predicate.test("cluster:admin/ilm/stop"), is(true));
+            assertThat(predicate.test("cluster:admin/ilm/operation_mode/get"), is(true));
+            // check non-slm action
+            assertThat(predicate.test("cluster:admin/whatever"), is(false));
+        }
+
+        {
+            Predicate<String> predicate = ClusterPrivilege.READ_SLM.predicate();
+            // check cluster actions
+            assertThat(predicate.test("cluster:admin/slm/delete"), is(false));
+            assertThat(predicate.test("cluster:admin/slm/put"), is(false));
+            assertThat(predicate.test("cluster:admin/slm/get"), is(true));
+            assertThat(predicate.test("cluster:admin/ilm/start"), is(false));
+            assertThat(predicate.test("cluster:admin/ilm/stop"), is(false));
+            assertThat(predicate.test("cluster:admin/ilm/operation_mode/get"), is(true));
+            // check non-slm action
+            assertThat(predicate.test("cluster:admin/whatever"), is(false));
+        }
+    }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/PrivilegeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/PrivilegeTests.java
@@ -214,6 +214,7 @@ public class PrivilegeTests extends ESTestCase {
             assertThat(predicate.test("cluster:admin/slm/get"), is(true));
             assertThat(predicate.test("cluster:admin/ilm/start"), is(true));
             assertThat(predicate.test("cluster:admin/ilm/stop"), is(true));
+            assertThat(predicate.test("cluster:admin/ilm/execute"), is(true));
             assertThat(predicate.test("cluster:admin/ilm/operation_mode/get"), is(true));
             // check non-slm action
             assertThat(predicate.test("cluster:admin/whatever"), is(false));
@@ -227,6 +228,7 @@ public class PrivilegeTests extends ESTestCase {
             assertThat(predicate.test("cluster:admin/slm/get"), is(true));
             assertThat(predicate.test("cluster:admin/ilm/start"), is(false));
             assertThat(predicate.test("cluster:admin/ilm/stop"), is(false));
+            assertThat(predicate.test("cluster:admin/ilm/execute"), is(false));
             assertThat(predicate.test("cluster:admin/ilm/operation_mode/get"), is(true));
             // check non-slm action
             assertThat(predicate.test("cluster:admin/whatever"), is(false));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/PrivilegeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/PrivilegeTests.java
@@ -214,7 +214,7 @@ public class PrivilegeTests extends ESTestCase {
             assertThat(predicate.test("cluster:admin/slm/get"), is(true));
             assertThat(predicate.test("cluster:admin/ilm/start"), is(true));
             assertThat(predicate.test("cluster:admin/ilm/stop"), is(true));
-            assertThat(predicate.test("cluster:admin/ilm/execute"), is(true));
+            assertThat(predicate.test("cluster:admin/slm/execute"), is(true));
             assertThat(predicate.test("cluster:admin/ilm/operation_mode/get"), is(true));
             // check non-slm action
             assertThat(predicate.test("cluster:admin/whatever"), is(false));
@@ -228,7 +228,7 @@ public class PrivilegeTests extends ESTestCase {
             assertThat(predicate.test("cluster:admin/slm/get"), is(true));
             assertThat(predicate.test("cluster:admin/ilm/start"), is(false));
             assertThat(predicate.test("cluster:admin/ilm/stop"), is(false));
-            assertThat(predicate.test("cluster:admin/ilm/execute"), is(false));
+            assertThat(predicate.test("cluster:admin/slm/execute"), is(false));
             assertThat(predicate.test("cluster:admin/ilm/operation_mode/get"), is(true));
             // check non-slm action
             assertThat(predicate.test("cluster:admin/whatever"), is(false));


### PR DESCRIPTION
This adds two more built in roles -

`manage_slm` which has permission to perform any of the SLM actions, as well as
stopping, starting, and retrieving the operation status of ILM.

`read_slm` which has permission to retrieve snapshot lifecycle policies as well
as retrieving the operation status of ILM.

Relates to #38461