### PR TITLE
[DOCS] Add conditional and escape quotes to render 'deprecated' macros in Cluster Module docs for Asciidoctor migration

### DIFF
--- a/docs/reference/modules/cluster.asciidoc
+++ b/docs/reference/modules/cluster.asciidoc
@@ -50,14 +50,29 @@ Can be set to:
 --
 
 `cluster.routing.allocation.disable_new_allocation`::
-    deprecated[1.0.0.RC1,Replaced by `cluster.routing.allocation.enable`]
+ifdef::asciidoctor[]
+deprecated:[1.0.0.RC1,"Replaced by `cluster.routing.allocation.enable`"]
+endif::[]
+ifndef::asciidoctor[]
+deprecated[1.0.0.RC1,Replaced by `cluster.routing.allocation.enable`]
+endif::[]
 
 `cluster.routing.allocation.disable_allocation`::
-    deprecated[1.0.0.RC1,Replaced by `cluster.routing.allocation.enable`]
+ifdef::asciidoctor[]
+deprecated:[1.0.0.RC1,"Replaced by `cluster.routing.allocation.enable`"]
+endif::[]
+ifndef::asciidoctor[]
+deprecated[1.0.0.RC1,Replaced by `cluster.routing.allocation.enable`]
+endif::[]
 
 
 `cluster.routing.allocation.disable_replica_allocation`::
-    deprecated[1.0.0.RC1,Replaced by `cluster.routing.allocation.enable`]
+ifdef::asciidoctor[]
+deprecated:[1.0.0.RC1,"Replaced by `cluster.routing.allocation.enable`"]
+endif::[]
+ifndef::asciidoctor[]
+deprecated[1.0.0.RC1,Replaced by `cluster.routing.allocation.enable`]
+endif::[]
 
 `cluster.routing.allocation.same_shard.host`::
       Allows to perform a check to prevent allocation of multiple instances


### PR DESCRIPTION
Adds `ifdef` conditionals and escape quotes to correctly render `deprecated` macros for Asciidoctor. Relates to elastic/docs#827.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="487" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/57811554-88e39180-7738-11e9-9d71-5e6c93a01296.png">

</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="482" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/57811560-8e40dc00-7738-11e9-8ed1-cf5cabe96668.png">

</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="582" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/57811573-9567ea00-7738-11e9-9d61-958a68503c7e.png">

</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="481" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/57811585-9ac53480-7738-11e9-8d9c-1b3f3d92264f.png">

</details>