### PR TITLE
check position before and after latch

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
@@ -236,10 +236,11 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
             assertThat(indexer.getState(), equalTo(IndexerState.STARTED));
             assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
             assertThat(indexer.getState(), equalTo(IndexerState.INDEXING));
+            assertTrue(awaitBusy(() -> indexer.getPosition() == 2));
             countDownLatch.countDown();
-
-            assertThat(indexer.getPosition(), equalTo(2));
             assertTrue(awaitBusy(() -> isFinished.get()));
+            assertThat(indexer.getPosition(), equalTo(3));
+
             assertFalse(isStopped.get());
             assertThat(indexer.getStep(), equalTo(6));
             assertThat(indexer.getStats().getNumInvocations(), equalTo(1L));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
@@ -225,7 +225,6 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/42084")
     public void testStateMachine() throws Exception {
         AtomicReference<IndexerState> state = new AtomicReference<>(IndexerState.STOPPED);
         final ExecutorService executor = Executors.newFixedThreadPool(1);


### PR DESCRIPTION
check position before and after latch

#fixes 42084

Note:
#42275 originally claimed to fix #42084, this fix wasn't wrong but it turned out that there is yet another edge case which this PR adresses