### PR TITLE
[DOCS] Removes inclusion of java.asciidoc

### DIFF
--- a/docs/reference/security/securing-communications/separating-node-client-traffic.asciidoc
+++ b/docs/reference/security/securing-communications/separating-node-client-traffic.asciidoc
@@ -65,5 +65,4 @@ transport.profiles.client.xpack.security.ssl.client_authentication: none
 
 This setting keeps certificate authentication active for node-to-node traffic,
 but removes the requirement to distribute a signed certificate to transport
-clients. For more information, see
-{stack-ov}/java-clients.html#transport-client[Configuring the Transport Client to work with a Secured Cluster].
+clients.

--- a/docs/reference/security/securing-communications/setting-up-ssl.asciidoc
+++ b/docs/reference/security/securing-communications/setting-up-ssl.asciidoc
@@ -32,8 +32,5 @@ the {kib} server and to connect to {es} via HTTPS. See
 
 . Configure Beats to use encrypted connections. See <<beats>>.
 
-. Configure the Java transport client to use encrypted communications.
-See <<java-clients>>.
-
 . Configure {es} for Apache Hadoop to use secured transport. See
 {hadoop-ref}/security.html[{es} for Apache Hadoop Security].

--- a/docs/reference/setup/setup-xclient.asciidoc
+++ b/docs/reference/setup/setup-xclient.asciidoc
@@ -111,6 +111,3 @@ Then in your project's `pom.xml` if using maven, add the following repositories 
   </repositories>
 --------------------------------------------------------------
 --
-
-. If you are using {stack} {security-features}, there are more configuration
-steps. See {stack-ov}/java-clients.html[Java Client and Security].

--- a/x-pack/docs/en/security/ccs-clients-integrations.asciidoc
+++ b/x-pack/docs/en/security/ccs-clients-integrations.asciidoc
@@ -11,7 +11,6 @@ clusters.
 You will need to update the configuration for several clients to work with a
 secured cluster:
 
-* <<java-clients, Java Clients>>
 * <<http-clients, HTTP Clients>>
 
 

--- a/x-pack/docs/en/security/ccs-clients-integrations.asciidoc
+++ b/x-pack/docs/en/security/ccs-clients-integrations.asciidoc
@@ -35,9 +35,6 @@ be secured as well, or at least communicate with the cluster in a secured way:
 :edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/ccs-clients-integrations/cross-cluster.asciidoc
 include::ccs-clients-integrations/cross-cluster.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/ccs-clients-integrations/java.asciidoc
-include::ccs-clients-integrations/java.asciidoc[]
-
 :edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/ccs-clients-integrations/http.asciidoc
 include::ccs-clients-integrations/http.asciidoc[]
 

--- a/x-pack/docs/en/watcher/index.asciidoc
+++ b/x-pack/docs/en/watcher/index.asciidoc
@@ -89,9 +89,6 @@ include::actions.asciidoc[]
 :edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/transform.asciidoc
 include::transform.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/java.asciidoc
-include::java.asciidoc[]
-
 :edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/managing-watches.asciidoc
 include::managing-watches.asciidoc[]
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/42202

The x-pack/docs/en/security/ccs-clients-integrations/java.asciidoc and x-pack/docs/en/watcher/java.asciidoc files were removed in #42202. This PR removes the lingering `include` statements and links to those files.

