### PR TITLE
Fix full text queries test that start with now

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/query/FullTextQueryTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/query/FullTextQueryTestCase.java
@@ -1,0 +1,41 @@
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.test.AbstractQueryTestCase;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+public abstract class FullTextQueryTestCase<QB extends AbstractQueryBuilder<QB>> extends AbstractQueryTestCase<QB> {
+    protected abstract boolean isCacheable(QB queryBuilder);
+
+    /**
+     * Full text queries that start with "now" are not cacheable if they
+     * target a {@link DateFieldMapper.DateFieldType} field.
+     */
+    protected final boolean isCacheable(Collection<String> fields, String value) {
+        if (value.length() < 3
+                || value.substring(0, 3).equalsIgnoreCase("now") == false) {
+            return true;
+        }
+        Set<String> dateFields = new HashSet<>();
+        getMapping().forEach(ft -> {
+            if (ft instanceof DateFieldMapper.DateFieldType) {
+                dateFields.add(ft.name());
+            }
+        });
+        for (MappedFieldType ft : getMapping()) {
+            if (ft instanceof DateFieldMapper.DateFieldType) {
+                dateFields.add(ft.name());
+            }
+        }
+        if (fields.isEmpty()) {
+            // special case: all fields are requested
+            return dateFields.isEmpty();
+        }
+        return fields.stream()
+            .anyMatch(dateFields::contains) == false;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/query/FullTextQueryTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/query/FullTextQueryTestCase.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.elasticsearch.index.query;
 
 import org.elasticsearch.index.mapper.DateFieldMapper;

--- a/server/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
@@ -46,7 +46,6 @@ import org.elasticsearch.index.search.MatchQuery;
 import org.elasticsearch.index.search.MatchQuery.Type;
 import org.elasticsearch.index.search.MatchQuery.ZeroTermsQuery;
 import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.test.AbstractQueryTestCase;
 import org.hamcrest.Matcher;
 
 import java.io.IOException;
@@ -56,13 +55,19 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.either;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
-public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuilder> {
+public class MatchQueryBuilderTests extends FullTextQueryTestCase<MatchQueryBuilder> {
+    @Override
+    protected boolean isCacheable(MatchQueryBuilder queryBuilder) {
+        return queryBuilder.fuzziness() != null
+                ||  isCacheable(singletonList(queryBuilder.fieldName()), queryBuilder.value().toString());
+    }
 
     @Override
     protected MatchQueryBuilder doCreateTestQueryBuilder() {

--- a/server/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
@@ -42,7 +42,6 @@ import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.query.MultiMatchQueryBuilder.Type;
 import org.elasticsearch.index.search.MatchQuery;
 import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.test.AbstractQueryTestCase;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -59,10 +58,15 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
-public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatchQueryBuilder> {
-
+public class MultiMatchQueryBuilderTests extends FullTextQueryTestCase<MultiMatchQueryBuilder> {
     private static final String MISSING_WILDCARD_FIELD_NAME = "missing_*";
     private static final String MISSING_FIELD_NAME = "missing";
+
+    @Override
+    protected boolean isCacheable(MultiMatchQueryBuilder queryBuilder) {
+        return queryBuilder.fuzziness() != null
+                || isCacheable(queryBuilder.fields().keySet(), queryBuilder.value().toString());
+    }
 
     @Override
     protected MultiMatchQueryBuilder doCreateTestQueryBuilder() {

--- a/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -62,7 +62,6 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.search.QueryStringQueryParser;
 import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.test.AbstractQueryTestCase;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 
@@ -84,7 +83,12 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 
-public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStringQueryBuilder> {
+public class QueryStringQueryBuilderTests extends FullTextQueryTestCase<QueryStringQueryBuilder> {
+    @Override
+    protected boolean isCacheable(QueryStringQueryBuilder queryBuilder) {
+        return queryBuilder.fuzziness() != null
+                || isCacheable(queryBuilder.fields().keySet(), queryBuilder.queryString());
+    }
 
     @Override
     protected void initializeAdditionalMappings(MapperService mapperService) throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
@@ -44,7 +44,6 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.search.SimpleQueryStringQueryParser;
 import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.test.AbstractQueryTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -65,7 +64,11 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
-public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQueryStringBuilder> {
+public class SimpleQueryStringBuilderTests extends FullTextQueryTestCase<SimpleQueryStringBuilder> {
+    @Override
+    protected boolean isCacheable(SimpleQueryStringBuilder queryBuilder) {
+        return isCacheable(queryBuilder.fields().keySet(), queryBuilder.value());
+    }
 
     @Override
     protected SimpleQueryStringBuilder doCreateTestQueryBuilder() {
@@ -106,11 +109,6 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
             } else {
                 fields.put(STRING_FIELD_NAME_2, 2.0f / randomIntBetween(1, 20));
             }
-        }
-        // special handling if query start with "now" and no field specified. This hits the "mapped_date" field which leads to the query not
-        // being cacheable and trigger later test failures (see https://github.com/elastic/elasticsearch/issues/35183)
-        if (fieldCount == 0 && queryText.length() >= 3 && queryText.substring(0,3).equalsIgnoreCase("now")) {
-            fields.put(STRING_FIELD_NAME_2, 2.0f / randomIntBetween(1, 20));
         }
 
         result.fields(fields);

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -193,6 +193,10 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
         return ALIAS_TO_CONCRETE_FIELD_NAME.getOrDefault(builderFieldName, builderFieldName);
     }
 
+    protected Iterable<MappedFieldType> getMapping() {
+        return serviceHolder.mapperService.fieldTypes();
+    }
+
     @AfterClass
     public static void afterClass() throws Exception {
         IOUtils.close(serviceHolder);


### PR DESCRIPTION
Full text queries that start with now are not cacheable if they target a date field.
However we assume in the query builder tests that all queries are cacheable and this assumption
fails when the random generated query string starts with "now". This fails twice in several years
since the probability that a random string starts with "now" is low but this commit ensures that
 isCacheable is correctly checked for full text queries that fall into this edge case.

 Closes #41847