### PR TITLE
WIP: Limit TLS write amount

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/nio/SSLDriver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/nio/SSLDriver.java
@@ -429,7 +429,7 @@ public class SSLDriver implements AutoCloseable {
 
     private class ApplicationMode implements Mode {
 
-        private static final int MAX_ENCRYPT_LIMIT = 1 << 17
+        private static final int MAX_ENCRYPT_LIMIT = 1 << 17;
 
         @Override
         public void read(InboundChannelBuffer buffer) throws SSLException {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/nio/SSLDriver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/nio/SSLDriver.java
@@ -429,6 +429,8 @@ public class SSLDriver implements AutoCloseable {
 
     private class ApplicationMode implements Mode {
 
+        private static final int MAX_ENCRYPT_LIMIT = 1 << 17
+
         @Override
         public void read(InboundChannelBuffer buffer) throws SSLException {
             ensureApplicationBufferSize(buffer);
@@ -446,7 +448,7 @@ public class SSLDriver implements AutoCloseable {
         public int write(FlushOperation applicationBytes) throws SSLException {
             boolean continueWrap = true;
             int totalBytesProduced = 0;
-            while (continueWrap && applicationBytes.isFullyFlushed() == false) {
+            while (continueWrap && applicationBytes.isFullyFlushed() == false && totalBytesProduced < MAX_ENCRYPT_LIMIT) {
                 SSLEngineResult result = wrap(outboundBuffer, applicationBytes);
                 int bytesProduced = result.bytesProduced();
                 totalBytesProduced += bytesProduced;


### PR DESCRIPTION
This commit limits the amount that we will encrypte in a single TLS
write call. It is just a POC for benchmarking purposes.