### PR TITLE
SQL: Suppress geo tests failing on tr-TR locale

### DIFF
--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/geo/GeoSqlSpecTestCase.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/geo/GeoSqlSpecTestCase.java
@@ -31,6 +31,8 @@ public abstract class GeoSqlSpecTestCase extends SpecBaseIntegrationTestCase {
 
     @ClassRule
     public static LocalH2 H2 = new LocalH2((c) -> {
+        assumeTrue("JTS inside H2 is using default local for toUpperCase() in string comparison making it fail to parse WKT on certain" +
+            " locales", "point".toUpperCase(Locale.getDefault()).equals("POINT"));
         // Load GIS extensions
         H2GISFunctions.load(c);
         c.createStatement().execute("RUNSCRIPT FROM 'classpath:/ogc/sqltsch.sql'");


### PR DESCRIPTION
Due to a bug in JTS WKT parser, JTS cannot parse most of WKT shapes if
the shape type is written in the lower case. For examples `point (1 2)`
is causing JTS inside H2GIS to fail on tr-TR locale as a result  of 
case-insensitive comparison. I will try to fix this issue in JTS as a follow 
up.
