### PR TITLE
[DOCS] Remove line break from deprecated[] macro

### DIFF
--- a/docs/reference/settings/monitoring-settings.asciidoc
+++ b/docs/reference/settings/monitoring-settings.asciidoc
@@ -55,8 +55,7 @@ ignored.
 `xpack.monitoring.collection.interval` (<<cluster-update-settings,Dynamic>>):: 
 
 Setting to `-1` to disable data collection is no longer supported beginning with
-7.0.0. deprecated[6.3.0, Use `xpack.monitoring.collection.enabled` set to
-`false` instead.]
+7.0.0. deprecated[6.3.0, Use `xpack.monitoring.collection.enabled` set to `false` instead.]
 +
 Controls how often data samples are collected. Defaults to `10s`. If you
 modify the collection interval, set the `xpack.monitoring.min_interval_seconds`


### PR DESCRIPTION
Asciidoctor does not render macros containing line breaks. This removes the line break from the `deprecated[]` macro in preparation for the Asciidoctor migration.

Relates to elastic/docs#827

### Asciidoctor before changes
<img width="703" alt="Asciidoctor-before" src="https://user-images.githubusercontent.com/40268737/56838441-fbed9c80-684b-11e9-91d8-21a11d063374.png">

### Asciidoctor after changes
<img width="721" alt="Asciidoctor-after" src="https://user-images.githubusercontent.com/40268737/56838447-014ae700-684c-11e9-99d5-d57a7faf3ac5.png">

### AsciiDoc after changes
<img width="727" alt="AsciiDoc-after" src="https://user-images.githubusercontent.com/40268737/56838455-09a32200-684c-11e9-94fe-73acff58fd45.png">