### PR TITLE
Fix for full cluster restart tests

### DIFF
--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/RandomizedTestingTask.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/RandomizedTestingTask.groovy
@@ -9,14 +9,13 @@ import org.apache.tools.ant.DefaultLogger
 import org.apache.tools.ant.Project
 import org.apache.tools.ant.RuntimeConfigurable
 import org.apache.tools.ant.UnknownElement
-import org.elasticsearch.gradle.BuildPlugin
 import org.gradle.api.DefaultTask
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileTreeElement
 import org.gradle.api.specs.Spec
+import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
@@ -39,7 +38,7 @@ class RandomizedTestingTask extends DefaultTask {
     File workingDir = new File(project.buildDir, 'testrun' + File.separator + name)
 
     @Optional
-    @Input
+    @Classpath
     FileCollection classpath
 
     @Input
@@ -253,7 +252,7 @@ class RandomizedTestingTask extends DefaultTask {
                 if (argLine != null) {
                     jvmarg(line: argLine)
                 }
-                testClassesDirs.each { testClassDir ->
+                testClassesDirs.filter { it.exists() }.each { testClassDir ->
                     fileset(dir: testClassDir) {
                         patternSet.getIncludes().each { include(name: it) }
                         patternSet.getExcludes().each { exclude(name: it) }

--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -101,6 +101,7 @@ subprojects {
     test {
       mainProject.sourceSets.test.output.classesDirs.each { dir ->
         output.addClassesDir { dir }
+        output.builtBy(mainProject.tasks.testClasses)
       }
       runtimeClasspath += mainProject.sourceSets.test.output
     }

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -92,6 +92,7 @@ subprojects {
     test {
       mainProject.sourceSets.test.output.classesDirs.each { dir ->
         output.addClassesDir { dir }
+        output.builtBy(mainProject.tasks.testClasses)
       }
       runtimeClasspath += mainProject.sourceSets.test.output
     }


### PR DESCRIPTION
This PR fixes some BWC tests on the 6.7 branch that started to break as a result of backporting IntelliJ 2019.1 compatibility changes that were not completely compatible with the old randomized testing task.