### PR TITLE
Geo: Refactor libs/geo parsers

### DIFF
--- a/libs/geo/src/main/java/org/elasticsearch/geo/utils/WellKnownText.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geo/utils/WellKnownText.java
@@ -56,13 +56,17 @@ public class WellKnownText {
     private static final String EOF = "END-OF-STREAM";
     private static final String EOL = "END-OF-LINE";
 
-    public static String toWKT(Geometry geometry) {
+    public WellKnownText() {
+
+    }
+
+    public String toWKT(Geometry geometry) {
         StringBuilder builder = new StringBuilder();
         toWKT(geometry, builder);
         return builder.toString();
     }
 
-    public static void toWKT(Geometry geometry, StringBuilder sb) {
+    public void toWKT(Geometry geometry, StringBuilder sb) {
         sb.append(getWKTName(geometry));
         sb.append(SPACE);
         if (geometry.isEmpty()) {
@@ -216,7 +220,7 @@ public class WellKnownText {
         }
     }
 
-    public static Geometry fromWKT(String wkt) throws IOException, ParseException {
+    public Geometry fromWKT(String wkt) throws IOException, ParseException {
         StringReader reader = new StringReader(wkt);
         try {
             // setup the tokenizer; configured to read words w/o numbers

--- a/libs/geo/src/test/java/org/elasticsearch/geo/geometry/BaseGeometryTestCase.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geo/geometry/BaseGeometryTestCase.java
@@ -53,9 +53,10 @@ abstract class BaseGeometryTestCase<T extends Geometry> extends AbstractWireTest
     @SuppressWarnings("unchecked")
     @Override
     protected T copyInstance(T instance, Version version) throws IOException {
-        String text = WellKnownText.toWKT(instance);
+        WellKnownText wkt = new WellKnownText();
+        String text = wkt.toWKT(instance);
         try {
-            return (T) WellKnownText.fromWKT(text);
+            return (T) wkt.fromWKT(text);
         } catch (ParseException e) {
             throw new ElasticsearchException(e);
         }

--- a/libs/geo/src/test/java/org/elasticsearch/geo/geometry/CircleTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geo/geometry/CircleTests.java
@@ -36,14 +36,15 @@ public class CircleTests extends BaseGeometryTestCase<Circle> {
     }
 
     public void testBasicSerialization() throws IOException, ParseException {
-        assertEquals("circle (20.0 10.0 15.0)", WellKnownText.toWKT(new Circle(10, 20, 15)));
-        assertEquals(new Circle(10, 20, 15), WellKnownText.fromWKT("circle (20.0 10.0 15.0)"));
+        WellKnownText wkt = new WellKnownText();
+        assertEquals("circle (20.0 10.0 15.0)", wkt.toWKT(new Circle(10, 20, 15)));
+        assertEquals(new Circle(10, 20, 15), wkt.fromWKT("circle (20.0 10.0 15.0)"));
 
-        assertEquals("circle (20.0 10.0 15.0 25.0)", WellKnownText.toWKT(new Circle(10, 20, 25, 15)));
-        assertEquals(new Circle(10, 20, 25, 15), WellKnownText.fromWKT("circle (20.0 10.0 15.0 25.0)"));
+        assertEquals("circle (20.0 10.0 15.0 25.0)", wkt.toWKT(new Circle(10, 20, 25, 15)));
+        assertEquals(new Circle(10, 20, 25, 15), wkt.fromWKT("circle (20.0 10.0 15.0 25.0)"));
 
-        assertEquals("circle EMPTY", WellKnownText.toWKT(Circle.EMPTY));
-        assertEquals(Circle.EMPTY, WellKnownText.fromWKT("circle EMPTY)"));
+        assertEquals("circle EMPTY", wkt.toWKT(Circle.EMPTY));
+        assertEquals(Circle.EMPTY, wkt.fromWKT("circle EMPTY)"));
     }
 
     public void testInitValidation() {

--- a/libs/geo/src/test/java/org/elasticsearch/geo/geometry/GeometryCollectionTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geo/geometry/GeometryCollectionTests.java
@@ -35,14 +35,15 @@ public class GeometryCollectionTests extends BaseGeometryTestCase<GeometryCollec
 
 
     public void testBasicSerialization() throws IOException, ParseException {
+        WellKnownText wkt = new WellKnownText();
         assertEquals("geometrycollection (point (20.0 10.0),point EMPTY)",
-            WellKnownText.toWKT(new GeometryCollection<Geometry>(Arrays.asList(new Point(10, 20), Point.EMPTY))));
+            wkt.toWKT(new GeometryCollection<Geometry>(Arrays.asList(new Point(10, 20), Point.EMPTY))));
 
         assertEquals(new GeometryCollection<Geometry>(Arrays.asList(new Point(10, 20), Point.EMPTY)),
-            WellKnownText.fromWKT("geometrycollection (point (20.0 10.0),point EMPTY)"));
+            wkt.fromWKT("geometrycollection (point (20.0 10.0),point EMPTY)"));
 
-        assertEquals("geometrycollection EMPTY", WellKnownText.toWKT(GeometryCollection.EMPTY));
-        assertEquals(GeometryCollection.EMPTY, WellKnownText.fromWKT("geometrycollection EMPTY)"));
+        assertEquals("geometrycollection EMPTY", wkt.toWKT(GeometryCollection.EMPTY));
+        assertEquals(GeometryCollection.EMPTY, wkt.fromWKT("geometrycollection EMPTY)"));
     }
 
     @SuppressWarnings("ConstantConditions")

--- a/libs/geo/src/test/java/org/elasticsearch/geo/geometry/LineTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geo/geometry/LineTests.java
@@ -31,16 +31,17 @@ public class LineTests extends BaseGeometryTestCase<Line> {
     }
 
     public void testBasicSerialization() throws IOException, ParseException {
-        assertEquals("linestring (3.0 1.0, 4.0 2.0)", WellKnownText.toWKT(new Line(new double[]{1, 2}, new double[]{3, 4})));
-        assertEquals(new Line(new double[]{1, 2}, new double[]{3, 4}), WellKnownText.fromWKT("linestring (3 1, 4 2)"));
+        WellKnownText wkt = new WellKnownText();
+        assertEquals("linestring (3.0 1.0, 4.0 2.0)", wkt.toWKT(new Line(new double[]{1, 2}, new double[]{3, 4})));
+        assertEquals(new Line(new double[]{1, 2}, new double[]{3, 4}), wkt.fromWKT("linestring (3 1, 4 2)"));
 
-        assertEquals("linestring (3.0 1.0 5.0, 4.0 2.0 6.0)", WellKnownText.toWKT(new Line(new double[]{1, 2}, new double[]{3, 4},
+        assertEquals("linestring (3.0 1.0 5.0, 4.0 2.0 6.0)", wkt.toWKT(new Line(new double[]{1, 2}, new double[]{3, 4},
             new double[]{5, 6})));
         assertEquals(new Line(new double[]{1, 2}, new double[]{3, 4}, new double[]{6, 5}),
-            WellKnownText.fromWKT("linestring (3 1 6, 4 2 5)"));
+            wkt.fromWKT("linestring (3 1 6, 4 2 5)"));
 
-        assertEquals("linestring EMPTY", WellKnownText.toWKT(Line.EMPTY));
-        assertEquals(Line.EMPTY, WellKnownText.fromWKT("linestring EMPTY)"));
+        assertEquals("linestring EMPTY", wkt.toWKT(Line.EMPTY));
+        assertEquals(Line.EMPTY, wkt.fromWKT("linestring EMPTY)"));
     }
 
     public void testInitValidation() {

--- a/libs/geo/src/test/java/org/elasticsearch/geo/geometry/LinearRingTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geo/geometry/LinearRingTests.java
@@ -26,7 +26,7 @@ public class LinearRingTests extends ESTestCase {
 
     public void testBasicSerialization() {
         UnsupportedOperationException ex = expectThrows(UnsupportedOperationException.class,
-            () -> WellKnownText.toWKT(new LinearRing(new double[]{1, 2, 3, 1}, new double[]{3, 4, 5, 3})));
+            () -> new WellKnownText().toWKT(new LinearRing(new double[]{1, 2, 3, 1}, new double[]{3, 4, 5, 3})));
         assertEquals("line ring cannot be serialized using WKT", ex.getMessage());
     }
 

--- a/libs/geo/src/test/java/org/elasticsearch/geo/geometry/MultiLineTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geo/geometry/MultiLineTests.java
@@ -40,12 +40,13 @@ public class MultiLineTests extends BaseGeometryTestCase<MultiLine> {
     }
 
     public void testBasicSerialization() throws IOException, ParseException {
-        assertEquals("multilinestring ((3.0 1.0, 4.0 2.0))", WellKnownText.toWKT(
+        WellKnownText wkt = new WellKnownText();
+        assertEquals("multilinestring ((3.0 1.0, 4.0 2.0))", wkt.toWKT(
             new MultiLine(Collections.singletonList(new Line(new double[]{1, 2}, new double[]{3, 4})))));
         assertEquals(new MultiLine(Collections.singletonList(new Line(new double[]{1, 2}, new double[]{3, 4}))),
-            WellKnownText.fromWKT("multilinestring ((3 1, 4 2))"));
+            wkt.fromWKT("multilinestring ((3 1, 4 2))"));
 
-        assertEquals("multilinestring EMPTY", WellKnownText.toWKT(MultiLine.EMPTY));
-        assertEquals(MultiLine.EMPTY, WellKnownText.fromWKT("multilinestring EMPTY)"));
+        assertEquals("multilinestring EMPTY", wkt.toWKT(MultiLine.EMPTY));
+        assertEquals(MultiLine.EMPTY, wkt.fromWKT("multilinestring EMPTY)"));
     }
 }

--- a/libs/geo/src/test/java/org/elasticsearch/geo/geometry/MultiPointTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geo/geometry/MultiPointTests.java
@@ -41,22 +41,23 @@ public class MultiPointTests extends BaseGeometryTestCase<MultiPoint> {
     }
 
     public void testBasicSerialization() throws IOException, ParseException {
-        assertEquals("multipoint (2.0 1.0)", WellKnownText.toWKT(
+        WellKnownText wkt = new WellKnownText();
+        assertEquals("multipoint (2.0 1.0)", wkt.toWKT(
             new MultiPoint(Collections.singletonList(new Point(1, 2)))));
         assertEquals(new MultiPoint(Collections.singletonList(new Point(1 ,2))),
-            WellKnownText.fromWKT("multipoint (2 1)"));
+            wkt.fromWKT("multipoint (2 1)"));
 
         assertEquals("multipoint (2.0 1.0, 3.0 4.0)",
-            WellKnownText.toWKT(new MultiPoint(Arrays.asList(new Point(1, 2), new Point(4, 3)))));
+            wkt.toWKT(new MultiPoint(Arrays.asList(new Point(1, 2), new Point(4, 3)))));
         assertEquals(new MultiPoint(Arrays.asList(new Point(1, 2), new Point(4, 3))),
-            WellKnownText.fromWKT("multipoint (2 1, 3 4)"));
+            wkt.fromWKT("multipoint (2 1, 3 4)"));
 
         assertEquals("multipoint (2.0 1.0 10.0, 3.0 4.0 20.0)",
-            WellKnownText.toWKT(new MultiPoint(Arrays.asList(new Point(1, 2, 10), new Point(4, 3, 20)))));
+            wkt.toWKT(new MultiPoint(Arrays.asList(new Point(1, 2, 10), new Point(4, 3, 20)))));
         assertEquals(new MultiPoint(Arrays.asList(new Point(1, 2, 10), new Point(4, 3, 20))),
-            WellKnownText.fromWKT("multipoint (2 1 10, 3 4 20)"));
+            wkt.fromWKT("multipoint (2 1 10, 3 4 20)"));
 
-        assertEquals("multipoint EMPTY", WellKnownText.toWKT(MultiPoint.EMPTY));
-        assertEquals(MultiPoint.EMPTY, WellKnownText.fromWKT("multipoint EMPTY)"));
+        assertEquals("multipoint EMPTY", wkt.toWKT(MultiPoint.EMPTY));
+        assertEquals(MultiPoint.EMPTY, wkt.fromWKT("multipoint EMPTY)"));
     }
 }

--- a/libs/geo/src/test/java/org/elasticsearch/geo/geometry/MultiPolygonTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geo/geometry/MultiPolygonTests.java
@@ -40,14 +40,15 @@ public class MultiPolygonTests extends BaseGeometryTestCase<MultiPolygon> {
     }
 
     public void testBasicSerialization() throws IOException, ParseException {
+        WellKnownText wkt = new WellKnownText();
         assertEquals("multipolygon (((3.0 1.0, 4.0 2.0, 5.0 3.0, 3.0 1.0)))",
-            WellKnownText.toWKT(new MultiPolygon(Collections.singletonList(
+            wkt.toWKT(new MultiPolygon(Collections.singletonList(
                 new Polygon(new LinearRing(new double[]{1, 2, 3, 1}, new double[]{3, 4, 5, 3}))))));
         assertEquals(new MultiPolygon(Collections.singletonList(
             new Polygon(new LinearRing(new double[]{1, 2, 3, 1}, new double[]{3, 4, 5, 3})))),
-            WellKnownText.fromWKT("multipolygon (((3.0 1.0, 4.0 2.0, 5.0 3.0, 3.0 1.0)))"));
+            wkt.fromWKT("multipolygon (((3.0 1.0, 4.0 2.0, 5.0 3.0, 3.0 1.0)))"));
 
-        assertEquals("multipolygon EMPTY", WellKnownText.toWKT(MultiPolygon.EMPTY));
-        assertEquals(MultiPolygon.EMPTY, WellKnownText.fromWKT("multipolygon EMPTY)"));
+        assertEquals("multipolygon EMPTY", wkt.toWKT(MultiPolygon.EMPTY));
+        assertEquals(MultiPolygon.EMPTY, wkt.fromWKT("multipolygon EMPTY)"));
     }
 }

--- a/libs/geo/src/test/java/org/elasticsearch/geo/geometry/PointTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geo/geometry/PointTests.java
@@ -31,14 +31,15 @@ public class PointTests extends BaseGeometryTestCase<Point> {
     }
 
     public void testBasicSerialization() throws IOException, ParseException {
-        assertEquals("point (20.0 10.0)", WellKnownText.toWKT(new Point(10, 20)));
-        assertEquals(new Point(10, 20), WellKnownText.fromWKT("point (20.0 10.0)"));
+        WellKnownText wkt = new WellKnownText();
+        assertEquals("point (20.0 10.0)", wkt.toWKT(new Point(10, 20)));
+        assertEquals(new Point(10, 20), wkt.fromWKT("point (20.0 10.0)"));
 
-        assertEquals("point (20.0 10.0 100.0)", WellKnownText.toWKT(new Point(10, 20, 100)));
-        assertEquals(new Point(10, 20, 100), WellKnownText.fromWKT("point (20.0 10.0 100.0)"));
+        assertEquals("point (20.0 10.0 100.0)", wkt.toWKT(new Point(10, 20, 100)));
+        assertEquals(new Point(10, 20, 100), wkt.fromWKT("point (20.0 10.0 100.0)"));
 
-        assertEquals("point EMPTY", WellKnownText.toWKT(Point.EMPTY));
-        assertEquals(Point.EMPTY, WellKnownText.fromWKT("point EMPTY)"));
+        assertEquals("point EMPTY", wkt.toWKT(Point.EMPTY));
+        assertEquals(Point.EMPTY, wkt.fromWKT("point EMPTY)"));
     }
 
     public void testInitValidation() {

--- a/libs/geo/src/test/java/org/elasticsearch/geo/geometry/PolygonTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geo/geometry/PolygonTests.java
@@ -32,18 +32,19 @@ public class PolygonTests extends BaseGeometryTestCase<Polygon> {
     }
 
     public void testBasicSerialization() throws IOException, ParseException {
+        WellKnownText wkt = new WellKnownText();
         assertEquals("polygon ((3.0 1.0, 4.0 2.0, 5.0 3.0, 3.0 1.0))",
-            WellKnownText.toWKT(new Polygon(new LinearRing(new double[]{1, 2, 3, 1}, new double[]{3, 4, 5, 3}))));
+            wkt.toWKT(new Polygon(new LinearRing(new double[]{1, 2, 3, 1}, new double[]{3, 4, 5, 3}))));
         assertEquals(new Polygon(new LinearRing(new double[]{1, 2, 3, 1}, new double[]{3, 4, 5, 3})),
-            WellKnownText.fromWKT("polygon ((3 1, 4 2, 5 3, 3 1))"));
+            wkt.fromWKT("polygon ((3 1, 4 2, 5 3, 3 1))"));
 
         assertEquals("polygon ((3.0 1.0 5.0, 4.0 2.0 4.0, 5.0 3.0 3.0, 3.0 1.0 5.0))",
-            WellKnownText.toWKT(new Polygon(new LinearRing(new double[]{1, 2, 3, 1}, new double[]{3, 4, 5, 3}, new double[]{5, 4, 3, 5}))));
+            wkt.toWKT(new Polygon(new LinearRing(new double[]{1, 2, 3, 1}, new double[]{3, 4, 5, 3}, new double[]{5, 4, 3, 5}))));
         assertEquals(new Polygon(new LinearRing(new double[]{1, 2, 3, 1}, new double[]{3, 4, 5, 3}, new double[]{5, 4, 3, 5})),
-            WellKnownText.fromWKT("polygon ((3 1 5, 4 2 4, 5 3 3, 3 1 5))"));
+            wkt.fromWKT("polygon ((3 1 5, 4 2 4, 5 3 3, 3 1 5))"));
 
-        assertEquals("polygon EMPTY", WellKnownText.toWKT(Polygon.EMPTY));
-        assertEquals(Polygon.EMPTY, WellKnownText.fromWKT("polygon EMPTY)"));
+        assertEquals("polygon EMPTY", wkt.toWKT(Polygon.EMPTY));
+        assertEquals(Polygon.EMPTY, wkt.fromWKT("polygon EMPTY)"));
     }
 
     public void testInitValidation() {

--- a/libs/geo/src/test/java/org/elasticsearch/geo/geometry/RectangleTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geo/geometry/RectangleTests.java
@@ -32,11 +32,12 @@ public class RectangleTests extends BaseGeometryTestCase<Rectangle> {
     }
 
     public void testBasicSerialization() throws IOException, ParseException {
-        assertEquals("bbox (10.0, 20.0, 40.0, 30.0)", WellKnownText.toWKT(new Rectangle(30, 40, 10, 20)));
-        assertEquals(new Rectangle(30, 40, 10, 20), WellKnownText.fromWKT("bbox (10.0, 20.0, 40.0, 30.0)"));
+        WellKnownText wkt = new WellKnownText();
+        assertEquals("bbox (10.0, 20.0, 40.0, 30.0)", wkt.toWKT(new Rectangle(30, 40, 10, 20)));
+        assertEquals(new Rectangle(30, 40, 10, 20), wkt.fromWKT("bbox (10.0, 20.0, 40.0, 30.0)"));
 
-        assertEquals("bbox EMPTY", WellKnownText.toWKT(Rectangle.EMPTY));
-        assertEquals(Rectangle.EMPTY, WellKnownText.fromWKT("bbox EMPTY)"));
+        assertEquals("bbox EMPTY", wkt.toWKT(Rectangle.EMPTY));
+        assertEquals(Rectangle.EMPTY, wkt.fromWKT("bbox EMPTY)"));
     }
 
     public void testInitValidation() {

--- a/server/src/main/java/org/elasticsearch/common/geo/GeometryParser.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeometryParser.java
@@ -32,22 +32,26 @@ import java.text.ParseException;
  */
 public final class GeometryParser {
 
-    private GeometryParser() {
+    private final GeoJson geoJsonParser;
+    private final WellKnownText wellKnownTextParser;
 
+    public GeometryParser(boolean rightOrientation, boolean coerce, boolean ignoreZValue) {
+        geoJsonParser = new GeoJson(rightOrientation, coerce, ignoreZValue);
+        wellKnownTextParser = new WellKnownText();
     }
 
     /**
      * Parses supplied XContent into Geometry
      */
-    public static Geometry parse(XContentParser parser, boolean orientation, boolean coerce, boolean ignoreZValue) throws IOException,
+    public Geometry parse(XContentParser parser) throws IOException,
         ParseException {
         if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
             return null;
         } else if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
-            return GeoJson.fromXContent(parser, orientation, coerce, ignoreZValue);
+            return geoJsonParser.fromXContent(parser);
         } else if (parser.currentToken() == XContentParser.Token.VALUE_STRING) {
             // TODO: Add support for ignoreZValue and coerce to WKT
-            return WellKnownText.fromWKT(parser.text());
+            return wellKnownTextParser.fromWKT(parser.text());
         }
         throw new ElasticsearchParseException("shape must be an object consisting of type and coordinates");
     }

--- a/server/src/test/java/org/elasticsearch/common/geo/BaseGeoParsingTestCase.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/BaseGeoParsingTestCase.java
@@ -70,7 +70,7 @@ abstract class BaseGeoParsingTestCase extends ESTestCase {
     protected void assertGeometryEquals(org.elasticsearch.geo.geometry.Geometry expected, XContentBuilder geoJson) throws IOException {
         try (XContentParser parser = createParser(geoJson)) {
             parser.nextToken();
-            assertEquals(expected, GeoJson.fromXContent(parser, true, false, false));
+            assertEquals(expected, new GeoJson(true, false, false).fromXContent(parser));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/common/geo/GeoJsonParserTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeoJsonParserTests.java
@@ -72,7 +72,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
         Line expected = new Line(new double[] {0.0, 1.0}, new double[] { 100.0, 101.0});
         try (XContentParser parser = createParser(lineGeoJson)) {
             parser.nextToken();
-            assertEquals(expected, GeoJson.fromXContent(parser, false, false, true));
+            assertEquals(expected, new GeoJson(false, false, true).fromXContent(parser));
         }
     }
 
@@ -124,7 +124,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
 
         try (XContentParser parser = createParser(pointGeoJson)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> GeoJson.fromXContent(parser, false, false, false));
+            expectThrows(XContentParseException.class, () -> new GeoJson(false, false, false).fromXContent(parser));
             assertNull(parser.nextToken());
         }
 
@@ -140,7 +140,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
 
         try (XContentParser parser = createParser(lineGeoJson)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> GeoJson.fromXContent(parser, false, false, false));
+            expectThrows(XContentParseException.class, () -> new GeoJson(false, false, false).fromXContent(parser));
             assertNull(parser.nextToken());
         }
     }
@@ -178,7 +178,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
                 .endObject();
         try (XContentParser parser = createParser(multilinesGeoJson)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> GeoJson.fromXContent(parser, false, false, false));
+            expectThrows(XContentParseException.class, () -> new GeoJson(false, false, false).fromXContent(parser));
             assertNull(parser.nextToken());
         }
 
@@ -189,7 +189,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
                 .endObject();
         try (XContentParser parser = createParser(multilinesGeoJson)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> GeoJson.fromXContent(parser, false, false, false));
+            expectThrows(XContentParseException.class, () -> new GeoJson(false, false, false).fromXContent(parser));
             assertNull(parser.nextToken());
         }
     }
@@ -239,7 +239,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
         ));
         try (XContentParser parser = createParser(polygonGeoJson)) {
             parser.nextToken();
-            assertEquals(expected, GeoJson.fromXContent(parser, true, false, true));
+            assertEquals(expected, new GeoJson(true, false, true).fromXContent(parser));
         }
     }
 
