### PR TITLE
[DOCS] Fix 'compression' param experimental macro for Asciidoctor

### DIFF
--- a/docs/reference/aggregations/metrics/percentile-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/percentile-aggregation.asciidoc
@@ -249,7 +249,12 @@ it. It would not be the case on more skewed distributions.
 [[search-aggregations-metrics-percentile-aggregation-compression]]
 ==== Compression
 
+ifdef::asciidoctor[]
+experimental["The `compression` parameter is specific to the current internal implementation of percentiles, and may change in the future"]
+endif::[]
+ifndef::asciidoctor[]
 experimental[The `compression` parameter is specific to the current internal implementation of percentiles, and may change in the future]
+endif::[]
 
 Approximate algorithms must balance memory utilization with estimation accuracy.
 This balance can be controlled using a `compression` parameter:

--- a/docs/reference/aggregations/metrics/percentile-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/percentile-aggregation.asciidoc
@@ -250,7 +250,7 @@ it. It would not be the case on more skewed distributions.
 ==== Compression
 
 ifdef::asciidoctor[]
-experimental["The `compression` parameter is specific to the current internal implementation of percentiles, and may change in the future"]
+experimental::["The `compression` parameter is specific to the current internal implementation of percentiles, and may change in the future"]
 endif::[]
 ifndef::asciidoctor[]
 experimental[The `compression` parameter is specific to the current internal implementation of percentiles, and may change in the future]


### PR DESCRIPTION
Fixes the `compression` parameter experimental macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 2.0

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="753" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58103970-ebfa7b80-7bb1-11e9-9567-e48ddead8feb.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="759" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58103984-ef8e0280-7bb1-11e9-8e38-56cdad716ae8.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="761" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58103993-f452b680-7bb1-11e9-9ab6-6f9b8ac091f0.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="755" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58104000-f87ed400-7bb1-11e9-9769-d6f2c72dd726.png">
</details>