### PR TITLE
[DOCS] Fix geo distance range query's deprecated macro for Asciidoctor

### DIFF
--- a/docs/reference/query-dsl/geo-distance-range-query.asciidoc
+++ b/docs/reference/query-dsl/geo-distance-range-query.asciidoc
@@ -1,10 +1,15 @@
 [[query-dsl-geo-distance-range-query]]
 === Geo Distance Range Query
 
+ifdef::asciidoctor[]
+deprecated:[5.0.0,"Elasticsearch will continue to support geo_distance_range queries on indexes created prior to 5.0.0. Range searches on indexes created in 5.0.0 and later will no longer be supported. Distance aggregations or sorting should be used instead. Alternatively a boolean query using MUST and MUST_NOT geo_distange query clauses can be used to achieve a similiar effect."]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[5.0.0,Elasticsearch will continue to support geo_distance_range queries on indexes created
 prior to 5.0.0. Range searches on indexes created in 5.0.0 and later will no longer be supported.
 Distance aggregations or sorting should be used instead. Alternatively a boolean query using MUST and 
 MUST_NOT geo_distange query clauses can be used to achieve a similiar effect.]
+endif::[]
 
 Filters documents that exists within a range from a specific point:
 


### PR DESCRIPTION
Fixes the geo distance range query's `deprecated` macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 5.1.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="460" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58125521-c46dd800-7bde-11e9-9583-75f7b4a62f6b.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="428" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58125682-1e6e9d80-7bdf-11e9-9e02-54f69003694b.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="745" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58125533-c768c880-7bde-11e9-971a-1bb3cafa1564.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="416" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58125690-22022480-7bdf-11e9-8f82-724e9ce74b3b.png">
</details>