@@ -259,7 +259,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
             .endObject();
         try (XContentParser parser = createParser(polygonGeoJson)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> GeoJson.fromXContent(parser, true, false, true));
+            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, true).fromXContent(parser));
             assertNull(parser.nextToken());
         }
     }
@@ -275,7 +275,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
                 .endObject();
         try (XContentParser parser = createParser(invalidPoint1)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> GeoJson.fromXContent(parser, true, false, false));
+            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, false).fromXContent(parser));
             assertNull(parser.nextToken());
         }
 
@@ -288,7 +288,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
                 .endObject();
         try (XContentParser parser = createParser(invalidPoint2)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> GeoJson.fromXContent(parser, true, false, false));
+            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, false).fromXContent(parser));
             assertNull(parser.nextToken());
         }
     }
@@ -302,7 +302,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
                 .endObject();
         try (XContentParser parser = createParser(invalidMultipoint1)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> GeoJson.fromXContent(parser, true, false, false));
+            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, false).fromXContent(parser));
             assertNull(parser.nextToken());
         }
 
@@ -315,7 +315,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
                 .endObject();
         try (XContentParser parser = createParser(invalidMultipoint2)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> GeoJson.fromXContent(parser, true, false, false));
+            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, false).fromXContent(parser));
             assertNull(parser.nextToken());
         }
 
