### PR TITLE
[DOCS] Fix classic similarity `deprecated` note for Asciidoctor

### DIFF
--- a/docs/reference/index-modules/similarity.asciidoc
+++ b/docs/reference/index-modules/similarity.asciidoc
@@ -86,7 +86,12 @@ Type name: `BM25`
 [[classic-similarity]]
 ==== Classic similarity
 
+ifdef::asciidoctor[]
+deprecated::[6.3.0, "The quality of the produced scores used to rely on coordination factors, which have been removed. It is advised to use BM25 instead."]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[6.3.0, The quality of the produced scores used to rely on coordination factors, which have been removed. It is advised to use BM25 instead.]
+endif::[]
 
 The classic similarity that is based on the TF/IDF model. This
 similarity has the following option:


### PR DESCRIPTION
Fixes a `deprecated` macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Will backport to 6.4.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="755" alt="AsciiDoc Before" src="https://user-images.githubusercontent.com/40268737/58200806-af0db200-7ca1-11e9-8137-ceb707c3dde1.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="755" alt="AsciiDoc After" src="https://user-images.githubusercontent.com/40268737/58200808-b1700c00-7ca1-11e9-9292-001bd810f763.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="760" alt="Asciidoctor Before" src="https://user-images.githubusercontent.com/40268737/58200812-b5039300-7ca1-11e9-93dd-9e8e0d60c165.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="756" alt="Asciidoctor After" src="https://user-images.githubusercontent.com/40268737/58200817-b765ed00-7ca1-11e9-91a5-70d904a6b615.png">
</details>