### PR TITLE
Fix javadoc of SearchRequestBuilder#setTrackTotalHits

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -378,7 +378,9 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
     }
 
     /**
-     * Indicates if the total hit count for the query should be tracked. Defaults to {@code true}
+     * Indicates if the total hit count for the query should be tracked. Requests will count total hit count accurately
+     * up to 10,000 by default, see {@link #setTrackTotalHitsUpTo(int)} to change this value or set to true/false to always/never
+     * count accurately.
      */
     public SearchRequestBuilder setTrackTotalHits(boolean trackTotalHits) {
         sourceBuilder().trackTotalHits(trackTotalHits);
@@ -386,7 +388,7 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
     }
 
     /**
-     * Indicates if the total hit count for the query should be tracked. Defaults to {@code true}
+     * Indicates the total hit count that should be tracked accurately or null if the value is unset. Defaults to 10,000.
      */
     public SearchRequestBuilder setTrackTotalHitsUpTo(int trackTotalHitsUpTo) {
         sourceBuilder().trackTotalHitsUpTo(trackTotalHitsUpTo);


### PR DESCRIPTION
This change fixes the javadoc for setTrackTotalHits that documents the wrong default value.