### PR TITLE
[DOCS] Fix 'size' parameter deprecated macro for Asciidoctor

### DIFF
--- a/docs/reference/aggregations/bucket/terms-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/terms-aggregation.asciidoc
@@ -62,7 +62,12 @@ This means that if the number of unique terms is greater than `size`, the return
 (it could be that the term counts are slightly off and it could even be that a term that should have been in the top
 size buckets was not returned).
 
+ifdef::asciidoctor[]
+deprecated::[2.4.0, "The ability to set size to 0, resulting in the size being set to Integer.MAX_VALUE, is deprecated, and will be removed in the next major release."]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[2.4.0, The ability to set size to 0, resulting in the size being set to Integer.MAX_VALUE, is deprecated, and will be removed in the next major release.]
+endif::[]
 
 [[search-aggregations-bucket-terms-aggregation-approximate-counts]]
 ==== Document counts are approximate


### PR DESCRIPTION
Fixes the `size` parameter deprecated macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="768" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58118895-d300c300-7bcf-11e9-8a6a-7613ce92a537.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="762" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58118904-d5631d00-7bcf-11e9-8a7a-d6fce0593543.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="758" alt="Asciidoctor -  Before" src="https://user-images.githubusercontent.com/40268737/58118915-d98f3a80-7bcf-11e9-803a-73750bccad6d.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="759" alt="Asciidoctor -  After" src="https://user-images.githubusercontent.com/40268737/58118922-dd22c180-7bcf-11e9-8e07-6998886966c0.png">
</details>