### PR TITLE
Split document and metadata fields in GetResult (#38373)

### DIFF
--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateQueryBuilderTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateQueryBuilderTests.java
@@ -153,12 +153,12 @@ public class PercolateQueryBuilderTests extends AbstractQueryTestCase<PercolateQ
         if (indexedDocumentExists) {
             return new GetResponse(
                     new GetResult(indexedDocumentIndex, MapperService.SINGLE_MAPPING_NAME, indexedDocumentId, 0, 1, 0L, true,
-                            documentSource.iterator().next(), Collections.emptyMap())
+                            documentSource.iterator().next(), Collections.emptyMap(), Collections.emptyMap())
             );
         } else {
             return new GetResponse(
                     new GetResult(indexedDocumentIndex, MapperService.SINGLE_MAPPING_NAME, indexedDocumentId, UNASSIGNED_SEQ_NO, 0, -1,
-                        false, null, Collections.emptyMap())
+                        false, null, Collections.emptyMap(), Collections.emptyMap())
             );
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -306,7 +306,7 @@ public class UpdateHelper {
 
         // TODO when using delete/none, we can still return the source as bytes by generating it (using the sourceContentType)
         return new GetResult(concreteIndex, request.type(), request.id(), seqNo, primaryTerm, version, true, sourceFilteredAsBytes,
-            Collections.emptyMap());
+            Collections.emptyMap(), Collections.emptyMap());
     }
 
     public static class Result {

--- a/server/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
@@ -164,7 +164,8 @@ public class UpdateResponse extends DocWriteResponse {
             if (getResult != null) {
                 update.setGetResult(new GetResult(update.getIndex(), update.getType(), update.getId(),
                     getResult.getSeqNo(), getResult.getPrimaryTerm(), update.getVersion(),
-                    getResult.isExists(), getResult.internalSourceRef(), getResult.getFields()));
+                    getResult.isExists(), getResult.internalSourceRef(), getResult.getDocumentFields(),
+                    getResult.getMetadataFields()));
             }
             update.setForcedRefresh(forcedRefresh);
             return update;

--- a/server/src/main/java/org/elasticsearch/index/get/GetResult.java
+++ b/server/src/main/java/org/elasticsearch/index/get/GetResult.java
@@ -37,11 +37,9 @@ import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -68,7 +66,8 @@ public class GetResult implements Streamable, Iterable<DocumentField>, ToXConten
     private long seqNo;
     private long primaryTerm;
     private boolean exists;
-    private Map<String, DocumentField> fields;
+    private Map<String, DocumentField> documentFields;
+    private Map<String, DocumentField> metaFields;
     private Map<String, Object> sourceAsMap;
     private BytesReference source;
     private byte[] sourceAsBytes;
@@ -77,7 +76,7 @@ public class GetResult implements Streamable, Iterable<DocumentField>, ToXConten
     }
 
     public GetResult(String index, String type, String id, long seqNo, long primaryTerm, long version, boolean exists,
-                     BytesReference source, Map<String, DocumentField> fields) {
+                     BytesReference source, Map<String, DocumentField> documentFields, Map<String, DocumentField> metaFields) {
         this.index = index;
         this.type = type;
         this.id = id;
@@ -90,9 +89,13 @@ public class GetResult implements Streamable, Iterable<DocumentField>, ToXConten
         this.version = version;
         this.exists = exists;
         this.source = source;
-        this.fields = fields;
-        if (this.fields == null) {
-            this.fields = emptyMap();
+        this.documentFields = documentFields;
+        if (this.documentFields == null) {
+            this.documentFields = emptyMap();
+        }
+        this.metaFields = metaFields;
+        if (this.metaFields == null) {
+            this.metaFields = emptyMap();
         }
     }
 
@@ -223,20 +226,31 @@ public class GetResult implements Streamable, Iterable<DocumentField>, ToXConten
         return sourceAsMap();
     }
 
