### PR TITLE
Remove mention of bulk threadpool in examples

### DIFF
--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -52,13 +52,14 @@ There are several thread pools, but the important ones include:
     Mainly for java client executing of action when listener threaded is set to true.
     Thread pool type is `scaling` with a default max of `min(10, (# of available processors)/2)`.
 
-Changing a specific thread pool can be done by setting its type-specific parameters; for example, changing the `bulk`
-thread pool to have more threads:
+Changing a specific thread pool can be done by setting its type-specific
+parameters; for example, changing the number of threads in the `write` thread
+pool:
 
 [source,yaml]
 --------------------------------------------------
 thread_pool:
-    bulk:
+    write:
         size: 30
 --------------------------------------------------
 
@@ -87,7 +88,7 @@ full, it will abort the request.
 [source,yaml]
 --------------------------------------------------
 thread_pool:
-    bulk:
+    write:
         size: 30
         queue_size: 1000
 --------------------------------------------------


### PR DESCRIPTION
The `bulk` threadpool is now called `write`, but `bulk` is still
used in some examples. This commit fixes that.

Also, the only way `threadpool.bulk.write: 30` is a valid increase in the size
of this threadpool is if you have 29 processors, which is an odd number of
processors to have. This commit removes the "more threads" bit.