### PR TITLE
Use translog to estimate number of operations in recovery

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -513,15 +513,8 @@ public class InternalEngine extends Engine {
      * Returns the estimated number of history operations whose seq# at least the provided seq# in this engine.
      */
     @Override
-    public int estimateNumberOfHistoryOperations(String source, MapperService mapperService, long startingSeqNo) throws IOException {
-        if (engineConfig.getIndexSettings().isSoftDeleteEnabled()) {
-            try (Translog.Snapshot snapshot = newChangesSnapshot(source, mapperService, Math.max(0, startingSeqNo),
-                Long.MAX_VALUE, false)) {
-                return snapshot.totalOperations();
-            }
-        } else {
-            return getTranslog().estimateTotalOperationsFromMinSeq(startingSeqNo);
-        }
+    public int estimateNumberOfHistoryOperations(String source, MapperService mapperService, long startingSeqNo) {
+        return getTranslog().estimateTotalOperationsFromMinSeq(startingSeqNo);
     }
 
     @Override


### PR DESCRIPTION
Currently, we ignore soft-deletes in peer recovery, thus `estimateNumberOfHistoryOperations` should always use translog.

Relates #38904