### PR TITLE
Make packaging tests use jdk downloader

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -256,10 +256,6 @@ def linux_common(config,
     touch /is_vagrant_vm # for consistency between linux and windows
   SHELL
 
-  config.vm.provision 'jdk-11', type: 'shell', inline: <<-SHELL
-    curl -sSL https://download.oracle.com/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz | tar xz -C /opt/
-  SHELL
-
   # This prevents leftovers from previous tests using the
   # same VM from messing up the current test
   config.vm.provision 'clean es installs in tmp', run: 'always', type: 'shell', inline: <<-SHELL
@@ -355,11 +351,10 @@ def sh_install_deps(config,
       return 1
     }
     cat \<\<JAVA > /etc/profile.d/java_home.sh
-if [ -z "\\\$JAVA_HOME" ]; then
-  export JAVA_HOME=/opt/jdk-11.0.2
+if [ ! -z "\\\$JAVA_HOME" ]; then
+  export SYSTEM_JAVA_HOME=\\\$JAVA_HOME
+  unset JAVA_HOME
 fi
-export SYSTEM_JAVA_HOME=\\\$JAVA_HOME
-unset JAVA_HOME
 JAVA
     ensure tar
     ensure curl
@@ -416,16 +411,9 @@ def windows_common(config, name)
     $ps_prompt | Out-File $PsHome/Microsoft.PowerShell_profile.ps1
   SHELL
 
-  config.vm.provision 'windows-jdk-11', type: 'shell', inline: <<-SHELL
-    New-Item -ItemType Directory -Force -Path "C:/java"
-    Invoke-WebRequest "https://download.oracle.com/java/GA/jdk11/9/GPL/openjdk-11.0.2_windows-x64_bin.zip" -OutFile "C:/java/jdk-11.zip"
-    Expand-Archive -Path "C:/java/jdk-11.zip" -DestinationPath "C:/java/"
-  SHELL
-
   config.vm.provision 'set env variables', type: 'shell', inline: <<-SHELL
     $ErrorActionPreference = "Stop"
     [Environment]::SetEnvironmentVariable("PACKAGING_ARCHIVES", "C:/project/build/packaging/archives", "Machine")
-    [Environment]::SetEnvironmentVariable("SYSTEM_JAVA_HOME", "C:\java\jdk-11.0.2", "Machine")
     [Environment]::SetEnvironmentVariable("PACKAGING_TESTS", "C:/project/build/packaging/tests", "Machine")
     [Environment]::SetEnvironmentVariable("JAVA_HOME", $null, "Machine")
   SHELL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,7 +69,7 @@ Vagrant.configure(2) do |config|
       config.vm.box = 'elastic/debian-8-x86_64'
       deb_common config, box, extra: <<-SHELL
         # this sometimes gets a bad ip, and doesn't appear to be needed
-        rm /etc/apt/sources.list.d/http_debian_net_debian.list
+        rm -f /etc/apt/sources.list.d/http_debian_net_debian.list
       SHELL
     end
   end

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/BatsOverVagrantTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/BatsOverVagrantTask.groovy
@@ -27,15 +27,15 @@ import org.gradle.api.tasks.Input
 public class BatsOverVagrantTask extends VagrantCommandTask {
 
     @Input
-    String remoteCommand
+    Object remoteCommand
 
     BatsOverVagrantTask() {
         command = 'ssh'
     }
 
-    void setRemoteCommand(String remoteCommand) {
+    void setRemoteCommand(Object remoteCommand) {
         this.remoteCommand = Objects.requireNonNull(remoteCommand)
-        setArgs(['--command', remoteCommand])
+        setArgs((Iterable<?>) ['--command', remoteCommand])
     }
 
     @Override

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -578,7 +578,7 @@ class VagrantTestPlugin implements Plugin<Project> {
 
             if (LINUX_BOXES.contains(box)) {
                 Task batsPackagingTest = project.tasks.create("vagrant${boxTask}#batsPackagingTest", BatsOverVagrantTask) {
-                    remoteCommand BATS_TEST_COMMAND
+                    remoteCommand "export SYSTEM_JAVA_HOME=\"${-> convertPath(project, linuxSystemJdk.toString())}\"; " + BATS_TEST_COMMAND
                     boxName box
                     environmentVars vagrantEnvVars
                     dependsOn up, setupPackagingTest

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -1,11 +1,18 @@
 package org.elasticsearch.gradle.vagrant
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.elasticsearch.gradle.BwcVersions
 import org.elasticsearch.gradle.FileContentsTask
+import org.elasticsearch.gradle.Jdk
+import org.elasticsearch.gradle.JdkDownloadPlugin
 import org.elasticsearch.gradle.LoggedExec
 import org.elasticsearch.gradle.Version
-import org.elasticsearch.gradle.BwcVersions
-import org.gradle.api.*
+import org.gradle.api.GradleException
+import org.gradle.api.InvalidUserDataException
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.execution.TaskExecutionAdapter
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency
@@ -14,6 +21,8 @@ import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.tasks.TaskState
+
+import java.nio.file.Paths
 
 import static java.util.Collections.unmodifiableList
 
@@ -85,8 +94,33 @@ class VagrantTestPlugin implements Plugin<Project> {
     /** extra env vars to pass to vagrant for box configuration **/
     Map<String, String> vagrantBoxEnvVars = [:]
 
+    private static final String SYSTEM_JDK_VERSION = "11.0.2+9"
+    private static final String GRADLE_JDK_VERSION = "12.0.1+12@69cfe15208a647278a19ef0990eea691"
+    private Jdk linuxSystemJdk;
+    private Jdk linuxGradleJdk;
+    private Jdk windowsSystemJdk;
+    private Jdk windowsGradleJdk;
+
     @Override
     void apply(Project project) {
+        project.pluginManager.apply(JdkDownloadPlugin.class)
+        NamedDomainObjectContainer<Jdk> jdksContainer = (NamedDomainObjectContainer<Jdk>) project.getExtensions().getByName("jdks");
+        linuxSystemJdk = jdksContainer.create("linux_system") {
+            version = SYSTEM_JDK_VERSION
+            platform = "linux"
+        }
+        linuxGradleJdk = jdksContainer.create("linux_gradle") {
+            version = GRADLE_JDK_VERSION
+            platform = "linux"
+        }
+        windowsSystemJdk = jdksContainer.create("windows_system") {
+            version = SYSTEM_JDK_VERSION
+            platform = "windows"
+        }
+        windowsGradleJdk = jdksContainer.create("windows_gradle") {
+            version = GRADLE_JDK_VERSION
+            platform = "windows"
+        }
 
         collectAvailableBoxes(project)
 
@@ -264,7 +298,7 @@ class VagrantTestPlugin implements Plugin<Project> {
         }
     }
 
-    private static void createPrepareVagrantTestEnvTask(Project project) {
+    private void createPrepareVagrantTestEnvTask(Project project) {
         File packagingDir = new File(project.buildDir, PACKAGING_CONFIGURATION)
 
         File archivesDir = new File(packagingDir, 'archives')
@@ -280,7 +314,7 @@ class VagrantTestPlugin implements Plugin<Project> {
         }
 
         Task createLinuxRunnerScript = project.tasks.create('createLinuxRunnerScript', FileContentsTask) {
-            dependsOn copyPackagingTests
+            dependsOn copyPackagingTests, linuxGradleJdk, linuxSystemJdk
             file "${testsDir}/run-tests.sh"
             contents """\
                      if [ "\$#" -eq 0 ]; then
@@ -288,11 +322,15 @@ class VagrantTestPlugin implements Plugin<Project> {
                      else
                        test_args=( "\$@" )
                      fi
-                     "\$SYSTEM_JAVA_HOME"/bin/java -cp "\$PACKAGING_TESTS/*" org.elasticsearch.packaging.VMTestRunner "\${test_args[@]}"
+                     
+                     if [ -z "\$SYSTEM_JAVA_HOME" ]; then
+                       export SYSTEM_JAVA_HOME="${-> convertPath(project, linuxSystemJdk.toString()) }"
+                     fi
+                     "${-> convertPath(project, linuxGradleJdk.toString()) }"/bin/java -cp "\$PACKAGING_TESTS/*" org.elasticsearch.packaging.VMTestRunner "\${test_args[@]}"
                      """
         }
         Task createWindowsRunnerScript = project.tasks.create('createWindowsRunnerScript', FileContentsTask) {
-            dependsOn copyPackagingTests
+            dependsOn copyPackagingTests, windowsGradleJdk, windowsSystemJdk
             file "${testsDir}/run-tests.ps1"
             // the use of $args rather than param() here is deliberate because the syntax for array (multivalued) parameters is likely
             // a little trappy for those unfamiliar with powershell
@@ -302,7 +340,8 @@ class VagrantTestPlugin implements Plugin<Project> {
                      } else {
                        \$testArgs = \$args
                      }
-                     & "\$Env:SYSTEM_JAVA_HOME"/bin/java -cp "\$Env:PACKAGING_TESTS/*" org.elasticsearch.packaging.VMTestRunner @testArgs
+                     \$Env:SYSTEM_JAVA_HOME = "${-> convertPath(project, windowsSystemJdk.toString()) }"
+                     & "${-> convertPath(project, windowsGradleJdk.toString()) }"/bin/java -cp "\$Env:PACKAGING_TESTS/*" org.elasticsearch.packaging.VMTestRunner @testArgs
                      exit \$LASTEXITCODE
                      """
         }
@@ -616,5 +655,10 @@ class VagrantTestPlugin implements Plugin<Project> {
                 }
             }
         }
+    }
+
+    // convert the given path from an elasticsearch repo path to a VM path
+    private String convertPath(Project project, String path) {
+        return "/elasticsearch/" + project.rootDir.toPath().relativize(Paths.get(path));
     }
 }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -581,7 +581,7 @@ class VagrantTestPlugin implements Plugin<Project> {
                     remoteCommand "export SYSTEM_JAVA_HOME=\"${-> convertPath(project, linuxSystemJdk.toString())}\"; " + BATS_TEST_COMMAND
                     boxName box
                     environmentVars vagrantEnvVars
-                    dependsOn up, setupPackagingTest
+                    dependsOn up, setupPackagingTest, linuxSystemJdk
                     finalizedBy halt
                 }
 


### PR DESCRIPTION
This commit removes the jdk11 download in vagrant provisioning and
converts it to using the jdk downloader for the system jdk, and sets up
a separate jdk for use by the test (which will be converted to running
gradle in a followup).