@@ -329,7 +329,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
                 .endObject();
         try (XContentParser parser = createParser(invalidMultipoint3)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> GeoJson.fromXContent(parser, true, false, false));
+            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, false).fromXContent(parser));
             assertNull(parser.nextToken());
         }
     }
@@ -370,7 +370,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, multiPolygonGeoJson)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> GeoJson.fromXContent(parser, true, false, false));
+            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, false).fromXContent(parser));
             assertNull(parser.nextToken());
         }
    }
@@ -391,7 +391,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
                 .endObject());
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, invalidPoly)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> GeoJson.fromXContent(parser, true, false, false));
+            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, false).fromXContent(parser));
             assertNull(parser.nextToken());
         }
 
@@ -406,7 +406,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, invalidPoly)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> GeoJson.fromXContent(parser, true, false, false));
+            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, false).fromXContent(parser));
             assertNull(parser.nextToken());
         }
 
@@ -421,7 +421,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, invalidPoly)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> GeoJson.fromXContent(parser, true, false, false));
+            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, false).fromXContent(parser));
             assertNull(parser.nextToken());
         }
 
@@ -436,7 +436,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, invalidPoly)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> GeoJson.fromXContent(parser, true, false, false));
+            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, false).fromXContent(parser));
             assertNull(parser.nextToken());
         }
 
