### PR TITLE
Ensure a unique WatchId for tests in SmokeTestWatcherWithSecurityIT

### DIFF
--- a/x-pack/qa/smoke-test-watcher-with-security/src/test/java/org/elasticsearch/smoketest/SmokeTestWatcherWithSecurityIT.java
+++ b/x-pack/qa/smoke-test-watcher-with-security/src/test/java/org/elasticsearch/smoketest/SmokeTestWatcherWithSecurityIT.java
@@ -6,7 +6,6 @@
 package org.elasticsearch.smoketest;
 
 import org.apache.http.util.EntityUtils;
-import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.Strings;

--- a/x-pack/qa/src/main/java/org/elasticsearch/xpack/test/rest/XPackRestTestConstants.java
+++ b/x-pack/qa/src/main/java/org/elasticsearch/xpack/test/rest/XPackRestTestConstants.java
@@ -11,13 +11,9 @@ public final class XPackRestTestConstants {
 
     // Watcher constants:
     public static final String INDEX_TEMPLATE_VERSION = "9";
-    public static final String HISTORY_TEMPLATE_NAME = ".watch-history-" + INDEX_TEMPLATE_VERSION;
     public static final String HISTORY_TEMPLATE_NAME_NO_ILM = ".watch-history-no-ilm-" + INDEX_TEMPLATE_VERSION;
     public static final String TRIGGERED_TEMPLATE_NAME = ".triggered_watches";
     public static final String WATCHES_TEMPLATE_NAME = ".watches";
-    public static final String[] TEMPLATE_NAMES = new String[] {
-        HISTORY_TEMPLATE_NAME, TRIGGERED_TEMPLATE_NAME, WATCHES_TEMPLATE_NAME
-    };
     public static final String[] TEMPLATE_NAMES_NO_ILM = new String[] {
         HISTORY_TEMPLATE_NAME_NO_ILM, TRIGGERED_TEMPLATE_NAME, WATCHES_TEMPLATE_NAME
     };


### PR DESCRIPTION
This commit un-mutes SmokeTestWatcherWithSecurityIT by ensuring that between test invocations
a new WatchId is used. It is believed that since the same WatchId is used between tests,
and that Watch is never deleted, the test failures may be due to a race condition between
the current Watch execution, the new Watch (with the same ID), and the busy wait for the
Watcher history document.

This race condtion can be avoided by simply using a new WatchId and removing the Watch
between test invocations.

This commit also adds a minor change (XPackRestTestConstants.TEMPLATE_NAMES_NO_ILM) that is
needed since the test was muted.

Fixes #35361
Fixes #30777
Fixes #35361
Fixes #33291
Fixes #29893

-------
Draft PR to manually run this through CI a few times. 