### PR TITLE
Remove the jdk directory to save space on bwc tests

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -936,6 +936,8 @@ class ClusterFormationTasks {
             }
             doLast {
                 project.delete(node.pidFile)
+                // Large tests can exhaust disk space, clean up on stop, but leave the data dir as some tests reuse it
+                project.delete(project.fileTree(node.baseDir).minus(project.fileTree(node.dataDir)))
             }
         }
     }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -936,8 +936,8 @@ class ClusterFormationTasks {
             }
             doLast {
                 project.delete(node.pidFile)
-                // Large tests can exhaust disk space, clean up on stop, but leave the data dir as some tests reuse it
-                project.delete(project.fileTree(node.baseDir).minus(project.fileTree(node.dataDir)))
+                // Large tests can exhaust disk space, clean up jdk from the distribution to save some space
+                project.delete(new File(node.homeDir, "jdk"))
             }
         }
     }


### PR DESCRIPTION


This PR adresses the same concern as #41187 in a different way.
It removes only the JDK from the distribution once the cluster stops,
so we keep the same disk space requirements as before adding the JDK.
This is still a temporary measure, testclusters already deals with this
by doing the equivalent of `cp -l` instead of an actual copy.