### PR TITLE
[DOCS] Add conditional and escape quotes to render 'added' macro in Index Warmers docs for Asciidoctor migration

### DIFF
--- a/docs/reference/indices/warmers.asciidoc
+++ b/docs/reference/indices/warmers.asciidoc
@@ -182,7 +182,12 @@ Getting a warmer for specific index (or alias, or several indices) based
 on its name. The provided name can be a simple wildcard expression or
 omitted to get all warmers. 
 
+ifdef::asciidoctor[]
+added[1.4.0.Beta1,"The API will always include a `warmers` section, even if there aren't any warmers. Previous versions would not return the `warmers` section"]
+endif::[]
+ifndef::asciidoctor[]
 added[1.4.0.Beta1,The API will always include a `warmers` section, even if there aren't any warmers. Previous versions would not return the `warmers` section]
+endif::[]
 
 Some examples:
 

--- a/docs/reference/indices/warmers.asciidoc
+++ b/docs/reference/indices/warmers.asciidoc
@@ -183,7 +183,7 @@ on its name. The provided name can be a simple wildcard expression or
 omitted to get all warmers. 
 
 ifdef::asciidoctor[]
-added[1.4.0.Beta1,"The API will always include a `warmers` section, even if there aren't any warmers. Previous versions would not return the `warmers` section"]
+added::[1.4.0.Beta1,"The API will always include a `warmers` section, even if there aren't any warmers. Previous versions would not return the `warmers` section"]
 endif::[]
 ifndef::asciidoctor[]
 added[1.4.0.Beta1,The API will always include a `warmers` section, even if there aren't any warmers. Previous versions would not return the `warmers` section]


### PR DESCRIPTION
Adds an `ifdef` conditional and escape quotes to correctly render an `added` macro for Asciidoctor. Relates to elastic/docs#827.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="762" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58027560-e421d500-7ae6-11e9-8d2c-6254468a0813.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="761" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58027568-e84df280-7ae6-11e9-9b71-b2d139883fee.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="767" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58027577-ed12a680-7ae6-11e9-8969-5e8b183e8be6.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="759" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58027583-f13ec400-7ae6-11e9-954b-1390388231fa.png">
</details>