### PR TITLE
Refactor Version class to make version bumps easier

### DIFF
--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -77,7 +77,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
                         final int revision = Integer.valueOf(fields[3]) * 100;
                         final int expectedId = major + minor + revision + 99;
                         assert version.id == expectedId :
-                                "expected version [" + version + "] to have id [" + expectedId + "] but was [" + version.id + "]";
+                                "expected version [" + declaredField.getName() + "] to have id [" + expectedId + "] but was [" + version.id + "]";
                     }
                     final Version maybePrevious = builder.put(version.id, version);
                     assert maybePrevious == null :

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -63,27 +63,28 @@ public class Version implements Comparable<Version>, ToXContentFragment {
 
         for (final Field declaredField : Version.class.getFields()) {
             if (declaredField.getType().equals(Version.class)) {
-                if (declaredField.getName().equals("CURRENT") || declaredField.getName().equals("V_EMPTY")) {
+                final String fieldName = declaredField.getName();
+                if (fieldName.equals("CURRENT") || fieldName.equals("V_EMPTY")) {
                     continue;
                 }
-                assert declaredField.getName().matches("V_\\d+_\\d+_\\d+")
-                        : "expected Version field [" + declaredField.getName() + "] to match V_\\d+_\\d+_\\d+";
+                assert fieldName.matches("V_\\d+_\\d+_\\d+")
+                        : "expected Version field [" + fieldName + "] to match V_\\d+_\\d+_\\d+";
                 try {
                     final Version version = (Version) declaredField.get(null);
                     if (Assertions.ENABLED) {
-                        final String[] fields = declaredField.getName().split("_");
+                        final String[] fields = fieldName.split("_");
                         final int major = Integer.valueOf(fields[1]) * 1000000;
                         final int minor = Integer.valueOf(fields[2]) * 10000;
                         final int revision = Integer.valueOf(fields[3]) * 100;
                         final int expectedId = major + minor + revision + 99;
                         assert version.id == expectedId :
-                                "expected version [" + declaredField.getName() + "] to have id [" + expectedId + "] but was [" + version.id + "]";
+                                "expected version [" + fieldName + "] to have id [" + expectedId + "] but was [" + version.id + "]";
                     }
                     final Version maybePrevious = builder.put(version.id, version);
                     assert maybePrevious == null :
                             "expected [" + version.id + "] to be uniquely mapped but saw [" + maybePrevious + "] and [" + version + "]";
                 } catch (final IllegalAccessException e) {
-                    assert false : "Version field [" + declaredField.getName() + "] should be public";
+                    assert false : "Version field [" + fieldName + "] should be public";
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -66,7 +66,8 @@ public class Version implements Comparable<Version>, ToXContentFragment {
                 if (declaredField.getName().equals("CURRENT") || declaredField.getName().equals("V_EMPTY")) {
                     continue;
                 }
-                assert declaredField.getName().matches("V_\\d+_\\d+_\\d+") : declaredField.getName();
+                assert declaredField.getName().matches("V_\\d+_\\d+_\\d+")
+                        : "expected Version field [" + declaredField.getName() + "] to match V_\\d+_\\d+_\\d+";
                 try {
                     final Version version = (Version) declaredField.get(null);
                     if (Assertions.ENABLED) {
@@ -82,7 +83,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
                     assert maybePrevious == null :
                             "expected [" + version.id + "] to be uniquely mapped but saw [" + maybePrevious + "] and [" + version + "]";
                 } catch (final IllegalAccessException e) {
-                    assert false : "version fields should be public";
+                    assert false : "Version field [" + declaredField.getName() + "] should be public";
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -34,8 +34,10 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 
 public class Version implements Comparable<Version>, ToXContentFragment {
@@ -46,26 +48,29 @@ public class Version implements Comparable<Version>, ToXContentFragment {
      */
     public static final int V_EMPTY_ID = 0;
     public static final Version V_EMPTY = new Version(V_EMPTY_ID, org.apache.lucene.util.Version.LATEST);
-    public static final int V_7_0_0_ID = 7000099;
-    public static final Version V_7_0_0 = new Version(V_7_0_0_ID, org.apache.lucene.util.Version.LUCENE_8_0_0);
-    public static final int V_7_0_1_ID = 7000199;
-    public static final Version V_7_0_1 = new Version(V_7_0_1_ID, org.apache.lucene.util.Version.LUCENE_8_0_0);
-    public static final int V_7_1_0_ID = 7010099;
-    public static final Version V_7_1_0 = new Version(V_7_1_0_ID, org.apache.lucene.util.Version.LUCENE_8_0_0);
-    public static final int V_7_1_1_ID = 7010199;
-    public static final Version V_7_1_1 = new Version(V_7_1_1_ID, org.apache.lucene.util.Version.LUCENE_8_0_0);
-    public static final int V_7_1_2_ID = 7010299;
-    public static final Version V_7_1_2 = new Version(V_7_1_2_ID, org.apache.lucene.util.Version.LUCENE_8_0_0);
-    public static final int V_7_2_0_ID = 7020099;
-    public static final Version V_7_2_0 = new Version(V_7_2_0_ID, org.apache.lucene.util.Version.LUCENE_8_0_0);
-    public static final int V_7_3_0_ID = 7030099;
-    public static final Version V_7_3_0 = new Version(V_7_3_0_ID, org.apache.lucene.util.Version.LUCENE_8_1_0);
-    public static final int V_8_0_0_ID = 8000099;
-    public static final Version V_8_0_0 = new Version(V_8_0_0_ID, org.apache.lucene.util.Version.LUCENE_8_1_0);
+    public static final Version V_7_0_0 = new Version(7000099, org.apache.lucene.util.Version.LUCENE_8_0_0);
+    public static final Version V_7_0_1 = new Version(7000199, org.apache.lucene.util.Version.LUCENE_8_0_0);
+    public static final Version V_7_1_0 = new Version(7010099, org.apache.lucene.util.Version.LUCENE_8_0_0);
+    public static final Version V_7_1_1 = new Version(7010199, org.apache.lucene.util.Version.LUCENE_8_0_0);
+    public static final Version V_7_2_0 = new Version(7020099, org.apache.lucene.util.Version.LUCENE_8_0_0);
+    public static final Version V_7_3_0 = new Version(7030099, org.apache.lucene.util.Version.LUCENE_8_1_0);
+    public static final Version V_8_0_0 = new Version(8000099, org.apache.lucene.util.Version.LUCENE_8_1_0);
     public static final Version CURRENT = V_8_0_0;
 
+    private static final Map<Integer, Version> idToVersion;
 
     static {
+        idToVersion = new HashMap<>();
+        for (Field declaredField : Version.class.getFields()) {
+            if (declaredField.getType().equals(Version.class)) {
+                try {
+                    Version version = (Version) declaredField.get(null);
+                    idToVersion.put(version.id, version);
+                } catch (IllegalAccessException e) {
+                    assert false : "version fields should be public";
+                }
+            }
+        }
         assert CURRENT.luceneVersion.equals(org.apache.lucene.util.Version.LATEST) : "Version must be upgraded to ["
                 + org.apache.lucene.util.Version.LATEST + "] is still set to [" + CURRENT.luceneVersion + "]";
     }
@@ -75,23 +80,10 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     }
 
     public static Version fromId(int id) {
+        if (idToVersion.containsKey(id)) {
+            return idToVersion.get(id);
+        }
         switch (id) {
-            case V_8_0_0_ID:
-                return V_8_0_0;
-            case V_7_3_0_ID:
-                return V_7_3_0;
-            case V_7_2_0_ID:
-                return V_7_2_0;
-            case V_7_1_2_ID:
-                return V_7_1_2;
-            case V_7_1_1_ID:
-                return V_7_1_1;
-            case V_7_1_0_ID:
-                return V_7_1_0;
-            case V_7_0_1_ID:
-                return V_7_0_1;
-            case V_7_0_0_ID:
-                return V_7_0_0;
             case V_EMPTY_ID:
                 return V_EMPTY;
             default:

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -51,6 +51,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_7_0_1 = new Version(7000199, org.apache.lucene.util.Version.LUCENE_8_0_0);
     public static final Version V_7_1_0 = new Version(7010099, org.apache.lucene.util.Version.LUCENE_8_0_0);
     public static final Version V_7_1_1 = new Version(7010199, org.apache.lucene.util.Version.LUCENE_8_0_0);
+    public static final Version V_7_1_2 = new Version(7010299, org.apache.lucene.util.Version.LUCENE_8_0_0);
     public static final Version V_7_2_0 = new Version(7020099, org.apache.lucene.util.Version.LUCENE_8_0_0);
     public static final Version V_7_3_0 = new Version(7030099, org.apache.lucene.util.Version.LUCENE_8_1_0);
     public static final Version V_8_0_0 = new Version(8000099, org.apache.lucene.util.Version.LUCENE_8_1_0);


### PR DESCRIPTION
With this change we only have to add one line to add a new version.
The intent is to make it less error prone and easier to write a script
to automate the process.

There are tools to generate source code or byte-code that would allow us to 
automate version bumps based on a plain list of versions,
but that would create friction with IDEs.
There are also tools that semantically understand java source and are able to reformat it, 
but unfortunately there's no existing tooling to edit a java source file. 
With this change it should be straight forward to automate it by manipulating the source 
as a plain text file. 

