### PR TITLE
[ML Data Frame] Persist and restore checkpoint and position

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameIndexerTransformStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameIndexerTransformStats.java
@@ -109,15 +109,6 @@ public class DataFrameIndexerTransformStats extends IndexerJobStats {
         out.writeString(transformId);
     }
 
-    /**
-     * Get the persisted stats document name from the Data Frame Transformer Id.
-     *
-     * @return The id of document the where the transform stats are persisted
-     */
-    public static String documentId(String transformId) {
-        return NAME + "-" + transformId;
-    }
-
     @Nullable
     public String getTransformId() {
         return transformId;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformProgress.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformProgress.java
@@ -23,9 +23,9 @@ import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optiona
 
 public class DataFrameTransformProgress implements Writeable, ToXContentObject {
 
-    private static final ParseField TOTAL_DOCS = new ParseField("total_docs");
-    private static final ParseField DOCS_REMAINING = new ParseField("docs_remaining");
-    private static final String PERCENT_COMPLETE = "percent_complete";
+    public static final ParseField TOTAL_DOCS = new ParseField("total_docs");
+    public static final ParseField DOCS_REMAINING = new ParseField("docs_remaining");
+    public static final String PERCENT_COMPLETE = "percent_complete";
 
     public static final ConstructingObjectParser<DataFrameTransformProgress, Void> PARSER = new ConstructingObjectParser<>(
         "data_frame_transform_progress",

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformState.java
@@ -42,12 +42,12 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
     @Nullable
     private final String reason;
 
-    private static final ParseField TASK_STATE = new ParseField("task_state");
-    private static final ParseField INDEXER_STATE = new ParseField("indexer_state");
-    private static final ParseField CURRENT_POSITION = new ParseField("current_position");
-    private static final ParseField CHECKPOINT = new ParseField("checkpoint");
-    private static final ParseField REASON = new ParseField("reason");
-    private static final ParseField PROGRESS = new ParseField("progress");
+    public static final ParseField TASK_STATE = new ParseField("task_state");
+    public static final ParseField INDEXER_STATE = new ParseField("indexer_state");
+    public static final ParseField CURRENT_POSITION = new ParseField("current_position");
+    public static final ParseField CHECKPOINT = new ParseField("checkpoint");
+    public static final ParseField REASON = new ParseField("reason");
+    public static final ParseField PROGRESS = new ParseField("progress");
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<DataFrameTransformState, Void> PARSER = new ConstructingObjectParser<>(NAME,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformStateAndStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformStateAndStats.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.core.dataframe.transforms;
 
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -14,6 +15,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 
@@ -22,7 +24,7 @@ import java.util.Objects;
 
 public class DataFrameTransformStateAndStats implements Writeable, ToXContentObject {
 
-    private static final String NAME = "data_frame_transform_state_and_stats";
+    public static final String NAME = "data_frame_transform_state_and_stats";
     public static final ParseField STATE_FIELD = new ParseField("state");
     public static final ParseField CHECKPOINTING_INFO_FIELD = new ParseField("checkpointing");
 
@@ -47,6 +49,10 @@ public class DataFrameTransformStateAndStats implements Writeable, ToXContentObj
                                 (p, c) -> DataFrameTransformCheckpointingInfo.fromXContent(p), CHECKPOINTING_INFO_FIELD);
     }
 
+    public static DataFrameTransformStateAndStats fromXContent(XContentParser parser) throws IOException {
+        return PARSER.parse(parser, null);
+    }
+
     public static DataFrameTransformStateAndStats initialStateAndStats(String id) {
         return initialStateAndStats(id, new DataFrameIndexerTransformStats(id));
     }
@@ -56,6 +62,15 @@ public class DataFrameTransformStateAndStats implements Writeable, ToXContentObj
             new DataFrameTransformState(DataFrameTransformTaskState.STOPPED, IndexerState.STOPPED, null, 0L, null, null),
             indexerTransformStats,
             DataFrameTransformCheckpointingInfo.EMPTY);
+    }
+
+    /**
+     * Get the persisted state and stats document name from the Data Frame Transform Id.
+     *
+     * @return The id of document the where the transform stats are persisted
+     */
+    public static String documentId(String transformId) {
+        return NAME + "-" + transformId;
     }
 
     public DataFrameTransformStateAndStats(String id, DataFrameTransformState state, DataFrameIndexerTransformStats stats,
@@ -73,6 +88,11 @@ public class DataFrameTransformStateAndStats implements Writeable, ToXContentObj
         this.checkpointingInfo = new DataFrameTransformCheckpointingInfo(in);
     }
 
+    @Nullable
+    public String getTransformId() {
+        return transformStats.getTransformId();
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
@@ -80,6 +100,9 @@ public class DataFrameTransformStateAndStats implements Writeable, ToXContentObj
         builder.field(STATE_FIELD.getPreferredName(), transformState, params);
         builder.field(DataFrameField.STATS_FIELD.getPreferredName(), transformStats, params);
         builder.field(CHECKPOINTING_INFO_FIELD.getPreferredName(), checkpointingInfo, params);
+        if (params.paramAsBoolean(DataFrameField.FOR_INTERNAL_STORAGE, false)) {
+            builder.field(DataFrameField.INDEX_DOC_TYPE.getPreferredName(), NAME);
+        }
         builder.endObject();
         return builder;
     }

--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameRestTestCase.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameRestTestCase.java
@@ -292,7 +292,7 @@ public abstract class DataFrameRestTestCase extends ESRestTestCase {
         wipeIndices();
     }
 
-    public void wipeDataFrameTransforms() throws IOException, InterruptedException {
+    public void wipeDataFrameTransforms() throws IOException {
         List<Map<String, Object>> transformConfigs = getDataFrameTransforms();
         for (Map<String, Object> transformConfig : transformConfigs) {
             String transformId = (String) transformConfig.get("id");

--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameUsageIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameUsageIT.java
@@ -10,7 +10,7 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.xpack.core.dataframe.DataFrameField;
-import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerTransformStats;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformStateAndStats;
 import org.elasticsearch.xpack.dataframe.persistence.DataFrameInternalIndex;
 import org.junit.Before;
 
@@ -72,7 +72,7 @@ public class DataFrameUsageIT extends DataFrameRestTestCase {
         Request statsExistsRequest = new Request("GET",
             DataFrameInternalIndex.INDEX_NAME+"/_search?q=" +
                 INDEX_DOC_TYPE.getPreferredName() + ":" +
-                DataFrameIndexerTransformStats.NAME);
+                DataFrameTransformStateAndStats.NAME);
         // Verify that we have our two stats documents
         assertBusy(() -> {
             Map<String, Object> hasStatsMap = entityAsMap(client().performRequest(statsExistsRequest));
@@ -100,7 +100,6 @@ public class DataFrameUsageIT extends DataFrameRestTestCase {
             expectedStats.merge(statName, statistic, Integer::sum);
         }
 
-
         usageResponse = client().performRequest(new Request("GET", "_xpack/usage"));
 
         usageAsMap = entityAsMap(usageResponse);
@@ -109,7 +108,8 @@ public class DataFrameUsageIT extends DataFrameRestTestCase {
         assertEquals(1, XContentMapValues.extractValue("data_frame.transforms.started", usageAsMap));
         assertEquals(2, XContentMapValues.extractValue("data_frame.transforms.stopped", usageAsMap));
         for(String statName : PROVIDED_STATS) {
-            assertEquals(expectedStats.get(statName), XContentMapValues.extractValue("data_frame.stats."+statName, usageAsMap));
+            assertEquals("Incorrect stat " +  statName,
+                    expectedStats.get(statName), XContentMapValues.extractValue("data_frame.stats." + statName, usageAsMap));
         }
     }
 }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportGetDataFrameTransformsStatsAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportGetDataFrameTransformsStatsAction.java
@@ -9,51 +9,29 @@ package org.elasticsearch.xpack.dataframe.action;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.TaskOperationFailure;
-import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.tasks.TransportTasksAction;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexNotFoundException;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.core.ClientHelper;
-import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.dataframe.action.GetDataFrameTransformsStatsAction;
 import org.elasticsearch.xpack.core.dataframe.action.GetDataFrameTransformsStatsAction.Request;
 import org.elasticsearch.xpack.core.dataframe.action.GetDataFrameTransformsStatsAction.Response;
-import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerTransformStats;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformCheckpointingInfo;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformStateAndStats;
 import org.elasticsearch.xpack.dataframe.checkpoint.DataFrameTransformsCheckpointService;
-import org.elasticsearch.xpack.dataframe.persistence.DataFrameInternalIndex;
 import org.elasticsearch.xpack.dataframe.persistence.DataFrameTransformsConfigManager;
 import org.elasticsearch.xpack.dataframe.transforms.DataFrameTransformTask;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -69,18 +47,16 @@ public class TransportGetDataFrameTransformsStatsAction extends
 
     private static final Logger logger = LogManager.getLogger(TransportGetDataFrameTransformsStatsAction.class);
 
-    private final Client client;
     private final DataFrameTransformsConfigManager dataFrameTransformsConfigManager;
     private final DataFrameTransformsCheckpointService transformsCheckpointService;
 
     @Inject
     public TransportGetDataFrameTransformsStatsAction(TransportService transportService, ActionFilters actionFilters,
-                                                      ClusterService clusterService, Client client,
+                                                      ClusterService clusterService,
                                                       DataFrameTransformsConfigManager dataFrameTransformsConfigManager,
                                                       DataFrameTransformsCheckpointService transformsCheckpointService) {
         super(GetDataFrameTransformsStatsAction.NAME, clusterService, transportService, actionFilters, Request::new, Response::new,
             Response::new, ThreadPool.Names.SAME);
-        this.client = client;
         this.dataFrameTransformsConfigManager = dataFrameTransformsConfigManager;
         this.transformsCheckpointService = transformsCheckpointService;
     }
@@ -157,32 +133,14 @@ public class TransportGetDataFrameTransformsStatsAction extends
         // Small assurance that we are at least below the max. Terms search has a hard limit of 10k, we should at least be below that.
         assert transformsWithoutTasks.size() <= Request.MAX_SIZE_RETURN;
 
-        ActionListener<SearchResponse> searchStatsListener = ActionListener.wrap(
-            searchResponse -> {
-                List<ElasticsearchException> nodeFailures = new ArrayList<>(response.getNodeFailures());
-                if (searchResponse.getShardFailures().length > 0) {
-                    for(ShardSearchFailure shardSearchFailure : searchResponse.getShardFailures()) {
-                        String nodeId = "";
-                        if (shardSearchFailure.shard() != null) {
-                            nodeId = shardSearchFailure.shard().getNodeId();
-                        }
-                        nodeFailures.add(new FailedNodeException(nodeId, shardSearchFailure.toString(), shardSearchFailure.getCause()));
-                    }
-                    logger.error("transform statistics document search returned shard failures: {}",
-                        Arrays.toString(searchResponse.getShardFailures()));
-                }
+        ActionListener<List<DataFrameTransformStateAndStats>> searchStatsListener = ActionListener.wrap(
+            stats -> {
                 List<DataFrameTransformStateAndStats> allStateAndStats = response.getTransformsStateAndStats();
-                for(SearchHit hit : searchResponse.getHits().getHits()) {
-                    BytesReference source = hit.getSourceRef();
-                    try {
-                        DataFrameIndexerTransformStats stats = parseFromSource(source);
-                        allStateAndStats.add(DataFrameTransformStateAndStats.initialStateAndStats(stats.getTransformId(), stats));
-                        transformsWithoutTasks.remove(stats.getTransformId());
-                    } catch (IOException e) {
-                        listener.onFailure(new ElasticsearchParseException("Could not parse data frame transform stats", e));
-                        return;
-                    }
-                }
+                allStateAndStats.addAll(stats);
+                transformsWithoutTasks.removeAll(
+                        stats.stream().map(DataFrameTransformStateAndStats::getId).collect(Collectors.toSet()));
+
+                // Transforms that have not been started and have no state or stats.
                 transformsWithoutTasks.forEach(transformId ->
                     allStateAndStats.add(DataFrameTransformStateAndStats.initialStateAndStats(transformId)));
 
@@ -190,7 +148,7 @@ public class TransportGetDataFrameTransformsStatsAction extends
                 // it can easily become arbitrarily ordered based on which transforms don't have a task or stats docs
                 allStateAndStats.sort(Comparator.comparing(DataFrameTransformStateAndStats::getId));
 
-                listener.onResponse(new Response(allStateAndStats, response.getTaskFailures(), nodeFailures));
+                listener.onResponse(new Response(allStateAndStats, response.getTaskFailures(), response.getNodeFailures()));
             },
             e -> {
                 if (e instanceof IndexNotFoundException) {
@@ -201,26 +159,6 @@ public class TransportGetDataFrameTransformsStatsAction extends
             }
         );
 
-        QueryBuilder builder = QueryBuilders.constantScoreQuery(QueryBuilders.boolQuery()
-            .filter(QueryBuilders.termsQuery(DataFrameField.ID.getPreferredName(), transformsWithoutTasks))
-            .filter(QueryBuilders.termQuery(DataFrameField.INDEX_DOC_TYPE.getPreferredName(), DataFrameIndexerTransformStats.NAME)));
-
-        SearchRequest searchRequest = client.prepareSearch(DataFrameInternalIndex.INDEX_NAME)
-            .addSort(DataFrameField.ID.getPreferredName(), SortOrder.ASC)
-            .setQuery(builder)
-            .request();
-
-        ClientHelper.executeAsyncWithOrigin(client.threadPool().getThreadContext(),
-            ClientHelper.DATA_FRAME_ORIGIN,
-            searchRequest,
-            searchStatsListener, client::search);
-    }
-
-    private static DataFrameIndexerTransformStats parseFromSource(BytesReference source) throws IOException {
-        try (InputStream stream = source.streamInput();
-             XContentParser parser = XContentFactory.xContent(XContentType.JSON)
-                 .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, stream)) {
-            return DataFrameIndexerTransformStats.fromXContent(parser);
-        }
+        dataFrameTransformsConfigManager.getTransformStats(transformsWithoutTasks, searchStatsListener);
     }
 }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportStartDataFrameTransformTaskAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportStartDataFrameTransformTaskAction.java
@@ -59,7 +59,7 @@ public class TransportStartDataFrameTransformTaskAction extends
     protected void taskOperation(StartDataFrameTransformTaskAction.Request request, DataFrameTransformTask transformTask,
                                  ActionListener<StartDataFrameTransformTaskAction.Response> listener) {
         if (transformTask.getTransformId().equals(request.getId())) {
-            transformTask.start(listener);
+            transformTask.start(null, listener);
         } else {
             listener.onFailure(new RuntimeException("ID of data frame transform task [" + transformTask.getTransformId()
                 + "] does not match request's ID [" + request.getId() + "]"));

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/persistence/DataFrameInternalIndex.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/persistence/DataFrameInternalIndex.java
@@ -17,6 +17,9 @@ import org.elasticsearch.xpack.core.common.notifications.AbstractAuditMessage;
 import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerTransformStats;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformProgress;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformState;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformStateAndStats;
 import org.elasticsearch.xpack.core.dataframe.transforms.DestConfig;
 import org.elasticsearch.xpack.core.dataframe.transforms.SourceConfig;
 
@@ -50,7 +53,7 @@ public final class DataFrameInternalIndex {
     public static final String RAW = "raw";
 
     // data types
-    public static final String DOUBLE = "double";
+    public static final String FLOAT = "float";
     public static final String LONG = "long";
     public static final String KEYWORD = "keyword";
 
@@ -129,7 +132,7 @@ public final class DataFrameInternalIndex {
         // add the schema for transform configurations
         addDataFrameTransformsConfigMappings(builder);
         // add the schema for transform stats
-        addDataFrameTransformsStatsMappings(builder);
+        addDataFrameTransformStateAndStatsMappings(builder);
         // end type
         builder.endObject();
         // end properties
@@ -140,37 +143,76 @@ public final class DataFrameInternalIndex {
     }
 
 
-    private static XContentBuilder addDataFrameTransformsStatsMappings(XContentBuilder builder) throws IOException {
+    private static XContentBuilder addDataFrameTransformStateAndStatsMappings(XContentBuilder builder) throws IOException {
         return builder
-            .startObject(DataFrameIndexerTransformStats.NUM_PAGES.getPreferredName())
-                .field(TYPE, LONG)
+            .startObject(DataFrameTransformStateAndStats.STATE_FIELD.getPreferredName())
+                .startObject(PROPERTIES)
+                    .startObject(DataFrameTransformState.TASK_STATE.getPreferredName())
+                        .field(TYPE, KEYWORD)
+                    .endObject()
+                    .startObject(DataFrameTransformState.INDEXER_STATE.getPreferredName())
+                        .field(TYPE, KEYWORD)
+                    .endObject()
+                    .startObject(DataFrameTransformState.CURRENT_POSITION.getPreferredName())
+                        .field(ENABLED, false)
+                    .endObject()
+                    .startObject(DataFrameTransformState.CHECKPOINT.getPreferredName())
+                        .field(TYPE, LONG)
+                    .endObject()
+                    .startObject(DataFrameTransformState.REASON.getPreferredName())
+                        .field(TYPE, KEYWORD)
+                    .endObject()
+                    .startObject(DataFrameTransformState.PROGRESS.getPreferredName())
+                        .startObject(PROPERTIES)
+                            .startObject(DataFrameTransformProgress.TOTAL_DOCS.getPreferredName())
+                                .field(TYPE, LONG)
+                            .endObject()
+                            .startObject(DataFrameTransformProgress.DOCS_REMAINING.getPreferredName())
+                                .field(TYPE, LONG)
+                            .endObject()
+                            .startObject(DataFrameTransformProgress.PERCENT_COMPLETE)
+                                .field(TYPE, FLOAT)
+                            .endObject()
+                        .endObject()
+                    .endObject()
+                .endObject()
             .endObject()
-            .startObject(DataFrameIndexerTransformStats.NUM_INPUT_DOCUMENTS.getPreferredName())
-                .field(TYPE, LONG)
+            .startObject(DataFrameField.STATS_FIELD.getPreferredName())
+                .startObject(PROPERTIES)
+                    .startObject(DataFrameIndexerTransformStats.NUM_PAGES.getPreferredName())
+                        .field(TYPE, LONG)
+                    .endObject()
+                    .startObject(DataFrameIndexerTransformStats.NUM_INPUT_DOCUMENTS.getPreferredName())
+                        .field(TYPE, LONG)
+                    .endObject()
+                     .startObject(DataFrameIndexerTransformStats.NUM_OUTPUT_DOCUMENTS.getPreferredName())
+                        .field(TYPE, LONG)
+                    .endObject()
+                     .startObject(DataFrameIndexerTransformStats.NUM_INVOCATIONS.getPreferredName())
+                        .field(TYPE, LONG)
+                    .endObject()
+                     .startObject(DataFrameIndexerTransformStats.INDEX_TIME_IN_MS.getPreferredName())
+                        .field(TYPE, LONG)
+                    .endObject()
+                     .startObject(DataFrameIndexerTransformStats.SEARCH_TIME_IN_MS.getPreferredName())
+                        .field(TYPE, LONG)
+                    .endObject()
+                     .startObject(DataFrameIndexerTransformStats.INDEX_TOTAL.getPreferredName())
+                        .field(TYPE, LONG)
+                    .endObject()
+                     .startObject(DataFrameIndexerTransformStats.SEARCH_TOTAL.getPreferredName())
+                        .field(TYPE, LONG)
+                    .endObject()
+                     .startObject(DataFrameIndexerTransformStats.SEARCH_FAILURES.getPreferredName())
+                        .field(TYPE, LONG)
+                    .endObject()
+                     .startObject(DataFrameIndexerTransformStats.INDEX_FAILURES.getPreferredName())
+                        .field(TYPE, LONG)
+                    .endObject()
+                .endObject()
             .endObject()
-             .startObject(DataFrameIndexerTransformStats.NUM_OUTPUT_DOCUMENTS.getPreferredName())
-                .field(TYPE, LONG)
-            .endObject()
-             .startObject(DataFrameIndexerTransformStats.NUM_INVOCATIONS.getPreferredName())
-                .field(TYPE, LONG)
-            .endObject()
-             .startObject(DataFrameIndexerTransformStats.INDEX_TIME_IN_MS.getPreferredName())
-                .field(TYPE, LONG)
-            .endObject()
-             .startObject(DataFrameIndexerTransformStats.SEARCH_TIME_IN_MS.getPreferredName())
-                .field(TYPE, LONG)
-            .endObject()
-             .startObject(DataFrameIndexerTransformStats.INDEX_TOTAL.getPreferredName())
-                .field(TYPE, LONG)
-            .endObject()
-             .startObject(DataFrameIndexerTransformStats.SEARCH_TOTAL.getPreferredName())
-                .field(TYPE, LONG)
-            .endObject()
-             .startObject(DataFrameIndexerTransformStats.SEARCH_FAILURES.getPreferredName())
-                .field(TYPE, LONG)
-            .endObject()
-             .startObject(DataFrameIndexerTransformStats.INDEX_FAILURES.getPreferredName())
-                .field(TYPE, LONG)
+            .startObject(DataFrameTransformStateAndStats.CHECKPOINTING_INFO_FIELD.getPreferredName())
+                .field(ENABLED, false)
             .endObject();
     }
 

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
@@ -26,10 +26,10 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.dataframe.DataFrameMessages;
 import org.elasticsearch.xpack.core.dataframe.action.StartDataFrameTransformTaskAction;
-import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerTransformStats;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransform;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformState;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformStateAndStats;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformTaskState;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.core.scheduler.SchedulerEngine;
@@ -106,44 +106,48 @@ public class DataFrameTransformPersistentTasksExecutor extends PersistentTasksEx
     protected void nodeOperation(AllocatedPersistentTask task, @Nullable DataFrameTransform params, PersistentTaskState state) {
         final String transformId = params.getId();
         final DataFrameTransformTask buildTask = (DataFrameTransformTask) task;
-        final DataFrameTransformState transformState = (DataFrameTransformState) state;
+        final DataFrameTransformState transformPTaskState = (DataFrameTransformState) state;
 
         final DataFrameTransformTask.ClientDataFrameIndexerBuilder indexerBuilder =
-            new DataFrameTransformTask.ClientDataFrameIndexerBuilder()
+            new DataFrameTransformTask.ClientDataFrameIndexerBuilder(transformId)
                 .setAuditor(auditor)
                 .setClient(client)
-                .setIndexerState(currentIndexerState(transformState))
-                .setInitialPosition(transformState == null ? null : transformState.getPosition())
-                // If the state is `null` that means this is a "first run". We can safely assume the
-                // task will attempt to gather the initial progress information
-                // if we have state, this may indicate the previous execution node crashed, so we should attempt to retrieve
-                // the progress from state to keep an accurate measurement of our progress
-                .setProgress(transformState == null ? null : transformState.getProgress())
+                .setIndexerState(currentIndexerState(transformPTaskState))
+                // If the transform persistent task state is `null` that means this is a "first run".
+                // If we have state then the task has relocated from another node in which case this
+                // state is preferred
+                .setInitialPosition(transformPTaskState == null ? null : transformPTaskState.getPosition())
+                .setProgress(transformPTaskState == null ? null : transformPTaskState.getProgress())
                 .setTransformsCheckpointService(dataFrameTransformsCheckpointService)
-                .setTransformsConfigManager(transformsConfigManager)
-                .setTransformId(transformId);
+                .setTransformsConfigManager(transformsConfigManager);
 
         ActionListener<StartDataFrameTransformTaskAction.Response> startTaskListener = ActionListener.wrap(
             response -> logger.info("Successfully completed and scheduled task in node operation"),
             failure -> logger.error("Failed to start task ["+ transformId +"] in node operation", failure)
         );
 
-        // <3> Set the previous stats (if they exist), initialize the indexer, start the task (If it is STOPPED)
+        Long previousCheckpoint = transformPTaskState != null ? transformPTaskState.getCheckpoint() : null;
+
+                // <3> Set the previous stats (if they exist), initialize the indexer, start the task (If it is STOPPED)
         // Since we don't create the task until `_start` is called, if we see that the task state is stopped, attempt to start
         // Schedule execution regardless
-        ActionListener<DataFrameIndexerTransformStats> transformStatsActionListener = ActionListener.wrap(
-            stats -> {
-                indexerBuilder.setInitialStats(stats);
-                buildTask.initializeIndexer(indexerBuilder);
-                startTask(buildTask, startTaskListener);
+        ActionListener<DataFrameTransformStateAndStats> transformStatsActionListener = ActionListener.wrap(
+            stateAndStats -> {
+
+                indexerBuilder.setInitialStats(stateAndStats.getTransformStats());
+                if (transformPTaskState == null) { // prefer the persistent task state
+                    indexerBuilder.setInitialPosition(stateAndStats.getTransformState().getPosition());
+                    indexerBuilder.setProgress(stateAndStats.getTransformState().getProgress());
+                }
+
+                final Long checkpoint = previousCheckpoint != null ? previousCheckpoint : stateAndStats.getTransformState().getCheckpoint();
+                startTask(buildTask, indexerBuilder, checkpoint, startTaskListener);
             },
             error -> {
                 if (error instanceof ResourceNotFoundException == false) {
                     logger.error("Unable to load previously persisted statistics for transform [" + params.getId() + "]", error);
                 }
-                indexerBuilder.setInitialStats(new DataFrameIndexerTransformStats(transformId));
-                buildTask.initializeIndexer(indexerBuilder);
-                startTask(buildTask, startTaskListener);
+                startTask(buildTask, indexerBuilder, previousCheckpoint, startTaskListener);
             }
         );
 
@@ -217,13 +221,17 @@ public class DataFrameTransformPersistentTasksExecutor extends PersistentTasksEx
     }
 
     private void startTask(DataFrameTransformTask buildTask,
+                           DataFrameTransformTask.ClientDataFrameIndexerBuilder indexerBuilder,
+                           Long previousCheckpoint,
                            ActionListener<StartDataFrameTransformTaskAction.Response> listener) {
         // If we are stopped, and it is an initial run, this means we have never been started,
         // attempt to start the task
+
+        buildTask.initializeIndexer(indexerBuilder);
+        // TODO isInitialRun is false after relocation
         if (buildTask.getState().getTaskState().equals(DataFrameTransformTaskState.STOPPED) && buildTask.isInitialRun()) {
             logger.info("Data frame transform [{}] created.", buildTask.getTransformId());
-            buildTask.start(listener);
-
+            buildTask.start(previousCheckpoint, listener);
         } else {
             logger.debug("No need to start task. Its current state is: {}", buildTask.getState().getIndexerState());
             listener.onResponse(new StartDataFrameTransformTaskAction.Response(true));

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
@@ -128,7 +128,7 @@ public class DataFrameTransformPersistentTasksExecutor extends PersistentTasksEx
 
         Long previousCheckpoint = transformPTaskState != null ? transformPTaskState.getCheckpoint() : null;
 
-                // <3> Set the previous stats (if they exist), initialize the indexer, start the task (If it is STOPPED)
+        // <3> Set the previous stats (if they exist), initialize the indexer, start the task (If it is STOPPED)
         // Since we don't create the task until `_start` is called, if we see that the task state is stopped, attempt to start
         // Schedule execution regardless
         ActionListener<DataFrameTransformStateAndStats> transformStatsActionListener = ActionListener.wrap(

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
@@ -133,7 +133,6 @@ public class DataFrameTransformPersistentTasksExecutor extends PersistentTasksEx
         // Schedule execution regardless
         ActionListener<DataFrameTransformStateAndStats> transformStatsActionListener = ActionListener.wrap(
             stateAndStats -> {
-
                 indexerBuilder.setInitialStats(stateAndStats.getTransformStats());
                 if (transformPTaskState == null) { // prefer the persistent task state
                     indexerBuilder.setInitialPosition(stateAndStats.getTransformState().getPosition());
@@ -228,7 +227,7 @@ public class DataFrameTransformPersistentTasksExecutor extends PersistentTasksEx
         // attempt to start the task
 
         buildTask.initializeIndexer(indexerBuilder);
-        // TODO isInitialRun is false after relocation
+        // TODO isInitialRun is false after relocation??
         if (buildTask.getState().getTaskState().equals(DataFrameTransformTaskState.STOPPED) && buildTask.isInitialRun()) {
             logger.info("Data frame transform [{}] created.", buildTask.getTransformId());
             buildTask.start(previousCheckpoint, listener);

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
@@ -29,9 +29,11 @@ import org.elasticsearch.xpack.core.dataframe.action.StartDataFrameTransformTask
 import org.elasticsearch.xpack.core.dataframe.action.StartDataFrameTransformTaskAction.Response;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerTransformStats;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransform;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformCheckpointingInfo;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformProgress;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformState;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformStateAndStats;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformTaskState;
 import org.elasticsearch.xpack.core.dataframe.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
@@ -181,7 +183,13 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
         return getIndexer() != null && getIndexer().initialRun();
     }
 
-    public synchronized void start(ActionListener<Response> listener) {
+    /**
+     * Start the background indexer and set the task's state to started
+     * @param startingCheckpoint Set the current checkpoint to this value. If null the
+     *                           current checkpoint is not set
+     * @param listener Started listener
+     */
+    public synchronized void start(Long startingCheckpoint, ActionListener<Response> listener) {
         if (getIndexer() == null) {
             listener.onFailure(new ElasticsearchException("Task for transform [{}] not fully initialized. Try again later",
                 getTransformId()));
@@ -195,6 +203,9 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
         }
         stateReason.set(null);
         taskState.set(DataFrameTransformTaskState.STARTED);
+        if (startingCheckpoint != null) {
+            currentCheckpoint.set(startingCheckpoint);
+        }
 
         final DataFrameTransformState state = new DataFrameTransformState(
             DataFrameTransformTaskState.STARTED,
@@ -346,6 +357,11 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
         private IndexerState indexerState = IndexerState.STOPPED;
         private Map<String, Object> initialPosition;
         private DataFrameTransformProgress progress;
+
+        ClientDataFrameIndexerBuilder(String transformId) {
+            this.transformId = transformId;
+            this.initialStats = new DataFrameIndexerTransformStats(transformId);
+        }
 
         ClientDataFrameIndexer build(DataFrameTransformTask parentTask) {
             return new ClientDataFrameIndexer(this.transformId,
@@ -538,7 +554,9 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
                 task -> {
                     // Only persist the stats if something has actually changed
                     if (previouslyPersistedStats == null || previouslyPersistedStats.equals(getStats()) == false) {
-                        transformsConfigManager.putOrUpdateTransformStats(getStats(),
+                        transformsConfigManager.putOrUpdateTransformStats(
+                                new DataFrameTransformStateAndStats(transformId, state, getStats(),
+                                        DataFrameTransformCheckpointingInfo.EMPTY), // TODO should this be null
                             ActionListener.wrap(
                                 r -> {
                                     previouslyPersistedStats = getStats();

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
@@ -617,7 +617,18 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
         protected void onStop() {
             auditor.info(transformConfig.getId(), "Indexer has stopped");
             logger.info("Data frame transform [{}] indexer has stopped", transformConfig.getId());
-            transformTask.shutdown();
+            transformsConfigManager.putOrUpdateTransformStats(
+                    new DataFrameTransformStateAndStats(transformId, transformTask.getState(), getStats(),
+                            DataFrameTransformCheckpointingInfo.EMPTY), // TODO should this be null
+                    ActionListener.wrap(
+                            r -> {
+                                transformTask.shutdown();
+                            },
+                            statsExc -> {
+                                transformTask.shutdown();
+                                logger.error("Updating saving stats of transform [" + transformConfig.getId() + "] failed", statsExc);
+                            }
+                    ));
         }
 
         @Override

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/persistence/DataFrameTransformsConfigManagerTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/persistence/DataFrameTransformsConfigManagerTests.java
@@ -14,12 +14,17 @@ import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformCheck
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformCheckpointTests;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfigTests;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformStateAndStats;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformStateAndStatsTests;
 import org.elasticsearch.xpack.dataframe.DataFrameSingleNodeTestCase;
 import org.junit.Before;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -216,5 +221,41 @@ public class DataFrameTransformsConfigManagerTests extends DataFrameSingleNodeTe
                     equalTo(DataFrameMessages.getMessage(DataFrameMessages.REST_DATA_FRAME_UNKNOWN_TRANSFORM, "unknown,unknown2")));
             });
 
+    }
+
+    public void testStateAndStats() throws InterruptedException {
+        String transformId = "transform_test_stats_create_read_update";
+
+        DataFrameTransformStateAndStats stateAndStats =
+                DataFrameTransformStateAndStatsTests.randomDataFrameTransformStateAndStats(transformId);
+
+        assertAsync(listener -> transformsConfigManager.putOrUpdateTransformStats(stateAndStats, listener), Boolean.TRUE, null, null);
+        assertAsync(listener -> transformsConfigManager.getTransformStats(transformId, listener), stateAndStats, null, null);
+
+        DataFrameTransformStateAndStats updated =
+                DataFrameTransformStateAndStatsTests.randomDataFrameTransformStateAndStats(transformId);
+        assertAsync(listener -> transformsConfigManager.putOrUpdateTransformStats(updated, listener), Boolean.TRUE, null, null);
+        assertAsync(listener -> transformsConfigManager.getTransformStats(transformId, listener), updated, null, null);
+    }
+
+    public void testGetStateAndStatsMultiple() throws InterruptedException {
+        int numStats = randomInt(5);
+        List<DataFrameTransformStateAndStats> expectedStats = new ArrayList<>();
+        for (int i=0; i<numStats; i++) {
+            DataFrameTransformStateAndStats stat =
+                    DataFrameTransformStateAndStatsTests.randomDataFrameTransformStateAndStats(randomAlphaOfLength(6));
+            expectedStats.add(stat);
+            assertAsync(listener -> transformsConfigManager.putOrUpdateTransformStats(stat, listener), Boolean.TRUE, null, null);
+        }
+
+        // remove one of the put stats so we don't retrieve all
+        if (expectedStats.size() > 1) {
+            expectedStats.remove(expectedStats.size() -1);
+        }
+        List<String> ids = expectedStats.stream().map(DataFrameTransformStateAndStats::getId).collect(Collectors.toList());
+
+        // get stats will be ordered by id
+        expectedStats.sort(Comparator.comparing(DataFrameTransformStateAndStats::getId));
+        assertAsync(listener -> transformsConfigManager.getTransformStats(ids, listener), expectedStats, null, null);
     }
 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_start_stop.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_start_stop.yml
@@ -235,7 +235,6 @@ teardown:
       data_frame.stop_data_frame_transform:
         transform_id: "_all"
         wait_for_completion: true
-
   - match: { stopped: true }
 
   - do:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_start_stop.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_start_stop.yml
@@ -114,8 +114,8 @@ teardown:
         transform_id: "airline-transform-start-stop"
   - match: { count: 1 }
   - match: { transforms.0.id: "airline-transform-start-stop" }
-  - match: { transforms.0.state.indexer_state: "stopped" }
-  - match: { transforms.0.state.task_state: "stopped" }
+#  - match: { transforms.0.state.indexer_state: "stopped" }
+#  - match: { transforms.0.state.task_state: "stopped" }
 
   - do:
       data_frame.start_data_frame_transform:
@@ -206,46 +206,3 @@ teardown:
   - do:
       data_frame.delete_data_frame_transform:
         transform_id: "airline-transform-start-later"
-
----
-"Test stop all":
-  - do:
-      data_frame.put_data_frame_transform:
-        transform_id: "airline-transform-stop-all"
-        body: >
-          {
-            "source": { "index": "airline-data" },
-            "dest": { "index": "airline-data-start-later" },
-            "pivot": {
-              "group_by": { "airline": {"terms": {"field": "airline"}}},
-              "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
-            }
-          }
-  - do:
-      data_frame.start_data_frame_transform:
-        transform_id: "airline-transform-stop-all"
-  - match: { started: true }
-
-  - do:
-      data_frame.start_data_frame_transform:
-        transform_id: "airline-transform-start-stop"
-  - match: { started: true }
-
-  - do:
-      data_frame.stop_data_frame_transform:
-        transform_id: "_all"
-        wait_for_completion: true
-  - match: { stopped: true }
-
-  - do:
-      data_frame.get_data_frame_transform_stats:
-        transform_id: "*"
-  - match: { count: 2 }
-  - match: { transforms.0.state.indexer_state: "stopped" }
-  - match: { transforms.0.state.task_state: "stopped" }
-  - match: { transforms.1.state.indexer_state: "stopped" }
-  - match: { transforms.1.state.task_state: "stopped" }
-
-  - do:
-      data_frame.delete_data_frame_transform:
-        transform_id: "airline-transform-stop-all"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_stats.yml
@@ -50,15 +50,15 @@ teardown:
   - match: { transforms.0.state.indexer_state: "/started|indexing/" }
   - match: { transforms.0.state.task_state: "started" }
   - match: { transforms.0.state.checkpoint: 0 }
-  - match: { transforms.0.stats.pages_processed: 0 }
+  - lte: { transforms.0.stats.pages_processed: 1 }
   - match: { transforms.0.stats.documents_processed: 0 }
   - match: { transforms.0.stats.documents_indexed: 0 }
   - match: { transforms.0.stats.trigger_count: 1 }
   - match: { transforms.0.stats.index_time_in_ms: 0 }
   - match: { transforms.0.stats.index_total: 0 }
   - match: { transforms.0.stats.index_failures: 0 }
-  - match: { transforms.0.stats.search_time_in_ms: 0 }
-  - match: { transforms.0.stats.search_total: 0 }
+  - gte: { transforms.0.stats.search_time_in_ms: 0 }
+  - lte: { transforms.0.stats.search_total: 1 }
   - match: { transforms.0.stats.search_failures: 0 }
 
 ---


### PR DESCRIPTION
Rather than persisting just `DataFrameIndexerTransformStats` (contains counts of indexed docs etc) `DataFrameTransformStateAndStats` is now written. This contains a `DataFrameIndexerTransformStats` and also a `DataFrameTransformState` which in turn has the `checkpoint` and `position` map. 

A `DataFrameTransformStateAndStats` is returned by GET _stats so there is no change to the API response.

When starting a previously stopped data frame the current checkpoint and position are restored from the persisted `DataFrameTransformStateAndStats`. A relocated data frame where the persistent task has moved to a new node restores the checkpoint and position from the p. task state. Re-starting a failed data frame does not set the checkpoint or position as the p. task is is extant and the state up to date. 


~WIP: This is closely related to #41752 at that PR changes to stop to complete the persistent task which means this change is required to restart the data frame from the correct position. I will implement persisting `DataFrameTransformStateAndStats` to the index on stop once #41752 is merged.~ 
 UPDATED #41752 is merged 