### PR TITLE
[DOCS] More Like This API: Add conditional to render 'deprecated' macro in Asciidoctor

### DIFF
--- a/docs/reference/search/more-like-this.asciidoc
+++ b/docs/reference/search/more-like-this.asciidoc
@@ -1,12 +1,12 @@
 [[search-more-like-this]]
 == More Like This API
 
-ifdef:asciidoctor[]
+ifdef::asciidoctor[]
 deprecated[1.6.0, "The More Like This API will be removed in 2.0, instead use the <<query-dsl-mlt-query, More Like This Query>>"]
-endif:[]
-ifndef:asciidoctor[]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[1.6.0, The More Like This API will be removed in 2.0, instead use the <<query-dsl-mlt-query, More Like This Query>>]
-endif:[]
+endif::[]
 
 The more like this (mlt) API allows to get documents that are "like" a
 specified document. Here is an example:

--- a/docs/reference/search/more-like-this.asciidoc
+++ b/docs/reference/search/more-like-this.asciidoc
@@ -1,12 +1,12 @@
 [[search-more-like-this]]
 == More Like This API
 
-ifdef::asciidoctor[]
+ifdef:asciidoctor[]
 deprecated[1.6.0, "The More Like This API will be removed in 2.0, instead use the <<query-dsl-mlt-query, More Like This Query>>"]
-endif::[]
-ifndef::asciidoctor[]
+endif:[]
+ifndef:asciidoctor[]
 deprecated[1.6.0, The More Like This API will be removed in 2.0, instead use the <<query-dsl-mlt-query, More Like This Query>>]
-endif::[]
+endif:[]
 
 The more like this (mlt) API allows to get documents that are "like" a
 specified document. Here is an example:

--- a/docs/reference/search/more-like-this.asciidoc
+++ b/docs/reference/search/more-like-this.asciidoc
@@ -1,7 +1,12 @@
 [[search-more-like-this]]
 == More Like This API
 
+ifdef::asciidoctor[]
+deprecated[1.6.0, "The More Like This API will be removed in 2.0, instead use the <<query-dsl-mlt-query, More Like This Query>>"]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[1.6.0, The More Like This API will be removed in 2.0, instead use the <<query-dsl-mlt-query, More Like This Query>>]
+endif::[]
 
 The more like this (mlt) API allows to get documents that are "like" a
 specified document. Here is an example:


### PR DESCRIPTION
Adds `ifdef` conditional and escape quotes to correctly render a `deprecated` macro for Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 1.6

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="760" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58040640-ef372e00-7b03-11e9-8c9f-7a2c4a2c65bc.png">

</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="760" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58040652-f2321e80-7b03-11e9-9479-5b0ee744afe7.png">

</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="761" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58040689-08d87580-7b04-11e9-9c5d-996ce701eb93.png">

</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="758" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58040664-f8c09600-7b03-11e9-8ebd-214117a20272.png">

</details>