### PR TITLE
[DOCS] Set explicit anchors for TLS/SSL settings

### DIFF
--- a/docs/reference/settings/monitoring-settings.asciidoc
+++ b/docs/reference/settings/monitoring-settings.asciidoc
@@ -283,5 +283,6 @@ For example: `["elasticsearch_version_mismatch","xpack_license_expiration"]`.
 :component:              {monitoring}
 :verifies:
 :server!:
+:ssl-context:            monitoring
 
 include::ssl-settings.asciidoc[]

--- a/docs/reference/settings/notification-settings.asciidoc
+++ b/docs/reference/settings/notification-settings.asciidoc
@@ -85,6 +85,7 @@ corresponding endpoints are whitelisted as well.
 :component:              {watcher}
 :verifies:
 :server!:
+:ssl-context:            watcher
 
 include::ssl-settings.asciidoc[]
 

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1566,6 +1566,7 @@ a PKCS#12 container includes trusted certificate ("anchor") entries look for
 :client-auth-default:    none
 :verifies!:
 :server:
+:ssl-context:            security-http
 
 include::ssl-settings.asciidoc[]
 
@@ -1575,6 +1576,7 @@ include::ssl-settings.asciidoc[]
 :client-auth-default!:
 :verifies:
 :server:
+:ssl-context:            security-transport
 
 include::ssl-settings.asciidoc[]
 

--- a/docs/reference/settings/ssl-settings.asciidoc
+++ b/docs/reference/settings/ssl-settings.asciidoc
@@ -1,4 +1,5 @@
 
+[[tls-ssl-settings]]
 ==== {component} TLS/SSL Settings
 You can configure the following TLS/SSL settings. If the settings are not configured,
 the {ref}/security-settings.html#ssl-tls-settings[Default TLS/SSL Settings]
@@ -39,6 +40,7 @@ endif::verifies[]
 Supported cipher suites can be found in Oracle's http://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html[
 Java Cryptography Architecture documentation]. Defaults to ``.
 
+[[tls-ssl-key-trusted-certificate-settings]]
 ===== {component} TLS/SSL Key and Trusted Certificate Settings
 
 The following settings are used to specify a private key, certificate, and the

--- a/docs/reference/settings/ssl-settings.asciidoc
+++ b/docs/reference/settings/ssl-settings.asciidoc
@@ -1,5 +1,5 @@
 
-[[tls-ssl-settings]]
+[[{ssl-context}-tls-ssl-settings]]
 ==== {component} TLS/SSL Settings
 You can configure the following TLS/SSL settings. If the settings are not configured,
 the {ref}/security-settings.html#ssl-tls-settings[Default TLS/SSL Settings]
@@ -40,7 +40,7 @@ endif::verifies[]
 Supported cipher suites can be found in Oracle's http://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html[
 Java Cryptography Architecture documentation]. Defaults to ``.
 
-[[tls-ssl-key-trusted-certificate-settings]]
+[[{ssl-context}-tls-ssl-key-trusted-certificate-settings]]
 ===== {component} TLS/SSL Key and Trusted Certificate Settings
 
 The following settings are used to specify a private key, certificate, and the
@@ -107,7 +107,7 @@ Password to the truststore.
 +{ssl-prefix}.ssl.truststore.secure_password+ (<<secure-settings,Secure>>)::
 Password to the truststore.
 
-[[pkcs12-files]]
+[[{ssl-context}-pkcs12-files]]
 ===== PKCS#12 Files
 
 {es} can be configured to use PKCS#12 container files (`.p12` or `.pfx` files)
@@ -146,7 +146,7 @@ Password to the PKCS#12 file.
 +{ssl-prefix}.ssl.truststore.secure_password+ (<<secure-settings,Secure>>)::
 Password to the PKCS#12 file.
 
-[[pkcs11-tokens]]
+[[{ssl-context}-pkcs11-tokens]]
 ===== PKCS#11 Tokens
 
 {es} can be configured to use a PKCS#11 token that contains the private key,

--- a/docs/reference/settings/ssl-settings.asciidoc
+++ b/docs/reference/settings/ssl-settings.asciidoc
@@ -1,5 +1,3 @@
-
-[[{ssl-context}-tls-ssl-settings]]
 ==== {component} TLS/SSL Settings
 You can configure the following TLS/SSL settings. If the settings are not configured,
 the {ref}/security-settings.html#ssl-tls-settings[Default TLS/SSL Settings]
@@ -40,8 +38,13 @@ endif::verifies[]
 Supported cipher suites can be found in Oracle's http://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html[
 Java Cryptography Architecture documentation]. Defaults to ``.
 
+ifdef::asciidoctor[]
 [[{ssl-context}-tls-ssl-key-trusted-certificate-settings]]
 ===== {component} TLS/SSL Key and Trusted Certificate Settings
+endif::[]
+ifndef::asciidoctor[]
+==== anchor:{ssl-context}-tls-ssl-key-trusted-certificate-settings[] {component} TLS/SSL Key and Trusted Certificate Settings
+endif::[]
 
 The following settings are used to specify a private key, certificate, and the
 trusted certificates that should be used when communicating over an SSL/TLS connection.
