### PR TITLE
Allow unknown task time in QueueResizingEsTPE

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/QueueResizingEsThreadPoolExecutor.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/QueueResizingEsThreadPoolExecutor.java
@@ -148,11 +148,13 @@ public final class QueueResizingEsThreadPoolExecutor extends EsThreadPoolExecuto
         assert super.unwrap(r) instanceof TimedRunnable : "expected only TimedRunnables in queue";
         final TimedRunnable timedRunnable = (TimedRunnable) super.unwrap(r);
         final long taskNanos = timedRunnable.getTotalNanos();
+        final boolean failedOrRejected = timedRunnable.getFailedOrRejected();
         final long totalNanos = totalTaskNanos.addAndGet(taskNanos);
 
         final long taskExecutionNanos = timedRunnable.getTotalExecutionNanos();
-        assert taskExecutionNanos >= 0 || taskExecutionNanos == -1 :
-            "expected task to always take longer than 0 nanoseconds or have '-1' failure code, got: " + taskExecutionNanos;
+        assert taskExecutionNanos >= 0 || (failedOrRejected && taskExecutionNanos == -1) :
+            "expected task to always take longer than 0 nanoseconds or have '-1' failure code, got: " + taskExecutionNanos +
+                ", failedOrRejected: " + failedOrRejected;
         if (taskExecutionNanos != -1) {
             // taskExecutionNanos may be -1 if the task threw an exception
             executionEWMA.addValue(taskExecutionNanos);

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/QueueResizingEsThreadPoolExecutor.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/QueueResizingEsThreadPoolExecutor.java
@@ -151,8 +151,12 @@ public final class QueueResizingEsThreadPoolExecutor extends EsThreadPoolExecuto
         final long totalNanos = totalTaskNanos.addAndGet(taskNanos);
 
         final long taskExecutionNanos = timedRunnable.getTotalExecutionNanos();
-        assert taskExecutionNanos >= 0 : "expected task to always take longer than 0 nanoseconds, got: " + taskExecutionNanos;
-        executionEWMA.addValue(taskExecutionNanos);
+        assert taskExecutionNanos >= 0 || taskExecutionNanos == -1 :
+            "expected task to always take longer than 0 nanoseconds or have '-1' failure code, got: " + taskExecutionNanos;
+        if (taskExecutionNanos != -1) {
+            // taskExecutionNanos may be -1 if the task threw an exception
+            executionEWMA.addValue(taskExecutionNanos);
+        }
 
         if (taskCount.incrementAndGet() == this.tasksPerFrame) {
             final long endTimeNs = System.nanoTime();

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/TimedRunnable.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/TimedRunnable.java
@@ -30,6 +30,7 @@ class TimedRunnable extends AbstractRunnable implements WrappedRunnable {
     private final long creationTimeNanos;
     private long startTimeNanos;
     private long finishTimeNanos = -1;
+    private boolean failedOrRejected = false;
 
     TimedRunnable(final Runnable original) {
         this.original = original;
@@ -48,6 +49,7 @@ class TimedRunnable extends AbstractRunnable implements WrappedRunnable {
 
     @Override
     public void onRejection(final Exception e) {
+        this.failedOrRejected = true;
         if (original instanceof AbstractRunnable) {
             ((AbstractRunnable) original).onRejection(e);
         } else {
@@ -64,6 +66,7 @@ class TimedRunnable extends AbstractRunnable implements WrappedRunnable {
 
     @Override
     public void onFailure(final Exception e) {
+        this.failedOrRejected = true;
         if (original instanceof AbstractRunnable) {
             ((AbstractRunnable) original).onFailure(e);
         } else {
@@ -98,6 +101,14 @@ class TimedRunnable extends AbstractRunnable implements WrappedRunnable {
             return -1;
         }
         return Math.max(finishTimeNanos - startTimeNanos, 1);
+    }
+
+    /**
+     * If the task was failed or rejected, return true.
+     * Otherwise, false.
+     */
+    boolean getFailedOrRejected() {
+        return this.failedOrRejected;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/node/NodeTests.java
+++ b/server/src/test/java/org/elasticsearch/node/NodeTests.java
@@ -174,7 +174,6 @@ public class NodeTests extends ESTestCase {
         shouldRun.set(false);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/41448")
     public void testCloseOnInterruptibleTask() throws Exception {
         Node node = new MockNode(baseSettings().build(), basePlugins());
         node.start();


### PR DESCRIPTION
The afterExecute method previously asserted that a TimedRunnable task
must have a positive execution time. However, the code in TimedRunnable
returns a value of -1 when a task time is unknown. Here, we expand the
logic in the assertion to allow for that possibility, and we don't
update our task time average if the value is negative.

Fixes #41448