### PR TITLE
[DOCS] Set explicit anchors in 7.x for Asciidoctor

### DIFF
--- a/docs/reference/migration/migrate_7_0/aggregations.asciidoc
+++ b/docs/reference/migration/migrate_7_0/aggregations.asciidoc
@@ -11,11 +11,13 @@
 
 
 [float]
+[[removed-global-ordinals-hash-and-global-ordinals-low-cardinality-terms-agg]]
 ==== Deprecated `global_ordinals_hash` and `global_ordinals_low_cardinality` execution hints for terms aggregations have been removed
 
 These `execution_hint` are removed and should be replaced by `global_ordinals`.
 
 [float]
+[[search-max-buckets-cluster-setting]]
 ==== `search.max_buckets` in the cluster setting
 
 The dynamic cluster setting named `search.max_buckets` now defaults
@@ -23,12 +25,14 @@ to 10,000 (instead of unlimited in the previous version).
 Requests that try to return more than the limit will fail with an exception.
 
 [float]
+[[missing-option-removed-composite-agg]]
 ==== `missing` option of the `composite` aggregation has been removed
 
 The `missing` option of the `composite` aggregation, deprecated in 6.x,
 has been removed. `missing_bucket` should be used instead.
 
 [float]
+[[replace-params-agg-with-state-context-variable]]
 ==== Replaced `params._agg` with `state` context variable in scripted metric aggregations
 
 The object used to share aggregation state between the scripts in a Scripted Metric
@@ -36,12 +40,14 @@ Aggregation is now a variable called `state` available in the script context, ra
 being provided via the `params` object as `params._agg`.
 
 [float]
+[[reduce-script-combine-script-params-mandatory]]
 ==== Make metric aggregation script parameters `reduce_script` and `combine_script` mandatory
 
 The metric aggregation has been changed to require these two script parameters to ensure users are
 explicitly defining how their data is processed.
 
 [float]
+[[percentiles-percentile-ranks-return-null-instead-nan]]
 ==== `percentiles` and `percentile_ranks` now return `null` instead of `NaN`
 
 The `percentiles` and `percentile_ranks` aggregations used to return `NaN` in
@@ -49,6 +55,7 @@ the response if they were applied to an empty set of values. Because `NaN` is
 not officially supported by JSON, it has been replaced with `null`.
 
 [float]
+[[stats-extended-stats-return-zero-instead-null]]
 ==== `stats` and `extended_stats` now return 0 instead of `null` for zero docs
 
 When the `stats` and `extended_stats` aggregations collected zero docs (`doc_count: 0`),

--- a/docs/reference/migration/migrate_7_0/analysis.asciidoc
+++ b/docs/reference/migration/migrate_7_0/analysis.asciidoc
@@ -10,6 +10,7 @@
 // end::notable-breaking-changes[]
 
 [float]
+[[limit-number-of-tokens-produced-by-analyze]]
 ==== Limiting the number of tokens produced by _analyze
 
 To safeguard against out of memory errors, the number of tokens that can be produced
@@ -27,6 +28,7 @@ limited to 1000000. This default limit can be changed
 for a particular index with the index setting `index.highlight.max_analyzed_offset`.
 
 [float]
+[[delimited-payload-filter-renaming]]
 ==== `delimited_payload_filter` renaming
 
 The `delimited_payload_filter` was deprecated and renamed to `delimited_payload` in 6.2.
