### PR TITLE
[ML] data frame, adding builder classes for complex config classes (#…

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformConfig.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformConfig.java
@@ -87,11 +87,11 @@ public class DataFrameTransformConfig implements ToXContentObject {
         return new DataFrameTransformConfig(null, source, null, pivotConfig, null);
     }
 
-    public DataFrameTransformConfig(final String id,
-                                    final SourceConfig source,
-                                    final DestConfig dest,
-                                    final PivotConfig pivotConfig,
-                                    final String description) {
+    DataFrameTransformConfig(final String id,
+                             final SourceConfig source,
+                             final DestConfig dest,
+                             final PivotConfig pivotConfig,
+                             final String description) {
         this.id = id;
         this.source = source;
         this.dest = dest;
@@ -169,5 +169,47 @@ public class DataFrameTransformConfig implements ToXContentObject {
     @Override
     public String toString() {
         return Strings.toString(this, true, true);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String id;
+        private SourceConfig source;
+        private DestConfig dest;
+        private PivotConfig pivotConfig;
+        private String description;
+
+        public Builder setId(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder setSource(SourceConfig source) {
+            this.source = source;
+            return this;
+        }
+
+        public Builder setDest(DestConfig dest) {
+            this.dest = dest;
+            return this;
+        }
+
+        public Builder setPivotConfig(PivotConfig pivotConfig) {
+            this.pivotConfig = pivotConfig;
+            return this;
+        }
+
+        public Builder setDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public DataFrameTransformConfig build() {
+            return new DataFrameTransformConfig(id, source, dest, pivotConfig, description);
+        }
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/SourceConfig.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/SourceConfig.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -76,7 +77,7 @@ public class SourceConfig implements ToXContentObject {
      * @param index Any number of indices. At least one non-null, non-empty, index should be provided
      * @param queryConfig A QueryConfig object that contains the desired query. Defaults to MatchAll query.
      */
-    public SourceConfig(String[] index, QueryConfig queryConfig) {
+    SourceConfig(String[] index, QueryConfig queryConfig) {
         this.index = index;
         this.queryConfig = queryConfig;
     }
@@ -120,5 +121,47 @@ public class SourceConfig implements ToXContentObject {
         // Using Arrays.hashCode as Objects.hash does not deeply hash nested arrays. Since we are doing Array.equals, this is necessary
         int hash = Arrays.hashCode(index);
         return 31 * hash + (queryConfig == null ? 0 : queryConfig.hashCode());
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String[] index;
+        private QueryConfig queryConfig;
+
+        /**
+         * Sets what indices from which to fetch data
+         * @param index The indices from which to fetch data
+         * @return The {@link Builder} with indices set
+         */
+        public Builder setIndex(String... index) {
+            this.index = index;
+            return this;
+        }
+
+        /**
+         * Sets the {@link QueryConfig} object that references the desired query to use when fetching the data
+         * @param queryConfig The {@link QueryConfig} to use when fetching data
+         * @return The {@link Builder} with queryConfig set
+         */
+        public Builder setQueryConfig(QueryConfig queryConfig) {
+            this.queryConfig = queryConfig;
+            return this;
+        }
+
+        /**
+         * Sets the query to use when fetching the data. Convenience method for {@link #setQueryConfig(QueryConfig)}
+         * @param query The {@link QueryBuilder} to use when fetch data (overwrites the {@link QueryConfig})
+         * @return The {@link Builder} with queryConfig set
+         */
+        public Builder setQuery(QueryBuilder query) {
+            return this.setQueryConfig(new QueryConfig(query));
+        }
+
+        public SourceConfig build() {
+            return new SourceConfig(index, queryConfig);
+        }
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/pivot/GroupConfig.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/pivot/GroupConfig.java
@@ -26,12 +26,16 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
+/**
+ * Class describing how to group data
+ */
 public class GroupConfig implements ToXContentObject {
 
     private final Map<String, SingleGroupSource> groups;
@@ -126,7 +130,7 @@ public class GroupConfig implements ToXContentObject {
         } while (endObjectCount != 0);
     }
 
-    public GroupConfig(Map<String, SingleGroupSource> groups) {
+    GroupConfig(Map<String, SingleGroupSource> groups) {
         this.groups = groups;
     }
 
@@ -173,5 +177,28 @@ public class GroupConfig implements ToXContentObject {
     @Override
     public String toString() {
         return Strings.toString(this, true, true);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private final Map<String, SingleGroupSource> groups = new HashMap<>();
+
+        /**
+         * Add a new grouping to the builder
+         * @param name The name of the resulting grouped field
+         * @param group The type of grouping referenced
+         * @return The {@link Builder} with a new grouping entry added
+         */
+        public Builder groupBy(String name, SingleGroupSource group) {
+            groups.put(name, group);
+            return this;
+        }
+
+        public GroupConfig build() {
+            return new GroupConfig(groups);
+        }
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/pivot/HistogramGroupSource.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/pivot/HistogramGroupSource.java
@@ -31,6 +31,9 @@ import java.util.Objects;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
+/**
+ * A grouping via a histogram aggregation referencing a numeric field
+ */
 public class HistogramGroupSource extends SingleGroupSource implements ToXContentObject {
 
     protected static final ParseField INTERVAL = new ParseField("interval");
@@ -49,7 +52,7 @@ public class HistogramGroupSource extends SingleGroupSource implements ToXConten
 
     private final double interval;
 
-    public HistogramGroupSource(String field, double interval) {
+    HistogramGroupSource(String field, double interval) {
         super(field);
         if (interval <= 0) {
             throw new IllegalArgumentException("[interval] must be greater than 0.");
@@ -96,5 +99,39 @@ public class HistogramGroupSource extends SingleGroupSource implements ToXConten
     @Override
     public int hashCode() {
         return Objects.hash(field, interval);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String field;
+        private double interval;
+
+        /**
+         * The field to reference in the histogram grouping
+         * @param field The numeric field name to use in the histogram grouping
+         * @return The {@link Builder} with the field set.
+         */
+        public Builder setField(String field) {
+            this.field = field;
+            return this;
+        }
+
+        /**
+         * Set the interval for the histogram aggregation
+         * @param interval The numeric interval for the histogram grouping
+         * @return The {@link Builder} with the interval set.
+         */
+        public Builder setInterval(double interval) {
+            this.interval = interval;
+            return this;
+        }
+
+        public HistogramGroupSource build() {
+            return new HistogramGroupSource(field, interval);
+        }
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/pivot/PivotConfig.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/pivot/PivotConfig.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -31,6 +32,9 @@ import java.util.Objects;
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
+/**
+ * Class describing how to pivot data via {@link GroupConfig} and {@link AggregationConfig} objects
+ */
 public class PivotConfig implements ToXContentObject {
 
     private static final ParseField GROUP_BY = new ParseField("group_by");
@@ -51,7 +55,7 @@ public class PivotConfig implements ToXContentObject {
         return PARSER.apply(parser, null);
     }
 
-    public PivotConfig(GroupConfig groups, final AggregationConfig aggregationConfig) {
+    PivotConfig(GroupConfig groups, final AggregationConfig aggregationConfig) {
         this.groups = groups;
         this.aggregationConfig = aggregationConfig;
     }
@@ -95,5 +99,48 @@ public class PivotConfig implements ToXContentObject {
 
     public boolean isValid() {
         return groups.isValid() && aggregationConfig.isValid();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private GroupConfig groups;
+        private AggregationConfig aggregationConfig;
+
+        /**
+         * Set how to group the source data
+         * @param groups The configuration describing how to group and pivot the source data
+         * @return the {@link Builder} with the interval set.
+         */
+        public Builder setGroups(GroupConfig groups) {
+            this.groups = groups;
+            return this;
+        }
+
+        /**
+         * Set the aggregated fields to include in the pivot config
+         * @param aggregationConfig The configuration describing the aggregated fields
+         * @return the {@link Builder} with the aggregations set.
+         */
+        public Builder setAggregationConfig(AggregationConfig aggregationConfig) {
+            this.aggregationConfig = aggregationConfig;
+            return this;
+        }
+
+        /**
+         * Set the aggregated fields to include in the pivot config
+         * @param aggregations The aggregated field builders
+         * @return the {@link Builder} with the aggregations set.
+         */
+        public Builder setAggregations(AggregatorFactories.Builder aggregations) {
+            this.aggregationConfig = new AggregationConfig(aggregations);
+            return this;
+        }
+
+        public PivotConfig build() {
+            return new PivotConfig(groups, aggregationConfig);
+        }
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/pivot/TermsGroupSource.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/pivot/TermsGroupSource.java
@@ -42,7 +42,7 @@ public class TermsGroupSource extends SingleGroupSource implements ToXContentObj
         return PARSER.apply(parser, null);
     }
 
-    public TermsGroupSource(final String field) {
+    TermsGroupSource(final String field) {
         super(field);
     }
 
@@ -59,5 +59,28 @@ public class TermsGroupSource extends SingleGroupSource implements ToXContentObj
         }
         builder.endObject();
         return builder;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String field;
+
+        /**
+         * The field with which to construct the date histogram grouping
+         * @param field The field name
+         * @return The {@link Builder} with the field set.
+         */
+        public Builder setField(String field) {
+            this.field = field;
+            return this;
+        }
+
+        public TermsGroupSource build() {
+            return new TermsGroupSource(field);
+        }
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/PreviewDataFrameTransformRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/PreviewDataFrameTransformRequestTests.java
@@ -70,7 +70,7 @@ public class PreviewDataFrameTransformRequestTests extends AbstractXContentTestC
         assertFalse(new PreviewDataFrameTransformRequest(config).validate().isPresent());
 
         // null source is not valid
-        config = new DataFrameTransformConfig(null, null, null, PivotConfigTests.randomPivotConfig(), null);
+        config = DataFrameTransformConfig.builder().setPivotConfig(PivotConfigTests.randomPivotConfig()).build();
 
         Optional<ValidationException> error = new PreviewDataFrameTransformRequest(config).validate();
         assertTrue(error.isPresent());

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/PutDataFrameTransformRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/PutDataFrameTransformRequestTests.java
@@ -40,7 +40,7 @@ public class PutDataFrameTransformRequestTests extends AbstractXContentTestCase<
     public void testValidate() {
         assertFalse(createTestInstance().validate().isPresent());
 
-        DataFrameTransformConfig config = new DataFrameTransformConfig(null, null, null, PivotConfigTests.randomPivotConfig(), null);
+        DataFrameTransformConfig config = DataFrameTransformConfig.builder().setPivotConfig(PivotConfigTests.randomPivotConfig()).build();
 
         Optional<ValidationException> error = new PutDataFrameTransformRequest(config).validate();
         assertTrue(error.isPresent());

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/pivot/DateHistogramGroupSourceTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/pivot/DateHistogramGroupSourceTests.java
@@ -29,20 +29,13 @@ public class DateHistogramGroupSourceTests extends AbstractXContentTestCase<Date
 
     public static DateHistogramGroupSource randomDateHistogramGroupSource() {
         String field = randomAlphaOfLengthBetween(1, 20);
-        DateHistogramGroupSource dateHistogramGroupSource = new DateHistogramGroupSource(field);
-        if (randomBoolean()) {
-            dateHistogramGroupSource.setInterval(randomLongBetween(1, 10_000));
-        } else {
-            dateHistogramGroupSource.setDateHistogramInterval(randomFrom(DateHistogramInterval.days(10),
-                    DateHistogramInterval.minutes(1), DateHistogramInterval.weeks(1)));
-        }
-        if (randomBoolean()) {
-            dateHistogramGroupSource.setTimeZone(randomZone());
-        }
-        if (randomBoolean()) {
-            dateHistogramGroupSource.setFormat(randomAlphaOfLength(10));
-        }
-        return dateHistogramGroupSource;
+        boolean setInterval = randomBoolean();
+        return new DateHistogramGroupSource(field,
+            setInterval ? randomLongBetween(1, 10_000) : 0,
+            setInterval ? null : randomFrom(DateHistogramInterval.days(10),
+                DateHistogramInterval.minutes(1), DateHistogramInterval.weeks(1)),
+            randomBoolean() ? randomAlphaOfLength(10) : null,
+            randomBoolean() ? randomZone() : null);
     }
 
     @Override


### PR DESCRIPTION
There are many ways to make the use of data frames simpler through the HLRC.

A step in the right direction is providing fluent builders for each of the more complicated configs.

backport of  #41638