### PR TITLE
[DOCS] Set explicit anchors in 6.6 for Asciidoctor

### DIFF
--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -1772,6 +1772,7 @@ Right padding modifier with empty key example
 * level = WARN
 |======
 
+[[_append_modifier_literal_literal]]
 ===== Append modifier (`+`)
 [[dissect-modifier-append-key]]
 Dissect supports appending two or more results together for the output.
@@ -1786,6 +1787,7 @@ Append modifier example
 * name = john jacob jingleheimer schmidt
 |======
 
+[[_append_with_order_modifier_literal_literal_and_literal_n_literal]]
 ===== Append with order modifier (`+` and `/n`)
 [[dissect-modifier-append-key-with-order]]
 Dissect supports appending two or more results together for the output.
@@ -1800,6 +1802,7 @@ Append with order modifier example
 * name = schmidt,john,jingleheimer,jacob
 |======
 
+[[_named_skip_key_literal_literal]]
 ===== Named skip key (`?`)
 [[dissect-modifier-named-skip-key]]
 Dissect supports ignoring matches in the final result. This can be done with an empty key `%{}`, but for readability
@@ -1814,6 +1817,7 @@ Named skip key modifier example
 * @timestamp = 30/Apr/1998:22:00:52 +0000
 |======
 
+[[_reference_keys_literal_literal_and_literal_amp_literal]]
 ===== Reference keys (`*` and `&`)
 [[dissect-modifier-reference-keys]]
 Dissect support using parsed values as the key/value pairings for the structured content. Imagine a system that 

--- a/docs/reference/search/profile.asciidoc
+++ b/docs/reference/search/profile.asciidoc
@@ -222,6 +222,7 @@ sufficient to see that a particular component of a query is slow, and not necess
 the `advance` phase of that query is the cause, for example.
 =======================================
 
+[[_literal_query_literal_section]]
 ==== `query` Section
 
 The `query` section contains detailed timing of the query tree executed by Lucene on a particular shard.

--- a/docs/reference/sql/limitations.asciidoc
+++ b/docs/reference/sql/limitations.asciidoc
@@ -6,6 +6,7 @@
 beta[]
 
 [float]
+[[_nested_fields_in_literal_sys_columns_literal_and_literal_describe_table_literal]]
 === Nested fields in `SYS COLUMNS` and `DESCRIBE TABLE`
 
 {es} has a special type of relationship fields called `nested` fields. In {es-sql} they can be used by referencing their inner
@@ -53,6 +54,7 @@ This is because of the way nested queries work in {es}: the root nested field wi
 pagination taking place on the **root nested document and not on its inner hits**.
 
 [float]
+[[_normalized_literal_keyword_literal_fields]]
 === Normalized `keyword` fields
 
 `keyword` fields in {es} can be normalized by defining a `normalizer`. Such fields are not supported in {es-sql}.


### PR DESCRIPTION
AsciiDoc and Asciidoctor generate missing anchors for headings differently. This sets explicit anchors so they render consistently in AsciiDoc and Asciidoctor.

Will backport as far back as possible.