### PR TITLE
[DOCS] Fix 'breaking java changes' anchor for Asciidoctor

### DIFF
--- a/docs/reference/release-notes/5.0.0-alpha2.asciidoc
+++ b/docs/reference/release-notes/5.0.0-alpha2.asciidoc
@@ -34,7 +34,7 @@ Settings::
 
 
 
-[[breaking java-5.0.0-alpha2]]
+[[breaking-java-5.0.0-alpha2]]
 [float]
 === Breaking Java changes
 

--- a/docs/reference/release-notes/5.0.0-alpha3.asciidoc
+++ b/docs/reference/release-notes/5.0.0-alpha3.asciidoc
@@ -38,7 +38,7 @@ Settings::
 
 
 
-[[breaking java-5.0.0-alpha3]]
+[[breaking-java-5.0.0-alpha3]]
 [float]
 === Breaking Java changes
 

--- a/docs/reference/release-notes/5.0.0-alpha4.asciidoc
+++ b/docs/reference/release-notes/5.0.0-alpha4.asciidoc
@@ -41,7 +41,7 @@ Snapshot/Restore::
 
 
 
-[[breaking java-5.0.0-alpha4]]
+[[breaking-java-5.0.0-alpha4]]
 [float]
 === Breaking Java changes
 


### PR DESCRIPTION
Fixes the anchor for "Breaking Java changes' heading so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 5.0.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="378" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58122437-a781d680-7bd7-11e9-8bde-51bc95d84984.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="503" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58122488-cb451c80-7bd7-11e9-9caf-e30e04c460fe.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="371" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58122442-ac468a80-7bd7-11e9-8ac0-8b9c4a59b32f.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="503" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58122498-cf713a00-7bd7-11e9-97aa-349aa741d1d0.png">
</details>