### PR TITLE
Fix Test Failures from MockNioTransport Logger

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/MockNioTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/MockNioTransport.java
@@ -372,7 +372,7 @@ public class MockNioTransport extends TcpTransport {
                 }
             }
             if (stopped == false) {
-                threadPool.schedule(this::logLongRunningExecutions, CHECK_INTERVAL, ThreadPool.Names.GENERIC);
+                threadPool.scheduleUnlessShuttingDown(CHECK_INTERVAL, ThreadPool.Names.GENERIC, this::logLongRunningExecutions);
             }
         }
 


### PR DESCRIPTION
* This call can fail when it tries to re-schedule the timeout check
after the threadpool was shut down already failing tests with
RejectedExecutionException
* Observed here https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+pull-request-1/14692/console