### PR TITLE
[DOCS] Add `:` to render multiple inline macros in Asciidoctor

### DIFF
--- a/docs/reference/settings/notification-settings.asciidoc
+++ b/docs/reference/settings/notification-settings.asciidoc
@@ -35,8 +35,14 @@ required. For more information, see
 {xpack-ref}/encrypting-data.html[Encrypting sensitive data in {watcher}].
 
 `xpack.watcher.history.cleaner_service.enabled`::
+ifdef::asciidoctor[]
 added:[6.3.0,Default changed to `true`.]
 deprecated:[7.0.0,Watcher history indices are now managed by the `watch-history-ilm-policy` ILM policy]
+endif::[]
+ifndef::asciidoctor[]
+added[6.3.0,Default changed to `true`.]
+deprecated[7.0.0,Watcher history indices are now managed by the `watch-history-ilm-policy` ILM policy]
+endif::[]
 +
 Set to `true` (default) to enable the cleaner service. If this setting is
 `true`, the `xpack.monitoring.enabled` setting must also be set to `true` with

--- a/docs/reference/settings/notification-settings.asciidoc
+++ b/docs/reference/settings/notification-settings.asciidoc
@@ -35,10 +35,8 @@ required. For more information, see
 {xpack-ref}/encrypting-data.html[Encrypting sensitive data in {watcher}].
 
 `xpack.watcher.history.cleaner_service.enabled`::
-// {empty} attributes are included so both macros render as intended.
-// Removing the attributes will break their display in Asciidoctor.
-added[6.3.0,Default changed to `true`.] {empty}
-deprecated[7.0.0,Watcher history indices are now managed by the `watch-history-ilm-policy` ILM policy] {empty}
+added:[6.3.0,Default changed to `true`.]
+deprecated:[7.0.0,Watcher history indices are now managed by the `watch-history-ilm-policy` ILM policy]
 +
 Set to `true` (default) to enable the cleaner service. If this setting is
 `true`, the `xpack.monitoring.enabled` setting must also be set to `true` with

--- a/docs/reference/settings/notification-settings.asciidoc
+++ b/docs/reference/settings/notification-settings.asciidoc
@@ -35,8 +35,10 @@ required. For more information, see
 {xpack-ref}/encrypting-data.html[Encrypting sensitive data in {watcher}].
 
 `xpack.watcher.history.cleaner_service.enabled`::
-added[6.3.0,Default changed to `true`.]
-deprecated[7.0.0,Watcher history indices are now managed by the `watch-history-ilm-policy` ILM policy]
+// {empty} attributes are included so both macros render as intended.
+// Removing the attributes will break their display in Asciidoctor.
+added[6.3.0,Default changed to `true`.] {empty}
+deprecated[7.0.0,Watcher history indices are now managed by the `watch-history-ilm-policy` ILM policy] {empty}
 +
 Set to `true` (default) to enable the cleaner service. If this setting is
 `true`, the `xpack.monitoring.enabled` setting must also be set to `true` with


### PR DESCRIPTION
Without some breaking text, Asciidoctor cannot render two consecutive inline macros without an `:` character. This adds that character so both AsciiDoc and AsciiDoctor render the macros as intended.

Relates to /elastic/docs#827

### Asciidoctor before changes
<img width="767" alt="Screen Shot 2019-04-26 at 5 37 11 PM" src="https://user-images.githubusercontent.com/40268737/56837854-f1320800-6849-11e9-939a-b0a0cae31641.png">

### Asciidoctor after changes
<img width="754" alt="Screen Shot 2019-04-26 at 5 35 08 PM" src="https://user-images.githubusercontent.com/40268737/56837797-ac0dd600-6849-11e9-8971-2d488df53780.png">

### AsciiDoc after changes
<img width="764" alt="Screen Shot 2019-04-26 at 5 34 49 PM" src="https://user-images.githubusercontent.com/40268737/56837780-9c8e8d00-6849-11e9-9a7f-20ba56c9a3fc.png">