### PR TITLE
[DOCS] Adds placeholders for 7.1 highlights and breaking changes

### DIFF
--- a/docs/reference/migration/index.asciidoc
+++ b/docs/reference/migration/index.asciidoc
@@ -7,9 +7,12 @@ This section discusses the changes that you need to be aware of to migrate
 your application to {version}. For more information about what's new in this
 release, see the <<release-highlights>> and <<es-release-notes>>.
 
+* <<breaking-changes-7.1,Breaking changes in 7.1>>
 * <<breaking-changes-7.0,Breaking changes in 7.0>>
 
 For information about how to upgrade your cluster, see <<setup-upgrade>>.
 
 --
+
+include::migrate_7_1.asciidoc[]
 include::migrate_7_0.asciidoc[]

--- a/docs/reference/migration/migrate_7_1.asciidoc
+++ b/docs/reference/migration/migrate_7_1.asciidoc
@@ -1,0 +1,66 @@
+[[breaking-changes-7.1]]
+== Breaking changes in 7.1
+++++
+<titleabbrev>7.1</titleabbrev>
+++++
+
+This section discusses the changes that you need to be aware of when migrating
+your application to Elasticsearch 7.1.
+
+See also <<release-highlights>> and <<es-release-notes>>.
+
+coming[7.1.0]
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+
+// end::notable-breaking-changes[]
+
+[float]
+[[breaking_71_http_changes]]
+=== HTTP changes
+
+[float]
+==== Deprecation of old HTTP settings
+
+The `http.tcp_no_delay` setting is deprecated in 7.1. It is replaced by
+`http.tcp.no_delay`.
+
+[float]
+[[breaking_71_network_changes]]
+=== Network changes
+
+[float]
+==== Deprecation of old network settings
+
+The `network.tcp.connect_timeout` setting is deprecated in 7.1. This setting
+was a fallback setting for `transport.connect_timeout`. To change the default
+connection timeout for client connections, modify `transport.connect_timeout`.
+
+[float]
+[[breaking_71_transport_changes]]
+=== Transport changes
+
+//tag::notable-breaking-changes[]
+[float]
+==== Deprecation of old transport settings
+
+The following settings are deprecated in 7.1. Each setting has a replacement
+setting that was introduced in 6.7.
+
+- `transport.tcp.port` is replaced by `transport.port`
+- `transport.tcp.compress` is replaced by `transport.compress`
+- `transport.tcp.connect_timeout` is replaced by `transport.connect_timeout`
+- `transport.tcp_no_delay` is replaced by `transport.tcp.no_delay`
+- `transport.profiles.profile_name.tcp_no_delay` is replaced by
+`transport.profiles.profile_name.tcp.no_delay`
+- `transport.profiles.profile_name.tcp_keep_alive` is replaced by
+`transport.profiles.profile_name.tcp.keep_alive`
+- `transport.profiles.profile_name.reuse_address` is replaced by
+`transport.profiles.profile_name.tcp.reuse_address`
+- `transport.profiles.profile_name.send_buffer_size` is replaced by `transport.profiles.profile_name.tcp.send_buffer_size`
+- `transport.profiles.profile_name.receive_buffer_size` is replaced by `transport.profiles.profile_name.tcp.receive_buffer_size`
+
+// end::notable-breaking-changes[]

--- a/docs/reference/release-notes/highlights-7.1.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.1.0.asciidoc
@@ -1,0 +1,14 @@
+[[release-highlights-7.1.0]]
+== 7.1.0 release highlights
+++++
+<titleabbrev>7.1.0</titleabbrev>
+++++
+
+coming[7.1.0]
+
+//NOTE: The notable-highlights tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+// tag::notable-highlights[]
+
+// end::notable-highlights[]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -6,8 +6,10 @@
 This section summarizes the most important changes in each release. For the 
 full list, see <<es-release-notes>> and <<breaking-changes>>. 
 
+* <<release-highlights-7.1.0>>
 * <<release-highlights-7.0.0>>
 
 --
 
+include::highlights-7.1.0.asciidoc[]
 include::highlights-7.0.0.asciidoc[]


### PR DESCRIPTION
This PR backports the https://raw.githubusercontent.com/elastic/elasticsearch/7.x/docs/reference/release-notes/highlights-7.1.0.asciidoc and https://github.com/elastic/elasticsearch/blob/7.x/docs/reference/release-notes/highlights-7.1.0.asciidoc files to the 7.1 branch. 