### PR TITLE
Remove deprecated _source_exclude and _source_include from get API spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get.json
@@ -65,14 +65,6 @@
           "type" : "list",
           "description" : "A list of fields to extract and return from the _source field"
         },
-        "_source_exclude": {
-          "type" : "list",
-          "description" : "A list of fields to exclude from the returned _source field"
-        },
-        "_source_include": {
-          "type" : "list",
-          "description" : "A list of fields to extract and return from the _source field"
-        },
         "version" : {
           "type" : "number",
           "description" : "Explicit version number for concurrency control"


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/33475 `_source_exclude` and `_source_include` have been deprecated.
In every other file in the spec only the new value is present, while in `get.json` there is also the deprecated one. This pr aligns this file to the rest of the spec.

This fix should be backported in `6.x` as well. 