### PR TITLE
[DOCS] Add conditionals and escape quotes to render 'deprecated' macros in 'Core Types' docs for Asciidoctor migration

### DIFF
--- a/docs/reference/mapping/types/core-types.asciidoc
+++ b/docs/reference/mapping/types/core-types.asciidoc
@@ -708,7 +708,7 @@ navigation notation: `name.raw`, or using the typed navigation notation
 `tweet.name.raw`. 
 
 ifdef::asciidoctor[]
-deprecated[1.0.0,"The `path` option below is deprecated.  Use <<copy-to,`copy_to`>> instead for setting up custom _all fields"]
+deprecated::[1.0.0,"The `path` option below is deprecated.  Use <<copy-to,`copy_to`>> instead for setting up custom _all fields"]
 endif::[]
 ifndef::asciidoctor[]
 deprecated[1.0.0,The `path` option below is deprecated.  Use <<copy-to,`copy_to`>> instead for setting up custom _all fields]

--- a/docs/reference/mapping/types/core-types.asciidoc
+++ b/docs/reference/mapping/types/core-types.asciidoc
@@ -83,8 +83,15 @@ The following table lists all the attributes that can be used with the
 [cols="<,<",options="header",]
 |=======================================================================
 |Attribute |Description
-|`index_name` |deprecated[1.5.0,Use <<copy-to,`copy_to`>> instead] The name of the field that will be stored in the index.
-Defaults to the property/field name.
+|`index_name` |
+ifdef::asciidoctor[]
+deprecated:[1.5.0,"Use <<copy-to,`copy_to`>> instead"] The name of the field
+that will be stored in the index. Defaults to the property/field name.
+endif::[]
+ifndef::asciidoctor[]
+deprecated[1.5.0,Use <<copy-to,`copy_to`>> instead] The name of the field
+that will be stored in the index. Defaults to the property/field name.
+endif::[]
 
 |`store` |Set to `true` to actually store the field in the index, `false` to not
 store it. Since by default Elasticsearch stores all fields of the source
@@ -247,8 +254,15 @@ numbered type:
 |`type` |The type of the number. Can be `float`, `double`, `integer`,
 `long`, `short`, `byte`. Required.
 