+
+    public Map<String, DocumentField> getMetadataFields() {
+        return metaFields;
+    }
+
+    public Map<String, DocumentField> getDocumentFields() {
+        return documentFields;
+    }
+
     public Map<String, DocumentField> getFields() {
+        Map<String, DocumentField> fields = new HashMap<>();
+        fields.putAll(metaFields);
+        fields.putAll(documentFields);
         return fields;
     }
 
     public DocumentField field(String name) {
-        return fields.get(name);
+        return getFields().get(name);
     }
 
     @Override
     public Iterator<DocumentField> iterator() {
-        if (fields == null) {
-            return Collections.emptyIterator();
-        }
-        return fields.values().iterator();
+        // need to join the fields and metadata fields
+        Map<String, DocumentField> allFields = this.getFields();
+        return allFields.values().iterator();
     }
 
     public XContentBuilder toXContentEmbedded(XContentBuilder builder, Params params) throws IOException {
@@ -245,21 +259,7 @@ public class GetResult implements Streamable, Iterable<DocumentField>, ToXConten
             builder.field(_PRIMARY_TERM, primaryTerm);
         }
 
-        List<DocumentField> metaFields = new ArrayList<>();
-        List<DocumentField> otherFields = new ArrayList<>();
-        if (fields != null && !fields.isEmpty()) {
-            for (DocumentField field : fields.values()) {
-                if (field.getValues().isEmpty()) {
-                    continue;
-                }
-                if (field.isMetadataField()) {
-                    metaFields.add(field);
-                } else {
-                    otherFields.add(field);
-                }
-            }
-        }
-        for (DocumentField field : metaFields) {
+        for (DocumentField field : metaFields.values()) {
             // TODO: can we avoid having an exception here?
             if (field.getName().equals(IgnoredFieldMapper.NAME)) {
                 builder.field(field.getName(), field.getValues());
@@ -274,9 +274,9 @@ public class GetResult implements Streamable, Iterable<DocumentField>, ToXConten
             XContentHelper.writeRawField(SourceFieldMapper.NAME, source, builder, params);
         }
 
-        if (!otherFields.isEmpty()) {
+        if (!documentFields.isEmpty()) {
             builder.startObject(FIELDS);
-            for (DocumentField field : otherFields) {
+            for (DocumentField field : documentFields.values()) {
                 field.toXContent(builder, params);
             }
             builder.endObject();
@@ -318,7 +318,8 @@ public class GetResult implements Streamable, Iterable<DocumentField>, ToXConten
         long primaryTerm = UNASSIGNED_PRIMARY_TERM;
         Boolean found = null;
         BytesReference source = null;
-        Map<String, DocumentField> fields = new HashMap<>();
+        Map<String, DocumentField> documentFields = new HashMap<>();
+        Map<String, DocumentField> metaFields = new HashMap<>();
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
@@ -338,7 +339,8 @@ public class GetResult implements Streamable, Iterable<DocumentField>, ToXConten
                 } else if (FOUND.equals(currentFieldName)) {
                     found = parser.booleanValue();
                 } else {
-                    fields.put(currentFieldName, new DocumentField(currentFieldName, Collections.singletonList(parser.objectText())));
+                    metaFields.put(currentFieldName, new DocumentField(currentFieldName, 
+                            Collections.singletonList(parser.objectText())));
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if (SourceFieldMapper.NAME.equals(currentFieldName)) {
@@ -351,20 +353,20 @@ public class GetResult implements Streamable, Iterable<DocumentField>, ToXConten
                 } else if (FIELDS.equals(currentFieldName)) {
                     while(parser.nextToken() != XContentParser.Token.END_OBJECT) {
                         DocumentField getField = DocumentField.fromXContent(parser);
-                        fields.put(getField.getName(), getField);
+                        documentFields.put(getField.getName(), getField);
                     }
                 } else {
                     parser.skipChildren(); // skip potential inner objects for forward compatibility
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if (IgnoredFieldMapper.NAME.equals(currentFieldName)) {
-                    fields.put(currentFieldName, new DocumentField(currentFieldName, parser.list()));
+                    metaFields.put(currentFieldName, new DocumentField(currentFieldName, parser.list()));
                 } else {
                     parser.skipChildren(); // skip potential inner arrays for forward compatibility
                 }
             }
         }
-        return new GetResult(index, type, id, seqNo, primaryTerm, version, found, source, fields);
+        return new GetResult(index, type, id, seqNo, primaryTerm, version, found, source, documentFields, metaFields);
     }
 
     public static GetResult fromXContent(XContentParser parser) throws IOException {
@@ -380,6 +382,35 @@ public class GetResult implements Streamable, Iterable<DocumentField>, ToXConten
         return result;
     }
 
+    private Map<String, DocumentField> readFields(StreamInput in) throws IOException {
+        Map<String, DocumentField> fields = null;
+        int size = in.readVInt();
+        if (size == 0) {
+            fields = new HashMap<>();
+        } else {
+            fields = new HashMap<>(size);
+            for (int i = 0; i < size; i++) {
+                DocumentField field = DocumentField.readDocumentField(in);
+                fields.put(field.getName(), field);
+            }
+        }
+        return fields;
+    }
+    
+    static void splitFieldsByMetadata(Map<String, DocumentField> fields, Map<String, DocumentField> outOther,
+                                       Map<String, DocumentField> outMetadata) {
+        if (fields == null) {
+            return;
+        }
+        for (Map.Entry<String, DocumentField> fieldEntry: fields.entrySet()) {
+            if (fieldEntry.getValue().isMetadataField()) {
+                outMetadata.put(fieldEntry.getKey(), fieldEntry.getValue());
+            } else {
+                outOther.put(fieldEntry.getKey(), fieldEntry.getValue());                
+            }
+        }
+    }
+    
     @Override
     public void readFrom(StreamInput in) throws IOException {
         index = in.readString();
@@ -399,15 +430,14 @@ public class GetResult implements Streamable, Iterable<DocumentField>, ToXConten
             if (source.length() == 0) {
                 source = null;
             }
-            int size = in.readVInt();
-            if (size == 0) {
-                fields = emptyMap();
+            if (in.getVersion().onOrAfter(Version.V_7_3_0)) {
+                documentFields = readFields(in);
+                metaFields = readFields(in);            
             } else {
-                fields = new HashMap<>(size);
-                for (int i = 0; i < size; i++) {
-                    DocumentField field = DocumentField.readDocumentField(in);
-                    fields.put(field.getName(), field);
-                }
+                Map<String, DocumentField> fields = readFields(in);
+                documentFields = new HashMap<>();
+                metaFields = new HashMap<>();
+                splitFieldsByMetadata(fields, documentFields, metaFields);
             }
         }
     }
@@ -425,13 +455,22 @@ public class GetResult implements Streamable, Iterable<DocumentField>, ToXConten
         out.writeBoolean(exists);
         if (exists) {
             out.writeBytesReference(source);
-            if (fields == null) {
-                out.writeVInt(0);
+            if (out.getVersion().onOrAfter(Version.V_7_3_0)) {
+                writeFields(out, documentFields);
+                writeFields(out, metaFields);
             } else {
-                out.writeVInt(fields.size());
-                for (DocumentField field : fields.values()) {
-                    field.writeTo(out);
-                }
+                writeFields(out, this.getFields());                
+            }
+        }
+    }
+    
+    private void writeFields(StreamOutput out,  Map<String, DocumentField> fields) throws IOException {
+        if (fields == null) {
+            out.writeVInt(0);
+        } else {
+            out.writeVInt(fields.size());
+            for (DocumentField field : fields.values()) {
+                field.writeTo(out);
             }
         }
     }
@@ -452,13 +491,14 @@ public class GetResult implements Streamable, Iterable<DocumentField>, ToXConten
                 Objects.equals(index, getResult.index) &&
                 Objects.equals(type, getResult.type) &&
                 Objects.equals(id, getResult.id) &&
-                Objects.equals(fields, getResult.fields) &&
+                Objects.equals(documentFields, getResult.documentFields) &&
+                Objects.equals(metaFields, getResult.metaFields) &&
                 Objects.equals(sourceAsMap(), getResult.sourceAsMap());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(version, seqNo, primaryTerm, exists, index, type, id, fields, sourceAsMap());
+        return Objects.hash(version, seqNo, primaryTerm, exists, index, type, id, documentFields, metaFields, sourceAsMap());
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/explain/ExplainResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/explain/ExplainResponseTests.java
@@ -70,7 +70,7 @@ public class ExplainResponseTests extends AbstractSerializingTestCase<ExplainRes
             0, 1, randomNonNegativeLong(),
             true,
             RandomObjects.randomSource(random()),
-            singletonMap(fieldName, new DocumentField(fieldName, values)));
+            singletonMap(fieldName, new DocumentField(fieldName, values)), null);
         return new ExplainResponse(index, type, id, exist, explanation, getResult);
     }
 
