### PR TITLE
Fix discovery config in docker-compose docs

### DIFF
--- a/docs/reference/security/securing-communications/configuring-tls-docker.asciidoc
+++ b/docs/reference/security/securing-communications/configuring-tls-docker.asciidoc
@@ -108,6 +108,7 @@ services:
     image: {docker-image}
     environment:
       - node.name=es01
+      - discovery.seed_hosts=es02
       - cluster.initial_master_nodes=es01,es02
       - ELASTIC_PASSWORD=$ELASTIC_PASSWORD <1>
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"


### PR DESCRIPTION
Today's `docker-compose` docs are missing the `discovery.seed_nodes` config on
one of the nodes. With today's configuration the cluster can still form the
first time it is started, because `cluster.initial_master_nodes` requires both
nodes to bootstrap the cluster which ensures that each discover the other.
However if `es02` is elected master it will remove `es01` from the voting
configuration and then when restarted it will form a cluster on its own without
needing to do any discovery. Meanwhile `es01` doesn't know how to find `es02`
after a restart so will be unable to join this cluster.

This commit fixes this by adding the missing configuration.

Relates #41394, which fixes a different `docker-compose.yml` in the same way.