### PR TITLE
[ML-DataFrame] refactor pivot to only take the pivot config

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/QueryConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/QueryConfig.java
@@ -39,7 +39,7 @@ public class QueryConfig extends AbstractDiffable<QueryConfig> implements Writea
     private final Map<String, Object> source;
     private final QueryBuilder query;
 
-    static QueryConfig matchAll() {
+    public static QueryConfig matchAll() {
         return new QueryConfig(Collections.singletonMap(MatchAllQueryBuilder.NAME, Collections.emptyMap()),
             new MatchAllQueryBuilder());
     }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportPutDataFrameTransformAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportPutDataFrameTransformAction.java
@@ -190,9 +190,7 @@ public class TransportPutDataFrameTransformAction
 
     private void putDataFrame(DataFrameTransformConfig config, ActionListener<AcknowledgedResponse> listener) {
 
-        final Pivot pivot = new Pivot(config.getSource().getIndex(),
-            config.getSource().getQueryConfig().getQuery(),
-            config.getPivotConfig());
+        final Pivot pivot = new Pivot(config.getPivotConfig());
 
 
         // <5> Return the listener, or clean up destination index on failure.
@@ -210,6 +208,6 @@ public class TransportPutDataFrameTransformAction
         );
 
         // <1> Validate our pivot
-        pivot.validate(client, pivotValidationListener);
+        pivot.validate(client, config.getSource(), pivotValidationListener);
     }
 }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportStartDataFrameTransformAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportStartDataFrameTransformAction.java
@@ -224,9 +224,7 @@ public class TransportStartDataFrameTransformAction extends
 
     private void createDestinationIndex(final DataFrameTransformConfig config, final ActionListener<Void> listener) {
 
-        final Pivot pivot = new Pivot(config.getSource().getIndex(),
-            config.getSource().getQueryConfig().getQuery(),
-            config.getPivotConfig());
+        final Pivot pivot = new Pivot(config.getPivotConfig());
 
         ActionListener<Map<String, String>> deduceMappingsListener = ActionListener.wrap(
             mappings -> DataframeIndex.createDestinationIndex(client,
@@ -238,7 +236,7 @@ public class TransportStartDataFrameTransformAction extends
                     deduceTargetMappingsException))
         );
 
