### PR TITLE
Build cache init script

### DIFF
--- a/.ci/build-cache.gradle
+++ b/.ci/build-cache.gradle
@@ -1,0 +1,18 @@
+if (System.getenv('GRADLE_BUILD_CACHE_URL')) {
+    gradle.settingsEvaluated { settings ->
+        settings.buildCache {
+            remote(HttpBuildCache) {
+                url = System.getenv('GRADLE_BUILD_CACHE_URL')
+                push = Boolean.valueOf(System.getenv('GRADLE_BUILD_CACHE_PUSH') ?: 'false')
+                if (System.getenv('GRADLE_BUILD_CACHE_USERNAME') && System.getenv('GRADLE_BUILD_CACHE_PASSWORD')) {
+                    credentials {
+                        username = System.getenv('GRADLE_BUILD_CACHE_USERNAME')
+                        password = System.getenv('GRADLE_BUILD_CACHE_PASSWORD')
+                    }
+                }
+            }
+        }
+    }
+} else {
+    throw new GradleException("You must supply a value for GRADLE_BUILD_CACHE_URL environment variable when applying build-cache.gradle init script")
+}


### PR DESCRIPTION
Add an init script that developers and CI can explicitly apply to enable the remote build cache.