### PR TITLE
[DOCS] Fix Field Stats API 'deprecated' macro for Asciidoctor

### DIFF
--- a/docs/reference/search/field-stats.asciidoc
+++ b/docs/reference/search/field-stats.asciidoc
@@ -3,7 +3,12 @@
 
 experimental[]
 
+ifdef::asciidoctor[]
+deprecated::[5.4.0, "`_field_stats` is deprecated, use `_field_caps` instead or run an min/max aggregation on the desired fields"]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[5.4.0, `_field_stats` is deprecated, use `_field_caps` instead or run an min/max aggregation on the desired fields]
+endif::[]
 
 The field stats api allows one to find statistical properties of a field
 without executing a search, but looking up measurements that are natively


### PR DESCRIPTION
Fixes the Field Stats API's `deprecated` macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 5.4.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="754" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58131376-85df1a00-7bec-11e9-8356-be7734629d02.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="757" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58131383-8c6d9180-7bec-11e9-80ff-8a0f6d1b7f79.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="755" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58131389-92637280-7bec-11e9-888b-76ffc958d6f0.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="753" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58131395-968f9000-7bec-11e9-8caf-1e41ce83fdb9.png">
</details>