### PR TITLE
Reenable testCloseOrDeleteIndexDuringSnapshot

### DIFF
--- a/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -2424,7 +2424,6 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/39828")
     public void testCloseOrDeleteIndexDuringSnapshot() throws Exception {
         Client client = client();
 


### PR DESCRIPTION
* Unmuting this since I expect this to not fail anymore and if it still fails we at least get a fresh failure log
* Relates #39828 