### PR TITLE
SQL: Add back the single node JDBC CSV Spec tests

### DIFF
--- a/x-pack/plugin/sql/qa/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcCsvSpecIT.java
+++ b/x-pack/plugin/sql/qa/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcCsvSpecIT.java
@@ -22,7 +22,8 @@ public class JdbcCsvSpecIT extends CsvSpecTestCase {
     public static List<Object[]> readScriptSpec() throws Exception {
         List<Object[]> list = new ArrayList<>();
         list.addAll(CsvSpecTestCase.readScriptSpec());
-        return readScriptSpec("/single-node-only/command-sys.csv-spec", specParser());
+        list.addAll(readScriptSpec("/single-node-only/command-sys.csv-spec", specParser()));
+        return list;
     }
 
     public JdbcCsvSpecIT(String fileName, String groupName, String testName, Integer lineNumber, CsvTestCase testCase) {


### PR DESCRIPTION
Adds back single node JDBC CSV Spec tests that were accidentally removed.

Relates to #40583