@@ -35,6 +37,7 @@ name in new indices created in 7.0 will throw an error. Use the new name `delimi
 instead.
 
 [float]
+[[standard-filter-removed]]
 ==== `standard` filter has been removed
 
 The `standard` token filter has been removed because it doesn't change anything in the stream.
@@ -48,6 +51,7 @@ Indexes created using this analyzer will still be readable in elasticsearch 7.0,
 but it will not be possible to create new indexes using it.
 
 [float]
+[[deprecated-ngram-edgengram-token-filter-cannot-be-used]]
 ==== The deprecated `nGram` and `edgeNGram` token filter cannot be used on new indices
 
 The `nGram` and `edgeNGram` token filter names have been deprecated in an earlier 6.x version.

--- a/docs/reference/migration/migrate_7_0/api.asciidoc
+++ b/docs/reference/migration/migrate_7_0/api.asciidoc
@@ -76,6 +76,7 @@ pools. Note that `core` and `max` will be populated for scaling thread pools,
 and `size` will be populated for fixed thread pools.
 
 [float]
+[[fields-param-removed-bulk-update-request]]
 ==== The parameter `fields` deprecated in 6.x has been removed from Bulk request
 and Update request. The Update API returns `400 - Bad request` if request contains
 unknown parameters (instead of ignored in the previous version).
@@ -118,6 +119,7 @@ body. Specifying `fields` in the request body as opposed to a parameter was depr
 in 6.4.0, and is now unsupported in 7.0.0.
 
 [float]
+[[copy-settings-deprecated-shrink-split-apis]]
 ==== `copy_settings` is deprecated on shrink and split APIs
 
 Versions of Elasticsearch prior to 6.4.0 did not copy index settings on shrink
@@ -143,6 +145,7 @@ current user was not authorized for any alias. An empty response with
 status 200 - OK is now returned instead at all times.
 
 [float]
+[[user-object-removed-put-user-api]]
 ==== Put User API response no longer has `user` object
 
 The Put User API response was changed in 6.5.0 to add the `created` field
@@ -150,6 +153,7 @@ outside of the user object where it previously had been. In 7.0.0 the user
 object has been removed in favor of the top level `created` field.
 
 [float]
+[[source-include-exclude-params-removed]]
 ==== Source filtering url parameters `_source_include` and `_source_exclude` have been removed
 
 The deprecated in 6.x url parameters are now removed. Use `_source_includes` and `_source_excludes` instead.
@@ -168,6 +172,7 @@ removed.
 
 
 [float]
+[[deprecated-termvector-endpoint-removed]]
 ==== Deprecated `_termvector` endpoint removed
 
 The `_termvector` endpoint was deprecated in 2.0 and has now been removed.
@@ -186,6 +191,7 @@ using the `allow_restricted_indices` flag on the permission (as any other index
 privilege).
 
 [float]
+[[remove-get-support-cache-clear-api]]
 ==== Removed support for `GET` on the `_cache/clear` API
 
 The `_cache/clear` API no longer supports the `GET` HTTP verb. It must be called

--- a/docs/reference/migration/migrate_7_0/cluster.asciidoc
+++ b/docs/reference/migration/migrate_7_0/cluster.asciidoc
@@ -17,6 +17,7 @@ Due to cross-cluster search using `:` to separate a cluster and index name,
 cluster names may no longer contain `:`.
 
 [float]
+[[new-default-wait-for-active-shards-param]]
 ==== New default for `wait_for_active_shards` parameter of the open index command
 
 The default value for the `wait_for_active_shards` parameter of the open index API
@@ -24,6 +25,7 @@ is changed from 0 to 1, which means that the command will now by default wait fo
 primary shards of the opened index to be allocated.
 
 [float]
+[[shard-preferences-removed]]
 ==== Shard preferences `_primary`, `_primary_first`, `_replica`, and `_replica_first` are removed
 These shard preferences are removed in favour of the `_prefer_nodes` and `_only_nodes` preferences.
 

--- a/docs/reference/migration/migrate_7_0/discovery.asciidoc
+++ b/docs/reference/migration/migrate_7_0/discovery.asciidoc
@@ -53,6 +53,7 @@ above. If you are preparing to upgrade from an earlier version, you must set
 `discovery.zen.ping.unicast.hosts` or `discovery.zen.hosts_provider`.
 
 [float]
+[[new-name-no-master-block-setting]]
 ==== New name for `no_master_block` setting
 
 The `discovery.zen.no_master_block` setting is now known as

--- a/docs/reference/migration/migrate_7_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_7_0/indices.asciidoc
@@ -22,12 +22,14 @@ Due to cross-cluster search using `:` to separate a cluster and index name,
 index names may no longer contain `:`.
 
 [float]
+[[index-unassigned-node-left-delayed-timeout-no-longer-negative]]
 ==== `index.unassigned.node_left.delayed_timeout` may no longer be negative
 
 Negative values were interpreted as zero in earlier versions but are no
 longer accepted.
 
 [float]
+[[flush-force-merge-no-longer-refresh]]
 ==== `_flush` and `_force_merge` will no longer refresh
 
 In previous versions issuing a `_flush` or `_force_merge` (with `flush=true`)
@@ -85,6 +87,7 @@ The following previously deprecated url parameter have been removed:
 * `field_data` - use `fielddata` instead
 
 [float]
+[[network-breaker-inflight-requests-overhead-increased-to-2]]
 ==== `network.breaker.inflight_requests.overhead` increased to 2
 
 Previously the in flight requests circuit breaker considered only the raw byte representation.
@@ -108,11 +111,13 @@ there is less need for fielddata. Therefore, the default value of the setting
 heap size.
 
 [float]
+[[fix-value-for-index-shard-check-on-startup-removed]]
 ==== `fix` value for `index.shard.check_on_startup` is removed
 
 Deprecated option value `fix` for setting `index.shard.check_on_startup` is not supported.
 
 [float]
+[[elasticsearch-translog-removed]]
 ==== `elasticsearch-translog` is removed
 
 Use the `elasticsearch-shard` tool to remove corrupted translog data.

--- a/docs/reference/migration/migrate_7_0/java.asciidoc
+++ b/docs/reference/migration/migrate_7_0/java.asciidoc
@@ -10,6 +10,7 @@
 // end::notable-breaking-changes[]
 
 [float]
+[[isshardsacked-removed]]
 ==== `isShardsAcked` deprecated in `6.2` has been removed
 
 `isShardsAcked` has been replaced by `isShardsAcknowledged` in
@@ -17,6 +18,7 @@
 `CreateIndexClusterStateUpdateResponse`.
 
 [float]
+[[prepareexecute-removed-client-api]]
 ==== `prepareExecute` removed from the client api
 
 The `prepareExecute` method which created a request builder has been
@@ -36,18 +38,21 @@ was moved to `org.elasticsearch.search.aggregations.PipelineAggregationBuilders`
 
 
 [float]
+[[retry-withbackoff-methods-removed]]
 ==== `Retry.withBackoff` methods with `Settings` removed
 
 The variants of `Retry.withBackoff` that included `Settings` have been removed
 because `Settings` is no longer needed.
 
 [float]
+[[client-termvector-removed]]
 ==== Deprecated method `Client#termVector` removed
 
 The client method `termVector`, deprecated in 2.0, has been removed. The method
 `termVectors` (plural) should be used instead.
 
 [float]
