### PR TITLE
[DOCS] Add conditional to render 'added' macro for Asciidoctor migration

### DIFF
--- a/docs/reference/analysis/analyzers/pattern-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/pattern-analyzer.asciidoc
@@ -14,8 +14,14 @@ type:
 |`pattern` |The regular expression pattern, defaults to `\W+`.
 |`flags` |The regular expression flags.
 |`stopwords` |A list of stopwords to initialize the stop filter with.
-Defaults to an 'empty' stopword list added[1.0.0.RC1, Previously 
-defaulted to the English stopwords list]. Check
+Defaults to an 'empty' stopword list.
+ifdef::asciidoctor[]
+added:[1.0.0.RC1, Previously defaulted to the English stopwords list].
+endif::[]
+ifndef::asciidoctor[]
+added[1.0.0.RC1, Previously defaulted to the English stopwords list].
+endif::[]
+Check
 <<analysis-stop-analyzer,Stop Analyzer>> for more details.
 |===================================================================
 

--- a/docs/reference/analysis/analyzers/standard-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/standard-analyzer.asciidoc
@@ -18,8 +18,14 @@ type:
 |=======================================================================
 |Setting |Description
 |`stopwords` |A list of stopwords to initialize the stop filter with.
-Defaults to an 'empty' stopword list added[1.0.0.Beta1, Previously 
-defaulted to the English stopwords list]. Check
+Defaults to an 'empty' stopword list added.
+ifdef::asciidoctor[]
+added:[1.0.0.RC1, Previously defaulted to the English stopwords list].
+endif::[]
+ifndef::asciidoctor[]
+added[1.0.0.RC1, Previously defaulted to the English stopwords list].
+endif::[]
+Check
 <<analysis-stop-analyzer,Stop Analyzer>> for more details.
 |`max_token_length` |The maximum token length. If a token is seen that
 exceeds this length then it is discarded. Defaults to `255`.


### PR DESCRIPTION
Adds an `ifdef` conditional to correctly render an `added` macro for Asciidoctor. Relates to elastic/docs#827.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="740" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/57717506-6aeb3380-7649-11e9-8f94-1564a8c7cbb2.png">

</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="748" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/57717517-7179ab00-7649-11e9-8b0f-7669f0e20b68.png">

</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="744" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/57717530-78a0b900-7649-11e9-8910-c27bb723e5e3.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="750" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/57717548-7e969a00-7649-11e9-80b9-274f8d73c733.png">
</details>