### PR TITLE
Change JDK distribution source

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -405,7 +405,7 @@ def windows_common(config, name)
 
   config.vm.provision 'windows-jdk-11', type: 'shell', inline: <<-SHELL
     New-Item -ItemType Directory -Force -Path "C:/java"
-    Invoke-WebRequest "https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_windows-x64_bin.zip" -OutFile "C:/java/jdk-11.zip"
+    Invoke-WebRequest "https://download.oracle.com/java/GA/jdk11/9/GPL/openjdk-11.0.2_windows-x64_bin.zip" -OutFile "C:/java/jdk-11.zip"
     Expand-Archive -Path "C:/java/jdk-11.zip" -DestinationPath "C:/java/"
   SHELL
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -244,7 +244,7 @@ def linux_common(config,
   SHELL
 
   config.vm.provision 'jdk-11', type: 'shell', inline: <<-SHELL
-    curl -sSL https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz | tar xz -C /opt/
+    curl -sSL https://download.oracle.com/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz | tar xz -C /opt/
   SHELL
 
   # This prevents leftovers from previous tests using the

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -235,7 +235,7 @@ String jdkBuild = jdkVersionMatcher.group(3)
 
 repositories {
   ivy {
-    url "https://download.java.net"
+    url "https://download.oracle.com"
     patternLayout {
       artifact "java/GA/jdk${jdkMajor}/${jdkBuild}/GPL/openjdk-[revision]_[module]-x64_bin.[ext]"
     }


### PR DESCRIPTION
We had been obtaining JDK distributions from download.java.net. This site is now presenting a certificate that does not list download.java.net as a SAN. Therefore with host verification, the build can not use this site. This commit switches to using download.oracle.com which appears to be an alternative name for the same CNAME download.oracle.com.edgekey.net. This allows our builds to resume.