### PR TITLE
[DOCS] Set explicit anchors in 5.6 for Asciidoctor

### DIFF
--- a/docs/reference/how-to/disk-usage.asciidoc
+++ b/docs/reference/how-to/disk-usage.asciidoc
@@ -145,6 +145,7 @@ document and can use significant space. If you never need to search against all
 fields at the same time, it can be disabled.
 
 [float]
+[[_use_literal_best_compression_literal]]
 === Use `best_compression`
 
 The `_source` and stored fields can easily take a non negligible amount of disk

--- a/docs/reference/how-to/general.asciidoc
+++ b/docs/reference/how-to/general.asciidoc
@@ -120,6 +120,7 @@ problems due to sparsity as described above. If your types do not have very
 similar mappings, you might want to consider moving them to a dedicated index.
 
 [float]
+[[_disable_literal_norms_literal_and_literal_doc_values_literal_on_sparse_fields]]
 ==== Disable `norms` and `doc_values` on sparse fields
 
 If none of the above recommendations apply in your case, you might want to

--- a/docs/reference/migration/migrate_5_0/aggregations.asciidoc
+++ b/docs/reference/migration/migrate_5_0/aggregations.asciidoc
@@ -14,6 +14,7 @@ or through a <<multi-fields,multi-field>> if the numeric representation is
 still needed for sorting, range queries or numeric aggregations like
 <<search-aggregations-metrics-stats-aggregation,`stats` aggregations>>.
 
+[[_literal_ip_range_literal_aggregations]]
 ==== `ip_range` aggregations
 
 Now that Elasticsearch supports `ipv6`, `ip` addresses are encoded in the index
@@ -21,6 +22,7 @@ using a binary representation rather than a numeric representation. As a
 consequence, the output of `ip_range` aggregations does not give numeric values
 for `from` and `to` anymore.
 
+[[_literal_size_0_literal_on_terms_significant_terms_and_geohash_grid_aggregations]]
 ==== `size: 0` on Terms, Significant Terms and Geohash Grid Aggregations
 
 `size: 0` is no longer valid for the terms, significant terms and geohash grid

--- a/docs/reference/migration/migrate_5_0/allocation.asciidoc
+++ b/docs/reference/migration/migrate_5_0/allocation.asciidoc
@@ -44,6 +44,7 @@ false. The new `allocate_empty_primary` command corresponds to the old
 Elasticsearch no longer supports plugins registering custom allocation
 commands. It was unused and hopefully unneeded.
 
+[[_literal_index_shared_filesystem_recover_on_any_node_literal_changes]]
 ==== `index.shared_filesystem.recover_on_any_node` changes
 
 The behavior of `index.shared_filesystem.recover_on_any_node: true` has been

--- a/docs/reference/migration/migrate_5_0/docs.asciidoc
+++ b/docs/reference/migration/migrate_5_0/docs.asciidoc
@@ -1,6 +1,7 @@
 [[breaking_50_document_api_changes]]
 === Document API changes
 
+[[_literal_refresh_literal_no_longer_supports_truthy_and_falsy_values]]
 ==== `?refresh` no longer supports truthy and falsy values
 The `?refresh` request parameter used to accept any value other than `false`,
 `0`, `off`, and `no` to mean "make the changes from this request visible for
@@ -11,6 +12,7 @@ url entirely. If you add `?refresh=wait_for` Elasticsearch will wait for the
 changes to become visible before replying to the request but won't take any
 immediate refresh related action. See <<docs-refresh>>.
 
+[[_literal_created_literal_field_deprecated_in_the_index_api]]
 ==== `created` field deprecated in the Index API
 
 The `created` field has been deprecated in the Index API. It now returns
@@ -18,6 +20,7 @@ The `created` field has been deprecated in the Index API. It now returns
 `"result": "updated"` when it updated the document. This is also true for
 `index` bulk operations.
 
+[[_literal_found_literal_field_deprecated_in_the_delete_api]]
 ==== `found` field deprecated in the Delete API
 
 The `found` field has been deprecated in the Delete API. It now returns

--- a/docs/reference/migration/migrate_5_0/index-apis.asciidoc
+++ b/docs/reference/migration/migrate_5_0/index-apis.asciidoc
@@ -50,6 +50,7 @@ CPU usage can be obtained from `OsStats.Cpu#getPercent`.
 Suggest stats exposed through `suggest` in indices stats has been merged
 with `search` stats. `suggest` stats is exposed as part of `search` stats.
 
