### PR TITLE
[DOCS] Fix Moving Avg Aggregation `deprecated` macro for Asciidoctor

### DIFF
--- a/docs/reference/aggregations/pipeline/movavg-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/movavg-aggregation.asciidoc
@@ -1,9 +1,14 @@
 [[search-aggregations-pipeline-movavg-aggregation]]
 === Moving Average Aggregation
 
+ifdef::asciidoctor[]
+deprecated:[6.4.0, "The Moving Average aggregation has been deprecated in favor of the more general <<search-aggregations-pipeline-movfn-aggregation,Moving Function Aggregation>>.  The new Moving Function aggregation provides all the same functionality as the Moving Average aggregation, but also provides more flexibility."]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[6.4.0, The Moving Average aggregation has been deprecated in favor of the more general
 <<search-aggregations-pipeline-movfn-aggregation,Moving Function Aggregation>>.  The new Moving Function aggregation provides
 all the same functionality as the Moving Average aggregation, but also provides more flexibility.]
+endif::[]
 
 Given an ordered series of data, the Moving Average aggregation will slide a window across the data and emit the average
 value of that window.  For example, given the data `[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]`, we can calculate a simple moving


### PR DESCRIPTION
Fixes a `deprecated` macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Will backport to 6.4.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="450" alt="AsciiDoc Before" src="https://user-images.githubusercontent.com/40268737/58206998-d4a1b800-7caf-11e9-9cdf-89af5b92a281.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="450" alt="AsciiDoc After" src="https://user-images.githubusercontent.com/40268737/58207002-d66b7b80-7caf-11e9-81f2-7755db186a21.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="749" alt="Asciidoctor Before" src="https://user-images.githubusercontent.com/40268737/58207008-d8353f00-7caf-11e9-92cc-f73a64ee0b7e.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="428" alt="Asciidoctor After" src="https://user-images.githubusercontent.com/40268737/58207012-da979900-7caf-11e9-8ab0-cd551f58575e.png">
</details>