### PR TITLE
Lazily compute Java 8 home in reindex configuration

### DIFF
--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -125,7 +125,7 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
       dependsOn unzip
       executable = new File(project.runtimeJavaHome, 'bin/java')
       env 'CLASSPATH', "${ -> project.configurations.oldesFixture.asPath }"
-      env 'JAVA_HOME', getJavaHome(it, 8)
+      env 'JAVA_HOME', "${ -> getJavaHome(it, 8)}"
       args 'oldes.OldElasticsearch',
            baseDir,
            unzip.temporaryDir,


### PR DESCRIPTION
In the reindex from old tests we require Java 8. Today when configuring the reindex from old tests, we eagerly evalulate Java 8 home, which means that we require JAVA8_HOME to be set even if the reindex from old test tasks are not in the task graph. This is an onerous requirement if, for example, all that you want to do is build a distribution. This commit addresses this by making evaluation of Java 8 home lazy, so that it is only done and required if the reindex from old test tasks would be executed.