+[[abstractlifecyclecomponent-constructor-removed]]
 ==== Deprecated constructor `AbstractLifecycleComponent(Settings settings)` removed
 
 The constructor `AbstractLifecycleComponent(Settings settings)`, deprecated in 6.7

--- a/docs/reference/migration/migrate_7_0/java_time.asciidoc
+++ b/docs/reference/migration/migrate_7_0/java_time.asciidoc
@@ -82,6 +82,7 @@ compile time, ensure you have proper test coverage for this in your
 own code.
 
 [float]
+[[parsing-gtm0-timezeone-jdk8-not-supported]]
 ==== Parsing `GMT0` timezone with JDK8 is not supported
 
 When you are running Elasticsearch 7 with Java 8, you are not able to parse

--- a/docs/reference/migration/migrate_7_0/logging.asciidoc
+++ b/docs/reference/migration/migrate_7_0/logging.asciidoc
@@ -10,6 +10,7 @@
 // end::notable-breaking-changes[]
 
 [float]
+[[new-json-format-log-directory]]
 ==== New JSON format log files in `log` directory
 
 Elasticsearch now will produce additional log files in JSON format. They will be stored in `*.json` suffix files.
@@ -28,6 +29,7 @@ Following files should be expected now in log directory:
 Note: You can configure which of these files are written by editing `log4j2.properties`.
 
 [float]
+[[log-files-ending-log-deprecated]]
 ==== Log files ending with `*.log` deprecated
 Log files with the `.log` file extension using the old pattern layout format
 are now considered deprecated and the newly added JSON log file format with

--- a/docs/reference/migration/migrate_7_0/low_level_restclient.asciidoc
+++ b/docs/reference/migration/migrate_7_0/low_level_restclient.asciidoc
@@ -10,6 +10,7 @@
 // end::notable-breaking-changes[]
 
 [float]
+[[maxretrytimeout-removed]]
 ==== Support for `maxRetryTimeout` removed from RestClient
 
 `RestClient` and `RestClientBuilder` no longer support the `maxRetryTimeout`

--- a/docs/reference/migration/migrate_7_0/mappings.asciidoc
+++ b/docs/reference/migration/migrate_7_0/mappings.asciidoc
@@ -10,11 +10,13 @@
 // end::notable-breaking-changes[]
 
 [float]
+[[all-meta-field-removed]]
 ==== The `_all` meta field is removed
 
 The `_all` field deprecated in 6 have now been removed.
 
 [float]
