### PR TITLE
Add corretto 11 to runtime javas

### DIFF
--- a/.ci/matrix-runtime-javas.yml
+++ b/.ci/matrix-runtime-javas.yml
@@ -11,3 +11,4 @@ ES_RUNTIME_JAVA:
   - openjdk12
   - zulu11
   - zulu12
+  - corretto11


### PR DESCRIPTION
We now have coretto on the ephemeral CI images so we can add it to our
regular java test matrix.
On backporting will also add  corretto8 to branches that support it.
