### PR TITLE
[DOCS] Move callouts to end of line for Asciidoctor migration

### DIFF
--- a/docs/reference/sql/functions/geo.asciidoc
+++ b/docs/reference/sql/functions/geo.asciidoc
@@ -27,7 +27,9 @@ interchangeably with the following exceptions:
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-ST_AsWKT(geometry<1>)
+ST_AsWKT(
+    geometry <1>
+)
 --------------------------------------------------
 
 *Input*:
@@ -52,7 +54,9 @@ include-tagged::{sql-specs}/docs/geo.csv-spec[aswkt]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-ST_WKTToSQL(string<1>)
+ST_WKTToSQL(
+    string <1>
+)
 --------------------------------------------------
 
 *Input*:
@@ -78,7 +82,9 @@ include-tagged::{sql-specs}/docs/geo.csv-spec[aswkt]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-ST_GeometryType(geometry<1>)
+ST_GeometryType(
+    geometry <1>
+)
 --------------------------------------------------
 
 *Input*:
@@ -102,7 +108,9 @@ include-tagged::{sql-specs}/docs/geo.csv-spec[geometrytype]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-ST_X(geometry<1>)
+ST_X(
+    geometry <1>
+)
 --------------------------------------------------
 
 *Input*:
@@ -126,7 +134,9 @@ include-tagged::{sql-specs}/docs/geo.csv-spec[x]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-ST_Y(geometry<1>)
+ST_Y(
+    geometry <1>
+)
 --------------------------------------------------
 
 *Input*:
@@ -150,7 +160,9 @@ include-tagged::{sql-specs}/docs/geo.csv-spec[y]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-ST_Z(geometry<1>)
+ST_Z(
+    geometry <1>
+)
 --------------------------------------------------
 
 *Input*:
@@ -174,7 +186,10 @@ include-tagged::{sql-specs}/docs/geo.csv-spec[z]
 .Synopsis:
 [source, sql]
 --------------------------------------------------
-ST_Distance(geometry<1>, geometry<2>)
+ST_Distance(
+    geometry, <1>
+    geometry  <2>
+)
 --------------------------------------------------
 
 *Input*:


### PR DESCRIPTION
Asciidoctor requires that all callouts be placed at the end of a line. This rewrites the snippets for the SQL Geo function query to prepare for the Asciidoctor migration.

Relates to elastic/docs#827