@@ -87,7 +87,7 @@ public class ExplainResponseTests extends AbstractSerializingTestCase<ExplainRes
         Explanation explanation = Explanation.match(1.0f, "description", Collections.emptySet());
         GetResult getResult = new GetResult(null, null, null, 0, 1, -1, true, new BytesArray("{ \"field1\" : " +
             "\"value1\", \"field2\":\"value2\"}"), singletonMap("field1", new DocumentField("field1",
-            singletonList("value1"))));
+            singletonList("value1"))), null);
         ExplainResponse response = new ExplainResponse(index, type, id, exist, explanation, getResult);
 
         XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);

--- a/server/src/test/java/org/elasticsearch/action/get/GetResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/get/GetResponseTests.java
@@ -94,14 +94,15 @@ public class GetResponseTests extends ESTestCase {
         {
             GetResponse getResponse = new GetResponse(new GetResult("index", "type", "id", 0, 1, 1, true, new BytesArray("{ \"field1\" : " +
                     "\"value1\", \"field2\":\"value2\"}"), Collections.singletonMap("field1", new DocumentField("field1",
-                    Collections.singletonList("value1")))));
+                    Collections.singletonList("value1"))), null));
             String output = Strings.toString(getResponse);
             assertEquals("{\"_index\":\"index\",\"_type\":\"type\",\"_id\":\"id\",\"_version\":1,\"_seq_no\":0,\"_primary_term\":1," +
                 "\"found\":true,\"_source\":{ \"field1\" : \"value1\", \"field2\":\"value2\"},\"fields\":{\"field1\":[\"value1\"]}}",
                 output);
         }
         {
-            GetResponse getResponse = new GetResponse(new GetResult("index", "type", "id", UNASSIGNED_SEQ_NO, 0, 1, false, null, null));
+            GetResponse getResponse = new GetResponse(new GetResult("index", "type", "id", UNASSIGNED_SEQ_NO,
+                0, 1, false, null, null, null));
             String output = Strings.toString(getResponse);
             assertEquals("{\"_index\":\"index\",\"_type\":\"type\",\"_id\":\"id\",\"found\":false}", output);
         }
