### PR TITLE
[DOCS] Fix significant_terms experimental macro for Asciidoctor

### DIFF
--- a/docs/reference/aggregations/bucket/significantterms-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/significantterms-aggregation.asciidoc
@@ -4,7 +4,7 @@
 An aggregation that returns interesting or unusual occurrences of terms in a set.
 
 ifdef::asciidoctor[]
-experimental["The `significant_terms` aggregation can be very heavy when run on large indices.  Work is in progress to provide more lightweight sampling techniques.  As a result, the API for this feature may change in non-backwards compatible ways"]
+experimental::["The `significant_terms` aggregation can be very heavy when run on large indices.  Work is in progress to provide more lightweight sampling techniques.  As a result, the API for this feature may change in non-backwards compatible ways"]
 endif::[]
 ifndef::asciidoctor[]
 experimental[The `significant_terms` aggregation can be very heavy when run on large indices.  Work is in progress to provide more lightweight sampling techniques.  As a result, the API for this feature may change in non-backwards compatible ways]

--- a/docs/reference/aggregations/bucket/significantterms-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/significantterms-aggregation.asciidoc
@@ -3,7 +3,12 @@
 
 An aggregation that returns interesting or unusual occurrences of terms in a set.
 
+ifdef::asciidoctor[]
+experimental["The `significant_terms` aggregation can be very heavy when run on large indices.  Work is in progress to provide more lightweight sampling techniques.  As a result, the API for this feature may change in non-backwards compatible ways"]
+endif::[]
+ifndef::asciidoctor[]
 experimental[The `significant_terms` aggregation can be very heavy when run on large indices.  Work is in progress to provide more lightweight sampling techniques.  As a result, the API for this feature may change in non-backwards compatible ways]
+endif::[]
 
 .Example use cases:
 * Suggesting "H5N1" when users search for "bird flu" in text


### PR DESCRIPTION
Fixes the `significant_terms` aggregation experimental macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 2.0

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="763" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58100615-fa459900-7bab-11e9-9510-66d974718a15.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="748" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58100623-fe71b680-7bab-11e9-8faa-1a2bed46d9d7.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="761" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58100634-029dd400-7bac-11e9-9a3f-ccb7a9a014bf.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="760" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58100646-0893b500-7bac-11e9-8e93-1d745830c5e0.png">
</details>