### PR TITLE
Prevent normalizer from accidentally not being closed on exception

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
@@ -523,14 +523,14 @@ public final class AnalysisRegistry implements Closeable {
         if (normalizerFactory instanceof CustomNormalizerProvider) {
             ((CustomNormalizerProvider) normalizerFactory).build(tokenizerName, tokenizerFactory, charFilters, tokenFilters);
         }
+        if (normalizers.containsKey(name)) {
+            throw new IllegalStateException("already registered analyzer with name: " + name);
+        }
         Analyzer normalizerF = normalizerFactory.get();
         if (normalizerF == null) {
             throw new IllegalArgumentException("normalizer [" + normalizerFactory.name() + "] created null normalizer");
         }
         NamedAnalyzer normalizer = new NamedAnalyzer(name, normalizerFactory.scope(), normalizerF);
-        if (normalizers.containsKey(name)) {
-            throw new IllegalStateException("already registered analyzer with name: " + name);
-        }
         normalizers.put(name, normalizer);
     }
 }


### PR DESCRIPTION
Currently AnalysisRegistry#processNormalizerFactory creates a normalizer and
only later checks whether it should be added to the normalizer map passed in. In
case we throw an exception it isn't closed. This can be prevented by moving the
check that throws the exception earlier.