### PR TITLE
[DOCS] Remove 'macros' option from Deprecation info API snippet for Asciidoctor

### DIFF
--- a/docs/reference/migration/apis/deprecation.asciidoc
+++ b/docs/reference/migration/apis/deprecation.asciidoc
@@ -47,7 +47,7 @@ GET /_xpack/migration/deprecations
 Example response:
 
 
-["source","js",subs="attributes,callouts,macros"]
+["source","js",subs="attributes,callouts"]
 --------------------------------------------------
 {
   "cluster_settings" : [


### PR DESCRIPTION
Removes the 'macros' option from a snippet so it renders consistently in AsciiDoc and Asciidoctor. Relates to elastic/docs#827.

Plan to backport to 5.6.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="739" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58182055-ef0d6e80-7c7a-11e9-9795-92588ae4cc03.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="748" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58182062-f2085f00-7c7a-11e9-8ec0-713f7409feda.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="745" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58182078-f7fe4000-7c7a-11e9-9ca2-0d9d9070bfdf.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="747" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58182087-fb91c700-7c7a-11e9-8581-92f34e9f11e5.png">
</details>