### PR TITLE
Drop the number of default iterations in AbstractQueryTestCase to 1

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
@@ -81,7 +81,7 @@ import static org.hamcrest.Matchers.instanceOf;
 
 public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>> extends AbstractBuilderTestCase {
 
-    private static final int NUMBER_OF_TESTQUERIES = 20;
+    private static final int NUMBER_OF_TESTQUERIES = 1;
 
     public final QB createTestQueryBuilder() {
         return createTestQueryBuilder(supportsBoost(), supportsQueryName());


### PR DESCRIPTION
As discussed in https://github.com/elastic/elasticsearch/pull/40362#discussion_r272630000,
given the number of runs our randomized CI does there is very little point in having multiple
iterations within individual tests.  This commit drops the default number of iterations in
AbstractQueryTestCase to 1, while leaving the loops in-place for development purposes.