@@ -449,7 +449,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, invalidPoly)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> GeoJson.fromXContent(parser, true, false, false));
+            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, false).fromXContent(parser));
             assertNull(parser.nextToken());
         }
 
@@ -460,7 +460,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, invalidPoly)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> GeoJson.fromXContent(parser, true, false, false));
+            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, false).fromXContent(parser));
             assertNull(parser.nextToken());
         }
 
@@ -473,7 +473,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, invalidPoly)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> GeoJson.fromXContent(parser, true, false, false));
+            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, false).fromXContent(parser));
             assertNull(parser.nextToken());
         }
     }
@@ -710,7 +710,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
 
         try (XContentParser parser = createParser(tooLittlePointGeoJson)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> GeoJson.fromXContent(parser, true, false, false));
+            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, false).fromXContent(parser));
             assertNull(parser.nextToken());
         }
 
@@ -723,7 +723,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
 
         try (XContentParser parser = createParser(emptyPointGeoJson)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> GeoJson.fromXContent(parser, true, false, false));
+            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, false).fromXContent(parser));
             assertNull(parser.nextToken());
         }
     }
@@ -749,7 +749,7 @@ public class GeoJsonParserTests extends BaseGeoParsingTestCase {
             parser.nextToken(); // foo
             parser.nextToken(); // start object
             parser.nextToken(); // start object
-            expectThrows(XContentParseException.class, () -> GeoJson.fromXContent(parser, true, false, false));
+            expectThrows(XContentParseException.class, () -> new GeoJson(true, false, false).fromXContent(parser));
             assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken()); // end of the document
             assertNull(parser.nextToken()); // no more elements afterwards
         }

