### PR TITLE
[Backport 7.x] Allow unknown task time in QueueResizingEsTPE

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/TimedRunnable.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/TimedRunnable.java
@@ -30,6 +30,7 @@ class TimedRunnable extends AbstractRunnable implements WrappedRunnable {
     private final long creationTimeNanos;
     private long startTimeNanos;
     private long finishTimeNanos = -1;
+    private boolean failedOrRejected = false;
 
     TimedRunnable(final Runnable original) {
         this.original = original;
@@ -48,6 +49,7 @@ class TimedRunnable extends AbstractRunnable implements WrappedRunnable {
 
     @Override
     public void onRejection(final Exception e) {
+        this.failedOrRejected = true;
         if (original instanceof AbstractRunnable) {
             ((AbstractRunnable) original).onRejection(e);
         } else {
@@ -64,6 +66,7 @@ class TimedRunnable extends AbstractRunnable implements WrappedRunnable {
 
     @Override
     public void onFailure(final Exception e) {
+        this.failedOrRejected = true;
         if (original instanceof AbstractRunnable) {
             ((AbstractRunnable) original).onFailure(e);
         } else {
@@ -98,6 +101,14 @@ class TimedRunnable extends AbstractRunnable implements WrappedRunnable {
             return -1;
         }
         return Math.max(finishTimeNanos - startTimeNanos, 1);
+    }
+
+    /**
+     * If the task was failed or rejected, return true.
+     * Otherwise, false.
+     */
+    boolean getFailedOrRejected() {
+        return this.failedOrRejected;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/QueueResizingEsThreadPoolExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/QueueResizingEsThreadPoolExecutorTests.java
@@ -226,16 +226,43 @@ public class QueueResizingEsThreadPoolExecutorTests extends ESTestCase {
         context.close();
     }
 
+    /** Use a runnable wrapper that simulates a task with unknown failures. */
+    public void testExceptionThrowingTask() throws Exception {
+        ThreadContext context = new ThreadContext(Settings.EMPTY);
+        ResizableBlockingQueue<Runnable> queue =
+            new ResizableBlockingQueue<>(ConcurrentCollections.<Runnable>newBlockingQueue(),
+                100);
+
+        QueueResizingEsThreadPoolExecutor executor =
+            new QueueResizingEsThreadPoolExecutor(
+                "test-threadpool", 1, 1, 1000,
+                TimeUnit.MILLISECONDS, queue, 10, 200, exceptionalWrapper(), 10, TimeValue.timeValueMillis(1),
+                EsExecutors.daemonThreadFactory("queuetest"), new EsAbortPolicy(), context);
+        executor.prestartAllCoreThreads();
+        logger.info("--> executor: {}", executor);
+
+        assertThat((long)executor.getTaskExecutionEWMA(), equalTo(0L));
+        executeTask(executor, 1);
+        executor.shutdown();
+        executor.awaitTermination(10, TimeUnit.SECONDS);
+        context.close();
+    }
+
     private Function<Runnable, WrappedRunnable> fastWrapper() {
-        return (runnable) -> {
-            return new SettableTimedRunnable(TimeUnit.NANOSECONDS.toNanos(100));
-        };
+        return (runnable) -> new SettableTimedRunnable(TimeUnit.NANOSECONDS.toNanos(100), false);
     }
 
     private Function<Runnable, WrappedRunnable> slowWrapper() {
-        return (runnable) -> {
-            return new SettableTimedRunnable(TimeUnit.MINUTES.toNanos(2));
-        };
+        return (runnable) -> new SettableTimedRunnable(TimeUnit.MINUTES.toNanos(2), false);
+    }
+
+    /**
+     * The returned function outputs a WrappedRunnabled that simulates the case
+     * where {@link TimedRunnable#getTotalExecutionNanos()} returns -1 because
+     * the job failed or was rejected before it finished.
+     */
+    private Function<Runnable, WrappedRunnable> exceptionalWrapper() {
+        return (runnable) -> new SettableTimedRunnable(TimeUnit.NANOSECONDS.toNanos(-1), true);
     }
 
     /** Execute a blank task {@code times} times for the executor */
@@ -248,10 +275,12 @@ public class QueueResizingEsThreadPoolExecutorTests extends ESTestCase {
 
     public class SettableTimedRunnable extends TimedRunnable {
         private final long timeTaken;
+        private final boolean testFailedOrRejected;
 
-        public SettableTimedRunnable(long timeTaken) {
+        public SettableTimedRunnable(long timeTaken, boolean failedOrRejected) {
             super(() -> {});
             this.timeTaken = timeTaken;
+            this.testFailedOrRejected = failedOrRejected;
         }
 
         @Override
@@ -262,6 +291,11 @@ public class QueueResizingEsThreadPoolExecutorTests extends ESTestCase {
         @Override
         public long getTotalExecutionNanos() {
             return timeTaken;
+        }
+
+        @Override
+        public boolean getFailedOrRejected() {
+            return testFailedOrRejected;
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/node/NodeTests.java
+++ b/server/src/test/java/org/elasticsearch/node/NodeTests.java
@@ -174,7 +174,6 @@ public class NodeTests extends ESTestCase {
         shouldRun.set(false);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/41448")
     public void testCloseOnInterruptibleTask() throws Exception {
         Node node = new MockNode(baseSettings().build(), basePlugins());
         node.start();


### PR DESCRIPTION
* Allow unknown task time in QueueResizingEsTPE

The afterExecute method previously asserted that a TimedRunnable task
must have a positive execution time. However, the code in TimedRunnable
returns a value of -1 when a task time is unknown. Here, we expand the
logic in the assertion to allow for that possibility, and we don't
update our task time average if the value is negative.

* Add a failure flag to TimedRunnable

In order to be sure that a task has an execution time of -1 because of
a failure, I'm adding a failure flag boolean to the TimedRunnable class.
If execution time is negative for some other reason, an assertion will
fail.

Backport of #41810
Fixes #41448
