### PR TITLE
Add shared access signature authentication support

### DIFF
--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureCredentials.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureCredentials.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.repositories.azure;
+
+public interface AzureCredentials {
+    String buildConnectionString(String endpointSuffix);
+}
+

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureKeyCredentials.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureKeyCredentials.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.repositories.azure;
+
+import org.elasticsearch.common.Strings;
+
+import java.util.Objects;
+
+public class AzureKeyCredentials implements AzureCredentials {
+    private final String account;
+    private final String key;
+
+    public AzureKeyCredentials(String account, String key) {
+        this.account = account;
+        this.key = key;
+    }
+
+    public String getAccount() {
+        return account;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String buildConnectionString(String endpointSuffix) {
+        final StringBuilder connectionStringBuilder = new StringBuilder();
+        connectionStringBuilder.append("DefaultEndpointsProtocol=https")
+            .append(";AccountName=")
+            .append(this.getAccount())
+            .append(";AccountKey=")
+            .append(this.getKey());
+        if (Strings.hasText(endpointSuffix)) {
+            connectionStringBuilder.append(";EndpointSuffix=").append(endpointSuffix);
+        }
+        return connectionStringBuilder.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AzureKeyCredentials that = (AzureKeyCredentials) o;
+        return Objects.equals(account, that.account) &&
+            Objects.equals(key, that.key);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(account, key);
+    }
+}

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepositoryPlugin.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepositoryPlugin.java
@@ -60,6 +60,7 @@ public class AzureRepositoryPlugin extends Plugin implements RepositoryPlugin, R
         return Arrays.asList(
             AzureStorageSettings.ACCOUNT_SETTING,
             AzureStorageSettings.KEY_SETTING,
+            AzureStorageSettings.SAS_TOKEN_SETTING,
             AzureStorageSettings.ENDPOINT_SUFFIX_SETTING,
             AzureStorageSettings.TIMEOUT_SETTING,
             AzureStorageSettings.MAX_RETRIES_SETTING,

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureSasCredentials.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureSasCredentials.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.repositories.azure;
+
+import org.elasticsearch.common.Strings;
+
+import java.util.Objects;
+
+public class AzureSasCredentials implements AzureCredentials {
+    private final String account;
+    private final String sasToken;
+
+    public AzureSasCredentials(String account, String sasToken) {
+        this.account = account;
+        this.sasToken = sasToken;
+    }
+
+    public String getSasToken() {
+        return sasToken;
+    }
+
+    public String getAccount() {
+        return account;
+    }
+
+    public String buildConnectionString(String endpointSuffix) {
+        final StringBuilder connectionStringBuilder = new StringBuilder();
+        connectionStringBuilder.append("DefaultEndpointsProtocol=https")
+            .append(";AccountName=")
+            .append(this.getAccount())
+            .append(";SharedAccessSignature=")
+            .append(this.getSasToken());
+        if (Strings.hasText(endpointSuffix)) {
+            connectionStringBuilder.append(";EndpointSuffix=").append(endpointSuffix);
+        }
+        return connectionStringBuilder.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) return false;
+        AzureSasCredentials that = (AzureSasCredentials) o;
+        return Objects.equals(sasToken, that.sasToken);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), sasToken);
+    }
+}

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageService.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageService.java
@@ -117,6 +117,7 @@ public class AzureStorageService {
 
     private static CloudBlobClient createClient(AzureStorageSettings azureStorageSettings) throws InvalidKeyException, URISyntaxException {
         final String connectionString = azureStorageSettings.buildConnectionString();
+
         return CloudStorageAccount.parse(connectionString).createCloudBlobClient();
     }
 

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceTests.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceTests.java
@@ -99,7 +99,10 @@ public class AzureStorageServiceTests extends ESTestCase {
             assertThat(client4.getEndpoint().toString(), equalTo("https://myaccount4.blob.core.windows.net"));
             assertThat(client4.getCredentials(), instanceOf(com.microsoft.azure.storage.StorageCredentialsSharedAccessSignature.class));
             StorageCredentialsSharedAccessSignature sas = (StorageCredentialsSharedAccessSignature) client4.getCredentials();
-            assertThat(sas.getToken(), equalTo(java.util.Base64.getEncoder().encodeToString(("sig=signature4&foo=b%r").getBytes(StandardCharsets.UTF_8))));
+            assertThat(
+                sas.getToken(),
+                equalTo(java.util.Base64.getEncoder().encodeToString(("sig=signature4&foo=b%r").getBytes(StandardCharsets.UTF_8)))
+            );
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

The current default authentication scheme for the azure repository plugin are the account name/key credentials of a storage account. This is basically "root" access for all the containers/blobs within a storage account and makes it hard to safely seperate multiple tenants within a storage account.

This change adds support for [shared access signatures](https://docs.microsoft.com/en-us/azure/storage/common/storage-dotnet-shared-access-signature-part-1), which allow to control access on container or blob level instead of only having service level authentication.

To achieve that I introduced a new config setting (`sas_token`) and had to move the connection String methods around a bit.
 
Since I last used Java about a decade ago I'm happy about any feedback regarding the code style, I tried my best ;)
