### PR TITLE
[DOCS] Set explicit anchors in 6.8 for Asciidoctor

### DIFF
--- a/docs/reference/how-to/indexing-speed.asciidoc
+++ b/docs/reference/how-to/indexing-speed.asciidoc
@@ -116,6 +116,7 @@ The default is `10%` which is often plenty: for example, if you give the JVM
 two shards that are heavily indexing.
 
 [float]
+[[_disable_literal__field_names_literal]]
 === Disable `_field_names`
 
 The <<mapping-field-names-field,`_field_names` field>> introduces some

--- a/docs/reference/migration/migrate_6_0/aggregations.asciidoc
+++ b/docs/reference/migration/migrate_6_0/aggregations.asciidoc
@@ -3,6 +3,7 @@
 === Aggregations changes
 
 [float]
+[[_deprecated_literal_pattern_literal_element_of_include_exclude_for_terms_aggregations_has_been_removed]]
 ==== Deprecated `pattern` element of include/exclude for terms aggregations has been removed
 
 The `include` and `exclude` options of `terms` aggregations used to accept a
@@ -53,6 +54,7 @@ POST /twitter/_search?size=0
 // TEST[setup:twitter]
 
 [float]
+[[_numeric_literal_to_literal_and_literal_from_literal_parameters_in_literal_date_range_literal_aggregation_are_interpreted_according_to_literal_format_literal_now]]
 ==== Numeric `to` and `from` parameters in `date_range` aggregation are interpreted according to `format` now
 
 Numeric `to` and `from` parameters in `date_range` aggregations used to always be interpreted as `epoch_millis`,
@@ -62,6 +64,7 @@ If the `format` in the mappings is not compatible with the numeric input value, 
 `format` (e.g. `epoch_millis`, `epoch_second`) must be specified in the `date_range` aggregation, otherwise an error is thrown.
 
 [float]
+[[_literal_global_ordinals_hash_literal_and_literal_global_ordinals_low_cardinality_literal_are_deprecated_in_the_literal_terms_literal_aggregation]]
 ==== `global_ordinals_hash` and `global_ordinals_low_cardinality` are deprecated in the `terms` aggregation
 
 The execution hints `global_ordinals_hash` and `global_ordinals_low_cardinality` are deprecated and should be replaced
@@ -69,6 +72,7 @@ by `global_ordinals` which now internally choose whether it should remap global 
 segment ordinals.
 
 [float]
+[[_literal_missing_literal_is_deprecated_in_the_literal_composite_literal_aggregation]]
 ==== `missing` is deprecated in the `composite` aggregation
 
 The `missing` option of the `composite` aggregation is deprecated, `missing_bucket`

--- a/docs/reference/migration/migrate_6_0/analysis.asciidoc
+++ b/docs/reference/migration/migrate_6_0/analysis.asciidoc
@@ -26,6 +26,7 @@ is not set. A deprecation warning will be issued when an analyzed text exceeds 1
 `index.highlight.max_analyzed_offset`.
 
 [float]
+[[_literal_standard_literal_filter_has_been_deprecated]]
 ==== `standard` filter has been deprecated
  The `standard` token filter has been deprecated because it doesn't change anything in
  the stream. It will be removed in the next major version.

--- a/docs/reference/migration/migrate_6_0/docs.asciidoc
+++ b/docs/reference/migration/migrate_6_0/docs.asciidoc
@@ -3,23 +3,27 @@
 === Document API changes
 
 [float]
+[[_version_type_literal_force_literal_removed]]
 ==== version type `force` removed
 
 Document modification operations may no longer specify the `version_type` of
 `force` to override any previous version checks.
 
 [float]
+[[_link_linkend_upserts_upserts_link_no_longer_support_versions]]
 ==== <<upserts,Upserts>> no longer support versions
 
 Adding a `version` to an upsert request is no longer supported.
 
 [float]
+[[_literal_created_literal_field_removed_in_the_index_api]]
 ==== `created` field removed in the Index API
 
 The `created` field has been removed in the Index API as in the `index` and
 `create` bulk operations. `operation` field should be used instead.
 
 [float]
