### PR TITLE
[DOCS] Common Options: Add conditional to render 'deprecated' macro in Asciidoctor

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -335,7 +335,12 @@ generates an edit distance based on the length of the term. For lengths:
 
 `0.0..1.0`::
 
+ifdef::asciidoctor[]
+deprecated:[1.7.0, Support for similarity will be removed in Elasticsearch 2.0]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[1.7.0, Support for similarity will be removed in Elasticsearch 2.0]
+endif::[]
 converted into an edit distance using the formula: `length(term) * (1.0 -
 fuzziness)`, eg a `fuzziness` of `0.6` with a term of length 10 would result
 in an edit distance of `4`. Note: in all APIs except for the


### PR DESCRIPTION
Adds `ifdef` conditional to correctly render a `deprecated` macro for Asciidoctor. Relates to elastic/docs#827.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="760" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58041053-193d2000-7b05-11e9-98b5-2d838d7971fe.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="745" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58041059-1e9a6a80-7b05-11e9-984a-4bfa6796cbca.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="769" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58041068-23f7b500-7b05-11e9-9983-cd0364363fdb.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="765" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58041073-28bc6900-7b05-11e9-80e2-0bbb33c3235a.png">
</details>