### PR TITLE
Disable rhel8 in packaging tests

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -30,7 +30,7 @@ class VagrantTestPlugin implements Plugin<Project> {
             'oel-6',
             'oel-7',
             'opensuse-42',
-            'rhel-8',
+            /* TODO: need a real RHEL license now that it is out of beta 'rhel-8',*/
             'sles-12',
             'ubuntu-1604',
             'ubuntu-1804'


### PR DESCRIPTION
This commit disable rhel 8 from being testing in vagrant packaging
tests. The vagrant image we use is beta release, but RHEL 8 was just
released, which has caused the package mirrors for the beta to stop
working.

