### PR TITLE
[DOCS] Fix attributes in X-Pack titleabbrevs for Asciidoctor

### DIFF
--- a/docs/reference/settings/configuring-xes.asciidoc
+++ b/docs/reference/settings/configuring-xes.asciidoc
@@ -1,6 +1,8 @@
 [role="xpack"]
 [[settings-xpack]]
 == {xpack} Settings in {es}
+
+[subs="attributes"]
 ++++
 <titleabbrev>{xpack} Settings</titleabbrev>
 ++++

--- a/docs/reference/setup/installing-xes.asciidoc
+++ b/docs/reference/setup/installing-xes.asciidoc
@@ -1,6 +1,8 @@
 [role="xpack"]
 [[installing-xpack-es]]
 == Installing X-Pack in Elasticsearch
+
+[subs="attributes"]
 ++++
 <titleabbrev>Installing {xpack}</titleabbrev>
 ++++


### PR DESCRIPTION
Fixes a few title abbreviations containing attributes so they render properly in Asciidoctor. Relates to elastic/docs#827.

Will backport to 6.3.