+[[_literal_found_literal_field_removed_in_the_delete_api]]
 ==== `found` field removed in the Delete API
 
 The `found` field has been removed in the Delete API as in the `delete` bulk

--- a/docs/reference/migration/migrate_6_0/geo.asciidoc
+++ b/docs/reference/migration/migrate_6_0/geo.asciidoc
@@ -3,6 +3,7 @@
 === Geo changes
 
 [float]
+[[_deprecated_literal_shapebuilders_literal_helper_class]]
 ==== Deprecated `ShapeBuilders` helper class
 
 The `ShapeBuilders` class containing static methods to create shape specific builders
@@ -10,6 +11,7 @@ The `ShapeBuilders` class containing static methods to create shape specific bui
 constructor instead (e.g., `new MultiPointBuilder()).
 
 [float]
+[[_deprecated_literal_shapebuilder_parse_literal_static_method]]
 ==== Deprecated `ShapeBuilder.parse` static method
 
 The `ShapeBuilder.parse` method has been deprecated. Use `ShapeParser.parse` instead.

--- a/docs/reference/migration/migrate_6_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_6_0/indices.asciidoc
@@ -3,6 +3,7 @@
 === Indices changes
 
 [float]
+[[_index_templates_use_literal_index_patterns_literal_instead_of_literal_template_literal]]
 ==== Index templates use `index_patterns` instead of `template`
 
 Previously templates expressed the indices that they should match using a glob
@@ -41,6 +42,7 @@ following settings:
 - `node.add_lock_id_to_custom_path`
 
 [float]
+[[_open_close_index_api_allows_wildcard_expressions_that_match_no_indices_by_default]]
 ==== Open/Close index API allows wildcard expressions that match no indices by default
 
 The default value of the `allow_no_indices` option for the Open/Close index API
@@ -70,6 +72,7 @@ Instead, it accepts only index names (or wildcards which will expand to
 matching indices).
 
 [float]
+[[_support_for_literal_literal_has_been_removed_in_index_expressions]]
 ==== Support for `+` has been removed in index expressions
 
 Omitting the `+` has the same effect as specifying it, hence support for `+`

--- a/docs/reference/migration/migrate_6_0/java.asciidoc
+++ b/docs/reference/migration/migrate_6_0/java.asciidoc
@@ -3,6 +3,7 @@
 === Java API changes
 
 [float]
+[[_literal_setsource_literal_methods_require_xcontenttype]]
 ==== `setSource` methods require XContentType
 
 Previously the `setSource` methods and other methods that accepted byte/string representations of
@@ -11,6 +12,7 @@ type is no longer used, so these methods now require the XContentType as an addi
 providing the source in bytes or as a string.
 
 [float]
+[[_literal_deletebyqueryrequest_literal_requires_an_explicitly_set_query]]
 ==== `DeleteByQueryRequest` requires an explicitly set query
 
 In previous versions of Elasticsearch, delete by query requests without an explicit query
@@ -18,6 +20,7 @@ were accepted, match_all was used as the default query and all documents were de
 as a result. From version 6.0.0, a `DeleteByQueryRequest` requires an explicit query be set.
 
 [float]
+[[_literal_internalstats_literal_and_literal_stats_literal_getcountasstring_method_removed]]
 ==== `InternalStats` and `Stats` getCountAsString() method removed
 
 The `count` value in the stats aggregation represents a doc count that shouldn't require a formatted
@@ -25,6 +28,7 @@ version. This method was deprecated in 5.4 in favour of just using
 `String.valueOf(getCount())` if needed
 
 [float]
+[[_literal_actionrequestbuilder_execute_literal_returns_literal_actionfuture_literal_rather_than_literal_listenableactionfuture_literal]]
 ==== `ActionRequestBuilder#execute` returns `ActionFuture` rather than `ListenableActionFuture`
 
 When sending a request through the request builders e.g. client.prepareSearch().execute(), it used to
@@ -34,6 +38,7 @@ it is not possible to associate the future with listeners. The `execute` method 
 as an argument can be used instead.
 
 [float]
+[[_literal_terms_order_literal_and_literal_histogram_order_literal_classes_replace_by_literal_bucketorder_literal]]
 ==== `Terms.Order` and `Histogram.Order` classes replace by `BucketOrder`
 
 The `terms`, `histogram`, and `date_histogram` aggregation code has been refactored to use common
@@ -43,6 +48,7 @@ accessing internal order instances, e.g. `BucketOrder.count(boolean)` and `Bucke
 Use `BucketOrder.key(boolean)` to order the `terms` aggregation buckets by `_term`.
 
 [float]
+[[_literal_gettookinmillis_literal_removed_in_literal_bulkresponse_literal_literal_searchresponse_literal_and_literal_termvectorsresponse_literal]]
 ==== `getTookInMillis()` removed in `BulkResponse`, `SearchResponse` and `TermVectorsResponse`
 
 In `BulkResponse`, `SearchResponse` and `TermVectorsResponse` `getTookInMiilis()` method
@@ -50,6 +56,7 @@ has been removed in favor of `getTook` method. `getTookInMiilis()` is easily rep
 `getTook().getMillis()`.
 
 [float]
+[[_literal_getfield_literal_and_literal_searchhitfield_literal_replaced_by_literal_documentfield_literal]]
 ==== `GetField` and `SearchHitField` replaced by `DocumentField`
 
 As `GetField` and `SearchHitField` have the same members, they have been unified into
@@ -67,6 +74,7 @@ The `org.elasticsearch.search.aggregations.bucket.terms.support` package was rem
 The filter aggregation classes were moved to `org.elasticsearch.search.aggregations.bucket.filter`
 
 [float]
+[[_constructor_for_literal_percentileranksaggregationbuilder_literal_has_changed]]
 ==== Constructor for `PercentileRanksAggregationBuilder` has changed
 
 It is now required to include the desired ranks as a non-null, non-empty array of doubles to the builder's constructor,

--- a/docs/reference/migration/migrate_6_0/mappings.asciidoc
+++ b/docs/reference/migration/migrate_6_0/mappings.asciidoc
@@ -12,6 +12,7 @@ mappings immediately. However, it is not possible to create new indices from exi
 coercion rules.
 
 [float]
+[[_the_literal__all_literal_meta_field_is_now_disabled_by_default]]
 ==== The `_all` meta field is now disabled by default
 
 On new mappings, the `_all` meta field that contains a copy of the text from
@@ -22,6 +23,7 @@ fields if `_all` is disabled. `_all` can no longer be configured for indices
 created with Elasticsearch version 6.0 or later.
 
 [float]
+[[_the_literal_include_in_all_literal_mapping_parameter_is_now_disallowed]]
 ==== The `include_in_all` mapping parameter is now disallowed
 
 Since the ++_all++ field is now disabled by default and cannot be configured for
@@ -29,6 +31,7 @@ indices created with Elasticsearch 6.0 or later, the `include_in_all` setting is
 now disallowed for these indices' mappings.
 
 [float]
+[[_unrecognized_literal_match_mapping_type_literal_options_not_silently_ignored]]
 ==== Unrecognized `match_mapping_type` options not silently ignored
 
 Previously Elasticsearch would silently ignore any dynamic templates that
@@ -36,6 +39,7 @@ included a `match_mapping_type` type that was unrecognized. An exception is now
 thrown on an unrecognized type.
 
 [float]
+[[_validation_of_literal_locale_literal_on_date_fields]]
 ==== Validation of `locale` on date fields
 
 The `locale` option of `date` fields previously allowed almost any string values,

--- a/docs/reference/migration/migrate_6_0/packaging.asciidoc
+++ b/docs/reference/migration/migrate_6_0/packaging.asciidoc
@@ -13,6 +13,7 @@ should use the tarball distribution instead of the provided RPM and DEB
 packages.
 
 [float]
+[[_literal_path_conf_literal_is_no_longer_a_configurable_setting]]
 ==== `path.conf` is no longer a configurable setting
 
 Previous versions of Elasticsearch enabled setting `path.conf` as a
@@ -22,6 +23,7 @@ Elasticsearch should use another config file. Instead, to configure a custom
 config directory, use the <<config-files-location,`ES_PATH_CONF` environment variable>>.
 
 [float]
+[[_literal_conf_dir_literal_is_no_longer_supported]]
 ==== `CONF_DIR` is no longer supported
 
 Previous versions of Elasticsearch enabled using the `CONF_DIR` environment
@@ -67,6 +69,7 @@ JVM (although a bootstrap check prevented using a 32-bit JVM in production). We
 are no longer maintaining this attempt.
 
 [float]
+[[_literal_server_literal_flag_no_longer_filtered_in_the_windows_service]]
 ==== `-server` flag no longer filtered in the Windows service
 
 Related to the previous change that 32-bit is no longer supported, the default
@@ -79,6 +82,7 @@ if you have a `jvm.options` file that includes this flag you will need to remove
 it.
 
 [float]
+[[_literal_es_jvm_options_literal_is_no_longer_supported]]
 ==== `ES_JVM_OPTIONS` is no longer supported
 
 The environment variable `ES_JVM_OPTIONS` that enabled a custom location for the
@@ -88,6 +92,7 @@ support relocating the configuration files so this change merely aligns the
 other configuration files with the location of the `jvm.options` file.
 
 [float]
+[[_literal_es_include_literal_is_no_longer_supported]]
 ==== `ES_INCLUDE` is no longer supported
 
 The environment variable `ES_INCLUDE` could previously be used to establish the

--- a/docs/reference/migration/migrate_6_0/plugins.asciidoc
+++ b/docs/reference/migration/migrate_6_0/plugins.asciidoc
@@ -92,6 +92,7 @@ in order to return correct (and correctly ordered) results,
 and to take advantage of new characters.
 
 [float]
+[[_plugins_should_not_construct_literal_environment_literal_instances_from_literal_settings_literal]]
 ==== Plugins should not construct `Environment` instances from `Settings`
 
 Previously, plugins could construct an `Environment` instance from `Settings` to

--- a/docs/reference/migration/migrate_6_0/reindex.asciidoc
+++ b/docs/reference/migration/migrate_6_0/reindex.asciidoc
@@ -3,6 +3,7 @@
 === Reindex changes
 
 [float]
+[[_literal_size_literal_parameter]]
 ==== `size` parameter
 
 The `size` parameter can no longer be explicitly set to `-1`. If all documents are required then the `size` parameter should not be set.

--- a/docs/reference/migration/migrate_6_0/rest.asciidoc
+++ b/docs/reference/migration/migrate_6_0/rest.asciidoc
@@ -46,6 +46,7 @@ In Elasticsearch 6.0.0, Analyze API can analyze a text as a keyword field with c
 or if `char_filter`/`filter` is set and `tokenizer`/`analyzer` is not set.
 
 [float]
+[[_literal_timestamp_literal_and_literal_ttl_literal_in_index_requests]]
 ==== `timestamp` and `ttl` in index requests
 
 `timestamp` and `ttl` are not accepted anymore as parameters of index/update
@@ -117,6 +118,7 @@ $ curl -v -XPOST 'localhost:9200/my_index/_settings'
 --------------------------------------------
 
 [float]
+[[_disallow_using_literal__cache_literal_and_literal__cache_key_literal]]
 ==== Disallow using `_cache` and `_cache_key`
 
 The `_cache` and `_cache_key` options in queries have been deprecated since version 2.0.0 and

--- a/docs/reference/migration/migrate_6_0/scripting.asciidoc
+++ b/docs/reference/migration/migrate_6_0/scripting.asciidoc
@@ -23,6 +23,7 @@ milliseconds since epoch as a `long`. The same is true for
 fetch the milliseconds since epoch if you need it.
 
 [float]
+[[_removed_access_to_index_internal_via_the_literal__index_literal_variable]]
 ==== Removed access to index internal via the `_index` variable
 
 The `_index` variable has been removed. If you used it for advanced scoring, consider writing a `Similarity` plugin.
@@ -34,6 +35,7 @@ All of the existing scripting security settings have been removed.  Instead
 they are replaced with `script.allowed_types` and `script.allowed_contexts`.
 
 [float]
+[[_literal_lang_literal_can_no_longer_be_specified_when_using_a_stored_script_as_part_of_a_request]]
 ==== `lang` can no longer be specified when using a stored script as part of a request
 
 The `lang` variable can no longer be specified as part of a request that uses a stored

--- a/docs/reference/migration/migrate_6_0/search.asciidoc
+++ b/docs/reference/migration/migrate_6_0/search.asciidoc
@@ -159,6 +159,7 @@ score is produced as a result of computation (e.g. in `script_score` or
 this major version, and an error will be thrown in the next major version.
 
 [float]
+[[_fielddata_on_literal__uid_literal]]
 ==== Fielddata on `_uid`
 
 Fielddata on `_uid` is deprecated. It is possible to switch to `_id` instead
@@ -180,17 +181,20 @@ The `unified` highlighter outputs the same highlighting when `index_options` is 
  to `offsets`.
 
 [float]
+[[_literal_fielddata_fields_literal]]
 ==== `fielddata_fields`
 
 The deprecated `fielddata_fields` have now been removed. `docvalue_fields` should be used instead.
 
 [float]
+[[_literal_docvalue_fields_literal]]
 ==== `docvalue_fields`
 
 `docvalue_fields` now have a default upper limit of 100 fields that can be requested.
 This limit can be overridden by using the `index.max_docvalue_fields_search` index setting.
 
 [float]
+[[_literal_script_fields_litera]]
 ==== `script_fields`
 
 `script_fields` now have a default upper limit of 32 script fields that can be requested.
@@ -209,6 +213,7 @@ The `from` parameter can no longer be used in the search request body when initi
 The parameter was already ignored in these situations, now in addition an error is thrown.
 
 [float]
+[[_limit_on_from_size_in_top_hits_and_inner_hits]]
 ==== Limit on from/size in top hits and inner hits
 
 The maximum number of results (`from` + `size`) that is allowed to be retrieved
@@ -234,6 +239,7 @@ Terms Query request has been limited to 65536. This default maximum can be chang
 for a particular index with the index setting `index.max_terms_count`.
 
 [float]
+[[_invalid_literal__search_literal_request_body]]
 ==== Invalid `_search` request body
 
 For 6.x and starting in 6.3 a deprecation warning will be printed to warn

--- a/docs/reference/migration/migrate_6_0/stats.asciidoc
+++ b/docs/reference/migration/migrate_6_0/stats.asciidoc
@@ -3,6 +3,7 @@
 === Stats and info changes
 
 [float]
+[[_removal_of_literal_throttle_time_literal_in_the_literal_store_literal_stats]]
 ==== Removal of `throttle_time` in the `store` stats
 
 Given that store throttling has been removed, the `store` stats do not report

--- a/docs/reference/migration/migrate_6_3.asciidoc
+++ b/docs/reference/migration/migrate_6_3.asciidoc
@@ -38,6 +38,7 @@ Starting with version 6.3, all of the {xpack} features ship with the default
 distribution of {es}. You no longer need to install {xpack} separately. 
 
 [float]
+[[deprecation_of_the_literal_x_pack_literal_configuration_directory]]
 ==== Deprecation of the `x-pack` configuration directory
  
 In 6.2 and earlier releases, the 

--- a/docs/reference/migration/migrate_6_4.asciidoc
+++ b/docs/reference/migration/migrate_6_4.asciidoc
@@ -72,6 +72,7 @@ formats that do not encapsulate the script inside a `script` json object.
 === REST Client
 
 [float]
+[[_old_low_level_literal_performrequest_literal_s_deprecated]]
 ==== Old low level ++performRequest++s deprecated
 The versions of `performRequest` and `performRequestAsync` that were in the
 low level client in 6.3 have been deprecated in favor of

--- a/docs/reference/migration/migrate_6_6.asciidoc
+++ b/docs/reference/migration/migrate_6_6.asciidoc
@@ -41,6 +41,7 @@ returns a `current_watches` list instead of a `queued_watches` list. The
 === Search changes
 
 [float]
+[[_literal_query_string_literal_literal_multi_match_literal_and_literal_simple_query_string_literal_query]]
 ==== `query_string`, `multi_match` and `simple_query_string` query
 
 Using automatically expanded fields for the "all fields" mode ("default_field": "*")
@@ -50,6 +51,7 @@ will be enforced with a hard error starting in 7.0 and is determined by the
 `indices.query.bool.max_clause_count` setting which defaults to 1024.
 
 [float]
+[[_deprecate_literal__source_exclude_literal_and_literal__source_include_literal_url_parameters]]
 ==== Deprecate `_source_exclude` and `_source_include` URL Parameters
 
 `_source_exclude` and `_source_include` are deprecated in favor of
@@ -65,6 +67,7 @@ Setting `boost` on inner span queries is deprecated. In the next major version
 setting `boost` on inner span queries will throw a parsing exception.
 
 [float]
+[[_deprecate_literal_values_literal_and_literal_getvalues_literal_on_doc_values_in_scripts]]
 ==== Deprecate `.values` and `.getValues()` on doc values in scripts
 
 In scripts `.values` and `.getValues()` hasn't been needed for a long, long
@@ -138,6 +141,7 @@ the cluster settings API.
 === Mappings changes
 
 [float]
+[[_changed_default_literal_geo_shape_literal_indexing_strategy]]
 ==== Changed default `geo_shape` indexing strategy
 
 `geo_shape` types now default to using a vector indexing approach based on Lucene's new
@@ -159,6 +163,7 @@ to update the `geo_shape` field mapping to explicitly define the `tree` paramete
 previously created indexes.
 
 [float]
+[[_deprecated_literal_geo_shape_literal_parameters]]
 ==== deprecated `geo_shape` parameters
 
 The following type parameters are deprecated for the `geo_shape` field type: `tree`,

--- a/docs/reference/migration/migrate_6_7.asciidoc
+++ b/docs/reference/migration/migrate_6_7.asciidoc
@@ -20,6 +20,7 @@ See also <<release-highlights>> and <<es-release-notes>>.
 === Indexing changes
 
 [float]
+[[_deprecated_usage_of_literal_internal_literal_versioning_for_optimistic_concurrency_control]]
 ==== Deprecated usage of `internal` versioning for optimistic concurrency control
 
 `internal` version may not uniquely identify a document's version if an indexed document
@@ -33,6 +34,7 @@ See <<optimistic-concurrency-control>> for more details.
 === Plugin changes
 
 [float]
+[[_literal_ingest_geoip_literal_and_literal_ingest_user_agent_literal_are_no_longer_distributed_as_plugins]]
 ==== `ingest-geoip` and `ingest-user-agent` are no longer distributed as plugins
 
 The `ingest-geoip` and `ingest-user-agent` plugins have been converted to

--- a/docs/reference/release-notes/highlights-6.5.0.asciidoc
+++ b/docs/reference/release-notes/highlights-6.5.0.asciidoc
@@ -91,6 +91,7 @@ new `authorization_realms` setting that you can configure in the
 {stack-ov}/realm-chains.html#authorization_realms[Realm chains] and <<realm-settings>>. 
 
 [float]
+[[_cross_cluster_replication_beta_superscript_superscript]]
 === Cross-cluster replication (beta^*^)
 
 Cross-cluster replication enables you to replicate indices that exist in remote 
@@ -106,6 +107,7 @@ For more information, see {stack-ov}/xpack-ccr.html[Cross-cluster replication]
 and <<ccr-apis>>. 
 
 [float]
+[[_monitor_elasticsearch_with_metricbeat_beta_superscript_superscript]]
 === Monitor {es} with {metricbeat} (beta^*^)
 
 In 6.4 and later, you can use {metricbeat} to collect data about {kib} and ship 


### PR DESCRIPTION
AsciiDoc and Asciidoctor generate missing anchors for headings differently. This sets explicit anchors so they render consistently in AsciiDoc and Asciidoctor.

Will backport as far back as possible.