### PR TITLE
Protect logged exec spooling from no output

### DIFF
--- a/buildSrc/src/main/minimumRuntime/org/elasticsearch/gradle/LoggedExec.java
+++ b/buildSrc/src/main/minimumRuntime/org/elasticsearch/gradle/LoggedExec.java
@@ -63,7 +63,10 @@ public class LoggedExec extends Exec {
             out = new LazyFileOutputStream(spoolFile);
             outputLogger = logger -> {
                 try {
-                    Files.lines(spoolFile.toPath()).forEach(logger::error);
+                    // the file may not exist if the command never output anything
+                    if (Files.exists(spoolFile.toPath())) {
+                        Files.lines(spoolFile.toPath()).forEach(logger::error);
+                    }
                 } catch (IOException e) {
                     throw new RuntimeException("could not log", e);
                 }


### PR DESCRIPTION
This commit adds a guard around reading the spooled LoggedExec output.
It is possible the exec command did not output anything, and failed,
which would trigger a failure to read the output file.