### PR TITLE
[DOCS] Add conditionals to render 'experimental' macros for Asciidoctor migration

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -17,13 +17,18 @@ specific module. These include:
 
 [[index-compound-format]]`index.compound_format`::
 
-        experimental[]
-	Should the compound file format be used (boolean or float setting).
-	The compound format was created to reduce the number of open
-	file handles when using file based storage.  If you set this
-        to `false` be sure the OS is also configured to give
-	Elasticsearch ``enough'' file handles.
-    See <<file-descriptors>>.
+ifdef::asciidoctor[]
+experimental:[]
+endif::[]
+ifndef::asciidoctor[]
+experimental[]
+endif::[]
+Should the compound file format be used (boolean or float setting).
+The compound format was created to reduce the number of open
+file handles when using file based storage.  If you set this
+to `false` be sure the OS is also configured to give
+Elasticsearch ``enough'' file handles.
+See <<file-descriptors>>.
 +
 Alternatively, `compound_format` can be set to a number between `0` and
 `1`, where `0` means `false`, `1` means `true` and a number in between
@@ -35,10 +40,15 @@ Default is 0.1.
 
 [[index-compound-on-flush]]`index.compound_on_flush`::
 
-    experimental[]
-    Should a new segment (create by indexing, not by merging) be written
-    in compound format or non-compound format? Defaults to `true`.
-    This is a dynamic setting.
+ifdef::asciidoctor[]
+experimental:[]
+endif::[]
+ifndef::asciidoctor[]
+experimental[]
+endif::[]
+Should a new segment (create by indexing, not by merging) be written
+in compound format or non-compound format? Defaults to `true`.
+This is a dynamic setting.
 
 `index.refresh_interval`::
 	A time setting controlling how often the
@@ -46,13 +56,18 @@ Default is 0.1.
 	in order to disable it.
 
 `index.shard.check_on_startup`::
-        experimental[]
-        Should shard consistency be checked upon opening.
-        When `true`, the shard will be checked, preventing it from being open in
-        case some segments appear to be corrupted.
-        When `fix`, the shard will also be checked but segments that were reported
-        as corrupted will be automatically removed.
-        Default value is `false`, which doesn't check shards.
+ifdef::asciidoctor[]
+experimental:[]
+endif::[]
+ifndef::asciidoctor[]
+experimental[]
+endif::[]
+Should shard consistency be checked upon opening.
+When `true`, the shard will be checked, preventing it from being open in
+case some segments appear to be corrupted.
+When `fix`, the shard will also be checked but segments that were reported
+as corrupted will be automatically removed.
+Default value is `false`, which doesn't check shards.
 
 NOTE: Checking shards may take a lot of time on large indices.
 


### PR DESCRIPTION
Adds `ifdef` conditionals to correctly render `experimental` macros for Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 1.5

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="760" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58029593-e8e88800-7aea-11e9-9285-315af7845e9a.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="761" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58029604-edad3c00-7aea-11e9-9639-28bc4a139652.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="758" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58029613-f43bb380-7aea-11e9-9f77-256a3c235462.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="754" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58029627-f998fe00-7aea-11e9-9e16-0a94bb6b1b46.png">
</details>