### PR TITLE
[DOCS] Disable Metricbeat system module

### DIFF
--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -81,6 +81,23 @@ Leave `xpack.monitoring.enabled` set to its default value (`true`).
 . {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}] on each
 {es} node in the production cluster.
 
+.. Optional: Disable the system module in {metricbeat}.
++
+--
+// tag::disable-system-module[]
+Run the following command:
+
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+metricbeat modules disable system
+----------------------------------------------------------------------
+
+For more information, see 
+{metricbeat-ref}/configuration-metricbeat.html[Specify which modules to run] and
+{metricbeat-ref}/metricbeat-module-system.html[System module].
+// end::disable-system-module[] 
+--
+
 . Enable the {es} {xpack} module in {metricbeat} on each {es} node. +
 +
 --

--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -81,23 +81,6 @@ Leave `xpack.monitoring.enabled` set to its default value (`true`).
 . {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}] on each
 {es} node in the production cluster.
 
-.. Optional: Disable the system module in {metricbeat}.
-+
---
-// tag::disable-system-module[]
-Run the following command:
-
-["source","sh",subs="attributes,callouts"]
-----------------------------------------------------------------------
-metricbeat modules disable system
-----------------------------------------------------------------------
-
-For more information, see 
-{metricbeat-ref}/configuration-metricbeat.html[Specify which modules to run] and
-{metricbeat-ref}/metricbeat-module-system.html[System module].
-// end::disable-system-module[] 
---
-
 . Enable the {es} {xpack} module in {metricbeat} on each {es} node. +
 +
 --
@@ -161,6 +144,23 @@ Alternatively, use the
 .. Add the `username` and `password` settings to the {es} module configuration
 file. 
 // end::remote-monitoring-user[]
+--
+
+. Optional: Disable the system module in {metricbeat}.
++
+--
+// tag::disable-system-module[]
+By default, the {metricbeat-ref}/metricbeat-module-system.html[system module] is
+enabled. The information it collects, however, does not get used on the
+*Monitoring* page in {kib}. Unless you want to use that information for other
+purposes, run the following command:
+
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+metricbeat modules disable system
+----------------------------------------------------------------------
+
+// end::disable-system-module[] 
 --
 
 . Identify where to send the monitoring data. +

--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -151,9 +151,9 @@ file.
 --
 // tag::disable-system-module[]
 By default, the {metricbeat-ref}/metricbeat-module-system.html[system module] is
-enabled. The information it collects, however, does not get used on the
-*Monitoring* page in {kib}. Unless you want to use that information for other
-purposes, run the following command:
+enabled. The information it collects, however, is not shown on the *Monitoring*
+page in {kib}. Unless you want to use that information for other purposes, run
+the following command:
 
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------


### PR DESCRIPTION
This PR adds an optional step to disable the Metricbeat system module in https://www.elastic.co/guide/en/elasticsearch/reference/master/configuring-metricbeat.html

