### PR TITLE
Run AbstractReq/RespTest parsing tests multiple times

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/AbstractRequestTestCase.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/AbstractRequestTestCase.java
@@ -41,19 +41,23 @@ import java.io.IOException;
  */
 public abstract class AbstractRequestTestCase<C extends ToXContent, S> extends ESTestCase {
 
+    private static final int NUMBER_OF_TEST_RUNS = 20;
+
     public final void testFromXContent() throws IOException {
-        final C clientTestInstance = createClientTestInstance();
+        for (int i = 0; i < NUMBER_OF_TEST_RUNS; i++) {
+            final C clientTestInstance = createClientTestInstance();
 
-        final XContentType xContentType = randomFrom(XContentType.values());
-        final BytesReference bytes = toShuffledXContent(clientTestInstance, xContentType, ToXContent.EMPTY_PARAMS, randomBoolean());
+            final XContentType xContentType = randomFrom(XContentType.values());
+            final BytesReference bytes = toShuffledXContent(clientTestInstance, xContentType, ToXContent.EMPTY_PARAMS, randomBoolean());
 
-        final XContent xContent = XContentFactory.xContent(xContentType);
-        final XContentParser parser = xContent.createParser(
-            NamedXContentRegistry.EMPTY,
-            LoggingDeprecationHandler.INSTANCE,
-            bytes.streamInput());
-        final S serverInstance = doParseToServerInstance(parser);
-        assertInstances(serverInstance, clientTestInstance);
+            final XContent xContent = XContentFactory.xContent(xContentType);
+            final XContentParser parser = xContent.createParser(
+                NamedXContentRegistry.EMPTY,
+                LoggingDeprecationHandler.INSTANCE,
+                bytes.streamInput());
+            final S serverInstance = doParseToServerInstance(parser);
+            assertInstances(serverInstance, clientTestInstance);
+        }
     }
 
     protected abstract C createClientTestInstance();

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/AbstractResponseTestCase.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/AbstractResponseTestCase.java
@@ -41,19 +41,23 @@ import java.io.IOException;
  */
 public abstract class AbstractResponseTestCase<S extends ToXContent, C> extends ESTestCase {
 
+    private static final int NUMBER_OF_TEST_RUNS = 20;
+
     public final void testFromXContent() throws IOException {
-        final S serverTestInstance = createServerTestInstance();
+        for (int i = 0; i < NUMBER_OF_TEST_RUNS; i++) {
+            final S serverTestInstance = createServerTestInstance();
 
-        final XContentType xContentType = randomFrom(XContentType.values());
-        final BytesReference bytes = toShuffledXContent(serverTestInstance, xContentType, ToXContent.EMPTY_PARAMS, randomBoolean());
+            final XContentType xContentType = randomFrom(XContentType.values());
+            final BytesReference bytes = toShuffledXContent(serverTestInstance, xContentType, ToXContent.EMPTY_PARAMS, randomBoolean());
 
-        final XContent xContent = XContentFactory.xContent(xContentType);
-        final XContentParser parser = xContent.createParser(
-            NamedXContentRegistry.EMPTY,
-            LoggingDeprecationHandler.INSTANCE,
-            bytes.streamInput());
-        final C clientInstance = doParseToClientInstance(parser);
-        assertInstances(serverTestInstance, clientInstance);
+            final XContent xContent = XContentFactory.xContent(xContentType);
+            final XContentParser parser = xContent.createParser(
+                NamedXContentRegistry.EMPTY,
+                LoggingDeprecationHandler.INSTANCE,
+                bytes.streamInput());
+            final C clientInstance = doParseToClientInstance(parser);
+            assertInstances(serverTestInstance, clientInstance);
+        }
     }
 
     protected abstract S createServerTestInstance();


### PR DESCRIPTION
AbstractRequestTest and AbstractResponseTest will check interconversion
between client-side and server-side request and response objects.  To do this,
they generate objects which may or may not use an element of randomization.
For better test coverage, these tests should run multiple times, so that highly-
randomized objects have a better chance of being thoroughly tested in a single 
run.

Compare `AbstractQueryTestCase`