### PR TITLE
[ML-DataFrame] simplify indexer by moving members to base class

### DIFF
--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
@@ -444,11 +444,7 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
         private final DataFrameTransformsConfigManager transformsConfigManager;
         private final DataFrameTransformsCheckpointService transformsCheckpointService;
         private final String transformId;
-        private final DataFrameAuditor auditor;
         private final DataFrameTransformTask transformTask;
-        private final Map<String, String> fieldMappings;
-        private final DataFrameTransformConfig transformConfig;
-        private volatile DataFrameTransformProgress progress;
         private volatile DataFrameIndexerTransformStats previouslyPersistedStats = null;
         private final AtomicInteger failureCount;
         // Keeps track of the last exception that was written to our audit, keeps us from spamming the audit index
@@ -470,19 +466,18 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
                     .threadPool
                     .executor(ThreadPool.Names.GENERIC),
                 ExceptionsHelper.requireNonNull(auditor, "auditor"),
+                transformConfig,
+                fieldMappings,
                 ExceptionsHelper.requireNonNull(initialState, "initialState"),
                 initialPosition,
-                initialStats == null ? new DataFrameIndexerTransformStats(transformId) : initialStats);
+                initialStats == null ? new DataFrameIndexerTransformStats(transformId) : initialStats,
+                transformProgress);
             this.transformId = ExceptionsHelper.requireNonNull(transformId, "transformId");
             this.transformsConfigManager = ExceptionsHelper.requireNonNull(transformsConfigManager, "transformsConfigManager");
             this.transformsCheckpointService = ExceptionsHelper.requireNonNull(transformsCheckpointService,
                 "transformsCheckpointService");
             this.client = ExceptionsHelper.requireNonNull(client, "client");
-            this.auditor = auditor;
-            this.transformConfig = ExceptionsHelper.requireNonNull(transformConfig, "transformConfig");
             this.transformTask = parentTask;
-            this.fieldMappings = ExceptionsHelper.requireNonNull(fieldMappings, "fieldMappings");
-            this.progress = transformProgress;
             this.failureCount = new AtomicInteger(0);
         }
 
@@ -508,21 +503,6 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
             } else {
                 super.onStart(now, listener);
             }
-        }
-
-        @Override
-        protected DataFrameTransformConfig getConfig() {
-            return transformConfig;
-        }
-
-        @Override
-        protected Map<String, String> getFieldMappings() {
-            return fieldMappings;
-        }
-
-        @Override
-        protected DataFrameTransformProgress getProgress() {
-            return progress;
         }
 
         @Override

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexerTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexerTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerTransformStats;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfigTests;
-import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformProgress;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.dataframe.notifications.DataFrameAuditor;
 import org.elasticsearch.xpack.dataframe.transforms.pivot.Pivot;
@@ -32,7 +31,6 @@ import org.junit.Before;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -48,13 +46,9 @@ import static org.mockito.Mockito.when;
 public class DataFrameIndexerTests extends ESTestCase {
 
     private Client client;
-    private static final String TEST_ORIGIN = "test_origin";
-    private static final String TEST_INDEX = "test_index";
 
     class MockedDataFrameIndexer extends DataFrameIndexer {
 
-        private final DataFrameTransformConfig transformConfig;
-        private final Map<String, String> fieldMappings;
         private final Function<SearchRequest, SearchResponse> searchFunction;
         private final Function<BulkRequest, BulkResponse> bulkFunction;
         private final Consumer<Exception> failureConsumer;
@@ -73,9 +67,8 @@ public class DataFrameIndexerTests extends ESTestCase {
                 Function<SearchRequest, SearchResponse> searchFunction,
                 Function<BulkRequest, BulkResponse> bulkFunction,
                 Consumer<Exception> failureConsumer) {
-            super(executor, auditor, initialState, initialPosition, jobStats);
-            this.transformConfig = Objects.requireNonNull(transformConfig);
-            this.fieldMappings = Objects.requireNonNull(fieldMappings);
+            super(executor, auditor, transformConfig, fieldMappings, initialState, initialPosition, jobStats,
+                    /* DataFrameTransformProgress */ null);
             this.searchFunction = searchFunction;
             this.bulkFunction = bulkFunction;
             this.failureConsumer = failureConsumer;
@@ -83,21 +76,6 @@ public class DataFrameIndexerTests extends ESTestCase {
 
         public CountDownLatch newLatch(int count) {
             return latch = new CountDownLatch(count);
-        }
-
-        @Override
-        protected DataFrameTransformConfig getConfig() {
-            return transformConfig;
-        }
-
-        @Override
-        protected Map<String, String> getFieldMappings() {
-            return fieldMappings;
-        }
-
-        @Override
-        protected DataFrameTransformProgress getProgress() {
-            return null;
         }
 
         @Override


### PR DESCRIPTION
simplifies indexer by moving members to base class

Note:

This re-factoring has been made possible by #41278, before that the abstract methods where necessary as these parts got loaded at runtime