### PR TITLE
Remove old assertion in resync replication request

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/resync/ResyncReplicationRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/resync/ResyncReplicationRequest.java
@@ -38,8 +38,6 @@ public final class ResyncReplicationRequest extends ReplicatedWriteRequest<Resyn
     private final long maxSeenAutoIdTimestampOnPrimary;
 
     ResyncReplicationRequest(StreamInput in) throws IOException {
-        //  TODO: https://github.com/elastic/elasticsearch/issues/38556
-        //assert Version.CURRENT.major <= 7;
         super(in);
         trimAboveSeqNo = in.readZLong();
         maxSeenAutoIdTimestampOnPrimary = in.readZLong();


### PR DESCRIPTION
This assertion was left behind from a previous cleanup. The assertion was there to remove some stale logic not needed when master would not talk to 6.x anymore. When that logic was removed, this assertion was left behind. This commit removes that stale assertion.

Relates #38556
Relates #39883