### PR TITLE
[DOCS] Date Histogram Aggregation: Add conditional to render 'deprecated' macro for Asciidoctor

### DIFF
--- a/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
@@ -51,12 +51,12 @@ By default, times are stored as UTC milliseconds since the epoch. Thus, all comp
 done on UTC. It is possible to provide a time zone value, which will cause all computations to take the relevant zone
 into account. The time returned for each bucket/entry is milliseconds since the epoch of the provided time zone.
 
-ifdef::asciidoctor[]
+ifdef:asciidoctor[]
 deprecated[1.5.0, "`pre_zone`, `post_zone` are replaced by `time_zone`"]
-endif::[]
-ifndef::asciidoctor[]
+endif:[]
+ifndef:asciidoctor[]
 deprecated[1.5.0, `pre_zone`, `post_zone` are replaced by `time_zone`]
-endif::[]
+endif:[]
 
 The parameters are `pre_zone` (pre rounding based on interval) and `post_zone` (post rounding based on interval). The
 `time_zone` parameter simply sets the `pre_zone` parameter. By default, those are set to `UTC`.

--- a/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
@@ -52,7 +52,7 @@ done on UTC. It is possible to provide a time zone value, which will cause all c
 into account. The time returned for each bucket/entry is milliseconds since the epoch of the provided time zone.
 
 ifdef::asciidoctor[]
-deprecated[1.5.0, "`pre_zone`, `post_zone` are replaced by `time_zone`"]
+deprecated::[1.5.0, "`pre_zone`, `post_zone` are replaced by `time_zone`"]
 endif::[]
 ifndef::asciidoctor[]
 deprecated[1.5.0, `pre_zone`, `post_zone` are replaced by `time_zone`]

--- a/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
@@ -51,12 +51,12 @@ By default, times are stored as UTC milliseconds since the epoch. Thus, all comp
 done on UTC. It is possible to provide a time zone value, which will cause all computations to take the relevant zone
 into account. The time returned for each bucket/entry is milliseconds since the epoch of the provided time zone.
 
-ifdef:asciidoctor[]
+ifdef::asciidoctor[]
 deprecated[1.5.0, "`pre_zone`, `post_zone` are replaced by `time_zone`"]
-endif:[]
-ifndef:asciidoctor[]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[1.5.0, `pre_zone`, `post_zone` are replaced by `time_zone`]
-endif:[]
+endif::[]
 
 The parameters are `pre_zone` (pre rounding based on interval) and `post_zone` (post rounding based on interval). The
 `time_zone` parameter simply sets the `pre_zone` parameter. By default, those are set to `UTC`.

--- a/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
@@ -51,7 +51,12 @@ By default, times are stored as UTC milliseconds since the epoch. Thus, all comp
 done on UTC. It is possible to provide a time zone value, which will cause all computations to take the relevant zone
 into account. The time returned for each bucket/entry is milliseconds since the epoch of the provided time zone.
 
+ifdef::asciidoctor[]
+deprecated[1.5.0, "`pre_zone`, `post_zone` are replaced by `time_zone`"]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[1.5.0, `pre_zone`, `post_zone` are replaced by `time_zone`]
+endif::[]
 
 The parameters are `pre_zone` (pre rounding based on interval) and `post_zone` (post rounding based on interval). The
 `time_zone` parameter simply sets the `pre_zone` parameter. By default, those are set to `UTC`.


### PR DESCRIPTION
Adds `ifdef` conditional and escape quotes to correctly render a `deprecated` macro for Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 1.6.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="759" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58040024-62d83b80-7b02-11e9-9290-40234bd36c58.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="761" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58040026-666bc280-7b02-11e9-9c67-3aa9c1eacc5d.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="766" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58040051-75527500-7b02-11e9-9bd5-be41c7a06603.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="764" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58040060-7a172900-7b02-11e9-88ff-99c7b14907b6.png">

</details>