### PR TITLE
Ignore JAR manifests when snapshotting runtime classpaths

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -129,6 +129,7 @@ class BuildPlugin implements Plugin<Project> {
         setupSeed(project)
         configureRepositories(project)
         project.extensions.getByType(ExtraPropertiesExtension).set('versions', VersionProperties.versions)
+        configureInputNormalization(project)
         configureSourceSets(project)
         configureCompile(project)
         configureJavadoc(project)
@@ -578,6 +579,13 @@ class BuildPlugin implements Plugin<Project> {
                 }
             }
         }
+    }
+
+    /**
+     * Apply runtime classpath input normalization so that changes in JAR manifests don't break build cacheability
+     */
+    static void configureInputNormalization(Project project) {
+        project.normalization.runtimeClasspath.ignore('META-INF/MANIFEST.MF')
     }
 
     /** Adds compiler settings to the project */

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/StandaloneRestTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/StandaloneRestTestPlugin.groovy
@@ -62,6 +62,7 @@ class StandaloneRestTestPlugin implements Plugin<Project> {
         project.getTasks().create("buildResources", ExportElasticsearchBuildResourcesTask)
         BuildPlugin.configureRepositories(project)
         BuildPlugin.configureTestTasks(project)
+        BuildPlugin.configureInputNormalization(project)
 
         ExtraPropertiesExtension ext = project.extensions.getByType(ExtraPropertiesExtension)
         project.extensions.getByType(JavaPluginExtension).sourceCompatibility = ext.get('minimumRuntimeVersion') as JavaVersion

--- a/plugins/discovery-azure-classic/build.gradle
+++ b/plugins/discovery-azure-classic/build.gradle
@@ -56,7 +56,7 @@ dependencies {
 }
 
 // needed to be consistent with ssl host checking
-String host = InetAddress.getLoopbackAddress().getHostAddress();
+String host = InetAddress.getLoopbackAddress().getHostAddress()
 
 // location of keystore and files to generate it
 File keystore = new File(project.buildDir, 'keystore/test-node.jks')
@@ -67,6 +67,7 @@ task createKey(type: LoggedExec) {
     project.delete(keystore.parentFile)
     keystore.parentFile.mkdirs()
   }
+  outputs.file(keystore).withPropertyName('keystoreFile')
   executable = new File(project.runtimeJavaHome, 'bin/keytool')
   standardInput = new ByteArrayInputStream('FirstName LastName\nUnit\nOrganization\nCity\nState\nNL\nyes\n\n'.getBytes('UTF-8'))
   args '-genkey',
@@ -81,8 +82,15 @@ task createKey(type: LoggedExec) {
 }
 
 // add keystore to test classpath: it expects it there
-sourceSets.test.resources.srcDir(keystore.parentFile)
-processTestResources.dependsOn(createKey)
+processTestResources {
+  from createKey
+}
+
+normalization {
+  runtimeClasspath {
+    ignore 'test-node.jks'
+  }
+}
 
 dependencyLicenses {
   mapping from: /azure-.*/, to: 'azure'


### PR DESCRIPTION
We use several of the Netflix Nebula plugins to decorate JAR manifests with build-time information such as host machine, branch, git commit, timestamp, etc. This is all good and fine but because this manifest is embedded in our JARs and then put on various runtime classpaths, those classpaths are considered constantly changing by Gradle. The side effect of this being that we get loads of build cache misses for anything that relies on these classpaths.

We solve this by simply telling Gradle to ignore this particular resource when snapshotting classpaths. This is safe because the manifest is purely metadata, and doesn't influence runtime behavior in any way.