### PR TITLE
[DOCS] Add conditional to render 'added' macro in Percolator docs for Asciidoctor migration

### DIFF
--- a/docs/reference/search/percolate.asciidoc
+++ b/docs/reference/search/percolate.asciidoc
@@ -18,7 +18,12 @@ in the percolate api.
 
 Field referred to in a percolator query must *already* exist in the mapping
 associated with the index used for percolation.
+ifdef::asciidoctor[]
+added:[1.4.0.Beta1,Applies to indices created in 1.4.0 or later]
+endif::[]
+ifndef::asciidoctor[]
 added[1.4.0.Beta1,Applies to indices created in 1.4.0 or later]
+endif::[]
 There are two ways to make sure that a field mapping exist:
 
 * Add or update a mapping via the <<indices-create-index,create index>> or


### PR DESCRIPTION
Adds an `ifdef` conditional to correctly render an `added` macro for Asciidoctor. Relates to elastic/docs#827.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="762" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58028307-7080c780-7ae8-11e9-82f0-b3255eebb1c9.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="758" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58028313-74144e80-7ae8-11e9-9624-f8c5231efdd5.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="764" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58028321-77a7d580-7ae8-11e9-9235-26fa7b2b70bf.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="764" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58028325-7c6c8980-7ae8-11e9-8746-6576dd66e22a.png">
</details>