### PR TITLE
Update date_histo interval version skips and constants after backport

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
@@ -241,7 +241,7 @@ setup:
 ---
 "Composite aggregation with format":
   - skip:
-      version: " - 7.99.99" #TODO change this after backport
+      version: " - 7.1.99"
       reason:  calendar_interval introduced in 7.2.0
       features: warnings
 
@@ -307,7 +307,7 @@ setup:
 ---
 "Composite aggregation with format and calendar_interval":
   - skip:
-      version: " - 7.99.99" #TODO change this after backport
+      version: " - 7.1.99"
       reason:  calendar_interval introduced in 7.2.0
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/250_moving_fn.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/250_moving_fn.yml
@@ -2,7 +2,7 @@
 "Bad window":
 
   - skip:
-      version: " - 7.99.0" #TODO change this after backport
+      version: " - 7.1.99"
       reason:  "calendar_interval added in 7.2"
 
   - do:
@@ -30,7 +30,7 @@
 "Bad window deprecated interval":
 
   - skip:
-      version: " - 7.99.0" #TODO change this after backport
+      version: " - 7.1.99"
       reason:  "interval deprecation added in 7.2"
       features: "warnings"
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/80_typed_keys.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/80_typed_keys.yml
@@ -206,7 +206,7 @@ setup:
 ---
 "Test typed keys parameter for date_histogram aggregation and max_bucket pipeline aggregation":
   - skip:
-      version: " - 7.99.0" #TODO change this after backport
+      version: " - 7.1.99"
       reason:  "calendar_interval added in 7.2"
   - do:
       search:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/240_date_nanos.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/240_date_nanos.yml
@@ -123,7 +123,7 @@ setup:
 ---
 "date histogram aggregation with date and date_nanos mapping":
   - skip:
-      version: " - 7.99.99" #TODO change this after backport
+      version: " - 7.1.99"
       reason:  calendar_interval introduced in 7.2.0
 
   - do:

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateIntervalWrapper.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateIntervalWrapper.java
@@ -113,7 +113,7 @@ public class DateIntervalWrapper implements ToXContentFragment, Writeable {
     public DateIntervalWrapper() {}
 
     public DateIntervalWrapper(StreamInput in) throws IOException {
-        if (in.getVersion().before(Version.V_8_0_0)) { // TODO change this after backport
+        if (in.getVersion().before(Version.V_7_2_0)) {
             long interval = in.readLong();
             DateHistogramInterval histoInterval = in.readOptionalWriteable(DateHistogramInterval::new);
 
@@ -374,7 +374,7 @@ public class DateIntervalWrapper implements ToXContentFragment, Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getVersion().before(Version.V_8_0_0)) { // TODO change this after backport
+        if (out.getVersion().before(Version.V_7_2_0)) {
             if (intervalType.equals(IntervalTypeEnum.LEGACY_INTERVAL)) {
                 out.writeLong(TimeValue.parseTimeValue(dateHistogramInterval.toString(),
                     DateHistogramAggregationBuilder.NAME + ".innerWriteTo").getMillis());

--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -229,7 +229,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             final Request createRollupJobRequest = new Request("PUT", getRollupEndpoint() + "/job/rollup-job-test");
 
             String intervalType;
-            if (getOldClusterVersion().onOrAfter(Version.V_8_0_0)) { // TODO change this after backport
+            if (getOldClusterVersion().onOrAfter(Version.V_7_2_0)) {
                 intervalType = "fixed_interval";
             } else {
                 intervalType = "interval";

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RollupDateHistoUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RollupDateHistoUpgradeIT.java
@@ -34,7 +34,7 @@ public class RollupDateHistoUpgradeIT extends AbstractUpgradeTestCase {
         Version.fromString(System.getProperty("tests.upgrade_from_version"));
 
     public void testDateHistoIntervalUpgrade() throws Exception {
-        assumeTrue("DateHisto interval changed in 7.1", UPGRADE_FROM_VERSION.before(Version.V_7_2_0));
+        assumeTrue("DateHisto interval changed in 7.2", UPGRADE_FROM_VERSION.before(Version.V_7_2_0));
         switch (CLUSTER_TYPE) {
             case OLD:
                 break;

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/40_ml_datafeed_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/40_ml_datafeed_crud.yml
@@ -109,6 +109,7 @@
   - do:
       warnings:
         - '[interval] on [date_histogram] is deprecated, use [fixed_interval] or [calendar_interval] in the future.'
+        - '[interval] on [date_histogram] is deprecated, use [fixed_interval] or [calendar_interval] in the future.'
       ml.put_datafeed:
         datafeed_id: mixed-cluster-datafeed-with-aggs
         body:  >

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/40_ml_datafeed_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/40_ml_datafeed_crud.yml
@@ -48,8 +48,8 @@
 ---
 "Put job and datafeed with aggs in old cluster - pre-deprecated interval":
   - skip:
-      version: "all"  #TODO change this after backport
-      reason:  "AwaitsFix https://github.com/elastic/elasticsearch/issues/42258; calendar_interval introduced in 7.2.0"
+      version: "7.1.99 - "
+      reason:  "calendar_interval introduced in 7.2.0"
 
   - do:
       ml.put_job:
@@ -118,8 +118,8 @@
 ---
 "Put job and datafeed with aggs in old cluster - deprecated interval with warning":
   - skip:
-      version: " - 7.99.99"  #TODO change this after backport
-      reason:  calendar_interval introduced in 7.1.0
+      version: " - 7.1.99"
+      reason:  calendar_interval introduced in 7.2.0
       features: warnings
 
   - do:


### PR DESCRIPTION
After https://github.com/elastic/elasticsearch/pull/41906 was backported, we need to update the various test skips and version constants

Non-trivial number of changes, and given recent version failures, I'm putting this up for a quick CI check.  No need for review

Closes https://github.com/elastic/elasticsearch/issues/42258