### PR TITLE
SQL: Add non-zero display size for geo types

### DIFF
--- a/x-pack/plugin/sql/qa/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/GeoJdbcCsvSpecIT.java
+++ b/x-pack/plugin/sql/qa/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/GeoJdbcCsvSpecIT.java
@@ -6,10 +6,25 @@
 
 package org.elasticsearch.xpack.sql.qa.single_node;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.elasticsearch.xpack.sql.qa.geo.GeoCsvSpecTestCase;
 import org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.CsvTestCase;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elasticsearch.xpack.sql.qa.jdbc.CsvTestUtils.specParser;
+
 public class GeoJdbcCsvSpecIT extends GeoCsvSpecTestCase {
+
+    @ParametersFactory(argumentFormatting = PARAM_FORMATTING)
+    public static List<Object[]> readScriptSpec() throws Exception {
+        List<Object[]> list = new ArrayList<>();
+        list.addAll(GeoCsvSpecTestCase.readScriptSpec());
+        list.addAll(readScriptSpec("/single-node-only/command-sys-geo.csv-spec", specParser()));
+        return list;
+    }
+
     public GeoJdbcCsvSpecIT(String fileName, String groupName, String testName, Integer lineNumber, CsvTestCase testCase) {
         super(fileName, groupName, testName, lineNumber, testCase);
     }

--- a/x-pack/plugin/sql/qa/src/main/resources/single-node-only/command-sys-geo.csv-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/single-node-only/command-sys-geo.csv-spec
@@ -1,0 +1,15 @@
+//
+// Geo-specific Sys Commands
+//
+
+geoSysColumns
+SYS COLUMNS TABLE LIKE 'geo';
+
+               TABLE_CAT:s                       |  TABLE_SCHEM:s|  TABLE_NAME:s | COLUMN_NAME:s |   DATA_TYPE:i |   TYPE_NAME:s |  COLUMN_SIZE:i|BUFFER_LENGTH:i|DECIMAL_DIGITS:i|NUM_PREC_RADIX:i| NULLABLE:i|    REMARKS:s  |  COLUMN_DEF:s |SQL_DATA_TYPE:i|SQL_DATETIME_SUB:i|CHAR_OCTET_LENGTH:i|ORDINAL_POSITION:i|IS_NULLABLE:s|SCOPE_CATALOG:s|SCOPE_SCHEMA:s|SCOPE_TABLE:s|SOURCE_DATA_TYPE:sh|IS_AUTOINCREMENT:s|IS_GENERATEDCOLUMN:s
+x-pack_plugin_sql_qa_single-node_integTestCluster|null           |geo            |city           |12             |KEYWORD        |32766          |2147483647     |null            |null            |1          |null           |null           |12             |0                 |2147483647         |1                 |YES          |null           |null          |null         |null               |NO                |NO
+x-pack_plugin_sql_qa_single-node_integTestCluster|null           |geo            |location       |114            |GEO_POINT      |58             |16             |null            |null            |1          |null           |null           |114            |0                 |null               |2                 |YES          |null           |null          |null         |null               |NO                |NO
+x-pack_plugin_sql_qa_single-node_integTestCluster|null           |geo            |location_no_dv |114            |GEO_POINT      |58             |16             |null            |null            |1          |null           |null           |114            |0                 |null               |3                 |YES          |null           |null          |null         |null               |NO                |NO
+x-pack_plugin_sql_qa_single-node_integTestCluster|null           |geo            |region         |12             |KEYWORD        |32766          |2147483647     |null            |null            |1          |null           |null           |12             |0                 |2147483647         |4                 |YES          |null           |null          |null         |null               |NO                |NO
+x-pack_plugin_sql_qa_single-node_integTestCluster|null           |geo            |region_point   |12             |KEYWORD        |32766          |2147483647     |null            |null            |1          |null           |null           |12             |0                 |2147483647         |5                 |YES          |null           |null          |null         |null               |NO                |NO
+x-pack_plugin_sql_qa_single-node_integTestCluster|null           |geo            |shape          |114            |GEO_SHAPE      |2147483647     |2147483647     |null            |null            |1          |null           |null           |114            |0                 |null               |6                 |YES          |null           |null          |null         |null               |NO                |NO
+;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/type/DataType.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/type/DataType.java
@@ -53,8 +53,9 @@ public enum DataType {
     //
     // specialized types
     //
-    GEO_SHAPE(             ExtTypes.GEOMETRY,  Integer.MAX_VALUE, Integer.MAX_VALUE, 0, false, false, false),
-    GEO_POINT(             ExtTypes.GEOMETRY,  Double.BYTES*2,    Integer.MAX_VALUE, 0, false, false, false),
+    GEO_SHAPE(                       ExtTypes.GEOMETRY,  Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, false, false, false),
+    //                                                                                 display size = 2 doubles + len("POINT( )")
+    GEO_POINT(                       ExtTypes.GEOMETRY,  Double.BYTES*2,    Integer.MAX_VALUE, 25 * 2 + 8, false, false, false),
     // IP can be v4 or v6. The latter has 2^128 addresses or 340,282,366,920,938,463,463,374,607,431,768,211,456
     // aka 39 chars
     IP(            "ip",             JDBCType.VARCHAR,   39,               39,                 0,  false, false, true),


### PR DESCRIPTION
Sets a proper display size value for geo types. For geo_points it is
set to 58 (size of POINT( ) plus 2 double numbers). The size of
geo_shape it is the same as size of TEXT type (max integer).

Closes #41809
