### PR TITLE
[DOCS] Fix 'fatal-errors' anchor for Asciidoctor

### DIFF
--- a/docs/reference/setup/stopping.asciidoc
+++ b/docs/reference/setup/stopping.asciidoc
@@ -36,7 +36,7 @@ $ cat /tmp/elasticsearch-pid && echo
 $ kill -SIGTERM 15516
 --------------------------------------------------
 
-[[fatal-errors]
+[[fatal-errors]]
 [float]
 === Stopping on Fatal Errors
 


### PR DESCRIPTION
Fixes the `[[fatal-errors]]` anchor so it renders properly in Asciidoctor. Relates to elastic/docs#827.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="758" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58126235-8671b380-7be0-11e9-9962-d37db30a17c1.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="757" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58126238-8a053a80-7be0-11e9-8f74-47bbc69063a3.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="756" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58126265-97222980-7be0-11e9-96a9-cb95c53f28fd.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="759" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58126268-9a1d1a00-7be0-11e9-932c-ac65add8e558.png">
</details>