### PR TITLE
[Backport] Increase the sample space for random inner hits name generator (#42057)

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/query/InnerHitBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/InnerHitBuilderTests.java
@@ -146,7 +146,7 @@ public class InnerHitBuilderTests extends ESTestCase {
     }
     public static InnerHitBuilder randomInnerHits() {
         InnerHitBuilder innerHits = new InnerHitBuilder();
-        innerHits.setName(randomAlphaOfLengthBetween(1, 16));
+        innerHits.setName(randomAlphaOfLengthBetween(5, 16));
         innerHits.setFrom(randomIntBetween(0, 32));
         innerHits.setSize(randomIntBetween(0, 32));
         innerHits.setExplain(randomBoolean());


### PR DESCRIPTION
This commits changes the minimum length for inner hits
name to avoid name collision which sometimes failed the
test.
