### PR TITLE
[DOCS] Remove unneeded quotes for Asciidoctor

### DIFF
--- a/docs/reference/migration/migrate_6_0/search.asciidoc
+++ b/docs/reference/migration/migrate_6_0/search.asciidoc
@@ -37,7 +37,7 @@ been removed. Also the deprecated `min_word_len` (a synonym for `min_word_length
 
 * The `query_string` query now correctly parses the maximum number of
   states allowed when
-  "https://en.wikipedia.org/wiki/Powerset_construction#Complexity[determinizing]"
+  https://en.wikipedia.org/wiki/Powerset_construction#Complexity[determinizing]
   a regex as `max_determinized_states` instead of the typo
   `max_determined_states`.
 


### PR DESCRIPTION
Removes unneeded quotes so a link renders properly in Asciidoctor. Relates to elastic/docs#827.

Will backport to 6.0

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="711" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58185544-4ca4b980-7c81-11e9-9a06-30e9454bbd36.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="717" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58185552-4f071380-7c81-11e9-892b-8984f36cc3e6.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="711" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58185564-529a9a80-7c81-11e9-8ac6-d483ed6d5d1a.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="706" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58185568-562e2180-7c81-11e9-9a98-44fb97cc0d20.png">
</details>