### PR TITLE
Ensure all JSON field types are available for lookup.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -86,7 +86,7 @@ class FieldTypeLookup implements Iterable<MappedFieldType> {
             }
 
             if (fieldMapper instanceof JsonFieldMapper) {
-                jsonMappers = fullNameToJsonMapper.copyAndPut(fieldName, (JsonFieldMapper) fieldMapper);
+                jsonMappers = jsonMappers.copyAndPut(fieldName, (JsonFieldMapper) fieldMapper);
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
@@ -167,6 +167,26 @@ public class FieldTypeLookupTests extends ESTestCase {
         assertEquals(objectKey, keyedFieldType.key());
     }
 
+    public void testMultipleJsonFieldTypes() {
+        String field1 = "object1.object2.field";
+        String field2 = "object1.field";
+        String field3 = "object2.field";
+
+        JsonFieldMapper mapper1 = createJsonMapper(field1);
+        JsonFieldMapper mapper2 = createJsonMapper(field2);
+        JsonFieldMapper mapper3 = createJsonMapper(field3);
+
+        FieldTypeLookup lookup = new FieldTypeLookup()
+            .copyAndAddAll("type", newList(mapper1, mapper2), emptyList());
+        assertNotNull(lookup.get(field1 + ".some.key"));
+        assertNotNull(lookup.get(field2 + ".some.key"));
+
+        lookup = lookup.copyAndAddAll("type", newList(mapper3), emptyList());
+        assertNotNull(lookup.get(field1 + ".some.key"));
+        assertNotNull(lookup.get(field2 + ".some.key"));
+        assertNotNull(lookup.get(field3 + ".some.key"));
+    }
+
     public void testJsonFieldTypeWithAlias() {
         String fieldName = "object1.object2.field";
         JsonFieldMapper mapper = createJsonMapper(fieldName);


### PR DESCRIPTION
Previously, if multiple `embedded_json` fields were added at once, only the last
one would be registered. This bug was uncovered when trying out different
scenarios for performance benchmarking.