### PR TITLE
[DOCS] Set explicit anchors in 1.4 for Asciidoctor

### DIFF
--- a/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/datehistogram-aggregation.asciidoc
@@ -72,6 +72,7 @@ set `pre_zone_adjust_large_interval` to `true`, which will apply the same conver
 example, to day and above intervals (it can be set regardless of the interval, but only kick in when using day and
 higher intervals).
 
+[[_pre_post_offset]]
 ==== Pre/Post Offset
 
 Specific offsets can be provided for pre rounding and post rounding. The `pre_offset` for pre rounding, and

--- a/docs/reference/search/facets/date-histogram-facet.asciidoc
+++ b/docs/reference/search/facets/date-histogram-facet.asciidoc
@@ -85,6 +85,7 @@ milliseconds to actual do the relevant rounding, and then be applied
 again to get to the original unit. For example, when storing in a
 numeric field seconds resolution, the `factor` can be set to `1000`.
 
+[[_pre_post_offset_2]]
 ==== Pre / Post Offset
 
 Specific offsets can be provided for pre rounding and post rounding. The


### PR DESCRIPTION
AsciiDoc and Asciidoctor generate missing anchors for headings differently. This sets explicit anchors so they render consistently in AsciiDoc and Asciidoctor.

Will backport as far back as possible.