### PR TITLE
[DOCS] Fix Context Suggester `deprecated` macro for Asciidoctor

### DIFF
--- a/docs/reference/search/suggesters/context-suggest.asciidoc
+++ b/docs/reference/search/suggesters/context-suggest.asciidoc
@@ -13,8 +13,13 @@ Every context mapping has a unique name and a type. There are two types: `catego
 and `geo`. Context mappings are configured under the `contexts` parameter in
 the field mapping.
 
+ifdef::asciidoctor[]
+deprecated:[6.4.0, "Indexing and querying without context on a context enabled completion field is deprecated and will be removed in the next major release."]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[6.4.0, Indexing and querying without context on a context enabled completion
 field is deprecated and will be removed in the next major release.]
+endif::[]
 
 The following defines types, each with two context mappings for a completion
 field:


### PR DESCRIPTION
Fixes a `deprecated` macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Will backport to 6.5.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="630" alt="AsciiDoc Before" src="https://user-images.githubusercontent.com/40268737/58208611-11bb7980-7cb3-11e9-8605-baf85582c7a5.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="630" alt="AsciiDoc After" src="https://user-images.githubusercontent.com/40268737/58208615-12eca680-7cb3-11e9-90c6-355db26224bc.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="760" alt="Asciidoctor Before" src="https://user-images.githubusercontent.com/40268737/58208625-16802d80-7cb3-11e9-8a48-49b76f4f3b8d.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="655" alt="Asciidoctor After" src="https://user-images.githubusercontent.com/40268737/58208652-2435b300-7cb3-11e9-997e-2a396a58f7ab.png">
</details>