### PR TITLE
Don’t verify evictions in testFilterCacheStats

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/stats/IndexStatsIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/stats/IndexStatsIT.java
@@ -62,7 +62,6 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 import org.elasticsearch.test.InternalSettingsPlugin;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -1008,8 +1007,6 @@ public class IndexStatsIT extends ESIntegTestCase {
         assertEquals(total, shardTotal);
     }
 
-    @TestLogging("_root:DEBUG")  // this fails at a very low rate on CI: https://github.com/elastic/elasticsearch/issues/32506
-    @AwaitsFix( bugUrl = "https://github.com/elastic/elasticsearch/issues/32506")
     public void testFilterCacheStats() throws Exception {
         Settings settings = Settings.builder().put(indexSettings()).put("number_of_replicas", 0).build();
         assertAcked(prepareCreate("index").setSettings(settings).get());
@@ -1034,7 +1031,6 @@ public class IndexStatsIT extends ESIntegTestCase {
             IndicesStatsResponse stats = client().admin().indices().prepareStats("index").setQueryCache(true).get();
             assertCumulativeQueryCacheStats(stats);
             assertThat(stats.getTotal().queryCache.getHitCount(), equalTo(0L));
-            assertThat(stats.getTotal().queryCache.getEvictions(), equalTo(0L));
             assertThat(stats.getTotal().queryCache.getMissCount(), greaterThan(0L));
             assertThat(stats.getTotal().queryCache.getCacheSize(), greaterThan(0L));
         });
@@ -1045,7 +1041,6 @@ public class IndexStatsIT extends ESIntegTestCase {
             IndicesStatsResponse stats = client().admin().indices().prepareStats("index").setQueryCache(true).get();
             assertCumulativeQueryCacheStats(stats);
             assertThat(stats.getTotal().queryCache.getHitCount(), greaterThan(0L));
-            assertThat(stats.getTotal().queryCache.getEvictions(), equalTo(0L));
             assertThat(stats.getTotal().queryCache.getMissCount(), greaterThan(0L));
             assertThat(stats.getTotal().queryCache.getCacheSize(), greaterThan(0L));
         });


### PR DESCRIPTION
If a background merge and refresh happens after a search (line 1032) but before a stats query (line 1034), then `evictions`  will be non-zero. I removed these assertions since they are quite brittle.

Closes #32506