### PR TITLE
[DOCS] Escape cross-ref link comma for Asciidoctor

### DIFF
--- a/docs/reference/rollup/rollup-api.asciidoc
+++ b/docs/reference/rollup/rollup-api.asciidoc
@@ -9,7 +9,7 @@
 
 * <<rollup-put-job,Create Job>>, <<rollup-delete-job,Delete Job>>,
 * <<rollup-start-job,Start Job>>, <<rollup-stop-job,Stop Job>>,
-* <<rollup-get-job,Get Job, List all Jobs>>
+* <<rollup-get-job,Get Job+++,+++ List all Jobs>>
 * <<rollup-job-config,Job configuration details>>
 
 [float]


### PR DESCRIPTION
Escapes a comma in a cross-reference link so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Will backport to 6.4.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="112" alt="AsciiDoc Before" src="https://user-images.githubusercontent.com/40268737/58205409-71625680-7cac-11e9-8268-f1e2a9b5959c.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="180" alt="AsciiDoc After" src="https://user-images.githubusercontent.com/40268737/58205412-73c4b080-7cac-11e9-9818-7727a128df37.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="175" alt="Asciidoctor Before" src="https://user-images.githubusercontent.com/40268737/58205420-76bfa100-7cac-11e9-9ec4-4d81d89b40db.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="175" alt="Asciidoctor After" src="https://user-images.githubusercontent.com/40268737/58205424-79ba9180-7cac-11e9-967e-68636610833a.png">
</details>