### PR TITLE
[ML Data Frame] Update Preview docs for source config change

### DIFF
--- a/docs/reference/data-frames/apis/preview-transform.asciidoc
+++ b/docs/reference/data-frames/apis/preview-transform.asciidoc
@@ -36,7 +36,9 @@ eCommerce sample data:
 --------------------------------------------------
 POST _data_frame/transforms/_preview
 {
-  "source": "kibana_sample_data_ecommerce",
+  "source": {
+    "index": "kibana_sample_data_ecommerce"
+  },
   "pivot": {
     "group_by": {
       "customer_id": {

--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -9,6 +9,7 @@ directly to configure and access {xpack} features.
 
 * <<info-api,Info API>>
 * <<ccr-apis,{ccr-cap} APIs>>
+* <<data-frame-apis,{dataframe-cap} APIs>>
 * <<graph-explore-api,Graph Explore API>>
 * <<freeze-index-api>>, <<unfreeze-index-api>>
 * <<index-lifecycle-management-api,Index lifecycle management APIs>>


### PR DESCRIPTION
... and add link to the data frame APIs from https://www.elastic.co/guide/en/elasticsearch/reference/master/xpack-api.html

The link was in the sidebar 
<img width="385" alt="sidebar" src="https://user-images.githubusercontent.com/2353640/57097118-c7c42100-6d0e-11e9-8589-70ad1e7400e1.png">

but not on the main page
<img width="666" alt="xpack-apis" src="https://user-images.githubusercontent.com/2353640/57097132-d3afe300-6d0e-11e9-9df7-f6dc5fa4f8fe.png">

