### PR TITLE
[DOCS] Set explicit anchors in 2.4 for Asciidoctor

### DIFF
--- a/docs/reference/aggregations/bucket/sampler-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/sampler-aggregation.asciidoc
@@ -150,6 +150,7 @@ In this situation an error will be thrown.
 ===== Limited de-dup logic.
 The de-duplication logic in the diversify settings applies only at a shard level so will not apply across shards.
 
+[[_no_specialized_syntax_for_geo_date_fields]]
 ===== No specialized syntax for geo/date fields
 Currently the syntax for defining the diversifying values is defined by a choice of `field` or `script` - there is no added syntactical sugar for expressing geo or date units such as "1w" (1 week).
 This support may be added in a later release and users will currently have to create these sorts of values using a script.

--- a/docs/reference/analysis/tokenizers/edgengram-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/edgengram-tokenizer.asciidoc
@@ -62,6 +62,7 @@ of these classes. |`[]` (Keep all characters)
 --------------------------------------------------
 
 [float]
+[[_literal_side_literal_deprecated]]
 ==== `side` deprecated
 
 There used to be a `side` parameter up to `0.90.1` but it is now deprecated. In

--- a/docs/reference/mapping/fields/ttl-field.asciidoc
+++ b/docs/reference/mapping/fields/ttl-field.asciidoc
@@ -106,6 +106,7 @@ may still be retrieved before they are purged.
 How many deletions are handled by a single <<docs-bulk,`bulk`>> request. The
 default value is `10000`.
 
+[[_note_on_literal_detect_noop_literal]]
 ==== Note on `detect_noop`
 If an update tries to update just the `_ttl` without changing the `_source` of
 the document it's expiration time won't be updated if `detect_noop` is `true`.

--- a/docs/reference/migration/migrate_2_0/aggs.asciidoc
+++ b/docs/reference/migration/migrate_2_0/aggs.asciidoc
@@ -30,6 +30,7 @@ returned in the time zone specified.
 In addition to this, the `pre_zone_adjust_large_interval` is removed because
 we now always return dates and bucket keys in UTC.
 
+[[_including_excluding_terms]]
 ==== Including/excluding terms
 
 `include`/`exclude` filtering on the `terms` aggregation now uses the same

--- a/docs/reference/migration/migrate_2_0/index_apis.asciidoc
+++ b/docs/reference/migration/migrate_2_0/index_apis.asciidoc
@@ -35,6 +35,7 @@ the node that receives the request or another node.
 The `text()` method on `AnalyzeRequest` now returns `String[]` instead of
 `String`.
 
+[[_removed_literal_id_cache_literal_from_clear_cache_api]]
 ==== Removed `id_cache` from clear cache api
 
 The <<indices-clearcache,clear cache>> API no longer supports the `id_cache`

--- a/docs/reference/migration/migrate_2_0/java.asciidoc
+++ b/docs/reference/migration/migrate_2_0/java.asciidoc
@@ -57,7 +57,7 @@ In 2.0, Elasticsearch automatically threads listeners that are used from the
 client when the client is a node client or a transport client. Threading can
 no longer be manually set.
 
-
+[[_query_filter_refactoring]]
 ==== Query/filter refactoring
 
 `org.elasticsearch.index.queries.FilterBuilders` has been removed as part of the merge of

--- a/docs/reference/migration/migrate_2_0/mapping.asciidoc
+++ b/docs/reference/migration/migrate_2_0/mapping.asciidoc
@@ -257,6 +257,7 @@ PUT my_index/my_type/1?routing=bar <2>
 <1> Routing can be marked as required to ensure it is not forgotten during indexing.
 <2> This indexing request uses a `routing` value of `bar`.
 
+[[_literal__timestamp_literal_and_literal__ttl_literal_deprecated]]
 ==== `_timestamp` and `_ttl` deprecated
 
 The `_timestamp` and `_ttl` fields are deprecated, but will remain functional
@@ -315,6 +316,7 @@ PUT my_index/my_type/1
 -------------------------
 <1> Has `format`: `"strict_date_optional_time||epoch_millis"`.
 
+[[_literal_mapping_date_round_ceil_literal_setting]]
 ==== `mapping.date.round_ceil` setting
 
 The `mapping.date.round_ceil` setting for date math parsing has been removed.
@@ -352,6 +354,7 @@ the user-friendly representation of boolean fields: `false`/`true`:
 ]
 ---------------
 
+[[_literal_index_name_literal_and_literal_path_literal_removed]]
 ==== `index_name` and `path` removed
 
 The `index_name` setting was used to change the name of the Lucene field,

