### PR TITLE
Fix typo in create-index.asciidoc

### DIFF
--- a/docs/reference/indices/create-index.asciidoc
+++ b/docs/reference/indices/create-index.asciidoc
@@ -12,7 +12,7 @@ PUT twitter
 --------------------------------------------------
 // CONSOLE
 
-This create an index named `twitter` with all default setting.
+This creates an index named `twitter` with all default setting.
 
 [NOTE]
 .Index name limitations


### PR DESCRIPTION
Just a quick fix to add a letter to a word in the create index documentation.