### PR TITLE
Change policy runner to use helper method on EnrichPolicy instead of

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichPolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichPolicy.java
@@ -29,6 +29,8 @@ import java.util.Objects;
  */
 public final class EnrichPolicy implements Writeable, ToXContentFragment {
 
+    private static final String ENRICH_INDEX_NAME_BASE = ".enrich-";
+
     public static final String EXACT_MATCH_TYPE = "exact_match";
     public static final String[] SUPPORTED_POLICY_TYPES = new String[]{EXACT_MATCH_TYPE};
 
@@ -130,9 +132,8 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
         return schedule;
     }
 
-    public String getAliasName(String policyName) {
-        // #41553 (list policy api) will add name to policy, so that we don't have to provide the name via a parameter.
-        return ".enrich-" + policyName;
+    public String getBaseName(String policyName) {
+        return ENRICH_INDEX_NAME_BASE + policyName;
     }
 
     @Override

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
@@ -49,8 +49,6 @@ public class EnrichPolicyRunner implements Runnable {
 
     private static final Logger logger = LogManager.getLogger(EnrichPolicyRunner.class);
 
-    private static final String ENRICH_INDEX_NAME_BASE = ".enrich-";
-
     private final String policyName;
     private final EnrichPolicy policy;
     private final ActionListener<PolicyExecutionResult> listener;
@@ -121,10 +119,6 @@ public class EnrichPolicyRunner implements Runnable {
         }
     }
 
-    private String getEnrichIndexBase(final String policyName) {
-        return ENRICH_INDEX_NAME_BASE + policyName;
-    }
-
     private XContentBuilder resolveEnrichMapping(final EnrichPolicy policy) {
         // Currently the only supported policy type is EnrichPolicy.EXACT_MATCH_TYPE, which is a keyword type
         String keyType;
@@ -160,7 +154,7 @@ public class EnrichPolicyRunner implements Runnable {
 
     private void prepareAndCreateEnrichIndex() {
         long nowTimestamp = nowSupplier.getAsLong();
-        String enrichIndexName = getEnrichIndexBase(policyName) + "-" + nowTimestamp;
+        String enrichIndexName = policy.getBaseName(policyName) + "-" + nowTimestamp;
         Settings enrichIndexSettings = Settings.builder()
             .put("index.auto_expand_replicas", "0-all")
             .build();
@@ -234,7 +228,7 @@ public class EnrichPolicyRunner implements Runnable {
     }
 
     private void updateEnrichPolicyAlias(final String destinationIndexName) {
-        String enrichIndexBase = getEnrichIndexBase(policyName);
+        String enrichIndexBase = policy.getBaseName(policyName);
         logger.debug("Policy [{}]: Promoting new enrich index [{}] to alias [{}]", policyName, destinationIndexName, enrichIndexBase);
         GetAliasesRequest aliasRequest = new GetAliasesRequest(enrichIndexBase);
         String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterService.state(), aliasRequest);

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/ExactMatchProcessor.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/ExactMatchProcessor.java
@@ -66,7 +66,7 @@ final class ExactMatchProcessor extends AbstractProcessor {
         }
 
         // TODO: re-use the engine searcher between enriching documents from the same write request
-        try (Engine.Searcher engineSearcher = searchProvider.apply(policy.getAliasName(policyName))) {
+        try (Engine.Searcher engineSearcher = searchProvider.apply(policy.getBaseName(policyName))) {
             if (engineSearcher.getDirectoryReader().leaves().size() == 0) {
                 return ingestDocument;
             } else if (engineSearcher.getDirectoryReader().leaves().size() != 1) {


### PR DESCRIPTION
its own helper method to determine alias / policy base name.

This way both the enrich processor and policy runner use the same logic
to determine the alias to use.

Relates to #32789
