### PR TITLE
[DOCS] Change 'Field data' modules doc to render 'deprecated' macro for Asciidoctor migration

### DIFF
--- a/docs/reference/index-modules/fielddata.asciidoc
+++ b/docs/reference/index-modules/fielddata.asciidoc
@@ -60,10 +60,20 @@ parameters:
     final estimation. Defaults to 1.03
 
 `indices.fielddata.breaker.limit`::
-    deprecated[1.4.0.Beta1,Replaced by `indices.breaker.fielddata.limit`]
+ifdef::asciidoctor[]
+deprecated:[1.4.0.Beta1,"Replaced by `indices.breaker.fielddata.limit`"]
+endif::[]
+ifndef::asciidoctor[]
+deprecated[1.4.0.Beta1,Replaced by `indices.breaker.fielddata.limit`]
+endif::[]
 
 `indices.fielddata.breaker.overhead`::
-    deprecated[1.4.0.Beta1,Replaced by `indices.breaker.fielddata.overhead`]
+ifdef::asciidoctor[]
+deprecated:[1.4.0.Beta1,"Replaced by `indices.breaker.fielddata.overhead`"]
+endif::[]
+ifndef::asciidoctor[]
+deprecated[1.4.0.Beta1,Replaced by `indices.breaker.fielddata.overhead`]
+endif::[]
 
 [float]
 [[request-circuit-breaker]]


### PR DESCRIPTION
Makes a few changes to correctly render `deprecated` macros for Asciidoctor:
- Fixes indentation
- Adds `ifdef`conditionals
- Adds escape quotes to the Asciidoctor `deprecated` macros

Relates to elastic/docs#827.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="343" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58025387-56dc8180-7ae2-11e9-8f21-30e4fe020830.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="340" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58025394-5c39cc00-7ae2-11e9-9ee3-674a781b39f9.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="597" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58025411-60fe8000-7ae2-11e9-887d-1bf8baaf6e29.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="349" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58025415-65c33400-7ae2-11e9-9f65-c0792e23e5bc.png">
</details>