### PR TITLE
[DOCS] Fix TLS/SSL `deprecated` macros for Asciidoctor

### DIFF
--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1253,9 +1253,14 @@ through the list of URLs will continue until a successful connection is made.
 [[ssl-tls-settings]]
 ==== Default TLS/SSL settings
 
+ifdef::asciidoctor[]
+deprecated:[6.7.0, "fallback to the default TLS/SSL settings is deprecated as it leads to ambiguity in what configuration is used. Fully configure each components' TLS/SSL settings as the default settings will be removed in 7.0"]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[6.7.0, fallback to the default TLS/SSL settings is deprecated as it
 leads to ambiguity in what configuration is used. Fully configure each components'
 TLS/SSL settings as the default settings will be removed in 7.0]
+endif::[]
 
 You can configure the following TLS/SSL settings in
 `elasticsearch.yml`. For more information, see

--- a/docs/reference/settings/ssl-settings.asciidoc
+++ b/docs/reference/settings/ssl-settings.asciidoc
@@ -1,9 +1,14 @@
 
 ==== {component} TLS/SSL Settings
 ifeval::["{component}"=="Auditing"]
+ifdef::asciidoctor[]
+deprecated:[6.7.0, "These settings configure the client used by the index audit output type which is deprecated and will be removed in 7.0. All the settings under the `xpack.security.audit.index` namespace are deprecated."]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[6.7.0, These settings configure the client used by the index audit
 output type which is deprecated and will be removed in 7.0. All the settings
 under the `xpack.security.audit.index` namespace are deprecated.]
+endif::[]
 endif::[]
 
 You can configure the following TLS/SSL settings. If the settings are not configured,


### PR DESCRIPTION
Fixes a few `deprecated` macros so they render properly in Asciidoctor. Relates to elastic/docs#827.

Will backport to 6.7.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="277" alt="AsciiDoc Before A" src="https://user-images.githubusercontent.com/40268737/58259410-75d94e80-7d42-11e9-842a-18febabbbc92.png">
<img width="340" alt="AsciiDoc Before B" src="https://user-images.githubusercontent.com/40268737/58259411-75d94e80-7d42-11e9-8f91-023eea42d081.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="277" alt="AsciiDoc After A" src="https://user-images.githubusercontent.com/40268737/58259416-796cd580-7d42-11e9-8d74-ad9a1f4c4c61.png">
<img width="340" alt="AsciiDoc After B" src="https://user-images.githubusercontent.com/40268737/58259418-7a056c00-7d42-11e9-819a-0d511efc27c8.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="775" alt="Asciidoctor Before A" src="https://user-images.githubusercontent.com/40268737/58259427-7eca2000-7d42-11e9-943f-0dfb442a46eb.png">
<img width="780" alt="Asciidoctor Before B" src="https://user-images.githubusercontent.com/40268737/58259428-7eca2000-7d42-11e9-9d7f-18b583ab5a99.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="258" alt="Asciidoctor After A" src="https://user-images.githubusercontent.com/40268737/58259439-838ed400-7d42-11e9-91d1-c0616ed4e011.png">
<img width="321" alt="Asciidoctor After B" src="https://user-images.githubusercontent.com/40268737/58259440-838ed400-7d42-11e9-9377-5c925759fd96.png">
</details>