### PR TITLE
[DOCS] Fix boolean datatype's 'deprecated' macro for Asciidoctor

### DIFF
--- a/docs/reference/mapping/types/boolean.asciidoc
+++ b/docs/reference/mapping/types/boolean.asciidoc
@@ -15,7 +15,12 @@ True values::
 
 deprecated[5.1.0,While Elasticsearch will currently accept the above values during index time. Searching a boolean field using these pseudo-boolean values is deprecated. Please use "true" or "false" instead.]
 
+ifdef::asciidoctor[]
+deprecated::[5.3.0,"Usage of any value other than `false`, `\"false\"`, `true` and `\"true\"` is deprecated."]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[5.3.0,Usage of any value other than `false`, `"false"`, `true` and `"true"` is deprecated.]
+endif::[]
 
 For example:
 


### PR DESCRIPTION
Fixes the `boolean` datatype's `deprecated` macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 5.3.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="753" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58127152-b15d0700-7be2-11e9-8531-ee374ea1b2d9.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="756" alt="AsiiDoc - After" src="https://user-images.githubusercontent.com/40268737/58127392-4cee7780-7be3-11e9-8da0-77d5a7eebcce.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="758" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58127159-b3bf6100-7be2-11e9-85ee-e475bc4bff53.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="755" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58127396-4fe96800-7be3-11e9-861d-4414de91eb0d.png">
</details>