### PR TITLE
[DOCS] Add conditional and escape quotes to render 'added' macro in Scroll docs for Asciidoctor migration

### DIFF
--- a/docs/reference/search/request/scroll.asciidoc
+++ b/docs/reference/search/request/scroll.asciidoc
@@ -82,7 +82,7 @@ return just 10 results.  This process has to be repeated for every page
 requested.
 
 ifdef::asciidoctor[]
-added[1.2.0,"Before 1.2.0, scrolling of sorted results was just as heavy as deep pagination"]
+added::[1.2.0,"Before 1.2.0, scrolling of sorted results was just as heavy as deep pagination"]
 endif::[]
 ifndef::asciidoctor[]
 added[1.2.0,Before 1.2.0, scrolling of sorted results was just as heavy as deep pagination]

--- a/docs/reference/search/request/scroll.asciidoc
+++ b/docs/reference/search/request/scroll.asciidoc
@@ -81,7 +81,12 @@ sorted results have to be retrieved from each shard and resorted in order to
 return just 10 results.  This process has to be repeated for every page
 requested.
 
+ifdef::asciidoctor[]
+added[1.2.0,"Before 1.2.0, scrolling of sorted results was just as heavy as deep pagination"]
+endif::[]
+ifndef::asciidoctor[]
 added[1.2.0,Before 1.2.0, scrolling of sorted results was just as heavy as deep pagination]
+endif::[]
 
 The `scroll` API keeps track of which results have already been returned and
 so is able to return sorted results more efficiently than with deep


### PR DESCRIPTION
Adds an `ifdef` conditional and escape quotes to correctly render an `added` macro for Asciidoctor. Relates to elastic/docs#827.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="724" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/57876709-02848980-77e4-11e9-9164-a9a9750a8a55.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="762" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/57876719-06b0a700-77e4-11e9-8ace-bdddd13bbe1d.png">

</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="760" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/57876722-0b755b00-77e4-11e9-9a08-f856769999e8.png">

</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="756" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/57876727-0fa17880-77e4-11e9-95b7-1d3e247c6333.png">

</details>