### PR TITLE
Closed index replica allocation

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/NodeAllocationResult.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/NodeAllocationResult.java
@@ -228,6 +228,10 @@ public class NodeAllocationResult implements ToXContentObject, Writeable, Compar
          * matching sync ids are irrelevant.
          */
         public boolean hasMatchingSyncId() {
+            // TODO: we should eventually either distinguish between sync-id and non sync-id equivalent closed shard allocation or
+            // rename this to isSynced().
+            // left this for now, since it changes the API and should preferably be handled together with seqno based
+            // replica shard allocation.
             return matchingBytes == Long.MAX_VALUE;
         }
 

--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -845,6 +845,13 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
             return numDocs;
         }
 
+        /**
+         * @return sequence number info from lucene commit
+         */
+        public SequenceNumbers.CommitInfo seqNoInfo() {
+            return SequenceNumbers.loadSeqNoInfoFromLuceneCommit(commitUserData.entrySet());
+        }
+
         static class LoadedMetadata {
             final Map<String, StoreFileMetaData> fileMetadata;
             final Map<String, String> userData;

--- a/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
@@ -43,6 +43,7 @@ import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.gateway.AsyncShardFetch;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardPath;
@@ -218,6 +219,13 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
          */
         public String syncId() {
             return metadataSnapshot.getSyncId();
+        }
+
+        /**
+         * @return sequence number info from lucene commit
+         */
+        public SequenceNumbers.CommitInfo seqNoInfo() {
+            return metadataSnapshot.seqNoInfo();
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
@@ -324,7 +324,7 @@ public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
 
     private RoutingAllocation onePrimaryOnNode1And1Replica(AllocationDeciders deciders, Settings settings, UnassignedInfo.Reason reason) {
         return onePrimaryOnNode1And1Replica(deciders, settings, reason,
-            randomBoolean() ? IndexMetaData.State.OPEN : IndexMetaData.State.CLOSE);
+            randomFrom(IndexMetaData.State.values()));
     }
 
     private RoutingAllocation onePrimaryOnNode1And1Replica(AllocationDeciders deciders, Settings settings, UnassignedInfo.Reason reason,

--- a/server/src/test/java/org/elasticsearch/indices/state/CloseIndexIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/state/CloseIndexIT.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaDataIndexStateService;
 import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -36,6 +37,7 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.indices.IndexClosedException;
 import org.elasticsearch.test.BackgroundIndexer;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.InternalTestCluster;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -336,6 +338,53 @@ public class CloseIndexIT extends ESIntegTestCase {
         assertTrue(closeIndexResponse.isAcknowledged());
         assertTrue(closeIndexResponse.isShardsAcknowledged());
         assertIndexIsClosed(indexName);
+    }
+
+    /**
+     * Verify that if we have two shard copies around, we prefer one with identical sequence numbers and do
+     * a noop recovery.
+     */
+    public void testClosedIndexRecoversFast() throws Exception {
+        final String indexName = "closed-index-fast-recovery";
+        internalCluster().ensureAtLeastNumDataNodes(3);
+        createIndex(indexName, Settings.builder()
+            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1)
+            .build());
+
+        indexRandom(randomBoolean(), randomBoolean(), randomBoolean(), IntStream.range(0, randomIntBetween(1, 50))
+            .mapToObj(i -> client().prepareIndex(indexName, "_doc", String.valueOf(i)).setSource("num", i)).collect(toList()));
+        ensureGreen(indexName);
+
+        internalCluster().restartRandomDataNode(new InternalTestCluster.RestartCallback() {
+            @Override
+            public Settings onNodeStopped(String nodeName) throws Exception {
+                indexRandom(randomBoolean(), randomBoolean(), randomBoolean(), IntStream.range(0, randomIntBetween(1, 50))
+                    .mapToObj(i -> client().prepareIndex(indexName, "_doc", "Extra" + i).setSource("num", i)).collect(toList()));
+                ensureGreen();
+
+                internalCluster().restartRandomDataNode(new InternalTestCluster.RestartCallback() {
+                    @Override
+                    public Settings onNodeStopped(String nodeName) throws Exception {
+                        ensureYellow();
+
+                        assertAcked(client().admin().indices().prepareClose(indexName).get());
+
+                        assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(Settings.builder()
+                            .put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), "none")).get());
+                        return super.onNodeStopped(nodeName);
+                    }
+                });
+                return super.onNodeStopped(nodeName);
+            }
+        });
+
+        assertThat(client().admin().cluster().prepareHealth(indexName).get().getStatus(), is(ClusterHealthStatus.YELLOW));
+        assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(Settings.builder()
+            .put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), (String) null)).get());
+        ensureGreen();
+        // needs merge of #41400 before we can check this.
+//        assertNoFileBasedRecovery(indexName);
     }
 
     static void assertIndexIsClosed(final String... indices) {


### PR DESCRIPTION
When an index is closed, we expect primary and replicas to be identical.
This commit improves the gateway replica shard allocator to consider
shards with identical sequence numbers sync'ed for closed indices. This
ensures that we will pick a fast recovery regardless of whether synced
flush was performed prior to closing an index.

Fixed `InternalTestCluster` to allow doing operations inside `onStopped()`
when using `restartXXXNode()`.

Relates #41400 and #33888

Please notice the todo on the explain API.