### PR TITLE
[DOCS] Set explicit anchors in 1.7 for Asciidoctor

### DIFF
--- a/docs/reference/mapping/types/geo-shape-type.asciidoc
+++ b/docs/reference/mapping/types/geo-shape-type.asciidoc
@@ -222,8 +222,8 @@ differs from many Geospatial APIs (e.g., Google Maps) that generally
 use the colloquial latitude, longitude (Y, X).
 =============================================
 
-[[point]]
 [float]
+[[_ulink_url_http_geojson_org_geojson_spec_html_id2_point_ulink]]
 ===== http://geojson.org/geojson-spec.html#id2[Point]
 
 A point is a single geographic coordinate, such as the location of a
@@ -241,6 +241,7 @@ API.
 --------------------------------------------------
 
 [float]
+[[_ulink_url_http_geojson_org_geojson_spec_html_id3_linestring_ulink]]
 ===== http://geojson.org/geojson-spec.html#id3[LineString]
 
 A `linestring` defined by an array of two or more positions. By
@@ -261,6 +262,7 @@ The above `linestring` would draw a straight line starting at the White
 House to the US Capitol Building.
 
 [float]
+[[_ulink_url_http_www_geojson_org_geojson_spec_html_id4_polygon_ulink]]
 ===== http://www.geojson.org/geojson-spec.html#id4[Polygon]
 
 A polygon is defined by a list of a list of points. The first and last
@@ -344,6 +346,7 @@ overriding the orientation on a document:
 --------------------------------------------------
 
 [float]
+[[_ulink_url_http_www_geojson_org_geojson_spec_html_id5_multipoint_ulink]]
 ===== http://www.geojson.org/geojson-spec.html#id5[MultiPoint]
 
 A list of geojson points.
@@ -361,6 +364,7 @@ A list of geojson points.
 --------------------------------------------------
 
 [float]
+[[_ulink_url_http_www_geojson_org_geojson_spec_html_id6_multilinestring_ulink]]
 ===== http://www.geojson.org/geojson-spec.html#id6[MultiLineString]
 
 A list of geojson linestrings.
@@ -380,6 +384,7 @@ A list of geojson linestrings.
 --------------------------------------------------
 
 [float]
+[[_ulink_url_http_www_geojson_org_geojson_spec_html_id7_multipolygon_ulink]]
 ===== http://www.geojson.org/geojson-spec.html#id7[MultiPolygon]
 
 A list of geojson polygons.
@@ -400,6 +405,7 @@ A list of geojson polygons.
 --------------------------------------------------
 
 [float]
+[[_ulink_url_http_geojson_org_geojson_spec_html_geometrycollection_geometry_collection_ulink]]
 ===== http://geojson.org/geojson-spec.html#geometrycollection[Geometry Collection]
 
 A collection of geojson geometry objects.

--- a/docs/reference/migration/migrate_1_6.asciidoc
+++ b/docs/reference/migration/migrate_1_6.asciidoc
@@ -10,6 +10,7 @@ your application from Elasticsearch 1.x to Elasticsearch 1.6.
 The More Like This API query has been deprecated and will be removed in 2.0. Instead use the <<query-dsl-mlt-query, More Like This Query>>.
 
 [float]
+[[_literal_top_children_literal_query]]
 === `top_children` query
 
 The `top_children` query has been deprecated and will be removed in 2.0. Instead the `has_child` query should be used.

--- a/docs/reference/modules/plugins.asciidoc
+++ b/docs/reference/modules/plugins.asciidoc
@@ -107,6 +107,7 @@ plugin --remove <pluginname>
 -----------------------------------
 
 [float]
+[[_silent_verbose_mode]]
 ==== Silent/Verbose mode
 
 When running the `plugin` script, you can get more information (debug mode) using `--verbose`.

--- a/docs/reference/query-dsl/filters/has-child-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/has-child-filter.asciidoc
@@ -43,6 +43,7 @@ The `has_child` filter also accepts a filter instead of a query:
 --------------------------------------------------
 
 [float]
+[[_min_max_children_2]]
 ==== Min/Max Children
 
 The `has_child` filter allows you to specify that a minimum and/or maximum

