### PR TITLE
[DOCS] Add attribute to escape minimal Portuguese token link in Asciidoctor

### DIFF
--- a/docs/reference/analysis/tokenfilters/stemmer-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/stemmer-tokenfilter.asciidoc
@@ -1,6 +1,12 @@
 [[analysis-stemmer-tokenfilter]]
 === Stemmer Token Filter
 
+// Adds attribute for the 'minimal_portuguese' stemmer values link.
+// This link contains ~, which is converted to subscript.
+// This attribute prevents that substitution.
+// See https://github.com/asciidoctor/asciidoctor/wiki/How-to-prevent-URLs-containing-formatting-characters-from-getting-mangled
+:min-pt-stemmer-values-url: http://www.inf.ufrgs.br/~buriol/papers/Orengo_CLEF07.pdf
+
 A filter that provides access to (almost) all of the available stemming token
 filters through a single unified interface. For example:
 
@@ -158,7 +164,7 @@ Portuguese::
 
 http://snowball.tartarus.org/algorithms/portuguese/stemmer.html[`portuguese`],
 http://dl.acm.org/citation.cfm?id=1141523&dl=ACM&coll=DL&CFID=179095584&CFTOKEN=80067181[*`light_portuguese`*],
-http://www.inf.ufrgs.br/\~buriol/papers/Orengo_CLEF07.pdf[`minimal_portuguese`],
+{min-pt-stemmer-values-url}[`minimal_portuguese`],
 http://www.inf.ufrgs.br/\~viviane/rslp/index.htm[`portuguese_rslp`]
 
 Romanian::


### PR DESCRIPTION
Adds an attribute for the 'minimal_portuguese' stemmer values link.

The current link contains `~`, which is converted to subscript in Asciidoctor. This attribute prevents that substitution to prepare for the Asciidoctor migration.

The current AsciiDoc implementation escapes the `~` character with `\`, but Asciidoctor renders the `\` literally.

Relates to elastic/docs#827