+[[uid-meta-field-removed]]
 ==== The `_uid` meta field is removed
 
 This field used to index a composite key formed of the `_type` and the `_id`.
@@ -23,6 +25,7 @@ of `_id`.
 
 //tag::notable-breaking-changes[]
 [float]
+[[default-mapping-not-allowed]]
 ==== The `_default_` mapping is no longer allowed
 
 The `_default_` mapping has been deprecated in 6.0 and is now no longer allowed
@@ -31,11 +34,13 @@ an error.
 //end::notable-breaking-changes[]
 
 [float]
+[[index-options-numeric-fields-removed]]
 ==== `index_options` for numeric fields has been removed
 
 The `index_options` field for numeric  fields has been deprecated in 6 and has now been removed.
 
 [float]
+[[limit-number-nested-json-objects]]
 ==== Limiting the number of `nested` json objects
 
 To safeguard against out of memory errors, the number of nested json objects within a single
@@ -43,11 +48,13 @@ document across all fields has been limited to 10000. This default limit can be 
 the index setting `index.mapping.nested_objects.limit`.
 
 [float]
+[[update-all-types-option-removed]]
 ==== The `update_all_types` option has been removed
 
 This option is useless now that all indices have at most one type.
 
 [float]
+[[classic-similarity-removed]]
 ==== The `classic` similarity has been removed
 
 The `classic` similarity relied on coordination factors for scoring to be good
@@ -63,6 +70,7 @@ An error will now be thrown when unknown configuration options are provided
 to similarities. Such unknown parameters were ignored before.
 
 [float]
+[[changed-default-geo-shape-index-strategy]]
 ==== Changed default `geo_shape` indexing strategy
 
 `geo_shape` types now default to using a vector indexing approach based on Lucene's new
