### PR TITLE
[DOCS] Set explicit anchors in 6.3 for Asciidoctor

### DIFF
--- a/docs/reference/how-to/search-speed.asciidoc
+++ b/docs/reference/how-to/search-speed.asciidoc
@@ -350,6 +350,7 @@ too many files will make search _slower_ if the filesystem cache is not large
 enough to hold all the data. Use with caution.
 
 [float]
+[[_map_identifiers_as_literal_keyword_literal]]
 === Map identifiers as `keyword`
 
 When you have numeric identifiers in your documents, it is tempting to map them


### PR DESCRIPTION
AsciiDoc and Asciidoctor generate missing anchors for headings differently. This sets explicit anchors so they render consistently in AsciiDoc and Asciidoctor.

Will backport as far back as possible.