### PR TITLE
[DOCS] Fix Groovy deprecated macro for Asciidoctor

### DIFF
--- a/docs/reference/modules/scripting/groovy.asciidoc
+++ b/docs/reference/modules/scripting/groovy.asciidoc
@@ -1,7 +1,12 @@
 [[modules-scripting-groovy]]
 === Groovy Scripting Language
 
+ifdef::asciidoctor[]
+deprecated::[5.0.0,"Groovy will be replaced by the new scripting language <<modules-scripting-painless, `Painless`>>"]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[5.0.0,Groovy will be replaced by the new scripting language <<modules-scripting-painless, `Painless`>>]
+endif::[]
 
 Groovy is available in Elasticsearch by default.  Although
 limited by the <<java-security-manager,Java Security Manager>>, it is not a


### PR DESCRIPTION
Fixes the Groovy language `deprecated` macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 5.0.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="764" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58121385-540e8900-7bd5-11e9-8572-69d7c3aa3baf.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="762" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58121607-cf703a80-7bd5-11e9-8703-6943a5e870b4.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="761" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58121395-5a9d0080-7bd5-11e9-8a3e-b3c62d185723.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="767" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58121618-d303c180-7bd5-11e9-85e8-68abb1789f71.png">
</details>