### PR TITLE
Use local outputstream reference

### DIFF
--- a/buildSrc/src/main/minimumRuntime/org/elasticsearch/gradle/LoggedExec.java
+++ b/buildSrc/src/main/minimumRuntime/org/elasticsearch/gradle/LoggedExec.java
@@ -70,7 +70,7 @@ public class LoggedExec extends Exec {
             };
         } else {
             out = new ByteArrayOutputStream();
-            outputLogger = logger -> logger.error(((ByteArrayOutputStream) getStandardOutput()).toString(StandardCharsets.UTF_8));
+            outputLogger = logger -> logger.error(((ByteArrayOutputStream) out).toString(StandardCharsets.UTF_8));
         }
         setStandardOutput(out);
         setErrorOutput(out);


### PR DESCRIPTION
This commit fixes the logging in LoggedExec which uses an in memory
buffer to read from a local reference, instead of with
getStandardOutput() of the Exec task. This is due to gradle internally
wrapping with a TeeOutputStream, breaking our cast.