### PR TITLE
[DOCS] Add conditional and escape quotes to render 'deprecated' macro for Asciidoctor migration

### DIFF
--- a/docs/reference/mapping/types/core-types.asciidoc
+++ b/docs/reference/mapping/types/core-types.asciidoc
@@ -709,7 +709,7 @@ navigation notation: `name.raw`, or using the typed navigation notation
 `tweet.name.raw`. 
 
 ifdef::asciidoctor[]
-deprecated[1.0.0,"The `path` option below is deprecated.  Use <<copy-to,`copy_to`>> instead for setting up custom _all fields"]
+deprecated::[1.0.0,"The `path` option below is deprecated.  Use <<copy-to,`copy_to`>> instead for setting up custom _all fields"]
 endif::[]
 ifndef::asciidoctor[]
 deprecated[1.0.0,The `path` option below is deprecated.  Use <<copy-to,`copy_to`>> instead for setting up custom _all fields]

--- a/docs/reference/mapping/types/core-types.asciidoc
+++ b/docs/reference/mapping/types/core-types.asciidoc
@@ -89,8 +89,8 @@ deprecated:[1.5.0,"Use <<copy-to,`copy_to`>> instead"] The name of the field
 that will be stored in the index. Defaults to the property/field name.
 endif::[]
 ifndef::asciidoctor[]
-deprecated[1.5.0,Use <<copy-to,`copy_to`>> instead] The name of the field
-that will be stored in the index. Defaults to the property/field name.
+deprecated[1.5.0,Use <<copy-to,`copy_to`>> instead] The name of the field that
+will be stored in the index. Defaults to the property/field name.
 endif::[]
 
 |`store` |Set to `true` to actually store the field in the index, `false` to not
@@ -260,8 +260,8 @@ deprecated:[1.5.0,"Use <<copy-to,`copy_to`>> instead"] The name of the field
 that will be stored in the index. Defaults to the property/field name.
 endif::[]
 ifndef::asciidoctor[]
-deprecated[1.5.0,Use <<copy-to,`copy_to`>> instead] The name of the field
-that will be stored in the index. Defaults to the property/field name.
+deprecated[1.5.0,Use <<copy-to,`copy_to`>> instead] The name of the field that
+will be stored in the index. Defaults to the property/field name.
 endif::[]
 
 |`store` |Set to `true` to store actual field in the index, `false` to not
@@ -374,8 +374,8 @@ deprecated:[1.5.0,"Use <<copy-to,`copy_to`>> instead"] The name of the field
 that will be stored in the index. Defaults to the property/field name.
 endif::[]
 ifndef::asciidoctor[]
-deprecated[1.5.0,Use <<copy-to,`copy_to`>> instead] The name of the field
-that will be stored in the index. Defaults to the property/field name.
+deprecated[1.5.0,Use <<copy-to,`copy_to`>> instead] The name of the field that
+will be stored in the index. Defaults to the property/field name.
 endif::[]
 
 |`format` |The <<mapping-date-format,date
@@ -450,8 +450,8 @@ deprecated:[1.5.0,"Use <<copy-to,`copy_to`>> instead"] The name of the field
 that will be stored in the index. Defaults to the property/field name.
 endif::[]
 ifndef::asciidoctor[]
-deprecated[1.5.0,Use <<copy-to,`copy_to`>> instead] The name of the field
-that will be stored in the index. Defaults to the property/field name.
+deprecated[1.5.0,Use <<copy-to,`copy_to`>> instead] The name of the field that
+will be stored in the index. Defaults to the property/field name.
 endif::[]
 
 |`store` |Set to `true` to store actual field in the index, `false` to not
@@ -497,14 +497,15 @@ binary type:
 [horizontal]
 
 `index_name`::
+
 ifdef::asciidoctor[]
-deprecated:[1.5.0,"Use <<copy-to,`copy_to`>> instead"] The name of the field
-that will be stored in the index. Defaults to the property/field name.
+deprecated:[1.5.0,"Use <<copy-to,`copy_to`>> instead"]
 endif::[]
 ifndef::asciidoctor[]
-deprecated[1.5.0,Use <<copy-to,`copy_to`>> instead] The name of the field
-that will be stored in the index. Defaults to the property/field name.
+deprecated[1.5.0,Use <<copy-to,`copy_to`>> instead]
 endif::[]
+The name of the field that will be stored in the index.
+Defaults to the property/field name.
 
 `store`::
 
@@ -708,7 +709,7 @@ navigation notation: `name.raw`, or using the typed navigation notation
 `tweet.name.raw`. 
 
 ifdef::asciidoctor[]
-deprecated::[1.0.0,"The `path` option below is deprecated.  Use <<copy-to,`copy_to`>> instead for setting up custom _all fields"]
+deprecated[1.0.0,"The `path` option below is deprecated.  Use <<copy-to,`copy_to`>> instead for setting up custom _all fields"]
 endif::[]
 ifndef::asciidoctor[]
 deprecated[1.0.0,The `path` option below is deprecated.  Use <<copy-to,`copy_to`>> instead for setting up custom _all fields]


### PR DESCRIPTION
Adds `ifdef` conditionals and escape quotes to correctly render an `deprecated` macro for Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 1.3.

## AsciiDoc Before
<details>
 <summary>Before images</summary>
<img width="763" alt="AsciiDoc - Before A" src="https://user-images.githubusercontent.com/40268737/57808050-9432bf00-7730-11e9-91a2-e55198b146b5.png">
<img width="770" alt="AsciiDoc - Before B" src="https://user-images.githubusercontent.com/40268737/57808056-972daf80-7730-11e9-9f65-f77c9d54290f.png">

</details>

## AsciiDoc After
<details>
 <summary>After images</summary>
<img width="758" alt="AsciiDoc - After A" src="https://user-images.githubusercontent.com/40268737/57808083-a44a9e80-7730-11e9-8f59-5854ee75464a.png">
<img width="761" alt="AsciiDoc - After B" src="https://user-images.githubusercontent.com/40268737/57808092-a6acf880-7730-11e9-85f1-20844564692f.png">

</details>

## Asciidoctor Before
<details>
 <summary>Before images</summary>
<img width="766" alt="Asciidoctor - Before A" src="https://user-images.githubusercontent.com/40268737/57808116-b1678d80-7730-11e9-9722-8f0dbb8942d7.png">
<img width="760" alt="Asciidoctor - Before B" src="https://user-images.githubusercontent.com/40268737/57808122-b4627e00-7730-11e9-9dde-3dd9f24f0903.png">


</details>

## Asciidoctor After
<details>
 <summary>After images</summary>
<img width="751" alt="Asciidoctor - After A" src="https://user-images.githubusercontent.com/40268737/57808133-ba585f00-7730-11e9-8b4a-a1886b693869.png">
<img width="768" alt="Asciidoctor - After B" src="https://user-images.githubusercontent.com/40268737/57808142-bf1d1300-7730-11e9-9891-7670597eaf6c.png">

</details>