### PR TITLE
[DOCS] Add ifdef to escape snippet attribute for Asciidoctor

### DIFF
--- a/docs/reference/security/securing-communications/configuring-tls-docker.asciidoc
+++ b/docs/reference/security/securing-communications/configuring-tls-docker.asciidoc
@@ -61,6 +61,33 @@ WARNING: Version {version} of {es} has not yet been released, so a
 endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
+
+ifdef::asciidoctor[]
+["source","yaml",subs="attributes"]
+----
+version: '2.2'
+
+services:
+  create_certs:
+    container_name: create_certs
+    image: {docker-image}
+    command: >
+      bash -c '
+        if [[ ! -d config/certificates/certs ]]; then
+          mkdir config/certificates/certs;
+        fi;
+        if [[ ! -f /local/certs/bundle.zip ]]; then
+          bin/elasticsearch-certgen --silent --in config/certificates/instances.yml --out config/certificates/certs/bundle.zip;
+          unzip config/certificates/certs/bundle.zip -d config/certificates/certs; <1>
+        fi;
+        chgrp -R 0 config/certificates/certs
+      '
+    user: ${UID:-1000}
+    working_dir: /usr/share/elasticsearch
+    volumes: ['.:/usr/share/elasticsearch/config/certificates']
+----
+endif::[]
+ifndef::asciidoctor[]
 ["source","yaml",subs="attributes"]
 ----
 version: '2.2'
@@ -84,6 +111,7 @@ services:
     working_dir: /usr/share/elasticsearch
     volumes: ['.:/usr/share/elasticsearch/config/certificates']
 ----
+endif::[]
 
 <1> The new node certificates and CA certificate+key are placed under the local directory `certs`.
 endif::[]


### PR DESCRIPTION
Adds an ifdef conditional to correctly render an escaped set of `{}` characters in Asciidoctor. Relates to elastic/docs#827.

Will backport to 6.0.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="191" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58189088-ccce1d80-7c87-11e9-8679-f7bf3b5c0f91.png">
</details>

## AsciiDoc After
<details>
<img width="189" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58189096-cf307780-7c87-11e9-97b1-a971351ff465.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="203" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58189101-d2c3fe80-7c87-11e9-86ae-0868ddb387ad.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="184" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58189106-d5265880-7c87-11e9-8e24-f13505d4f725.png">
</details>