### PR TITLE
Reject port ranges in `discovery.seed_hosts`

### DIFF
--- a/docs/reference/migration/migrate_7_2.asciidoc
+++ b/docs/reference/migration/migrate_7_2.asciidoc
@@ -17,3 +17,15 @@ coming[7.2.0]
 //tag::notable-breaking-changes[]
 
 // end::notable-breaking-changes[]
+
+[[breaking_72_discovery_changes]]
+=== Discovery changes
+
+[float]
+==== Only a single port may be given for each seed host.
+
+In earlier versions you could include a range of ports in entries in the
+`discovery.seed_hosts` list, but {es} used only the first port in the range and
+unexpectedly ignored the rest.  For instance if you set `discovery.seed_hosts:
+"10.11.12.13:9300-9310"` then {es} would only use `10.11.12.13:9300` for
+discovery. Seed host addresses containing port ranges are now rejected.

--- a/plugins/discovery-azure-classic/src/main/java/org/elasticsearch/discovery/azure/classic/AzureSeedHostsProvider.java
+++ b/plugins/discovery-azure-classic/src/main/java/org/elasticsearch/discovery/azure/classic/AzureSeedHostsProvider.java
@@ -208,8 +208,7 @@ public class AzureSeedHostsProvider implements SeedHostsProvider {
                 }
 
                 try {
-                    // we only limit to 1 port per address, makes no sense to ping 100 ports
-                    TransportAddress[] addresses = transportService.addressesFromString(networkAddress, 1);
+                    TransportAddress[] addresses = transportService.addressesFromString(networkAddress);
                     for (TransportAddress address : addresses) {
                         logger.trace("adding {}, transport_address {}", networkAddress, address);
                         dynamicHosts.add(address);

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2SeedHostsProvider.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2SeedHostsProvider.java
@@ -174,8 +174,7 @@ class AwsEc2SeedHostsProvider implements SeedHostsProvider {
                 }
                 if (address != null) {
                     try {
-                        // we only limit to 1 port per address, makes no sense to ping 100 ports
-                        final TransportAddress[] addresses = transportService.addressesFromString(address, 1);
+                        final TransportAddress[] addresses = transportService.addressesFromString(address);
                         for (int i = 0; i < addresses.length; i++) {
                             logger.trace("adding {}, address {}, transport_address {}", instance.getInstanceId(), address, addresses[i]);
                             dynamicHosts.add(addresses[i]);

--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryTests.java
@@ -77,7 +77,7 @@ public class Ec2DiscoveryTests extends ESTestCase {
             new NetworkService(Collections.emptyList()), PageCacheRecycler.NON_RECYCLING_INSTANCE, namedWriteableRegistry,
             new NoneCircuitBreakerService()) {
             @Override
-            public TransportAddress[] addressesFromString(String address, int perAddressLimit) throws UnknownHostException {
+            public TransportAddress[] addressesFromString(String address) throws UnknownHostException {
                 // we just need to ensure we don't resolve DNS here
                 return new TransportAddress[] {poorMansDNS.getOrDefault(address, buildNewFakeTransportAddress())};
             }

--- a/plugins/discovery-gce/src/main/java/org/elasticsearch/discovery/gce/GceSeedHostsProvider.java
+++ b/plugins/discovery-gce/src/main/java/org/elasticsearch/discovery/gce/GceSeedHostsProvider.java
@@ -233,8 +233,7 @@ public class GceSeedHostsProvider implements SeedHostsProvider {
 
                         // ip_private is a single IP Address. We need to build a TransportAddress from it
                         // If user has set `es_port` metadata, we don't need to ping all ports
-                        // we only limit to 1 addresses, makes no sense to ping 100 ports
-                        TransportAddress[] addresses = transportService.addressesFromString(address, 1);
+                        TransportAddress[] addresses = transportService.addressesFromString(address);
 
                         for (TransportAddress transportAddress : addresses) {
                             logger.trace("adding {}, type {}, address {}, transport_address {}, status {}", name, type,

--- a/server/src/main/java/org/elasticsearch/discovery/FileBasedSeedHostsProvider.java
+++ b/server/src/main/java/org/elasticsearch/discovery/FileBasedSeedHostsProvider.java
@@ -75,7 +75,7 @@ public class FileBasedSeedHostsProvider implements SeedHostsProvider {
 
     @Override
     public List<TransportAddress> getSeedAddresses(HostsResolver hostsResolver) {
-        final List<TransportAddress> transportAddresses = hostsResolver.resolveHosts(getHostsList(), 1);
+        final List<TransportAddress> transportAddresses = hostsResolver.resolveHosts(getHostsList());
         logger.debug("seed addresses: {}", transportAddresses);
         return transportAddresses;
     }

--- a/server/src/main/java/org/elasticsearch/discovery/SeedHostsProvider.java
+++ b/server/src/main/java/org/elasticsearch/discovery/SeedHostsProvider.java
@@ -36,10 +36,9 @@ public interface SeedHostsProvider {
 
     /**
      * Helper object that allows to resolve a list of hosts to a list of transport addresses.
-     * Each host is resolved into a transport address (or a collection of addresses if the
-     * number of ports is greater than one)
+     * Each host is resolved into a transport address
      */
     interface HostsResolver {
-        List<TransportAddress> resolveHosts(List<String> hosts, int limitPortCounts);
+        List<TransportAddress> resolveHosts(List<String> hosts);
     }
 }

--- a/server/src/main/java/org/elasticsearch/discovery/SeedHostsResolver.java
+++ b/server/src/main/java/org/elasticsearch/discovery/SeedHostsResolver.java
@@ -116,7 +116,6 @@ public class SeedHostsResolver extends AbstractLifecycleComponent implements Con
      * @param executorService  the executor service used to parallelize hostname lookups
      * @param logger           logger used for logging messages regarding hostname lookups
      * @param hosts            the hosts to resolve
-     * @param limitPortCounts  the number of ports to resolve (should be 1 for non-local transport)
      * @param transportService the transport service
      * @param resolveTimeout   the timeout before returning from hostname lookups
      * @return a list of resolved transport addresses
@@ -125,7 +124,6 @@ public class SeedHostsResolver extends AbstractLifecycleComponent implements Con
         final ExecutorService executorService,
         final Logger logger,
         final List<String> hosts,
-        final int limitPortCounts,
         final TransportService transportService,
         final TimeValue resolveTimeout) {
         Objects.requireNonNull(executorService);
@@ -140,7 +138,7 @@ public class SeedHostsResolver extends AbstractLifecycleComponent implements Con
         final List<Callable<TransportAddress[]>> callables =
             hosts
                 .stream()
-                .map(hn -> (Callable<TransportAddress[]>) () -> transportService.addressesFromString(hn, limitPortCounts))
+                .map(hn -> (Callable<TransportAddress[]>) () -> transportService.addressesFromString(hn))
                 .collect(Collectors.toList());
         final List<Future<TransportAddress[]>> futures;
         try {
@@ -224,9 +222,8 @@ public class SeedHostsResolver extends AbstractLifecycleComponent implements Con
                     }
 
                     List<TransportAddress> providedAddresses
-                        = hostsProvider.getSeedAddresses((hosts, limitPortCounts)
-                        -> resolveHostsLists(executorService.get(), logger, hosts, limitPortCounts,
-                        transportService, resolveTimeout));
+                        = hostsProvider.getSeedAddresses(hosts ->
+                            resolveHostsLists(executorService.get(), logger, hosts, transportService, resolveTimeout));
 
                     consumer.accept(providedAddresses);
                 }

--- a/server/src/main/java/org/elasticsearch/discovery/SettingsBasedSeedHostsProvider.java
+++ b/server/src/main/java/org/elasticsearch/discovery/SettingsBasedSeedHostsProvider.java
@@ -50,12 +50,7 @@ public class SettingsBasedSeedHostsProvider implements SeedHostsProvider {
     public static final Setting<List<String>> DISCOVERY_SEED_HOSTS_SETTING =
         Setting.listSetting("discovery.seed_hosts", emptyList(), Function.identity(), Property.NodeScope);
 
-    // these limits are per-address
-    private static final int LIMIT_FOREIGN_PORTS_COUNT = 1;
-    private static final int LIMIT_LOCAL_PORTS_COUNT = 5;
-
     private final List<String> configuredHosts;
-    private final int limitPortCounts;
 
     public SettingsBasedSeedHostsProvider(Settings settings, TransportService transportService) {
         if (LEGACY_DISCOVERY_ZEN_PING_UNICAST_HOSTS_SETTING.exists(settings)) {
@@ -66,15 +61,11 @@ public class SettingsBasedSeedHostsProvider implements SeedHostsProvider {
             }
             configuredHosts = LEGACY_DISCOVERY_ZEN_PING_UNICAST_HOSTS_SETTING.get(settings);
             // we only limit to 1 address, makes no sense to ping 100 ports
-            limitPortCounts = LIMIT_FOREIGN_PORTS_COUNT;
         } else if (DISCOVERY_SEED_HOSTS_SETTING.exists(settings)) {
             configuredHosts = DISCOVERY_SEED_HOSTS_SETTING.get(settings);
-            // we only limit to 1 address, makes no sense to ping 100 ports
-            limitPortCounts = LIMIT_FOREIGN_PORTS_COUNT;
         } else {
             // if unicast hosts are not specified, fill with simple defaults on the local machine
-            configuredHosts = transportService.getLocalAddresses();
-            limitPortCounts = LIMIT_LOCAL_PORTS_COUNT;
+            configuredHosts = transportService.getDefaultSeedAddresses();
         }
 
         logger.debug("using initial hosts {}", configuredHosts);
@@ -82,6 +73,6 @@ public class SettingsBasedSeedHostsProvider implements SeedHostsProvider {
 
     @Override
     public List<TransportAddress> getSeedAddresses(HostsResolver hostsResolver) {
-        return hostsResolver.resolveHosts(configuredHosts, limitPortCounts);
+        return hostsResolver.resolveHosts(configuredHosts);
     }
 }

--- a/server/src/main/java/org/elasticsearch/discovery/zen/UnicastZenPing.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/UnicastZenPing.java
@@ -144,8 +144,7 @@ public class UnicastZenPing implements ZenPing {
     }
 
     private SeedHostsProvider.HostsResolver createHostsResolver() {
-        return (hosts, limitPortCounts) -> SeedHostsResolver.resolveHostsLists(unicastZenPingExecutorService, logger, hosts,
-            limitPortCounts, transportService, resolveTimeout);
+        return hosts -> SeedHostsResolver.resolveHostsLists(unicastZenPingExecutorService, logger, hosts, transportService, resolveTimeout);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/transport/Transport.java
+++ b/server/src/main/java/org/elasticsearch/transport/Transport.java
@@ -68,12 +68,12 @@ public interface Transport extends LifecycleComponent {
     /**
      * Returns an address from its string representation.
      */
-    TransportAddress[] addressesFromString(String address, int perAddressLimit) throws UnknownHostException;
+    TransportAddress[] addressesFromString(String address) throws UnknownHostException;
 
     /**
-     * Returns a list of all local adresses for this transport
+     * Returns a list of all local addresses for this transport
      */
-    List<String> getLocalAddresses();
+    List<String> getDefaultSeedAddresses();
 
     default CircuitBreaker getInFlightRequestBreaker() {
         return new NoopCircuitBreaker("in-flight-noop");

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -313,8 +313,8 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
         return transport.boundAddress();
     }
 
-    public List<String> getLocalAddresses() {
-        return transport.getLocalAddresses();
+    public List<String> getDefaultSeedAddresses() {
+        return transport.getDefaultSeedAddresses();
     }
 
     /**
@@ -750,8 +750,8 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
         return true;
     }
 
-    public TransportAddress[] addressesFromString(String address, int perAddressLimit) throws UnknownHostException {
-        return transport.addressesFromString(address, perAddressLimit);
+    public TransportAddress[] addressesFromString(String address) throws UnknownHostException {
+        return transport.addressesFromString(address);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/client/transport/FailAndRetryMockTransport.java
+++ b/server/src/test/java/org/elasticsearch/client/transport/FailAndRetryMockTransport.java
@@ -170,7 +170,7 @@ abstract class FailAndRetryMockTransport<Response extends TransportResponse> imp
     }
 
     @Override
-    public TransportAddress[] addressesFromString(String address, int perAddressLimit) throws UnknownHostException {
+    public TransportAddress[] addressesFromString(String address) throws UnknownHostException {
         throw new UnsupportedOperationException();
     }
 

--- a/server/src/test/java/org/elasticsearch/client/transport/TransportClientNodesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/client/transport/TransportClientNodesServiceTests.java
@@ -128,7 +128,7 @@ public class TransportClientNodesServiceTests extends ESTestCase {
             threadPool = new TestThreadPool("transport-client-nodes-service-tests");
             transport = new FailAndRetryMockTransport<TestResponse>(random(), clusterName) {
                 @Override
-                public List<String> getLocalAddresses() {
+                public List<String> getDefaultSeedAddresses() {
                     return Collections.emptyList();
                 }
 

--- a/server/src/test/java/org/elasticsearch/cluster/NodeConnectionsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/NodeConnectionsServiceTests.java
@@ -401,7 +401,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
         }
 
         @Override
-        public TransportAddress[] addressesFromString(String address, int perAddressLimit) {
+        public TransportAddress[] addressesFromString(String address) {
             return new TransportAddress[0];
         }
 
@@ -440,7 +440,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
         }
 
         @Override
-        public List<String> getLocalAddresses() {
+        public List<String> getDefaultSeedAddresses() {
             return null;
         }
 

--- a/server/src/test/java/org/elasticsearch/discovery/FileBasedSeedHostsProviderTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/FileBasedSeedHostsProviderTests.java
@@ -115,9 +115,8 @@ public class FileBasedSeedHostsProviderTests extends ESTestCase {
 
     public void testUnicastHostsDoesNotExist() {
         final FileBasedSeedHostsProvider provider = new FileBasedSeedHostsProvider(createTempDir().toAbsolutePath());
-        final List<TransportAddress> addresses = provider.getSeedAddresses((hosts, limitPortCounts) ->
-            SeedHostsResolver.resolveHostsLists(executorService, logger, hosts, limitPortCounts, transportService,
-                TimeValue.timeValueSeconds(10)));
+        final List<TransportAddress> addresses = provider.getSeedAddresses(hosts ->
+            SeedHostsResolver.resolveHostsLists(executorService, logger, hosts, transportService, TimeValue.timeValueSeconds(10)));
         assertEquals(0, addresses.size());
     }
 
@@ -145,8 +144,7 @@ public class FileBasedSeedHostsProviderTests extends ESTestCase {
             writer.write(String.join("\n", hostEntries));
         }
 
-        return new FileBasedSeedHostsProvider(configPath).getSeedAddresses((hosts, limitPortCounts) ->
-            SeedHostsResolver.resolveHostsLists(executorService, logger, hosts, limitPortCounts, transportService,
-                TimeValue.timeValueSeconds(10)));
+        return new FileBasedSeedHostsProvider(configPath).getSeedAddresses(hosts ->
+            SeedHostsResolver.resolveHostsLists(executorService, logger, hosts, transportService, TimeValue.timeValueSeconds(10)));
     }
 }

--- a/server/src/test/java/org/elasticsearch/discovery/SettingsBasedSeedHostsProviderTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/SettingsBasedSeedHostsProviderTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.discovery.SeedHostsProvider.HostsResolver;
-import org.elasticsearch.discovery.SettingsBasedSeedHostsProvider;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.TransportService;
 
@@ -38,18 +37,15 @@ public class SettingsBasedSeedHostsProviderTests extends ESTestCase {
 
     private class AssertingHostsResolver implements HostsResolver {
         private final Set<String> expectedHosts;
-        private final int expectedPortCount;
 
         private boolean resolvedHosts;
 
-        AssertingHostsResolver(int expectedPortCount, String... expectedHosts) {
-            this.expectedPortCount = expectedPortCount;
+        AssertingHostsResolver(String... expectedHosts) {
             this.expectedHosts = Sets.newHashSet(expectedHosts);
         }
 
         @Override
-        public List<TransportAddress> resolveHosts(List<String> hosts, int limitPortCounts) {
-            assertEquals(expectedPortCount, limitPortCounts);
+        public List<TransportAddress> resolveHosts(List<String> hosts) {
             assertEquals(expectedHosts, Sets.newHashSet(hosts));
             resolvedHosts = true;
             return emptyList();
@@ -61,15 +57,19 @@ public class SettingsBasedSeedHostsProviderTests extends ESTestCase {
     }
 
     public void testScansPortsByDefault() {
-        final AssertingHostsResolver hostsResolver = new AssertingHostsResolver(5, "::1", "127.0.0.1");
+        final AssertingHostsResolver hostsResolver = new AssertingHostsResolver(
+            "[::1]:9300", "[::1]:9301", "127.0.0.1:9300", "127.0.0.1:9301"
+        );
         final TransportService transportService = mock(TransportService.class);
-        when(transportService.getLocalAddresses()).thenReturn(Arrays.asList("::1", "127.0.0.1"));
+        when(transportService.getDefaultSeedAddresses()).thenReturn(
+            Arrays.asList("[::1]:9300", "[::1]:9301", "127.0.0.1:9300", "127.0.0.1:9301")
+        );
         new SettingsBasedSeedHostsProvider(Settings.EMPTY, transportService).getSeedAddresses(hostsResolver);
         assertTrue(hostsResolver.getResolvedHosts());
     }
 
     public void testGetsHostsFromSetting() {
-        final AssertingHostsResolver hostsResolver = new AssertingHostsResolver(1, "bar", "foo");
+        final AssertingHostsResolver hostsResolver = new AssertingHostsResolver("bar", "foo");
         new SettingsBasedSeedHostsProvider(Settings.builder()
             .putList(SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING.getKey(), "foo", "bar")
             .build(), null).getSeedAddresses(hostsResolver);
@@ -77,7 +77,7 @@ public class SettingsBasedSeedHostsProviderTests extends ESTestCase {
     }
 
     public void testGetsHostsFromLegacySetting() {
-        final AssertingHostsResolver hostsResolver = new AssertingHostsResolver(1, "bar", "foo");
+        final AssertingHostsResolver hostsResolver = new AssertingHostsResolver("bar", "foo");
         new SettingsBasedSeedHostsProvider(Settings.builder()
             .putList(SettingsBasedSeedHostsProvider.LEGACY_DISCOVERY_ZEN_PING_UNICAST_HOSTS_SETTING.getKey(), "foo", "bar")
             .build(), null).getSeedAddresses(hostsResolver);

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransport.java
@@ -208,7 +208,7 @@ public class MockTransport implements Transport, LifecycleComponent {
     }
 
     @Override
-    public TransportAddress[] addressesFromString(String address, int perAddressLimit) {
+    public TransportAddress[] addressesFromString(String address) {
         return new TransportAddress[0];
     }
 
@@ -238,7 +238,7 @@ public class MockTransport implements Transport, LifecycleComponent {
     }
 
     @Override
-    public List<String> getLocalAddresses() {
+    public List<String> getDefaultSeedAddresses() {
         return Collections.emptyList();
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableTransport.java
@@ -118,13 +118,13 @@ public final class StubbableTransport implements Transport {
     }
 
     @Override
-    public TransportAddress[] addressesFromString(String address, int perAddressLimit) throws UnknownHostException {
-        return delegate.addressesFromString(address, perAddressLimit);
+    public TransportAddress[] addressesFromString(String address) throws UnknownHostException {
+        return delegate.addressesFromString(address);
     }
 
     @Override
-    public List<String> getLocalAddresses() {
-        return delegate.getLocalAddresses();
+    public List<String> getDefaultSeedAddresses() {
+        return delegate.getDefaultSeedAddresses();
     }
 
     @Override


### PR DESCRIPTION
Today Elasticsearch accepts, but silently ignores, port ranges in the
`discovery.seed_hosts` setting:

```
discovery.seed_hosts: 10.1.2.3:9300-9400
```

Silently ignoring part of a setting like this is trappy. With this change we
reject seed host addresses of this form.

Closes #40786
Backport of #41404