### PR TITLE
[DOCS] Set explicit anchors in 0.90 for Asciidoctor

### DIFF
--- a/docs/reference/analysis/tokenizers/edgengram-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/edgengram-tokenizer.asciidoc
@@ -62,7 +62,7 @@ of these classes. |`[]` (Keep all characters)
 --------------------------------------------------
 
 [float]
-[[side-deprecated]]
+[[_literal_side_literal_deprecated]]
 ==== `side` deprecated
 
 There used to be a `side` parameter up to `0.90.1` but it is now deprecated. In

--- a/docs/reference/analysis/tokenizers/edgengram-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/edgengram-tokenizer.asciidoc
@@ -62,6 +62,7 @@ of these classes. |`[]` (Keep all characters)
 --------------------------------------------------
 
 [float]
+[[side-deprecated]]
 ==== `side` deprecated
 
 There used to be a `side` parameter up to `0.90.1` but it is now deprecated. In

--- a/docs/reference/setup/as-a-service.asciidoc
+++ b/docs/reference/setup/as-a-service.asciidoc
@@ -44,7 +44,7 @@ java -version
 
 The last command should verify a successful installation of the Oracle JDK.
 
-
+[[redhat-centos-fedora]]
 ==== RedHat/Centos/Fedora
 
 RedHat based distributions are using `chkconfig` to enable and disable services. The init script is at `/etc/init.d/elasticsearch`, where as the configuration file is placed at `/etc/sysconfig/elasticsearch`.

--- a/docs/reference/setup/as-a-service.asciidoc
+++ b/docs/reference/setup/as-a-service.asciidoc
@@ -44,7 +44,7 @@ java -version
 
 The last command should verify a successful installation of the Oracle JDK.
 
-[[redhat-centos-fedora]]
+[[__redhat_centos_fedora]]
 ==== RedHat/Centos/Fedora
 
 RedHat based distributions are using `chkconfig` to enable and disable services. The init script is at `/etc/init.d/elasticsearch`, where as the configuration file is placed at `/etc/sysconfig/elasticsearch`.


### PR DESCRIPTION
AsciiDoc and Asciidoctor generate missing anchors for headings differently. This sets explicit anchors so they render consistently in AsciiDoc and Asciidoctor.