### PR TITLE
[DOCS] Fix precision_threshold experimental macro for Asciidoctor

### DIFF
--- a/docs/reference/aggregations/metrics/cardinality-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/cardinality-aggregation.asciidoc
@@ -42,7 +42,12 @@ Response:
 
 This aggregation also supports the `precision_threshold` option:
 
+ifdef::asciidoctor[]
+experimental["The `precision_threshold` option is specific to the current internal implementation of the `cardinality` agg, which may change in the future"]
+endif::[]
+ifndef::asciidoctor[]
 experimental[The `precision_threshold` option is specific to the current internal implementation of the `cardinality` agg, which may change in the future]
+endif::[]
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/aggregations/metrics/cardinality-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/cardinality-aggregation.asciidoc
@@ -43,7 +43,7 @@ Response:
 This aggregation also supports the `precision_threshold` option:
 
 ifdef::asciidoctor[]
-experimental["The `precision_threshold` option is specific to the current internal implementation of the `cardinality` agg, which may change in the future"]
+experimental::["The `precision_threshold` option is specific to the current internal implementation of the `cardinality` agg, which may change in the future"]
 endif::[]
 ifndef::asciidoctor[]
 experimental[The `precision_threshold` option is specific to the current internal implementation of the `cardinality` agg, which may change in the future]


### PR DESCRIPTION
Fixes the `precision_threshold` aggregation experimental macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 2.0

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="759" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58102765-d2f0cb00-7baf-11e9-8b47-3fc8489d1b76.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="762" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58102773-d8e6ac00-7baf-11e9-97fb-e9f1c985f023.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="755" alt="Asiidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58102783-de43f680-7baf-11e9-9dd3-3e58f8373375.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="756" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58102803-e4d26e00-7baf-11e9-9cc9-3485a1dbd404.png">
</details>