### PR TITLE
[DOCS] Add conditional and escape quotes to render 'added' macro in Gateway Module for Asciidoctor migration

### DIFF
--- a/docs/reference/modules/gateway.asciidoc
+++ b/docs/reference/modules/gateway.asciidoc
@@ -43,8 +43,14 @@ once all `gateway.recover_after...nodes` conditions are met.
 The `gateway.expected_nodes` allows to set how many data and master
 eligible nodes are expected to be in the cluster, and once met, the
 `gateway.recover_after_time` is ignored and recovery starts.
-Setting `gateway.expected_nodes` also defaults `gateway.recovery_after_time` to `5m` added[1.3.0, before `expected_nodes`
-required `recovery_after_time` to be set]. The `gateway.expected_data_nodes` and `gateway.expected_master_nodes`
+Setting `gateway.expected_nodes` also defaults `gateway.recovery_after_time` to `5m` 
+ifdef::asciidoctor[]
+added:[1.3.0,"before `expected_nodes` required `recovery_after_time` to be set"]. 
+endif::[]
+ifndef::asciidoctor[]
+added[1.3.0, before `expected_nodes` required `recovery_after_time` to be set]. 
+endif::[]
+The `gateway.expected_data_nodes` and `gateway.expected_master_nodes`
 settings are also supported. For example setting:
 
 [source,js]


### PR DESCRIPTION
Adds an `ifdef` conditional and escape quotes to correctly render an `added` macro for Asciidoctor. Relates to elastic/docs#827.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="825" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/57858839-c63f3200-77bf-11e9-8339-27b14f95f8ca.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="829" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/57858853-cccda980-77bf-11e9-8440-439787106e26.png">

</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="765" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/57858865-d2c38a80-77bf-11e9-98fe-ea9b3516e7e7.png">

</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="824" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/57858875-d9520200-77bf-11e9-92ea-1a4144f752f3.png">

</details>