### PR TITLE
Fix max_bucket test by specifying number of shards

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/240_max_buckets.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/240_max_buckets.yml
@@ -4,6 +4,9 @@ setup:
         indices.create:
           index: test
           body:
+              settings:
+                number_of_shards: 1
+                number_of_replicas: 0
               mappings:
                 properties:
                   keyword:
@@ -75,9 +78,7 @@ setup:
 
 ---
 "Max bucket":
-  - skip:
-      version: "all"
-      reason:  "AwaitsFix: https://github.com/elastic/elasticsearch/issues/41947"
+
   - do:
       cluster.put_settings:
         body:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/240_max_buckets.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/240_max_buckets.yml
@@ -4,9 +4,6 @@ setup:
         indices.create:
           index: test
           body:
-              settings:
-                number_of_shards: 1
-                number_of_replicas: 0
               mappings:
                 properties:
                   keyword:
@@ -89,6 +86,7 @@ setup:
       catch: /.*Trying to create too many buckets.*/
       search:
         rest_total_hits_as_int: true
+        allow_partial_search_results: false
         index: test
         body:
           aggregations:
@@ -106,6 +104,7 @@ setup:
       catch: /.*Trying to create too many buckets.*/
       search:
         rest_total_hits_as_int: true
+        allow_partial_search_results: false
         index: test
         body:
           aggregations:


### PR DESCRIPTION
The Max Bucket test can potentially return a partial response, where one of the shards suceeds but another fails due to the max_bucket setting.  In the case of a partial failure, the status code is 200 OK since some results were returned (with failures listed in the body).

This makes the yaml test fail since it is expecting a 4xx/5xx failure when catching exception messages.

We need to force the test to use a single shard, which will guarantee that the max_bucket setting is tripped for the entire request.

Closes https://github.com/elastic/elasticsearch/issues/41947