### PR TITLE
Reenable RareClusterStateIT Mapping Propagation Tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/RareClusterStateIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/RareClusterStateIT.java
@@ -181,7 +181,6 @@ public class RareClusterStateIT extends ESIntegTestCase {
         assertHitCount(client().prepareSearch("test").get(), 0);
     }
 
-    @AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/41030")
     public void testDelayedMappingPropagationOnPrimary() throws Exception {
         // Here we want to test that things go well if there is a first request
         // that adds mappings but before mappings are propagated to all nodes
@@ -274,7 +273,6 @@ public class RareClusterStateIT extends ESIntegTestCase {
         });
     }
 
-    @AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/36813")
     public void testDelayedMappingPropagationOnReplica() throws Exception {
         // This is essentially the same thing as testDelayedMappingPropagationOnPrimary
         // but for replicas


### PR DESCRIPTION
* Reenabling these to get fresh failure logs since they are not
reproducible locally
* Relates # #36813, #41030

