### PR TITLE
[ML] verify that there are no duplicate leaf fields in aggs (#41895)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/action/PutDataFrameTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/action/PutDataFrameTransformAction.java
@@ -20,6 +20,8 @@ import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfi
 import java.io.IOException;
 import java.util.Objects;
 
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+
 public class PutDataFrameTransformAction extends Action<AcknowledgedResponse> {
 
     public static final PutDataFrameTransformAction INSTANCE = new PutDataFrameTransformAction();
@@ -53,7 +55,11 @@ public class PutDataFrameTransformAction extends Action<AcknowledgedResponse> {
 
         @Override
         public ActionRequestValidationException validate() {
-            return null;
+            ActionRequestValidationException validationException = null;
+            for(String failure : config.getPivotConfig().aggFieldValidation()) {
+                validationException = addValidationError(failure, validationException);
+            }
+            return validationException;
         }
 
         @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/PivotConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/transforms/pivot/PivotConfigTests.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.core.dataframe.transforms.pivot;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -13,6 +14,12 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.xpack.core.dataframe.transforms.AbstractSerializingDataFrameTestCase;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 
 public class PivotConfigTests extends AbstractSerializingDataFrameTestCase<PivotConfig> {
 
@@ -103,7 +110,7 @@ public class PivotConfigTests extends AbstractSerializingDataFrameTestCase<Pivot
         assertFalse(pivotConfig.isValid());
     }
 
-    public void testMissingGroupBy() throws IOException {
+    public void testMissingGroupBy() {
         String pivot = "{"
                 + " \"aggs\": {"
                 + "   \"avg\": {"
@@ -114,7 +121,7 @@ public class PivotConfigTests extends AbstractSerializingDataFrameTestCase<Pivot
         expectThrows(IllegalArgumentException.class, () -> createPivotConfigFromString(pivot, false));
     }
 
-    public void testDoubleAggs() throws IOException {
+    public void testDoubleAggs() {
         String pivot = "{"
                 + " \"group_by\": {"
                 + "   \"id\": {"
@@ -134,6 +141,68 @@ public class PivotConfigTests extends AbstractSerializingDataFrameTestCase<Pivot
                 + "}";
 
         expectThrows(IllegalArgumentException.class, () -> createPivotConfigFromString(pivot, false));
+    }
+
+    public void testValidAggNames() throws IOException {
+        String pivotAggs = "{"
+            + " \"group_by\": {"
+            + "   \"user.id.field\": {"
+            + "     \"terms\": {"
+            + "       \"field\": \"id\""
+            + "} } },"
+            + " \"aggs\": {"
+            + "   \"avg.field.value\": {"
+            + "     \"avg\": {"
+            + "       \"field\": \"points\""
+            + "} } } }";
+        PivotConfig pivotConfig = createPivotConfigFromString(pivotAggs, true);
+        assertTrue(pivotConfig.isValid());
+        List<String> fieldValidation = pivotConfig.aggFieldValidation();
+        assertTrue(fieldValidation.isEmpty());
+    }
+
+    public void testAggNameValidationsWithoutIssues() {
+        String prefix = randomAlphaOfLength(10) + "1";
+        String prefix2 = randomAlphaOfLength(10) + "2";
+        String nestedField1 = randomAlphaOfLength(10) + "3";
+        String nestedField2 = randomAlphaOfLength(10) + "4";
+
+        assertThat(PivotConfig.aggFieldValidation(Arrays.asList(prefix + nestedField1 + nestedField2,
+            prefix + nestedField1,
+            prefix,
+            prefix2)), is(empty()));
+
+        assertThat(PivotConfig.aggFieldValidation(
+            Arrays.asList(
+                dotJoin(prefix, nestedField1, nestedField2),
+                dotJoin(nestedField1, nestedField2),
+                nestedField2,
+                prefix2)), is(empty()));
+    }
+
+    public void testAggNameValidationsWithDuplicatesAndNestingIssues() {
+        String prefix = randomAlphaOfLength(10) + "1";
+        String prefix2 = randomAlphaOfLength(10) + "2";
+        String nestedField1 = randomAlphaOfLength(10) + "3";
+        String nestedField2 = randomAlphaOfLength(10) + "4";
+
+        List<String> failures = PivotConfig.aggFieldValidation(
+            Arrays.asList(
+                dotJoin(prefix, nestedField1, nestedField2),
+                dotJoin(prefix, nestedField2),
+                dotJoin(prefix, nestedField1),
+                dotJoin(prefix2, nestedField1),
+                dotJoin(prefix2, nestedField1),
+                prefix2));
+
+        assertThat(failures,
+            containsInAnyOrder("duplicate field [" + dotJoin(prefix2, nestedField1) + "] detected",
+                "field [" + prefix2 + "] cannot be both an object and a field",
+                "field [" + dotJoin(prefix, nestedField1) + "] cannot be both an object and a field"));
+    }
+
+    private static String dotJoin(String... fields) {
+        return Strings.arrayToDelimitedString(fields, ".");
     }
 
     private PivotConfig createPivotConfigFromString(String json, boolean lenient) throws IOException {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_crud.yml
@@ -302,3 +302,35 @@ setup:
               "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
             }
           }
+---
+"Test creation failures due to duplicate and conflicting field names":
+  - do:
+      catch: /duplicate field \[airline\] detected/
+      data_frame.put_data_frame_transform:
+        transform_id: "duplicate-field-transform"
+        body: >
+          {
+            "source": {
+              "index": "source-index"
+            },
+            "dest": { "index": "dest-index" },
+            "pivot": {
+              "group_by": { "airline": {"terms": {"field": "airline"}}},
+              "aggs": {"airline": {"avg": {"field": "responsetime"}}}
+            }
+          }
+  - do:
+      catch: /field \[airline\] cannot be both an object and a field/
+      data_frame.put_data_frame_transform:
+        transform_id: "duplicate-field-transform"
+        body: >
+          {
+            "source": {
+              "index": "source-index"
+            },
+            "dest": { "index": "dest-index" },
+            "pivot": {
+              "group_by": { "airline": {"terms": {"field": "airline"}}},
+              "aggs": {"airline.responsetime": {"avg": {"field": "responsetime"}}}
+            }
+          }


### PR DESCRIPTION
This PR adds two validations for the data frame pivot config:

 * That there are no duplicate fields in the `group_by` or the `aggs` definitions
 * That there are no fields that are declared as an both an object and not, e.g. both `foo.bar.baz` and `foo.bar`

The best case scenario before this PR is that we can automatically determine the mapped type and we prevent the transform from even being started. However, if we rely on the dynamic mapping, index mapping failures will spam the logs until the task eventually fails due to the indexing failures. 

Backport of #41895