### PR TITLE
[DOCS] Add conditional to render an 'added' macro in Zen Discovery Modules for Asciidoctor migration

### DIFF
--- a/docs/reference/modules/discovery/zen.asciidoc
+++ b/docs/reference/modules/discovery/zen.asciidoc
@@ -162,5 +162,10 @@ updates its own cluster state and replies to the master node, which waits for
 all nodes to respond, up to a timeout, before going ahead processing the next
 updates in the queue. The `discovery.zen.publish_timeout` is set by default
 to 30 seconds and can be changed dynamically through the
-<<cluster-update-settings,cluster update settings api>> added[1.1.0, The
-setting existed before but wasn't dynamic].
+<<cluster-update-settings,cluster update settings api>> 
+ifdef::asciidoctor[]
+added:[1.1.0, The setting existed before but wasn't dynamic].
+endif::[]
+ifndef::asciidoctor[]
+added[1.1.0, The setting existed before but wasn't dynamic].
+endif::[]


### PR DESCRIPTION
Adds an `ifdef` conditional to correctly render an `added` macro for Asciidoctor. Relates to elastic/docs#827.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="742" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/57857538-59c33380-77bd-11e9-9632-d83a66d9be2b.png">

</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="740" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/57857545-5e87e780-77bd-11e9-8989-9c778713a468.png">

</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="749" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/57857569-68a9e600-77bd-11e9-952b-e651969662f0.png">

</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="748" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/57857576-6cd60380-77bd-11e9-8d6d-1a86c2789d29.png">

</details>