### PR TITLE
[6.7] Add note about ILM action ordering (#41771)

### DIFF
--- a/docs/reference/ilm/policy-definitions.asciidoc
+++ b/docs/reference/ilm/policy-definitions.asciidoc
@@ -84,6 +84,10 @@ executing.
 
 The below list shows the actions which are available in each phase.
 
+NOTE: The order that configured actions are performed in within each phase is
+determined by automatically by {ilm-init}, and cannot be changed by changing the
+policy definition.
+
 * Hot
   - <<ilm-set-priority-action,Set Priority>>
   - <<ilm-rollover-action,Rollover>>


### PR DESCRIPTION
Backports the following commits to 6.7:
 - Add note about ILM action ordering  (#41771)