### PR TITLE
Use 'in' keyword rather than a colon

### DIFF
--- a/docs/painless/painless-lang-spec/painless-statements.asciidoc
+++ b/docs/painless/painless-lang-spec/painless-statements.asciidoc
@@ -8,7 +8,7 @@ Painless also supports the `for in` syntax from Groovy:
 
 [source,painless]
 ---------------------------------------------------------
-for (item : list) {
+for (def item : list) {
   ...
 }
 ---------------------------------------------------------


### PR DESCRIPTION
The latter introduced a compilation error when I used it in my code.