### PR TITLE
Add chainCluster DSL to testclusters

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -365,8 +365,12 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         LOGGER.info("Restarting {}", this);
         stop(false);
         try {
-            Files.delete(httpPortsFile);
-            Files.delete(transportPortFile);
+            if (Files.exists(httpPortsFile)) {
+                Files.delete(httpPortsFile);
+            }
+            if (Files.exists(transportPortFile)) {
+                Files.delete(transportPortFile);
+            }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/x-pack/plugin/ccr/qa/downgrade-to-basic-license/build.gradle
+++ b/x-pack/plugin/ccr/qa/downgrade-to-basic-license/build.gradle
@@ -40,8 +40,8 @@ task writeJavaPolicy {
 }
 
 task "follow-cluster"(type: RestIntegTestTask) {
-    dependsOn writeJavaPolicy, "leader-cluster"
-    useCluster testClusters."leader-cluster"
+    dependsOn writeJavaPolicy
+    chainCluster "leader-cluster"
     runner {
         systemProperty 'java.security.policy', "file://${writeJavaPolicy.policyFile}"
         systemProperty 'tests.target_cluster', 'follow'
@@ -56,7 +56,6 @@ testClusters."follow-cluster" {
     setting 'xpack.license.self_generated.type', 'trial'
     setting 'cluster.remote.leader_cluster.seeds', { "\"${testClusters."leader-cluster".getAllTransportPortURI().join(",")}\"" }
 }
-
 
 check.dependsOn "follow-cluster"
 test.enabled = false // no unit tests for multi-cluster-search, only the rest integration test

--- a/x-pack/plugin/ccr/qa/multi-cluster/build.gradle
+++ b/x-pack/plugin/ccr/qa/multi-cluster/build.gradle
@@ -26,8 +26,7 @@ testClusters."leader-cluster" {
 
 
 task "middle-cluster"(type: RestIntegTestTask) {
-    dependsOn "leader-cluster"
-    useCluster testClusters."leader-cluster"
+    chainCluster "leader-cluster"
     runner {
         systemProperty 'tests.target_cluster', 'middle'
         nonInputProperties.systemProperty 'tests.leader_host',
@@ -42,9 +41,7 @@ testClusters."middle-cluster" {
 }
 
 task 'follow-cluster'(type: RestIntegTestTask) {
-    dependsOn "leader-cluster", "middle-cluster"
-    useCluster testClusters."leader-cluster"
-    useCluster testClusters."middle-cluster"
+    chainCluster "middle-cluster"
     runner {
         systemProperty 'tests.target_cluster', 'follow'
         nonInputProperties.systemProperty 'tests.leader_host',

--- a/x-pack/plugin/ccr/qa/non-compliant-license/build.gradle
+++ b/x-pack/plugin/ccr/qa/non-compliant-license/build.gradle
@@ -23,8 +23,7 @@ testClusters.'leader-cluster' {
 }
 
 task 'follow-cluster'(type: RestIntegTestTask) {
-    dependsOn 'leader-cluster'
-    useCluster testClusters.'leader-cluster'
+    chainCluster "leader-cluster"
     runner {
         systemProperty 'tests.target_cluster', 'follow'
         nonInputProperties.systemProperty 'tests.leader_host',

--- a/x-pack/plugin/ccr/qa/restart/build.gradle
+++ b/x-pack/plugin/ccr/qa/restart/build.gradle
@@ -37,18 +37,18 @@ testClusters.'follow-cluster' {
 }
 
 task followClusterRestartTest(type: Test) {
-    dependsOn tasks.'follow-cluster'
-    useCluster testClusters.'leader-cluster'
-    useCluster testClusters.'follow-cluster'
+    chainCluster "follow-cluster"
 
     maxParallelForks = 1
     systemProperty 'tests.rest.load_packaged', 'false'
     systemProperty 'tests.target_cluster', 'follow-restart'
+
     doFirst {
         testClusters.'follow-cluster'.restart()
         nonInputProperties.systemProperty 'tests.leader_host', "${-> testClusters.'leader-cluster'.getAllHttpSocketURI().get(0)}"
         nonInputProperties.systemProperty 'tests.rest.cluster', "${-> testClusters.'follow-cluster'.getAllHttpSocketURI().join(",")}"
     }
+
     outputs.doNotCacheIf "Caching of REST tests not implemented yet", { false }
 }
 


### PR DESCRIPTION
With this change tasks get a `chainCluster` method that accepts a Task.
This is a short-hand to express that the task depends on the other and
needs to use all it's cluers and it's dependencies clusters.

As a show-case this is applied to CCR tests, but it will also be usefull
in BWC tests to eliminate boilerplate.

