### PR TITLE
[DOCS] Fix `preference` parameter `deprecated` macro for Asciidoctor

### DIFF
--- a/docs/reference/search/request/preference.asciidoc
+++ b/docs/reference/search/request/preference.asciidoc
@@ -13,25 +13,48 @@ The `preference` is a query string parameter which can be set to:
 
 [horizontal]
 `_primary`::
-	The operation will be executed only on primary shards.  deprecated[6.1.0,
-	will be removed in 7.0. See the warning below for more information.]
+The operation will be executed only on primary shards. 
+ifdef::asciidoctor[]
+deprecated:[6.1.0, "will be removed in 7.0. See the warning below for more information."]
+endif::[]
+ifndef::asciidoctor[]
+deprecated[6.1.0,
+will be removed in 7.0. See the warning below for more information.]
+endif::[]
 
 `_primary_first`::
-	The operation will be executed on primary shards if possible, but will fall
-	back to other shards if not. deprecated[6.1.0, will be removed in 7.0. See
-	the warning below for more information.]
+The operation will be executed on primary shards if possible, but will fall
+back to other shards if not. 
+ifdef::asciidoctor[]
+deprecated:[6.1.0, "will be removed in 7.0. See the warning below for more information."]
+endif::[]
+ifndef::asciidoctor[]
+deprecated[6.1.0,
+will be removed in 7.0. See the warning below for more information.]
+endif::[]
 
 `_replica`::
-	The operation will be executed only on replica shards. If there are multiple
-	replicas then the order of preference between them is unspecified.
-	deprecated[6.1.0, will be removed in 7.0. See the warning below for more
-	information.]
+The operation will be executed only on replica shards. If there are multiple
+replicas then the order of preference between them is unspecified. 
+ifdef::asciidoctor[]
+deprecated:[6.1.0, "will be removed in 7.0. See the warning below for more information."]
+endif::[]
+ifndef::asciidoctor[]
+deprecated[6.1.0,
+will be removed in 7.0. See the warning below for more information.]
+endif::[]
 
 `_replica_first`::
-	The operation will be executed on replica shards if possible, but will fall
-	back to other shards if not. If there are multiple replicas then the order of
-	preference between them is unspecified.  deprecated[6.1.0, will be removed in
-	7.0. See the warning below for more information.]
+The operation will be executed on replica shards if possible, but will fall
+back to other shards if not. If there are multiple replicas then the order of
+preference between them is unspecified. 
+ifdef::asciidoctor[]
+deprecated:[6.1.0, "will be removed in 7.0. See the warning below for more information."]
+endif::[]
+ifndef::asciidoctor[]
+deprecated[6.1.0,
+will be removed in 7.0. See the warning below for more information.]
+endif::[]
 
 `_only_local`::
 	The operation will be executed only on shards allocated to the local


### PR DESCRIPTION
Fixes a few `deprecated` macros so they render properly in Asciidoctor. Relates to elastic/docs#827.

Will backport to 6.1.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="763" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58197010-66ea9180-7c99-11e9-8dc9-a6ce64310ea3.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="763" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58197015-6b16af00-7c99-11e9-80a3-b78fe6f77ac5.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="761" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58197024-6e119f80-7c99-11e9-8855-0881747774cf.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="766" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58197038-710c9000-7c99-11e9-9aea-84354529ddac.png">
</details>