### PR TITLE
[DOCS] Fix 6.50 RN placeholder syntax for Asciidoctor

### DIFF
--- a/docs/reference/release-notes/6.5.asciidoc
+++ b/docs/reference/release-notes/6.5.asciidoc
@@ -736,7 +736,7 @@ Recovery::
 Rollup::
 * [Rollup] Proactively resolve index patterns in RollupSearch endoint {pull}34930[#34930] (issue: {issue}34828[#34828])
 * Address BWC bug due to default metrics in (#34764) {pull}34810[#34810] (issue: {issue}34764[#34764])
-* Allowing {index}/_xpack/rollup/data to accept comma delimited list {pull}34115[#34115]
+* Allowing \{index\}/_xpack/rollup/data to accept comma delimited list {pull}34115[#34115]
 * [Rollup] Fix Caps Comparator to handle calendar/fixed time {pull}33336[#33336] (issue: {issue}32052[#32052])
 * [Rollup] Better error message when trying to set non-rollup index {pull}32965[#32965]
 * [Rollup] Return empty response when aggs are missing {pull}32796[#32796] (issue: {issue}32256[#32256])


### PR DESCRIPTION
Fixes some broken placeholder `{index}` syntax so it renders consistently in AsciiDoc and Asciidoctor. Relates to elastic/docs#827.

Will backport to 6.6.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="620" alt="AsciiDoc Before" src="https://user-images.githubusercontent.com/40268737/58209437-184af080-7cb5-11e9-9247-5859ffe56fc7.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="613" alt="AsciiDoc After" src="https://user-images.githubusercontent.com/40268737/58209452-1b45e100-7cb5-11e9-9b59-9e512a17cdd5.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="613" alt="Asciidoctor Before" src="https://user-images.githubusercontent.com/40268737/58209453-1da83b00-7cb5-11e9-9e64-54ed10268f2c.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="618" alt="Asciidoctor After" src="https://user-images.githubusercontent.com/40268737/58209471-213bc200-7cb5-11e9-88f3-7cf767df8439.png">
</details>