### PR TITLE
Bump the bundled JDK to 12.0.1

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -405,7 +405,7 @@ def windows_common(config, name)
 
   config.vm.provision 'windows-jdk-11', type: 'shell', inline: <<-SHELL
     New-Item -ItemType Directory -Force -Path "C:/java"
-    Invoke-WebRequest "https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_windows-x64_bin.zip" -OutFile "C:/java/jdk-11.zip"
+    Invoke-WebRequest "https://download.oracle.com/java/GA/jdk11/9/GPL/openjdk-11.0.2_windows-x64_bin.zip" -OutFile "C:/java/jdk-11.zip"
     Expand-Archive -Path "C:/java/jdk-11.zip" -DestinationPath "C:/java/"
   SHELL
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -244,7 +244,7 @@ def linux_common(config,
   SHELL
 
   config.vm.provision 'jdk-11', type: 'shell', inline: <<-SHELL
-    curl -sSL https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz | tar xz -C /opt/
+    curl -sSL https://download.oracle.com/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz | tar xz -C /opt/
   SHELL
 
   # This prevents leftovers from previous tests using the

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -1,7 +1,7 @@
 elasticsearch     = 8.0.0
 lucene            = 8.1.0-snapshot-e460356abe
 
-bundled_jdk       = 12+33
+bundled_jdk       = 12.0.1+12@69cfe15208a647278a19ef0990eea691
 
 # optional dependencies
 spatial4j         = 0.7

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -224,7 +224,7 @@ xpack.subprojects.findAll { it.parent == xpack }.each { Project xpackModule ->
  *****************************************************************************/
 // extract the bundled jdk version, broken into elements as: [feature, interim, update, build]
 // Note the "patch" version is not yet handled here, as it has not yet been used by java.
-Pattern JDK_VERSION = Pattern.compile("(\\d+)(\\.\\d+\\.\\d+)?\\+(\\d+)")
+Pattern JDK_VERSION = Pattern.compile("(\\d+)(\\.\\d+\\.\\d+)?\\+(\\d+)@([a-f0-9]{32})?")
 Matcher jdkVersionMatcher = JDK_VERSION.matcher(VersionProperties.bundledJdk)
 if (jdkVersionMatcher.matches() == false) {
   throw new IllegalArgumentException("Malformed jdk version [" + VersionProperties.bundledJdk + "]")
@@ -232,12 +232,21 @@ if (jdkVersionMatcher.matches() == false) {
 String jdkVersion = jdkVersionMatcher.group(1) + (jdkVersionMatcher.group(2) != null ? (jdkVersionMatcher.group(2)) : "")
 String jdkMajor = jdkVersionMatcher.group(1)
 String jdkBuild = jdkVersionMatcher.group(3)
+String hash = jdkVersionMatcher.group(4)
 
 repositories {
+  // simpler legacy pattern from JDK 9 to JDK 12 that we are advocating to Oracle to bring back
   ivy {
-    url "https://download.java.net"
+    url "https://download.oracle.com"
     patternLayout {
       artifact "java/GA/jdk${jdkMajor}/${jdkBuild}/GPL/openjdk-[revision]_[module]-x64_bin.[ext]"
+    }
+  }
+  // current pattern since 12.0.1
+  ivy {
+    url "https://download.oracle.com"
+    patternLayout {
+      artifact "java/GA/jdk${jdkVersion}/${hash}/${jdkBuild}/GPL/openjdk-[revision]_[module]-x64_bin.[ext]"
     }
   }
 }


### PR DESCRIPTION
This commit bumps the bundled JDK to version 12.0.1. Note that we had to add a new pattern here as Oracle has changed the source of the builds. This commit will be backported to 6.7 in a different form to bump the bundled JDK in the Docker images too.
