### PR TITLE
Remove client jar support from build

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -19,7 +19,6 @@
 package org.elasticsearch.gradle.plugin
 
 import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
-import nebula.plugin.publishing.maven.MavenScmPlugin
 import org.elasticsearch.gradle.BuildPlugin
 import org.elasticsearch.gradle.NoticeTask
 import org.elasticsearch.gradle.Version
@@ -33,11 +32,9 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
-import org.gradle.api.publish.maven.tasks.GenerateMavenPom
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.bundling.Zip
-import org.gradle.jvm.tasks.Jar
 
 import java.util.regex.Matcher
 import java.util.regex.Pattern
@@ -131,25 +128,10 @@ class PluginBuildPlugin implements Plugin<Project> {
     }
 
     private void configurePublishing(Project project, PluginPropertiesExtension extension) {
-        // Only configure publishing if applied externally
-        if (extension.hasClientJar) {
-            project.plugins.apply(MavenScmPlugin.class)
-            // Only change Jar tasks, we don't want a -client zip so we can't change archivesBaseName
-            project.tasks.withType(Jar) {
-                baseName = baseName + "-client"
-            }
-            // always configure publishing for client jars
-            project.plugins.apply(MavenScmPlugin.class)
-            project.publishing.publications.nebula(MavenPublication).artifactId(extension.name + "-client")
-            project.tasks.withType(GenerateMavenPom.class) { GenerateMavenPom generatePOMTask ->
-                generatePOMTask.ext.pomFileName = "${project.archivesBaseName}-client-${project.versions.elasticsearch}.pom"
-            }
-        } else {
-            if (project.plugins.hasPlugin(MavenPublishPlugin)) {
-                project.publishing.publications.nebula(MavenPublication).artifactId(extension.name)
-            }
-
+        if (project.plugins.hasPlugin(MavenPublishPlugin)) {
+            project.publishing.publications.nebula(MavenPublication).artifactId(extension.name)
         }
+
     }
 
     private static void configureDependencies(Project project) {
@@ -259,8 +241,6 @@ class PluginBuildPlugin implements Plugin<Project> {
         project.configurations.create('zip')
         project.artifacts.add('zip', bundle)
     }
-
-    /** Adds a task to move jar and associated files to a "-client" name. */
 
     static final Pattern GIT_PATTERN = Pattern.compile(/git@([^:]+):([^\.]+)\.git/)
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesExtension.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesExtension.groovy
@@ -47,10 +47,6 @@ class PluginPropertiesExtension {
     @Input
     boolean hasNativeController = false
 
-    /** Indicates whether the plugin jar should be made available for the transport client. */
-    @Input
-    boolean hasClientJar = false
-
     /** True if the plugin requires the elasticsearch keystore to exist, false otherwise. */
     @Input
     boolean requiresKeystore = false

--- a/modules/aggs-matrix-stats/build.gradle
+++ b/modules/aggs-matrix-stats/build.gradle
@@ -20,5 +20,4 @@
 esplugin {
     description 'Adds aggregations whose input are a list of numeric fields and output includes a matrix.'
     classname 'org.elasticsearch.search.aggregations.matrix.MatrixAggregationPlugin'
-    hasClientJar = true
 }

--- a/modules/lang-mustache/build.gradle
+++ b/modules/lang-mustache/build.gradle
@@ -20,7 +20,6 @@
 esplugin {
   description 'Mustache scripting integration for Elasticsearch'
   classname 'org.elasticsearch.script.mustache.MustachePlugin'
-  hasClientJar = true // For the template apis and query
 }
 
 dependencies {

--- a/modules/parent-join/build.gradle
+++ b/modules/parent-join/build.gradle
@@ -20,5 +20,4 @@
 esplugin {
   description 'This module adds the support parent-child queries and aggregations'
   classname 'org.elasticsearch.join.ParentJoinPlugin'
-  hasClientJar = true
 }

--- a/modules/percolator/build.gradle
+++ b/modules/percolator/build.gradle
@@ -20,7 +20,6 @@
 esplugin {
     description 'Percolator module adds capability to index queries and query these queries by specifying documents'
     classname 'org.elasticsearch.percolator.PercolatorPlugin'
-    hasClientJar = true
 }
 
 dependencies {

--- a/modules/rank-eval/build.gradle
+++ b/modules/rank-eval/build.gradle
@@ -20,7 +20,6 @@
 esplugin {
   description 'The Rank Eval module adds APIs to evaluate ranking quality.'
   classname 'org.elasticsearch.index.rankeval.RankEvalPlugin'
-  hasClientJar = true
 }
 
 testClusters.integTest {

--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -26,7 +26,6 @@ apply plugin: 'elasticsearch.test-with-dependencies'
 esplugin {
   description 'The Reindex module adds APIs to reindex from one index to another or update documents in place.'
   classname 'org.elasticsearch.index.reindex.ReindexPlugin'
-  hasClientJar = true
 }
 
 testClusters.integTest {

--- a/modules/transport-netty4/build.gradle
+++ b/modules/transport-netty4/build.gradle
@@ -26,7 +26,6 @@
 esplugin {
     description 'Netty 4 based transport implementation'
     classname 'org.elasticsearch.transport.Netty4Plugin'
-    hasClientJar = true
 }
 
 compileTestJava.options.compilerArgs << "-Xlint:-cast,-rawtypes,-unchecked"

--- a/plugins/analysis-icu/build.gradle
+++ b/plugins/analysis-icu/build.gradle
@@ -22,7 +22,6 @@ import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApis
 esplugin {
   description 'The ICU Analysis plugin integrates Lucene ICU module into elasticsearch, adding ICU relates analysis components.'
   classname 'org.elasticsearch.plugin.analysis.icu.AnalysisICUPlugin'
-  hasClientJar = true
 }
 
 tasks.withType(CheckForbiddenApis) {

--- a/plugins/transport-nio/build.gradle
+++ b/plugins/transport-nio/build.gradle
@@ -21,7 +21,6 @@ apply plugin: "nebula.maven-scm"
 esplugin {
     description 'The nio transport.'
     classname 'org.elasticsearch.transport.nio.NioTransportPlugin'
-    hasClientJar = true
 }
 
 dependencies {


### PR DESCRIPTION
The client jars were a way for modules and plugins to produce an
additional jar that contained classes for use by the transport client.
This commit removes that configuration as the transport client is being
removed.

relates #42638