### PR TITLE
[DOCS] Adds ml-cpp PR to 7.0.1 release notes

### DIFF
--- a/docs/reference/release-notes/7.0.asciidoc
+++ b/docs/reference/release-notes/7.0.asciidoc
@@ -15,6 +15,7 @@ Infra/Packaging::
 
 Machine Learning::
 * Allow xpack.ml.max_machine_memory_percent higher than 100% {pull}41193[#41193]
+* Add the "time" system call to the syscall filter {ml-pull}459[#459] (issue: {issue}41101[#41101])
 
 
 


### PR DESCRIPTION
This PR adds https://github.com/elastic/ml-cpp/pull/459 to the 7.0.1 Elasticsearch Release Notes (https://www.elastic.co/guide/en/elasticsearch/reference/7.0/release-notes-7.0.1.html)