### PR TITLE
Cleanup AllocateDangledResponse

### DIFF
--- a/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
+++ b/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
@@ -89,9 +89,7 @@ public class LocalAllocateDangledIndices {
         transportService.sendRequest(masterNode, ACTION_NAME, request, new TransportResponseHandler<AllocateDangledResponse>() {
             @Override
             public AllocateDangledResponse read(StreamInput in) throws IOException {
-                final AllocateDangledResponse response = new AllocateDangledResponse();
-                response.readFrom(in);
-                return response;
+                return new AllocateDangledResponse(in);
             }
 
             @Override
@@ -198,7 +196,7 @@ public class LocalAllocateDangledIndices {
                 @Override
                 public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
                     try {
-                        channel.sendResponse(new AllocateDangledResponse(true));
+                        channel.sendResponse(new AllocateDangledResponse());
                     } catch (IOException e) {
                         logger.warn("failed send response for allocating dangled", e);
                     }
@@ -243,25 +241,21 @@ public class LocalAllocateDangledIndices {
 
     public static class AllocateDangledResponse extends TransportResponse {
 
-        private boolean ack;
-
-        AllocateDangledResponse() {
+        private AllocateDangledResponse(StreamInput in) throws IOException {
+            if (in.getVersion().before(Version.V_8_0_0)) {
+                in.readBoolean();
+            }
         }
 
-        AllocateDangledResponse(boolean ack) {
-            this.ack = ack;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            ack = in.readBoolean();
+        private AllocateDangledResponse() {
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeBoolean(ack);
+            if (out.getVersion().before(Version.V_8_0_0)) {
+                out.writeBoolean(true);
+            }
         }
     }
 }


### PR DESCRIPTION
* Field `ack` is unused so it was removed along with the constructor argument
* Added BwC logic to the serialization for now, once that has become unnecessary we can just use `org.elasticsearch.transport.TransportResponse.Empty` here
