### PR TITLE
Add trace logging when SSLService is set

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
@@ -5,8 +5,8 @@
  */
 package org.elasticsearch.xpack.core;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.Version;
@@ -155,7 +155,12 @@ public class XPackPlugin extends XPackClientPlugin implements ScriptPlugin, Exte
     protected SSLService getSslService() { return getSharedSslService(); }
     protected LicenseService getLicenseService() { return getSharedLicenseService(); }
     protected XPackLicenseState getLicenseState() { return getSharedLicenseState(); }
-    protected void setSslService(SSLService sslService) { XPackPlugin.sslService.set(sslService); }
+
+    protected void setSslService(SSLService sslService) {
+        logger.trace("Setting SSLService to [{}] for plugin [{}]", sslService, this);
+        XPackPlugin.sslService.set(sslService);
+    }
+
     protected void setLicenseService(LicenseService licenseService) { XPackPlugin.licenseService.set(licenseService); }
     protected void setLicenseState(XPackLicenseState licenseState) { XPackPlugin.licenseState.set(licenseState); }
     public static SSLService getSharedSslService() { return sslService.get(); }

--- a/x-pack/qa/tribe-tests-with-license/src/test/java/org/elasticsearch/license/LicenseTribeTests.java
+++ b/x-pack/qa/tribe-tests-with-license/src/test/java/org/elasticsearch/license/LicenseTribeTests.java
@@ -9,9 +9,11 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.protocol.xpack.license.DeleteLicenseRequest;
 import org.elasticsearch.protocol.xpack.license.GetLicenseRequest;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 
 import static org.elasticsearch.license.TestUtils.generateSignedLicense;
 
+@TestLogging("org.elasticsearch.xpack.core.XPackPlugin:TRACE,org.elasticsearch.xpack.CompositeTestingXPackPlugin:TRACE")
 public class LicenseTribeTests extends TribeTransportTestCase {
 
     @Override


### PR DESCRIPTION
Something is causing this to be set twice in LicenseTribeTests.
These tribe tests do weird things to work around the SetOnce that
XPackPlugin uses for the SslService, but that seems to be failing
randomly.

This additional logging will help work out which plugin instance is
setting the SSLService when it should not be.

Relates: #42004