### PR TITLE
Remove Comma in Example

### DIFF
--- a/x-pack/docs/en/watcher/condition/array-compare.asciidoc
+++ b/x-pack/docs/en/watcher/condition/array-compare.asciidoc
@@ -27,7 +27,7 @@ than or equal to 25:
       "ctx.payload.aggregations.top_tweeters.buckets" : { <1>
         "path": "doc_count", <2>
         "gte": { <3>
-          "value": 25, <4>
+          "value": 25 <4>
         }
       }
     }


### PR DESCRIPTION
The comma is there in error as there are no other parameters after **value**