@@ -76,6 +84,7 @@ should also be changed in the template to explicitly define `tree` to one of `ge
 or `quadtree`. This will ensure compatibility with previously created indexes.
 
 [float]
+[[deprecated-geo-shape-params]]
 ==== Deprecated `geo_shape` parameters
 
 The following type parameters are deprecated for the `geo_shape` field type: `tree`,
@@ -90,6 +99,7 @@ to 10 in the next major version. Completion fields that define more than 10
 contexts in a mapping will log a deprecation warning in this version.
 
 [float]
+[[include-type-name-defaults-false]]
 ==== `include_type_name` now defaults to `false`
 The default for `include_type_name` is now `false` for all APIs that accept
 the parameter.

--- a/docs/reference/migration/migrate_7_0/plugins.asciidoc
+++ b/docs/reference/migration/migrate_7_0/plugins.asciidoc
@@ -84,6 +84,7 @@ Tribe node functionality has been removed in favor of
   can no longer provide their own discovery implementations.
 
 [float]
+[[watcher-hipchat-action-removed]]
 ==== Watcher 'hipchat' action removed
 
 Hipchat has been deprecated and shut down as a service. The `hipchat` action for

--- a/docs/reference/migration/migrate_7_0/restclient.asciidoc
+++ b/docs/reference/migration/migrate_7_0/restclient.asciidoc
@@ -10,6 +10,7 @@
 // end::notable-breaking-changes[]
 
 [float]
+[[remove-header-args]]
 ==== API methods accepting `Header` argument have been removed
 
 All API methods accepting headers as a `Header` varargs argument, deprecated
@@ -22,6 +23,7 @@ e.g. `client.index(indexRequest, new Header("name" "value"))` becomes
 `client.index(indexRequest, RequestOptions.DEFAULT.toBuilder().addHeader("name", "value").build());`
 
 [float]
+[[cluster-health-api-default-cluster-level]]
 ==== Cluster Health API default to `cluster` level
 
 The Cluster Health API used to default to `shards` level to ease migration

--- a/docs/reference/migration/migrate_7_0/scripting.asciidoc
+++ b/docs/reference/migration/migrate_7_0/scripting.asciidoc
@@ -32,6 +32,7 @@ To check if a document is missing a value, you can use
 
 
 [float]
+[[script-errors-return-400-error-codes]]
 ==== Script errors will return as `400` error codes
 
 Malformed scripts, either in search templates, ingest pipelines or search 

--- a/docs/reference/migration/migrate_7_0/search.asciidoc
+++ b/docs/reference/migration/migrate_7_0/search.asciidoc
@@ -77,6 +77,7 @@ PUT /_cluster/settings
 // CONSOLE
 
 [float]
+[[search-api-returns-400-invalid-requests]]
 ==== Search API returns `400` for invalid requests
 
 The Search API returns `400 - Bad request` while it would previously return
@@ -91,6 +92,7 @@ The Search API returns `400 - Bad request` while it would previously return
 *   script compilation errors
 
 [float]
+[[scroll-queries-cannot-use-request-cache]]
 ==== Scroll queries cannot use the `request_cache` anymore
 
 Setting `request_cache:true` on a query that creates a scroll (`scroll=1m`)
@@ -98,6 +100,7 @@ has been deprecated in 6 and will now return a `400 - Bad request`.
 Scroll queries are not meant to be cached.
 
 [float]
+[[scroll-queries-cannot-use-rescore]]
 ==== Scroll queries cannot use `rescore`  anymore
 
 Including a rescore clause on a query that creates a scroll (`scroll=1m`) has
@@ -117,6 +120,7 @@ removed.
 * 	`jarowinkler` - replaced by `jaro_winkler`
 
 [float]
+[[popular-mode-suggesters]]
 ==== `popular` mode for Suggesters
 
 The `popular` mode for Suggesters (`term` and `phrase`) now uses the doc frequency
@@ -149,6 +153,7 @@ To safeguard against this, a hard limit of 1024 fields has been introduced for q
 using the "all fields" mode ("default_field": "*") or other fieldname expansions (e.g. "foo*").
 
 [float]
+[[invalid-search-request-body]]
 ==== Invalid `_search` request body
 
 Search requests with extra content after the main object will no longer be accepted
@@ -176,6 +181,7 @@ For geo context the value of the `path` parameter is now validated against the m
 and the context is only accepted if `path` points to a field with `geo_point` type.
 
 [float]
+[[semantics-changed-max-concurrent-shared-requests]]
 ==== Semantics changed for `max_concurrent_shard_requests`
 
 `max_concurrent_shard_requests` used to limit the total number of concurrent shard
@@ -183,6 +189,7 @@ requests a single high level search request can execute. In 7.0 this changed to 
 max number of concurrent shard requests per node. The default is now `5`.
 
 [float]
+[[max-score-set-to-null-when-untracked]]
 ==== `max_score` set to `null` when scores are not tracked
 
 `max_score` used to be set to `0` whenever scores are not tracked. `null` is now used
@@ -214,6 +221,7 @@ major version.
 
 //tag::notable-breaking-changes[]
 [float]
+[[hits-total-now-object-search-response]]
 ==== `hits.total` is now an object in the search response
 
 The total hits that match the search request is now returned as an object
@@ -245,6 +253,7 @@ will be removed in the next major version (8.0).
 //end::notable-breaking-changes[]
 
 [float]
+[[hits-total-omitted-if-disabled]]
 ==== `hits.total` is omitted in the response if `track_total_hits` is disabled (false)
 
 If `track_total_hits` is set to `false` in the search request the search response
@@ -254,6 +263,7 @@ to get the old format back (`"total": -1`).
 
 //tag::notable-breaking-changes[]
 [float]
+[[track-total-hits-10000-default]]
 ==== `track_total_hits` defaults to 10,000
 
 By default search request will count the total hits accurately up to `10,000`

--- a/docs/reference/migration/migrate_7_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_7_0/settings.asciidoc
@@ -10,6 +10,7 @@
 // end::notable-breaking-changes[]
 
 [float]
+[[default-node-name-now-hostname]]
 ==== The default for `node.name` is now the hostname
 
 `node.name` now defaults to the hostname at the time when Elasticsearch

--- a/docs/reference/migration/migrate_7_0/snapshotstats.asciidoc
+++ b/docs/reference/migration/migrate_7_0/snapshotstats.asciidoc
@@ -16,6 +16,7 @@ Snapshot stats details are provided in a new structured way:
 * In case of a snapshot that's still in progress, there's also a `processed` section for files that are in the process of being copied.
 
 [float]
+[[snapshot-stats-deprecated]]
 ==== Deprecated `number_of_files`, `processed_files`, `total_size_in_bytes` and `processed_size_in_bytes` snapshot stats properties have been removed
 
 * Properties `number_of_files` and `total_size_in_bytes` are removed and should be replaced by values of nested object `total`.


### PR DESCRIPTION
AsciiDoc and Asciidoctor generate missing anchors for headings differently. This sets explicit anchors so they render consistently in AsciiDoc and Asciidoctor.

Will backport to 7.0