### PR TITLE
Add explicit build flag for experimenting with test execution cacheability

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/SystemPropertyCommandLineArgumentProvider.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/SystemPropertyCommandLineArgumentProvider.java
@@ -16,7 +16,10 @@ public class SystemPropertyCommandLineArgumentProvider implements CommandLineArg
 
     @Override
     public Iterable<String> asArguments() {
-        return systemProperties.entrySet().stream().map(entry -> "-D" + entry.getKey() + "=" + entry.getValue()).collect(Collectors.toList());
+        return systemProperties.entrySet()
+            .stream()
+            .map(entry -> "-D" + entry.getKey() + "=" + entry.getValue())
+            .collect(Collectors.toList());
     }
 
     // Track system property keys as an input so our build cache key will change if we add properties but values are still ignored

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/SystemPropertyCommandLineArgumentProvider.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/SystemPropertyCommandLineArgumentProvider.java
@@ -1,0 +1,27 @@
+package org.elasticsearch.gradle;
+
+import org.gradle.api.tasks.Input;
+import org.gradle.process.CommandLineArgumentProvider;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class SystemPropertyCommandLineArgumentProvider implements CommandLineArgumentProvider {
+    private final Map<String, Object> systemProperties = new LinkedHashMap<>();
+
+    public void systemProperty(String key, Object value) {
+        systemProperties.put(key, value);
+    }
+
+    @Override
+    public Iterable<String> asArguments() {
+        return systemProperties.entrySet().stream().map(entry -> "-D" + entry.getKey() + "=" + entry.getValue()).collect(Collectors.toList());
+    }
+
+    // Track system property keys as an input so our build cache key will change if we add properties but values are still ignored
+    @Input
+    public Iterable<String> getPropertyNames() {
+        return systemProperties.keySet();
+    }
+}

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
@@ -124,7 +124,8 @@ public class TestFixturesPlugin implements Plugin<Project> {
                 configureServiceInfoForTask(
                     task,
                     fixtureProject,
-                    (name, host) -> task.getExtensions().getByType(SystemPropertyCommandLineArgumentProvider.class).systemProperty(name, host)
+                    (name, host) ->
+                        task.getExtensions().getByType(SystemPropertyCommandLineArgumentProvider.class).systemProperty(name, host)
                 );
                 task.dependsOn(fixtureProject.getTasks().getByName("postProcessFixture"));
             })

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
@@ -22,9 +22,11 @@ import com.avast.gradle.dockercompose.ComposeExtension;
 import com.avast.gradle.dockercompose.DockerComposePlugin;
 import com.avast.gradle.dockercompose.tasks.ComposeUp;
 import org.elasticsearch.gradle.OS;
+import org.elasticsearch.gradle.SystemPropertyCommandLineArgumentProvider;
 import org.elasticsearch.gradle.precommit.JarHellTask;
 import org.elasticsearch.gradle.precommit.TestingConventionsTasks;
 import org.elasticsearch.gradle.precommit.ThirdPartyAuditTask;
+import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -122,7 +124,7 @@ public class TestFixturesPlugin implements Plugin<Project> {
                 configureServiceInfoForTask(
                     task,
                     fixtureProject,
-                    task::systemProperty
+                    (name, host) -> task.getExtensions().getByType(SystemPropertyCommandLineArgumentProvider.class).systemProperty(name, host)
                 );
                 task.dependsOn(fixtureProject.getTasks().getByName("postProcessFixture"));
             })
@@ -143,28 +145,32 @@ public class TestFixturesPlugin implements Plugin<Project> {
     private void configureServiceInfoForTask(Task task, Project fixtureProject, BiConsumer<String, Integer> consumer) {
         // Configure ports for the tests as system properties.
         // We only know these at execution time so we need to do it in doFirst
-        task.doFirst(theTask ->
-            fixtureProject.getExtensions().getByType(ComposeExtension.class).getServicesInfos()
-                .forEach((service, infos) -> {
-                    infos.getTcpPorts()
-                        .forEach((container, host) -> {
-                            String name = "test.fixtures." + service + ".tcp." + container;
-                            theTask.getLogger().info("port mapping property: {}={}", name, host);
-                            consumer.accept(
-                                name,
-                                host
-                            );
-                        });
-                    infos.getUdpPorts()
-                        .forEach((container, host) -> {
-                            String name = "test.fixtures." + service + ".udp." + container;
-                            theTask.getLogger().info("port mapping property: {}={}", name, host);
-                            consumer.accept(
-                                name,
-                                host
-                            );
-                        });
-                })
+        task.doFirst(new Action<Task>() {
+                         @Override
+                         public void execute(Task theTask) {
+                             fixtureProject.getExtensions().getByType(ComposeExtension.class).getServicesInfos()
+                                 .forEach((service, infos) -> {
+                                     infos.getTcpPorts()
+                                         .forEach((container, host) -> {
+                                             String name = "test.fixtures." + service + ".tcp." + container;
+                                             theTask.getLogger().info("port mapping property: {}={}", name, host);
+                                             consumer.accept(
+                                                 name,
+                                                 host
+                                             );
+                                         });
+                                     infos.getUdpPorts()
+                                         .forEach((container, host) -> {
+                                             String name = "test.fixtures." + service + ".udp." + container;
+                                             theTask.getLogger().info("port mapping property: {}={}", name, host);
+                                             consumer.accept(
+                                                 name,
+                                                 host
+                                             );
+                                         });
+                                 });
+                         }
+                     }
         );
     }
 


### PR DESCRIPTION
This PR addresses the fact that no test execution in our builds will ever be cached due to the implicit variability in test inputs due to our use of randomized tests. There has been extensive discussion about to what degree we want to still leverage random testing, but for the purposes of ongoing experimentation in build cacheability, we simply want to see what the _potential_ gains are here. For that we introduce and explicit build flag (`-Dignore.tests.seed`) that when added to the build will instruct Gradle to ignore the random test seed as a task input. Essentially, if the same code has already been tested with _any_ seed, go ahead and skip the tests. We'll explicitly configure this for our build cache Jenkins build to measure performance benefit.