### PR TITLE
Increase the sample space for random inner hits name generator

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/query/InnerHitBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/InnerHitBuilderTests.java
@@ -146,7 +146,7 @@ public class InnerHitBuilderTests extends ESTestCase {
     }
     public static InnerHitBuilder randomInnerHits() {
         InnerHitBuilder innerHits = new InnerHitBuilder();
-        innerHits.setName(randomAlphaOfLengthBetween(1, 16));
+        innerHits.setName(randomAlphaOfLengthBetween(5, 16));
         innerHits.setFrom(randomIntBetween(0, 32));
         innerHits.setSize(randomIntBetween(0, 32));
         innerHits.setExplain(randomBoolean());


### PR DESCRIPTION
This commits changes the minimum length for inner hits
name to avoid name collision which sometimes failed the
test.

```
10:16:33    > Throwable #1: java.lang.IllegalArgumentException: [inner_hits] already contains an entry for key [c]
10:16:33    > 	at __randomizedtesting.SeedInfo.seed([D46D4C4A38DAD36D:2FDCEEEB49548B4D]:0)
10:16:33    > 	at org.elasticsearch.index.query.NestedQueryBuilder.extractInnerHitBuilders(NestedQueryBuilder.java:337)
10:16:33    > 	at org.elasticsearch.index.query.InnerHitContextBuilder.extractInnerHits(InnerHitContextBuilder.java:68)
10:16:33    > 	at org.elasticsearch.index.query.BoostingQueryBuilder.extractInnerHitBuilders(BoostingQueryBuilder.java:234)
10:16:33    > 	at org.elasticsearch.index.query.NestedQueryBuilderTests.testInlineLeafInnerHitsNestedQueryViaBoostingQuery(NestedQueryBuilderTests.java:312)
```
