### PR TITLE
[DOCS] Add conditional to render 'deprecated' macro in Object Type Mapping for Asciidoctor migration

### DIFF
--- a/docs/reference/mapping/types/object-type.asciidoc
+++ b/docs/reference/mapping/types/object-type.asciidoc
@@ -180,7 +180,7 @@ that do not explicitly set it.
 [float]
 ==== path
 ifdef::asciidoctor[]
-deprecated[1.0.0,"Use <<copy-to,`copy_to`>> instead"]
+deprecated::[1.0.0,"Use <<copy-to,`copy_to`>> instead"]
 endif::[]
 ifndef::asciidoctor[]
 deprecated[1.0.0,Use <<copy-to,`copy_to`>> instead]

--- a/docs/reference/mapping/types/object-type.asciidoc
+++ b/docs/reference/mapping/types/object-type.asciidoc
@@ -179,8 +179,12 @@ that do not explicitly set it.
 
 [float]
 ==== path
-
+ifdef::asciidoctor[]
+deprecated[1.0.0,"Use <<copy-to,`copy_to`>> instead"]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[1.0.0,Use <<copy-to,`copy_to`>> instead]
+endif::[]
 
 In the <<mapping-core-types,core_types>>
 section, a field can have a `index_name` associated with it in order to


### PR DESCRIPTION
Adds an `ifdef` conditional and escape quotes to correctly render an `added` macro for Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 1.3.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="763" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/57810669-58025d00-7736-11e9-9efe-c8fca452de30.png">

</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="761" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/57810677-5d5fa780-7736-11e9-9878-0956484f2d76.png">

</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="767" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/57810695-66e90f80-7736-11e9-8e33-edcb9965fd8e.png">

</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="774" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/57810711-6d778700-7736-11e9-81a3-cbf334b23ad9.png">

</details>