### PR TITLE
[DOCS] Fix Audit Security Settings `deprecated` macros for Asciidoctor

### DIFF
--- a/docs/reference/settings/audit-settings.asciidoc
+++ b/docs/reference/settings/audit-settings.asciidoc
@@ -22,11 +22,17 @@ file named `<clustername>_audit.log` on each node.
 +
 You can also specify `index`, which puts the auditing events in an {es} index
 that is prefixed with `.security_audit_log`. The index can reside on the same
-cluster or a separate cluster. deprecated[6.7.0, The outputs setting will be
+cluster or a separate cluster. 
+ifdef::asciidoctor[]
+deprecated:[6.7.0, "The outputs setting will be removed in 7.0 as there will only be one supported output type (`logfile`). Users who wish to store their audit information in an Elasticsearch index should write to the log file output, and a use a file ingestion component to index it into Elasticsearch."]
+endif::[]
+ifndef::asciidoctor[]
+deprecated[6.7.0, The outputs setting will be
 removed in 7.0 as there will only be one supported output type (`logfile`).
 Users who wish to store their audit information in an Elasticsearch index
 should write to the log file output, and a use a file ingestion component to
 index it into Elasticsearch.]
+endif::[]
 +
 For backwards compatibility reasons, if you use the logfile output type, a
 `<clustername>_access.log` file is also created. It contains the same
@@ -123,8 +129,13 @@ these values. If the event concerns several indices, some of which are
 
 [[index-audit-settings]]
 ==== Audit Log Indexing Configuration Settings
+ifdef::asciidoctor[]
+deprecated:[6.7.0, "`xpack.security.audit.index` settings namespace refers to the `index` audit output type which is deprecated and will be removed in 7.0"]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[6.7.0, `xpack.security.audit.index` settings namespace refers to the
 `index` audit output type which is deprecated and will be removed in 7.0]
+endif::[]
 
 `xpack.security.audit.index.bulk_size`::
 Controls how many audit events are batched into a single write. The default
@@ -178,8 +189,13 @@ even if they are unspecified (i.e. left to defaults).
 
 [[remote-audit-settings]]
 ==== Remote Audit Log Indexing Configuration Settings
+ifdef::asciidoctor[]
+deprecated:[6.7.0, "`xpack.security.audit.index` settings namespace refers to the `index` audit output type which is deprecated and will be removed in 7.0"]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[6.7.0, `xpack.security.audit.index` settings namespace refers to the
 `index` audit output type which is deprecated and will be removed in 7.0]
+endif::[]
 
 To index audit events to a remote {es} cluster, you configure the following
 `xpack.security.audit.index.client` settings:


### PR DESCRIPTION
Fixes a few `deprecated` macros so they render properly in Asciidoctor. Relates to elastic/docs#827.

Will backport to 6.7.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="707" alt="AsiiDoc Before A" src="https://user-images.githubusercontent.com/40268737/58210340-269a0c00-7cb7-11e9-9bae-fe69e3905c67.png">
<img width="538" alt="AsiiDoc Before B" src="https://user-images.githubusercontent.com/40268737/58210345-28fc6600-7cb7-11e9-91d8-7c088c1ab7fd.png">
<img width="621" alt="AsiiDoc Before C" src="https://user-images.githubusercontent.com/40268737/58210350-2a2d9300-7cb7-11e9-985c-ff74ac0b85d0.png">

</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="707" alt="AsiiDoc After A" src="https://user-images.githubusercontent.com/40268737/58210356-30237400-7cb7-11e9-9ec8-5f375b689078.png">
<img width="538" alt="AsiiDoc After B" src="https://user-images.githubusercontent.com/40268737/58210357-31ed3780-7cb7-11e9-9b1c-a430a1d46b78.png">
<img width="621" alt="AsiiDoc After C" src="https://user-images.githubusercontent.com/40268737/58210360-331e6480-7cb7-11e9-8a8b-16e85678adc5.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="714" alt="Asciidoctor Before A" src="https://user-images.githubusercontent.com/40268737/58210375-3a457280-7cb7-11e9-8844-53abbe8fcd39.png">
<img width="723" alt="Asciidoctor Before B" src="https://user-images.githubusercontent.com/40268737/58210379-3c0f3600-7cb7-11e9-9394-ec1dec918b73.png">
<img width="722" alt="Asciidoctor Before C" src="https://user-images.githubusercontent.com/40268737/58210384-3dd8f980-7cb7-11e9-9a20-32cc4b113e2c.png">

</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="705" alt="Asciidoctor After A" src="https://user-images.githubusercontent.com/40268737/58210389-43ceda80-7cb7-11e9-81f9-f37a3fb2ea6f.png">
<img width="515" alt="Asciidoctor After B" src="https://user-images.githubusercontent.com/40268737/58210395-45989e00-7cb7-11e9-8e8a-0188187a6f23.png">
<img width="632" alt="Asciidoctor After C" src="https://user-images.githubusercontent.com/40268737/58210397-47faf800-7cb7-11e9-82f1-06354d22a1f7.png">
</details>