### PR TITLE
[DOCS] Query DSL Limit Filter: Add conditional to render 'deprecated' macro for Asciidoctor

### DIFF
--- a/docs/reference/query-dsl/filters/limit-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/limit-filter.asciidoc
@@ -1,12 +1,12 @@
 [[query-dsl-limit-filter]]
 === Limit Filter
 
-ifdef:asciidoctor[]
+ifdef::asciidoctor[]
 deprecated[1.6.0, "Use <<search-request-body,terminate_after>> instead"]
-endif:[]
-ifndef:asciidoctor[]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[1.6.0, Use <<search-request-body,terminate_after>> instead]
-endif:[]
+endif::[]
 
 A limit filter limits the number of documents (per shard) to execute on.
 For example:

--- a/docs/reference/query-dsl/filters/limit-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/limit-filter.asciidoc
@@ -1,12 +1,12 @@
 [[query-dsl-limit-filter]]
 === Limit Filter
 
-ifdef::asciidoctor[]
+ifdef:asciidoctor[]
 deprecated[1.6.0, "Use <<search-request-body,terminate_after>> instead"]
-endif::[]
-ifndef::asciidoctor[]
+endif:[]
+ifndef:asciidoctor[]
 deprecated[1.6.0, Use <<search-request-body,terminate_after>> instead]
-endif::[]
+endif:[]
 
 A limit filter limits the number of documents (per shard) to execute on.
 For example:

--- a/docs/reference/query-dsl/filters/limit-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/limit-filter.asciidoc
@@ -1,7 +1,12 @@
 [[query-dsl-limit-filter]]
 === Limit Filter
 
+ifdef::asciidoctor[]
+deprecated[1.6.0, "Use <<search-request-body,terminate_after>> instead"]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[1.6.0, Use <<search-request-body,terminate_after>> instead]
+endif::[]
 
 A limit filter limits the number of documents (per shard) to execute on.
 For example:


### PR DESCRIPTION
Adds `ifdef` conditional and escape quotes to correctly render a `deprecated` macro for Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 1.6

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="758" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58039345-839f9180-7b00-11e9-9f3f-49eca9fa0138.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="754" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58039348-88644580-7b00-11e9-9eb5-655e8eda7a0d.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="754" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58039351-8d28f980-7b00-11e9-9cf1-e41228f5d0a1.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="756" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58039355-91551700-7b00-11e9-8c7f-e65ab2ab27b0.png">
</details>