### PR TITLE
[DOCS] Add conditional to render 'added' macro for Asciidoctor migration

### DIFF
--- a/docs/reference/analysis/tokenfilters/stemmer-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/stemmer-tokenfilter.asciidoc
@@ -75,11 +75,29 @@ http://snowball.tartarus.org/algorithms/kraaij_pohlmann/stemmer.html[`dutch_kp`]
 
 English::
 
-http://snowball.tartarus.org/algorithms/porter/stemmer.html[*`english`*] added[1.3.0,Returns the <<analysis-porterstem-tokenfilter,`porter_stem`>> instead of the <<analysis-snowball-tokenfilter,`english` Snowball token filter>>],
-http://ciir.cs.umass.edu/pubfiles/ir-35.pdf[`light_english`] added[1.3.0,Returns the <<analysis-kstem-tokenfilter,`kstem` token filter>>],
+http://snowball.tartarus.org/algorithms/porter/stemmer.html[*`english`*] 
+ifdef::asciidoctor[]
+added:[1.3.0,Returns the <<analysis-porterstem-tokenfilter,`porter_stem`>> instead of the <<analysis-snowball-tokenfilter,`english` Snowball token filter>>],
+endif::[]
+ifndef::asciidoctor[]
+added[1.3.0,Returns the <<analysis-porterstem-tokenfilter,`porter_stem`>> instead of the <<analysis-snowball-tokenfilter,`english` Snowball token filter>>],
+endif::[]
+http://ciir.cs.umass.edu/pubfiles/ir-35.pdf[`light_english`]
+ifdef::asciidoctor[]
+added:[1.3.0,Returns the <<analysis-kstem-tokenfilter,`kstem` token filter>>],
+endif::[]
+ifndef::asciidoctor[]
+added[1.3.0,Returns the <<analysis-kstem-tokenfilter,`kstem` token filter>>],
+endif::[]
 http://www.researchgate.net/publication/220433848_How_effective_is_suffixing[`minimal_english`],
 http://lucene.apache.org/core/4_9_0/analyzers-common/org/apache/lucene/analysis/en/EnglishPossessiveFilter.html[`possessive_english`],
-http://snowball.tartarus.org/algorithms/english/stemmer.html[`porter2`] added[1.3.0,Returns the <<analysis-snowball-tokenfilter,`english` Snowball token filter>> instead of the <<analysis-snowball-tokenfilter,`porter` Snowball token filter>>],
+http://snowball.tartarus.org/algorithms/english/stemmer.html[`porter2`] 
+ifdef::asciidoctor[]
+added:[1.3.0,Returns the <<analysis-snowball-tokenfilter,`english` Snowball token filter>> instead of the <<analysis-snowball-tokenfilter,`porter` Snowball token filter>>],
+endif::[]
+ifndef::asciidoctor[]
+added[1.3.0,Returns the <<analysis-snowball-tokenfilter,`english` Snowball token filter>> instead of the <<analysis-snowball-tokenfilter,`porter` Snowball token filter>>],
+endif::[]
 http://snowball.tartarus.org/algorithms/lovins/stemmer.html[`lovins`]
 
 Finnish::


### PR DESCRIPTION
Adds an `ifdef` conditional to correctly render an `added` macro for Asciidoctor. Relates to elastic/docs#827.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="766" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/57787044-ab5ab800-7702-11e9-8c93-34fc5960b8e6.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="756" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/57787059-b6154d00-7702-11e9-937d-46da219afc09.png">

</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="766" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/57787082-c0374b80-7702-11e9-8da2-b4c0676aa54e.png">

</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="762" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/57787106-c62d2c80-7702-11e9-8080-cd73affa5aa7.png">

</details>