### PR TITLE
[DOCS] Fix _uid field `deprecated` macro for Asciidoctor

### DIFF
--- a/docs/reference/mapping/fields/uid-field.asciidoc
+++ b/docs/reference/mapping/fields/uid-field.asciidoc
@@ -1,7 +1,12 @@
 [[mapping-uid-field]]
 === `_uid` field
 
+ifdef::asciidoctor[]
+deprecated::[6.0.0, "Now that types have been removed, documents are uniquely identified by their `_id` and the `_uid` field has only been kept as a view over the `_id` field for backward compatibility."]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[6.0.0, Now that types have been removed, documents are uniquely identified by their `_id` and the `_uid` field has only been kept as a view over the `_id` field for backward compatibility.]
+endif::[]
 
 Each document indexed is associated with a <<mapping-type-field,`_type`>> (see
 <<mapping-type>>) and an <<mapping-id-field,`_id`>>.  These values are


### PR DESCRIPTION
Fixes a `deprecated macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Will backport to 6.0

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="757" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58195252-897aab80-7c95-11e9-8156-4ee0943940e4.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="757" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58195262-8da6c900-7c95-11e9-8e7d-fd67dca755d0.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="756" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58195270-91d2e680-7c95-11e9-8b9e-2283be8a12ca.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="753" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58195282-95ff0400-7c95-11e9-8c03-bc11618b2fb5.png">
</details>