### PR TITLE
Fix TopHitsAggregationBuilder adding duplicate _score sort clauses

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
@@ -232,8 +232,9 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
         }
         if (name.equals(ScoreSortBuilder.NAME)) {
             sort(SortBuilders.scoreSort().order(order));
+        } else {
+            sort(SortBuilders.fieldSort(name).order(order));
         }
-        sort(SortBuilders.fieldSort(name).order(order));
         return this;
     }
 
@@ -249,8 +250,9 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
         }
         if (name.equals(ScoreSortBuilder.NAME)) {
             sort(SortBuilders.scoreSort());
+        } else {
+            sort(SortBuilders.fieldSort(name));
         }
-        sort(SortBuilders.fieldSort(name));
         return this;
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregatorTests.java
@@ -49,7 +49,6 @@ import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
-import org.elasticsearch.search.aggregations.metrics.TopHits;
 import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
 import org.elasticsearch.search.sort.SortOrder;
 
@@ -206,5 +205,11 @@ public class TopHitsAggregatorTests extends AggregatorTestCase {
         assertEquals(3, result.getHits().getTotalHits().value);
         reader.close();
         directory.close();
+    }
+
+    public void testSortByScore() throws Exception {
+        // just check that it does not fail with exceptions
+        testCase(new MatchAllDocsQuery(), topHits("_name").sort("_score", SortOrder.DESC));
+        testCase(new MatchAllDocsQuery(), topHits("_name").sort("_score"));
     }
 }


### PR DESCRIPTION
When using High Level Rest Client Java API to produce search query, using `AggregationBuilders.topHits("th").sort("_score", SortOrder.DESC)`
caused query to contain duplicate sort clauses:
```
"sort": [
    {
        "_score": {
            "order": "desc"
        }
    },
    {
        "_score": {
            "order": "desc"
        }
    }
],
```
Fixes https://github.com/elastic/elasticsearch/issues/42154