### PR TITLE
[DOCS] Add conditional to render 'added' macro for Asciidoctor migration

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -32,9 +32,15 @@ otherwise it is written in non-compound format.  added[0.90.2]
 
 [[index-compound-on-flush]]`index.compound_on_flush`::
 
-    Should a new segment (create by indexing, not by merging) be written
-    in compound format or non-compound format? Defaults to `true`.
-    added[0.90.4]. This is a dynamic setting. added[0.90.6,Previously not dynamic]
+Should a new segment (create by indexing, not by merging) be written
+in compound format or non-compound format? Defaults to `true`.
+ifdef::asciidoctor[]
+added:[0.90.4]. This is a dynamic setting. added:[0.90.6,Previously not dynamic]
+endif::[]
+ifndef::asciidoctor[]
+added[0.90.4]. This is a dynamic setting. added[0.90.6,Previously not dynamic]
+endif::[]
+
 
 `index.refresh_interval`::
 	A time setting controlling how often the


### PR DESCRIPTION
Adds an `ifdef` conditional to correctly render a `added` macro for Asciidoctor. Relates to elastic/docs#827.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="738" alt="AsciiDoc - before" src="https://user-images.githubusercontent.com/40268737/57638981-f054e200-757c-11e9-947b-75883a0b24dc.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="755" alt="AsciiDoc - after" src="https://user-images.githubusercontent.com/40268737/57638995-f77bf000-757c-11e9-9981-a78bc5485e70.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="739" alt="Asciidoctor - before" src="https://user-images.githubusercontent.com/40268737/57639024-0367b200-757d-11e9-9467-9e15c773c7b5.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="752" alt="Asciidoctor - after" src="https://user-images.githubusercontent.com/40268737/57639042-0b275680-757d-11e9-9879-c90105c20331.png">
</details>