### PR TITLE
Fix settings prefix for realm truststore password

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLConfigurationSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLConfigurationSettings.java
@@ -117,7 +117,7 @@ public class SSLConfigurationSettings {
     public static final Setting<SecureString> LEGACY_TRUSTSTORE_PASSWORD_PROFILES = Setting.affixKeySetting("transport.profiles.",
             "xpack.security.ssl.truststore.password", LEGACY_TRUSTSTORE_PASSWORD_TEMPLATE);
     public static final Function<String, Setting.AffixSetting<SecureString>> LEGACY_TRUST_STORE_PASSWORD_REALM = realmType ->
-            Setting.affixKeySetting("xpack.security.authc.realms." + realmType + ".", "truststore.password",
+            Setting.affixKeySetting("xpack.security.authc.realms." + realmType + ".", "ssl.truststore.password",
                     LEGACY_TRUSTSTORE_PASSWORD_TEMPLATE);
 
     public static final Function<String, Setting<SecureString>> TRUSTSTORE_PASSWORD_TEMPLATE = key ->

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SSLConfigurationSettingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SSLConfigurationSettingsTests.java
@@ -5,15 +5,17 @@
  */
 package org.elasticsearch.xpack.core.ssl;
 
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
-
 import java.util.Arrays;
 
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 
 public class SSLConfigurationSettingsTests extends ESTestCase {
 
@@ -24,12 +26,12 @@ public class SSLConfigurationSettingsTests extends ESTestCase {
         assertThat(ssl.ciphers.match("xpack.transport.security.ssl.cipher_suites"), is(false));
 
         final Settings settings = Settings.builder()
-                .put("cipher_suites.0", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256")
-                .put("cipher_suites.1", "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256")
-                .put("cipher_suites.2", "TLS_RSA_WITH_AES_128_CBC_SHA256")
-                .build();
+            .put("cipher_suites.0", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256")
+            .put("cipher_suites.1", "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256")
+            .put("cipher_suites.2", "TLS_RSA_WITH_AES_128_CBC_SHA256")
+            .build();
         assertThat(ssl.ciphers.get(settings), is(Arrays.asList(
-                "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256", "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256", "TLS_RSA_WITH_AES_128_CBC_SHA256"
+            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256", "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256", "TLS_RSA_WITH_AES_128_CBC_SHA256"
         )));
     }
 
@@ -39,8 +41,8 @@ public class SSLConfigurationSettingsTests extends ESTestCase {
         assertThat(ssl.clientAuth.match("client_authentication"), is(false));
 
         final Settings settings = Settings.builder()
-                .put("xpack.security.http.ssl.client_authentication", SSLClientAuth.OPTIONAL.name())
-                .build();
+            .put("xpack.security.http.ssl.client_authentication", SSLClientAuth.OPTIONAL.name())
+            .build();
         assertThat(ssl.clientAuth.get(settings).get(), is(SSLClientAuth.OPTIONAL));
     }
 
@@ -50,8 +52,8 @@ public class SSLConfigurationSettingsTests extends ESTestCase {
 
         final String algo = randomAlphaOfLength(16);
         final Settings settings = Settings.builder()
-                .put("xpack.security.authc.realms.ldap1.ssl.keystore.algorithm", algo)
-                .build();
+            .put("xpack.security.authc.realms.ldap1.ssl.keystore.algorithm", algo)
+            .build();
         assertThat(ssl.x509KeyPair.keystoreAlgorithm.get(settings), is(algo));
     }
 
@@ -60,8 +62,8 @@ public class SSLConfigurationSettingsTests extends ESTestCase {
         assertThat(ssl.supportedProtocols.match("ssl.supported_protocols"), is(true));
 
         final Settings settings = Settings.builder()
-                .putList("ssl.supported_protocols", "SSLv3", "SSLv2Hello", "SSLv2")
-                .build();
+            .putList("ssl.supported_protocols", "SSLv3", "SSLv2Hello", "SSLv2")
+            .build();
         assertThat(ssl.supportedProtocols.get(settings), is(Arrays.asList("SSLv3", "SSLv2Hello", "SSLv2")));
     }
 
@@ -89,6 +91,21 @@ public class SSLConfigurationSettingsTests extends ESTestCase {
 
         assertThat(SSLConfigurationSettings.getKeyStoreType(ssl.x509KeyPair.keystoreType, settings, null), is("jks"));
         assertThat(SSLConfigurationSettings.getKeyStoreType(ssl.truststoreType, settings, null), is("jks"));
+    }
+
+    public void testRealmSettingPrefixes() {
+        SSLConfigurationSettings.getRealmSettings("_type").forEach(affix -> {
+            final String key = affix.getConcreteSettingForNamespace("_name").getKey();
+            assertThat(key, startsWith("xpack.security.authc.realms._type._name.ssl."));
+        });
+    }
+
+    public void testProfileSettingPrefixes() {
+        SSLConfigurationSettings.getProfileSettings().forEach(affix -> {
+            assertThat(affix, instanceOf(Setting.AffixSetting.class));
+            final String key = ((Setting.AffixSetting) affix).getConcreteSettingForNamespace("_name").getKey();
+            assertThat(key, startsWith("transport.profiles._name.xpack.security.ssl."));
+        });
     }
 
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SSLConfigurationSettingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SSLConfigurationSettingsTests.java
@@ -26,12 +26,12 @@ public class SSLConfigurationSettingsTests extends ESTestCase {
         assertThat(ssl.ciphers.match("xpack.transport.security.ssl.cipher_suites"), is(false));
 
         final Settings settings = Settings.builder()
-            .put("cipher_suites.0", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256")
-            .put("cipher_suites.1", "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256")
-            .put("cipher_suites.2", "TLS_RSA_WITH_AES_128_CBC_SHA256")
-            .build();
+                .put("cipher_suites.0", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256")
+                .put("cipher_suites.1", "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256")
+                .put("cipher_suites.2", "TLS_RSA_WITH_AES_128_CBC_SHA256")
+                .build();
         assertThat(ssl.ciphers.get(settings), is(Arrays.asList(
-            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256", "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256", "TLS_RSA_WITH_AES_128_CBC_SHA256"
+                "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256", "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256", "TLS_RSA_WITH_AES_128_CBC_SHA256"
         )));
     }
 
@@ -41,8 +41,8 @@ public class SSLConfigurationSettingsTests extends ESTestCase {
         assertThat(ssl.clientAuth.match("client_authentication"), is(false));
 
         final Settings settings = Settings.builder()
-            .put("xpack.security.http.ssl.client_authentication", SSLClientAuth.OPTIONAL.name())
-            .build();
+                .put("xpack.security.http.ssl.client_authentication", SSLClientAuth.OPTIONAL.name())
+                .build();
         assertThat(ssl.clientAuth.get(settings).get(), is(SSLClientAuth.OPTIONAL));
     }
 
@@ -52,8 +52,8 @@ public class SSLConfigurationSettingsTests extends ESTestCase {
 
         final String algo = randomAlphaOfLength(16);
         final Settings settings = Settings.builder()
-            .put("xpack.security.authc.realms.ldap1.ssl.keystore.algorithm", algo)
-            .build();
+                .put("xpack.security.authc.realms.ldap1.ssl.keystore.algorithm", algo)
+                .build();
         assertThat(ssl.x509KeyPair.keystoreAlgorithm.get(settings), is(algo));
     }
 
@@ -62,8 +62,8 @@ public class SSLConfigurationSettingsTests extends ESTestCase {
         assertThat(ssl.supportedProtocols.match("ssl.supported_protocols"), is(true));
 
         final Settings settings = Settings.builder()
-            .putList("ssl.supported_protocols", "SSLv3", "SSLv2Hello", "SSLv2")
-            .build();
+                .putList("ssl.supported_protocols", "SSLv3", "SSLv2Hello", "SSLv2")
+                .build();
         assertThat(ssl.supportedProtocols.get(settings), is(Arrays.asList("SSLv3", "SSLv2Hello", "SSLv2")));
     }
 


### PR DESCRIPTION
As part of #30241 realm settings were changed to be true affix
settings. In the process of this change, the "ssl." prefix was lost
from the realm truststore password. It should be:

    xpack.security.authc.realms.<type>.<name>.ssl.truststore.password

Due to a mismatch between the way we define SSL settings and  load SSL
contexts, there was no way to define this legacy password setting in a
realm config.

The settings validation would reject "ssl.truststore.password" but the
SSL service would ignore "truststore.password".

Resolves: #41663