### PR TITLE
[ML-DataFrame] timebased continuous dataframe

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameMessages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameMessages.java
@@ -37,7 +37,9 @@ public class DataFrameMessages {
     public static final String FAILED_TO_PARSE_TRANSFORM_CONFIGURATION =
             "Failed to parse transform configuration for data frame transform [{0}]";
     public static final String FAILED_TO_PARSE_TRANSFORM_STATISTICS_CONFIGURATION =
-        "Failed to parse transform statistics for data frame transform [{0}]";
+            "Failed to parse transform statistics for data frame transform [{0}]";
+    public static final String FAILED_TO_LOAD_TRANSFORM_CHECKPOINT =
+            "Failed to load data frame transform configuration for transform [{0}]";
     public static final String DATA_FRAME_TRANSFORM_CONFIGURATION_NO_TRANSFORM =
             "Data frame transform configuration must specify exactly 1 function";
     public static final String DATA_FRAME_TRANSFORM_CONFIGURATION_PIVOT_NO_GROUP_BY =

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/SyncConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/SyncConfig.java
@@ -19,7 +19,7 @@ public interface SyncConfig extends ToXContentObject, NamedWriteable {
      */
     boolean isValid();
 
-    QueryBuilder getBoundaryQuery(DataFrameTransformCheckpoint checkpoint);
+    QueryBuilder getRangeQuery(DataFrameTransformCheckpoint newCheckpoint);
 
-    QueryBuilder getChangesQuery(DataFrameTransformCheckpoint oldCheckpoint, DataFrameTransformCheckpoint newCheckpoint);
+    QueryBuilder getRangeQuery(DataFrameTransformCheckpoint oldCheckpoint, DataFrameTransformCheckpoint newCheckpoint);
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/TimeSyncConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/TimeSyncConfig.java
@@ -136,12 +136,12 @@ public class TimeSyncConfig  implements SyncConfig {
     }
 
     @Override
-    public QueryBuilder getBoundaryQuery(DataFrameTransformCheckpoint checkpoint) {
-        return new RangeQueryBuilder(field).lt(checkpoint.getTimeUpperBound()).format("epoch_millis");
+    public QueryBuilder getRangeQuery(DataFrameTransformCheckpoint newCheckpoint) {
+        return new RangeQueryBuilder(field).lt(newCheckpoint.getTimeUpperBound()).format("epoch_millis");
     }
 
     @Override
-    public QueryBuilder getChangesQuery(DataFrameTransformCheckpoint oldCheckpoint, DataFrameTransformCheckpoint newCheckpoint) {
+    public QueryBuilder getRangeQuery(DataFrameTransformCheckpoint oldCheckpoint, DataFrameTransformCheckpoint newCheckpoint) {
         return new RangeQueryBuilder(field).gte(oldCheckpoint.getTimeUpperBound()).lt(newCheckpoint.getTimeUpperBound())
                 .format("epoch_millis");
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/DateHistogramGroupSource.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/DateHistogramGroupSource.java
@@ -12,11 +12,13 @@ import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 
 import java.io.IOException;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Objects;
 
 
@@ -178,5 +180,11 @@ public class DateHistogramGroupSource extends SingleGroupSource {
     @Override
     public int hashCode() {
         return Objects.hash(field, interval, dateHistogramInterval, timeZone, format);
+    }
+
+    @Override
+    public QueryBuilder getFilterQuery(List<String> changedBuckets) {
+        // no need for an extra range filter as this is already done by checkpoints
+        return null;
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/DateHistogramGroupSource.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/DateHistogramGroupSource.java
@@ -18,8 +18,8 @@ import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInter
 import java.io.IOException;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 
 public class DateHistogramGroupSource extends SingleGroupSource {
@@ -183,8 +183,13 @@ public class DateHistogramGroupSource extends SingleGroupSource {
     }
 
     @Override
-    public QueryBuilder getFilterQuery(List<String> changedBuckets) {
+    public QueryBuilder getIncrementalBucketUpdateFilterQuery(Set<String> changedBuckets) {
         // no need for an extra range filter as this is already done by checkpoints
         return null;
+    }
+
+    @Override
+    public boolean supportsIncrementalBucketUpdate() {
+        return false;
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/HistogramGroupSource.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/HistogramGroupSource.java
@@ -11,8 +11,10 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.QueryBuilder;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Objects;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
@@ -98,5 +100,11 @@ public class HistogramGroupSource extends SingleGroupSource {
     @Override
     public int hashCode() {
         return Objects.hash(field, interval);
+    }
+
+    @Override
+    public QueryBuilder getFilterQuery(List<String> changedBuckets) {
+        // histograms are simple and cheap, so we skip this optimization
+        return null;
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/HistogramGroupSource.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/HistogramGroupSource.java
@@ -14,8 +14,8 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryBuilder;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
@@ -103,8 +103,13 @@ public class HistogramGroupSource extends SingleGroupSource {
     }
 
     @Override
-    public QueryBuilder getFilterQuery(List<String> changedBuckets) {
+    public QueryBuilder getIncrementalBucketUpdateFilterQuery(Set<String> changedBuckets) {
         // histograms are simple and cheap, so we skip this optimization
         return null;
+    }
+
+    @Override
+    public boolean supportsIncrementalBucketUpdate() {
+        return false;
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/PivotConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/PivotConfig.java
@@ -86,12 +86,16 @@ public class PivotConfig implements Writeable, ToXContentObject {
         return builder;
     }
 
-    public void toCompositeAggXContent(XContentBuilder builder, Params params) throws IOException {
+    public void toCompositeAggXContent(XContentBuilder builder, boolean forChangeDetection) throws IOException {
         builder.startObject();
         builder.field(CompositeAggregationBuilder.SOURCES_FIELD_NAME.getPreferredName());
         builder.startArray();
 
         for (Entry<String, SingleGroupSource> groupBy : groups.getGroups().entrySet()) {
+            // some group source do not implement change detection or not makes no sense, skip those
+            if (forChangeDetection && groupBy.getValue().supportsIncrementalBucketUpdate() == false) {
+                continue;
+            }
             builder.startObject();
             builder.startObject(groupBy.getKey());
             builder.field(groupBy.getValue().getType().value(), groupBy.getValue());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/SingleGroupSource.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/SingleGroupSource.java
@@ -14,8 +14,10 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.AbstractObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
@@ -93,6 +95,8 @@ public abstract class SingleGroupSource implements Writeable, ToXContentObject {
     }
 
     public abstract Type getType();
+
+    public abstract QueryBuilder getFilterQuery(List<String> changedBuckets);
 
     public String getField() {
         return field;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/SingleGroupSource.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/SingleGroupSource.java
@@ -17,9 +17,9 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
@@ -96,7 +96,9 @@ public abstract class SingleGroupSource implements Writeable, ToXContentObject {
 
     public abstract Type getType();
 
-    public abstract QueryBuilder getFilterQuery(List<String> changedBuckets);
+    public abstract boolean supportsIncrementalBucketUpdate();
+
+    public abstract QueryBuilder getIncrementalBucketUpdateFilterQuery(Set<String> changedBuckets);
 
     public String getField() {
         return field;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/TermsGroupSource.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/TermsGroupSource.java
@@ -9,8 +9,11 @@ package org.elasticsearch.xpack.core.dataframe.transforms.pivot;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.TermsQueryBuilder;
 
 import java.io.IOException;
+import java.util.List;
 
 /*
  * A terms aggregation source for group_by
@@ -46,5 +49,10 @@ public class TermsGroupSource extends SingleGroupSource {
 
     public static TermsGroupSource fromXContent(final XContentParser parser, boolean lenient) throws IOException {
         return lenient ? LENIENT_PARSER.apply(parser, null) : STRICT_PARSER.apply(parser, null);
+    }
+
+    @Override
+    public QueryBuilder getFilterQuery(List<String> changedBuckets) {
+        return new TermsQueryBuilder(field, changedBuckets);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/TermsGroupSource.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/TermsGroupSource.java
@@ -13,7 +13,7 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.TermsQueryBuilder;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Set;
 
 /*
  * A terms aggregation source for group_by
@@ -52,7 +52,12 @@ public class TermsGroupSource extends SingleGroupSource {
     }
 
     @Override
-    public QueryBuilder getFilterQuery(List<String> changedBuckets) {
+    public QueryBuilder getIncrementalBucketUpdateFilterQuery(Set<String> changedBuckets) {
         return new TermsQueryBuilder(field, changedBuckets);
+    }
+
+    @Override
+    public boolean supportsIncrementalBucketUpdate() {
+        return true;
     }
 }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
@@ -16,12 +16,18 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
+import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.dataframe.DataFrameMessages;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerTransformStats;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformCheckpoint;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformProgress;
+import org.elasticsearch.xpack.core.dataframe.transforms.pivot.SingleGroupSource;
 import org.elasticsearch.xpack.core.dataframe.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.indexing.AsyncTwoPhaseIndexer;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
@@ -31,8 +37,12 @@ import org.elasticsearch.xpack.dataframe.transforms.pivot.Pivot;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
@@ -55,6 +65,8 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<Map<String, 
 
     private Pivot pivot;
     private int pageSize = 0;
+    protected volatile DataFrameTransformCheckpoint inProgressOrLastCheckpoint;
+    private volatile Map<String, List<String>> changedBuckets;
 
     public DataFrameIndexer(Executor executor,
                             DataFrameAuditor auditor,
@@ -63,12 +75,14 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<Map<String, 
                             AtomicReference<IndexerState> initialState,
                             Map<String, Object> initialPosition,
                             DataFrameIndexerTransformStats jobStats,
-                            DataFrameTransformProgress transformProgress) {
+                            DataFrameTransformProgress transformProgress,
+                            DataFrameTransformCheckpoint inProgressOrLastCheckpoint) {
         super(executor, initialState, initialPosition, jobStats);
         this.auditor = Objects.requireNonNull(auditor);
         this.transformConfig = ExceptionsHelper.requireNonNull(transformConfig, "transformConfig");
         this.fieldMappings = ExceptionsHelper.requireNonNull(fieldMappings, "fieldMappings");
         this.progress = transformProgress;
+        this.inProgressOrLastCheckpoint = inProgressOrLastCheckpoint;
     }
 
     protected abstract void failIndexer(String message);
@@ -79,6 +93,10 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<Map<String, 
 
     public DataFrameTransformConfig getConfig() {
         return transformConfig;
+    }
+
+    public boolean isContinuous() {
+        return getConfig().getSyncConfig() != null;
     }
 
     public Map<String, String> getFieldMappings() {
@@ -92,7 +110,7 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<Map<String, 
     /**
      * Request a checkpoint
      */
-    protected abstract void createCheckpoint(ActionListener<Void> listener);
+    protected abstract void createCheckpoint(ActionListener<DataFrameTransformCheckpoint> listener);
 
     @Override
     protected void onStart(long now, ActionListener<Void> listener) {
@@ -106,7 +124,23 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<Map<String, 
 
             // if run for the 1st time, create checkpoint
             if (initialRun()) {
-                createCheckpoint(listener);
+                createCheckpoint(ActionListener.wrap(cp -> {
+                    DataFrameTransformCheckpoint oldCheckpoint = inProgressOrLastCheckpoint;
+
+                    if (oldCheckpoint.isEmpty()) {
+                        // this is the 1st run, accept the new in progress checkpoint and go on
+                        inProgressOrLastCheckpoint = cp;
+                        listener.onResponse(null);
+                    } else {
+                        logger.debug ("Getting changes from {} to {}", oldCheckpoint.getTimeUpperBound(), cp.getTimeUpperBound());
+
+                        getChangedBuckets(oldCheckpoint, cp, ActionListener.wrap(changedBuckets -> {
+                            inProgressOrLastCheckpoint = cp;
+                            this.changedBuckets = changedBuckets;
+                            listener.onResponse(null);
+                        }, listener::onFailure));
+                    }
+                }, listener::onFailure));
             } else {
                 listener.onResponse(null);
             }
@@ -123,6 +157,8 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<Map<String, 
     protected void onFinish(ActionListener<Void> listener) {
         // reset the page size, so we do not memorize a low page size forever, the pagesize will be re-calculated on start
         pageSize = 0;
+        // reset the changed bucket to free memory
+        changedBuckets = null;
     }
 
     @Override
@@ -185,7 +221,38 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<Map<String, 
 
     @Override
     protected SearchRequest buildSearchRequest() {
-        return pivot.buildSearchRequest(getConfig().getSource(), getPosition(), pageSize);
+        SearchRequest searchRequest = new SearchRequest(getConfig().getSource().getIndex());
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.aggregation(pivot.buildAggregation(getPosition(), pageSize));
+        sourceBuilder.size(0);
+
+        QueryBuilder pivotQueryBuilder = getConfig().getSource().getQueryConfig().getQuery();
+
+        DataFrameTransformConfig config = getConfig();
+        if (config.getSyncConfig() != null) {
+            if (inProgressOrLastCheckpoint == null) {
+                throw new RuntimeException("in progress checkpoint not found");
+            }
+
+            BoolQueryBuilder filteredQuery = new BoolQueryBuilder().
+                    filter(pivotQueryBuilder).
+                    filter(config.getSyncConfig().getRangeQuery(inProgressOrLastCheckpoint));
+
+            if (changedBuckets != null && changedBuckets.isEmpty() == false) {
+                QueryBuilder pivotFilter = pivot.filterBuckets(changedBuckets);
+                if (pivotFilter != null) {
+                    filteredQuery.filter(pivotFilter);
+                }
+            }
+
+            logger.trace("running filtered query: {}", filteredQuery);
+            sourceBuilder.query(filteredQuery);
+        } else {
+            sourceBuilder.query(pivotQueryBuilder);
+        }
+
+        searchRequest.source(sourceBuilder);
+        return searchRequest;
     }
 
     /**
@@ -226,6 +293,72 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<Map<String, 
         return true;
     }
 
+    private void getChangedBuckets(DataFrameTransformCheckpoint oldCheckpoint, DataFrameTransformCheckpoint newCheckpoint,
+            ActionListener<Map<String, List<String>>> listener) {
+        SearchRequest searchRequest = new SearchRequest(getConfig().getSource().getIndex());
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+
+        // we do not need the sub-aggs
+        CompositeAggregationBuilder changesAgg = pivot.buildChangedBucketsAggregation(pageSize);
+        sourceBuilder.aggregation(changesAgg);
+        sourceBuilder.size(0);
+
+        QueryBuilder pivotQueryBuilder = getConfig().getSource().getQueryConfig().getQuery();
+
+        DataFrameTransformConfig config = getConfig();
+        if (config.getSyncConfig() != null) {
+            BoolQueryBuilder filteredQuery = new BoolQueryBuilder().
+                    filter(pivotQueryBuilder).
+                    filter(config.getSyncConfig().getRangeQuery(oldCheckpoint, newCheckpoint));
+
+            logger.trace("Gathering changes using query {}", filteredQuery);
+            sourceBuilder.query(filteredQuery);
+        } else {
+            logger.trace("No sync configured");
+            listener.onResponse(null);
+            return;
+        }
+
+        searchRequest.source(sourceBuilder);
+        searchRequest.allowPartialSearchResults(false);
+
+        // pre-fill the hashmap with the expected keys
+        // note that changed bucket might be empty due to the query
+        HashMap<String, List<String>> keys = new HashMap<>();
+        for(Entry<String, SingleGroupSource> entry: config.getPivotConfig().getGroupConfig().getGroups().entrySet()) {
+            keys.put(entry.getKey(), new ArrayList<>());
+        }
+
+        collectChangedBuckets(searchRequest, changesAgg, keys, ActionListener.wrap(listener::onResponse, e -> {
+            // fall back if bucket collection failed
+            logger.error("Failed to retrieve changed buckets, fall back to complete retrieval", e);
+            listener.onResponse(null);
+        }));
+    }
+
+    void collectChangedBuckets(SearchRequest searchRequest, CompositeAggregationBuilder changesAgg, Map<String, List<String>> keys,
+            ActionListener<Map<String, List<String>>> finalListener) {
+
+        // re-using the existing search hook
+        doNextSearch(searchRequest, ActionListener.wrap(searchResponse -> {
+            final CompositeAggregation agg = searchResponse.getAggregations().get(COMPOSITE_AGGREGATION_NAME);
+
+            agg.getBuckets().stream().forEach(bucket -> {
+                bucket.getKey().forEach((k, v) -> {
+                    keys.get(k).add(v.toString());
+                });
+            });
+
+            if (agg.getBuckets().isEmpty()) {
+                finalListener.onResponse(keys);
+            } else {
+                // adjust the after key
+                changesAgg.aggregateAfter(agg.afterKey());
+                collectChangedBuckets(searchRequest, changesAgg, keys, finalListener);
+            }
+        }, finalListener::onFailure));
+    }
+
     /**
      * Inspect exception for circuit breaking exception and return the first one it can find.
      *
@@ -251,4 +384,6 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<Map<String, 
 
         return null;
     }
+
+    protected abstract boolean sourceHasChanged();
 }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
@@ -275,10 +275,10 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
             logger.warn("Data frame task [{}] triggered with an unintialized indexer", getTransformId());
             return;
         }
-        //  for now no rerun, so only trigger if checkpoint == 0
         if (event.getJobName().equals(SCHEDULE_NAME + "_" + transform.getId())) {
             logger.info("Data frame indexer [{}] schedule has triggered, state: [{}]", event.getJobName(), getIndexer().getState());
 
+            // if it runs for the 1st time we just do it, if not we check for changes
             if (currentCheckpoint.get() == 0 ) {
                 logger.debug("Trigger initial run");
                 getIndexer().maybeTriggerAsyncJob(System.currentTimeMillis());


### PR DESCRIPTION
**Feature Branch PR**

adds continuous dataframes based on timestamps in the source data for term groups

The algorithm in a nutshell:
 - the source index is checked for changes in regular intervals using checkpoints and triggers a indexer run if necessary
 - on indexer start the changed buckets are collected
 - the indexer injects a query to only re-create changed buckets instead of running a full re-index
 - changed documents are updated/overwritten
 - a new checkpoint gets created

Notes: 
 - this is the 1st version, expect various issues and bugs
 - I changed to scheduler to run less frequently, this is a temporary solution until scheduling logic has been re-factored on master
 - tests to be improved