### PR TITLE
[DOCS] Rewrite 'rewrite' parameter docs

### DIFF
--- a/docs/reference/modules/indices/search-settings.asciidoc
+++ b/docs/reference/modules/indices/search-settings.asciidoc
@@ -3,6 +3,7 @@
 
 The following _expert_ setting can be set to manage global search limits.
 
+[[indices-query-bool-max-clause-count]]
 `indices.query.bool.max_clause_count`::
     Defaults to `1024`.
 

--- a/docs/reference/query-dsl/multi-term-rewrite.asciidoc
+++ b/docs/reference/query-dsl/multi-term-rewrite.asciidoc
@@ -1,36 +1,46 @@
 [[query-dsl-multi-term-rewrite]]
 == `rewrite` Parameter
 
-WARNING: This parameter is for expert users only. Changing the value of this
-parameter can impact search performance and relevance.
+WARNING: This parameter is for expert users only. Changing the value of
+this parameter can impact search performance and relevance.
 
-To improve performance, {es} rewrites the following queries:
+{es} uses https://lucene.apache.org/core/[Apache Lucene] internally to power
+indexing and searching. In their original form, Lucene cannot execute the
+following queries:
 
+* <<query-dsl-fuzzy-query, `fuzzy`>>
 * <<query-dsl-prefix-query, `prefix`>>
 * <<query-dsl-query-string-query, `query_string`>>
+* <<query-dsl-regexp-query, `regexp`>>
 * <<query-dsl-wildcard-query, `wildcard`>>
 
-In their original form, these queries are expensive. {es} changes the
-original query to a less expensive <<query-dsl-bool-query, `bool` query>>. This
-`bool` query contains a `should` clause and <<query-dsl-term-query, `term`
-query>> for each matching term.
+To execute them, Lucene changes these queries to a simpler form, such as a
+<<query-dsl-bool-query, `bool` query>> or a
+https://en.wikipedia.org/wiki/Bit_array[bit set].
 
 The `rewrite` parameter determines:
 
-* How {es} calculates the relevance scores for each matching document
-* Which `term` queries are included in the final `bool` query
+* How Lucene calculates the relevance scores for each matching document
+* Whether Lucene changes the original query to a `bool`
+query or bit set
+* If changed to a `bool` query, which `term` query clauses are included
 
 [float]
 [[rewrite-param-valid-values]]
 === Valid values
 
 `constant_score` (Default)::
-Automatically uses the `constant_score_boolean` or `scoring_boolean` method,
-based on the number of matching terms. For fewer matching terms, the
-`constant_score_boolean` method is used.
+Uses the `constant_score_boolean` method for fewer matching terms. Otherwise,
+this method finds all matching terms in sequence and returns matching documents
+using a bit set.
 
 `constant_score_boolean`::
-Assigns each document a relevance score equal to the `boost` parameter.
+Assigns each document a relevance score equal to the `boost`
+parameter.
++
+This method changes the original query to a <<query-dsl-bool-query, `bool`
+query>>. This `bool` query contains a `should` clause and
+<<query-dsl-term-query, `term` query>> for each matching term.
 +
 This method can cause the final `bool` query to exceed the clause limit in the
 <<indices-query-bool-max-clause-count, `indices.query.bool.max_clause_count`>>
@@ -39,6 +49,10 @@ setting. If the query exceeds this limit, {es} returns an error.
 `scoring_boolean`::
 Calculates a relevance score for each matching document.
 +
+This method changes the original query to a <<query-dsl-bool-query, `bool`
+query>>. This `bool` query contains a `should` clause and
+<<query-dsl-term-query, `term` query>> for each matching term.
++
 This method can cause the final `bool` query to exceed the clause limit in the
 <<indices-query-bool-max-clause-count, `indices.query.bool.max_clause_count`>>
 setting. If the query exceeds this limit, {es} returns an error.
@@ -46,6 +60,11 @@ setting. If the query exceeds this limit, {es} returns an error.
 `top_terms_blended_freqs_N`::
 Calculates a relevance score for each matching document as if all terms had the
 same frequency. This frequency is the maximum frequency of all matching terms.
