### PR TITLE
[DOCS] Fix `internal` `deprecated` macro for Asciidoctor

### DIFF
--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -389,7 +389,12 @@ the different version types and their semantics.
 
 `internal`:: Only index the document if the given version is identical to the version
 of the stored document.
+ifdef::asciidoctor[]
+deprecated:[6.7.0, "Please use `if_seq_no` & `if_primary_term` instead. See <<optimistic-concurrency-control>> for more details."]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[6.7.0, Please use `if_seq_no` & `if_primary_term` instead. See <<optimistic-concurrency-control>> for more details.]
+endif::[]
 
 
 `external` or `external_gt`:: Only index the document if the given version is strictly higher


### PR DESCRIPTION
Fixes a `deprecated` macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Will backport to 6.7.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="761" alt="AsciiDoc Before" src="https://user-images.githubusercontent.com/40268737/58253255-0198ae00-7d36-11e9-879c-067bcf19b398.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="761" alt="AsciiDoc After" src="https://user-images.githubusercontent.com/40268737/58253263-05c4cb80-7d36-11e9-9c91-6aade9101927.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="734" alt="Asciidoctor Before" src="https://user-images.githubusercontent.com/40268737/58253269-09f0e900-7d36-11e9-8bb9-cf9522a7af7d.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="764" alt="Asciidoctor After" src="https://user-images.githubusercontent.com/40268737/58253277-0d847000-7d36-11e9-95e3-ad5d438c487c.png">
</details>