### PR TITLE
[DOCS] Fix default index 'deprecated' macro

### DIFF
--- a/docs/reference/query-dsl/terms-query.asciidoc
+++ b/docs/reference/query-dsl/terms-query.asciidoc
@@ -37,9 +37,16 @@ The terms lookup mechanism supports the following options:
 
 [horizontal]
 `index`::
-    The index to fetch the term values from. Defaults to the
-    current index. deprecated[5.6.0, omitting the index is deprecated
-    future version will require the index to be set explicitly]
+The index to fetch the term values from. Defaults to the
+current index. 
+ifdef::asciidoctor[]
+deprecated:[5.6.0, "omitting the index is deprecated future version will require the index to be set explicitly"]
+endif::[]
+ifndef::asciidoctor[]
+deprecated[5.6.0, omitting the index is deprecated
+future version will require the index to be set explicitly]
+endif::[]
+    
 
 `type`::
     The type to fetch the term values from.


### PR DESCRIPTION
Fixes a `deprecated` macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="675" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58183023-9b9c2000-7c7c-11e9-8849-a0f5b8661c23.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="685" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58183036-9fc83d80-7c7c-11e9-8f3d-63786c007547.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="751" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58183049-a35bc480-7c7c-11e9-8bd7-2aa77cd0e3f8.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="681" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58183066-a8b90f00-7c7c-11e9-9ab0-fd3c7cae01fd.png">
</details>