### PR TITLE
[DOCS] Fix Standard Token Filter `deprecated` macro for Asciidoctor

### DIFF
--- a/docs/reference/analysis/tokenfilters/standard-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/standard-tokenfilter.asciidoc
@@ -1,8 +1,13 @@
 [[analysis-standard-tokenfilter]]
 === Standard Token Filter
 
+ifdef::asciidoctor[]
+deprecated:[6.5.0, "This filter is deprecated and will be removed in the next major version."]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[6.5.0, This filter is deprecated and will be removed in the next
 major version.]
+endif::[]
 
 A token filter of type `standard` that normalizes tokens extracted with
 the <<analysis-standard-tokenizer,Standard Tokenizer>>.


### PR DESCRIPTION
Fixes a `deprecated` macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Will backport to 6.5.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="320" alt="AsciiDoc Before" src="https://user-images.githubusercontent.com/40268737/58207639-0ff0b680-7cb1-11e9-8297-48ca93dc362c.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="320" alt="AsciiDoc After" src="https://user-images.githubusercontent.com/40268737/58207647-12531080-7cb1-11e9-9a6f-41ac22cbef38.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="701" alt="Asciidoctor Before" src="https://user-images.githubusercontent.com/40268737/58207652-154e0100-7cb1-11e9-9573-958be9ec5fef.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="367" alt="Asciidoctor After" src="https://user-images.githubusercontent.com/40268737/58207656-1848f180-7cb1-11e9-9874-f35d8b064d8e.png">
</details>