### PR TITLE
Added a new use case for transport.port

### DIFF
--- a/docs/reference/modules/transport.asciidoc
+++ b/docs/reference/modules/transport.asciidoc
@@ -7,7 +7,6 @@ the transport module (for example, when an HTTP GET request is processed
 by one node, and should actually be processed by another node that holds
 the data). The transport module is also used for the `TransportClient` in the
 {es} Java API.
-the Cloudian Sync for Object Storage Integration into Elasticsearch)
 
 The transport mechanism is completely asynchronous in nature, meaning
 that there is no blocking thread waiting for a response. The benefit of

--- a/docs/reference/modules/transport.asciidoc
+++ b/docs/reference/modules/transport.asciidoc
@@ -5,7 +5,8 @@ The transport module is used for internal communication between nodes
 within the cluster. Each call that goes from one node to the other uses
 the transport module (for example, when an HTTP GET request is processed
 by one node, and should actually be processed by another node that holds
-the data). The transport module is also used for other Java Clients. (i.e.
+the data). The transport module is also used for the `TransportClient` in the
+{es} Java API.
 the Cloudian Sync for Object Storage Integration into Elasticsearch)
 
 The transport mechanism is completely asynchronous in nature, meaning

--- a/docs/reference/modules/transport.asciidoc
+++ b/docs/reference/modules/transport.asciidoc
@@ -5,7 +5,8 @@ The transport module is used for internal communication between nodes
 within the cluster. Each call that goes from one node to the other uses
 the transport module (for example, when an HTTP GET request is processed
 by one node, and should actually be processed by another node that holds
-the data).
+the data). The transport module is also used for other Java Clients. (i.e.
+the Cloudian Sync for Object Storage Integration into Elasticsearch)
 
 The transport mechanism is completely asynchronous in nature, meaning
 that there is no blocking thread waiting for a response. The benefit of


### PR DESCRIPTION
I've had the problem that I was allowing only the http.port setting and I couldn't get a connection..

After I tried using the transport port I had a successful connection and the sync work perfectly. 

On Wednesday I can show the issue that I tried it on the other port..

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
