### PR TITLE
[DOCS] Fix 'normalizer' parameter's `experimental` macro for Asciidoctor

### DIFF
--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -106,9 +106,14 @@ The following parameters are accepted by `keyword` fields:
 
 <<normalizer,`normalizer`>>::
 
-    experimental[]
-    How to pre-process the keyword prior to indexing. Defaults to `null`,
-    meaning the keyword is kept as-is.
+ifdef::asciidoctor[]
+experimental:[]
+endif::[]
+ifndef::asciidoctor[]
+experimental[]
+endif::[]
+How to pre-process the keyword prior to indexing. Defaults to `null`,
+meaning the keyword is kept as-is.
 
 NOTE: Indexes imported from 2.x do not support `keyword`. Instead they will
 attempt to downgrade `keyword` into `string`. This allows you to merge modern


### PR DESCRIPTION
Fixes the `normalizer` parameter's `experimental` macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 5.2.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="755" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58126695-845c2480-7be1-11e9-9192-382c2d760847.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="755" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58126814-ddc45380-7be1-11e9-8a6c-46a181138877.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="756" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58126705-89b96f00-7be1-11e9-95af-8cfca56235b1.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="755" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58126817-e026ad80-7be1-11e9-8b39-90de68e2f95f.png">
</details>