### PR TITLE
Fix IAE on cross_fields query introduced in 7.0.1

### DIFF
--- a/server/src/main/java/org/apache/lucene/queries/BlendedTermQuery.java
+++ b/server/src/main/java/org/apache/lucene/queries/BlendedTermQuery.java
@@ -118,7 +118,9 @@ public abstract class BlendedTermQuery extends Query {
                 // otherwise the statistics don't match
                 minSumTTF = Math.min(minSumTTF, reader.getSumTotalTermFreq(terms[i].field()));
             }
-
+        }
+        if (maxDoc > minSumTTF) {
+            maxDoc = (int)minSumTTF;
         }
         if (max == 0) {
             return; // we are done that term doesn't exist at all


### PR DESCRIPTION
If the max doc in the index is greater than the minimum total term frequency
among the requested fields we need to adjust max doc to be equal to the min ttf.
This was removed by mistake when fixing #41125.

Closes #41934