### PR TITLE
[DOCS] Set explicit anchors in 6.2 for Asciidoctor

### DIFF
--- a/docs/reference/migration/migrate_6_0/aggregations.asciidoc
+++ b/docs/reference/migration/migrate_6_0/aggregations.asciidoc
@@ -1,6 +1,7 @@
 [[breaking_60_aggregations_changes]]
 === Aggregations changes
 
+[[_deprecated_literal_pattern_literal_element_of_include_exclude_for_terms_aggregations_has_been_removed]]
 ==== Deprecated `pattern` element of include/exclude for terms aggregations has been removed
 
 The `include` and `exclude` options of `terms` aggregations used to accept a
@@ -50,6 +51,7 @@ POST /twitter/_search?size=0
 // CONSOLE
 // TEST[setup:twitter]
 
+[[_numeric_literal_to_literal_and_literal_from_literal_parameters_in_literal_date_range_literal_aggregation_are_interpreted_according_to_literal_format_literal_now]]
 ==== Numeric `to` and `from` parameters in `date_range` aggregation are interpreted according to `format` now
 
 Numeric `to` and `from` parameters in `date_range` aggregations used to always be interpreted as `epoch_millis`,
@@ -58,7 +60,7 @@ Now we interpret these parameters according to the `format` of the target field.
 If the `format` in the mappings is not compatible with the numeric input value, a compatible 
 `format` (e.g. `epoch_millis`, `epoch_second`) must be specified in the `date_range` aggregation, otherwise an error is thrown.
 
-
+[[_literal_global_ordinals_hash_literal_and_literal_global_ordinals_low_cardinality_literal_are_deprecated_in_the_literal_terms_literal_aggregation]]
 ==== `global_ordinals_hash` and `global_ordinals_low_cardinality` are deprecated in the `terms` aggregation
 
 The execution hints `global_ordinals_hash` and `global_ordinals_low_cardinality` are deprecated and should be replaced

--- a/docs/reference/migration/migrate_6_0/docs.asciidoc
+++ b/docs/reference/migration/migrate_6_0/docs.asciidoc
@@ -1,6 +1,7 @@
 [[breaking_60_docs_changes]]
 === Document API changes
 
+[[_version_type_literal_force_literal_removed]]
 ==== version type `force` removed
 
 Document modification operations may no longer specify the `version_type` of
@@ -10,12 +11,13 @@ Document modification operations may no longer specify the `version_type` of
 
 Adding a `version` to an upsert request is no longer supported.
 
+[[_literal_created_literal_field_removed_in_the_index_api]]
 ==== `created` field removed in the Index API
 
 The `created` field has been removed in the Index API as in the `index` and
 `create` bulk operations. `operation` field should be used instead.
 
-
+[[_literal_found_literal_field_removed_in_the_delete_api]]
 ==== `found` field removed in the Delete API
 
 The `found` field has been removed in the Delete API as in the `delete` bulk

--- a/docs/reference/migration/migrate_6_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_6_0/indices.asciidoc
@@ -1,6 +1,7 @@
 [[breaking_60_indices_changes]]
 === Indices changes
 
+[[_index_templates_use_literal_index_patterns_literal_instead_of_literal_template_literal]]
 ==== Index templates use `index_patterns` instead of `template`
 
 Previously templates expressed the indices that they should match using a glob


### PR DESCRIPTION
AsciiDoc and Asciidoctor generate missing anchors for headings differently. This sets explicit anchors so they render consistently in AsciiDoc and Asciidoctor.

Will backport as far back as possible.