### PR TITLE
[DOCS] Fix `version` `deprecated` macro for Asciidoctor

### DIFF
--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -340,8 +340,12 @@ The update API uses the Elasticsearch versioning support internally to make
 sure the document doesn't change during the update. You can use the `version`
 parameter to specify that the document should only be updated if its version
 matches the one specified.
+ifdef::asciidoctor[]
+deprecated:[6.7.0, "Please use `if_seq_no` & `if_primary_term` instead. See <<optimistic-concurrency-control>> for more details."]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[6.7.0, Please use `if_seq_no` & `if_primary_term` instead. See <<optimistic-concurrency-control>> for more details.]
-
+endif::[]
 
 [NOTE]
 .The update API does not support versioning other than internal


### PR DESCRIPTION
Fixes a `deprecated` macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Will backport to 6.7.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="763" alt="AsciiDoc Before" src="https://user-images.githubusercontent.com/40268737/58253590-cfd41700-7d36-11e9-93fb-6d7f15bb6eaf.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="763" alt="AsciiDoc After" src="https://user-images.githubusercontent.com/40268737/58253596-d2cf0780-7d36-11e9-8cb3-f52280fbcad9.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="760" alt="Asciidoctor Before" src="https://user-images.githubusercontent.com/40268737/58253599-d5c9f800-7d36-11e9-9801-82472a2fefee.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="764" alt="Asciidoctor After" src="https://user-images.githubusercontent.com/40268737/58253609-d8c4e880-7d36-11e9-9a86-9a519dc8e1a3.png">
</details>