### PR TITLE
[DOCS] Fix 'warmers' deprecated macro for Asciidoctor

### DIFF
--- a/docs/reference/indices/warmers.asciidoc
+++ b/docs/reference/indices/warmers.asciidoc
@@ -1,7 +1,12 @@
 [[indices-warmers]]
 == Warmers
 
+ifdef::asciidoctor[]
+deprecated::[2.3.0,"Thanks to disk-based norms and doc values, warmers don't have use-cases anymore"]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[2.3.0,Thanks to disk-based norms and doc values, warmers don't have use-cases anymore]
+endif::[]
 
 Index warming allows to run registered search requests to warm up the index
 before it is available for search. With the near real time aspect of search,


### PR DESCRIPTION
Fixes the warmers deprecated macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="755" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58117776-553bb800-7bcd-11e9-8a3c-5e759da44e02.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="755" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58117781-5967d580-7bcd-11e9-871c-9a0b6399c146.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="760" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58117784-5e2c8980-7bcd-11e9-8b21-af90f469d222.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="751" alt="Asciidoctor- After" src="https://user-images.githubusercontent.com/40268737/58117792-6389d400-7bcd-11e9-9efa-5256e6d75521.png">
</details>