### PR TITLE
Concurrent tests wait for threads to be ready

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/CountDownTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/CountDownTests.java
@@ -34,12 +34,13 @@ public class CountDownTests extends ESTestCase {
         final AtomicInteger count = new AtomicInteger(0);
         final CountDown countDown = new CountDown(scaledRandomIntBetween(10, 1000));
         Thread[] threads = new Thread[between(3, 10)];
-        final CountDownLatch latch = new CountDownLatch(1);
+        final CountDownLatch latch = new CountDownLatch(1 + threads.length);
         for (int i = 0; i < threads.length; i++) {
             threads[i] = new Thread() {
 
                 @Override
                 public void run() {
+                    latch.countDown();
                     try {
                         latch.await();
                     } catch (InterruptedException e) {

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/KeyedLockTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/KeyedLockTests.java
@@ -45,8 +45,8 @@ public class KeyedLockTests extends ESTestCase {
         for (int i = 0; i < names.length; i++) {
             names[i] = randomRealisticUnicodeOfLengthBetween(10, 20);
         }
-        CountDownLatch startLatch = new CountDownLatch(1);
         int numThreads = randomIntBetween(3, 10);
+        final CountDownLatch startLatch = new CountDownLatch(1 + numThreads);
         AcquireAndReleaseThread[] threads = new AcquireAndReleaseThread[numThreads];
         for (int i = 0; i < numThreads; i++) {
             threads[i] = new AcquireAndReleaseThread(startLatch, connectionLock, names, counter, safeCounter);
@@ -157,6 +157,7 @@ public class KeyedLockTests extends ESTestCase {
 
         @Override
         public void run() {
+            startLatch.countDown();
             try {
                 startLatch.await();
             } catch (InterruptedException e) {

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/RunOnceTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/RunOnceTests.java
@@ -45,9 +45,10 @@ public class RunOnceTests extends ESTestCase {
         final RunOnce runOnce = new RunOnce(counter::incrementAndGet);
 
         final Thread[] threads = new Thread[between(3, 10)];
-        final CountDownLatch latch = new CountDownLatch(1);
+        final CountDownLatch latch = new CountDownLatch(1 + threads.length);
         for (int i = 0; i < threads.length; i++) {
             threads[i] = new Thread(() -> {
+                latch.countDown();
                 try {
                     latch.await();
                 } catch (InterruptedException e) {

--- a/server/src/test/java/org/elasticsearch/node/ResponseCollectorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/node/ResponseCollectorServiceTests.java
@@ -77,9 +77,10 @@ public class ResponseCollectorServiceTests extends ESTestCase {
     public void testConcurrentAddingAndRemoving() throws Exception {
         String[] nodes = new String[] {"a", "b", "c", "d"};
 
-        final CountDownLatch latch = new CountDownLatch(1);
+        final CountDownLatch latch = new CountDownLatch(5);
 
         Runnable f = () -> {
+            latch.countDown();
             try {
                 latch.await();
             } catch (InterruptedException e) {


### PR DESCRIPTION
This change updates tests that use a CountDownLatch to synchronize the
running of threads when testing concurrent operations so that we ensure
the thread has been fully created and run by the scheduler. Previously,
these tests used a latch with a value of 1 and the test thread counted
down while the threads performing concurrent operations just waited.
This change updates the value of the latch to be 1 + the number of
threads. Each thread counts down and then waits. This means that each
thread has been constructed and has started running. All threads will
have a common start point now.