### PR TITLE
[DOCS] Fix _all field 'deprecated' macro for Asciidoctor

### DIFF
--- a/docs/reference/mapping/fields/all-field.asciidoc
+++ b/docs/reference/mapping/fields/all-field.asciidoc
@@ -1,7 +1,12 @@
 [[mapping-all-field]]
 === `_all` field
 
+ifdef::asciidoctor[]
+deprecated::[6.0.0, "`_all` may no longer be enabled for indices created in 6.0+, use a custom field and the mapping `copy_to` parameter"]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[6.0.0, `_all` may no longer be enabled for indices created in 6.0+, use a custom field and the mapping `copy_to` parameter]
+endif::[]
 
 The `_all` field is a special _catch-all_ field which concatenates the values
 of all of the other fields into one big string, using space as a delimiter, which is then


### PR DESCRIPTION
Fixes a `deprecated macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Will backport to 6.0

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="755" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58194792-7adfc480-7c94-11e9-9ba4-5414625849f4.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="755" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58194801-7e734b80-7c94-11e9-8e55-a5951f9ffbf8.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="758" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58194804-8206d280-7c94-11e9-81cb-3df75a501350.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="757" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58194812-859a5980-7c94-11e9-9bfd-05feef403968.png">

</details>