--- a/docs/reference/query-dsl/filters/missing-filter.asciidoc
+++ b/docs/reference/query-dsl/filters/missing-filter.asciidoc
@@ -42,6 +42,7 @@ These documents would *not* match the above filter:
 <3> This field has one non-`null` value.
 
 [float]
+[[_literal_null_value_literal_mapping]]
 ==== `null_value` mapping
 
 If the field mapping includes a `null_value` (see <<mapping-core-types>>) then explicit `null` values

--- a/docs/reference/query-dsl/queries/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/queries/function-score-query.asciidoc
@@ -522,6 +522,7 @@ Only numeric, date, and geo-point fields are supported.
 If the numeric field is missing in the document, the function will
 return 1.
 
+[[_relation_to_literal_custom_boost_literal_literal_custom_score_literal_and_literal_custom_filters_score_literal]]
 ==== Relation to `custom_boost`, `custom_score` and `custom_filters_score`
 
 The `custom_boost_factor` query

--- a/docs/reference/query-dsl/queries/has-child-query.asciidoc
+++ b/docs/reference/query-dsl/queries/has-child-query.asciidoc
@@ -54,6 +54,7 @@ inside the `has_child` query:
 --------------------------------------------------
 
 [float]
+[[_min_max_children]]
 ==== Min/Max Children
 
 The `has_child` query allows you to specify that a minimum and/or maximum

--- a/docs/reference/query-dsl/queries/multi-match-query.asciidoc
+++ b/docs/reference/query-dsl/queries/multi-match-query.asciidoc
@@ -17,6 +17,7 @@ to allow multi-field queries:
 <2> The fields to be queried.
 
 [float]
+[[_literal_fields_literal_and_per_field_boosting]]
 === `fields` and per-field boosting
 
 Fields can be specified with wildcards, eg:
@@ -46,6 +47,7 @@ Individual fields can be boosted with the caret (`^`) notation:
 <1> The `subject` field is three times as important as the `message` field.
 
 [float]
+[[_literal_use_dis_max_literal]]
 === `use_dis_max`
 
 By default, the `multi_match` query generates a `match` clause per field, then wraps them
@@ -331,6 +333,7 @@ Also, accepts `analyzer`, `boost`, `operator`, `minimum_should_match`,
 `zero_terms_query` and `cutoff_frequency`, as explained in
 <<query-dsl-match-query, match query>>.
 
+[[_literal_cross_field_literal_and_analysis]]
 ===== `cross_field` and analysis
 
 The `cross_field` type can only work in term-centric mode on fields that have
@@ -425,6 +428,7 @@ which will be executed as:
     blended("will",  fields: [first, first.edge, last.edge, last])
     blended("smith", fields: [first, first.edge, last.edge, last])
 
+[[_literal_tie_breaker_literal]]
 ===== `tie_breaker`
 
 By default, each per-term `blended` query will use the best score returned by

--- a/docs/reference/search/aggregations/bucket/significantterms-aggregation.asciidoc
+++ b/docs/reference/search/aggregations/bucket/significantterms-aggregation.asciidoc
@@ -374,6 +374,7 @@ Available parameters in the script are
 `_subset_size`:: Number of documents in the subset.
 `_superset_size`:: Number of documents in the superset.
 
+[[_size_amp_shard_size]]
 ===== Size & Shard Size
 
 The `size` parameter can be set to define how many term buckets should be returned out of the overall terms list. By

--- a/docs/reference/search/facets.asciidoc
+++ b/docs/reference/search/facets.asciidoc
@@ -164,6 +164,7 @@ Note that this is different from a facet of the
 <<search-facets-filter-facet,filter>> type.
 
 [float]
+[[_facets_with_the_emphasis_nested_emphasis_types]]
 === Facets with the _nested_ types
 
 <<mapping-nested-type,Nested>> mapping allows


### PR DESCRIPTION
AsciiDoc and Asciidoctor generate missing anchors for headings differently. This sets explicit anchors so they render consistently in AsciiDoc and Asciidoctor.

Will backport as far back as possible.