@@ -107,8 +110,13 @@ Password to the truststore.
 +{ssl-prefix}.ssl.truststore.secure_password+ (<<secure-settings,Secure>>)::
 Password to the truststore.
 
+ifdef::asciidoctor[]
 [[{ssl-context}-pkcs12-files]]
 ===== PKCS#12 Files
+endif::[]
+ifndef::asciidoctor[]
+==== anchor:{ssl-context}-pkcs12-files[] PKCS#12 Files
+endif::[]
 
 {es} can be configured to use PKCS#12 container files (`.p12` or `.pfx` files)
 that contain the private key, certificate and certificates that should be trusted.
@@ -146,8 +154,13 @@ Password to the PKCS#12 file.
 +{ssl-prefix}.ssl.truststore.secure_password+ (<<secure-settings,Secure>>)::
 Password to the PKCS#12 file.
 
+ifdef::asciidoctor[]
 [[{ssl-context}-pkcs11-tokens]]
 ===== PKCS#11 Tokens
+endif::[]
+ifndef::asciidoctor[]
+==== anchor:{ssl-context}-pkcs11-tokens[] PKCS#11 Tokens
+endif::[]
 
 {es} can be configured to use a PKCS#11 token that contains the private key,
 certificate and certificates that should be trusted.

--- a/docs/reference/settings/ssl-settings.asciidoc
+++ b/docs/reference/settings/ssl-settings.asciidoc
@@ -107,6 +107,7 @@ Password to the truststore.
 +{ssl-prefix}.ssl.truststore.secure_password+ (<<secure-settings,Secure>>)::
 Password to the truststore.
 
+[[pkcs12-files]]
 ===== PKCS#12 Files
 
 {es} can be configured to use PKCS#12 container files (`.p12` or `.pfx` files)
@@ -145,6 +146,7 @@ Password to the PKCS#12 file.
 +{ssl-prefix}.ssl.truststore.secure_password+ (<<secure-settings,Secure>>)::
 Password to the PKCS#12 file.
 
+[[pkcs11-tokens]]
 ===== PKCS#11 Tokens
 
 {es} can be configured to use a PKCS#11 token that contains the private key,

--- a/docs/reference/settings/ssl-settings.asciidoc
+++ b/docs/reference/settings/ssl-settings.asciidoc
@@ -39,11 +39,11 @@ Supported cipher suites can be found in Oracle's http://docs.oracle.com/javase/8
 Java Cryptography Architecture documentation]. Defaults to ``.
 
 ifdef::asciidoctor[]
