### PR TITLE
Remove unused mapStringsOrdered method

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
@@ -136,11 +136,9 @@ public interface XContentParser extends Closeable {
 
     Map<String, String> mapStrings() throws IOException;
 
-    Map<String, String> mapStringsOrdered() throws IOException;
-
     /**
      * Returns an instance of {@link Map} holding parsed map.
-     * Serves as a replacement for the "map", "mapOrdered", "mapStrings" and "mapStringsOrdered" methods above.
+     * Serves as a replacement for the "map", "mapOrdered" and "mapStrings" methods above.
      *
      * @param mapFactory factory for creating new {@link Map} objects
      * @param mapValueParser parser for parsing a single map value

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentSubParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentSubParser.java
@@ -109,11 +109,6 @@ public class XContentSubParser implements XContentParser {
     }
 
     @Override
-    public Map<String, String> mapStringsOrdered() throws IOException {
-        return parser.mapStringsOrdered();
-    }
-
-    @Override
     public <T> Map<String, T> map(
             Supplier<Map<String, T>> mapFactory, CheckedFunction<XContentParser, T, IOException> mapValueParser) throws IOException {
         return parser.map(mapFactory, mapValueParser);

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
@@ -277,11 +277,6 @@ public abstract class AbstractXContentParser implements XContentParser {
     }
 
     @Override
-    public Map<String, String> mapStringsOrdered() throws IOException {
-        return readOrderedMapStrings(this);
-    }
-
-    @Override
     public <T> Map<String, T> map(
             Supplier<Map<String, T>> mapFactory, CheckedFunction<XContentParser, T, IOException> mapValueParser) throws IOException {
         return readGenericMap(this, mapFactory, mapValueParser);
@@ -303,8 +298,6 @@ public abstract class AbstractXContentParser implements XContentParser {
 
     static final Supplier<Map<String, String>> SIMPLE_MAP_STRINGS_FACTORY = HashMap::new;
 
-    static final Supplier<Map<String, String>> ORDERED_MAP_STRINGS_FACTORY = LinkedHashMap::new;
-
     static Map<String, Object> readMap(XContentParser parser) throws IOException {
         return readMap(parser, SIMPLE_MAP_FACTORY);
     }
@@ -313,12 +306,12 @@ public abstract class AbstractXContentParser implements XContentParser {
         return readMap(parser, ORDERED_MAP_FACTORY);
     }
 
-    static Map<String, String> readMapStrings(XContentParser parser) throws IOException {
-        return readMapStrings(parser, SIMPLE_MAP_STRINGS_FACTORY);
+    static Map<String, Object> readMap(XContentParser parser, Supplier<Map<String, Object>> mapFactory) throws IOException {
+        return readGenericMap(parser, mapFactory, p -> readValue(p, mapFactory));
     }
 
-    static Map<String, String> readOrderedMapStrings(XContentParser parser) throws IOException {
-        return readMapStrings(parser, ORDERED_MAP_STRINGS_FACTORY);
+    static Map<String, String> readMapStrings(XContentParser parser) throws IOException {
+        return readGenericMap(parser, SIMPLE_MAP_STRINGS_FACTORY, XContentParser::text);
     }
 
     static List<Object> readList(XContentParser parser) throws IOException {
@@ -327,14 +320,6 @@ public abstract class AbstractXContentParser implements XContentParser {
 
     static List<Object> readListOrderedMap(XContentParser parser) throws IOException {
         return readList(parser, ORDERED_MAP_FACTORY);
-    }
-
-    static Map<String, Object> readMap(XContentParser parser, Supplier<Map<String, Object>> mapFactory) throws IOException {
-        return readGenericMap(parser, mapFactory, p -> readValue(p, mapFactory));
-    }
-
-    static Map<String, String> readMapStrings(XContentParser parser, Supplier<Map<String, String>> mapFactory) throws IOException {
-        return readGenericMap(parser, mapFactory, XContentParser::text);
     }
 
     static <T> Map<String, T> readGenericMap(

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
@@ -306,10 +306,6 @@ public abstract class AbstractXContentParser implements XContentParser {
         return readMap(parser, ORDERED_MAP_FACTORY);
     }
 
-    static Map<String, Object> readMap(XContentParser parser, Supplier<Map<String, Object>> mapFactory) throws IOException {
-        return readGenericMap(parser, mapFactory, p -> readValue(p, mapFactory));
-    }
-
     static Map<String, String> readMapStrings(XContentParser parser) throws IOException {
         return readGenericMap(parser, SIMPLE_MAP_STRINGS_FACTORY, XContentParser::text);
     }
@@ -320,6 +316,10 @@ public abstract class AbstractXContentParser implements XContentParser {
 
     static List<Object> readListOrderedMap(XContentParser parser) throws IOException {
         return readList(parser, ORDERED_MAP_FACTORY);
+    }
+
+    static Map<String, Object> readMap(XContentParser parser, Supplier<Map<String, Object>> mapFactory) throws IOException {
+        return readGenericMap(parser, mapFactory, p -> readValue(p, mapFactory));
     }
 
     static <T> Map<String, T> readGenericMap(

--- a/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/XContentParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/XContentParserTests.java
@@ -189,7 +189,7 @@ public class XContentParserTests extends ESTestCase {
             assertThat(parser.currentName(), equalTo("foo"));
             token = parser.nextToken();
             assertThat(token, equalTo(XContentParser.Token.START_OBJECT));
-            return randomBoolean() ? parser.mapStringsOrdered() : parser.mapStrings();
+            return parser.mapStrings();
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/xcontent/WatcherXContentParser.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/xcontent/WatcherXContentParser.java
@@ -121,11 +121,6 @@ public class WatcherXContentParser implements XContentParser {
     }
 
     @Override
-    public Map<String, String> mapStringsOrdered() throws IOException {
-        return parser.mapStringsOrdered();
-    }
-
-    @Override
     public <T> Map<String, T> map(
             Supplier<Map<String, T>> mapFactory, CheckedFunction<XContentParser, T, IOException> mapValueParser) throws IOException {
         return parser.map(mapFactory, mapValueParser);


### PR DESCRIPTION
Currently mapStringsOrdered has no usages.
If its functionality is ever needed, the following code should be used:
parser.genericMap(LinkedHashMap::new, XContentParser::text)
