### PR TITLE
High level rest client encodes `+` in paths

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -1122,6 +1122,7 @@ final class RequestConverters {
         }
 
         private static String encodePart(String pathPart) {
+            // TODO: look at using URLEncodedUtils#formatSegments instead of this hand rolled impl
             try {
                 //encode each part (e.g. index, type and id) separately before merging them into the path
                 //we prepend "/" to the path part to make this path absolute, otherwise there can be issues with
@@ -1129,8 +1130,10 @@ final class RequestConverters {
                 //the authority must be an empty string and not null, else paths that being with slashes could have them
                 //misinterpreted as part of the authority.
                 URI uri = new URI(null, "", "/" + pathPart, null, null);
-                //manually encode any slash that each part may contain
-                return uri.getRawPath().substring(1).replaceAll("/", "%2F");
+                //manually encode any slash or plus that each part may contain
+                return uri.getRawPath().substring(1)
+                    .replaceAll("/", "%2F")
+                    .replaceAll("\\+", "%2B");
             } catch (URISyntaxException e) {
                 throw new IllegalArgumentException("Path part [" + pathPart + "] couldn't be encoded", e);
             }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
@@ -1751,11 +1751,11 @@ public class RequestConvertersTests extends ESTestCase {
         }
         {
             EndpointBuilder endpointBuilder = new EndpointBuilder().addPathPart("foo+bar");
-            assertEquals("/foo+bar", endpointBuilder.build());
+            assertEquals("/foo%2Bbar", endpointBuilder.build());
         }
         {
             EndpointBuilder endpointBuilder = new EndpointBuilder().addPathPart("foo+bar");
-            assertEquals("/foo+bar", endpointBuilder.build());
+            assertEquals("/foo%2Bbar", endpointBuilder.build());
         }
         {
             EndpointBuilder endpointBuilder = new EndpointBuilder().addPathPart("foo/bar");


### PR DESCRIPTION
The high level rest client previously did not encode a `+` character
in a given path segment. The `+` character is an allowed character for
path segments in a URL but when decoding the path, elasticsearch treats
the `+` as an encoding for a space. This becomes an issue if a document
has a `+` in its id as this will be interpreted as a space, which leads
to a missing document error or the wrong document.