### PR TITLE
Fix a rendering issue in the geo envelope docs.

### DIFF
--- a/docs/reference/mapping/types/geo-shape.asciidoc
+++ b/docs/reference/mapping/types/geo-shape.asciidoc
@@ -615,7 +615,7 @@ POST /example/_doc
 
 Elasticsearch supports an `envelope` type, which consists of coordinates
 for upper left and lower right points of the shape to represent a
-bounding rectangle in the format [[minLon, maxLat],[maxLon, minLat]]:
+bounding rectangle in the format `[[minLon, maxLat], [maxLon, minLat]]`:
 
 [source,js]
 --------------------------------------------------


### PR DESCRIPTION
Previously the formatting information didn't display in the docs, and the
sentence just rendered as "bounding rectangle in the format :".
