### PR TITLE
Clean up ShardId usage of Streamable

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/DocWriteResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/DocWriteResponse.java
@@ -259,7 +259,7 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        shardId = ShardId.readShardId(in);
+        shardId = new ShardId(in);
         type = in.readString();
         id = in.readString();
         version = in.readZLong();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsGroup.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsGroup.java
@@ -40,7 +40,7 @@ public class ClusterSearchShardsGroup implements Writeable, ToXContentObject {
     }
 
     ClusterSearchShardsGroup(StreamInput in) throws IOException {
-        shardId = ShardId.readShardId(in);
+        shardId = new ShardId(in);
         shards = new ShardRouting[in.readVInt()];
         for (int i = 0; i < shards.length; i++) {
             shards[i] = new ShardRouting(shardId, in);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
@@ -214,7 +214,7 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<Transpor
                 int numberOfShards = in.readVInt();
                 Map<ShardId, SnapshotIndexShardStatus> shardMapBuilder = new HashMap<>(numberOfShards);
                 for (int j = 0; j < numberOfShards; j++) {
-                    ShardId shardId =  ShardId.readShardId(in);
+                    ShardId shardId =  new ShardId(in);
                     SnapshotIndexShardStatus status = SnapshotIndexShardStatus.readShardSnapshotStatus(in);
                     shardMapBuilder.put(shardId, status);
                 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndexShardStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndexShardStats.java
@@ -90,7 +90,7 @@ public class IndexShardStats implements Iterable<ShardStats>, Streamable {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        shardId = ShardId.readShardId(in);
+        shardId = new ShardId(in);
         int shardSize = in.readVInt();
         shards = new ShardStats[shardSize];
         for (int i = 0; i < shardSize; i++) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/ShardUpgradeResult.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/ShardUpgradeResult.java
@@ -68,7 +68,7 @@ class ShardUpgradeResult implements Streamable {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        shardId = ShardId.readShardId(in);
+        shardId = new ShardId(in);
         primary = in.readBoolean();
         upgradeVersion = Version.readVersion(in);
         try {

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkShardResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkShardResponse.java
@@ -67,7 +67,7 @@ public class BulkShardResponse extends ReplicationResponse implements WriteRespo
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        shardId = ShardId.readShardId(in);
+        shardId = new ShardId(in);
         responses = new BulkItemResponse[in.readVInt()];
         for (int i = 0; i < responses.length; i++) {
             responses[i] = BulkItemResponse.readBulkItem(in);

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardRequest.java
@@ -60,7 +60,7 @@ public abstract class BroadcastShardRequest extends TransportRequest implements 
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        shardId = ShardId.readShardId(in);
+        shardId = new ShardId(in);
         originalIndices = OriginalIndices.readOriginalIndices(in);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardResponse.java
@@ -49,7 +49,7 @@ public abstract class BroadcastShardResponse extends TransportResponse {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        shardId = ShardId.readShardId(in);
+        shardId = new ShardId(in);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
@@ -69,7 +69,7 @@ public abstract class ReplicationRequest<Request extends ReplicationRequest<Requ
     public ReplicationRequest(StreamInput in) throws IOException {
         super(in);
         if (in.readBoolean()) {
-            shardId = ShardId.readShardId(in);
+            shardId = new ShardId(in);
         } else {
             shardId = null;
         }

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationResponse.java
@@ -269,7 +269,7 @@ public class ReplicationResponse extends ActionResponse {
 
             @Override
             public void readFrom(StreamInput in) throws IOException {
-                shardId = ShardId.readShardId(in);
+                shardId = new ShardId(in);
                 super.shardId = shardId.getId();
                 index = shardId.getIndexName();
                 nodeId = in.readOptionalString();

--- a/server/src/main/java/org/elasticsearch/action/support/single/instance/InstanceShardOperationRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/instance/InstanceShardOperationRequest.java
@@ -114,7 +114,7 @@ public abstract class InstanceShardOperationRequest<Request extends InstanceShar
         super.readFrom(in);
         index = in.readString();
         if (in.readBoolean()) {
-            shardId = ShardId.readShardId(in);
+            shardId = new ShardId(in);
         } else {
             shardId = null;
         }
@@ -126,7 +126,7 @@ public abstract class InstanceShardOperationRequest<Request extends InstanceShar
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeString(index);
-        out.writeOptionalStreamable(shardId);
+        out.writeOptionalWriteable(shardId);
         out.writeTimeValue(timeout);
         out.writeOptionalString(concreteIndex);
     }

--- a/server/src/main/java/org/elasticsearch/action/support/single/shard/SingleShardRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/shard/SingleShardRequest.java
@@ -97,7 +97,7 @@ public abstract class SingleShardRequest<Request extends SingleShardRequest<Requ
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         if (in.readBoolean()) {
-            internalShardId = ShardId.readShardId(in);
+            internalShardId = new ShardId(in);
         }
         index = in.readOptionalString();
         // no need to pass threading over the network, they are always false when coming throw a thread pool
@@ -106,9 +106,8 @@ public abstract class SingleShardRequest<Request extends SingleShardRequest<Requ
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeOptionalStreamable(internalShardId);
+        out.writeOptionalWriteable(internalShardId);
         out.writeOptionalString(index);
     }
-
 }
 

--- a/server/src/main/java/org/elasticsearch/cluster/RestoreInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/RestoreInProgress.java
@@ -440,7 +440,7 @@ public class RestoreInProgress extends AbstractNamedDiffable<Custom> implements 
             ImmutableOpenMap.Builder<ShardId, ShardRestoreStatus> builder = ImmutableOpenMap.builder();
             int shards = in.readVInt();
             for (int j = 0; j < shards; j++) {
-                ShardId shardId = ShardId.readShardId(in);
+                ShardId shardId = new ShardId(in);
                 ShardRestoreStatus shardState = ShardRestoreStatus.readShardRestoreStatus(in);
                 builder.put(shardId, shardState);
             }

--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -432,7 +432,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             ImmutableOpenMap.Builder<ShardId, ShardSnapshotStatus> builder = ImmutableOpenMap.builder();
             int shards = in.readVInt();
             for (int j = 0; j < shards; j++) {
-                ShardId shardId = ShardId.readShardId(in);
+                ShardId shardId = new ShardId(in);
                 builder.put(shardId, new ShardSnapshotStatus(in));
             }
             long repositoryStateId = in.readLong();

--- a/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -394,7 +394,7 @@ public class ShardStateAction {
 
         FailedShardEntry(StreamInput in) throws IOException {
             super(in);
-            shardId = ShardId.readShardId(in);
+            shardId = new ShardId(in);
             allocationId = in.readString();
             primaryTerm = in.readVLong();
             message = in.readString();
@@ -592,7 +592,7 @@ public class ShardStateAction {
 
         StartedShardEntry(StreamInput in) throws IOException {
             super(in);
-            shardId = ShardId.readShardId(in);
+            shardId = new ShardId(in);
             allocationId = in.readString();
             primaryTerm = in.readVLong();
             this.message = in.readString();

--- a/server/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
@@ -279,7 +279,7 @@ public final class ShardRouting implements Writeable, ToXContentObject {
     }
 
     public ShardRouting(StreamInput in) throws IOException {
-        this(ShardId.readShardId(in), in);
+        this(new ShardId(in), in);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
+++ b/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
@@ -185,7 +185,7 @@ public class TransportNodesListGatewayStartedShards extends
         @Override
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
-            shardId = ShardId.readShardId(in);
+            shardId = new ShardId(in);
         }
 
         @Override
@@ -229,7 +229,7 @@ public class TransportNodesListGatewayStartedShards extends
         @Override
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
-            shardId = ShardId.readShardId(in);
+            shardId = new ShardId(in);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseActions.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseActions.java
@@ -302,7 +302,7 @@ public class RetentionLeaseActions {
         @Override
         public void readFrom(final StreamInput in) throws IOException {
             super.readFrom(in);
-            shardId = ShardId.readShardId(in);
+            shardId = new ShardId(in);
             id = in.readString();
         }
 

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardId.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardId.java
@@ -22,7 +22,6 @@ package org.elasticsearch.index.shard;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -33,19 +32,11 @@ import java.io.IOException;
 /**
  * Allows for shard level components to be injected with the shard id.
  */
-public class ShardId implements Streamable, Comparable<ShardId>, ToXContentFragment, Writeable {
+public class ShardId implements Comparable<ShardId>, ToXContentFragment, Writeable {
 
     private final Index index;
-
     private final int shardId;
-
     private final int hashCode;
-
-    public ShardId(StreamInput in) throws IOException {
-        index = new Index(in);
-        shardId = in.readVInt();
-        hashCode = computeHashCode();
-    }
 
     public ShardId(Index index, int shardId) {
         this.index = index;
@@ -55,6 +46,18 @@ public class ShardId implements Streamable, Comparable<ShardId>, ToXContentFragm
 
     public ShardId(String index, String indexUUID, int shardId) {
         this(new Index(index, indexUUID), shardId);
+    }
+
+    public ShardId(StreamInput in) throws IOException {
+        index = new Index(in);
+        shardId = in.readVInt();
+        hashCode = computeHashCode();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        index.writeTo(out);
+        out.writeVInt(shardId);
     }
 
     public Index getIndex() {
@@ -111,21 +114,6 @@ public class ShardId implements Streamable, Comparable<ShardId>, ToXContentFragm
         int result = index != null ? index.hashCode() : 0;
         result = 31 * result + shardId;
         return result;
-    }
-
-    public static ShardId readShardId(StreamInput in) throws IOException {
-        return new ShardId(in);
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        index.writeTo(out);
-        out.writeVInt(shardId);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/indices/flush/ShardsSyncedFlushResult.java
+++ b/server/src/main/java/org/elasticsearch/indices/flush/ShardsSyncedFlushResult.java
@@ -148,7 +148,7 @@ public class ShardsSyncedFlushResult implements Streamable {
             shardResponses.put(shardRouting, response);
         }
         syncId = in.readOptionalString();
-        shardId = ShardId.readShardId(in);
+        shardId = new ShardId(in);
         totalShards = in.readInt();
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
+++ b/server/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
@@ -567,7 +567,7 @@ public class SyncedFlushService implements IndexEventListener {
         @Override
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
-            this.shardId = ShardId.readShardId(in);
+            this.shardId = new ShardId(in);
         }
 
         public ShardId shardId() {
@@ -647,7 +647,7 @@ public class SyncedFlushService implements IndexEventListener {
         @Override
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
-            shardId = ShardId.readShardId(in);
+            shardId = new ShardId(in);
             expectedCommitId = new Engine.CommitId(in);
             syncId = in.readString();
         }
@@ -749,7 +749,7 @@ public class SyncedFlushService implements IndexEventListener {
         @Override
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
-            shardId = ShardId.readShardId(in);
+            shardId = new ShardId(in);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryCleanFilesRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryCleanFilesRequest.java
@@ -49,7 +49,7 @@ public class RecoveryCleanFilesRequest extends TransportRequest {
     RecoveryCleanFilesRequest(StreamInput in) throws IOException {
         super(in);
         recoveryId = in.readLong();
-        shardId = ShardId.readShardId(in);
+        shardId = new ShardId(in);
         snapshotFiles = new Store.MetadataSnapshot(in);
         totalTranslogOps = in.readVInt();
         if (in.getVersion().onOrAfter(Version.V_7_2_0)) {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFileChunkRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFileChunkRequest.java
@@ -96,7 +96,7 @@ public final class RecoveryFileChunkRequest extends TransportRequest {
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         recoveryId = in.readLong();
-        shardId = ShardId.readShardId(in);
+        shardId = new ShardId(in);
         String name = in.readString();
         position = in.readVLong();
         long length = in.readVLong();

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFilesInfoRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFilesInfoRequest.java
@@ -66,7 +66,7 @@ public class RecoveryFilesInfoRequest extends TransportRequest {
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         recoveryId = in.readLong();
-        shardId = ShardId.readShardId(in);
+        shardId = new ShardId(in);
         int size = in.readVInt();
         phase1FileNames = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFinalizeRecoveryRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFinalizeRecoveryRequest.java
@@ -57,7 +57,7 @@ public class RecoveryFinalizeRecoveryRequest extends TransportRequest {
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         recoveryId = in.readLong();
-        shardId = ShardId.readShardId(in);
+        shardId = new ShardId(in);
         globalCheckpoint = in.readZLong();
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryHandoffPrimaryContextRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryHandoffPrimaryContextRequest.java
@@ -72,7 +72,7 @@ class RecoveryHandoffPrimaryContextRequest extends TransportRequest {
     public void readFrom(final StreamInput in) throws IOException {
         super.readFrom(in);
         recoveryId = in.readLong();
-        shardId = ShardId.readShardId(in);
+        shardId = new ShardId(in);
         primaryContext = new ReplicationTracker.PrimaryContext(in);
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryPrepareForTranslogOperationsRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryPrepareForTranslogOperationsRequest.java
@@ -43,7 +43,7 @@ class RecoveryPrepareForTranslogOperationsRequest extends TransportRequest {
     RecoveryPrepareForTranslogOperationsRequest(StreamInput in) throws IOException {
         super.readFrom(in);
         recoveryId = in.readLong();
-        shardId = ShardId.readShardId(in);
+        shardId = new ShardId(in);
         totalTranslogOps = in.readVInt();
         fileBasedRecovery = in.readBoolean();
     }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -134,7 +134,7 @@ public class RecoveryState implements ToXContentFragment, Streamable, Writeable 
     public RecoveryState(StreamInput in) throws IOException {
         timer = new Timer(in);
         stage = Stage.fromId(in.readByte());
-        shardId = ShardId.readShardId(in);
+        shardId = new ShardId(in);
         recoverySource = RecoverySource.readFrom(in);
         targetNode = new DiscoveryNode(in);
         sourceNode = in.readOptionalWriteable(DiscoveryNode::new);

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTranslogOperationsRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTranslogOperationsRequest.java
@@ -100,7 +100,7 @@ public class RecoveryTranslogOperationsRequest extends TransportRequest {
     RecoveryTranslogOperationsRequest(StreamInput in) throws IOException {
         super.readFrom(in);
         recoveryId = in.readLong();
-        shardId = ShardId.readShardId(in);
+        shardId = new ShardId(in);
         operations = Translog.readOperations(in, "recovery");
         totalTranslogOps = in.readVInt();
         maxSeenAutoIdTimestampOnPrimary = in.readZLong();

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryWaitForClusterStateRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryWaitForClusterStateRequest.java
@@ -56,7 +56,7 @@ public class RecoveryWaitForClusterStateRequest extends TransportRequest {
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         recoveryId = in.readLong();
-        shardId = ShardId.readShardId(in);
+        shardId = new ShardId(in);
         clusterStateVersion = in.readVLong();
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
@@ -114,7 +114,7 @@ public class StartRecoveryRequest extends TransportRequest {
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         recoveryId = in.readLong();
-        shardId = ShardId.readShardId(in);
+        shardId = new ShardId(in);
         targetAllocationId = in.readString();
         sourceNode = new DiscoveryNode(in);
         targetNode = new DiscoveryNode(in);

--- a/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -412,7 +412,7 @@ public class IndicesStore implements ClusterStateListener, Closeable {
             super.readFrom(in);
             clusterName = new ClusterName(in);
             indexUUID = in.readString();
-            shardId = ShardId.readShardId(in);
+            shardId = new ShardId(in);
             timeout = new TimeValue(in.readLong(), TimeUnit.MILLISECONDS);
         }
 

--- a/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
@@ -203,7 +203,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            shardId = ShardId.readShardId(in);
+            shardId = new ShardId(in);
             this.metadataSnapshot = new Store.MetadataSnapshot(in);
         }
 
@@ -245,7 +245,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
         @Override
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
-            shardId = ShardId.readShardId(in);
+            shardId = new ShardId(in);
         }
 
         @Override
@@ -288,7 +288,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
         @Override
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
-            shardId = ShardId.readShardId(in);
+            shardId = new ShardId(in);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/SearchShardTarget.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchShardTarget.java
@@ -49,7 +49,7 @@ public final class SearchShardTarget implements Writeable, Comparable<SearchShar
         } else {
             nodeId = null;
         }
-        shardId = ShardId.readShardId(in);
+        shardId = new ShardId(in);
         this.originalIndices = null;
         clusterAlias = in.readOptionalString();
     }

--- a/server/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
@@ -107,7 +107,7 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
     }
 
     ShardSearchLocalRequest(StreamInput in) throws IOException {
-        shardId = ShardId.readShardId(in);
+        shardId = new ShardId(in);
         searchType = SearchType.fromId(in.readByte());
         numberOfShards = in.readVInt();
         scroll = in.readOptionalWriteable(Scroll::new);

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardFailure.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardFailure.java
@@ -99,7 +99,7 @@ public class SnapshotShardFailure extends ShardOperationFailedException {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         nodeId = in.readOptionalString();
-        shardId = ShardId.readShardId(in);
+        shardId = new ShardId(in);
         super.shardId = shardId.getId();
         index = shardId.getIndexName();
         reason = in.readString();

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -448,7 +448,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
             snapshot = new Snapshot(in);
-            shardId = ShardId.readShardId(in);
+            shardId = new ShardId(in);
             status = new ShardSnapshotStatus(in);
         }
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardChangesAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardChangesAction.java
@@ -146,7 +146,7 @@ public class ShardChangesAction extends Action<ShardChangesAction.Response> {
             super.readFrom(in);
             fromSeqNo = in.readVLong();
             maxOperationCount = in.readVInt();
-            shardId = ShardId.readShardId(in);
+            shardId = new ShardId(in);
             expectedHistoryUUID = in.readString();
             pollTimeout = in.readTimeValue();
             maxBatchSize = new ByteSizeValue(in);

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTask.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTask.java
@@ -92,8 +92,8 @@ public class ShardFollowTask extends ImmutableFollowParameters implements XPackP
 
     public static ShardFollowTask readFrom(StreamInput in) throws IOException {
         String remoteCluster = in.readString();
-        ShardId followShardId = ShardId.readShardId(in);
-        ShardId leaderShardId = ShardId.readShardId(in);
+        ShardId followShardId = new ShardId(in);
+        ShardId leaderShardId = new ShardId(in);
         return new ShardFollowTask(remoteCluster, followShardId, leaderShardId, in);
     }
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/PutCcrRestoreSessionRequest.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/PutCcrRestoreSessionRequest.java
@@ -37,7 +37,7 @@ public class PutCcrRestoreSessionRequest extends SingleShardRequest<PutCcrRestor
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         sessionUUID = in.readString();
-        shardId = ShardId.readShardId(in);
+        shardId = new ShardId(in);
     }
 
     @Override


### PR DESCRIPTION
ShardId already implements Writeable so there is no need for it to implement Streamable too. Also the readShardId static method can be
easily replaced with direct usages of the constructor that takes a
StreamInput as argument.