### PR TITLE
Suppress illegal access in plugin install

### DIFF
--- a/distribution/src/bin/elasticsearch-plugin
+++ b/distribution/src/bin/elasticsearch-plugin
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-ES_MAIN_CLASS=org.elasticsearch.plugins.PluginCli \
+ES_JAVA_OPTS="--add-opens java.base/sun.security.provider=ALL-UNNAMED $ES_JAVA_OPTS" \
+  ES_MAIN_CLASS=org.elasticsearch.plugins.PluginCli \
   ES_ADDITIONAL_CLASSPATH_DIRECTORIES=lib/tools/plugin-cli \
   "`dirname "$0"`"/elasticsearch-cli \
   "$@"

--- a/distribution/src/bin/elasticsearch-plugin.bat
+++ b/distribution/src/bin/elasticsearch-plugin.bat
@@ -3,6 +3,7 @@
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
+set ES_JAVA_OPTS="--add-opens java.base/sun.security.provider=ALL-UNNAMED %ES_JAVA_OPTS%"
 set ES_MAIN_CLASS=org.elasticsearch.plugins.PluginCli
 set ES_ADDITIONAL_CLASSPATH_DIRECTORIES=lib/tools/plugin-cli
 call "%~dp0elasticsearch-cli.bat" ^


### PR DESCRIPTION
We use Bouncy Castle to verify signatures when installing official plugins. This leads to illegal access warnings because Bouncy Castle accesses the Sun security provider constructor. This commit adds an add-opens flag to suppress this illegal access.

Relates #41478