### PR TITLE
[DOCS] Remove API Quick Reference rollup attribute for Asciidoctor

### DIFF
--- a/docs/reference/rollup/api-quickref.asciidoc
+++ b/docs/reference/rollup/api-quickref.asciidoc
@@ -5,7 +5,7 @@
 
 experimental[]
 
-Most {rollup} endpoints have the following base:
+Most rollup endpoints have the following base:
 
 [source,js]
 ----


### PR DESCRIPTION
Removes a missing attribute so a sentence renders consistently in AsciiDoc and Asciidoctor. Relates to elastic/docs#827.

Will backport to 6.4.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="757" alt="AsciiDoc - Before" src="https://user-images.githubusercontent.com/40268737/58206298-6dcfcf00-7cae-11e9-96ee-aa1e45503419.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="769" alt="AsciiDoc - After" src="https://user-images.githubusercontent.com/40268737/58206316-70cabf80-7cae-11e9-8060-477c03d95aed.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="768" alt="Asciidoctor - Before" src="https://user-images.githubusercontent.com/40268737/58206325-732d1980-7cae-11e9-9369-99eb4f68bb5e.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="762" alt="Asciidoctor - After" src="https://user-images.githubusercontent.com/40268737/58206331-758f7380-7cae-11e9-98be-3f3255b2570e.png">
</details>