### PR TITLE
[DOCS] Fix 'scan' deprecated macro for Asciidoctor

### DIFF
--- a/docs/reference/search/uri-request.asciidoc
+++ b/docs/reference/search/uri-request.asciidoc
@@ -103,7 +103,12 @@ Defaults to no terminate_after.
 
 |`search_type` |The type of the search operation to perform. Can be
 `dfs_query_then_fetch`, `query_then_fetch`, `scan`
-deprecated[2.1.0,Replaced by a regular `scroll` sorted by `_doc`]
+ifdef::asciidoctor[]
+deprecated:[2.1.0,"Replaced by a regular `scroll` sorted by `_doc`"] 
+endif::[]
+ifndef::asciidoctor[]
+deprecated[2.1.0,Replaced by a regular `scroll` sorted by `_doc`] 
+endif::[]
 or `count`
 deprecated[2.0.0-beta1,Replaced by `size: 0`]. Defaults to `query_then_fetch`. See
 <<search-request-search-type,_Search Type_>> for


### PR DESCRIPTION
Fixes the `scan` deprecated macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 2.1

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="783" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58111032-a85a3e80-7bbe-11e9-9d59-a20c1e31d107.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="779" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58111036-ac865c00-7bbe-11e9-986e-14845ec6b851.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="752" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58111043-b14b1000-7bbe-11e9-8d84-d59fd66ed09e.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="783" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58111050-b4de9700-7bbe-11e9-81d1-b6a80af4003c.png">
</details>