### PR TITLE
[DOCS] Escape smart quotes for Asciidoctor migration

### DIFF
--- a/docs/reference/mapping/date-format.asciidoc
+++ b/docs/reference/mapping/date-format.asciidoc
@@ -56,21 +56,21 @@ The following tables lists all the defaults ISO formats supported:
 digit month of year, and two digit day of month (yyyyMMdd).
 
 |`basic_date_time`|A basic formatter that combines a basic date and time,
-separated by a 'T' (yyyyMMdd'T'HHmmss.SSSZ).
+separated by a +++'T'+++ (yyyyMMdd+++'T'+++HHmmss.SSSZ).
 
 |`basic_date_time_no_millis`|A basic formatter that combines a basic date
-and time without millis, separated by a 'T' (yyyyMMdd'T'HHmmssZ).
+and time without millis, separated by a +++'T'+++ (yyyyMMdd+++'T'+++HHmmssZ).
 
 |`basic_ordinal_date`|A formatter for a full ordinal date, using a four
 digit year and three digit dayOfYear (yyyyDDD).
 
 |`basic_ordinal_date_time`|A formatter for a full ordinal date and time,
 using a four digit year and three digit dayOfYear
-(yyyyDDD'T'HHmmss.SSSZ).
+(yyyyDDD+++'T'+++HHmmss.SSSZ).
 
 |`basic_ordinal_date_time_no_millis`|A formatter for a full ordinal date
 and time without millis, using a four digit year and three digit
-dayOfYear (yyyyDDD'T'HHmmssZ).
+dayOfYear (yyyyDDD+++'T'+++HHmmssZ).
 
 |`basic_time`|A basic formatter for a two digit hour of day, two digit
 minute of hour, two digit second of minute, three digit millis, and time
@@ -82,22 +82,22 @@ offset (HHmmssZ).
 
 |`basic_t_time`|A basic formatter for a two digit hour of day, two digit
 minute of hour, two digit second of minute, three digit millis, and time
-zone off set prefixed by 'T' ('T'HHmmss.SSSZ).
+zone off set prefixed by +++'T'+++ (+++'T'+++HHmmss.SSSZ).
 
 |`basic_t_time_no_millis`|A basic formatter for a two digit hour of day,
 two digit minute of hour, two digit second of minute, and time zone
-offset prefixed by 'T' ('T'HHmmssZ).
+offset prefixed by +++'T'+++ (+++'T'+++HHmmssZ).
 
 |`basic_week_date`|A basic formatter for a full date as four digit
 weekyear, two digit week of weekyear, and one digit day of week
-(xxxx'W'wwe).
+(xxxx+++'W'+++wwe).
 
 |`basic_week_date_time`|A basic formatter that combines a basic weekyear
-date and time, separated by a 'T' (xxxx'W'wwe'T'HHmmss.SSSZ).
+date and time, separated by a +++'T'+++ (xxxx+++'W'+++wwe+++'T'+++HHmmss.SSSZ).
 
 |`basic_week_date_time_no_millis`|A basic formatter that combines a basic
-weekyear date and time without millis, separated by a 'T'
-(xxxx'W'wwe'T'HHmmssZ).
+weekyear date and time without millis, separated by a +++'T'+++
+(xxxx+++'W'+++wwe+++'T'+++HHmmssZ).
 
 |`date`|A formatter for a full date as four digit year, two digit month
 of year, and two digit day of month (yyyy-MM-dd).
@@ -115,20 +115,20 @@ minute.
 |`date_hour_minute_second_fraction`|A formatter that combines a full
 date, two digit hour of day, two digit minute of hour, two digit second
 of minute, and three digit fraction of second
-(yyyy-MM-dd'T'HH:mm:ss.SSS).
+(yyyy-MM-dd+++'T'+++HH:mm:ss.SSS).
 
 |`date_hour_minute_second_millis`|A formatter that combines a full date,
 two digit hour of day, two digit minute of hour, two digit second of
