### PR TITLE
fix org.elasticsearch.xpack.watcher.test.integration.RejectedExecutionTests

### DIFF
--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/RejectedExecutionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/RejectedExecutionTests.java
@@ -25,7 +25,6 @@ import static org.elasticsearch.xpack.watcher.input.InputBuilders.searchInput;
 import static org.elasticsearch.xpack.watcher.test.WatcherTestUtils.templateRequest;
 import static org.elasticsearch.xpack.watcher.trigger.TriggerBuilders.schedule;
 import static org.elasticsearch.xpack.watcher.trigger.schedule.Schedules.interval;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 public class RejectedExecutionTests extends AbstractWatcherIntegrationTestCase {
@@ -36,8 +35,7 @@ public class RejectedExecutionTests extends AbstractWatcherIntegrationTestCase {
         return false;
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/41734")
-    public void testHistoryAndTriggeredOnRejection() throws Exception {
+    public void testHistoryOnRejection() throws Exception {
         WatcherClient watcherClient = watcherClient();
         createIndex("idx");
         client().prepareIndex("idx", "_doc").setSource("field", "a").get();
@@ -56,11 +54,7 @@ public class RejectedExecutionTests extends AbstractWatcherIntegrationTestCase {
             flushAndRefresh(".watcher-history-*");
             SearchResponse searchResponse = client().prepareSearch(".watcher-history-*").get();
             assertThat(searchResponse.getHits().getTotalHits().value, greaterThanOrEqualTo(2L));
-        }, 10, TimeUnit.SECONDS);
-
-        flushAndRefresh(".triggered_watches");
-        SearchResponse searchResponse = client().prepareSearch(".triggered_watches").get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(0L));
+        });
     }
 
     @Override

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/RejectedExecutionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/RejectedExecutionTests.java
@@ -15,8 +15,6 @@ import org.elasticsearch.xpack.watcher.support.search.WatcherSearchTemplateReque
 import org.elasticsearch.xpack.watcher.test.AbstractWatcherIntegrationTestCase;
 import org.elasticsearch.xpack.watcher.trigger.schedule.IntervalSchedule;
 
-import java.util.concurrent.TimeUnit;
-
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
 import static org.elasticsearch.xpack.watcher.actions.ActionBuilders.loggingAction;


### PR DESCRIPTION
This commit un-mutes org.elasticsearch.xpack.watcher.test.integration.RejectedExecutionTests
which was failing intermittently due to a logic bug. It is not possible to use the real
Watcher scheduler (which is needed for this test since the TimeWarp scheduler doesn't 
use the Watcher threadpool) and reliably count the .triggered-watches
since current count of documents in the .triggered-watches index is based on the timing of the
scheduler and the ability to delete based those watches due to the Watcher and Write thread pools.

This commit simply removes the .triggered-watch check and relies soley on the .watcher-history
index as an indication that operations that can occur when the Watcher threadpool is rejecting.

closes #41734
