### PR TITLE
[ML] Use map and filter instead of flatMap in find_file_structure

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/filestructurefinder/FileStructureUtils.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/filestructurefinder/FileStructureUtils.java
@@ -187,11 +187,8 @@ public final class FileStructureUtils {
 
         for (String fieldName : uniqueFieldNames) {
 
-            List<Object> fieldValues = sampleRecords.stream().flatMap(record -> {
-                    Object fieldValue = record.get(fieldName);
-                    return (fieldValue == null) ? Stream.empty() : Stream.of(fieldValue);
-                }
-            ).collect(Collectors.toList());
+            List<Object> fieldValues = sampleRecords.stream().map(record -> record.get(fieldName)).filter(fieldValue -> fieldValue != null)
+                .collect(Collectors.toList());
 
             Tuple<Map<String, String>, FieldStats> mappingAndFieldStats =
                 guessMappingAndCalculateFieldStats(explanation, fieldName, fieldValues, timeoutChecker);


### PR DESCRIPTION
Using map and filter avoids the garbage from all the
Stream.of calls that flatMap necessitated. Performance
is better when there are masses of fields.