### PR TITLE
Remove Delete Method from BlobStore (#41619)

### DIFF
--- a/modules/repository-url/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobStore.java
+++ b/modules/repository-url/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobStore.java
@@ -57,9 +57,6 @@ public class URLBlobStore implements BlobStore {
             new ByteSizeValue(100, ByteSizeUnit.KB)).getBytes();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         return path.toString();
@@ -83,9 +80,6 @@ public class URLBlobStore implements BlobStore {
         return this.bufferSizeInBytes;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public BlobContainer blobContainer(BlobPath path) {
         try {
@@ -95,17 +89,6 @@ public class URLBlobStore implements BlobStore {
         }
     }
 
-    /**
-     * This operation is not supported by URL Blob Store
-     */
-    @Override
-    public void delete(BlobPath path) {
-        throw new UnsupportedOperationException("URL repository is read only");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void close() {
         // nothing to do here...

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
@@ -22,8 +22,6 @@ package org.elasticsearch.repositories.azure;
 import com.microsoft.azure.storage.LocationMode;
 import com.microsoft.azure.storage.StorageException;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.metadata.RepositoryMetaData;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobMetaData;
@@ -40,8 +38,6 @@ import java.util.Map;
 import static java.util.Collections.emptyMap;
 
 public class AzureBlobStore implements BlobStore {
-    
-    private static final Logger logger = LogManager.getLogger(AzureBlobStore.class);
 
     private final AzureStorageService service;
 
@@ -80,17 +76,6 @@ public class AzureBlobStore implements BlobStore {
     @Override
     public BlobContainer blobContainer(BlobPath path) {
         return new AzureBlobContainer(path, this);
-    }
-
-    @Override
-    public void delete(BlobPath path) throws IOException {
-        final String keyPath = path.buildAsString();
-        try {
-            service.deleteFiles(clientName, container, keyPath);
-        } catch (URISyntaxException | StorageException e) {
-            logger.warn("cannot access [{}] in container {{}}: {}", keyPath, container, e.getMessage());
-            throw new IOException(e);
-        }
     }
 
     @Override

--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStore.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStore.java
@@ -50,11 +50,11 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.NoSuchFileException;
+import java.util.Map;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -89,11 +89,6 @@ class GoogleCloudStorageBlobStore implements BlobStore {
     @Override
     public BlobContainer blobContainer(BlobPath path) {
         return new GoogleCloudStorageBlobContainer(path, this);
-    }
-
-    @Override
-    public void delete(BlobPath path) throws IOException {
-        deleteBlobsByPrefix(path.buildAsString());
     }
 
     @Override
@@ -289,15 +284,6 @@ class GoogleCloudStorageBlobStore implements BlobStore {
         if (deleted == false) {
             throw new NoSuchFileException("Blob [" + blobName + "] does not exist");
         }
-    }
-
-    /**
-     * Deletes multiple blobs from the specific bucket all of which have prefixed names
-     *
-     * @param prefix prefix of the blobs to delete
-     */
-    private void deleteBlobsByPrefix(String prefix) throws IOException {
-        deleteBlobsIgnoringIfNotExists(listBlobsByPrefix("", prefix).keySet());
     }
 
     /**

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobStore.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobStore.java
@@ -67,14 +67,6 @@ final class HdfsBlobStore implements BlobStore {
     }
 
     @Override
-    public void delete(BlobPath path) throws IOException {
-        execute((Operation<Void>) fc -> {
-            fc.delete(translateToHdfsPath(path), true);
-            return null;
-        });
-    }
-
-    @Override
     public String toString() {
         return root.toUri().toString();
     }

--- a/server/src/main/java/org/elasticsearch/common/blobstore/BlobStore.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/BlobStore.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.common.blobstore;
 
 import java.io.Closeable;
-import java.io.IOException;
 
 /**
  * An interface for storing blobs.
@@ -30,10 +29,4 @@ public interface BlobStore extends Closeable {
      * Get a blob container instance for storing blobs at the given {@link BlobPath}.
      */
     BlobContainer blobContainer(BlobPath path);
-
-    /**
-     * Delete the blob store at the given {@link BlobPath}.
-     */
-    void delete(BlobPath path) throws IOException;
-
 }

--- a/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobStore.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobStore.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.common.blobstore.fs;
 
-import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
@@ -70,16 +69,6 @@ public class FsBlobStore implements BlobStore {
         } catch (IOException ex) {
             throw new ElasticsearchException("failed to create blob container", ex);
         }
-    }
-
-    @Override
-    public void delete(BlobPath path) throws IOException {
-        assert readOnly == false : "should not delete anything from a readonly repository: " + path;
-        //noinspection ConstantConditions in case assertions are disabled
-        if (readOnly) {
-            throw new ElasticsearchException("unexpectedly deleting [" + path + "] from a readonly repository");
-        }
-        IOUtils.rm(buildPath(path));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -636,7 +636,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             try {
                 final String testPrefix = testBlobPrefix(seed);
                 final BlobContainer container = blobStore().blobContainer(basePath().add(testPrefix));
-                container.deleteBlobsIgnoringIfNotExists(List.copyOf(container.listBlobs().keySet()));
+                container.deleteBlobsIgnoringIfNotExists(new ArrayList<>(container.listBlobs().keySet()));
                 blobStore().blobContainer(basePath()).deleteBlobIgnoringIfNotExists(testPrefix);
             } catch (IOException exp) {
                 throw new RepositoryVerificationException(metadata.name(), "cannot delete test data at " + basePath(), exp);

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -634,7 +634,10 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     public void endVerification(String seed) {
         if (isReadOnly() == false) {
             try {
-                blobStore().delete(basePath().add(testBlobPrefix(seed)));
+                final String testPrefix = testBlobPrefix(seed);
+                final BlobContainer container = blobStore().blobContainer(basePath().add(testPrefix));
+                container.deleteBlobsIgnoringIfNotExists(List.copyOf(container.listBlobs().keySet()));
+                blobStore().blobContainer(basePath()).deleteBlobIgnoringIfNotExists(testPrefix);
             } catch (IOException exp) {
                 throw new RepositoryVerificationException(metadata.name(), "cannot delete test data at " + basePath(), exp);
             }

--- a/server/src/test/java/org/elasticsearch/snapshots/mockstore/BlobStoreWrapper.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/mockstore/BlobStoreWrapper.java
@@ -38,11 +38,6 @@ public class BlobStoreWrapper implements BlobStore {
     }
 
     @Override
-    public void delete(BlobPath path) throws IOException {
-        delegate.delete(path);
-    }
-
-    @Override
     public void close() throws IOException {
         delegate.close();
     }

--- a/test/framework/src/main/java/org/elasticsearch/repositories/ESBlobStoreTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/ESBlobStoreTestCase.java
@@ -49,9 +49,6 @@ public abstract class ESBlobStoreTestCase extends ESTestCase {
 
             assertTrue(containerFoo.blobExists("test"));
             assertTrue(containerBar.blobExists("test"));
-            store.delete(new BlobPath());
-            assertFalse(containerFoo.blobExists("test"));
-            assertFalse(containerBar.blobExists("test"));
         }
     }
 


### PR DESCRIPTION
* Remove Delete Method from BlobStore

* The delete method on the blob store was used almost nowhere and just duplicates the delete method on the blob containers
  * The fact that it provided for some recursive delete logic (that did not behave the same way on all implementations) was not used and not properly tested either

back port of #41619 