### PR TITLE
Mute tests for backport #41673

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -180,7 +180,7 @@ public final class TokenService {
     private static final String TOKEN_DOC_ID_PREFIX = TOKEN_DOC_TYPE + "_";
     static final int MINIMUM_BYTES = VERSION_BYTES + SALT_BYTES + IV_BYTES + 1;
     static final int MINIMUM_BASE64_BYTES = Double.valueOf(Math.ceil((4 * MINIMUM_BYTES) / 3)).intValue();
-    static final Version VERSION_TOKENS_INDEX_INTRODUCED = Version.V_8_0_0; // TODO change upon backport
+    static final Version VERSION_TOKENS_INDEX_INTRODUCED = Version.V_7_1_0;
     static final Version VERSION_ACCESS_TOKENS_AS_UUIDS = Version.V_7_1_0;
     static final Version VERSION_MULTIPLE_CONCURRENT_REFRESHES = Version.V_7_1_0;
     // UUIDs are 16 bytes encoded base64 without padding, therefore the length is (16 / 3) * 4 + ((16 % 3) * 8 + 5) / 6 chars

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TokenBackwardsCompatibilityIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TokenBackwardsCompatibilityIT.java
@@ -7,6 +7,7 @@ package org.elasticsearch.upgrades;
 
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpHost;
+import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
@@ -25,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/41673")
 public class TokenBackwardsCompatibilityIT extends AbstractUpgradeTestCase {
 
     private Collection<RestClient> twoClients = null;

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/50_token_auth.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/50_token_auth.yml
@@ -2,6 +2,8 @@
 "Get the indexed token and use if to authenticate":
   - skip:
       features: headers
+      version: "all"
+      reason: "Backport https://github.com/elastic/elasticsearch/pull/41673"
 
   - do:
       cluster.health:
@@ -59,6 +61,8 @@
 "Get the indexed refreshed access token and use if to authenticate":
   - skip:
       features: headers
+      version: "all"
+      reason: "Backport https://github.com/elastic/elasticsearch/pull/41673"
 
   - do:
       get:
@@ -111,6 +115,8 @@
 "Get the indexed refresh token and use it to get another access token and authenticate":
   - skip:
       features: headers
+      version: "all"
+      reason: "Backport https://github.com/elastic/elasticsearch/pull/41673"
 
   - do:
       get:

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/50_token_auth.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/50_token_auth.yml
@@ -2,6 +2,8 @@
 "Create a token and reuse it across the upgrade":
   - skip:
       features: headers
+      version: "all"
+      reason: "Backport https://github.com/elastic/elasticsearch/pull/41673"
 
   - do:
       cluster.health:

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/50_token_auth.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/50_token_auth.yml
@@ -2,6 +2,8 @@
 "Get the indexed token and use if to authenticate":
   - skip:
       features: headers
+      version: "all"
+      reason: "Backport https://github.com/elastic/elasticsearch/pull/41673"
 
   - do:
       cluster.health:
@@ -49,6 +51,8 @@
 "Get the indexed refresh token and use if to get another access token and authenticate":
   - skip:
       features: headers
+      version: "all"
+      reason: "Backport https://github.com/elastic/elasticsearch/pull/41673"
 
   - do:
       get:


### PR DESCRIPTION
Mutes security tokens BWC tests for the https://github.com/elastic/elasticsearch/pull/41673  backport.