### PR TITLE
[ML] addresses preview bug, and adds check to PUT

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameMessages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameMessages.java
@@ -21,8 +21,9 @@ public class DataFrameMessages {
             "Failed to validate data frame configuration";
     public static final String REST_PUT_DATA_FRAME_FAILED_PERSIST_TRANSFORM_CONFIGURATION = "Failed to persist data frame configuration";
     public static final String REST_PUT_DATA_FRAME_FAILED_TO_DEDUCE_DEST_MAPPINGS = "Failed to deduce dest mappings";
-    public static final String REST_PUT_DATA_FRAME_FAILED_TO_CREATE_DEST_INDEX = "Failed to create dest index";
     public static final String REST_PUT_DATA_FRAME_SOURCE_INDEX_MISSING = "Source index [{0}] does not exist";
+    public static final String REST_PUT_DATA_FRAME_DEST_IN_SOURCE = "Destination index [{0}] is included in source expression [{1}]";
+    public static final String REST_PUT_DATA_FRAME_DEST_SINGLE_INDEX = "Destination index [{0}] should refer to a single index";
     public static final String REST_PUT_DATA_FRAME_INCONSISTENT_ID =
             "Inconsistent id; ''{0}'' specified in the body differs from ''{1}'' specified as a URL argument";
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/preview_transforms.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/preview_transforms.yml
@@ -102,3 +102,18 @@ setup:
               "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
             }
           }
+---
+"Test preview with non-existing source index":
+  - do:
+      catch: /Source index \[does_not_exist\] does not exist/
+      data_frame.preview_data_frame_transform:
+        body: >
+          {
+            "source": { "index": ["airline-data", "does_not_exist"] },
+            "pivot": {
+              "group_by": {
+                "airline": {"terms": {"field": "airline"}},
+                "by-hour": {"date_histogram": {"interval": "1h", "field": "time", "format": "yyyy-MM-DD HH"}}},
+              "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+            }
+          }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_crud.yml
@@ -190,4 +190,115 @@ setup:
         transform_id: "_all"
         from: 0
         size: 10000
+---
+"Test transform where dest is included in source":
+  - do:
+      catch: /Destination index \[airline-data-by-airline\] is included in source expression \[airline-data/
+      data_frame.put_data_frame_transform:
+        transform_id: "airline-transform"
+        body: >
+          {
+            "source": {
+              "index": ["airline-data*"]
+            },
+            "dest": { "index": "airline-data-by-airline" },
+            "pivot": {
+              "group_by": { "airline": {"terms": {"field": "airline"}}},
+              "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+            }
+          }
+---
+"Test transform where dest is a simple index pattern":
+  - do:
+      catch: /Destination index .* should refer to a single index/
+      data_frame.put_data_frame_transform:
+        transform_id: "airline-transform"
+        body: >
+          {
+            "source": {
+              "index": ["airline-data*"]
+            },
+            "dest": { "index": "destination*" },
+            "pivot": {
+              "group_by": { "airline": {"terms": {"field": "airline"}}},
+              "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+            }
+          }
+---
+"Test alias scenarios":
+  - do:
+      indices.create:
+        index: created-destination-index
+  - do:
+      indices.create:
+        index: second-created-destination-index
+  - do:
+      indices.put_alias:
+        index: airline-data
+        name: source-index
+  - do:
+      indices.put_alias:
+        index: created-destination-index
+        name: dest-index
+  - do:
+      data_frame.put_data_frame_transform:
+        transform_id: "transform-from-aliases"
+        body: >
+          {
+            "source": {
+              "index": "source-index"
+            },
+            "dest": { "index": "dest-index" },
+            "pivot": {
+              "group_by": { "airline": {"terms": {"field": "airline"}}},
+              "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+            }
+          }
+  - match: { acknowledged: true }
 
+  - do:
+      indices.put_alias:
+        index: created-destination-index
+        name: source-index
+
+  - do:
+      catch: /Destination index \[created-destination-index\] is included in source expression \[airline-data,created-destination-index\]/
+      data_frame.put_data_frame_transform:
+        transform_id: "transform-from-aliases-failures"
+        body: >
+          {
+            "source": {
+              "index": "source-index"
+            },
+            "dest": { "index": "dest-index" },
+            "pivot": {
+              "group_by": { "airline": {"terms": {"field": "airline"}}},
+              "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+            }
+          }
+
+  - do:
+      indices.delete_alias:
+        index: created-destination-index
+        name: source-index
+
+  - do:
+      indices.put_alias:
+        index: second-created-destination-index
+        name: dest-index
+
+  - do:
+      catch: /Destination index \[dest-index\] should refer to a single index/
+      data_frame.put_data_frame_transform:
+        transform_id: "airline-transform"
+        body: >
+          {
+            "source": {
+              "index": ["source-index"]
+            },
+            "dest": { "index": "dest-index" },
+            "pivot": {
+              "group_by": { "airline": {"terms": {"field": "airline"}}},
+              "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+            }
+          }


### PR DESCRIPTION
Bug fixes:
* NPE error on `_preview` if source index does not exists
* NPE error on `put` if destination index exists and security is enabled

Additionally checks for the following `dest.index` and `source.index` are done:
* That any of the `source` index names match (simple regex) the `dest.index`
* That any of the concrete indices behind the `source` index names match `dest.index`
* That `dest.index` is NOT a simple regex pattern, and if it exists, is not backed by more than one index
* If the `dest.index` exists, that its concrete index is not contained in `source.index` concrete index names