++
+This method changes the original query to a <<query-dsl-bool-query, `bool`
+query>>. This `bool` query contains a `should` clause and
+<<query-dsl-term-query, `term` query>> for each matching term.
++
 The final `bool` query only includes `term` queries for the top `N` scoring
 terms.
 +
@@ -55,6 +74,11 @@ setting.
 
 `top_terms_boost_N`::
 Assigns each matching document a relevance score equal to the `boost` parameter.
++
+This method changes the original query to a <<query-dsl-bool-query, `bool`
+query>>. This `bool` query contains a `should` clause and
+<<query-dsl-term-query, `term` query>> for each matching term.
++
 The final `bool` query only includes `term` queries for the top `N` terms.
 +
 You can use this method to avoid exceeding the clause limit in the
@@ -62,7 +86,13 @@ You can use this method to avoid exceeding the clause limit in the
 setting.
 
 `top_terms_N`::
-Calculates a relevance score for each matching document. The final `bool` query
+Calculates a relevance score for each matching document.
++
+This method changes the original query to a <<query-dsl-bool-query, `bool`
+query>>. This `bool` query contains a `should` clause and
+<<query-dsl-term-query, `term` query>> for each matching term.
++
+The final `bool` query
 only includes `term` queries for the top `N` scoring terms.
 +
 You can use this method to avoid exceeding the clause limit in the
@@ -72,8 +102,8 @@ setting.
 [float]
 [[rewrite-param-perf-considerations]]
 === Performance considerations for the `rewrite` parameter
-In most uses, we recommend using the `constant_score`,
+For most uses, we recommend using the `constant_score`,
 `constant_score_boolean`, or `top_terms_boost_N` rewrite methods.
 
 Other methods calculate relevance scores. These score calculations are often
-expensive and do not improve the query results.
+expensive and do not improve query results.

--- a/docs/reference/query-dsl/multi-term-rewrite.asciidoc
+++ b/docs/reference/query-dsl/multi-term-rewrite.asciidoc
@@ -1,45 +1,79 @@
 [[query-dsl-multi-term-rewrite]]
-== Multi Term Query Rewrite
+== `rewrite` Parameter
 
-Multi term queries, like
-<<query-dsl-wildcard-query,wildcard>> and
-<<query-dsl-prefix-query,prefix>> are called
-multi term queries and end up going through a process of rewrite. This
-also happens on the
-<<query-dsl-query-string-query,query_string>>.
-All of those queries allow to control how they will get rewritten using
-the `rewrite` parameter:
+WARNING: This parameter is for expert users only. Changing the value of this
+parameter can impact search performance and relevance.
 
