### PR TITLE
[DOCS] Set explicit anchor for "SysV `init` vs `systemd`" section

### DIFF
--- a/docs/reference/setup/install/deb.asciidoc
+++ b/docs/reference/setup/install/deb.asciidoc
@@ -128,6 +128,8 @@ sudo dpkg -i elasticsearch-{version}.deb
 
 endif::[]
 
+:int-context: deb
+
 include::init-systemd.asciidoc[]
 
 [[deb-running-init]]

--- a/docs/reference/setup/install/deb.asciidoc
+++ b/docs/reference/setup/install/deb.asciidoc
@@ -128,7 +128,7 @@ sudo dpkg -i elasticsearch-{version}.deb
 
 endif::[]
 
-:int-context: deb
+:init-context: deb
 
 include::init-systemd.asciidoc[]
 

--- a/docs/reference/setup/install/init-systemd.asciidoc
+++ b/docs/reference/setup/install/init-systemd.asciidoc
@@ -1,4 +1,4 @@
-[[{int-context}-sysv-init-vs-systemd]]
+[[{init-context}-sysv-init-vs-systemd]]
 ==== SysV `init` vs `systemd`
 
 Elasticsearch is not started automatically after installation. How to start

--- a/docs/reference/setup/install/init-systemd.asciidoc
+++ b/docs/reference/setup/install/init-systemd.asciidoc
@@ -1,4 +1,4 @@
-[[_sysv_literal_init_literal_vs_literal_systemd_literal]]
+[[{int-context}-sysv-init-vs-systemd]]
 ==== SysV `init` vs `systemd`
 
 Elasticsearch is not started automatically after installation. How to start

--- a/docs/reference/setup/install/init-systemd.asciidoc
+++ b/docs/reference/setup/install/init-systemd.asciidoc
@@ -1,3 +1,4 @@
+[[_sysv_literal_init_literal_vs_literal_systemd_literal]]
 ==== SysV `init` vs `systemd`
 
 Elasticsearch is not started automatically after installation. How to start

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -115,6 +115,8 @@ endif::[]
 
 include::skip-set-kernel-parameters.asciidoc[]
 
+:int-context: rpm
+
 include::init-systemd.asciidoc[]
 
 [[rpm-running-init]]

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -115,7 +115,7 @@ endif::[]
 
 include::skip-set-kernel-parameters.asciidoc[]
 
-:int-context: rpm
+:init-context: rpm
 
 include::init-systemd.asciidoc[]
 


### PR DESCRIPTION
This PR attempts to fix the following autogenerated anchors so they render consistently in AsciiDoc and Asciidoctor:
* (5.0 - 6.2) _sysv_literal_init_literal_vs_literal_systemd_literal_2 -> _sysv_init_vs_systemd_2
* (5.0 - 6.2) _sysv_literal_init_literal_vs_literal_systemd_literal -> _sysv_init_vs_systemd

However, the `init-systemd.asciidoc` file containing the anchor is included in two other files:
- deb.asciidoc
- rpm.asciidoc

This means the explicit anchors is reused. Reusing the anchor results in the following errors:
```
INFO:build_docs:asciidoctor: WARNING: setup/install/init-systemd.asciidoc: line 2: id assigned to section already in use: _sysv_literal_init_literal_vs_literal_systemd_literal
```

### Next steps
@nik9000
Let me know if you have any suggestions. We might be better off just accepting the anchor change.