-|`index_name` |deprecated[1.5.0,Use <<copy-to,`copy_to`>> instead] The name of the field that will be stored in the index.
-Defaults to the property/field name.
+|`index_name` |
+ifdef::asciidoctor[]
+deprecated:[1.5.0,"Use <<copy-to,`copy_to`>> instead"] The name of the field
+that will be stored in the index. Defaults to the property/field name.
+endif::[]
+ifndef::asciidoctor[]
+deprecated[1.5.0,Use <<copy-to,`copy_to`>> instead] The name of the field
+that will be stored in the index. Defaults to the property/field name.
+endif::[]
 
 |`store` |Set to `true` to store actual field in the index, `false` to not
 store it. Defaults to `false` (note, the JSON document itself is stored,
@@ -354,8 +368,15 @@ date type:
 [cols="<,<",options="header",]
 |=======================================================================
 |Attribute |Description
-|`index_name` |deprecated[1.5.0,Use <<copy-to,`copy_to`>> instead] The name of the field that will be stored in the index.
-Defaults to the property/field name.
+|`index_name` |
+ifdef::asciidoctor[]
+deprecated:[1.5.0,"Use <<copy-to,`copy_to`>> instead"] The name of the field
+that will be stored in the index. Defaults to the property/field name.
+endif::[]
+ifndef::asciidoctor[]
+deprecated[1.5.0,Use <<copy-to,`copy_to`>> instead] The name of the field
+that will be stored in the index. Defaults to the property/field name.
+endif::[]
 
 |`format` |The <<mapping-date-format,date
 format>>. Defaults to `dateOptionalTime`.
@@ -423,8 +444,15 @@ boolean type:
 [cols="<,<",options="header",]
 |=======================================================================
 |Attribute |Description
-|`index_name` |deprecated[1.5.0,Use <<copy-to,`copy_to`>> instead] The name of the field that will be stored in the index.
-Defaults to the property/field name.
+|`index_name` |
+ifdef::asciidoctor[]
+deprecated:[1.5.0,"Use <<copy-to,`copy_to`>> instead"] The name of the field
+that will be stored in the index. Defaults to the property/field name.
+endif::[]
+ifndef::asciidoctor[]
+deprecated[1.5.0,Use <<copy-to,`copy_to`>> instead] The name of the field
+that will be stored in the index. Defaults to the property/field name.
+endif::[]
 
 |`store` |Set to `true` to store actual field in the index, `false` to not
 store it. Defaults to `false` (note, the JSON document itself is stored,
@@ -469,9 +497,14 @@ binary type:
 [horizontal]
 
 `index_name`::
-
-    deprecated[1.5.0,Use <<copy-to,`copy_to`>> instead] The name of the field that will be stored in the index.
-    Defaults to the property/field name.
+ifdef::asciidoctor[]
+deprecated:[1.5.0,"Use <<copy-to,`copy_to`>> instead"] The name of the field
+that will be stored in the index. Defaults to the property/field name.
+endif::[]
+ifndef::asciidoctor[]
+deprecated[1.5.0,Use <<copy-to,`copy_to`>> instead] The name of the field
+that will be stored in the index. Defaults to the property/field name.
+endif::[]
 
 `store`::
 
@@ -674,7 +707,12 @@ name of the main field and can be accessed by their full path using the
 navigation notation: `name.raw`, or using the typed navigation notation
 `tweet.name.raw`. 
 
+ifdef::asciidoctor[]
+deprecated[1.0.0,"The `path` option below is deprecated.  Use <<copy-to,`copy_to`>> instead for setting up custom _all fields"]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[1.0.0,The `path` option below is deprecated.  Use <<copy-to,`copy_to`>> instead for setting up custom _all fields]
+endif::[]
 
 In older releases, the `path` option allows to control how fields are accessed.
 If the `path` option is set to `full`, then the full path of the main field


### PR DESCRIPTION
Adds `ifdef` conditionals and escape quotes to correctly render `deprecated` macros for Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 1.5

## AsciiDoc Before
<details>
 <summary>Before images</summary>
<img width="761" alt="AsciiDoc - Before A" src="https://user-images.githubusercontent.com/40268737/58034222-0e2dc400-7af4-11e9-968f-9ae2554a8c0a.png">
<img width="756" alt="AsciiDoc - Before B" src="https://user-images.githubusercontent.com/40268737/58033714-f86bcf00-7af2-11e9-8586-90ad3a444d20.png">
</details>

## AsciiDoc After
<details>
 <summary>After images</summary>
<img width="757" alt="AsciiDoc - After A" src="https://user-images.githubusercontent.com/40268737/58034230-1554d200-7af4-11e9-8269-5013091b01d1.png">
<img width="754" alt="AsciiDoc - After B" src="https://user-images.githubusercontent.com/40268737/58033734-04f02780-7af3-11e9-9096-73b380646ee7.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before images</summary>
<img width="756" alt="Asciidoctor - Before A" src="https://user-images.githubusercontent.com/40268737/58034238-1ab21c80-7af4-11e9-80cc-db497b1dcfc4.png">
<img width="764" alt="Asciidoctor - Before B" src="https://user-images.githubusercontent.com/40268737/58033760-10dbe980-7af3-11e9-9278-960de411a126.png">
</details>

## Asciidoctor After
<details>
 <summary>After images</summary>
<img width="756" alt="Asciidoctor - After A" src="https://user-images.githubusercontent.com/40268737/58034242-1f76d080-7af4-11e9-945e-05c07644d9fe.png">
<img width="762" alt="Asciidoctor - After B" src="https://user-images.githubusercontent.com/40268737/58033779-19342480-7af3-11e9-8589-024e5d984817.png">
</details>