### PR TITLE
[DOCS] Fix _timestamp deprecated macro for Asciidoctor

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -131,7 +131,12 @@ operation based on the `_parent` / `_routing` mapping.
 [[bulk-timestamp]]
 === Timestamp
 
+ifdef::asciidoctor[]
+deprecated[2.0.0-beta2,"The `_timestamp` field is deprecated.  Instead, use a normal <<date,`date`>> field and set its value explicitly"]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[2.0.0-beta2,The `_timestamp` field is deprecated.  Instead, use a normal <<date,`date`>> field and set its value explicitly]
+endif::[]
 
 Each bulk item can include the timestamp value using the
 `_timestamp`/`timestamp` field. It automatically follows the behavior of

--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -132,7 +132,7 @@ operation based on the `_parent` / `_routing` mapping.
 === Timestamp
 
 ifdef::asciidoctor[]
-deprecated[2.0.0-beta2,"The `_timestamp` field is deprecated.  Instead, use a normal <<date,`date`>> field and set its value explicitly"]
+deprecated::[2.0.0-beta2,"The `_timestamp` field is deprecated.  Instead, use a normal <<date,`date`>> field and set its value explicitly"]
 endif::[]
 ifndef::asciidoctor[]
 deprecated[2.0.0-beta2,The `_timestamp` field is deprecated.  Instead, use a normal <<date,`date`>> field and set its value explicitly]

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -255,7 +255,12 @@ specified using the `routing` parameter.
 [[index-timestamp]]
 === Timestamp
 
+ifdef::asciidoctor[]
+deprecated[2.0.0-beta2,"The `_timestamp` field is deprecated.  Instead, use a normal <<date,`date`>> field and set its value explicitly"]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[2.0.0-beta2,The `_timestamp` field is deprecated.  Instead, use a normal <<date,`date`>> field and set its value explicitly]
+endif::[]
 
 A document can be indexed with a `timestamp` associated with it. The
 `timestamp` value of a document can be set using the `timestamp`

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -256,7 +256,7 @@ specified using the `routing` parameter.
 === Timestamp
 
 ifdef::asciidoctor[]
-deprecated[2.0.0-beta2,"The `_timestamp` field is deprecated.  Instead, use a normal <<date,`date`>> field and set its value explicitly"]
+deprecated::[2.0.0-beta2,"The `_timestamp` field is deprecated.  Instead, use a normal <<date,`date`>> field and set its value explicitly"]
 endif::[]
 ifndef::asciidoctor[]
 deprecated[2.0.0-beta2,The `_timestamp` field is deprecated.  Instead, use a normal <<date,`date`>> field and set its value explicitly]

--- a/docs/reference/mapping/fields/timestamp-field.asciidoc
+++ b/docs/reference/mapping/fields/timestamp-field.asciidoc
@@ -1,7 +1,12 @@
 [[mapping-timestamp-field]]
 === `_timestamp` field
 
+ifdef::asciidoctor[]
+deprecated[2.0.0-beta2,"The `_timestamp` field is deprecated.  Instead, use a normal <<date,`date`>> field and set its value explicitly"]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[2.0.0-beta2,The `_timestamp` field is deprecated.  Instead, use a normal <<date,`date`>> field and set its value explicitly]
+endif::[]
 
 The `_timestamp` field, when enabled, allows a timestamp to be indexed and
 stored with a document. The timestamp may be specified manually, generated

--- a/docs/reference/mapping/fields/timestamp-field.asciidoc
+++ b/docs/reference/mapping/fields/timestamp-field.asciidoc
@@ -2,7 +2,7 @@
 === `_timestamp` field
 
 ifdef::asciidoctor[]
-deprecated[2.0.0-beta2,"The `_timestamp` field is deprecated.  Instead, use a normal <<date,`date`>> field and set its value explicitly"]
+deprecated::[2.0.0-beta2,"The `_timestamp` field is deprecated.  Instead, use a normal <<date,`date`>> field and set its value explicitly"]
 endif::[]
 ifndef::asciidoctor[]
 deprecated[2.0.0-beta2,The `_timestamp` field is deprecated.  Instead, use a normal <<date,`date`>> field and set its value explicitly]


### PR DESCRIPTION
Fixes the `_timestamp` field deprecated macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 2.0

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="756" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58099661-18aa9500-7baa-11e9-9c0c-2a8e981c074a.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="759" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58099667-1cd6b280-7baa-11e9-81ab-b34b62270721.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="755" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58099680-252eed80-7baa-11e9-9ca1-ea535e9f120c.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="760" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58099689-295b0b00-7baa-11e9-84a2-9147f4b395c6.png">
</details>