-[[{ssl-context}-tls-ssl-key-trusted-certificate-settings]]
+[#{ssl-context}-tls-ssl-key-trusted-certificate-settings]
 ===== {component} TLS/SSL Key and Trusted Certificate Settings
 endif::[]
 ifndef::asciidoctor[]
-==== anchor:{ssl-context}-tls-ssl-key-trusted-certificate-settings[] {component} TLS/SSL Key and Trusted Certificate Settings
+===== anchor:{ssl-context}-tls-ssl-key-trusted-certificate-settings[] {component} TLS/SSL Key and Trusted Certificate Settings
 endif::[]
 
 The following settings are used to specify a private key, certificate, and the
@@ -111,11 +111,11 @@ Password to the truststore.
 Password to the truststore.
 
 ifdef::asciidoctor[]
-[[{ssl-context}-pkcs12-files]]
+[#{ssl-context}-pkcs12-files]
 ===== PKCS#12 Files
 endif::[]
 ifndef::asciidoctor[]
-==== anchor:{ssl-context}-pkcs12-files[] PKCS#12 Files
+===== anchor:{ssl-context}-pkcs12-files[] PKCS#12 Files
 endif::[]
 
 {es} can be configured to use PKCS#12 container files (`.p12` or `.pfx` files)
@@ -155,11 +155,11 @@ Password to the PKCS#12 file.
 Password to the PKCS#12 file.
 
 ifdef::asciidoctor[]
-[[{ssl-context}-pkcs11-tokens]]
+[#{ssl-context}-pkcs11-tokens]
 ===== PKCS#11 Tokens
 endif::[]
 ifndef::asciidoctor[]
-==== anchor:{ssl-context}-pkcs11-tokens[] PKCS#11 Tokens
+===== anchor:{ssl-context}-pkcs11-tokens[] PKCS#11 Tokens
 endif::[]
 
 {es} can be configured to use a PKCS#11 token that contains the private key,


### PR DESCRIPTION
This PR attempts to fix the following autogenerated anchors so they render consistently in AsciiDoc and Asciidoctor:
* _pkcs_12_files -> _pkcs12_files
* _pkcs_12_files_2 -> _pkcs12_files_2
* _pkcs_12_files_3 -> _pkcs12_files_3
* _pkcs_12_files_4 -> _pkcs12_files_4
* _pkcs_12_files_5 -> _pkcs12_files_5
* _pkcs_12_files_6 -> _pkcs12_files_6
* _pkcs_11_tokens -> _pkcs11_tokens
* _pkcs_11_tokens_2 -> _pkcs11_tokens_2
* _pkcs_11_tokens_3 -> _pkcs11_tokens_3
* _pkcs_11_tokens_4 -> _pkcs11_tokens_4
* _pkcs_11_tokens_5 -> _pkcs11_tokens_5
* _pkcs_11_tokens_6 -> _pkcs11_tokens_6
* _auditing_tls_ssl_key_and_trusted_certificate_settings -> _auditing_tlsssl_key_and_trusted_certificate_settings
* _http_tls_ssl_key_and_trusted_certificate_settings -> _http_tlsssl_key_and_trusted_certificate_settings
* _transport_tls_ssl_key_and_trusted_certificate_settings -> _transport_tlsssl_key_and_trusted_certificate_settings
* _watcher_tls_ssl_key_and_trusted_certificate_settings -> _watcher_tlsssl_key_and_trusted_certificate_settings
* _x_pack_monitoring_tls_ssl_key_and_trusted_certificate_settings -> _x_pack_monitoring_tlsssl_key_and_trusted_certificate_settings

However, the `ssl-settings.asciidoc` file containing the anchors is included in several other files:
- monitoring-settings.asciidoc
- notification-settings.asciidoc
- security-settings.asciidoc

This means any explicit anchors are reused. Reusing anchors results in the following errors:
```
INFO:build_docs:asciidoctor: WARNING: invalid reference: ssl-monitoring-settings
INFO:build_docs:asciidoctor: WARNING: invalid reference: http-tls-ssl-settings
INFO:build_docs:asciidoctor: WARNING: invalid reference: transport-tls-ssl-settings/out/html_docs/index.xml:6848: element section: validity error : ID tls-ssl-settings already defined
INFO:build_docs:<section id="tls-ssl-settings">
INFO:build_docs:                              ^
INFO:build_docs:/out/html_docs/index.xml:6886: element section: validity error : ID tls-ssl-key-trusted-certificate-settings already defined
INFO:build_docs:<section id="tls-ssl-key-trusted-certificate-settings">
INFO:build_docs:                                                      ^
INFO:build_docs:/out/html_docs/index.xml:6988: element section: validity error : ID pkcs12-files already defined
INFO:build_docs:<section id="pkcs12-files">
INFO:build_docs:                          ^
INFO:build_docs:/out/html_docs/index.xml:7057: element section: validity error : ID pkcs11-tokens already defined
INFO:build_docs:<section id="pkcs11-tokens">
INFO:build_docs:                           ^
INFO:build_docs:/out/html_docs/index.xml:7089: element section: validity error : ID tls-ssl-settings already defined
INFO:build_docs:<section id="tls-ssl-settings">
INFO:build_docs:                              ^
INFO:build_docs:/out/html_docs/index.xml:7134: element section: validity error : ID tls-ssl-key-trusted-certificate-settings already defined
INFO:build_docs:<section id="tls-ssl-key-trusted-certificate-settings">
INFO:build_docs:                                                      ^
INFO:build_docs:/out/html_docs/index.xml:7236: element section: validity error : ID pkcs12-files already defined
INFO:build_docs:<section id="pkcs12-files">
INFO:build_docs:                          ^
INFO:build_docs:/out/html_docs/index.xml:7305: element section: validity error : ID pkcs11-tokens already defined
INFO:build_docs:<section id="pkcs11-tokens">
INFO:build_docs:                           ^
INFO:build_docs:/out/html_docs/index.xml:7792: element section: validity error : ID tls-ssl-settings already defined
INFO:build_docs:<section id="tls-ssl-settings">
INFO:build_docs:                              ^
INFO:build_docs:/out/html_docs/index.xml:7821: element section: validity error : ID tls-ssl-key-trusted-certificate-settings already defined
INFO:build_docs:<section id="tls-ssl-key-trusted-certificate-settings">
INFO:build_docs:                                                      ^
INFO:build_docs:/out/html_docs/index.xml:7924: element section: validity error : ID pkcs12-files already defined
INFO:build_docs:<section id="pkcs12-files">
INFO:build_docs:                          ^
INFO:build_docs:/out/html_docs/index.xml:7993: element section: validity error : ID pkcs11-tokens already defined
INFO:build_docs:<section id="pkcs11-tokens">
INFO:build_docs:                           ^
INFO:build_docs:Error: no ID for constraint linkend: ssl-monitoring-settings.
INFO:build_docs:ERROR: xref linking to http-tls-ssl-settings has no generated link text.
INFO:build_docs:Error: no ID for constraint linkend: http-tls-ssl-settings.
INFO:build_docs:Error: no ID for constraint linkend: transport-tls-ssl-settings.
```

### Next steps
@nik9000 @lcawl
Let me know if you have any suggestions. I couldn't figure out a way to use attributes in anchors. We might be better off just accepting the anchor change.