### PR TITLE
Use reproducible method of generating properties file for better caching

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -45,21 +45,17 @@ if (project == rootProject) {
 // we update the version property to reflect if we are building a snapshot or a release build
 // we write this back out below to load it in the Build.java which will be shown in rest main action
 // to indicate this being a snapshot build or a release build.
-File propsFile = project.file('version.properties')
-Properties props = VersionPropertiesLoader.loadBuildSrcVersion(propsFile)
+Properties props = VersionPropertiesLoader.loadBuildSrcVersion(project.file('version.properties'))
 version = props.getProperty("elasticsearch")
+
+task generateVersionProperties(type: WriteProperties) {
+  outputFile = "${buildDir}/version.properties"
+  comment = 'Generated version properties'
+  properties(props)
+}
+
 processResources {
-  inputs.file(propsFile)
-  // We need to be explicit with the version because we add snapshot and qualifier to it based on properties
-  inputs.property("dynamic_elasticsearch_version", props.getProperty("elasticsearch"))
-  doLast {
-    Writer writer = file("$destinationDir/version.properties").newWriter()
-    try {
-      props.store(writer, "Generated version properties")
-    } finally {
-      writer.close()
-    }
-  }
+  from(generateVersionProperties)
 }
 
 /*****************************************************************************


### PR DESCRIPTION
The default Java implementation of `Properties.store()` is non-reproducible. First, because it stores properties internally in a `HashTable` so the final ordering will be non-deterministic and secondly because it injects a comment with a timestamp into the generated file. Both of these things break build cacheability since this file eventually ends up on the build classpath.

Here we use Gradle's [`WriteProperties`](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.WriteProperties.html) task instead which solves both issues and ensures for the same set on inputs, reproducible output will be generated.