### PR TITLE
[DOCS] Replace table with def list for `ids` query

### DIFF
--- a/docs/reference/query-dsl/ids-query.asciidoc
+++ b/docs/reference/query-dsl/ids-query.asciidoc
@@ -21,8 +21,5 @@ GET /_search
 [[ids-query-top-level-parameters]]
 ==== Top-level parameters for `ids`
 
-[cols="v,v",options="header"]
-|======
-|Parameter  |Description
-|`values`   |An array of <<mapping-id-field, document IDs>>.
-|======
+`values`::
+An array of <<mapping-id-field, document IDs>>.


### PR DESCRIPTION
Replaces the parameters table for the `ids` query with a definition list. This should make ongoing maintenance easier. No substantive changes.

## Before
<img width="768" alt="Screen Shot 2019-05-06 at 3 15 49 PM" src="https://user-images.githubusercontent.com/40268737/57249244-6eac0400-7012-11e9-9c5c-773a94d6e598.png">

## After
<img width="766" alt="Screen Shot 2019-05-06 at 3 18 13 PM" src="https://user-images.githubusercontent.com/40268737/57249248-7370b800-7012-11e9-8bf5-4f7c3c52f5b3.png">
