### PR TITLE
[DOCS] Upgrading ES: Fix table columns value for Asciidoctor

### DIFF
--- a/docs/reference/setup/upgrade.asciidoc
+++ b/docs/reference/setup/upgrade.asciidoc
@@ -21,7 +21,7 @@ both rolling upgrades and upgrades with full cluster restarts.
 To determine whether a rolling upgrade is supported for your release, please
 consult this table:
 
-[cols="1<m,1<m,3",options="header",]
+[cols="<1m,<1m,3",options="header",]
 |=======================================================================
 |Upgrade From   |Upgrade To     |Supported Upgrade Type
 |1.x            |5.x            |<<reindex-upgrade,Reindex to upgrade>>


### PR DESCRIPTION
Fixes the order of a table's `cols` attribute value so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 1.7

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="775" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58044479-d7fd3e00-7b0d-11e9-8d2e-e37650b87d35.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="763" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58044486-daf82e80-7b0d-11e9-9969-37c31ab3d495.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="758" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58044491-de8bb580-7b0d-11e9-9906-a7ebd4241606.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="763" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58044498-e2b7d300-7b0d-11e9-8618-fca9c87aa428.png">
</details>