--- a/docs/reference/migration/migrate_2_0/packaging.asciidoc
+++ b/docs/reference/migration/migrate_2_0/packaging.asciidoc
@@ -9,6 +9,7 @@ configured, e.g. `path.data`, `path.scripts`, `path.repo`.  A configured path
 may itself be a symbolic link, but no symlinks under that path will be
 followed.
 
+[[_running_literal_bin_elasticsearch_literal]]
 ==== Running `bin/elasticsearch`
 
 The command line parameter parsing has been rewritten to deal properly with
@@ -25,11 +26,13 @@ bin/elasticsearch -d -p /tmp/foo.pid --http.cors.enabled=true --http.cors.allow-
 
 For a list of static parameters, run `bin/elasticsearch -h`
 
+[[_literal_f_literal_removed]]
 ==== `-f` removed
 
 The `-f` parameter, which used to indicate that Elasticsearch should be run in
 the foreground, was deprecated in 1.0 and removed in 2.0.
 
+[[_literal_v_literal_for_version]]
 ==== `V` for version
 
 The `-v` parameter now means `--verbose` for both `bin/plugin` and

--- a/docs/reference/migration/migrate_2_0/parent_child.asciidoc
+++ b/docs/reference/migration/migrate_2_0/parent_child.asciidoc
@@ -35,6 +35,7 @@ PUT my_index
 The mapping for the parent type can be added at the same time as the mapping
 for the child type, but cannot be added before the child type.
 
+[[_literal_top_children_literal_query_removed]]
 ==== `top_children` query removed
 
 The `top_children` query has been removed in favour of the `has_child` query.

--- a/docs/reference/migration/migrate_2_0/query_dsl.asciidoc
+++ b/docs/reference/migration/migrate_2_0/query_dsl.asciidoc
@@ -26,12 +26,14 @@ be cacheable. Filter context is introduced by:
   aggregations or index aliases
 --
 
+[[_literal_terms_literal_query_and_filter]]
 ==== `terms` query and filter
 
 The `execution` option of the `terms` filter is now deprecated and is ignored
 if provided. Similarly, the `terms` query no longer supports the
 `minimum_should_match` parameter.
 
+[[_literal_or_literal_and_literal_and_literal_now_implemented_via_literal_bool_literal]]
 ==== `or` and `and` now implemented via `bool`
 
 The `or` and `and` filters previously had a different execution pattern to the
@@ -43,6 +45,7 @@ handle both cases optimally.  As a result of this change, the `or` and `and`
 filters are now sugar syntax which are executed internally as a `bool` query.
 These filters may be removed in the future.
 
+[[_literal_filtered_literal_query_and_literal_query_literal_filter_deprecated]]
 ==== `filtered` query and `query` filter deprecated
 
 The `query` filter is deprecated as is it no longer needed -- all queries can
@@ -177,6 +180,7 @@ query have been removed in favor of the
 The parameter `percent_terms_to_match` has been removed in favor of
 `minimum_should_match`.
 
+[[_literal_limit_literal_filter_deprecated]]
 ==== `limit` filter deprecated
 
 The `limit` filter is deprecated and becomes a no-op. You can achieve similar

--- a/docs/reference/migration/migrate_2_0/removals.asciidoc
+++ b/docs/reference/migration/migrate_2_0/removals.asciidoc
@@ -60,11 +60,13 @@ still need to use multicast discovery, you can install the plugin with:
 
 See {plugins}/discovery-multicast.html for more information.
 
+[[_literal__shutdown_literal_api]]
 ==== `_shutdown` API
 
 The `_shutdown` API has been removed without a replacement. Nodes should be
 managed via the operating system and the provided start/stop scripts.
 
+[[_literal_murmur3_literal_is_now_a_plugin]]
 ==== `murmur3` is now a plugin
 
 The `murmur3` field, which indexes hashes of the field values, has been moved
@@ -75,6 +77,7 @@ out of core and is available as a plugin. It can be installed as:
 ./bin/plugin install mapper-murmur3
 ------------------
 
+[[_literal__size_literal_is_now_a_plugin]]
 ==== `_size` is now a plugin
 
 The `_size` meta-data field, which indexes the size in bytes of the original

--- a/docs/reference/migration/migrate_2_0/search.asciidoc
+++ b/docs/reference/migration/migrate_2_0/search.asciidoc
@@ -5,6 +5,7 @@
 
 Partial fields have been removed in favor of <<search-request-source-filtering,source filtering>>.
 
+[[_literal_search_type_count_literal_deprecated]]
 ==== `search_type=count` deprecated
 
 The `count` search type has been deprecated. All benefits from this search
