### PR TITLE
Fix Incorrect Time Math in MockTransport (#42595)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/MockNioTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/MockNioTransport.java
@@ -371,11 +371,11 @@ public class MockNioTransport extends TcpTransport {
 
         private void logLongRunningExecutions() {
             for (Map.Entry<Thread, Long> entry : registry.entrySet()) {
-                final long elapsedTime = threadPool.relativeTimeInMillis() - entry.getValue();
-                if (elapsedTime > WARN_THRESHOLD) {
+                final long elapsedTimeInNanos = threadPool.relativeTimeInNanos() - entry.getValue();
+                if (elapsedTimeInNanos > WARN_THRESHOLD) {
                     final Thread thread = entry.getKey();
-                    logger.warn("Slow execution on network thread [{}] [{} milliseconds]: \n{}", thread.getName(),
-                        TimeUnit.NANOSECONDS.toMillis(elapsedTime),
+                    logger.warn("Potentially blocked execution on network thread [{}] [{} milliseconds]: \n{}", thread.getName(),
+                        TimeUnit.NANOSECONDS.toMillis(elapsedTimeInNanos),
                         Arrays.stream(thread.getStackTrace()).map(Object::toString).collect(Collectors.joining("\n")));
                 }
             }


### PR DESCRIPTION
* Fix Incorrect Time Math in MockTransport

* The timeunit here must be nanos for the current time (we even convert it accordingly in the logging)
* Also, changed the log message when dumping stack traces a little to make it easier to grep for (otherwise it's the same as the message on unregister)
