### PR TITLE
Set metadata sources for Ivy repositories

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -238,6 +238,9 @@ repositories {
   // simpler legacy pattern from JDK 9 to JDK 12 that we are advocating to Oracle to bring back
   ivy {
     url "https://download.oracle.com"
+    metadataSources {
+      artifact()
+    }
     patternLayout {
       artifact "java/GA/jdk${jdkMajor}/${jdkBuild}/GPL/openjdk-[revision]_[module]-x64_bin.[ext]"
     }
@@ -245,6 +248,9 @@ repositories {
   // current pattern since 12.0.1
   ivy {
     url "https://download.oracle.com"
+    metadataSources {
+      artifact()
+    }
     patternLayout {
       artifact "java/GA/jdk${jdkVersion}/${hash}/${jdkBuild}/GPL/openjdk-[revision]_[module]-x64_bin.[ext]"
     }

--- a/qa/wildfly/build.gradle
+++ b/qa/wildfly/build.gradle
@@ -38,6 +38,9 @@ repositories {
     // the Wildfly distribution is not available via a repository, so we fake an Ivy repository on top of the download site
     ivy {
         url "https://download.jboss.org"
+        metadataSources {
+            artifact()
+        }
         patternLayout {
             artifact 'wildfly/[revision]/[module]-[revision].[ext]'
         }


### PR DESCRIPTION
We have faked some Ivy repositories on a few artifact locations. Today when Gradle attempts to resolve these artifacts, it follows its default strategy to search for Gradle metadata, then Maven POM files, then Ivy descriptors, and finally will fallback to looking directly for the artifact. This wastes times on remote network calls that will 404 anyway since these metadata resources will not exist for these fake Ivy repositories. This commit overrides the Gradle strategy to look directly for artifacts.
