### PR TITLE
[ML Data Frame] Account for completed data frames in test

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_stats.yml
@@ -49,7 +49,7 @@ teardown:
   - match: { transforms.0.id: "airline-transform-stats" }
   - match: { transforms.0.state.indexer_state: "/started|indexing/" }
   - match: { transforms.0.state.task_state: "started" }
-  - match: { transforms.0.state.checkpoint: 0 }
+  - lte: { transforms.0.state.checkpoint: 1 }
   - lte: { transforms.0.stats.pages_processed: 1 }
   - match: { transforms.0.stats.documents_processed: 0 }
   - match: { transforms.0.stats.documents_indexed: 0 }
@@ -163,7 +163,7 @@ teardown:
         transform_id: "*"
   - match: { count: 2 }
   - match: { transforms.0.id: "airline-transform-stats" }
-  - match: { transforms.0.state.indexer_state: "started" }
+  - match: { transforms.0.state.indexer_state: "/started|indexing/" }
   - match: { transforms.1.id: "airline-transform-stats-dos" }
   - match: { transforms.1.state.indexer_state: "stopped" }
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_stats.yml
@@ -42,9 +42,6 @@ teardown:
 
 ---
 "Test get transform stats":
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/42309"
   - do:
       data_frame.get_data_frame_transform_stats:
         transform_id: "airline-transform-stats"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_stats.yml
@@ -149,9 +149,6 @@ teardown:
 
 ---
 "Test get multiple transform stats where one does not have a task":
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/42309"
   - do:
       data_frame.put_data_frame_transform:
         transform_id: "airline-transform-stats-dos"


### PR DESCRIPTION
When asserting on the checkpoint value if the DF has completed the checkpoint may be 1. Similarly state may be `started` or `indexing`.  

Closes #42309, depends on #42347