-minute, and three digit fraction of second (yyyy-MM-dd'T'HH:mm:ss.SSS).
+minute, and three digit fraction of second (yyyy-MM-dd+++'T'+++HH:mm:ss.SSS).
 
 |`date_optional_time`|a generic ISO datetime parser where the date is
 mandatory and the time is optional.
 
 |`date_time`|A formatter that combines a full date and time, separated by
-a 'T' (yyyy-MM-dd'T'HH:mm:ss.SSSZZ).
+a +++'T'+++ (yyyy-MM-dd+++'T'+++HH:mm:ss.SSSZZ).
 
 |`date_time_no_millis`|A formatter that combines a full date and time
-without millis, separated by a 'T' (yyyy-MM-dd'T'HH:mm:ssZZ).
+without millis, separated by a +++'T'+++ (yyyy-MM-dd+++'T'+++HH:mm:ssZZ).
 
 |`hour`|A formatter for a two digit hour of day.
 
@@ -150,11 +150,11 @@ fraction of second (HH:mm:ss.SSS).
 year and three digit dayOfYear (yyyy-DDD).
 
 |`ordinal_date_time`|A formatter for a full ordinal date and time, using
-a four digit year and three digit dayOfYear (yyyy-DDD'T'HH:mm:ss.SSSZZ).
+a four digit year and three digit dayOfYear (yyyy-DDD+++'T'+++HH:mm:ss.SSSZZ).
 
 |`ordinal_date_time_no_millis`|A formatter for a full ordinal date and
 time without millis, using a four digit year and three digit dayOfYear
-(yyyy-DDD'T'HH:mm:ssZZ).
+(yyyy-DDD+++'T'+++HH:mm:ssZZ).
 
 |`time`|A formatter for a two digit hour of day, two digit minute of
 hour, two digit second of minute, three digit fraction of second, and
@@ -166,20 +166,20 @@ minute of hour, two digit second of minute, and time zone offset
 
 |`t_time`|A formatter for a two digit hour of day, two digit minute of
 hour, two digit second of minute, three digit fraction of second, and
-time zone offset prefixed by 'T' ('T'HH:mm:ss.SSSZZ).
+time zone offset prefixed by +++'T'+++ (+++'T'+++HH:mm:ss.SSSZZ).
 
 |`t_time_no_millis`|A formatter for a two digit hour of day, two digit
 minute of hour, two digit second of minute, and time zone offset
-prefixed by 'T' ('T'HH:mm:ssZZ).
+prefixed by +++'T'+++ (+++'T'+++HH:mm:ssZZ).
 
 |`week_date`|A formatter for a full date as four digit weekyear, two
-digit week of weekyear, and one digit day of week (xxxx-'W'ww-e).
+digit week of weekyear, and one digit day of week (xxxx-+++'W'+++ww-e).
 
 |`week_date_time`|A formatter that combines a full weekyear date and
-time, separated by a 'T' (xxxx-'W'ww-e'T'HH:mm:ss.SSSZZ).
+time, separated by a +++'T'+++ (xxxx-+++'W'+++ww-e+++'T'+++HH:mm:ss.SSSZZ).
 
 |`weekDateTimeNoMillis`|A formatter that combines a full weekyear date
-and time without millis, separated by a 'T' (xxxx-'W'ww-e'T'HH:mm:ssZZ).
+and time without millis, separated by a +++'T'+++ (xxxx-+++'W'+++ww-e+++'T'+++HH:mm:ssZZ).
 
 |`week_year`|A formatter for a four digit weekyear.
 


### PR DESCRIPTION
Both AsciiDoc and Asciidoctor convert quotes (') into smart quotes (’). This escapes those quotes for the Asciidoctor migration. Relates to elastic/docs#827

Plan to backport to 0.90. 

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="760" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/57641912-29dd1b80-7584-11e9-8d9d-d8ea0b618ac3.png">
</details>

## AsciiDoc After
<details>
<img width="760" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/57642583-a91f1f00-7585-11e9-82d2-75b437d503eb.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="760" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/57641998-57c26000-7584-11e9-93c2-8bcbe27d22c8.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="760" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/57642664-ea173380-7585-11e9-9755-97626e9b4156.png">
</details>