### PR TITLE
Simplify filtering addresses on interfaces

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/common/network/InetAddressHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/common/network/InetAddressHelper.java
@@ -7,7 +7,6 @@ package org.elasticsearch.common.network;
 
 import java.io.IOException;
 import java.net.InetAddress;
-import java.net.SocketException;
 
 /**
  * We use this class to access the package private method in NetworkUtils to resolve anyLocalAddress InetAddresses for certificate

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/common/network/InetAddressHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/common/network/InetAddressHelper.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.common.network;
 
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.SocketException;
 
@@ -16,7 +17,7 @@ public class InetAddressHelper {
 
     private InetAddressHelper() {}
 
-    public static InetAddress[] getAllAddresses() throws SocketException {
+    public static InetAddress[] getAllAddresses() throws IOException {
         return NetworkUtils.getAllAddresses();
     }
 

--- a/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/CertGenUtils.java
+++ b/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/CertGenUtils.java
@@ -268,7 +268,7 @@ public class CertGenUtils {
     /**
      * Converts the {@link InetAddress} objects into a {@link GeneralNames} object that is used to represent subject alternative names.
      */
-    public static GeneralNames getSubjectAlternativeNames(boolean resolveName, Set<InetAddress> addresses) throws SocketException {
+    public static GeneralNames getSubjectAlternativeNames(boolean resolveName, Set<InetAddress> addresses) throws IOException {
         Set<GeneralName> generalNameList = new HashSet<>();
         for (InetAddress address : addresses) {
             if (address.isAnyLocalAddress()) {

--- a/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/CertGenUtils.java
+++ b/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/CertGenUtils.java
@@ -42,7 +42,6 @@ import javax.security.auth.x500.X500Principal;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.net.InetAddress;
-import java.net.SocketException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.KeyStore;


### PR DESCRIPTION
This commit is a refactoring of how we filter addresses on interfaces. In particular, we refactor all of these methods into a common private method. We also change the order of logic to first check if an address matches our filter and then check if the interface is up. This is to possibly avoid problems we are seeing where devices are flapping up and down while we are checking for loopback addresses. We do not expect the loopback device to flap up and down so by reversing the logic here we avoid that problem on CI machines. Finally, we expand the error message when this does occur so that we know which device is flapping.

Relates #41549