### PR TITLE
Change the reindex fetch in policy runner from 1000 to 10000 and

### DIFF
--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPlugin.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPlugin.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -53,6 +54,9 @@ import static java.util.Collections.emptyList;
 import static org.elasticsearch.xpack.core.XPackSettings.ENRICH_ENABLED_SETTING;
 
 public class EnrichPlugin extends Plugin implements ActionPlugin, IngestPlugin {
+
+    public static final Setting<Integer> ENRICH_FETCH_SIZE_SETTING =
+        Setting.intSetting("index.xpack.enrich.fetch_size", 10000, Setting.Property.NodeScope);
 
     private final Settings settings;
     private final Boolean enabled;
@@ -106,7 +110,7 @@ public class EnrichPlugin extends Plugin implements ActionPlugin, IngestPlugin {
                                                ResourceWatcherService resourceWatcherService, ScriptService scriptService,
                                                NamedXContentRegistry xContentRegistry, Environment environment,
                                                NodeEnvironment nodeEnvironment, NamedWriteableRegistry namedWriteableRegistry) {
-        EnrichPolicyExecutor enrichPolicyExecutor = new EnrichPolicyExecutor(clusterService, client, threadPool,
+        EnrichPolicyExecutor enrichPolicyExecutor = new EnrichPolicyExecutor(settings, clusterService, client, threadPool,
             new IndexNameExpressionResolver(), System::currentTimeMillis);
         return Collections.singleton(enrichPolicyExecutor);
     }
@@ -120,5 +124,10 @@ public class EnrichPlugin extends Plugin implements ActionPlugin, IngestPlugin {
     public List<NamedXContentRegistry.Entry> getNamedXContent() {
         return Collections.singletonList(new NamedXContentRegistry.Entry(MetaData.Custom.class, new ParseField(EnrichMetadata.TYPE),
             EnrichMetadata::fromXContent));
+    }
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        return List.of(ENRICH_FETCH_SIZE_SETTING);
     }
 }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPlugin.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPlugin.java
@@ -55,8 +55,8 @@ import static org.elasticsearch.xpack.core.XPackSettings.ENRICH_ENABLED_SETTING;
 
 public class EnrichPlugin extends Plugin implements ActionPlugin, IngestPlugin {
 
-    public static final Setting<Integer> ENRICH_FETCH_SIZE_SETTING =
-        Setting.intSetting("index.xpack.enrich.fetch_size", 10000, Setting.Property.NodeScope);
+    static final Setting<Integer> ENRICH_FETCH_SIZE_SETTING =
+        Setting.intSetting("index.xpack.enrich.fetch_size", 10000, 1, 1000000, Setting.Property.NodeScope);
 
     private final Settings settings;
     private final Boolean enabled;

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
@@ -58,10 +58,11 @@ public class EnrichPolicyRunner implements Runnable {
     private final Client client;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final LongSupplier nowSupplier;
+    private final int fetchSize;
 
     EnrichPolicyRunner(String policyName, EnrichPolicy policy, ActionListener<PolicyExecutionResult> listener,
                        ClusterService clusterService, Client client, IndexNameExpressionResolver indexNameExpressionResolver,
-                       LongSupplier nowSupplier) {
+                       LongSupplier nowSupplier, int fetchSize) {
         this.policyName = policyName;
         this.policy = policy;
         this.listener = listener;
@@ -69,6 +70,7 @@ public class EnrichPolicyRunner implements Runnable {
         this.client = client;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.nowSupplier = nowSupplier;
+        this.fetchSize = fetchSize;
     }
 
     @Override
@@ -187,6 +189,7 @@ public class EnrichPolicyRunner implements Runnable {
         retainFields.add(policy.getEnrichKey());
         retainFields.addAll(policy.getEnrichValues());
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.size(fetchSize);
         searchSourceBuilder.fetchSource(retainFields.toArray(new String[0]), new String[0]);
         if (policy.getQuery() != null) {
             searchSourceBuilder.query(QueryBuilders.wrapperQuery(policy.getQuery().getQuery()));

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunnerTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunnerTests.java
@@ -106,7 +106,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         };
 
         EnrichPolicyRunner enrichPolicyRunner =
-            new EnrichPolicyRunner(policyName, policy, listener, clusterService, client(), resolver, () -> createTime);
+            new EnrichPolicyRunner(policyName, policy, listener, clusterService, client(), resolver, () -> createTime, 1000);
 
         logger.info("Starting policy run");
 
@@ -221,7 +221,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         };
 
         EnrichPolicyRunner enrichPolicyRunner =
-            new EnrichPolicyRunner(policyName, policy, listener, clusterService, client(), resolver, () -> createTime);
+            new EnrichPolicyRunner(policyName, policy, listener, clusterService, client(), resolver, () -> createTime, 1000);
 
         logger.info("Starting policy run");
 

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunnerTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunnerTests.java
@@ -90,7 +90,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.EXACT_MATCH_TYPE, null, sourceIndex, "field1", enrichFields, "");
         String policyName = "test1";
 
-        ActionListener<PolicyExecutionResult> listener = new ActionListener<PolicyExecutionResult>() {
+        ActionListener<PolicyExecutionResult> listener = new ActionListener<>() {
             @Override
             public void onResponse(PolicyExecutionResult policyExecutionResult) {
                 logger.info("Run complete");
@@ -105,8 +105,8 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
             }
         };
 
-        EnrichPolicyRunner enrichPolicyRunner =
-            new EnrichPolicyRunner(policyName, policy, listener, clusterService, client(), resolver, () -> createTime, 1000);
+        EnrichPolicyRunner enrichPolicyRunner = new EnrichPolicyRunner(policyName, policy, listener, clusterService,
+            client(), resolver, () -> createTime, randomIntBetween(1, 10000));
 
         logger.info("Starting policy run");
 
@@ -205,7 +205,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.EXACT_MATCH_TYPE, null, sourceIndexPattern, "field1", enrichFields, "");
         String policyName = "test1";
 
-        ActionListener<PolicyExecutionResult> listener = new ActionListener<PolicyExecutionResult>() {
+        ActionListener<PolicyExecutionResult> listener = new ActionListener<>() {
             @Override
             public void onResponse(PolicyExecutionResult policyExecutionResult) {
                 logger.info("Run complete");
@@ -220,8 +220,8 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
             }
         };
 
-        EnrichPolicyRunner enrichPolicyRunner =
-            new EnrichPolicyRunner(policyName, policy, listener, clusterService, client(), resolver, () -> createTime, 1000);
+        EnrichPolicyRunner enrichPolicyRunner = new EnrichPolicyRunner(policyName, policy, listener, clusterService,
+            client(), resolver, () -> createTime, randomIntBetween(1, 10000));
 
         logger.info("Starting policy run");
 


### PR DESCRIPTION
make it configurable.

Reindex uses scroll searches to read the source data. It is more efficient
to read more data in one search scroll round then several. I think 10000
is a good sweet spot.

Relates to #32789