### PR TITLE
[DOCS] Set explicit anchors in 2.0 for Asciidoctor

### DIFF
--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -114,6 +114,7 @@ If both `doc` and `script` is specified, then `doc` is ignored. Best is
 to put your field pairs of the partial document in the script itself.
 
 [float]
+[[_literal_detect_noop_literal]]
 === `detect_noop`
 
 By default if `doc` is specified then the document is always updated even


### PR DESCRIPTION
AsciiDoc and Asciidoctor generate missing anchors for headings differently. This sets explicit anchors so they render consistently in AsciiDoc and Asciidoctor.

Will backport as far back as possible.