### PR TITLE
[DOCS] Fix Percolate API's `deprecated` macro for Asciidoctor

### DIFF
--- a/docs/reference/search/percolate.asciidoc
+++ b/docs/reference/search/percolate.asciidoc
@@ -1,6 +1,11 @@
 [[search-percolate]]
 == Percolator
 
+ifdef::asciidoctor[]
+deprecated::[5.0.0,"Percolate and multi percolate APIs are deprecated and have been replaced by the new <<query-dsl-percolate-query,`percolate` query>>"]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[5.0.0,Percolate and multi percolate APIs are deprecated and have been replaced by the new <<query-dsl-percolate-query,`percolate` query>>]
+endif::[]
 
 For indices created on or after version 5.0.0-alpha1 the percolator automatically indexes the query terms with the percolator queries. This allows the percolator to percolate documents more quickly. It is advisable to reindex any pre 5.0.0 indices to take advantage of this new optimization.


### PR DESCRIPTION
Fixes the percolate API's `deprecated` macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 5.0.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="758" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58124905-507f0000-7bdd-11e9-9f61-61ef0b165e98.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="758" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58124906-5248c380-7bdd-11e9-8e45-370b5f4854e7.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="757" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58124911-5543b400-7bdd-11e9-878d-4f3fa4959de0.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="757" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58124918-583ea480-7bdd-11e9-83ec-4ab9f427fdb6.png">
</details>