### PR TITLE
[ML] Fix logger declaration in ML plugins

### DIFF
--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/DataFrame.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/DataFrame.java
@@ -76,10 +76,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
@@ -89,10 +87,6 @@ public class DataFrame extends Plugin implements ActionPlugin, PersistentTaskPlu
 
     public static final String NAME = "data_frame";
     public static final String TASK_THREAD_POOL_NAME = "data_frame_indexing";
-
-    // list of headers that will be stored when a transform is created
-    public static final Set<String> HEADER_FILTERS = new HashSet<>(
-            Arrays.asList("es-security-runas-user", "_xpack_security_authentication"));
 
     private static final Logger logger = LogManager.getLogger(DataFrame.class);
 

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/DataFrame.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/DataFrame.java
@@ -94,7 +94,7 @@ public class DataFrame extends Plugin implements ActionPlugin, PersistentTaskPlu
     public static final Set<String> HEADER_FILTERS = new HashSet<>(
             Arrays.asList("es-security-runas-user", "_xpack_security_authentication"));
 
-    private static final Logger logger = LogManager.getLogger(XPackPlugin.class);
+    private static final Logger logger = LogManager.getLogger(DataFrame.class);
 
     private final boolean enabled;
     private final Settings settings;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -300,7 +300,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
     public static final Setting<ByteSizeValue> MIN_DISK_SPACE_OFF_HEAP =
         Setting.byteSizeSetting("xpack.ml.min_disk_space_off_heap", new ByteSizeValue(5, ByteSizeUnit.GB), Setting.Property.NodeScope);
 
-    private static final Logger logger = LogManager.getLogger(XPackPlugin.class);
+    private static final Logger logger = LogManager.getLogger(MachineLearning.class);
 
     private final Settings settings;
     private final Environment env;


### PR DESCRIPTION
This corrects what appears to have been a copy-paste error
where the logger for `MachineLearning` and `DataFrame` was wrongly
set to be that of `XPackPlugin`.
