### PR TITLE
[DOCS] Fix 'Deprecated script setting' anchor for Asciidoctor

### DIFF
--- a/docs/reference/modules/scripting/security.asciidoc
+++ b/docs/reference/modules/scripting/security.asciidoc
@@ -122,7 +122,7 @@ script.allowed_contexts: search, update <1>
 <1> This will allow only search and update scripts to be executed but not
 aggs or plugin scripts (or any other contexts).
 
-[[deprecated-script=settings]]
+[[deprecated-script-settings]]
 [float]
 === Deprecated script settings
 


### PR DESCRIPTION
Fixes a broken anchor so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 5.5.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="350" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58175657-a059d780-7c6e-11e9-87ec-3120c59f3531.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="362" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58175664-a485f500-7c6e-11e9-9e89-f0d62c72d4a3.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="355" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58175671-a8197c00-7c6e-11e9-8f8a-4512bdcb5b07.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="355" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58175673-abad0300-7c6e-11e9-9d64-d06804e7cbce.png">
</details>