### PR TITLE
[DOCS] Fix copying settings `deprecated` macros for Asciidoctor

### DIFF
--- a/docs/reference/indices/shrink-index.asciidoc
+++ b/docs/reference/indices/shrink-index.asciidoc
@@ -137,8 +137,13 @@ from the source index can be copied to the target index by adding the URL
 parameter `copy_settings=true` to the request. Note that `copy_settings` can not
 be set to `false`. The parameter `copy_settings` will be removed in 8.0.0
 
+ifdef::asciidoctor[]
+deprecated:[6.4.0, "not copying settings is deprecated, copying settings will be the default behavior in 7.x"]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[6.4.0, not copying settings is deprecated, copying settings will be
 the default behavior in 7.x]
+endif::[]
 
 [float]
 === Monitoring the shrink process

--- a/docs/reference/indices/split-index.asciidoc
+++ b/docs/reference/indices/split-index.asciidoc
@@ -179,8 +179,13 @@ from the source index can be copied to the target index by adding the URL
 parameter `copy_settings=true` to the request. Note that `copy_settings` can not
 be set to `false`. The parameter `copy_settings` will be removed in 8.0.0
 
+ifdef::asciidoctor[]
+deprecated:[6.4.0, "not copying settings is deprecated, copying settings will be the default behavior in 7.x"]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[6.4.0, not copying settings is deprecated, copying settings will be
 the default behavior in 7.x]
+endif::[]
 
 [float]
 === Monitoring the split process


### PR DESCRIPTION
Fixes a few `deprecated` macros so they render properly in Asciidoctor. Relates to elastic/docs#827.

Will backport to 6.4.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="103" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58201892-3e1bc980-7ca4-11e9-8ba6-c3911f78a2f9.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="103" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58201900-4116ba00-7ca4-11e9-81dd-3587ff21f8b9.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="767" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58201915-45db6e00-7ca4-11e9-96b6-b5e77fa9a8ee.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="69" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58201921-496ef500-7ca4-11e9-9239-0d3ff4c88aa2.png">
</details>