### PR TITLE
[DOCS] Fix X-Pack tags for Asciidoctor

### DIFF
--- a/docs/reference/ccr/apis/follow-request-body.asciidoc
+++ b/docs/reference/ccr/apis/follow-request-body.asciidoc
@@ -1,3 +1,5 @@
+// [role="xpack"]
+// [testenv="platinum"]
 `max_read_request_operation_count`::
   (integer) the maximum number of operations to pull per read from the remote
   cluster

--- a/docs/reference/ccr/apis/follow-request-body.asciidoc
+++ b/docs/reference/ccr/apis/follow-request-body.asciidoc
@@ -1,5 +1,4 @@
-// [role="xpack"]
-// [testenv="platinum"]
+[testenv="platinum"]
 `max_read_request_operation_count`::
   (integer) the maximum number of operations to pull per read from the remote
   cluster

--- a/docs/reference/ccr/apis/follow-request-body.asciidoc
+++ b/docs/reference/ccr/apis/follow-request-body.asciidoc
@@ -1,5 +1,3 @@
-[role="xpack"]
-[testenv="platinum"]
 `max_read_request_operation_count`::
   (integer) the maximum number of operations to pull per read from the remote
   cluster


### PR DESCRIPTION
Removes a few X-Pack tags from an included so it renders consistenyl in AsciiDoc and Asciidoctor. Relates to elastic/docs#827.

Will backport to 6.7.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="758" alt="AsciiDoc Before" src="https://user-images.githubusercontent.com/40268737/58260246-1f6d0f80-7d44-11e9-9ae8-ea33cd75f073.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="770" alt="AsciiDoc After" src="https://user-images.githubusercontent.com/40268737/58260464-7e328900-7d44-11e9-888d-6171c95451ad.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="769" alt="Asciidoctor Before" src="https://user-images.githubusercontent.com/40268737/58260263-2562f080-7d44-11e9-8bd9-0ee24a0cd6db.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="766" alt="Asciidoctor After" src="https://user-images.githubusercontent.com/40268737/58260272-28f67780-7d44-11e9-96ca-43813d125ced.png">
</details>