### PR TITLE
Use correct global checkpoint sync interval

### DIFF
--- a/server/src/test/java/org/elasticsearch/versioning/ConcurrentSeqNoVersioningIT.java
+++ b/server/src/test/java/org/elasticsearch/versioning/ConcurrentSeqNoVersioningIT.java
@@ -136,6 +136,7 @@ public class ConcurrentSeqNoVersioningIT extends AbstractDisruptionTestCase {
 
         assertAcked(prepareCreate("test")
             .setSettings(Settings.builder()
+                .put(indexSettings())
                 .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1 + randomInt(2))
                 .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, randomInt(3))
             ));


### PR DESCRIPTION
A disruption test case need to use a lower checkpoint sync interval
since they verify sequence numbers after the test waiting max 10 seconds
for it to stabilize.

Closes #42637 