@@ -112,6 +113,7 @@ to `false` to ignore field names completely when highlighting.
 The postings highlighter doesn't support the `require_field_match` option
 anymore, it will only highlight fields that were queried.
 
+[[_postings_highlighter_doesn_8217_t_support_literal_match_phrase_prefix_literal]]
 ==== Postings highlighter doesn't support `match_phrase_prefix`
 
 The `match` query with type set to `phrase_prefix` (or the

--- a/docs/reference/migration/migrate_2_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_2_0/settings.asciidoc
@@ -197,6 +197,7 @@ It is no longer possible to set custom file path outside `CONF_DIR` for `*_path`
 in <<analysis-charfilters,char>> or <<analysis-tokenfilters,token>> filters.
 You must specify either relative path to `CONF_DIR` location or absolute path inside `CONF_DIR` location.
 
+[[_literal_es_classpath_removed_literal]]
 ==== `ES_CLASSPATH removed`
 
 The `ES_CLASSPATH` environment variable is no longer used to set the class

--- a/docs/reference/migration/migrate_2_0/stats.asciidoc
+++ b/docs/reference/migration/migrate_2_0/stats.asciidoc
@@ -15,6 +15,7 @@ info, and node stats responses:
 * `os.mem.total` and `os.swap.total` have been removed from nodes info.
 * `process.mem.resident` and `process.mem.share` have been removed from node stats.
 
+[[_removed_literal_id_cache_literal_from_stats_apis]]
 ==== Removed `id_cache` from stats apis
 
 Removed `id_cache` metric from nodes stats, indices stats and cluster stats

--- a/docs/reference/migration/migrate_2_1.asciidoc
+++ b/docs/reference/migration/migrate_2_1.asciidoc
@@ -12,6 +12,7 @@ your application to Elasticsearch 2.1.
 [[breaking_21_search_changes]]
 === Search changes
 
+[[_literal_search_type_scan_literal_deprecated]]
 ==== `search_type=scan` deprecated
 
 The `scan` search type has been deprecated. All benefits from this search
@@ -32,6 +33,7 @@ Scroll requests sorted by `_doc` have been optimized to more efficiently resume
 from where the previous request stopped, so this will have the same performance
 characteristics as the former `scan` search type.
 
+[[_literal_search_type_count_literal_deprecated_2]]
 ==== `search_type=count` deprecated
 
 The `count` search type has been deprecated. All benefits from this search
@@ -74,6 +76,7 @@ MoreLikeThisBuilder#addLikeItem.
 [[breaking_21_update_changes]]
 === Update changes
 
+[[_updates_now_literal_detect_noop_literal_by_default]]
 ==== Updates now `detect_noop` by default
 
 We've switched the default value of the `detect_noop` option from `false` to
@@ -97,6 +100,7 @@ The value for the `queue_size` in nodes info/stats was sometimes shown as
 [[breaking_21_removed_features]]
 === Removed features
 
+[[_literal_indices_fielddata_cache_expire_literal]]
 ==== `indices.fielddata.cache.expire`
 
 The experimental feature `indices.fielddata.cache.expire` has been removed.

--- a/docs/reference/migration/migrate_2_3.asciidoc
+++ b/docs/reference/migration/migrate_2_3.asciidoc
@@ -19,6 +19,7 @@ A change to the CORS implementation means that CORS support for pre-flight
 === Mappings
 
 [float]
+[[_limit_to_the_number_of_literal_nested_literal_fields]]
 ==== Limit to the number of `nested` fields
 
 Indexing a document with 100 nested fields actually indexes 101 documents as each nested

--- a/docs/reference/query-dsl/missing-query.asciidoc
+++ b/docs/reference/query-dsl/missing-query.asciidoc
@@ -44,6 +44,7 @@ These documents would *not* match the above filter:
 <3> This field has one non-`null` value.
 
 [float]
+[[_literal_null_value_literal_mapping]]
 ==== `null_value` mapping
 
 If the field mapping includes a <<null-value,`null_value`>> then explicit `null` values
@@ -77,6 +78,7 @@ no values in the `user` field and thus would match the `missing` filter:
 --------------------------------------------------
 
 [float]
+[[_literal_existence_literal_and_literal_null_value_literal_parameters]]
 ===== `existence` and `null_value` parameters
 
 When the field being queried has a `null_value` mapping, then the behaviour of


### PR DESCRIPTION
AsciiDoc and Asciidoctor generate missing anchors for headings differently. This sets explicit anchors so they render consistently in AsciiDoc and Asciidoctor.

Will backport as far back as possible.