### PR TITLE
Fix Race in Closing IndicesService.CacheCleaner

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -66,6 +66,7 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.iterable.Iterables;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -1219,7 +1220,13 @@ public class IndicesService extends AbstractLifecycleComponent
             }
             // Reschedule itself to run again if not closed
             if (closed.get() == false) {
-                threadPool.schedule(this, interval, ThreadPool.Names.SAME);
+                try {
+                    threadPool.schedule(this, interval, ThreadPool.Names.SAME);
+                } catch (EsRejectedExecutionException e) {
+                    if (closed.get() == false) {
+                        throw e;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
* When close becomes true while the management pool that would execute the `Runnable` here is being shut down, we run into an unhandeled `EsRejectedExecutionException` that fails tests
* Found this while trying to reproduce #32506
   * Running the `IndexStatsIT` in a loop is a way of reproducing this
