### PR TITLE
Make JarHellTask cacheable

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
@@ -107,14 +107,12 @@ class PrecommitTasks {
     }
 
     private static Task configureJarHell(Project project) {
-        Task task = project.tasks.create('jarHell', JarHellTask.class)
-        task.classpath = project.sourceSets.test.runtimeClasspath
-        if (project.plugins.hasPlugin(ShadowPlugin)) {
-            task.classpath += project.configurations.bundle
+        return project.tasks.create('jarHell', JarHellTask) { task ->
+            task.classpath = project.sourceSets.test.runtimeClasspath
+            if (project.plugins.hasPlugin(ShadowPlugin)) {
+                task.classpath += project.configurations.bundle
+            }
         }
-        task.dependsOn(project.sourceSets.test.classesTaskName)
-        task.javaHome = project.runtimeJavaHome
-        return task
     }
 
     private static Task configureThirdPartyAudit(Project project) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/JarHellTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/JarHellTask.java
@@ -21,18 +21,19 @@ package org.elasticsearch.gradle.precommit;
 
 import org.elasticsearch.gradle.LoggedExec;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.tasks.Classpath;
-import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
 
 /**
  * Runs CheckJarHell on a classpath.
  */
+@CacheableTask
 public class JarHellTask extends PrecommitTask {
 
     private FileCollection classpath;
-
-    private Object javaHome;
 
     public JarHellTask() {
         setDescription("Runs CheckJarHell on the configured classpath");
@@ -42,23 +43,15 @@ public class JarHellTask extends PrecommitTask {
     public void runJarHellCheck() {
         LoggedExec.javaexec(getProject(), spec -> {
             spec.classpath(getClasspath());
-            spec.executable(getJavaHome() + "/bin/java");
             spec.setMain("org.elasticsearch.bootstrap.JarHell");
         });
     }
 
-    @Input
-    public Object getJavaHome() {
-        return javaHome;
-    }
-
-    public void setJavaHome(Object javaHome) {
-        this.javaHome = javaHome;
-    }
-
-    @Classpath
+    // We use compile classpath normalization here because class implementation changes are irrelevant for the purposes of jar hell.
+    // We only care about the runtime classpath ABI here.
+    @CompileClasspath
     public FileCollection getClasspath() {
-        return classpath.filter(file -> file.exists());
+        return classpath.filter(File::exists);
     }
 
     public void setClasspath(FileCollection classpath) {


### PR DESCRIPTION
Continuing the campaign to make all precommit tasks cacheable. This PR make the `JarHellTask` cacheable as well as some other improvements. We now use compile classpath normalization here instead of runtime classpath normalization to get some better avoidance benefits since the jar hell detection only cares about what classes are on the classpath, not their implementations. If we cared, we could make this even better, by normalizing out everything but class names and file paths but that's probably overkill.