### PR TITLE
[DOCS] Adds page header for Groovy API

### DIFF
--- a/docs/groovy-api/page_header.html
+++ b/docs/groovy-api/page_header.html
@@ -1,1 +1,1 @@
-The Groovy scripting language is deprecated in Elasticsearch 5.0.0 and is replaced by the <a href=https://www.elastic.co/guide/en/elasticsearch/painless/current/index.html>Painless scripting language</a>.
+The Groovy API is no longer actively maintained or supported. 

--- a/docs/groovy-api/page_header.html
+++ b/docs/groovy-api/page_header.html
@@ -1,0 +1,1 @@
+The Groovy scripting language is deprecated in Elasticsearch 5.0.0 and is replaced by the <a href=https://www.elastic.co/guide/en/elasticsearch/painless/current/index.html>Painless scripting language</a>.


### PR DESCRIPTION
This PR adds a header in the Groovy API documentation (https://www.elastic.co/guide/en/elasticsearch/client/groovy-api/current/index.html).
 