-* `constant_score` (default): A rewrite method that performs like
-`constant_score_boolean` when there are few matching terms and otherwise
-visits all matching terms in sequence and marks documents for that term.
-Matching documents are assigned a constant score equal to the query's
-boost.
-* `scoring_boolean`: A rewrite method that first translates each term
-into a should clause in a boolean query, and keeps the scores as
-computed by the query. Note that typically such scores are meaningless
-to the user, and require non-trivial CPU to compute, so it's almost
-always better to use `constant_score`. This rewrite method will hit
-too many clauses failure if it exceeds the boolean query limit (defaults
-to `1024`).
-* `constant_score_boolean`: Similar to `scoring_boolean` except scores
-are not computed. Instead, each matching document receives a constant
-score equal to the query's boost. This rewrite method will hit too many
-clauses failure if it exceeds the boolean query limit (defaults to
-`1024`).
-* `top_terms_N`: A rewrite method that first translates each term into
-should clause in boolean query, and keeps the scores as computed by the
-query. This rewrite method only uses the top scoring terms so it will
-not overflow boolean max clause count. The `N` controls the size of the
-top scoring terms to use.
-* `top_terms_boost_N`: A rewrite method that first translates each term
-into should clause in boolean query, but the scores are only computed as
-the boost. This rewrite method only uses the top scoring terms so it
-will not overflow the boolean max clause count. The `N` controls the
-size of the top scoring terms to use.
-* `top_terms_blended_freqs_N`: A rewrite method that first translates each
-term into should clause in boolean query, but all term queries compute scores
-as if they had the same frequency. In practice the frequency which is used
-is the maximum frequency of all matching terms. This rewrite method only uses
-the top scoring terms so it will not overflow boolean max clause count. The
-`N` controls the size of the top scoring terms to use.
+To improve performance, {es} rewrites the following queries:
+
+* <<query-dsl-prefix-query, `prefix`>>
+* <<query-dsl-query-string-query, `query_string`>>
+* <<query-dsl-wildcard-query, `wildcard`>>
+
+In their original form, these queries are expensive. {es} changes the
+original query to a less expensive <<query-dsl-bool-query, `bool` query>>. This
+`bool` query contains a `should` clause and <<query-dsl-term-query, `term`
+query>> for each matching term.
+
+The `rewrite` parameter determines:
+
+* How {es} calculates the relevance scores for each matching document
+* Which `term` queries are included in the final `bool` query
+
+[float]
+[[rewrite-param-valid-values]]
+=== Valid values
+
+`constant_score` (Default)::
+Automatically uses the `constant_score_boolean` or `scoring_boolean` method,
+based on the number of matching terms. For fewer matching terms, the
+`constant_score_boolean` method is used.
+
+`constant_score_boolean`::
+Assigns each document a relevance score equal to the `boost` parameter.
++
+This method can cause the final `bool` query to exceed the clause limit in the
+<<indices-query-bool-max-clause-count, `indices.query.bool.max_clause_count`>>
+setting. If the query exceeds this limit, {es} returns an error.
+
+`scoring_boolean`::
+Calculates a relevance score for each matching document.
++
+This method can cause the final `bool` query to exceed the clause limit in the
+<<indices-query-bool-max-clause-count, `indices.query.bool.max_clause_count`>>
+setting. If the query exceeds this limit, {es} returns an error.
+
+`top_terms_blended_freqs_N`::
+Calculates a relevance score for each matching document as if all terms had the
+same frequency. This frequency is the maximum frequency of all matching terms.
+The final `bool` query only includes `term` queries for the top `N` scoring
+terms.
++
+You can use this method to avoid exceeding the clause limit in the
+<<indices-query-bool-max-clause-count, `indices.query.bool.max_clause_count`>>
+setting.
+
+`top_terms_boost_N`::
+Assigns each matching document a relevance score equal to the `boost` parameter.
+The final `bool` query only includes `term` queries for the top `N` terms.
++
+You can use this method to avoid exceeding the clause limit in the
+<<indices-query-bool-max-clause-count, `indices.query.bool.max_clause_count`>>
+setting.
+
+`top_terms_N`::
+Calculates a relevance score for each matching document. The final `bool` query
+only includes `term` queries for the top `N` scoring terms.
++
+You can use this method to avoid exceeding the clause limit in the
+<<indices-query-bool-max-clause-count, `indices.query.bool.max_clause_count`>>
+setting.
+
+[float]
+[[rewrite-param-perf-considerations]]
+=== Performance considerations for the `rewrite` parameter
+In most uses, we recommend using the `constant_score`,
+`constant_score_boolean`, or `top_terms_boost_N` rewrite methods.
+
+Other methods calculate relevance scores. These score calculations are often
+expensive and do not improve the query results.


### PR DESCRIPTION
### Changes
- Retitles page and removes references to multi term query. If users understand which queries are rewritten, I'm not sure if an understanding of the 'multi term query' concept is needed.
- Adds a warning noting the parameter is for expert users.
- Adds details about how impacted queries are rewritten.
- Rewrites value definitions
- Adds section for performance considerations.

This is part of #40977, an effort to standardize documentation for query types.

Any and all feedback welcome!

## Before
<details>
 <summary>Before image</summary>
<img width="777" alt="rewrite-before" src="https://user-images.githubusercontent.com/40268737/57460527-46efb280-7243-11e9-947f-66909b8a0ff7.png">
</details>

## After
<details>
 <summary>After image</summary>
<img width="777" alt="rewrite-before" src="https://user-images.githubusercontent.com/40268737/57460752-b796cf00-7243-11e9-99ed-07b99e9caffd.png">
</details>

