### PR TITLE
Fix test for JDBC version check

### DIFF
--- a/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/VersionParityTests.java
+++ b/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/VersionParityTests.java
@@ -25,7 +25,8 @@ import java.sql.SQLException;
 public class VersionParityTests extends WebServerTestCase {
 
     public void testExceptionThrownOnIncompatibleVersions() throws IOException, SQLException {
-        Version version = VersionUtils.randomPreviousCompatibleVersion(random(), Version.CURRENT);
+        Version version = VersionUtils.randomVersionBetween(random(), null, VersionUtils.getPreviousVersion());
+        logger.info("Checking exception is thrown for version {}", version);
         prepareRequest(version);
         
         String url = JdbcConfiguration.URL_PREFIX + webServer().getHostName() + ":" + webServer().getPort();


### PR DESCRIPTION
The testExceptionThrownOnIncompatibleVersions test simply requires
that the randomly selected version is not equal to the current version.

The previous implementation of this test would sometimes randomly
select CURRENT.
