### PR TITLE
[DOCS] Add conditional to render 'deprecated' macro for Asciidoctor migration

### DIFF
--- a/docs/reference/analysis/tokenfilters/stop-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/stop-tokenfilter.asciidoc
@@ -20,7 +20,12 @@ encoded.
 
 |`enable_position_increments` |Set to `true` if token positions should
 record the removed stop words, `false` otherwise. Defaults to `true`.
+ifdef::asciidoctor[]
+deprecated:[0.90.3,Removed in Lucene 4.4]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[0.90.3,Removed in Lucene 4.4]
+endif::[]
 
 |`ignore_case` |Set to `true` to lower case all words first. Defaults to
 `false`.


### PR DESCRIPTION
Adds an `ifdef` conditional to correctly render a `deprecated` macro for Asciidoctor. Relates to elastic/docs#827.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="758" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/57635216-bd0e5500-7574-11e9-8655-879972e9a4b2.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="754" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/57635254-c5669000-7574-11e9-83fa-3db0f5801412.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="758" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/57635276-d0212500-7574-11e9-8cd4-3fbe2e233542.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="751" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/57635300-da432380-7574-11e9-95ef-8b0f1d7a32b3.png">
</details>