+[[_creating_indices_starting_with_emphasis_emphasis_or_emphasis_emphasis]]
 ==== Creating indices starting with '-' or '+'
 
 Elasticsearch no longer allows indices to be created started with '-' or '+', so

--- a/docs/reference/migration/migrate_5_0/java.asciidoc
+++ b/docs/reference/migration/migrate_5_0/java.asciidoc
@@ -353,6 +353,7 @@ Removed the `getMemoryAvailable` method from `OsStats`, which could be previousl
 `clusterStatsResponse.getNodesStats().getOs().getMem()` which exposes `getTotal()`, `getFree()`,
 `getUsed()`, `getFreePercent()` and `getUsedPercent()`.
 
+[[_setrefresh_boolean_has_been_removed]]
 ==== setRefresh(boolean) has been removed
 
 `setRefresh(boolean)` has been removed in favor of `setRefreshPolicy(RefreshPolicy)` because there
@@ -393,6 +394,7 @@ The `setWaitForRelocatingShards(int)` method has been removed in favor of `setWa
 which instead uses a boolean flag to denote whether the cluster health operation should wait for there to
 be no relocating shards in the cluster before returning.
 
+[[_blobcontainer_interface_for_snapshot_restore]]
 ==== BlobContainer Interface for Snapshot/Restore
 
 Some methods have been removed from the `BlobContainer` interface for Snapshot/Restore repositories.  In particular,

--- a/docs/reference/migration/migrate_5_0/mapping.asciidoc
+++ b/docs/reference/migration/migrate_5_0/mapping.asciidoc
@@ -77,6 +77,7 @@ PUT my_index
 Also the `precision_step` parameter is now irrelevant and will be rejected on
 indices that are created on or after 5.0.
 
+[[_literal_geo_point_literal_fields]]
 ==== `geo_point` fields
 
 Like Numeric fields the Geo point field now uses the new BKD tree structure. Since
@@ -86,6 +87,7 @@ following field parameters are no longer needed or supported: `geohash`,
 an API perspective, and can still be accessed using the `.geohash` field extension,
 but they are no longer used to index geo point data.
 
+[[_literal__timestamp_literal_and_literal__ttl_literal]]
 ==== `_timestamp` and `_ttl`
 
 The `_timestamp` and `_ttl` fields were deprecated and are now removed. As a
@@ -94,6 +96,7 @@ current timestamp on application side. For `_ttl`, you should either use
 time-based indices when applicable, or cron a delete-by-query with a range
 query on a timestamp field
 
+[[_literal_index_literal_property]]
 ==== `index` property
 
 On all field datatypes (except for the deprecated `string` field), the `index`
@@ -106,6 +109,7 @@ Previously, setting a field to `index:no` would also disable doc-values.  Now,
 doc-values are enabled by default on all types but `text` and `binary`,
 regardless of the value of the `index` property.
 
+[[_floating_points_use_literal_float_literal_instead_of_literal_double_literal]]
 ==== Floating points use `float` instead of `double`
 
 When dynamically mapping a field containing a floating point number, the field
@@ -113,18 +117,21 @@ now defaults to using `float` instead of `double`. The reasoning is that
 floats should be more than enough for most cases but would decrease storage
 requirements significantly.
 
+[[_literal_norms_literal]]
 ==== `norms`
 
 `norms` now take a boolean instead of an object. This boolean is the replacement
 for `norms.enabled`. There is no replacement for `norms.loading` since eager
 loading of norms is not useful anymore now that norms are disk-based.
 
+[[_literal_fielddata_format_literal]]
 ==== `fielddata.format`
 
 Setting `fielddata.format: doc_values` in the mappings used to implicitly
 enable doc-values on a field. This no longer works: the only way to enable or
 disable doc-values is by using the `doc_values` property of mappings.
 
+[[_literal_fielddata_filter_regex_literal]]
 ==== `fielddata.filter.regex`
 
 Regex filters are not supported anymore and will be dropped on upgrade.
@@ -145,7 +152,7 @@ created in 5.x:
 
 See <<mapping-limit-settings>> for more.
 
-
+[[_literal__parent_literal_field_no_longer_indexed]]
 ==== `_parent` field no longer indexed
 
 The join between parent and child documents no longer relies on indexed fields
@@ -154,6 +161,7 @@ order to find documents that refer to a specific parent id, the new
 `parent_id` query can be used. The GET response and hits inside the search
 response still include the parent id under the `_parent` key.
 
+[[_source_literal_format_literal_option]]
 ==== Source `format` option
 
 The `_source` mapping no longer supports the `format` option. It will still be
@@ -174,6 +182,7 @@ per document boosts as follows:
 }
 ---------------
 
+[[_boost_accuracy_for_queries_on_literal__all_literal]]
 ==== Boost accuracy for queries on `_all`
 
 Per-field boosts on the `_all` are now compressed into a single byte instead
@@ -181,6 +190,7 @@ of the 4 bytes used previously. While this will make the index much more
 space-efficient, it also means that index time boosts will be less accurately
 encoded.
 
+[[_literal__ttl_literal_and_literal__timestamp_literal_cannot_be_created]]
 ==== `_ttl` and `_timestamp` cannot be created
 
 You can no longer create indexes with `_ttl` or `_timestamp` enabled. Indexes

--- a/docs/reference/migration/migrate_5_0/packaging.asciidoc
+++ b/docs/reference/migration/migrate_5_0/packaging.asciidoc
@@ -1,6 +1,7 @@
 [[breaking_50_packaging]]
 === Packaging
 
+[[_apt_yum_repository_url_changes]]
 ==== APT/YUM repository URL changes
 
 The repository for apt and yum packages has changed from
@@ -54,6 +55,7 @@ longer configures the thread stack size. When installing the Windows
 service, you must configure thread stack size. For additional details,
 see the <<windows-service,installation docs>>.
 
+[[_bin_bash_is_now_required]]
 ==== /bin/bash is now required
 
 Previously, the scripts used to start Elasticsearch and run plugin

--- a/docs/reference/migration/migrate_5_0/rest.asciidoc
+++ b/docs/reference/migration/migrate_5_0/rest.asciidoc
@@ -16,6 +16,7 @@ that contains unrecognized query string parameters.
 When specifying an `_id` value longer than 512 bytes, the request will be
 rejected.
 
+[[_literal__optimize_literal_endpoint_removed]]
 ==== `/_optimize` endpoint removed
 
 The deprecated `/_optimize` endpoint has been removed. The `/_forcemerge`
@@ -24,11 +25,13 @@ endpoint should be used in lieu of optimize.
 The `GET` HTTP verb for `/_forcemerge` is no longer supported, please use the
 `POST` HTTP verb.
 
+[[_index_creation_endpoint_only_accepts_literal_put_literal]]
 ==== Index creation endpoint only accepts `PUT`
 
 It used to be possible to create an index by either calling `PUT index_name`
 or `POST index_name`. Only the former is now supported.
 
+[[_literal_head_index_type_literal_replaced_with_literal_head_index__mapping_type_literal]]
 ==== `HEAD {index}/{type}` replaced with `HEAD {index}/_mapping/{type}`
 
 The endpoint for checking whether a type exists has been changed from
@@ -36,12 +39,14 @@ The endpoint for checking whether a type exists has been changed from
 removal of types when `HEAD {index}/{id}` will be used to check whether a
 document exists in an index. The old endpoint will keep working until 6.0.
 
+[[_removed_literal_mem_literal_section_from_literal__cluster_stats_literal_response]]
 ==== Removed `mem` section from `/_cluster/stats` response
 
 The `mem` section contained only the `total` value, which was actually the
 memory available throughout all nodes in the cluster. The section contains now
 `total`, `free`, `used`, `used_percent` and `free_percent`.
 
+[[_revised_node_roles_aggregate_returned_by_literal__cluster_stats_literal]]
 ==== Revised node roles aggregate returned by `/_cluster/stats`
 
 The `client`, `master_only`, `data_only` and `master_data` fields have been
@@ -50,6 +55,7 @@ node can contribute to multiple counts as it can have multiple roles. Every
 node is implicitly a coordinating node, so whenever a node has no explicit
 roles, it will be counted as coordinating only.
 
+[[_removed_shard_literal_version_literal_information_from_literal__cluster_state_literal_routing_table]]
 ==== Removed shard `version` information from `/_cluster/state` routing table
 
 We now store allocation id's of shards in the cluster state and use that to 
@@ -79,6 +85,7 @@ removed in Elasticsearch 6.0.0.
 The `filters` and `char_filters` parameters have been renamed `filter` and `char_filter`.
 The `token_filters` parameter has been removed. Use `filter` instead.
 
+[[_literal_delete__query_literal_endpoint_removed]]
 ==== `DELETE /_query` endpoint removed
 
 The `DELETE /_query` endpoint provided by the Delete-By-Query plugin has been
@@ -101,6 +108,7 @@ The `PUT /_search/template/{id}/_create` endpoint that previously allowed to cre
 Some REST endpoints (e.g., cluster update index settings) supported detecting content in the Java
 properties format (line-delimited key=value pairs). This support has been removed.
 
+[[_literal_wait_for_relocating_shards_literal_is_now_literal_wait_for_no_relocating_shards_literal_in_literal__cluster_health_literal]]
 ==== `wait_for_relocating_shards` is now `wait_for_no_relocating_shards` in `/_cluster/health`
 
 The `wait_for_relocating_shards` parameter that used to take a number is now simply a boolean

--- a/docs/reference/migration/migrate_5_0/scripting.asciidoc
+++ b/docs/reference/migration/migrate_5_0/scripting.asciidoc
@@ -332,6 +332,7 @@ Prior to 5.0.0 scripting engines could register multiple extensions. The only
 engine doing this was the Javascript engine, which registered "js" and
 "javascript". It now only registers the "js" file extension for on-disk scripts.
 
+[[_literal_javascript_literal_files_are_no_longer_supported_use_literal_js_literal]]
 ==== `.javascript` files are no longer supported (use `.js`)
 
 The Javascript engine previously registered "js" and "javascript". It now only

--- a/docs/reference/migration/migrate_5_0/search.asciidoc
+++ b/docs/reference/migration/migrate_5_0/search.asciidoc
@@ -1,8 +1,10 @@
 [[breaking_50_search_changes]]
 === Search and Query DSL changes
 
+[[_literal_search_type_literal]]
 ==== `search_type`
 
+[[_literal_search_type_count_literal_removed]]
 ===== `search_type=count` removed
 
 The `count` search type was deprecated since version 2.0.0 and is now removed.
@@ -42,6 +44,7 @@ GET /my_index/_search
 }
 ---------------
 
+[[_literal_search_type_scan_literal_removed]]
 ===== `search_type=scan` removed
 
 The `scan` search type was deprecated since version 2.1.0 and is now removed.
@@ -72,12 +75,14 @@ larger shards. In case you would like to bypass this limit, which is
 discouraged, you can update the `action.search.shard_count.limit` cluster
 setting to a greater value.
 
+[[_literal_fields_literal_parameter]]
 ==== `fields` parameter
 
 The `fields` parameter has been replaced by `stored_fields`.
 The `stored_fields` parameter will only return stored fields
 -- it will no longer extract values from the `_source`.
 
+[[_literal_fielddata_fields_literal_parameter]]
 ==== `fielddata_fields` parameter
 
 The `fielddata_fields` has been deprecated, use parameter `docvalue_fields` instead.
@@ -164,6 +169,7 @@ This parameter was undocumented and silently ignored before for these types of `
 
 * For `geo_distance` query, aggregation, and sort the `sloppy_arc` option for the `distance_type` parameter has been deprecated.
 
+[[_top_level_literal_filter_literal_parameter]]
 ==== Top level `filter` parameter
 
 Removed support for the deprecated top level `filter` in the search api,

--- a/docs/reference/migration/migrate_5_2.asciidoc
+++ b/docs/reference/migration/migrate_5_2.asciidoc
@@ -33,6 +33,7 @@ removed in Elasticsearch 6.0.0.
 === Java API changes
 
 [float]
+[[_removed_some_of_the_literal_source_literal_overrides]]
 ==== Removed some of the `source` overrides
 
 In an effort to clean up internals we've removed the following methods:


### PR DESCRIPTION
AsciiDoc and Asciidoctor generate missing anchors for headings differently. This sets explicit anchors so they render consistently in AsciiDoc and Asciidoctor.

Will backport as far back as possible.