### PR TITLE
[DOCS] Reorg monitoring configuration for re-use

### DIFF
--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -99,8 +99,7 @@ For more information, see
 +
 --
 // tag::configure-es-module[]
-You must specify the following settings in the
-`modules.d/elasticsearch-xpack.yml` file:
+The `modules.d/elasticsearch-xpack.yml` file contains the following settings:
 
 [source,yaml]
 ----------------------------------
@@ -115,19 +114,17 @@ You must specify the following settings in the
       - node_stats
       - shard
     period: 10s
-    hosts: ["ELASTICSEARCH_URL"] <1>
+    hosts: ["http://localhost:9200"]
     #username: "user"
     #password: "secret"
-    xpack.enabled: true <2>
+    xpack.enabled: true
 ----------------------------------
-<1> Replace `ELASTICSEARCH_URL` with the appropriate host and port number that
-you use to access {es}. The default value is `http://localhost:9200`.
-<2> This setting ensures that {es} can read the monitoring data successfully. 
-That is to say, it's stored in the same location and format as monitoring data 
-that is sent by {ref}/es-monitoring-exporters.html[exporters].
 
-If you configured {es} to use encrypted communications, you must access it via
-HTTPS. For example, use a `hosts` setting like `https://localhost:9200`.
+By default, the module collects {es} monitoring metrics from
+`http://localhost:9200`. If that host and port number are not correct, you must
+update the `hosts` setting. If you configured {es} to use encrypted
+communications, you must access it via HTTPS. For example, use a `hosts` setting
+like `https://localhost:9200`.
 // end::configure-es-module[]
 
 // tag::remote-monitoring-user[]

--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -17,6 +17,8 @@ image::monitoring/images/metricbeat.png[Example monitoring architecture]
 To learn about monitoring in general, see 
 {stack-ov}/xpack-monitoring.html[Monitoring the {stack}]. 
 
+//NOTE: The tagged regions are re-used in the Stack Overview.
+
 . Enable the collection of monitoring data. Set 
 `xpack.monitoring.collection.enabled` to `true` on each node in the production 
 cluster. By default, it is is disabled (`false`). 
@@ -71,13 +73,13 @@ PUT _cluster/settings
 Leave `xpack.monitoring.enabled` set to its default value (`true`). 
 --
 
-. On each {es} node in the production cluster:
+. {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}] on each
+{es} node in the production cluster.
 
-.. {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}].
-
-.. Enable the {es} module in {metricbeat}. +
+. Enable the {es} {xpack} module in {metricbeat} on each {es} node. +
 +
 --
+// tag::enable-es-module[]
 For example, to enable the default configuration in the `modules.d` directory, 
 run the following command:
 
@@ -89,37 +91,58 @@ metricbeat modules enable elasticsearch-xpack
 For more information, see 
 {metricbeat-ref}/configuration-metricbeat.html[Specify which modules to run] and 
 {metricbeat-ref}/metricbeat-module-elasticsearch.html[{es} module]. 
+
+// tag::enable-es-module[]
 --
 
-.. By default the module will collect {es} monitoring metrics from `http://localhost:9200`.
-If the local {es} node has a different address, you must specify it via the `hosts` setting
-in the `modules.d/elasticsearch-xpack.yml` file.
-
-.. If Elastic {security-features} are enabled, you must also provide a user ID
-and password so that {metricbeat} can collect metrics successfully. 
-
-... Create a user on the production cluster that has the
-{stack-ov}/built-in-roles.html[`remote_monitoring_collector` built-in role]. 
-Alternatively, use the {stack-ov}/built-in-users.html[`remote_monitoring_user` built-in user].
-
-... Add the `username` and `password` settings to the {es} module configuration
-file.
+. Configure the {es} {xpack} module in {metricbeat} on each {es} node. +
 +
 --
-For example, add the following settings in the `modules.d/elasticsearch-xpack.yml` file:
+// tag::configure-es-module[]
+You must specify the following settings in the
+`modules.d/elasticsearch-xpack.yml` file:
 
 [source,yaml]
 ----------------------------------
-- module: elasticsearch
-  ...
-  username: remote_monitoring_user
-  password: YOUR_PASSWORD
+  - module: elasticsearch
+    metricsets:
+      - ccr
+      - cluster_stats
+      - index
+      - index_recovery
+      - index_summary
+      - ml_job
+      - node_stats
+      - shard
+    period: 10s
+    hosts: ["ELASTICSEARCH_URL"] <1>
+    #username: "user"
+    #password: "secret"
+    xpack.enabled: true <2>
 ----------------------------------
---
+<1> Replace `ELASTICSEARCH_URL` with the appropriate host and port number that
+you use to access {es}. The default value is `http://localhost:9200`.
+<2> This setting ensures that {es} can read the monitoring data successfully. 
+That is to say, it's stored in the same location and format as monitoring data 
+that is sent by {ref}/es-monitoring-exporters.html[exporters].
 
