### PR TITLE
[DOCS] Fix indentation of ICU Analysis Plugin documentation  for Asciidoctor migration

### DIFF
--- a/docs/reference/analysis/icu-plugin.asciidoc
+++ b/docs/reference/analysis/icu-plugin.asciidoc
@@ -156,12 +156,13 @@ And here is a sample of custom collation:
 
 [horizontal]
 `strength`::
-    The strength property determines the minimum level of difference considered significant during comparison.
-     The default strength for the Collator is `tertiary`, unless specified otherwise by the locale used to create the Collator.
-     Possible values: `primary`, `secondary`, `tertiary`, `quaternary` or `identical`.
- +
- See http://icu-project.org/apiref/icu4j/com/ibm/icu/text/Collator.html[ICU Collation] documentation for a more detailed
- explanation for the specific values.
+The strength property determines the minimum level of difference considered significant during comparison.
++
+The default strength for the Collator is `tertiary`, unless specified otherwise by the locale used to create the Collator.
+Possible values: `primary`, `secondary`, `tertiary`, `quaternary` or `identical`.
++
+See http://icu-project.org/apiref/icu4j/com/ibm/icu/text/Collator.html[ICU Collation] documentation for a more detailed
+explanation for the specific values.
 
 `decomposition`::
     Possible values: `no` or `canonical`. Defaults to `no`. Setting this decomposition property with


### PR DESCRIPTION
Fixes indentation to properly render whitespace for Asciidoctor migration. Relates to elastic/docs#827.

Plan to backport to 0.90.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="786" alt="before" src="https://user-images.githubusercontent.com/40268737/57633702-e37ec100-7571-11e9-87de-b0df2957030c.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="763" alt="asciidoc-after" src="https://user-images.githubusercontent.com/40268737/57633721-eb3e6580-7571-11e9-9cff-97331953eba6.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="771" alt="Screen Shot 2019-05-13 at 11 28 49 AM" src="https://user-images.githubusercontent.com/40268737/57633923-5425dd80-7572-11e9-9aaa-5e737c972f6d.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="767" alt="asciidoctor-after" src="https://user-images.githubusercontent.com/40268737/57633730-f2657380-7571-11e9-8adc-64fc167dffaa.png">
</details>