### PR TITLE
[DOCS] Escape inline code samples in 'deprecated' macros for Asciidoctor

### DIFF
--- a/docs/reference/query-dsl/filters/numeric-range-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/numeric-range-filter.asciidoc
@@ -1,7 +1,7 @@
 [[query-dsl-numeric-range-filter]]
 === Numeric Range Filter
 
-deprecated[0.90.8,Use the <<query-dsl-range-filter,range filter>> with the `fielddata` execution mode instead]
+deprecated[0.90.8,"Use the <<query-dsl-range-filter,range filter>> with the `fielddata` execution mode instead"]
 
 Filters documents with fields that have values within a certain numeric
 range. Similar to
@@ -41,7 +41,7 @@ The `numeric_range` filter accepts the following parameters:
 `lte`::     Less-than or equal to
 `lt`::      Less-than
 
-deprecated[0.90.4,The `from`, `to`, `include_lower` and `include_upper` parameters have been deprecated in favour of `gt`,`gte`,`lt`,`lte`]
+deprecated[0.90.4,"The `from`, `to`, `include_lower` and `include_upper` parameters have been deprecated in favour of `gt`,`gte`,`lt`,`lte`"]
 
 [float]
 ==== Caching

--- a/docs/reference/query-dsl/filters/range-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/range-filter.asciidoc
@@ -30,7 +30,7 @@ The `range` filter accepts the following parameters:
 `lte`::     Less-than or equal to
 `lt`::      Less-than
 
-deprecated[0.90.4,The `from`, `to`, `include_lower` and `include_upper` parameters have been deprecated in favour of `gt`,`gte`,`lt`,`lte`]
+deprecated[0.90.4,"The `from`, `to`, `include_lower` and `include_upper` parameters have been deprecated in favour of `gt`,`gte`,`lt`,`lte`"]
 
 [float]
 ==== Execution

--- a/docs/reference/query-dsl/queries/range-query.asciidoc
+++ b/docs/reference/query-dsl/queries/range-query.asciidoc
@@ -29,4 +29,4 @@ The `range` query accepts the following parameters:
 `lt`::  	Less-than
 `boost`:: 	Sets the boost value of the query, defaults to `1.0`
 
-deprecated[0.90.4,The `from`, `to`, `include_lower` and `include_upper` parameters have been deprecated in favour of `gt`,`gte`,`lt`,`lte`]
+deprecated[0.90.4,"The `from`, `to`, `include_lower` and `include_upper` parameters have been deprecated in favour of `gt`,`gte`,`lt`,`lte`"]


### PR DESCRIPTION
Asciidoctor does not correctly render inline code samples or cross-ref links in `deprecated` macros.

Relates to elastic/docs#827

Plan to backport to 0.90. 

## AsciiDoc Before
<details>
 <summary>Before images</summary>
<img width="758" alt="AsciiDoc - Before A" src="https://user-images.githubusercontent.com/40268737/57645199-c48d2880-758b-11e9-900d-5a7fd5f705aa.png">
<img width="755" alt="AsciiDoc - Before B" src="https://user-images.githubusercontent.com/40268737/57645205-c820af80-758b-11e9-9e26-bf6bf33b9fff.png">
</details>

## AsciiDoc After
<details>
 <summary>After images</summary>
<img width="768" alt="AsciiDoc - After A" src="https://user-images.githubusercontent.com/40268737/57645236-d66ecb80-758b-11e9-94d3-723acd5f467d.png">
<img width="755" alt="AsciiDoc - After B" src="https://user-images.githubusercontent.com/40268737/57645240-d969bc00-758b-11e9-8c4a-63cf59b88dfe.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before images</summary>
<img width="755" alt="Asciidoctor - Before A" src="https://user-images.githubusercontent.com/40268737/57645261-e2f32400-758b-11e9-9978-93f7144a26bf.png">
<img width="754" alt="Asciidoctor - Before B" src="https://user-images.githubusercontent.com/40268737/57645267-e5557e00-758b-11e9-8053-d28d7a436b62.png">
</details>

## Asciidoctor After
<details>
 <summary>After images</summary>
<img width="764" alt="Asciidoctor - After A" src="https://user-images.githubusercontent.com/40268737/57645289-f1414000-758b-11e9-888a-79b40d055646.png">
<img width="764" alt="Asciidoctor - After B" src="https://user-images.githubusercontent.com/40268737/57645294-f56d5d80-758b-11e9-9a1a-0e3bcb3c6604.png">
</details>