### PR TITLE
[DOCS] Fix nested PagerDuty settings def list for Asciidoctor

### DIFF
--- a/docs/reference/settings/notification-settings.asciidoc
+++ b/docs/reference/settings/notification-settings.asciidoc
@@ -304,38 +304,39 @@ Specifies account information for sending notifications
 via PagerDuty. You can specify the following PagerDuty account attributes:
 +
 --
-  `name`;;
-  A name for the PagerDuty account associated with the API key you
-  are using to access PagerDuty. Required.
+`name`;;
+A name for the PagerDuty account associated with the API key you
+are using to access PagerDuty. Required.
 
-  `secure_service_api_key` (<<secure-settings,Secure>>);;
-   The https://developer.pagerduty.com/documentation/rest/authentication[
-   PagerDuty API key] to use to access PagerDuty. Required.
+`secure_service_api_key` (<<secure-settings,Secure>>);;
+The https://developer.pagerduty.com/documentation/rest/authentication[
+PagerDuty API key] to use to access PagerDuty. Required.
+--
++
+`event_defaults`;;
+Default values for  {xpack-ref}/actions-pagerduty.html#pagerduty-event-trigger-incident-attributes[
+PagerDuty event attributes]. Optional.
++
+--
+`description`::
+A string that contains the default description for PagerDuty events.
+If no default is configured, each PagerDuty action must specify a
+`description`.
 
+`incident_key`::
+A string that contains the default incident key to use when sending
+PagerDuty events.
 
-  `event_defaults`;;
-  Default values for  {xpack-ref}/actions-pagerduty.html#pagerduty-event-trigger-incident-attributes[
-  PagerDuty event attributes]. Optional.
-        +
-        `description`::
-        A string that contains the default description for PagerDuty events.
-        If no default is configured, each PagerDuty action must specify a
-        `description`.
-        +
-        `incident_key`::
-        A string that contains the default incident key to use when sending
-        PagerDuty events.
-        +
-        `client`::
-        A string that specifies the default monitoring client.
-        +
-        `client_url`::
-        The URL of the default monitoring client.
-        +
-        `event_type`::
-        The default event type. Valid values: `trigger`,`resolve`, `acknowledge`.
-        +
-        `attach_payload`::
-        Whether or not to provide the watch payload as context for
-        the event by default. Valid values: `true`, `false`.
+`client`::
+A string that specifies the default monitoring client.
+
+`client_url`::
+The URL of the default monitoring client.
+
+`event_type`::
+The default event type. Valid values: `trigger`,`resolve`, `acknowledge`.
+
+`attach_payload`::
+Whether or not to provide the watch payload as context for
+the event by default. Valid values: `true`, `false`.
 --


### PR DESCRIPTION
Fixes a nested definition list so it indents properly in AsciiDoc and Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 5.5.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="732" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58177197-e9f7f180-7c71-11e9-82b3-68692f357cbb.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="732" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58177207-ee240f00-7c71-11e9-8c89-0062e43a4239.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="745" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58177214-f11eff80-7c71-11e9-8f79-84111c1e5f9a.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="740" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58177220-f419f000-7c71-11e9-91eb-d07fec4c2b19.png">
</details>