### PR TITLE
Limit max direct memory size to half of heap size

### DIFF
--- a/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/JvmErgonomics.java
+++ b/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/JvmErgonomics.java
@@ -63,6 +63,10 @@ final class JvmErgonomics {
                 ergonomicChoices.add("-Dio.netty.allocator.type=pooled");
             }
         }
+        final long maxDirectMemorySize = extractMaxDirectMemorySize(finalJvmOptions);
+        if (maxDirectMemorySize == 0) {
+            ergonomicChoices.add("-XX:MaxDirectMemorySize=" + heapSize / 2);
+        }
         return ergonomicChoices;
     }
 
@@ -118,6 +122,10 @@ final class JvmErgonomics {
     // package private for testing
     static Long extractHeapSize(final Map<String, Optional<String>> finalJvmOptions) {
         return Long.parseLong(finalJvmOptions.get("MaxHeapSize").get());
+    }
+
+    static long extractMaxDirectMemorySize(final Map<String, Optional<String>> finalJvmOptions) {
+        return Long.parseLong(finalJvmOptions.get("MaxDirectMemorySize").get());
     }
 
     private static final Pattern SYSTEM_PROPERTY = Pattern.compile("^-D(?<key>[\\w+].*?)=(?<value>.*)$");

--- a/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/JvmErgonomicsTests.java
+++ b/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/JvmErgonomicsTests.java
@@ -23,12 +23,12 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasToString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -85,6 +85,19 @@ public class JvmErgonomicsTests extends LaunchersTestCase {
         }
     }
 
+    public void testMaxDirectMemorySizeUnset() throws InterruptedException, IOException {
+        assertThat(
+                JvmErgonomics.extractMaxDirectMemorySize(JvmErgonomics.finalJvmOptions(Collections.singletonList("-Xmx1g"))),
+                equalTo(0L));
+    }
+
+    public void testMaxDirectMemorySizeSet() throws InterruptedException, IOException {
+        assertThat(
+                JvmErgonomics.extractMaxDirectMemorySize(JvmErgonomics.finalJvmOptions(
+                        Arrays.asList("-Xmx1g", "-XX:MaxDirectMemorySize=512m"))),
+                equalTo(512L << 20));
+    }
+
     public void testExtractSystemProperties() {
         Map<String, String> expectedSystemProperties = new HashMap<>();
         expectedSystemProperties.put("file.encoding", "UTF-8");
@@ -101,16 +114,33 @@ public class JvmErgonomicsTests extends LaunchersTestCase {
         assertTrue(parsedSystemProperties.isEmpty());
     }
 
-    public void testLittleMemoryErgonomicChoices() throws InterruptedException, IOException {
-        String smallHeap = randomFrom(Arrays.asList("64M", "512M", "1024M", "1G"));
-        List<String> expectedChoices = Collections.singletonList("-Dio.netty.allocator.type=unpooled");
-        assertEquals(expectedChoices, JvmErgonomics.choose(Arrays.asList("-Xms" + smallHeap, "-Xmx" + smallHeap)));
+    public void testPooledMemoryChoiceOnSmallHeap() throws InterruptedException, IOException {
+        final String smallHeap = randomFrom(Arrays.asList("64M", "512M", "1024M", "1G"));
+        assertThat(
+                JvmErgonomics.choose(Arrays.asList("-Xms" + smallHeap, "-Xmx" + smallHeap)),
+                hasItem("-Dio.netty.allocator.type=unpooled"));
     }
 
-    public void testPlentyMemoryErgonomicChoices() throws InterruptedException, IOException {
-        String largeHeap = randomFrom(Arrays.asList("1025M", "2048M", "2G", "8G"));
-        List<String> expectedChoices = Collections.singletonList("-Dio.netty.allocator.type=pooled");
-        assertEquals(expectedChoices, JvmErgonomics.choose(Arrays.asList("-Xms" + largeHeap, "-Xmx" + largeHeap)));
+    public void testPooledMemoryChoiceOnNotSmallHeap() throws InterruptedException, IOException {
+        final String largeHeap = randomFrom(Arrays.asList("1025M", "2048M", "2G", "8G"));
+        assertThat(
+                JvmErgonomics.choose(Arrays.asList("-Xms" + largeHeap, "-Xmx" + largeHeap)),
+                hasItem("-Dio.netty.allocator.type=pooled"));
+    }
+
+    public void testMaxDirectMemorySizeChoice() throws InterruptedException, IOException {
+        final Map<String, String> heapMaxDirectMemorySize = Map.of(
+                        "64M", Long.toString((64L << 20) / 2),
+                        "512M", Long.toString((512L << 20) / 2),
+                        "1024M", Long.toString((1024L << 20) / 2),
+                        "1G",  Long.toString((1L << 30) / 2),
+                        "2048M", Long.toString((2048L << 20) / 2),
+                        "2G", Long.toString((2L << 30) / 2),
+                        "8G", Long.toString((8L << 30) / 2));
+        final String heapSize = randomFrom(heapMaxDirectMemorySize.keySet().toArray(String[]::new));
+        assertThat(
+                JvmErgonomics.choose(Arrays.asList("-Xms" + heapSize, "-Xmx" + heapSize)),
+                hasItem("-XX:MaxDirectMemorySize=" + heapMaxDirectMemorySize.get(heapSize)));
     }
 
 }

--- a/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/JvmErgonomicsTests.java
+++ b/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/JvmErgonomicsTests.java
@@ -27,9 +27,12 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -141,6 +144,12 @@ public class JvmErgonomicsTests extends LaunchersTestCase {
         assertThat(
                 JvmErgonomics.choose(Arrays.asList("-Xms" + heapSize, "-Xmx" + heapSize)),
                 hasItem("-XX:MaxDirectMemorySize=" + heapMaxDirectMemorySize.get(heapSize)));
+    }
+
+    public void testMaxDirectMemorySizeChoiceWhenSet() throws InterruptedException, IOException {
+        assertThat(
+                JvmErgonomics.choose(Arrays.asList("-Xms1g", "-Xmx1g", "-XX:MaxDirectMemorySize=1g")),
+                everyItem(not(startsWith("-XX:MaxDirectMemorySize="))));
     }
 
 }


### PR DESCRIPTION
This commit adds an ergonomic choice ot the max direct memory size such that if it is not set, we default it to half of the heap size.

Closes #41954
Relates #41962