### PR TITLE
[DOCS] Fix 6.4.3 RN PR link for Asciidoctor

### DIFF
--- a/docs/reference/release-notes/6.4.asciidoc
+++ b/docs/reference/release-notes/6.4.asciidoc
@@ -69,7 +69,7 @@ Machine learning::
 than one day ({ml-pull}243[#243])
 * Rules that trigger the `skip_model_update` action should also apply to the 
 anomaly model. This fixes an issue where anomaly scores of results that triggered 
-the rule would decrease if they occurred frequently. {ml-pull}222[#222] (issue:{ml-issue}217[#217])
+the rule would decrease if they occurred frequently. {ml-pull}222[#222] (issue: {ml-issue}217[#217])
 
 Network::
 *  Support PKCS#11 tokens as keystores and truststores  {pull}34063[#34063] (issue: {issue}11[#11])


### PR DESCRIPTION
Fixes a broken link so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Will backport to 6.4.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="695" alt="Asciidoc Before" src="https://user-images.githubusercontent.com/40268737/58204656-be452d80-7caa-11e9-8a28-1618761ff8e5.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="691" alt="Asciidoc After" src="https://user-images.githubusercontent.com/40268737/58204663-c1d8b480-7caa-11e9-89b4-941d6df58535.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="688" alt="Asciidoctor Before" src="https://user-images.githubusercontent.com/40268737/58204673-c604d200-7caa-11e9-85fb-15809aa69f15.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="698" alt="Asciidoctor After" src="https://user-images.githubusercontent.com/40268737/58204680-cc934980-7caa-11e9-87aa-64ada89d383c.png">
</details>