### PR TITLE
[DOCS] Fix migration upgrade API `deprecated` macro for Asciidoctor

### DIFF
--- a/docs/reference/migration/apis/upgrade.asciidoc
+++ b/docs/reference/migration/apis/upgrade.asciidoc
@@ -10,9 +10,14 @@ IMPORTANT: To prepare a cluster for an upgrade to Elasticsearch version 7, use
 the {kibana-ref}/upgrade-assistant.html[{kib} Upgrade Assistant] or
 <<reindex-upgrade,reindex manually>> before upgrading.
 
+ifdef::asciidoctor[]
+deprecated::[6.7, "Use the {kibana-ref}/upgrade-assistant.html[{kib} Upgrade Assistant] or <<reindex-upgrade,reindex manually>> before upgrading."]
+endif::[]
+ifndef::asciidoctor[]
 deprecated[6.7, Use the {kibana-ref}/upgrade-assistant.html[{kib} Upgrade
-Assistant] or <<reindex-upgrade,reindex manually>> before upgrading.] The
-migration upgrade API performs the upgrade of internal indices to make them
+Assistant] or <<reindex-upgrade,reindex manually>> before upgrading.]
+endif::[]
+The migration upgrade API performs the upgrade of internal indices to make them
 compatible with version 6 of Elasticsearch.
 
 [float]


### PR DESCRIPTION
Fixes a `deprecated` macro so it renders properly in Asciidoctor. Relates to elastic/docs#827.

Will backport as far back as possible.

## AsciiDoc Before
<details>
 <summary>Before image</summary>
<img width="760" alt="AsciiDoc Before" src="https://user-images.githubusercontent.com/40268737/58341798-1439e280-7e1d-11e9-9dd8-57b2c756db6b.png">
</details>

## AsciiDoc After
<details>
 <summary>After image</summary>
<img width="758" alt="AsciiDoc After" src="https://user-images.githubusercontent.com/40268737/58341806-1734d300-7e1d-11e9-8dea-a97790951b64.png">
</details>

## Asciidoctor Before
<details>
 <summary>Before image</summary>
<img width="758" alt="Asciidoctor Before" src="https://user-images.githubusercontent.com/40268737/58341813-1a2fc380-7e1d-11e9-86a9-3398ba204ddd.png">
</details>

## Asciidoctor After
<details>
 <summary>After image</summary>
<img width="767" alt="Asciidoctor After" src="https://user-images.githubusercontent.com/40268737/58341815-1d2ab400-7e1d-11e9-8451-88075f56ffb4.png">
</details>

## Implementation Notes
@nik9000  I attempted to use `deprecated:` here, but it looks like Asciidoctor was choking on the nested macros. Tried explicitly defining the subs and creating an attribute for the upgrade assistant link, but that had no effect.

Let me know if you have any ideas. Thanks!