### PR TITLE
[DOCS] Fix frozen indices cross reference for Asciidoctor

### DIFF
--- a/docs/reference/frozen-indices.asciidoc
+++ b/docs/reference/frozen-indices.asciidoc
@@ -14,7 +14,7 @@ into a frozen state. Once an index is frozen, all of its transient shard memory 
 is moved to persistent storage. This allows for a much higher disk to heap storage ratio on individual nodes. Once an index is
 frozen, it is made read-only and drops its transient data structures from memory.  These data structures will need to be reloaded on demand (and subsequently dropped) for each search request that targets the frozen index.  A search request that hits
 one or more frozen shards will be executed on a throttled threadpool that ensures that we never search more than
-`N` (`1` by default) searches concurrently (see <<search-throttled>>). This protects nodes from exceeding the available memory due to incoming search requests.
+`N` (`1` by default) searches concurrently (see <<search-throttled,`search-throttled`>>). This protects nodes from exceeding the available memory due to incoming search requests.
 
 In contrast to ordinary open indices, frozen indices are expected to execute slowly and are not designed for high query load. Parallelism is
 gained only on a per-node level and loading data-structures on demand is expected to be one or more orders of a magnitude slower than query


### PR DESCRIPTION
Fixes a cross-reference link so it renders consistently in AsciiDoc and Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 6.6.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="753" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58180764-9b018a80-7c78-11e9-8a88-66dcfb4a8f50.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="748" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58180773-9d63e480-7c78-11e9-97f2-a5f55cd375f2.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="731" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58180780-a0f76b80-7c78-11e9-96cc-31bc25dcf9f9.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="750" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58180792-a48af280-7c78-11e9-881d-8d084953de66.png">
</details>