### PR TITLE
[DOCS] Fix cross-ref link in Upgrade guide for Asciidoctor

### DIFF
--- a/docs/reference/setup/cluster_restart.asciidoc
+++ b/docs/reference/setup/cluster_restart.asciidoc
@@ -53,7 +53,7 @@ multiple times if necessary.
 --
 
 Stop all Elasticsearch services on all nodes in the cluster. Each node can be
-upgraded following the same procedure described in <<upgrade-node>>.
+upgraded following the same procedure described in <<upgrade-node, Stop and upgrade a single node>>.
 --
 
 . *Upgrade any plugins*


### PR DESCRIPTION
Fixes a broken cross-reference link so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 5.0.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="664" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58123941-fc731c00-7bda-11e9-8caf-d7c0f09a7d45.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="671" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58123948-0006a300-7bdb-11e9-891c-d04f33d138bc.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="682" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58123957-03019380-7bdb-11e9-8f7b-2263f0b082ab.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="665" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58123966-06951a80-7bdb-11e9-8275-5752b3ae2bd8.png">
</details>