### PR TITLE
Wildfly tests use rest high level client

### DIFF
--- a/qa/wildfly/build.gradle
+++ b/qa/wildfly/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     compile "com.fasterxml.jackson.module:jackson-module-jaxb-annotations:${versions.jackson}"
     compile "org.apache.logging.log4j:log4j-api:${versions.log4j}"
     compile "org.apache.logging.log4j:log4j-core:${versions.log4j}"
-    compile project(path: ':client:transport', configuration: 'runtime')
+    compile project(path: ':client:rest-high-level')
     wildfly "org.jboss:wildfly:${wildflyVersion}@zip"
     testCompile "org.elasticsearch.test:framework:${VersionProperties.elasticsearch}"
 }
@@ -93,8 +93,7 @@ task writeElasticsearchProperties {
         final File elasticsearchProperties = file("${wildflyInstall}/standalone/configuration/elasticsearch.properties")
         elasticsearchProperties.write(
                 [
-                        "transport.uri=${-> integTest.getNodes().get(0).transportUri()}",
-                        "cluster.name=${-> integTest.getNodes().get(0).clusterName}"
+                        "http.uri=${-> integTest.getNodes().get(0).httpUri()}"
                 ].join("\n"))
     }
 }
@@ -167,7 +166,7 @@ task startWildfly {
     }
 }
 
-task configureTransportClient(type: LoggedExec) {
+task configureClient(type: LoggedExec) {
     dependsOn startWildfly
     // we skip these tests on Windows so we do not need to worry about compatibility here
     commandLine "${wildflyInstall}/bin/jboss-cli.sh",
@@ -182,7 +181,7 @@ task stopWildfly(type: LoggedExec) {
 }
 
 if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
-    integTestRunner.dependsOn(configureTransportClient)
+    integTestRunner.dependsOn(configureClient)
     final TaskExecutionAdapter logDumpListener = new TaskExecutionAdapter() {
         @Override
         void afterExecute(final Task task, final TaskState state) {

--- a/qa/wildfly/src/main/java/org/elasticsearch/wildfly/transport/RestHighLevelClientActivator.java
+++ b/qa/wildfly/src/main/java/org/elasticsearch/wildfly/transport/RestHighLevelClientActivator.java
@@ -26,11 +26,11 @@ import java.util.Collections;
 import java.util.Set;
 
 @ApplicationPath("/transport")
-public class TransportClientActivator extends Application {
+public class RestHighLevelClientActivator extends Application {
 
     @Override
     public Set<Class<?>> getClasses() {
-        return Collections.singleton(TransportClientEmployeeResource.class);
+        return Collections.singleton(RestHighLevelClientEmployeeResource.class);
     }
 
 }

--- a/qa/wildfly/src/main/java/org/elasticsearch/wildfly/transport/RestHighLevelClientProducer.java
+++ b/qa/wildfly/src/main/java/org/elasticsearch/wildfly/transport/RestHighLevelClientProducer.java
@@ -19,46 +19,34 @@
 
 package org.elasticsearch.wildfly.transport;
 
-import org.elasticsearch.client.transport.TransportClient;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.io.PathUtils;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.transport.client.PreBuiltTransportClient;
 
 import javax.enterprise.inject.Produces;
-
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.Properties;
 
 @SuppressWarnings("unused")
-public final class TransportClientProducer {
+public final class RestHighLevelClientProducer {
 
     @Produces
-    public TransportClient createTransportClient() throws IOException {
+    public RestHighLevelClient createRestHighLevelClient() throws IOException {
         final String elasticsearchProperties = System.getProperty("elasticsearch.properties");
         final Properties properties = new Properties();
 
-        final String transportUri;
-        final String clusterName;
+        final String httpUri;
         try (InputStream is = Files.newInputStream(getPath(elasticsearchProperties))) {
             properties.load(is);
-            transportUri = properties.getProperty("transport.uri");
-            clusterName = properties.getProperty("cluster.name");
+            httpUri = properties.getProperty("http.uri");
         }
 
-        final int lastColon = transportUri.lastIndexOf(':');
-        final String host = transportUri.substring(0, lastColon);
-        final int port = Integer.parseInt(transportUri.substring(lastColon + 1));
-        final Settings settings = Settings.builder().put("cluster.name", clusterName).build();
-        final TransportClient transportClient = new PreBuiltTransportClient(settings, Collections.emptyList());
-        transportClient.addTransportAddress(new TransportAddress(InetAddress.getByName(host), port));
-        return transportClient;
+        return new RestHighLevelClient(RestClient.builder(HttpHost.create(httpUri)));
     }
 
     @SuppressForbidden(reason = "get path not configured in environment")

--- a/qa/wildfly/src/main/java/org/elasticsearch/wildfly/transport/RestHighLevelJacksonJsonProvider.java
+++ b/qa/wildfly/src/main/java/org/elasticsearch/wildfly/transport/RestHighLevelJacksonJsonProvider.java
@@ -24,5 +24,5 @@ import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
 import javax.ws.rs.ext.Provider;
 
 @Provider
-public class TransportJacksonJsonProvider extends ResteasyJackson2Provider {
+public class RestHighLevelJacksonJsonProvider extends ResteasyJackson2Provider {
 }

--- a/qa/wildfly/src/test/java/org/elasticsearch/wildfly/WildflyIT.java
+++ b/qa/wildfly/src/test/java/org/elasticsearch/wildfly/WildflyIT.java
@@ -53,7 +53,7 @@ import static org.hamcrest.Matchers.instanceOf;
 @TestRuleLimitSysouts.Limit(bytes = 14000)
 public class WildflyIT extends LuceneTestCase {
 
-    Logger logger = Logger.getLogger(WildflyIT.class);
+    private Logger logger = Logger.getLogger(WildflyIT.class);
 
     public void testTransportClient() throws URISyntaxException, IOException {
         try (CloseableHttpClient client = HttpClientBuilder.create().build()) {


### PR DESCRIPTION
This change updates the Wildfly qa tests to make use of the
RestHighLevelClient in place of the transport client to pave the way
for the future removal of the transport client.