### PR TITLE
[DOCS] Set explicit anchors in 5.5 for Asciidoctor

### DIFF
--- a/docs/reference/migration/migrate_5_5.asciidoc
+++ b/docs/reference/migration/migrate_5_5.asciidoc
@@ -21,6 +21,7 @@ instead the same functionality can be achieved by masking the `systemd-sysctl`
 service.
 
 [float]
+[[_rpm_and_debian_packages_literal_setgid_literal_on_literal_etc_elasticsearch_literal]]
 === RPM and Debian packages `setgid` on `/etc/elasticsearch`
 
 The RPM and Debian packages now set the `setgid` flag on `/etc/elasticsearch` so


### PR DESCRIPTION
AsciiDoc and Asciidoctor generate missing anchors for headings differently. This sets explicit anchors so they render consistently in AsciiDoc and Asciidoctor.

Will backport as far back as possible.