### PR TITLE
Tidy-up TimedRunnable

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/QueueResizingEsThreadPoolExecutor.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/QueueResizingEsThreadPoolExecutor.java
@@ -151,7 +151,8 @@ public final class QueueResizingEsThreadPoolExecutor extends EsThreadPoolExecuto
         final long totalNanos = totalTaskNanos.addAndGet(taskNanos);
 
         final long taskExecutionNanos = timedRunnable.getTotalExecutionNanos();
-        assert taskExecutionNanos >= 0 : "expected task to always take longer than 0 nanoseconds, got: " + taskExecutionNanos;
+        assert taskExecutionNanos > 0 :
+            "expected task to always take longer than 0 nanoseconds, got: " + taskExecutionNanos + " for " + timedRunnable;
         executionEWMA.addValue(taskExecutionNanos);
 
         if (taskCount.incrementAndGet() == this.tasksPerFrame) {

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/TimedRunnable.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/TimedRunnable.java
@@ -39,6 +39,7 @@ class TimedRunnable extends AbstractRunnable implements WrappedRunnable {
     @Override
     public void doRun() {
         try {
+            assert finishTimeNanos == -1 : "task already run: finishTimeNanos=" + finishTimeNanos + " for " + this;
             startTimeNanos = System.nanoTime();
             original.run();
         } finally {
@@ -82,7 +83,6 @@ class TimedRunnable extends AbstractRunnable implements WrappedRunnable {
      */
     long getTotalNanos() {
         if (finishTimeNanos == -1) {
-            // There must have been an exception thrown, the total time is unknown (-1)
             return -1;
         }
         return Math.max(finishTimeNanos - creationTimeNanos, 1);
@@ -93,8 +93,7 @@ class TimedRunnable extends AbstractRunnable implements WrappedRunnable {
      * If the task is still running or has not yet been run, returns -1.
      */
     long getTotalExecutionNanos() {
-        if (startTimeNanos == -1 || finishTimeNanos == -1) {
-            // There must have been an exception thrown, the total time is unknown (-1)
+        if (finishTimeNanos == -1) {
             return -1;
         }
         return Math.max(finishTimeNanos - startTimeNanos, 1);
@@ -105,4 +104,10 @@ class TimedRunnable extends AbstractRunnable implements WrappedRunnable {
         return original;
     }
 
+    @Override
+    public String toString() {
+        return "TimedRunnable{" +
+            "original=" + original +
+            '}';
+    }
 }

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/TimedRunnable.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/TimedRunnable.java
@@ -110,4 +110,9 @@ class TimedRunnable extends AbstractRunnable implements WrappedRunnable {
             "original=" + original +
             '}';
     }
+
+    // used by assertions only
+    public boolean isStarted() {
+        return startTimeNanos != 0;
+    }
 }


### PR DESCRIPTION
- Asserts that taskExecutionNanos is _strictly_ positive

- Removes impossible `startTimeNanos == -1` condition

- Implements `toString()`

This last point is because there have been two recent failures of PR builds of
the following form:

```
  2> KKN 22, 2019 11:40:12 PM com.carrotsearch.randomizedtesting.RandomizedRunner$QueueUncaughtExceptionsHandler uncaughtException
  2> WARNING: Uncaught exception in thread: Thread[elasticsearch[mock_ node][search][T#1],5,TGRP-NodeTests]
  2> java.lang.AssertionError: expected task to always take longer than 0 nanoseconds, got: -1
  2> 	at __randomizedtesting.SeedInfo.seed([99E328AA85EDFC3A]:0)
  2> 	at org.elasticsearch.common.util.concurrent.QueueResizingEsThreadPoolExecutor.afterExecute(QueueResizingEsThreadPoolExecutor.java:154)
  2> 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1131)
  2> 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
  2> 	at java.base/java.lang.Thread.run(Thread.java:834)
```

See for instance
https://scans.gradle.com/s/itejjhgbqu4uo/console-log?task=:server:test

I cannot immediately see how this can happen, but cannot deduce much from this
failure message, so have added more details to help a future investigation.