### PR TITLE
[DOCS] Set explicit anchors for Asciidoctor

### DIFF
--- a/docs/reference/mapping/types/nested.asciidoc
+++ b/docs/reference/mapping/types/nested.asciidoc
@@ -193,7 +193,7 @@ phase.  Instead, highlighting needs to be performed via
 
 =============================================
 
-
+[[limit-number-nested-fields]]
 ==== Limiting the number of `nested` fields
 
 Indexing a document with 100 nested fields actually indexes 101 documents as each nested


### PR DESCRIPTION
AsciiDoc and Asciidoctor generate missing anchors for headings differently. This sets explicit anchors so they render consistently in AsciiDoc and Asciidoctor.

Will backport as far back as possible.