### PR TITLE
[DOCS] Fix Migration Assistance API `deprecated` macro for Asciidoctor

### DIFF
--- a/docs/reference/migration/apis/assistance.asciidoc
+++ b/docs/reference/migration/apis/assistance.asciidoc
@@ -10,8 +10,14 @@ IMPORTANT: The Migration Assistance API is deprecated, use the
 <<migration-api-deprecation,deprecation info API>> instead, which provides more
 complete and detailed information about actions necessary prior to upgrade.
 
+ifdef::asciidoctor[]
+deprecated:[6.7, "Use the <<migration-api-deprecation,Deprecation Info API>> instead."]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[6.7, Use the <<migration-api-deprecation,Deprecation Info API>>
-instead.] The migration assistance API analyzes existing indices in the cluster
+instead.] 
+endif::[]
+The migration assistance API analyzes existing indices in the cluster
 and returns the information about indices that require some changes before the
 cluster can be upgraded to the next major version.
 


### PR DESCRIPTION
Fixes a `deprecated` macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Will backport to 6.7.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="767" alt="AsciiDoc Before" src="https://user-images.githubusercontent.com/40268737/58253956-af588c80-7d37-11e9-9e2d-cf51769dfc6a.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="767" alt="AsciiDoc After" src="https://user-images.githubusercontent.com/40268737/58253961-b2ec1380-7d37-11e9-9cad-25bd0f3bb764.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="753" alt="Asciidoctor Before" src="https://user-images.githubusercontent.com/40268737/58253964-b54e6d80-7d37-11e9-89d4-cf8935e5a504.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="767" alt="Asciidoctor After" src="https://user-images.githubusercontent.com/40268737/58253970-b97a8b00-7d37-11e9-8a57-86515391836b.png">
</details>