### PR TITLE
Allocate to data-only nodes in ReopenWhileClosingIT

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/state/ReopenWhileClosingIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/state/ReopenWhileClosingIT.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Glob;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.RunOnce;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -50,7 +51,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
-@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, minNumDataNodes = 2)
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST)
 public class ReopenWhileClosingIT extends ESIntegTestCase {
 
     @Override
@@ -64,8 +65,9 @@ public class ReopenWhileClosingIT extends ESIntegTestCase {
     }
 
     public void testReopenDuringClose() throws Exception {
+        List<String> dataOnlyNodes = internalCluster().startDataOnlyNodes(randomIntBetween(2, 3));
         final String indexName = "test";
-        createIndexWithDocs(indexName);
+        createIndexWithDocs(indexName, dataOnlyNodes);
 
         ensureYellowAndNoInitializingShards(indexName);
 
@@ -84,12 +86,12 @@ public class ReopenWhileClosingIT extends ESIntegTestCase {
         assertIndexIsOpened(indexName);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/39757")
     public void testReopenDuringCloseOnMultipleIndices() throws Exception {
+        List<String> dataOnlyNodes = internalCluster().startDataOnlyNodes(randomIntBetween(2, 3));
         final List<String> indices = new ArrayList<>();
         for (int i = 0; i < randomIntBetween(2, 10); i++) {
             indices.add("index-" + i);
-            createIndexWithDocs(indices.get(i));
+            createIndexWithDocs(indices.get(i), dataOnlyNodes);
         }
 
         ensureYellowAndNoInitializingShards(indices.toArray(Strings.EMPTY_ARRAY));
@@ -117,8 +119,9 @@ public class ReopenWhileClosingIT extends ESIntegTestCase {
         });
     }
 
-    private void createIndexWithDocs(final String indexName) {
-        createIndex(indexName);
+    private void createIndexWithDocs(final String indexName, final Collection<String> dataOnlyNodes) {
+        createIndex(indexName,
+            Settings.builder().put(indexSettings()).put("index.routing.allocation.include._name", String.join(",", dataOnlyNodes)).build());
         final int nbDocs =  scaledRandomIntBetween(1, 100);
         for (int i = 0; i < nbDocs; i++) {
             index(indexName, "_doc", String.valueOf(i), "num", i);


### PR DESCRIPTION
If all primary shards are allocated on the master node, then the verifying before close step will never interact with MockTransportService. This change prefers to allocate shards on data-only nodes.

Closes #39757