### PR TITLE
Fix testTracerLog Network Tests (#42286)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -1047,10 +1047,9 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             .build());
 
         MockLogAppender appender = new MockLogAppender();
-        Loggers.addAppender(LogManager.getLogger("org.elasticsearch.transport.TransportService.tracer"), appender);
         try {
             appender.start();
-
+            Loggers.addAppender(LogManager.getLogger("org.elasticsearch.transport.TransportService.tracer"), appender);
             final String requestSent = ".*\\[internal:test].*sent to.*\\{TS_B}.*";
             final MockLogAppender.LoggingExpectation requestSentExpectation =
                 new MockLogAppender.PatternSeenEventExpectation(


### PR DESCRIPTION
* Fix testTracerLog Network Tests

* Start appender before using it like we do for e.g. the Netty leak detection appender to avoid interference from actions on the network threads that might still be dangling from previous tests in the same suite
* Closes #41890

back port of #42286 