### PR TITLE
unmute 'Test url escaping with url mustache function' and bump logging

### DIFF
--- a/x-pack/qa/smoke-test-watcher/build.gradle
+++ b/x-pack/qa/smoke-test-watcher/build.gradle
@@ -12,6 +12,7 @@ integTestCluster {
   setting 'xpack.ml.enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'
   setting 'logger.org.elasticsearch.xpack.watcher', 'DEBUG'
+  setting 'logger.org.elasticsearch.xpack.core.watcher', 'DEBUG'
 }
 
 integTestRunner {

--- a/x-pack/qa/smoke-test-watcher/src/test/resources/rest-api-spec/test/mustache/50_webhook_url_escaping.yml
+++ b/x-pack/qa/smoke-test-watcher/src/test/resources/rest-api-spec/test/mustache/50_webhook_url_escaping.yml
@@ -1,8 +1,6 @@
 ---
 "Test url escaping with url mustache function":
-  - skip:
-        version: "all"
-        reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/41172"
+
   - do:
       cluster.health:
           wait_for_status: yellow


### PR DESCRIPTION
Address test failures on #41172

If (when?) this test fails again please obtain the following information:

* Copy of the relevant failure
* Copy of the reproduce line
* The Jenkins build link 
* The Gradle scan link
* The relevant cluster logs from "Google Cloud Storage Upload Report" (link found in Jenkins build)