### PR TITLE
[DOCS] Add conditional and escape quotes to render 'added' macro in Index Aliases doc for Asciidoctor migration

### DIFF
--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -312,7 +312,12 @@ Possible options:
 
 The rest endpoint is: `/{index}/_alias/{alias}`.
 
+ifdef::asciidoctor[]
+added[1.4.0.Beta1,"The API will always include an `aliases` section, even if there aren't any aliases. Previous versions would not return the `aliases` section"]
+endif::[]
+ifndef::asciidoctor[]
 added[1.4.0.Beta1,The API will always include an `aliases` section, even if there aren't any aliases. Previous versions would not return the `aliases` section]
+endif::[]
 
 WARNING: For future versions of Elasticsearch, the default <<multi-index>> options will error if a requested index is unavailable. This is to bring 
 this API in line with the other indices GET APIs

--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -313,7 +313,7 @@ Possible options:
 The rest endpoint is: `/{index}/_alias/{alias}`.
 
 ifdef::asciidoctor[]
-added[1.4.0.Beta1,"The API will always include an `aliases` section, even if there aren't any aliases. Previous versions would not return the `aliases` section"]
+added::[1.4.0.Beta1,"The API will always include an `aliases` section, even if there aren't any aliases. Previous versions would not return the `aliases` section"]
 endif::[]
 ifndef::asciidoctor[]
 added[1.4.0.Beta1,The API will always include an `aliases` section, even if there aren't any aliases. Previous versions would not return the `aliases` section]


### PR DESCRIPTION
Adds an `ifdef` conditional and escape quotes to correctly render an `added` macro for Asciidoctor. Relates to elastic/docs#827.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="768" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58026268-154cd600-7ae4-11e9-8ca1-c4747de8659d.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="759" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58026276-1a118a00-7ae4-11e9-8e26-145763064333.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="760" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58026285-1ed63e00-7ae4-11e9-97ea-090056b5ccb8.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="760" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58026294-24cc1f00-7ae4-11e9-9e25-9486c464df72.png">
</details>