### PR TITLE
[DOCS] Fix 'geohash' deprecated macro for Asciidoctor

### DIFF
--- a/docs/reference/mapping/types/geo-point.asciidoc
+++ b/docs/reference/mapping/types/geo-point.asciidoc
@@ -117,9 +117,14 @@ The following parameters are accepted by `geo_point` fields:
 
 <<geohash,`geohash`>>::
 
-    Should the geo-point also be indexed as a geohash in the `.geohash`
-    sub-field? Defaults to `false`, unless `geohash_prefix` is `true`.
-    deprecated[2.4]
+Should the geo-point also be indexed as a geohash in the `.geohash`
+sub-field? Defaults to `false`, unless `geohash_prefix` is `true`.
+ifdef::asciidoctor[]
+deprecated:[2.4]
+endif::[]
+ifndef::asciidoctor[]
+deprecated[2.4]
+endif::[]
 
 <<geohash-precision,`geohash_precision`>>::
 


### PR DESCRIPTION
Fixes the `geohash` deprecated macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="761" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58118285-849ef480-7bce-11e9-86ce-904428c88f31.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="761" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58118341-98e2f180-7bce-11e9-831f-bcaca3d0f4f4.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="756" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58118351-9ed8d280-7bce-11e9-9e0b-ccbe07fcfea7.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="759" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58118357-a26c5980-7bce-11e9-815e-bbbf3bb04e90.png">
</details>