### PR TITLE
Wipe repositories more often

### DIFF
--- a/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -27,7 +27,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.blobstore.ESBlobStoreRepositoryIntegTestCase;
-import org.junit.AfterClass;
+import org.junit.After;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -67,8 +67,8 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESBlobStoreRepos
         assertThat(repository, instanceOf(GoogleCloudStorageRepository.class));
     }
 
-    @AfterClass
-    public static void wipeRepository() {
+    @After
+    public void wipeRepository() {
         blobs.clear();
     }
 

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
@@ -38,7 +38,7 @@ import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.action.admin.cluster.RestGetRepositoriesAction;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.BeforeClass;
 
 import java.util.Collection;
@@ -78,8 +78,8 @@ public class S3BlobStoreRepositoryTests extends ESBlobStoreRepositoryIntegTestCa
         }
     }
 
-    @AfterClass
-    public static void wipeRepository() {
+    @After
+    public void wipeRepository() {
         blobs.clear();
     }
 


### PR DESCRIPTION
Fixes an issue where repositories are unintentionally shared among tests (given that the repo contents is captured in a static variable on the test class, to allow "sharing" among nodes) and two tests randomly chose the same snapshot name, leading to a conflict.

Test failure for GCS: https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+7.x+release-tests/359/console
Test failure for S3: https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+7.0+matrix-java-periodic/ES_BUILD_JAVA=openjdk12,ES_RUNTIME_JAVA=java12,nodes=immutable&&linux&&docker/137/console


Relevant output:

```
InvalidSnapshotNameException[[gqu:s] Invalid snapshot name [s], snapshot with the same name already exists]
	at __randomizedtesting.SeedInfo.seed([F3A37A4723ACFE7F:33C41934FE630348]:0)
	at org.elasticsearch.repositories.blobstore.BlobStoreRepository.initializeSnapshot(BlobStoreRepository.java:393)
	at org.elasticsearch.snapshots.SnapshotsService$2.doRun(SnapshotsService.java:414)
	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:758)
	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```