### PR TITLE
[DOCS] Add conditionals to render 'deprecated' macros in 'Merge' Docs for Asciidoctor migration

### DIFF
--- a/docs/reference/index-modules/merge.asciidoc
+++ b/docs/reference/index-modules/merge.asciidoc
@@ -109,7 +109,12 @@ call for the index (try and aim to issue it on a low traffic time).
 [[log-byte-size]]
 ==== log_byte_size
 
+ifdef::asciidoctor[]
+deprecated[1.6.0,"This policy will be removed in 2.0 in favour of the <<tiered,tiered>> merge policy"]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[1.6.0,This policy will be removed in 2.0 in favour of the <<tiered,tiered>> merge policy]
+endif::[]
 
 A merge policy that merges segments into levels of exponentially
 increasing *byte size*, where each level has fewer segments than the
@@ -153,7 +158,12 @@ Defaults to unbounded.
 [[log-doc]]
 ==== log_doc
 
+ifdef::asciidoctor[]
+deprecated[1.6.0,"This policy will be removed in 2.0 in favour of the <<tiered,tiered>> merge policy"]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[1.6.0,This policy will be removed in 2.0 in favour of the <<tiered,tiered>> merge policy]
+endif::[]
 
 A merge policy that tries to merge segments into levels of exponentially
 increasing *document count*, where each level has fewer segments than


### PR DESCRIPTION
Adds `ifdef` conditionals and escape quotes to correctly render a `deprecated` macro for Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 1.6

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="762" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58038785-f0b22780-7afe-11e9-89e6-e72edbb41690.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="758" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58038796-f576db80-7afe-11e9-8156-cfeeef804cfa.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="755" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58038803-fad42600-7afe-11e9-8d47-b902127a85e6.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="759" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58038809-ff98da00-7afe-11e9-8e23-789d4a56597a.png">
</details>