### PR TITLE
[DOCS] Escape deprecated[] macro for Asciidoctor migration

### DIFF
--- a/docs/reference/commands/certgen.asciidoc
+++ b/docs/reference/commands/certgen.asciidoc
@@ -3,7 +3,7 @@
 [[certgen]]
 == elasticsearch-certgen
 
-deprecated[6.1,Replaced by <<certutil,`elasticsearch-certutil`>>.]
+deprecated[6.1,"Replaced by <<certutil,`elasticsearch-certutil`>>."]
 
 The `elasticsearch-certgen` command simplifies the creation of certificate
 authorities (CA), certificate signing requests (CSR), and signed certificates


### PR DESCRIPTION
Asciidoctor does not render text following the second comma in `deprecated[]` macros. This escapes the text in the `deprecated[]` macro in preparation for the Asciidoctor migration.

Quotes will be included in the existing AsciiDoc output, but I don't think that's too disruptive. It'll also be removed after the Asciidoctor migration is complete.

Relates to elastic/docs#827