### PR TITLE
[DOCS] Fix 'adjacency_matrix' aggregation's 'experimental' macro for Asciidoctor

### DIFF
--- a/docs/reference/aggregations/bucket/adjacency-matrix-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/adjacency-matrix-aggregation.asciidoc
@@ -6,7 +6,12 @@ The request provides a collection of named filter expressions, similar to the `f
 request. 
 Each bucket in the response represents a non-empty cell in the matrix of intersecting filters.
 
+ifdef::asciidoctor[]
+beta::["The `adjacency_matrix` aggregation is a new feature and we may evolve its design as we get feedback on its use.  As a result, the API for this feature may change in non-backwards compatible ways"]
+endif::[]
+ifndef::asciidoctor[]
 beta[The `adjacency_matrix` aggregation is a new feature and we may evolve its design as we get feedback on its use.  As a result, the API for this feature may change in non-backwards compatible ways]
+endif::[]
 
 
 Given filters named `A`, `B` and `C` the response would return buckets with the following names:


### PR DESCRIPTION
Fixes the `adjacency_matrix` aggregation's `experimental` macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 5.3.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="754" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58128055-c9358a80-7be4-11e9-95d8-f82c72214dd3.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="751" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58128396-87f1aa80-7be5-11e9-9d7a-890c81198c9a.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="755" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58128059-cb97e480-7be4-11e9-8576-cf07b1f54db3.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="759" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58128447-a9eb2d00-7be5-11e9-9b40-669728417c15.png">
</details>