-        pivot.deduceMappings(client, deduceMappingsListener);
+        pivot.deduceMappings(client, config.getSource(), deduceMappingsListener);
     }
 
     @Override

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
@@ -16,9 +16,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
-import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.dataframe.DataFrameMessages;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerTransformStats;
@@ -180,16 +178,7 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<Map<String, 
 
     @Override
     protected SearchRequest buildSearchRequest() {
-        SearchRequest searchRequest = new SearchRequest(getConfig().getSource().getIndex());
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
-        sourceBuilder.aggregation(pivot.buildAggregation(getPosition(), pageSize));
-        sourceBuilder.size(0);
-
-        QueryBuilder pivotQueryBuilder = getConfig().getSource().getQueryConfig().getQuery();
-        sourceBuilder.query(pivotQueryBuilder);
-
-        searchRequest.source(sourceBuilder);
-        return searchRequest;
+        return pivot.buildSearchRequest(getConfig().getSource(), getPosition(), pageSize);
     }
 
     /**

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/pivot/PivotTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/pivot/PivotTests.java
@@ -22,12 +22,13 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexNotFoundException;
-import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.xpack.core.dataframe.transforms.QueryConfig;
+import org.elasticsearch.xpack.core.dataframe.transforms.SourceConfig;
 import org.elasticsearch.xpack.core.dataframe.transforms.pivot.AggregationConfig;
 import org.elasticsearch.xpack.core.dataframe.transforms.pivot.GroupConfigTests;
 import org.elasticsearch.xpack.core.dataframe.transforms.pivot.PivotConfig;
@@ -83,42 +84,46 @@ public class PivotTests extends ESTestCase {
     }
 
     public void testValidateExistingIndex() throws Exception {
-        Pivot pivot = new Pivot(new String[]{"existing_source_index"}, new MatchAllQueryBuilder(), getValidPivotConfig());
+        SourceConfig source = new SourceConfig(new String[]{"existing_source_index"}, QueryConfig.matchAll());
+        Pivot pivot = new Pivot(getValidPivotConfig());
 
-        assertValidTransform(client, pivot);
+        assertValidTransform(client, source, pivot);
     }
 
     public void testValidateNonExistingIndex() throws Exception {
-        Pivot pivot = new Pivot(new String[]{"non_existing_source_index"}, new MatchAllQueryBuilder(), getValidPivotConfig());
+        SourceConfig source = new SourceConfig(new String[]{"non_existing_source_index"}, QueryConfig.matchAll());
+        Pivot pivot = new Pivot(getValidPivotConfig());
 
-        assertInvalidTransform(client, pivot);
+        assertInvalidTransform(client, source, pivot);
     }
 
     public void testSearchFailure() throws Exception {
         // test a failure during the search operation, transform creation fails if
         // search has failures although they might just be temporary
-        Pivot pivot = new Pivot(new String[]{"existing_source_index_with_failing_shards"},
-            new MatchAllQueryBuilder(),
-            getValidPivotConfig());
+        SourceConfig source = new SourceConfig(new String[] { "existing_source_index_with_failing_shards" }, QueryConfig.matchAll());
 
-        assertInvalidTransform(client, pivot);
+        Pivot pivot = new Pivot(getValidPivotConfig());
+
+        assertInvalidTransform(client, source, pivot);
     }
 
     public void testValidateAllSupportedAggregations() throws Exception {
         for (String agg : supportedAggregations) {
             AggregationConfig aggregationConfig = getAggregationConfig(agg);
+            SourceConfig source = new SourceConfig(new String[]{"existing_source"}, QueryConfig.matchAll());
 
-            Pivot pivot = new Pivot(new String[]{"existing_source"}, new MatchAllQueryBuilder(), getValidPivotConfig(aggregationConfig));
-            assertValidTransform(client, pivot);
+            Pivot pivot = new Pivot(getValidPivotConfig(aggregationConfig));
+            assertValidTransform(client, source, pivot);
         }
     }
 
     public void testValidateAllUnsupportedAggregations() throws Exception {
         for (String agg : unsupportedAggregations) {
             AggregationConfig aggregationConfig = getAggregationConfig(agg);
+            SourceConfig source = new SourceConfig(new String[]{"existing_source"}, QueryConfig.matchAll());
 
-            Pivot pivot = new Pivot(new String[]{"existing_source"}, new MatchAllQueryBuilder(), getValidPivotConfig(aggregationConfig));
-            assertInvalidTransform(client, pivot);
+            Pivot pivot = new Pivot(getValidPivotConfig(aggregationConfig));
+            assertInvalidTransform(client, source, pivot);
         }
     }
 
@@ -202,18 +207,18 @@ public class PivotTests extends ESTestCase {
         return AggregationConfig.fromXContent(parser, false);
     }
 
-    private static void assertValidTransform(Client client, Pivot pivot) throws Exception {
-        validate(client, pivot, true);
+    private static void assertValidTransform(Client client, SourceConfig source, Pivot pivot) throws Exception {
+        validate(client, source, pivot, true);
     }
 
-    private static void assertInvalidTransform(Client client, Pivot pivot) throws Exception {
-        validate(client, pivot, false);
+    private static void assertInvalidTransform(Client client, SourceConfig source, Pivot pivot) throws Exception {
+        validate(client, source, pivot, false);
     }
 
-    private static void validate(Client client, Pivot pivot, boolean expectValid) throws Exception {
+    private static void validate(Client client, SourceConfig source, Pivot pivot, boolean expectValid) throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
-        pivot.validate(client, ActionListener.wrap(validity -> {
+        pivot.validate(client, source, ActionListener.wrap(validity -> {
             assertEquals(expectValid, validity);
             latch.countDown();
         }, e -> {


### PR DESCRIPTION
refactor pivot class to only take the config at construction, other parameters are passed in as part of method that require them