### PR TITLE
[DOCS] Escape cross-ref link comma for Asciidoctor

### DIFF
--- a/docs/reference/rollup/rollup-api.asciidoc
+++ b/docs/reference/rollup/rollup-api.asciidoc
@@ -9,7 +9,7 @@
 
 * <<rollup-put-job,Create Job>>, <<rollup-delete-job,Delete Job>>,
 * <<rollup-start-job,Start Job>>, <<rollup-stop-job,Stop Job>>,
-* <<rollup-get-job,Get Job, List all Jobs>>
+* <<rollup-get-job,Get Job+++,+++ List all Jobs>>
 * <<rollup-job-config,Job configuration details>>
 
 [float]


### PR DESCRIPTION
Escapes a comma in a cross-reference link so it renders properly in Asciidoctor. Relates to elastic/docs#827.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="257" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58200401-b7192200-7ca0-11e9-9c96-80a2439d61b0.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="259" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58200412-b97b7c00-7ca0-11e9-924b-bc787a211644.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="249" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58200416-bbddd600-7ca0-11e9-9177-e79e64ede27c.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="241" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58200423-bed8c680-7ca0-11e9-80c2-8db1120c03c7.png">
</details>