### PR TITLE
Fix Incorrect Time Math in MockTransport

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/MockNioTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/MockNioTransport.java
@@ -363,10 +363,10 @@ public class MockNioTransport extends TcpTransport {
 
         private void logLongRunningExecutions() {
             for (Map.Entry<Thread, Long> entry : registry.entrySet()) {
-                final long elapsedTime = threadPool.relativeTimeInMillis() - entry.getValue();
+                final long elapsedTime = threadPool.relativeTimeInNanos() - entry.getValue();
                 if (elapsedTime > WARN_THRESHOLD) {
                     final Thread thread = entry.getKey();
-                    logger.warn("Slow execution on network thread [{}] [{} milliseconds]: \n{}", thread.getName(),
+                    logger.warn("Potentially blocked execution on network thread [{}] [{} milliseconds]: \n{}", thread.getName(),
                         TimeUnit.NANOSECONDS.toMillis(elapsedTime),
                         Arrays.stream(thread.getStackTrace()).map(Object::toString).collect(Collectors.joining("\n")));
                 }

--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/MockNioTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/MockNioTransport.java
@@ -363,11 +363,11 @@ public class MockNioTransport extends TcpTransport {
 
         private void logLongRunningExecutions() {
             for (Map.Entry<Thread, Long> entry : registry.entrySet()) {
-                final long elapsedTime = threadPool.relativeTimeInNanos() - entry.getValue();
-                if (elapsedTime > WARN_THRESHOLD) {
+                final long elapsedTimeInNanos = threadPool.relativeTimeInNanos() - entry.getValue();
+                if (elapsedTimeInNanos > WARN_THRESHOLD) {
                     final Thread thread = entry.getKey();
                     logger.warn("Potentially blocked execution on network thread [{}] [{} milliseconds]: \n{}", thread.getName(),
-                        TimeUnit.NANOSECONDS.toMillis(elapsedTime),
+                        TimeUnit.NANOSECONDS.toMillis(elapsedTimeInNanos),
                         Arrays.stream(thread.getStackTrace()).map(Object::toString).collect(Collectors.joining("\n")));
                 }
             }


### PR DESCRIPTION
* The timeunit here must be nanos for the current time (we even convert it accordingly in the logging)
* Also, changed the log message when dumping stack traces a little to make it easier to grep for (otherwise it's the same as the message on unregister)

-------------

This must have snuck in somewhere between me manually testing the functionality and opening the PR ... manually verified that this code works now though :)