### PR TITLE
Wait for active shard after close in mixed cluster

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/30_segments.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/30_segments.yml
@@ -1,9 +1,5 @@
 ---
 setup:
-  - skip:
-      version: "all"
-      reason: "AwaitsFix: https://github.com/elastic/elasticsearch/issues/40331"
-
   - do:
       indices.create:
           index: test
@@ -47,6 +43,7 @@ setup:
   - do:
       indices.close:
         index: test
+        wait_for_active_shards: all
 
   - do:
       indices.stats:


### PR DESCRIPTION
The segment stats can be null in a mixed cluster because we [do not wait](https://github.com/elastic/elasticsearch/blob/7.x/server/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequest.java#L43) for active shards after closing an index in 7.x. 

Closes #40331