### PR TITLE
Cacheability improvements for thirdparty audit task

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/ThirdPartyAuditTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/ThirdPartyAuditTask.java
@@ -28,11 +28,13 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
-import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;
@@ -45,6 +47,8 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
@@ -113,12 +117,17 @@ public class ThirdPartyAuditTask extends DefaultTask {
         this.javaHome = javaHome;
     }
 
-    @OutputDirectory
+    @Internal
     public File getJarExpandDir() {
         return new File(
             new File(getProject().getBuildDir(), "precommit/thirdPartyAudit"),
             getName()
         );
+    }
+
+    @OutputFile
+    public File getSuccessMarker() {
+        return new File(getProject().getBuildDir(), "markers/" + getName());
     }
 
     public void ignoreMissingClasses(String... classesOrPackages) {
@@ -157,8 +166,7 @@ public class ThirdPartyAuditTask extends DefaultTask {
         return missingClassExcludes;
     }
 
-    @InputFiles
-    @PathSensitive(PathSensitivity.NAME_ONLY)
+    @Classpath
     @SkipWhenEmpty
     public Set<File> getJarsToScan() {
         // These are SelfResolvingDependency, and some of them backed by file collections, like  the Gradle API files,
@@ -241,6 +249,10 @@ public class ThirdPartyAuditTask extends DefaultTask {
         }
 
         assertNoJarHell(jdkJarHellClasses);
+
+        // Mark successful third party audit check
+        getSuccessMarker().getParentFile().mkdirs();
+        Files.write(getSuccessMarker().toPath(), new byte[]{}, StandardOpenOption.CREATE);
     }
 
     private void logForbiddenAPIsOutput(String forbiddenApisOutput) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/ThirdPartyAuditTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/ThirdPartyAuditTask.java
@@ -48,7 +48,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/ThirdPartyAuditTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/ThirdPartyAuditTask.java
@@ -252,7 +252,7 @@ public class ThirdPartyAuditTask extends DefaultTask {
 
         // Mark successful third party audit check
         getSuccessMarker().getParentFile().mkdirs();
-        Files.write(getSuccessMarker().toPath(), new byte[]{}, StandardOpenOption.CREATE);
+        Files.write(getSuccessMarker().toPath(), new byte[]{});
     }
 
     private void logForbiddenAPIsOutput(String forbiddenApisOutput) {


### PR DESCRIPTION
While doing some build cache experimentation I noticed that we had already made our `ThirdPartyAuditTask` cacheable. This PR makes some improvements here:

First, we no longer consider the expanded jars directory as an output. While it is technically "output" that the task creates, it's not the "result" of the task. This is just intermediary output that is created but the result of the task is effectively the error (or lack of error) thrown to the console if an issue is detected. The issue with tracking that expanded jar directory as an output is when we cache this task we pack all that up, essentially, the entire project runtime classpath. This can be quite large and negatively effects build cache performance. When we fetch this task from the cache we don't really need any of that so instead this has been refactored to use the "success marker" pattern of simply writing an empty file to the build directory to indicate this task was successful.

Second, we now use the runtime classpath normalization strategy for the `jarsToScan`. This ensures that things like jar entry order or creation timestamps don't affect the cache hash. When using `@InputFiles` we do a strict byte-to-byte comparison of the files, so for archives, this can cause cache misses when the upstream archive is rebuilt, but effectively identical.