### PR TITLE
[DOCS] Add conditional and escape quotes to render 'deprecated' macros in 'IP Type' docs for Asciidoctor

### DIFF
--- a/docs/reference/mapping/types/ip-type.asciidoc
+++ b/docs/reference/mapping/types/ip-type.asciidoc
@@ -10,8 +10,15 @@ type:
 [cols="<,<",options="header",]
 |=======================================================================
 |Attribute |Description
-|`index_name` |deprecated[1.5.0,Use <<copy-to,`copy_to`>> instead] The name of the field that will be stored in the index.
-Defaults to the property/field name.
+|`index_name` |
+ifdef::asciidoctor[]
+deprecated[1.5.0,"Use <<copy-to,`copy_to`>> instead"] The name of the field that
+will be stored in the index. Defaults to the property/field name.
+endif::[]
+ifndef::asciidoctor[]
+deprecated[1.5.0,Use <<copy-to,`copy_to`>> instead] The name of the field that
+will be stored in the index. Defaults to the property/field name.
+endif::[]
 
 |`store` |Set to `true` to store actual field in the index, `false` to not
 store it. Defaults to `false` (note, the JSON document itself is stored,

--- a/docs/reference/mapping/types/ip-type.asciidoc
+++ b/docs/reference/mapping/types/ip-type.asciidoc
@@ -12,7 +12,7 @@ type:
 |Attribute |Description
 |`index_name` |
 ifdef::asciidoctor[]
-deprecated[1.5.0,"Use <<copy-to,`copy_to`>> instead"] The name of the field that
+deprecated::[1.5.0,"Use <<copy-to,`copy_to`>> instead"] The name of the field that
 will be stored in the index. Defaults to the property/field name.
 endif::[]
 ifndef::asciidoctor[]

--- a/docs/reference/mapping/types/ip-type.asciidoc
+++ b/docs/reference/mapping/types/ip-type.asciidoc
@@ -12,7 +12,7 @@ type:
 |Attribute |Description
 |`index_name` |
 ifdef::asciidoctor[]
-deprecated::[1.5.0,"Use <<copy-to,`copy_to`>> instead"] The name of the field that
+deprecated:[1.5.0,"Use <<copy-to,`copy_to`>> instead"] The name of the field that
 will be stored in the index. Defaults to the property/field name.
 endif::[]
 ifndef::asciidoctor[]


### PR DESCRIPTION
Adds an `ifdef` conditional and escape quotes to correctly render a `deprecated` macro for Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 1.5

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="760" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58035010-daec3480-7af5-11e9-89cf-fcaf08b8201b.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="754" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58035021-df185200-7af5-11e9-9837-369fadcfc9d6.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="752" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58035031-e3dd0600-7af5-11e9-8c83-4a67d6d6c159.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="757" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58035045-e8a1ba00-7af5-11e9-8d77-85565792dac0.png">
</details>