### PR TITLE
[DOCS] Add conditional to render 'added' macro in Indices Recovery docs for Asciidoctor migration

### DIFF
--- a/docs/reference/indices/recovery.asciidoc
+++ b/docs/reference/indices/recovery.asciidoc
@@ -19,7 +19,13 @@ curl -XGET http://localhost:9200/_recovery?pretty&human
 --------------------------------------------------
 
 Response:
+ifdef::asciidoctor[]
+added:[1.5.0, this syntax was change to fix inconsistencies with other API]
+endif::[]
+ifndef::asciidoctor[]
 added[1.5.0, this syntax was change to fix inconsistencies with other API]
+endif::[]
+
 [source,js]
 --------------------------------------------------
 {


### PR DESCRIPTION
Adds an `ifdef` conditional to correctly render an `added` macro for Asciidoctor. Relates to elastic/docs#827.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="158" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58030434-8a240e00-7aec-11e9-9215-32575f590b9f.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="151" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58030450-8f815880-7aec-11e9-8532-ce420133bbd3.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="649" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58030463-95773980-7aec-11e9-8e9b-4b75300710cf.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="143" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58030477-99a35700-7aec-11e9-9605-07ce0e2f0cc2.png">
</details>