--- a/server/src/test/java/org/elasticsearch/common/geo/GeoJsonSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeoJsonSerializationTests.java
@@ -49,6 +49,7 @@ public class GeoJsonSerializationTests extends ESTestCase {
     private static class GeometryWrapper implements ToXContentObject {
 
         private Geometry geometry;
+        private static GeoJson PARSER = new GeoJson(true, false, true);
 
         GeometryWrapper(Geometry geometry) {
             this.geometry = geometry;
@@ -61,7 +62,7 @@ public class GeoJsonSerializationTests extends ESTestCase {
 
         public static GeometryWrapper fromXContent(XContentParser parser) throws IOException {
             parser.nextToken();
-            return new GeometryWrapper(GeoJson.fromXContent(parser, true, false, true));
+            return new GeometryWrapper(PARSER.fromXContent(parser));
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/common/geo/GeometryParserTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeometryParserTests.java
@@ -44,7 +44,7 @@ public class GeometryParserTests extends ESTestCase {
 
         try (XContentParser parser = createParser(pointGeoJson)) {
             parser.nextToken();
-            assertEquals(new Point(0, 100), GeometryParser.parse(parser, true, randomBoolean(), randomBoolean()));
+            assertEquals(new Point(0, 100), new GeometryParser(true, randomBoolean(), randomBoolean()).parse(parser));
         }
 
         XContentBuilder pointGeoJsonWithZ = XContentFactory.jsonBuilder()
@@ -55,13 +55,13 @@ public class GeometryParserTests extends ESTestCase {
 
         try (XContentParser parser = createParser(pointGeoJsonWithZ)) {
             parser.nextToken();
-            assertEquals(new Point(0, 100, 10.0), GeometryParser.parse(parser, true, randomBoolean(), true));
+            assertEquals(new Point(0, 100, 10.0), new GeometryParser(true, randomBoolean(), true).parse(parser));
         }
 
 
         try (XContentParser parser = createParser(pointGeoJsonWithZ)) {
             parser.nextToken();
-            expectThrows(XContentParseException.class, () -> GeometryParser.parse(parser, true, randomBoolean(), false));
+            expectThrows(XContentParseException.class, () -> new GeometryParser(true, randomBoolean(), false).parse(parser));
         }
 
         XContentBuilder polygonGeoJson = XContentFactory.jsonBuilder()
@@ -81,13 +81,13 @@ public class GeometryParserTests extends ESTestCase {
         try (XContentParser parser = createParser(polygonGeoJson)) {
             parser.nextToken();
             // Coerce should automatically close the polygon
-            assertEquals(p, GeometryParser.parse(parser, true, true, randomBoolean()));
+            assertEquals(p, new GeometryParser(true, true, randomBoolean()).parse(parser));
         }
 
         try (XContentParser parser = createParser(polygonGeoJson)) {
             parser.nextToken();
             // No coerce - the polygon parsing should fail
-            expectThrows(XContentParseException.class, () -> GeometryParser.parse(parser, true, false, randomBoolean()));
+            expectThrows(XContentParseException.class, () -> new GeometryParser(true, false, randomBoolean()).parse(parser));
         }
     }
 
@@ -101,7 +101,7 @@ public class GeometryParserTests extends ESTestCase {
             parser.nextToken(); // Start object
             parser.nextToken(); // Field Name
             parser.nextToken(); // Field Value
-            assertEquals(new Point(0, 100), GeometryParser.parse(parser, true, randomBoolean(), randomBoolean()));
+            assertEquals(new Point(0, 100), new GeometryParser(true, randomBoolean(), randomBoolean()).parse(parser));
         }
     }
 
@@ -115,7 +115,7 @@ public class GeometryParserTests extends ESTestCase {
             parser.nextToken(); // Start object
             parser.nextToken(); // Field Name
             parser.nextToken(); // Field Value
-            assertNull(GeometryParser.parse(parser, true, randomBoolean(), randomBoolean()));
+            assertNull(new GeometryParser(true, randomBoolean(), randomBoolean()).parse(parser));
         }
     }
 
@@ -130,7 +130,7 @@ public class GeometryParserTests extends ESTestCase {
             parser.nextToken(); // Field Name
             parser.nextToken(); // Field Value
             ElasticsearchParseException ex = expectThrows(ElasticsearchParseException.class,
-                () -> GeometryParser.parse(parser, true, randomBoolean(), randomBoolean()));
+                () -> new GeometryParser(true, randomBoolean(), randomBoolean()).parse(parser));
             assertEquals("shape must be an object consisting of type and coordinates", ex.getMessage());
         }
     }

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/TypeConverter.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/TypeConverter.java
@@ -54,6 +54,8 @@ import static org.elasticsearch.xpack.sql.jdbc.JdbcDateUtils.timeAsTime;
  */
 final class TypeConverter {
 
+    private static WellKnownText WKT = new WellKnownText();
+
     private TypeConverter() {}
 
     /**
@@ -246,7 +248,7 @@ final class TypeConverter {
             case GEO_POINT:
             case GEO_SHAPE:
                 try {
-                    return WellKnownText.fromWKT(v.toString());
+                    return WKT.fromWKT(v.toString());
                 } catch (IOException | ParseException ex) {
                     throw new SQLException("Cannot parse geo_shape", ex);
                 }

--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcAssert.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcAssert.java
@@ -51,6 +51,8 @@ public class JdbcAssert {
 
     private static final IntObjectHashMap<EsType> SQL_TO_TYPE = new IntObjectHashMap<>();
 
+    private static final WellKnownText WKT = new WellKnownText();
+
     static {
         for (EsType type : EsType.values()) {
             SQL_TO_TYPE.putIfAbsent(type.getVendorTypeNumber().intValue(), type);
@@ -270,7 +272,7 @@ public class JdbcAssert {
                         if (actualObject instanceof Geometry) {
                             // We need to convert the expected object to libs/geo Geometry for comparision
                             try {
-                                expectedObject = WellKnownText.fromWKT(expectedObject.toString());
+                                expectedObject = WKT.fromWKT(expectedObject.toString());
                             } catch (IOException | ParseException ex) {
                                 fail(ex.getMessage());
                             }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/geo/GeoShape.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/geo/GeoShape.java
@@ -49,6 +49,10 @@ public class GeoShape implements ToXContentFragment, NamedWriteable {
 
     private final Geometry shape;
 
+    private static final GeometryParser GEOMETRY_PARSER = new GeometryParser(true, true, true);
+
+    private static final WellKnownText WKT_PARSER = new WellKnownText();
+
     public GeoShape(double lon, double lat) {
         shape = new Point(lat, lon);
     }
@@ -72,17 +76,17 @@ public class GeoShape implements ToXContentFragment, NamedWriteable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(WellKnownText.toWKT(shape));
+        out.writeString(WKT_PARSER.toWKT(shape));
     }
 
     @Override
     public String toString() {
-        return WellKnownText.toWKT(shape);
+        return WKT_PARSER.toWKT(shape);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        return builder.value(WellKnownText.toWKT(shape));
+        return builder.value(WKT_PARSER.toWKT(shape));
     }
 
     public Geometry toGeometry() {
@@ -216,7 +220,7 @@ public class GeoShape implements ToXContentFragment, NamedWriteable {
             parser.nextToken(); // start object
             parser.nextToken(); // field name
             parser.nextToken(); // field value
-            return GeometryParser.parse(parser, true, true, true);
+            return GEOMETRY_PARSER.parse(parser);
         }
     }
 }


### PR DESCRIPTION
Refactors the WKT and GeoJSON parsers from an utility class into an
instantiatable objects. This is a preliminary step in
preparation for moving out coordinate validators from Geometry
constructors. This should allow us to make validators plugable.
