### PR TITLE
[ML-DataFrame]backport dataframe changes from 42202, using client instead of transport

### DIFF
--- a/x-pack/plugin/data-frame/qa/multi-node-tests/build.gradle
+++ b/x-pack/plugin/data-frame/qa/multi-node-tests/build.gradle
@@ -5,6 +5,7 @@ dependencies {
   testCompile project(path: xpackModule('core'), configuration: 'default')
   testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
   testCompile project(path: xpackModule('data-frame'), configuration: 'runtime')
+  testCompile "org.elasticsearch.client:elasticsearch-rest-high-level-client:${versions.elasticsearch}"
 }
 
 // location for keys and certificates

--- a/x-pack/plugin/data-frame/qa/multi-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameTransformIT.java
+++ b/x-pack/plugin/data-frame/qa/multi-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameTransformIT.java
@@ -6,16 +6,18 @@
 
 package org.elasticsearch.xpack.dataframe.integration;
 
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.core.IndexerState;
+import org.elasticsearch.client.dataframe.transforms.DataFrameTransformConfig;
+import org.elasticsearch.client.dataframe.transforms.DataFrameTransformStateAndStats;
+import org.elasticsearch.client.dataframe.transforms.pivot.SingleGroupSource;
+import org.elasticsearch.client.dataframe.transforms.pivot.TermsGroupSource;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
-import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
-import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformStateAndStats;
-import org.elasticsearch.xpack.core.dataframe.transforms.pivot.SingleGroupSource;
-import org.elasticsearch.xpack.core.dataframe.transforms.pivot.TermsGroupSource;
-import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.junit.After;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,7 +26,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class DataFrameTransformIT extends DataFrameIntegTestCase {
 
     @After
-    public void cleanTransforms() {
+    public void cleanTransforms() throws IOException {
         cleanUp();
     }
 
@@ -34,8 +36,8 @@ public class DataFrameTransformIT extends DataFrameIntegTestCase {
 
         Map<String, SingleGroupSource> groups = new HashMap<>();
         groups.put("by-day", createDateHistogramGroupSource("timestamp", DateHistogramInterval.DAY, null, null));
-        groups.put("by-user", new TermsGroupSource("user_id"));
-        groups.put("by-business", new TermsGroupSource("business_id"));
+        groups.put("by-user", TermsGroupSource.builder().setField("user_id").build());
+        groups.put("by-business", TermsGroupSource.builder().setField("business_id").build());
 
         AggregatorFactories.Builder aggs = AggregatorFactories.builder()
             .addAggregator(AggregationBuilders.avg("review_score").field("stars"))
@@ -47,8 +49,10 @@ public class DataFrameTransformIT extends DataFrameIntegTestCase {
             "reviews-by-user-business-day",
             REVIEWS_INDEX_NAME);
 
-        assertTrue(putDataFrameTransform(config).isAcknowledged());
-        assertTrue(startDataFrameTransform(config.getId()).isStarted());
+        final RequestOptions options =
+            expectWarnings("[interval] on [date_histogram] is deprecated, use [fixed_interval] or [calendar_interval] in the future.");
+        assertTrue(putDataFrameTransform(config, options).isAcknowledged());
+        assertTrue(startDataFrameTransform(config.getId(), options).isStarted());
 
         waitUntilCheckpoint(config.getId(), 1L);
 

--- a/x-pack/plugin/data-frame/qa/single-node-tests/build.gradle
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/build.gradle
@@ -5,6 +5,7 @@ dependencies {
   testCompile project(path: xpackModule('core'), configuration: 'default')
   testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
   testCompile project(path: xpackModule('data-frame'), configuration: 'runtime')
+  testCompile "org.elasticsearch.client:elasticsearch-rest-high-level-client:${versions.elasticsearch}"
 }
 
 integTestCluster {

--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameTransformProgressIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameTransformProgressIT.java
@@ -7,24 +7,23 @@
 package org.elasticsearch.xpack.dataframe.integration;
 
 import org.apache.lucene.util.LuceneTestCase;
-import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
-import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.common.network.NetworkModule;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.CreateIndexRequest;
+import org.elasticsearch.client.indices.CreateIndexResponse;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
-import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.SecuritySettingsSourceField;
-import org.elasticsearch.transport.Netty4Plugin;
-import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
-import org.elasticsearch.xpack.core.XPackClientPlugin;
+import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformProgress;
 import org.elasticsearch.xpack.core.dataframe.transforms.DestConfig;
@@ -34,11 +33,10 @@ import org.elasticsearch.xpack.core.dataframe.transforms.pivot.AggregationConfig
 import org.elasticsearch.xpack.core.dataframe.transforms.pivot.GroupConfig;
 import org.elasticsearch.xpack.core.dataframe.transforms.pivot.HistogramGroupSource;
 import org.elasticsearch.xpack.core.dataframe.transforms.pivot.PivotConfig;
-import org.elasticsearch.xpack.core.security.SecurityField;
 import org.elasticsearch.xpack.dataframe.transforms.TransformProgressGatherer;
 
-import java.util.Arrays;
-import java.util.Collection;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collections;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -47,10 +45,11 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 @LuceneTestCase.AwaitsFix( bugUrl = "https://github.com/elastic/elasticsearch/issues/42344")
-public class DataFrameTransformProgressIT extends ESIntegTestCase {
+public class DataFrameTransformProgressIT extends ESRestTestCase {
 
     protected void createReviewsIndex() throws Exception {
         final int numDocs = 1000;
+        final RestHighLevelClient restClient = new TestRestHighLevelClient();
 
         // create mapping
         try (XContentBuilder builder = jsonBuilder()) {
@@ -75,16 +74,13 @@ public class DataFrameTransformProgressIT extends ESIntegTestCase {
                     .endObject();
             }
             builder.endObject();
-            CreateIndexResponse response = client().admin()
-                .indices()
-                .prepareCreate(REVIEWS_INDEX_NAME)
-                .addMapping("_doc", builder)
-                .get();
+            CreateIndexResponse response = restClient.indices()
+                .create(new CreateIndexRequest(REVIEWS_INDEX_NAME).mapping(builder), RequestOptions.DEFAULT);
             assertThat(response.isAcknowledged(), is(true));
         }
 
         // create index
-        BulkRequestBuilder bulk = client().prepareBulk(REVIEWS_INDEX_NAME, "_doc");
+        BulkRequest bulk = new BulkRequest(REVIEWS_INDEX_NAME);
         int day = 10;
         for (int i = 0; i < numDocs; i++) {
             long user = i % 28;
@@ -113,14 +109,14 @@ public class DataFrameTransformProgressIT extends ESIntegTestCase {
             bulk.add(new IndexRequest().source(sourceBuilder.toString(), XContentType.JSON));
 
             if (i % 50 == 0) {
-                BulkResponse response = client().bulk(bulk.request()).get();
+                BulkResponse response = restClient.bulk(bulk, RequestOptions.DEFAULT);
                 assertThat(response.buildFailureMessage(), response.hasFailures(), is(false));
-                bulk = client().prepareBulk(REVIEWS_INDEX_NAME, "_doc");
+                bulk = new BulkRequest(REVIEWS_INDEX_NAME);
                 day += 1;
             }
         }
-        client().bulk(bulk.request()).get();
-        client().admin().indices().prepareRefresh(REVIEWS_INDEX_NAME).get();
+        restClient.bulk(bulk, RequestOptions.DEFAULT);
+        restClient.indices().refresh(new RefreshRequest(REVIEWS_INDEX_NAME), RequestOptions.DEFAULT);
     }
 
     public void testGetProgress() throws Exception {
@@ -140,10 +136,11 @@ public class DataFrameTransformProgressIT extends ESIntegTestCase {
             pivotConfig,
             null);
 
-        PlainActionFuture<DataFrameTransformProgress> progressFuture = new PlainActionFuture<>();
-        TransformProgressGatherer.getInitialProgress(client(), config, progressFuture);
+        final RestHighLevelClient restClient = new TestRestHighLevelClient();
+        SearchResponse response = restClient.search(TransformProgressGatherer.getSearchRequest(config), RequestOptions.DEFAULT);
 
-        DataFrameTransformProgress progress = progressFuture.get();
+        DataFrameTransformProgress progress =
+            TransformProgressGatherer.searchResponseToDataFrameTransformProgressFunction().apply(response);
 
         assertThat(progress.getTotalDocs(), equalTo(1000L));
         assertThat(progress.getRemainingDocs(), equalTo(1000L));
@@ -160,34 +157,28 @@ public class DataFrameTransformProgressIT extends ESIntegTestCase {
             pivotConfig,
             null);
 
-
-        progressFuture = new PlainActionFuture<>();
-
-        TransformProgressGatherer.getInitialProgress(client(), config, progressFuture);
-        progress = progressFuture.get();
+        response = restClient.search(TransformProgressGatherer.getSearchRequest(config), RequestOptions.DEFAULT);
+        progress = TransformProgressGatherer.searchResponseToDataFrameTransformProgressFunction().apply(response);
 
         assertThat(progress.getTotalDocs(), equalTo(35L));
         assertThat(progress.getRemainingDocs(), equalTo(35L));
         assertThat(progress.getPercentComplete(), equalTo(0.0));
 
-        client().admin().indices().prepareDelete(REVIEWS_INDEX_NAME).get();
+        deleteIndex(REVIEWS_INDEX_NAME);
     }
 
     @Override
-    protected Settings externalClusterClientSettings() {
-        Settings.Builder builder = Settings.builder();
-        builder.put(NetworkModule.TRANSPORT_TYPE_KEY, SecurityField.NAME4);
-        builder.put(SecurityField.USER_SETTING.getKey(), "x_pack_rest_user:" +  SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING);
-        return builder.build();
+    protected Settings restClientSettings() {
+        final String token = "Basic " +
+            Base64.getEncoder().encodeToString(("x_pack_rest_user:x-pack-test-password").getBytes(StandardCharsets.UTF_8));
+        return Settings.builder()
+            .put(ThreadContext.PREFIX + ".Authorization", token)
+            .build();
     }
 
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Arrays.asList(LocalStateCompositeXPackPlugin.class, Netty4Plugin.class);
-    }
-
-    @Override
-    protected Collection<Class<? extends Plugin>> transportClientPlugins() {
-        return Arrays.asList(XPackClientPlugin.class, Netty4Plugin.class);
+    private class TestRestHighLevelClient extends RestHighLevelClient {
+        TestRestHighLevelClient() {
+            super(client(), restClient -> {}, Collections.emptyList());
+        }
     }
 }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/TransformProgressGatherer.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/TransformProgressGatherer.java
@@ -11,9 +11,12 @@ import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformProgress;
+
+import java.util.function.Function;
 
 /**
  * Utility class to gather the progress information for a given config and its cursor position
@@ -29,17 +32,10 @@ public final class TransformProgressGatherer {
     public static void getInitialProgress(Client client,
                                           DataFrameTransformConfig config,
                                           ActionListener<DataFrameTransformProgress> progressListener) {
-        SearchRequest request = client.prepareSearch(config.getSource().getIndex())
-            .setSize(0)
-            .setAllowPartialSearchResults(false)
-            .setTrackTotalHits(true)
-            .setQuery(config.getSource().getQueryConfig().getQuery())
-            .request();
+        SearchRequest request = getSearchRequest(config);
 
         ActionListener<SearchResponse> searchResponseActionListener = ActionListener.wrap(
-            searchResponse -> {
-                progressListener.onResponse(new DataFrameTransformProgress(searchResponse.getHits().getTotalHits().value, null));
-            },
+            searchResponse -> progressListener.onResponse(searchResponseToDataFrameTransformProgressFunction().apply(searchResponse)),
             progressListener::onFailure
         );
         ClientHelper.executeWithHeadersAsync(config.getHeaders(),
@@ -50,4 +46,17 @@ public final class TransformProgressGatherer {
             searchResponseActionListener);
     }
 
+    public static SearchRequest getSearchRequest(DataFrameTransformConfig config) {
+        SearchRequest request = new SearchRequest(config.getSource().getIndex());
+        request.allowPartialSearchResults(false);
+        request.source(new SearchSourceBuilder()
+            .size(0)
+            .trackTotalHits(true)
+            .query(config.getSource().getQueryConfig().getQuery()));
+        return request;
+    }
+
+    public static Function<SearchResponse, DataFrameTransformProgress> searchResponseToDataFrameTransformProgressFunction() {
+        return searchResponse -> new DataFrameTransformProgress(searchResponse.getHits().getTotalHits().value, null);
+    }
 }


### PR DESCRIPTION
backport dataframe changes from #42202, using client instead of transport

Note: Due to upcoming planned fixes this backport should be applied to the 7.2 branch as well to avoid merge conflicts for upcoming PR's.