### PR TITLE
Remove Harmful Exists Check from BlobStoreFormat

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreFormat.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreFormat.java
@@ -97,13 +97,6 @@ public abstract class BlobStoreFormat<T extends ToXContent> {
         blobContainer.deleteBlob(blobName(name));
     }
 
-    /**
-     * Checks obj in the blob container
-     */
-    public boolean exists(BlobContainer blobContainer, String name) {
-        return blobContainer.blobExists(blobName(name));
-    }
-
     public String blobName(String name) {
         return String.format(Locale.ROOT, blobNameFormat, name);
     }

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -395,9 +395,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             if (repositoryData.getAllSnapshotIds().stream().anyMatch(s -> s.getName().equals(snapshotName))) {
                 throw new InvalidSnapshotNameException(metadata.name(), snapshotId.getName(), "snapshot with the same name already exists");
             }
-            if (snapshotFormat.exists(blobContainer(), snapshotId.getUUID())) {
-                throw new InvalidSnapshotNameException(metadata.name(), snapshotId.getName(), "snapshot with the same name already exists");
-            }
 
             // Write Global MetaData
             globalMetaDataFormat.write(clusterMetaData, blobContainer(), snapshotId.getUUID());


### PR DESCRIPTION
* First off, this exists check is somewhat pointless in that it checks
for the existence of a blob that contains a UUID in its name so we don't
expect collisions here ever. Just checking for no name collision is
completely sufficient.
   * Since this check was the only user of the blob store format method I removed that now dead method
* More importantly though, this check introduces an issue on S3 because
we will run it against a non existing snap-{uuid}.dat blob
  * This leads to the fact that subsequent reads of this blob after it
was written can still return a 404 because AWS S3 only guarantees first
read after write consistency. If a read of a key is made before a write
is made this guarantee goes out the window. (see
https://docs.aws.amazon.com/AmazonS3/latest/dev/Introduction.html#ConsistencyModel
for more)
* Closes #41882
