### PR TITLE
Add details to BulkShardRequest#getDescription()

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkShardRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkShardRequest.java
@@ -115,7 +115,15 @@ public class BulkShardRequest extends ReplicatedWriteRequest<BulkShardRequest> {
 
     @Override
     public String getDescription() {
-        return "requests[" + items.length + "], index[" + index + "]";
+        final StringBuilder stringBuilder = new StringBuilder().append("requests[").append(items.length).append("], index").append(shardId);
+        final RefreshPolicy refreshPolicy = getRefreshPolicy();
+        switch (refreshPolicy) {
+            case IMMEDIATE:
+            case WAIT_UNTIL:
+                stringBuilder.append(", refresh[").append(refreshPolicy).append(']');
+                break;
+        }
+        return stringBuilder.toString();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkShardRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkShardRequest.java
@@ -117,11 +117,8 @@ public class BulkShardRequest extends ReplicatedWriteRequest<BulkShardRequest> {
     public String getDescription() {
         final StringBuilder stringBuilder = new StringBuilder().append("requests[").append(items.length).append("], index").append(shardId);
         final RefreshPolicy refreshPolicy = getRefreshPolicy();
-        switch (refreshPolicy) {
-            case IMMEDIATE:
-            case WAIT_UNTIL:
-                stringBuilder.append(", refresh[").append(refreshPolicy).append(']');
-                break;
+        if (refreshPolicy == RefreshPolicy.IMMEDIATE || refreshPolicy == RefreshPolicy.WAIT_UNTIL) {
+            stringBuilder.append(", refresh[").append(refreshPolicy).append(']');
         }
         return stringBuilder.toString();
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
@@ -320,22 +320,20 @@ public class TasksIT extends ESIntegTestCase {
             shardTask = shardTasks.get(0);
             // and it should have the main task as a parent
             assertParentTask(shardTask, findEvents(BulkAction.NAME, Tuple::v1).get(0));
-            assertEquals("requests[1], index[test]", shardTask.getDescription());
         } else {
             if (shardTasks.get(0).getParentTaskId().equals(shardTasks.get(1).getTaskId())) {
                 // task 1 is the parent of task 0, that means that task 0 will control [s][p] and [s][r] tasks
                  shardTask = shardTasks.get(0);
                 // in turn the parent of the task 1 should be the main task
                 assertParentTask(shardTasks.get(1), findEvents(BulkAction.NAME, Tuple::v1).get(0));
-                assertEquals("requests[1], index[test]", shardTask.getDescription());
             } else {
                 // otherwise task 1 will control [s][p] and [s][r] tasks
                 shardTask = shardTasks.get(1);
                 // in turn the parent of the task 0 should be the main task
                 assertParentTask(shardTasks.get(0), findEvents(BulkAction.NAME, Tuple::v1).get(0));
-                assertEquals("requests[1], index[test]", shardTask.getDescription());
             }
         }
+        assertThat(shardTask.getDescription(), startsWith("requests[1], index[test]["));
 
         // we should also get one [s][p] operation with shard operation as a parent
         assertEquals(1, numberOfEvents(BulkAction.NAME + "[s][p]", Tuple::v1));

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkShardRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkShardRequestTests.java
@@ -32,9 +32,14 @@ public class BulkShardRequestTests extends ESTestCase {
         final ShardId shardId = new ShardId(index, "ignored", 0);
         BulkShardRequest r = new BulkShardRequest(shardId, RefreshPolicy.NONE, new BulkItemRequest[count]);
         assertEquals("BulkShardRequest [" + shardId + "] containing [" + count + "] requests", r.toString());
+        assertEquals("requests[" + count + "], index[" + index + "][0]", r.getDescription());
+
         r = new BulkShardRequest(shardId, RefreshPolicy.IMMEDIATE, new BulkItemRequest[count]);
         assertEquals("BulkShardRequest [" + shardId + "] containing [" + count + "] requests and a refresh", r.toString());
+        assertEquals("requests[" + count + "], index[" + index + "][0], refresh[IMMEDIATE]", r.getDescription());
+
         r = new BulkShardRequest(shardId, RefreshPolicy.WAIT_UNTIL, new BulkItemRequest[count]);
         assertEquals("BulkShardRequest [" + shardId + "] containing [" + count + "] requests blocking until refresh", r.toString());
+        assertEquals("requests[" + count + "], index[" + index + "][0], refresh[WAIT_UNTIL]", r.getDescription());
     }
 }


### PR DESCRIPTION
Today a bulk shard request appears as follows in the detailed task list:

    requests[42], index[my_index]

This change adds the shard index and refresh policy too:

    requests[42], index[my_index][2], refresh[IMMEDIATE]