### PR TITLE
[DOCS] Fix broken link for Asciidoctor migration

### DIFF
--- a/docs/reference/mapping/types/core-types.asciidoc
+++ b/docs/reference/mapping/types/core-types.asciidoc
@@ -476,7 +476,7 @@ formats:
         A postings format that uses disk-based storage but loads
         its terms and postings directly into memory. Note this postings format
         is very memory intensive and has certain limitation that don't allow
-        segments to grow beyond 2.1GB see \{@link DirectPostingsFormat} for
+        segments to grow beyond 2.1GB. See <<direct-postings, Direct postings format>> for
         details. 
 
 `memory`:: 


### PR DESCRIPTION
Fixes a broken link for Asciidoctor migration. As it turns out, this link was already broken in the original AsciiDoc documentation.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="753" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/57640170-b802d300-757f-11e9-81b3-cf448c298837.png">
</details>

## AsciiDoc After
<details>
<img width="760" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/57640182-bdf8b400-757f-11e9-8fea-0fdd02d5be25.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="760" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/57640201-c51fc200-757f-11e9-92c1-af898709fac3.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="755" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/57640210-cb15a300-757f-11e9-8f64-b41702d7d405.png">
</details>