### PR TITLE
Update lintian overrides (#41561)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -161,13 +161,17 @@ def deb_common(config, name, extra: '')
       s.privileged = false
       s.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
   end
+  extra_with_lintian = <<-SHELL
+    install lintian
+    #{extra}
+  SHELL
   linux_common(
     config,
     name,
     update_command: 'apt-get update',
     update_tracking_file: '/var/cache/apt/archives/last_update',
     install_command: 'apt-get install -y',
-    extra: extra
+    extra: extra_with_lintian
   )
 end
 

--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -270,13 +270,13 @@ apply plugin: 'nebula.ospackage-base'
 // this is package indepdendent configuration
 ospackage {
   maintainer 'Elasticsearch Team <info@elastic.co>'
-  summary '''
-    Elasticsearch is a distributed RESTful search engine built for the cloud.
+  summary 'Distributed RESTful search engine built for the cloud'
+  packageDescription '''
     Reference documentation can be found at
     https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
     and the 'Elasticsearch: The Definitive Guide' book can be found at
     https://www.elastic.co/guide/en/elasticsearch/guide/current/index.html
-    '''.stripIndent().replace('\n', ' ').trim()
+  '''.stripIndent().trim()
   url 'https://www.elastic.co/'
 
   // signing setup
@@ -288,7 +288,8 @@ ospackage {
             new File(new File(System.getProperty('user.home'), '.gnupg'), 'secring.gpg')
   }
 
-  requires('coreutils')
+  // version found on oldest supported distro, centos-6
+  requires('coreutils', '8.4', GREATER | EQUAL)
 
   fileMode 0644
   dirMode 0755
@@ -312,12 +313,18 @@ Closure commonDebConfig(boolean oss, boolean jdk) {
 
     version = project.version.replace('-', '~')
     packageGroup 'web'
-    requires 'bash'
+
+    // versions found on oldest supported distro, centos-6
+    requires('bash', '4.1', GREATER | EQUAL)
+    requires('lsb-base', '4', GREATER | EQUAL)
     requires 'libc6'
     requires 'adduser'
 
     into('/usr/share/lintian/overrides') {
       from('src/deb/lintian/elasticsearch')
+      if (oss) {
+        rename('elasticsearch', 'elasticsearch-oss')
+      }
     }
   }
 }

--- a/distribution/packages/src/deb/lintian/elasticsearch
+++ b/distribution/packages/src/deb/lintian/elasticsearch
@@ -1,8 +1,48 @@
-# Ignore arch dependent warnings, we chose the right libs on start
-elasticsearch binary: arch-independent-package-contains-binary-or-object
-# Not stripping external libraries
-elasticsearch binary: unstripped-binary-or-object
-# Ignore arch dependent warnings, we chose the right libs on start
-elasticsearch binary: arch-dependent-file-in-usr-share
-# Please check our changelog at http://www.elastic.co/downloads/elasticsearch
-elasticsearch binary: changelog-file-missing-in-native-package
+# we don't have a changelog, but we put our copyright file
+# under /usr/share/doc/elasticsearch, which triggers this warning
+changelog-file-missing-in-native-package
+
+# we intentionally copy our copyright file for all deb packages
+copyright-file-contains-full-apache-2-license
+copyright-should-refer-to-common-license-file-for-apache-2
+copyright-without-copyright-notice
+
+# we still put all our files under /usr/share/elasticsearch even after transition to platform dependent packages
+arch-dependent-file-in-usr-share
+
+# we have a bundled jdk, so don't use jarwrapper
+missing-dep-on-jarwrapper
+
+# we prefer to not make our config and log files world readable
+non-standard-file-perm etc/default/elasticsearch 0660 != 0644
+non-standard-dir-perm etc/elasticsearch/ 2750 != 0755
+non-standard-file-perm etc/elasticsearch/*
+non-standard-dir-perm var/lib/elasticsearch/ 2750 != 0755
+non-standard-dir-perm var/log/elasticsearch/ 2750 != 0755
+executable-is-not-world-readable etc/init.d/elasticsearch 0750
+non-standard-file-permissions-for-etc-init.d-script etc/init.d/elasticsearch 0750 != 0755
+
+# this lintian tag is simply wrong; contrary to the explanation, debian systemd
+# does actually look at /usr/lib/systemd/system
+systemd-service-file-outside-lib usr/lib/systemd/system/elasticsearch.service
+
+# we do not automatically enable the service in init.d or systemd
+script-in-etc-init.d-not-registered-via-update-rc.d etc/init.d/elasticsearch
+
+# the package scripts handle init.d/systemd directly and don't need to use deb helpers
+maintainer-script-calls-systemctl
+prerm-calls-updaterc.d elasticsearch
+
+# bundled JDK
+embedded-library
+arch-dependent-file-in-usr-share usr/share/elasticsearch/jdk/*
+unstripped-binary-or-object usr/share/elasticsearch/jdk/*
+extra-license-file usr/share/elasticsearch/jdk/legal/*
+hardening-no-pie usr/share/elasticsearch/jdk/bin/*
+hardening-no-pie usr/share/elasticsearch/jdk/lib/*
+
+# the system java version that lintian assumes is far behind what elasticsearch uses
+unknown-java-class-version
+
+# elastic licensed modules contain elastic license
+extra-license-file usr/share/elasticsearch/modules/*

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/PackageTestCase.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/PackageTestCase.java
@@ -56,6 +56,7 @@ import static org.elasticsearch.packaging.util.Packages.startElasticsearch;
 import static org.elasticsearch.packaging.util.Packages.stopElasticsearch;
 import static org.elasticsearch.packaging.util.Packages.verifyPackageInstallation;
 import static org.elasticsearch.packaging.util.Platforms.getOsRelease;
+import static org.elasticsearch.packaging.util.Platforms.isDPKG;
 import static org.elasticsearch.packaging.util.Platforms.isSystemd;
 import static org.elasticsearch.packaging.util.ServerUtils.makeRequest;
 import static org.elasticsearch.packaging.util.ServerUtils.runElasticsearchTests;
@@ -76,6 +77,11 @@ public abstract class PackageTestCase extends PackagingTestCase {
     public void onlyCompatibleDistributions() throws Exception {
         assumeTrue("only compatible distributions", distribution().packaging.compatible);
         sh = newShell();
+    }
+
+    public void test05CheckLintian() throws Exception {
+        assumeTrue(isDPKG());
+        sh.run("lintian --fail-on-warnings " + FileUtils.getDistributionFile(distribution()));
     }
 
     public void test10InstallPackage() throws Exception {


### PR DESCRIPTION
The deb package has been updated several times in the past to contain
overrides in order to pass lintian inspection. However, there have never
been any tests to ensure we do not fallback to failure. This commit
updates the overrides file given things that have changed since 2.x like
adding ML and bundling the jdk.

closes #17185