### PR TITLE
[7.x] Remove toStepKeys from LifecycleAction (#41775)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/AllocateAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/AllocateAction.java
@@ -150,13 +150,6 @@ public class AllocateAction implements LifecycleAction {
     }
 
     @Override
-    public List<StepKey> toStepKeys(String phase) {
-        StepKey allocateKey = new StepKey(phase, NAME, NAME);
-        StepKey allocationRoutedKey = new StepKey(phase, NAME, AllocationRoutedStep.NAME);
-        return Arrays.asList(allocateKey, allocationRoutedKey);
-    }
-
-    @Override
     public int hashCode() {
         return Objects.hash(numberOfReplicas, include, exclude, require);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/DeleteAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/DeleteAction.java
@@ -12,7 +12,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -65,14 +64,6 @@ public class DeleteAction implements LifecycleAction {
         WaitForNoFollowersStep waitForNoFollowersStep = new WaitForNoFollowersStep(waitForNoFollowerStepKey, deleteStepKey, client);
         DeleteStep deleteStep = new DeleteStep(deleteStepKey, nextStepKey, client);
         return Arrays.asList(waitForNoFollowersStep, deleteStep);
-    }
-
-    @Override
-    public List<StepKey> toStepKeys(String phase) {
-        Step.StepKey waitForNoFollowerStepKey = new Step.StepKey(phase, NAME, WaitForNoFollowersStep.NAME);
-        Step.StepKey deleteStepKey = new Step.StepKey(phase, NAME, DeleteStep.NAME);
-
-        return Arrays.asList(waitForNoFollowerStepKey, deleteStepKey);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ForceMergeAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ForceMergeAction.java
@@ -99,14 +99,6 @@ public class ForceMergeAction implements LifecycleAction {
     }
 
     @Override
-    public List<StepKey> toStepKeys(String phase) {
-        StepKey readOnlyKey = new StepKey(phase, NAME, ReadOnlyAction.NAME);
-        StepKey forceMergeKey = new StepKey(phase, NAME, ForceMergeStep.NAME);
-        StepKey countKey = new StepKey(phase, NAME, SegmentCountStep.NAME);
-        return Arrays.asList(readOnlyKey, forceMergeKey, countKey);
-    }
-
-    @Override
     public int hashCode() {
         return Objects.hash(maxNumSegments);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/FreezeAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/FreezeAction.java
@@ -65,12 +65,6 @@ public class FreezeAction implements LifecycleAction {
     }
 
     @Override
-    public List<StepKey> toStepKeys(String phase) {
-        StepKey freezeStepKey = new StepKey(phase, NAME, FreezeStep.NAME);
-        return Arrays.asList(freezeStepKey);
-    }
-
-    @Override
     public int hashCode() {
         return 1;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecycleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecycleAction.java
@@ -9,7 +9,6 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.xcontent.ToXContentObject;
-import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
 
 import java.util.List;
 
@@ -29,15 +28,6 @@ public interface LifecycleAction extends ToXContentObject, NamedWriteable {
      * @return an ordered list of steps that represent the execution plan of the action
      */
     List<Step> toSteps(Client client, String phase, @Nullable Step.StepKey nextStepKey);
-
-    /**
-     * 
-     * @param phase
-     *            the name of the phase this action is being executed within
-     * @return the {@link StepKey}s for the steps which will be executed in this
-     *         action
-     */
-    List<StepKey> toStepKeys(String phase);
 
     /**
      * @return true if this action is considered safe. An action is not safe if

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ReadOnlyAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ReadOnlyAction.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -64,11 +63,6 @@ public class ReadOnlyAction implements LifecycleAction {
         Step.StepKey key = new Step.StepKey(phase, NAME, NAME);
         Settings readOnlySettings = Settings.builder().put(IndexMetaData.SETTING_BLOCKS_WRITE, true).build();
         return Collections.singletonList(new UpdateSettingsStep(key, nextStepKey, client, readOnlySettings));
-    }
-    
-    @Override
-    public List<StepKey> toStepKeys(String phase) {
-        return Collections.singletonList(new Step.StepKey(phase, NAME, NAME));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/RolloverAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/RolloverAction.java
@@ -152,15 +152,6 @@ public class RolloverAction implements LifecycleAction {
     }
 
     @Override
-    public List<StepKey> toStepKeys(String phase) {
-        StepKey rolloverReadyStepKey = new StepKey(phase, NAME, WaitForRolloverReadyStep.NAME);
-        StepKey rolloverStepKey = new StepKey(phase, NAME, RolloverStep.NAME);
-        StepKey updateDateStepKey = new StepKey(phase, NAME, UpdateRolloverLifecycleDateStep.NAME);
-        StepKey setIndexingCompleteStepKey = new StepKey(phase, NAME, INDEXING_COMPLETE_STEP_NAME);
-        return Arrays.asList(rolloverReadyStepKey, rolloverStepKey, updateDateStepKey, setIndexingCompleteStepKey);
-    }
-
-    @Override
     public int hashCode() {
         return Objects.hash(maxSize, maxAge, maxDocs);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/SetPriorityAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/SetPriorityAction.java
@@ -91,11 +91,6 @@ public class SetPriorityAction implements LifecycleAction {
     }
 
     @Override
-    public List<StepKey> toStepKeys(String phase) {
-        return Collections.singletonList(new StepKey(phase, NAME, NAME));
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ShrinkAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ShrinkAction.java
@@ -112,22 +112,6 @@ public class ShrinkAction implements LifecycleAction {
     }
 
     @Override
-    public List<StepKey> toStepKeys(String phase) {
-        StepKey conditionalSkipKey = new StepKey(phase, NAME, BranchingStep.NAME);
-        StepKey waitForNoFollowerStepKey = new StepKey(phase, NAME, WaitForNoFollowersStep.NAME);
-        StepKey readOnlyKey = new StepKey(phase, NAME, ReadOnlyAction.NAME);
-        StepKey setSingleNodeKey = new StepKey(phase, NAME, SetSingleNodeAllocateStep.NAME);
-        StepKey checkShrinkReadyKey = new StepKey(phase, NAME, CheckShrinkReadyStep.NAME);
-        StepKey shrinkKey = new StepKey(phase, NAME, ShrinkStep.NAME);
-        StepKey enoughShardsKey = new StepKey(phase, NAME, ShrunkShardsAllocatedStep.NAME);
-        StepKey copyMetadataKey = new StepKey(phase, NAME, CopyExecutionStateStep.NAME);
-        StepKey aliasKey = new StepKey(phase, NAME, ShrinkSetAliasStep.NAME);
-        StepKey isShrunkIndexKey = new StepKey(phase, NAME, ShrunkenIndexCheckStep.NAME);
-        return Arrays.asList(conditionalSkipKey, waitForNoFollowerStepKey, readOnlyKey, setSingleNodeKey, checkShrinkReadyKey, shrinkKey,
-            enoughShardsKey, copyMetadataKey, aliasKey, isShrunkIndexKey);
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/UnfollowAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/UnfollowAction.java
@@ -55,19 +55,6 @@ public final class UnfollowAction implements LifecycleAction {
     }
 
     @Override
-    public List<StepKey> toStepKeys(String phase) {
-        StepKey indexingCompleteStep = new StepKey(phase, NAME, WaitForIndexingCompleteStep.NAME);
-        StepKey waitForFollowShardTasksStep = new StepKey(phase, NAME, WaitForFollowShardTasksStep.NAME);
-        StepKey pauseFollowerIndexStep = new StepKey(phase, NAME, PauseFollowerIndexStep.NAME);
-        StepKey closeFollowerIndexStep = new StepKey(phase, NAME, CloseFollowerIndexStep.NAME);
-        StepKey unfollowIndexStep = new StepKey(phase, NAME, UnfollowFollowIndexStep.NAME);
-        StepKey openFollowerIndexStep = new StepKey(phase, NAME, OpenFollowerIndexStep.NAME);
-        StepKey waitForYellowStep = new StepKey(phase, NAME, WaitForYellowStep.NAME);
-        return Arrays.asList(indexingCompleteStep, waitForFollowShardTasksStep, pauseFollowerIndexStep,
-            closeFollowerIndexStep, unfollowIndexStep, openFollowerIndexStep, waitForYellowStep);
-    }
-
-    @Override
     public boolean isSafeAction() {
         // There are no settings to change, so therefor this action should be safe:
         return true;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/AbstractActionTestCase.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/AbstractActionTestCase.java
@@ -7,10 +7,6 @@
 package org.elasticsearch.xpack.core.indexlifecycle;
 
 import org.elasticsearch.test.AbstractSerializingTestCase;
-import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 public abstract class AbstractActionTestCase<T extends LifecycleAction> extends AbstractSerializingTestCase<T> {
 
@@ -25,16 +21,4 @@ public abstract class AbstractActionTestCase<T extends LifecycleAction> extends 
         assertEquals(isSafeAction(), action.isSafeAction());
     }
 
-    public void testToStepKeys() {
-        T action = createTestInstance();
-        String phase = randomAlphaOfLengthBetween(1, 10);
-        StepKey nextStepKey = new StepKey(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10),
-                randomAlphaOfLengthBetween(1, 10));
-        List<Step> steps = action.toSteps(null, phase, nextStepKey);
-        assertNotNull(steps);
-        List<StepKey> stepKeys = action.toStepKeys(phase);
-        assertNotNull(stepKeys);
-        List<StepKey> expectedStepKeys = steps.stream().map(Step::getKey).collect(Collectors.toList());
-        assertEquals(expectedStepKeys, stepKeys);
-    }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/MockAction.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/MockAction.java
@@ -11,7 +11,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -73,11 +72,6 @@ public class MockAction implements LifecycleAction {
     @Override
     public List<Step> toSteps(Client client, String phase, Step.StepKey nextStepKey) {
         return new ArrayList<>(steps);
-    }
-
-    @Override
-    public List<StepKey> toStepKeys(String phase) {
-        return steps.stream().map(Step::getKey).collect(Collectors.toList());
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Remove toStepKeys from LifecycleAction  (#41775)