### PR TITLE
Fix Class Load Order in Netty4Plugin

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/Netty4Plugin.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/Netty4Plugin.java
@@ -35,7 +35,6 @@ import org.elasticsearch.plugins.NetworkPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.netty4.Netty4Transport;
-import org.elasticsearch.transport.netty4.Netty4Utils;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -44,10 +43,6 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 public class Netty4Plugin extends Plugin implements NetworkPlugin {
-
-    static {
-        Netty4Utils.setup();
-    }
 
     public static final String NETTY_TRANSPORT_NAME = "netty4";
     public static final String NETTY_HTTP_TRANSPORT_NAME = "netty4";


### PR DESCRIPTION
* Don't force the logger in the Netty4Plugin class already, at this point log4j might not be fully initialized.
   * The call was redundant anyway since we do the same thing (call the setup method on Netty4Utils to force classloading) in the Netty4Transport and Netty4HttpServerTransport classes already and there we do it properly after setting up log4j by initializing a loggers
* Relates #42532 (I'm not sure this is  fix, but it's worth a shot imo, see https://github.com/netty/netty/issues/5806#issuecomment-247437535)