-.. If you configured {es} to use <<configuring-tls,encrypted communications>>, 
-you must access it via HTTPS. For example, use a `hosts` setting like 
-`https://localhost:9200` in the `modules.d/elasticsearch-xpack.yml` file.
+If you configured {es} to use encrypted communications, you must access it via
+HTTPS. For example, use a `hosts` setting like `https://localhost:9200`.
+// end::configure-es-module[]
+
+// tag::remote-monitoring-user[]
+If Elastic {security-features} are enabled, you must also provide a user ID
+and password so that {metricbeat} can collect metrics successfully: 
+
+.. Create a user on the production cluster that has the
+{stack-ov}/built-in-roles.html[`remote_monitoring_collector` built-in role]. 
+Alternatively, use the
+{stack-ov}/built-in-users.html[`remote_monitoring_user` built-in user].
+
+.. Add the `username` and `password` settings to the {es} module configuration
+file. 
+// end::remote-monitoring-user[]
+--
 
 .. Identify where to send the monitoring data. +
 +
@@ -136,48 +159,43 @@ configuration file (`metricbeat.yml`):
 [source,yaml]
 ----------------------------------
 output.elasticsearch:
+  # Array of hosts to connect to.
   hosts: ["http://es-mon-1:9200", "http://es-mon2:9200"] <1>
+  
+  # Optional protocol and basic auth credentials.
+  #protocol: "https"
+  #username: "elastic"
+  #password: "changeme"
 ----------------------------------
 <1> In this example, the data is stored on a monitoring cluster with nodes 
 `es-mon-1` and `es-mon-2`. 
+
+If you configured the monitoring cluster to use encrypted communications, you
+must access it via HTTPS. For example, use a `hosts` setting like
+`https://es-mon-1:9200`.
 
 IMPORTANT: The {es} {monitor-features} use ingest pipelines, therefore the
 cluster that stores the monitoring data must have at least one 
 <<ingest,ingest node>>. 
 
-For more information about these configuration options, see 
-{metricbeat-ref}/elasticsearch-output.html[Configure the {es} output].
---
+If {es} {security-features} are enabled on the monitoring cluster, you must
+provide a valid user ID and password so that {metricbeat} can send metrics 
+successfully: 
 
-.. If {es} {security-features} are enabled on the monitoring cluster, you 
-must provide a valid user ID and password so that {metricbeat} can send metrics 
-successfully. 
-
-... Create a user on the monitoring cluster that has the 
+.. Create a user on the monitoring cluster that has the 
 {stack-ov}/built-in-roles.html[`remote_monitoring_agent` built-in role]. 
 Alternatively, use the 
 {stack-ov}/built-in-users.html[`remote_monitoring_user` built-in user].
 
-... Add the `username` and `password` settings to the {es} output information in 
-the {metricbeat} configuration file (`metricbeat.yml`):
-+
---
-[source,yaml]
-----------------------------------
-output.elasticsearch:
-  ...
-  username: remote_monitoring_user
-  password: YOUR_PASSWORD
-----------------------------------
+.. Add the `username` and `password` settings to the {es} output information in 
+the {metricbeat} configuration file.
+
+For more information about these configuration options, see 
+{metricbeat-ref}/elasticsearch-output.html[Configure the {es} output].
 --
 
-.. If you configured the monitoring cluster to use 
-<<configuring-tls,encrypted communications>>, you must access it via 
-HTTPS. For example, use a `hosts` setting like `https://es-mon-1:9200` in the 
-`metricbeat.yml` file. 
+. <<starting-elasticsearch,Start {es}>> on each node.
 
-. <<starting-elasticsearch,Start {es}>>.
-
-. {metricbeat-ref}/metricbeat-starting.html[Start {metricbeat}]. 
+. {metricbeat-ref}/metricbeat-starting.html[Start {metricbeat}] on each node. 
 
 . {kibana-ref}/monitoring-data.html[View the monitoring data in {kib}]. 

--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -92,7 +92,7 @@ For more information, see
 {metricbeat-ref}/configuration-metricbeat.html[Specify which modules to run] and 
 {metricbeat-ref}/metricbeat-module-elasticsearch.html[{es} module]. 
 
-// tag::enable-es-module[]
+// end::enable-es-module[]
 --
 
 . Configure the {es} {xpack} module in {metricbeat} on each {es} node. +

--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -144,7 +144,7 @@ file.
 // end::remote-monitoring-user[]
 --
 
-.. Identify where to send the monitoring data. +
+. Identify where to send the monitoring data. +
 +
 --
 TIP: In production environments, we strongly recommend using a separate cluster 


### PR DESCRIPTION
This PR reorganizes the information in https://www.elastic.co/guide/en/elasticsearch/reference/master/configuring-metricbeat.html such that its content can be re-used (via tagged regions) from other places (e.g. the Stack Overview).

It also adds fuller configuration file examples and clarifies that the steps related to the Elasticsearch X-Pack module for Metricbeat instead of the Elasticsearch module.

Related to https://github.com/elastic/stack-docs/pull/318


