### PR TITLE
Minor improvement translog docs

### DIFF
--- a/docs/reference/index-modules/translog.asciidoc
+++ b/docs/reference/index-modules/translog.asciidoc
@@ -29,13 +29,11 @@ The data in the translog is only persisted to disk when the translog is
 ++fsync++ed and committed.  In the event of hardware failure, any data written
 since the previous translog commit will be lost.
 
-By default, Elasticsearch ++fsync++s and commits the translog every 5 seconds
-if `index.translog.durability` is set to `async` or if set to `request`
-(default) at the end of every <<docs-index_,index>>, <<docs-delete,delete>>,
-<<docs-update,update>>, or  <<docs-bulk,bulk>> request. More precisely, if set
-to `request`, Elasticsearch will only report success of an index, delete,
+By default, Elasticsearch will only report success of an index, delete,
 update, or bulk request to the client after the translog has been successfully
-++fsync++ed and committed on the primary and on every allocated replica.
+++fsync++ed and committed on the primary and on every allocated replica. If
+`index.translog.durability` is set to `async` then Elasticsearch ++fsync++s
+and commits the translog every `index.translog.sync_interval` (defaults to 5 seconds).
 
 The following <<indices-update-settings,dynamically updatable>> per-index
 settings control the behaviour of the translog:

--- a/docs/reference/index-modules/translog.asciidoc
+++ b/docs/reference/index-modules/translog.asciidoc
@@ -29,7 +29,7 @@ The data in the translog is only persisted to disk when the translog is
 ++fsync++ed and committed.  In the event of hardware failure, any data written
 since the previous translog commit will be lost.
 
-By default, Elasticsearch will only report success of an index, delete,
+By default, `index.translog.durability` is set to `request` meaning that Elasticsearch will only report success of an index, delete,
 update, or bulk request to the client after the translog has been successfully
 ++fsync++ed and committed on the primary and on every allocated replica. If
 `index.translog.durability` is set to `async` then Elasticsearch ++fsync++s


### PR DESCRIPTION
This change explains the default behavior of fsync in the first sentence.

Closes #42183