### PR TITLE
[DOCS] Bump docs 'branch' attribute for 7.2

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -7,7 +7,7 @@ bare_version never includes -alpha or -beta
 :prev-major-version:    6.x
 :lucene_version:        8.0.0
 :lucene_version_path:   8_0_0
-:branch:                7.x
+:branch:                7.2
 :jdk:                   1.8.0_131
 :jdk_major:             8
 :build_flavor:          default


### PR DESCRIPTION
Bumps the `{branch}` attribute to `7.2` to enable doc builds.