@@ -110,7 +111,7 @@ public class GetResponseTests extends ESTestCase {
     public void testToString() {
         GetResponse getResponse = new GetResponse(new GetResult("index", "type", "id", 0, 1, 1, true,
                     new BytesArray("{ \"field1\" : " + "\"value1\", \"field2\":\"value2\"}"),
-                        Collections.singletonMap("field1", new DocumentField("field1", Collections.singletonList("value1")))));
+                        Collections.singletonMap("field1", new DocumentField("field1", Collections.singletonList("value1"))), null));
         assertEquals("{\"_index\":\"index\",\"_type\":\"type\",\"_id\":\"id\",\"_version\":1,\"_seq_no\":0,\"_primary_term\":1," +
             "\"found\":true,\"_source\":{ \"field1\" : \"value1\", \"field2\":\"value2\"},\"fields\":{\"field1\":[\"value1\"]}}",
             getResponse.toString());
@@ -123,7 +124,8 @@ public class GetResponseTests extends ESTestCase {
 
     public void testFromXContentThrowsParsingException() throws IOException {
         GetResponse getResponse =
-            new GetResponse(new GetResult(null, null, null, UNASSIGNED_SEQ_NO, 0, randomIntBetween(1, 5), randomBoolean(), null, null));
+            new GetResponse(new GetResult(null, null, null, UNASSIGNED_SEQ_NO, 0, randomIntBetween(1, 5),
+                randomBoolean(), null, null, null));
 
         XContentType xContentType = randomFrom(XContentType.values());
         BytesReference originalBytes = toShuffledXContent(getResponse, xContentType, ToXContent.EMPTY_PARAMS, randomBoolean());

--- a/server/src/test/java/org/elasticsearch/action/get/MultiGetResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/get/MultiGetResponseTests.java
@@ -71,7 +71,7 @@ public class MultiGetResponseTests extends ESTestCase {
             if (randomBoolean()) {
                 items[i] = new MultiGetItemResponse(new GetResponse(new GetResult(
                         randomAlphaOfLength(4), randomAlphaOfLength(4), randomAlphaOfLength(4), 0, 1, randomNonNegativeLong(),
-                        true, null, null
+                        true, null, null, null
                 )), null);
             } else {
                 items[i] = new MultiGetItemResponse(null, new MultiGetResponse.Failure(randomAlphaOfLength(4),

--- a/server/src/test/java/org/elasticsearch/action/update/UpdateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/update/UpdateRequestTests.java
@@ -359,7 +359,7 @@ public class UpdateRequestTests extends ESTestCase {
                 .scriptedUpsert(true);
             long nowInMillis = randomNonNegativeLong();
             // We simulate that the document is not existing yet
-            GetResult getResult = new GetResult("test", "type1", "2", UNASSIGNED_SEQ_NO, 0, 0, false, null, null);
+            GetResult getResult = new GetResult("test", "type1", "2", UNASSIGNED_SEQ_NO, 0, 0, false, null, null, null);
             UpdateHelper.Result result = updateHelper.prepare(new ShardId("test", "_na_", 0), updateRequest, getResult, () -> nowInMillis);
             Streamable action = result.action();
             assertThat(action, instanceOf(IndexRequest.class));
@@ -372,7 +372,7 @@ public class UpdateRequestTests extends ESTestCase {
                 .script(mockInlineScript("ctx._timestamp = ctx._now"))
                 .scriptedUpsert(true);
             // We simulate that the document is not existing yet
-            GetResult getResult = new GetResult("test", "type1", "2", 0, 1, 0, true, new BytesArray("{}"), null);
+            GetResult getResult = new GetResult("test", "type1", "2", 0, 1, 0, true, new BytesArray("{}"), null, null);
             UpdateHelper.Result result = updateHelper.prepare(new ShardId("test", "_na_", 0), updateRequest, getResult, () -> 42L);
             Streamable action = result.action();
             assertThat(action, instanceOf(IndexRequest.class));
@@ -381,7 +381,7 @@ public class UpdateRequestTests extends ESTestCase {
 
     public void testIndexTimeout() {
         final GetResult getResult =
-                new GetResult("test", "type", "1", 0, 1, 0, true, new BytesArray("{\"f\":\"v\"}"), null);
+                new GetResult("test", "type", "1", 0, 1, 0, true, new BytesArray("{\"f\":\"v\"}"), null, null);
         final UpdateRequest updateRequest =
                 new UpdateRequest("test", "type", "1")
                         .script(mockInlineScript("return"))
@@ -391,7 +391,7 @@ public class UpdateRequestTests extends ESTestCase {
 
     public void testDeleteTimeout() {
         final GetResult getResult =
-                new GetResult("test", "type", "1", 0, 1, 0, true, new BytesArray("{\"f\":\"v\"}"), null);
+                new GetResult("test", "type", "1", 0, 1, 0, true, new BytesArray("{\"f\":\"v\"}"), null, null);
         final UpdateRequest updateRequest =
                 new UpdateRequest("test", "type", "1")
                         .script(mockInlineScript("ctx.op = delete"))
@@ -402,7 +402,7 @@ public class UpdateRequestTests extends ESTestCase {
     public void testUpsertTimeout() throws IOException {
         final boolean exists = randomBoolean();
         final BytesReference source = exists ? new BytesArray("{\"f\":\"v\"}") : null;
-        final GetResult getResult = new GetResult("test", "type", "1", UNASSIGNED_SEQ_NO, 0, 0, exists, source, null);
+        final GetResult getResult = new GetResult("test", "type", "1", UNASSIGNED_SEQ_NO, 0, 0, exists, source, null, null);
         final XContentBuilder sourceBuilder = jsonBuilder();
         sourceBuilder.startObject();
         {
@@ -546,7 +546,7 @@ public class UpdateRequestTests extends ESTestCase {
     }
 
     public void testRoutingExtraction() throws Exception {
-        GetResult getResult = new GetResult("test", "type", "1", UNASSIGNED_SEQ_NO, 0, 0, false, null, null);
+        GetResult getResult = new GetResult("test", "type", "1", UNASSIGNED_SEQ_NO, 0, 0, false, null, null, null);
         IndexRequest indexRequest = new IndexRequest("test", "type", "1");
 
         // There is no routing and parent because the document doesn't exist
@@ -556,7 +556,7 @@ public class UpdateRequestTests extends ESTestCase {
         assertNull(UpdateHelper.calculateRouting(getResult, indexRequest));
 
         // Doc exists but has no source or fields
-        getResult = new GetResult("test", "type", "1", 0, 1, 0, true, null, null);
+        getResult = new GetResult("test", "type", "1", 0, 1, 0, true, null, null, null);
 
         // There is no routing and parent on either request
         assertNull(UpdateHelper.calculateRouting(getResult, indexRequest));
@@ -565,7 +565,7 @@ public class UpdateRequestTests extends ESTestCase {
         fields.put("_routing", new DocumentField("_routing", Collections.singletonList("routing1")));
 
         // Doc exists and has the parent and routing fields
-        getResult = new GetResult("test", "type", "1", 0, 1, 0, true, null, fields);
+        getResult = new GetResult("test", "type", "1", 0, 1, 0, true, null, fields, null);
 
         // Use the get result parent and routing
         assertThat(UpdateHelper.calculateRouting(getResult, indexRequest), equalTo("routing1"));
@@ -575,7 +575,7 @@ public class UpdateRequestTests extends ESTestCase {
         ShardId shardId = new ShardId("test", "", 0);
         GetResult getResult = new GetResult("test", "type", "1", 0, 1, 0, true,
                 new BytesArray("{\"body\": \"foo\"}"),
-                null);
+                null, null);
 
         UpdateRequest request = new UpdateRequest("test", "type1", "1").fromXContent(
                 createParser(JsonXContent.jsonXContent, new BytesArray("{\"doc\": {\"body\": \"foo\"}}")));
@@ -606,7 +606,7 @@ public class UpdateRequestTests extends ESTestCase {
         ShardId shardId = new ShardId("test", "", 0);
         GetResult getResult = new GetResult("test", "type", "1", 0, 1, 0, true,
                 new BytesArray("{\"body\": \"bar\"}"),
-                null);
+                null, null);
 
         UpdateRequest request = new UpdateRequest("test", "type1", "1")
                 .script(mockInlineScript("ctx._source.body = \"foo\""));

--- a/server/src/test/java/org/elasticsearch/action/update/UpdateResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/update/UpdateResponseTests.java
@@ -74,7 +74,7 @@ public class UpdateResponseTests extends ESTestCase {
 
             UpdateResponse updateResponse = new UpdateResponse(new ReplicationResponse.ShardInfo(3, 2),
                     new ShardId("books", "books_uuid", 2), "book", "1", 7, 17, 2, UPDATED);
-            updateResponse.setGetResult(new GetResult("books", "book", "1",0, 1, 2, true, source, fields));
+            updateResponse.setGetResult(new GetResult("books", "book", "1",0, 1, 2, true, source, fields, null));
 
             String output = Strings.toString(updateResponse);
             assertEquals("{\"_index\":\"books\",\"_type\":\"book\",\"_id\":\"1\",\"_version\":2,\"result\":\"updated\"," +

--- a/server/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderTests.java
@@ -151,7 +151,7 @@ public class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<GeoShapeQue
             throw new ElasticsearchException("boom", ex);
         }
         return new GetResponse(new GetResult(indexedShapeIndex, indexedType, indexedShapeId, 0, 1, 0, true, new BytesArray(json),
-            null));
+            null, null));
     }
 
     @After

--- a/server/src/test/java/org/elasticsearch/index/query/TermsQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/TermsQueryBuilderTests.java
@@ -210,7 +210,7 @@ public class TermsQueryBuilderTests extends AbstractQueryTestCase<TermsQueryBuil
             throw new ElasticsearchException("boom", ex);
         }
         return new GetResponse(new GetResult(getRequest.index(), getRequest.type(), getRequest.id(), 0, 1, 0, true,
-            new BytesArray(json), null));
+            new BytesArray(json), null, null));
     }
 
     public void testNumeric() throws IOException {

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestGetSourceActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestGetSourceActionTests.java
@@ -96,7 +96,7 @@ public class RestGetSourceActionTests extends RestActionTestCase {
     public void testRestGetSourceAction() throws Exception {
         final BytesReference source = new BytesArray("{\"foo\": \"bar\"}");
         final GetResponse response =
-            new GetResponse(new GetResult("index1", "_doc", "1", UNASSIGNED_SEQ_NO, 0, -1, true, source, emptyMap()));
+            new GetResponse(new GetResult("index1", "_doc", "1", UNASSIGNED_SEQ_NO, 0, -1, true, source, emptyMap(), null));
 
         final RestResponse restResponse = listener.buildResponse(response);
 
@@ -107,7 +107,7 @@ public class RestGetSourceActionTests extends RestActionTestCase {
 
     public void testRestGetSourceActionWithMissingDocument() {
         final GetResponse response =
-            new GetResponse(new GetResult("index1", "_doc", "1", UNASSIGNED_SEQ_NO, 0, -1, false, null, emptyMap()));
+            new GetResponse(new GetResult("index1", "_doc", "1", UNASSIGNED_SEQ_NO, 0, -1, false, null, emptyMap(), null));
 
         final ResourceNotFoundException exception = expectThrows(ResourceNotFoundException.class, () -> listener.buildResponse(response));
 
@@ -116,7 +116,7 @@ public class RestGetSourceActionTests extends RestActionTestCase {
 
     public void testRestGetSourceActionWithMissingDocumentSource() {
         final GetResponse response =
-            new GetResponse(new GetResult("index1", "_doc", "1", UNASSIGNED_SEQ_NO, 0, -1, true, null, emptyMap()));
+            new GetResponse(new GetResult("index1", "_doc", "1", UNASSIGNED_SEQ_NO, 0, -1, true, null, emptyMap(), null));
 
         final ResourceNotFoundException exception = expectThrows(ResourceNotFoundException.class, () -> listener.buildResponse(response));
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -1249,11 +1249,12 @@ public class AuthenticationServiceTests extends ESTestCase {
                 creatorMap.put("realm", "auth realm");
                 source.put("creator", creatorMap);
                 GetResponse getResponse = new GetResponse(new GetResult(request.index(), request.type(), request.id(), 0, 1, 1L, true,
-                    BytesReference.bytes(JsonXContent.contentBuilder().map(source)), Collections.emptyMap()));
+                    BytesReference.bytes(JsonXContent.contentBuilder().map(source)), Collections.emptyMap(), Collections.emptyMap()));
                 listener.onResponse(getResponse);
             } else {
                 listener.onResponse(new GetResponse(new GetResult(request.index(), request.type(), request.id(),
-                        SequenceNumbers.UNASSIGNED_SEQ_NO, 1, -1L, false, null, Collections.emptyMap())));
+                        SequenceNumbers.UNASSIGNED_SEQ_NO, 1, -1L, false, null,
+                    Collections.emptyMap(), Collections.emptyMap())));
             }
             return Void.TYPE;
         }).when(client).get(any(GetRequest.class), any(ActionListener.class));
@@ -1288,11 +1289,12 @@ public class AuthenticationServiceTests extends ESTestCase {
                 creatorMap.put("realm", "auth realm");
                 source.put("creator", creatorMap);
                 GetResponse getResponse = new GetResponse(new GetResult(request.index(), request.type(), request.id(), 0, 1, 1L, true,
-                        BytesReference.bytes(JsonXContent.contentBuilder().map(source)), Collections.emptyMap()));
+                        BytesReference.bytes(JsonXContent.contentBuilder().map(source)), Collections.emptyMap(), Collections.emptyMap()));
                 listener.onResponse(getResponse);
             } else {
                 listener.onResponse(new GetResponse(new GetResult(request.index(), request.type(), request.id(),
-                        SequenceNumbers.UNASSIGNED_SEQ_NO, 1, -1L, false, null, Collections.emptyMap())));
+                        SequenceNumbers.UNASSIGNED_SEQ_NO, 1, -1L, false, null,
+                    Collections.emptyMap(), Collections.emptyMap())));
             }
             return Void.TYPE;
         }).when(client).get(any(GetRequest.class), any(ActionListener.class));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/NativeUsersStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/NativeUsersStoreTests.java
@@ -118,6 +118,7 @@ public class NativeUsersStoreTests extends ESTestCase {
             0, 1, 1L,
                 true,
                 BytesReference.bytes(jsonBuilder().map(values)),
+                Collections.emptyMap(),
                 Collections.emptyMap());
 
         final PlainActionFuture<NativeUsersStore.ReservedUserInfo> future = new PlainActionFuture<>();
@@ -187,6 +188,7 @@ public class NativeUsersStoreTests extends ESTestCase {
                 UNASSIGNED_SEQ_NO, 0, 1L,
                 false,
                 null,
+                Collections.emptyMap(),
                 Collections.emptyMap());
 
         actionRespond(GetRequest.class, new GetResponse(getResult));
@@ -229,6 +231,7 @@ public class NativeUsersStoreTests extends ESTestCase {
                 0, 1, 1L,
                 true,
                 source,
+                Collections.emptyMap(),
                 Collections.emptyMap());
 
         actionRespond(GetRequest.class, new GetResponse(getResult));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreTests.java
@@ -132,7 +132,8 @@ public class NativePrivilegeStoreTests extends ESTestCase {
 
         final String docSource = Strings.toString(sourcePrivilege);
         listener.get().onResponse(new GetResponse(
-            new GetResult(request.index(), request.type(), request.id(), 0, 1, 1L, true, new BytesArray(docSource), emptyMap())
+            new GetResult(request.index(), request.type(), request.id(), 0, 1, 1L, true,
+                new BytesArray(docSource), emptyMap(), emptyMap())
         ));
         final ApplicationPrivilegeDescriptor getPrivilege = future.get(1, TimeUnit.SECONDS);
         assertThat(getPrivilege, equalTo(sourcePrivilege));
@@ -149,7 +150,8 @@ public class NativePrivilegeStoreTests extends ESTestCase {
         assertThat(request.id(), equalTo("application-privilege_myapp:admin"));
 
         listener.get().onResponse(new GetResponse(
-            new GetResult(request.index(), request.type(), request.id(), UNASSIGNED_SEQ_NO, 0, -1, false, null, emptyMap())
+            new GetResult(request.index(), request.type(), request.id(), UNASSIGNED_SEQ_NO, 0, -1,
+                false, null, emptyMap(), emptyMap())
         ));
         final ApplicationPrivilegeDescriptor getPrivilege = future.get(1, TimeUnit.SECONDS);
         assertThat(getPrivilege, Matchers.nullValue());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/test/SecurityMocks.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/test/SecurityMocks.java
@@ -65,7 +65,8 @@ public final class SecurityMocks {
     }
 
     public static void mockGetRequest(Client client, String documentId, BytesReference source) {
-        GetResult result = new GetResult(SECURITY_MAIN_ALIAS, SINGLE_MAPPING_NAME, documentId, 0, 1, 1, true, source, emptyMap());
+        GetResult result = new GetResult(SECURITY_MAIN_ALIAS, SINGLE_MAPPING_NAME, documentId, 0, 1, 1, true, source,
+            emptyMap(), emptyMap());
         mockGetRequest(client, documentId, result);
     }
 

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/execution/ExecutionServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/execution/ExecutionServiceTests.java
@@ -1217,7 +1217,8 @@ public class ExecutionServiceTests extends ESTestCase {
                 listener.onResponse(response);
             } else {
                 GetResult notFoundResult =
-                    new GetResult(request.index(), request.type(), request.id(), UNASSIGNED_SEQ_NO, 0, -1, false, null, null);
+                    new GetResult(request.index(), request.type(), request.id(), UNASSIGNED_SEQ_NO, 0,
+                        -1, false, null, null, null);
                 listener.onResponse(new GetResponse(notFoundResult));
             }
             return null;
@@ -1232,7 +1233,8 @@ public class ExecutionServiceTests extends ESTestCase {
                 listener.onFailure(e);
             } else {
                 GetResult notFoundResult =
-                    new GetResult(request.index(), request.type(), request.id(), UNASSIGNED_SEQ_NO, 0, -1, false, null, null);
+                    new GetResult(request.index(), request.type(), request.id(), UNASSIGNED_SEQ_NO, 0, -1,
+                        false, null, null, null);
                 listener.onResponse(new GetResponse(notFoundResult));
             }
             return null;

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/ack/TransportAckWatchActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/ack/TransportAckWatchActionTests.java
@@ -71,7 +71,7 @@ public class TransportAckWatchActionTests extends ESTestCase {
         doAnswer(invocation -> {
             ActionListener<GetResponse> listener = (ActionListener<GetResponse>) invocation.getArguments()[1];
             listener.onResponse(new GetResponse(new GetResult(Watch.INDEX, MapperService.SINGLE_MAPPING_NAME, watchId, UNASSIGNED_SEQ_NO,
-                0, -1, false, BytesArray.EMPTY, Collections.emptyMap())));
+                0, -1, false, BytesArray.EMPTY, Collections.emptyMap(), Collections.emptyMap())));
             return null;
         }).when(client).get(anyObject(), anyObject());
 


### PR DESCRIPTION
This commit makes creators of GetField split the fields into document fields and metadata fields. It is part of larger refactoring that aims to remove the calls to static methods of MapperService related to metadata fields, as discussed in #24422.
