### PR TITLE
[DOCS] Updates TLS configuration info 

### DIFF
--- a/docs/reference/security/securing-communications/configuring-tls-docker.asciidoc
+++ b/docs/reference/security/securing-communications/configuring-tls-docker.asciidoc
@@ -2,10 +2,8 @@
 [[configuring-tls-docker]]
 === Encrypting communications in an {es} Docker Container
 
-Starting with version 6.0.0, {stack} {security-features}
-(Gold, Platinum or Enterprise subscriptions)
-https://www.elastic.co/guide/en/elasticsearch/reference/6.0/breaking-6.0.0-xes.html[require SSL/TLS]
-encryption for the transport networking layer.
+Unless you are using a trial license, {stack} {security-features} require
+SSL/TLS encryption for the transport networking layer.
 
 This section demonstrates an easy path to get started with SSL/TLS for both
 HTTPS and transport using the {es} Docker image. The example uses

--- a/docs/reference/security/securing-communications/securing-elasticsearch.asciidoc
+++ b/docs/reference/security/securing-communications/securing-elasticsearch.asciidoc
@@ -7,8 +7,8 @@ your {es} cluster. Connections are secured using Transport Layer Security
 (TLS/SSL).
 
 WARNING: Clusters that do not have encryption enabled send all data in plain text
-including passwords and will not be able to install a license that enables
-{security-features}.
+including passwords. If the {es} {security-features} are enabled, unless you
+have a trial license, you must configure SSL/TLS for internode-communication.
 
 To enable encryption, you need to perform the following steps on each node in
 the cluster:

--- a/docs/reference/security/securing-communications/setting-up-ssl.asciidoc
+++ b/docs/reference/security/securing-communications/setting-up-ssl.asciidoc
@@ -1,16 +1,15 @@
 [[ssl-tls]]
-=== Setting Up TLS on a cluster
+=== Setting up TLS on a cluster
 
-The {stack} {security-features} enables you to encrypt traffic to, from, and
+The {stack} {security-features} enable you to encrypt traffic to, from, and
 within your {es} cluster. Connections are secured using Transport Layer Security
 (TLS), which is commonly referred to as "SSL".
 
 WARNING: Clusters that do not have encryption enabled send all data in plain text
-including passwords and will not be able to install a license that enables
-{security-features}.
+including passwords. If the {es} {security-features} are enabled, unless you have a trial license, you must configure SSL/TLS for internode-communication.
 
 The following steps describe how to enable encryption across the various
-components of the Elastic Stack. You must perform each of the steps that are
+components of the {stack}. You must perform each of the steps that are
 applicable to your cluster.
 
 . Generate a private key and X.509 certificate for each of your {es} nodes. See
@@ -22,14 +21,14 @@ enable TLS on the HTTP layer. See
 {ref}/configuring-tls.html#tls-transport[Encrypting Communications Between Nodes in a Cluster] and
 {ref}/configuring-tls.html#tls-http[Encrypting HTTP Client Communications]. 
 
-. Configure {monitoring} to use encrypted connections. See <<secure-monitoring>>.
+. Configure the {monitor-features} to use encrypted connections. See <<secure-monitoring>>.
 
 . Configure {kib} to encrypt communications between the browser and
 the {kib} server and to connect to {es} via HTTPS. See
-{kibana-ref}/using-kibana-with-security.html[Configuring Security in {kib}].
+{kibana-ref}/using-kibana-with-security.html[Configuring security in {kib}].
 
 . Configure Logstash to use TLS encryption. See
-{logstash-ref}/ls-security.html[Configuring Security in Logstash].
+{logstash-ref}/ls-security.html[Configuring security in {ls}].
 
 . Configure Beats to use encrypted connections. See <<beats>>.
 

--- a/docs/reference/setup/bootstrap-checks-xes.asciidoc
+++ b/docs/reference/setup/bootstrap-checks-xes.asciidoc
@@ -53,9 +53,8 @@ must also be valid.
 === SSL/TLS check
 //See TLSLicenseBootstrapCheck.java
 
-In 6.0 and later releases, if you have a gold, platinum, or enterprise license
-and {es} {security-features} are enabled, you must configure SSL/TLS for
-internode-communication.
+If you enable {es} {security-features}, unless you have a trial license, you 
+must configure SSL/TLS for internode-communication.
 
 NOTE: Single-node clusters that use a loopback interface do not have this
 requirement.  For more information, see

--- a/x-pack/docs/en/security/securing-communications.asciidoc
+++ b/x-pack/docs/en/security/securing-communications.asciidoc
@@ -5,8 +5,7 @@
 Elasticsearch nodes store data that may be confidential. Attacks on the data may
 come from the network. These attacks could include sniffing of the data,
 manipulation of the data, and attempts to gain access to the server and thus the
-files storing the data. Securing your nodes is required in order to use a production
-license that enables {security-features} and helps reduce the risk from
+files storing the data. Securing your nodes helps reduce the risk from
 network-based attacks.
 
 This section shows how to:


### PR DESCRIPTION
This PR updates the following pages in the Elasticsearch Reference:
https://www.elastic.co/guide/en/elasticsearch/reference/master/configuring-tls.html
https://www.elastic.co/guide/en/elasticsearch/reference/master/configuring-tls-docker.html
https://www.elastic.co/guide/en/elasticsearch/reference/master/bootstrap-checks-xpack.html#bootstrap-checks-tls

It also updates the following pages in the Stack Overview:
https://www.elastic.co/guide/en/elastic-stack-overview/master/encrypting-communications.html
https://www.elastic.co/guide/en/elastic-stack-overview/master/ssl-tls.html