### PR TITLE
Deprecate the native realm migration tool

### DIFF
--- a/docs/reference/commands/migrate-tool.asciidoc
+++ b/docs/reference/commands/migrate-tool.asciidoc
@@ -3,6 +3,8 @@
 [[migrate-tool]]
 == elasticsearch-migrate
 
+deprecated:[7.2.0, "This tool is deprecated. Use the native realm directly."]
+
 The `elasticsearch-migrate` command migrates existing file-based users and roles
 to the native realm. From 5.0 onward, you should use the `native` realm to
 manage roles and local users.

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/ESNativeRealmMigrateTool.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/ESNativeRealmMigrateTool.java
@@ -133,6 +133,7 @@ public class ESNativeRealmMigrateTool extends LoggingAwareMultiCommand {
         // Visible for testing
         @Override
         public void execute(Terminal terminal, OptionSet options, Environment env) throws Exception {
+            terminal.println("Warning: The migrate tool is deprecated. Use the native realm directly instead of file realms.");
             terminal.println("starting migration of users and roles...");
             importUsers(terminal, env, options);
             importRoles(terminal, env, options);


### PR DESCRIPTION
The migrate tool was added when the native realm was created, to aid
users in converting from file realms that were per node, into the
cluster managed native realm. While this tool was useful at the time,
users should now be using the native realm directly. This commit
deprecates the tool, to be removed in a followup for 8.0.