### PR TITLE
Add note about ILM action ordering

### DIFF
--- a/docs/reference/ilm/policy-definitions.asciidoc
+++ b/docs/reference/ilm/policy-definitions.asciidoc
@@ -84,6 +84,10 @@ executing.
 
 The below list shows the actions which are available in each phase.
 
+NOTE: The order that configured actions are performed in within each phase is
+determined by automatically by {ilm-init}, and cannot be changed by changing the
+policy definition.
+
 * Hot
   - <<ilm-set-priority-action,Set Priority>>
   - <<ilm-rollover-action,Rollover>>


### PR DESCRIPTION
Adds a note clarifying that actions are ordered automatically.

Relates to https://github.com/elastic/elasticsearch/issues/41729