### PR TITLE
[DOCS] Fix 6.2.3 RN PR link for Asciidoctor

### DIFF
--- a/docs/reference/release-notes/6.2.asciidoc
+++ b/docs/reference/release-notes/6.2.asciidoc
@@ -143,7 +143,7 @@ analysis module.  ({pull}30397[#30397])
 Highlighting::
 * Limit analyzed text for highlighting (improvements) {pull}28808[#28808] (issues: {issue}16764[#16764], {issue}27934[#27934]) 
 
-<<copy-source-settings-on-resize,Allow copying source settings on index resize operations>> ({pull}30255[#30255],{pull}30404[#30404])
+<<copy-source-settings-on-resize,Allow copying source settings on index resize operations>> ({pull}30255[#30255], {pull}30404[#30404])
 
 Added new "Request" object flavored request methods in the RestClient. Prefer
 these instead of the multi-argument versions. ({pull}29623[#29623])


### PR DESCRIPTION
Fixes a broken link so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Will backport to 6.4.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="572" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58202763-65739600-7ca6-11e9-8dea-695680bf498e.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="575" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58202770-69071d00-7ca6-11e9-86cc-4c99faa8325a.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="540" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58202774-6c020d80-7ca6-11e9-96ad-790039ab63e8.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="572" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58202778-6efcfe00-7ca6-11e9-8f10-472f11eee945.png">
</details>