### PR TITLE
[7.x] Refactor HLRC RequestConverters parameters to be more explicit (#42128)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/CcrRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/CcrRequestConverters.java
@@ -48,9 +48,10 @@ final class CcrRequestConverters {
             .addPathPartAsIs("_ccr", "follow")
             .build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withWaitForActiveShards(putFollowRequest.waitForActiveShards());
         request.setEntity(createEntity(putFollowRequest, REQUEST_BODY_CONTENT_TYPE));
+        request.addParameters(parameters.asMap());
         return request;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ClusterRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ClusterRequestConverters.java
@@ -36,22 +36,21 @@ final class ClusterRequestConverters {
     static Request clusterPutSettings(ClusterUpdateSettingsRequest clusterUpdateSettingsRequest) throws IOException {
         Request request = new Request(HttpPut.METHOD_NAME, "/_cluster/settings");
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(clusterUpdateSettingsRequest.timeout());
         parameters.withMasterTimeout(clusterUpdateSettingsRequest.masterNodeTimeout());
-
+        request.addParameters(parameters.asMap());
         request.setEntity(RequestConverters.createEntity(clusterUpdateSettingsRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
 
     static Request clusterGetSettings(ClusterGetSettingsRequest clusterGetSettingsRequest) throws IOException {
         Request request = new Request(HttpGet.METHOD_NAME, "/_cluster/settings");
-
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withLocal(clusterGetSettingsRequest.local());
         parameters.withIncludeDefaults(clusterGetSettingsRequest.includeDefaults());
         parameters.withMasterTimeout(clusterGetSettingsRequest.masterNodeTimeout());
-
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -63,7 +62,7 @@ final class ClusterRequestConverters {
             .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        new RequestConverters.Params(request)
+        RequestConverters.Params params = new RequestConverters.Params()
             .withWaitForStatus(healthRequest.waitForStatus())
             .withWaitForNoRelocatingShards(healthRequest.waitForNoRelocatingShards())
             .withWaitForNoInitializingShards(healthRequest.waitForNoInitializingShards())
@@ -74,6 +73,7 @@ final class ClusterRequestConverters {
             .withMasterTimeout(healthRequest.masterNodeTimeout())
             .withLocal(healthRequest.local())
             .withLevel(healthRequest.level());
+        request.addParameters(params.asMap());
         return request;
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/DataFrameRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/DataFrameRequestConverters.java
@@ -82,10 +82,11 @@ final class DataFrameRequestConverters {
                 .addPathPartAsIs("_start")
                 .build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         if (startRequest.getTimeout() != null) {
             params.withTimeout(startRequest.getTimeout());
         }
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -96,13 +97,14 @@ final class DataFrameRequestConverters {
                     .addPathPartAsIs("_stop")
                     .build();
             Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-            RequestConverters.Params params = new RequestConverters.Params(request);
+            RequestConverters.Params params = new RequestConverters.Params();
             if (stopRequest.getWaitForCompletion() != null) {
                 params.withWaitForCompletion(stopRequest.getWaitForCompletion());
             }
             if (stopRequest.getTimeout() != null) {
                 params.withTimeout(stopRequest.getTimeout());
             }
+            request.addParameters(params.asMap());
             return request;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleRequestConverters.java
@@ -44,9 +44,10 @@ final class IndexLifecycleRequestConverters {
         String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_ilm/policy")
                 .addCommaSeparatedPathParts(getLifecyclePolicyRequest.getPolicyNames()).build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withMasterTimeout(getLifecyclePolicyRequest.masterNodeTimeout());
         params.withTimeout(getLifecyclePolicyRequest.timeout());
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -56,9 +57,10 @@ final class IndexLifecycleRequestConverters {
             .addPathPartAsIs(putLifecycleRequest.getName())
             .build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withMasterTimeout(putLifecycleRequest.masterNodeTimeout());
         params.withTimeout(putLifecycleRequest.timeout());
+        request.addParameters(params.asMap());
         request.setEntity(RequestConverters.createEntity(putLifecycleRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -69,9 +71,10 @@ final class IndexLifecycleRequestConverters {
                 .addPathPartAsIs("_ilm/policy")
                 .addPathPartAsIs(deleteLifecyclePolicyRequest.getLifecyclePolicy())
                 .build());
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withMasterTimeout(deleteLifecyclePolicyRequest.masterNodeTimeout());
         params.withTimeout(deleteLifecyclePolicyRequest.timeout());
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -83,9 +86,10 @@ final class IndexLifecycleRequestConverters {
                         .addCommaSeparatedPathParts(indices)
                         .addPathPartAsIs("_ilm", "remove")
                         .build());
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withIndicesOptions(removePolicyRequest.indicesOptions());
         params.withMasterTimeout(removePolicyRequest.masterNodeTimeout());
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -95,9 +99,10 @@ final class IndexLifecycleRequestConverters {
                 .addPathPartAsIs("_ilm")
                 .addPathPartAsIs("start")
             .build());
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withMasterTimeout(startILMRequest.masterNodeTimeout());
         params.withTimeout(startILMRequest.timeout());
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -107,9 +112,10 @@ final class IndexLifecycleRequestConverters {
                 .addPathPartAsIs("_ilm")
                 .addPathPartAsIs("stop")
             .build());
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withMasterTimeout(stopILMRequest.masterNodeTimeout());
         params.withTimeout(stopILMRequest.timeout());
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -119,9 +125,10 @@ final class IndexLifecycleRequestConverters {
                 .addPathPartAsIs("_ilm")
                 .addPathPartAsIs("status")
             .build());
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withMasterTimeout(lifecycleManagementStatusRequest.masterNodeTimeout());
         params.withTimeout(lifecycleManagementStatusRequest.timeout());
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -132,9 +139,10 @@ final class IndexLifecycleRequestConverters {
                 .addPathPartAsIs("_ilm")
                 .addPathPartAsIs("explain")
             .build());
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withIndicesOptions(explainLifecycleRequest.indicesOptions());
         params.withMasterTimeout(explainLifecycleRequest.masterNodeTimeout());
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -145,9 +153,10 @@ final class IndexLifecycleRequestConverters {
                 .addPathPartAsIs("_ilm")
                 .addPathPartAsIs("retry")
                 .build());
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withMasterTimeout(retryLifecyclePolicyRequest.masterNodeTimeout());
         params.withTimeout(retryLifecyclePolicyRequest.timeout());
+        request.addParameters(params.asMap());
         return request;
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
@@ -67,10 +67,11 @@ final class IndicesRequestConverters {
         String endpoint = RequestConverters.endpoint(deleteIndexRequest.indices());
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(deleteIndexRequest.timeout());
         parameters.withMasterTimeout(deleteIndexRequest.masterNodeTimeout());
         parameters.withIndicesOptions(deleteIndexRequest.indicesOptions());
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -78,11 +79,12 @@ final class IndicesRequestConverters {
         String endpoint = RequestConverters.endpoint(openIndexRequest.indices(), "_open");
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(openIndexRequest.timeout());
         parameters.withMasterTimeout(openIndexRequest.masterNodeTimeout());
         parameters.withWaitForActiveShards(openIndexRequest.waitForActiveShards());
         parameters.withIndicesOptions(openIndexRequest.indicesOptions());
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -90,10 +92,11 @@ final class IndicesRequestConverters {
         String endpoint = RequestConverters.endpoint(closeIndexRequest.indices(), "_close");
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(closeIndexRequest.timeout());
         parameters.withMasterTimeout(closeIndexRequest.masterNodeTimeout());
         parameters.withIndicesOptions(closeIndexRequest.indicesOptions());
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -102,11 +105,11 @@ final class IndicesRequestConverters {
             .addPathPart(createIndexRequest.index()).build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(createIndexRequest.timeout());
         parameters.withMasterTimeout(createIndexRequest.masterNodeTimeout());
         parameters.withWaitForActiveShards(createIndexRequest.waitForActiveShards());
-
+        request.addParameters(parameters.asMap());
         request.setEntity(RequestConverters.createEntity(createIndexRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -116,12 +119,12 @@ final class IndicesRequestConverters {
         String endpoint = RequestConverters.endpoint(createIndexRequest.indices());
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(createIndexRequest.timeout());
         parameters.withMasterTimeout(createIndexRequest.masterNodeTimeout());
         parameters.withWaitForActiveShards(createIndexRequest.waitForActiveShards());
         parameters.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
-
+        request.addParameters(parameters.asMap());
         request.setEntity(RequestConverters.createEntity(createIndexRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -129,10 +132,10 @@ final class IndicesRequestConverters {
     static Request updateAliases(IndicesAliasesRequest indicesAliasesRequest) throws IOException {
         Request request = new Request(HttpPost.METHOD_NAME, "/_aliases");
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(indicesAliasesRequest.timeout());
         parameters.withMasterTimeout(indicesAliasesRequest.masterNodeTimeout());
-
+        request.addParameters(parameters.asMap());
         request.setEntity(RequestConverters.createEntity(indicesAliasesRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -141,9 +144,10 @@ final class IndicesRequestConverters {
     static Request putMapping(PutMappingRequest putMappingRequest) throws IOException {
         Request request = new Request(HttpPut.METHOD_NAME, RequestConverters.endpoint(putMappingRequest.indices(), "_mapping"));
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(putMappingRequest.timeout());
         parameters.withMasterTimeout(putMappingRequest.masterNodeTimeout());
+        request.addParameters(parameters.asMap());
         request.setEntity(RequestConverters.createEntity(putMappingRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -162,11 +166,11 @@ final class IndicesRequestConverters {
         Request request = new Request(HttpPut.METHOD_NAME, RequestConverters.endpoint(putMappingRequest.indices(),
             "_mapping", putMappingRequest.type()));
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(putMappingRequest.timeout());
         parameters.withMasterTimeout(putMappingRequest.masterNodeTimeout());
         parameters.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
-
+        request.addParameters(parameters.asMap());
         request.setEntity(RequestConverters.createEntity(putMappingRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -176,11 +180,11 @@ final class IndicesRequestConverters {
 
         Request request = new Request(HttpGet.METHOD_NAME, RequestConverters.endpoint(indices, "_mapping"));
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(getMappingsRequest.masterNodeTimeout());
         parameters.withIndicesOptions(getMappingsRequest.indicesOptions());
         parameters.withLocal(getMappingsRequest.local());
-
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -191,12 +195,12 @@ final class IndicesRequestConverters {
 
         Request request = new Request(HttpGet.METHOD_NAME, RequestConverters.endpoint(indices, "_mapping", types));
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(getMappingsRequest.masterNodeTimeout());
         parameters.withIndicesOptions(getMappingsRequest.indicesOptions());
         parameters.withLocal(getMappingsRequest.local());
         parameters.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
-
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -213,11 +217,11 @@ final class IndicesRequestConverters {
 
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withIndicesOptions(getFieldMappingsRequest.indicesOptions());
         parameters.withIncludeDefaults(getFieldMappingsRequest.includeDefaults());
         parameters.withLocal(getFieldMappingsRequest.local());
-
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -234,12 +238,12 @@ final class IndicesRequestConverters {
 
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withIndicesOptions(getFieldMappingsRequest.indicesOptions());
         parameters.withIncludeDefaults(getFieldMappingsRequest.includeDefaults());
         parameters.withLocal(getFieldMappingsRequest.local());
         parameters.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
-
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -247,8 +251,9 @@ final class IndicesRequestConverters {
         String[] indices = refreshRequest.indices() == null ? Strings.EMPTY_ARRAY : refreshRequest.indices();
         Request request = new Request(HttpPost.METHOD_NAME, RequestConverters.endpoint(indices, "_refresh"));
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withIndicesOptions(refreshRequest.indicesOptions());
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -256,18 +261,20 @@ final class IndicesRequestConverters {
         String[] indices = flushRequest.indices() == null ? Strings.EMPTY_ARRAY : flushRequest.indices();
         Request request = new Request(HttpPost.METHOD_NAME, RequestConverters.endpoint(indices, "_flush"));
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withIndicesOptions(flushRequest.indicesOptions());
         parameters.putParam("wait_if_ongoing", Boolean.toString(flushRequest.waitIfOngoing()));
         parameters.putParam("force", Boolean.toString(flushRequest.force()));
+        request.addParameters(parameters.asMap());
         return request;
     }
 
     static Request flushSynced(SyncedFlushRequest syncedFlushRequest) {
         String[] indices = syncedFlushRequest.indices() == null ? Strings.EMPTY_ARRAY : syncedFlushRequest.indices();
         Request request = new Request(HttpPost.METHOD_NAME, RequestConverters.endpoint(indices, "_flush/synced"));
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withIndicesOptions(syncedFlushRequest.indicesOptions());
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -275,11 +282,12 @@ final class IndicesRequestConverters {
         String[] indices = forceMergeRequest.indices() == null ? Strings.EMPTY_ARRAY : forceMergeRequest.indices();
         Request request = new Request(HttpPost.METHOD_NAME, RequestConverters.endpoint(indices, "_forcemerge"));
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withIndicesOptions(forceMergeRequest.indicesOptions());
         parameters.putParam("max_num_segments", Integer.toString(forceMergeRequest.maxNumSegments()));
         parameters.putParam("only_expunge_deletes", Boolean.toString(forceMergeRequest.onlyExpungeDeletes()));
         parameters.putParam("flush", Boolean.toString(forceMergeRequest.flush()));
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -287,12 +295,13 @@ final class IndicesRequestConverters {
         String[] indices = clearIndicesCacheRequest.indices() == null ? Strings.EMPTY_ARRAY :clearIndicesCacheRequest.indices();
         Request request = new Request(HttpPost.METHOD_NAME, RequestConverters.endpoint(indices, "_cache/clear"));
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withIndicesOptions(clearIndicesCacheRequest.indicesOptions());
         parameters.putParam("query", Boolean.toString(clearIndicesCacheRequest.queryCache()));
         parameters.putParam("fielddata", Boolean.toString(clearIndicesCacheRequest.fieldDataCache()));
         parameters.putParam("request", Boolean.toString(clearIndicesCacheRequest.requestCache()));
         parameters.putParam("fields", String.join(",", clearIndicesCacheRequest.fields()));
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -306,9 +315,10 @@ final class IndicesRequestConverters {
 
         Request request = new Request(HttpHead.METHOD_NAME, RequestConverters.endpoint(indices, "_alias", aliases));
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withIndicesOptions(getAliasesRequest.indicesOptions());
         params.withLocal(getAliasesRequest.local());
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -332,11 +342,11 @@ final class IndicesRequestConverters {
                 .addPathPart(resizeRequest.getTargetIndexRequest().index()).build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withTimeout(resizeRequest.timeout());
         params.withMasterTimeout(resizeRequest.masterNodeTimeout());
         params.withWaitForActiveShards(resizeRequest.getTargetIndexRequest().waitForActiveShards());
-
+        request.addParameters(params.asMap());
         request.setEntity(RequestConverters.createEntity(resizeRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -346,14 +356,14 @@ final class IndicesRequestConverters {
             .addPathPart(rolloverRequest.getNewIndexName()).build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withTimeout(rolloverRequest.timeout());
         params.withMasterTimeout(rolloverRequest.masterNodeTimeout());
         params.withWaitForActiveShards(rolloverRequest.getCreateIndexRequest().waitForActiveShards());
         if (rolloverRequest.isDryRun()) {
             params.putParam("dry_run", Boolean.TRUE.toString());
         }
-
+        request.addParameters(params.asMap());
         request.setEntity(RequestConverters.createEntity(rolloverRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -364,7 +374,7 @@ final class IndicesRequestConverters {
             .addPathPart(rolloverRequest.getNewIndexName()).build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withTimeout(rolloverRequest.timeout());
         params.withMasterTimeout(rolloverRequest.masterNodeTimeout());
         params.withWaitForActiveShards(rolloverRequest.getCreateIndexRequest().waitForActiveShards());
@@ -373,7 +383,7 @@ final class IndicesRequestConverters {
         }
         params.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
         request.setEntity(RequestConverters.createEntity(rolloverRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
-
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -384,12 +394,12 @@ final class IndicesRequestConverters {
         String endpoint = RequestConverters.endpoint(indices, "_settings", names);
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withIndicesOptions(getSettingsRequest.indicesOptions());
         params.withLocal(getSettingsRequest.local());
         params.withIncludeDefaults(getSettingsRequest.includeDefaults());
         params.withMasterTimeout(getSettingsRequest.masterNodeTimeout());
-
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -404,14 +414,14 @@ final class IndicesRequestConverters {
         String endpoint = RequestConverters.endpoint(indices);
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withIndicesOptions(getIndexRequest.indicesOptions());
         params.withLocal(getIndexRequest.local());
         params.withIncludeDefaults(getIndexRequest.includeDefaults());
         params.withHuman(getIndexRequest.humanReadable());
         params.withMasterTimeout(getIndexRequest.masterNodeTimeout());
         params.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
-
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -421,13 +431,13 @@ final class IndicesRequestConverters {
         String endpoint = RequestConverters.endpoint(indices);
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withIndicesOptions(getIndexRequest.indicesOptions());
         params.withLocal(getIndexRequest.local());
         params.withIncludeDefaults(getIndexRequest.includeDefaults());
         params.withHuman(getIndexRequest.humanReadable());
         params.withMasterTimeout(getIndexRequest.masterNodeTimeout());
-
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -444,12 +454,13 @@ final class IndicesRequestConverters {
         String endpoint = RequestConverters.endpoint(getIndexRequest.indices(), "");
         Request request = new Request(HttpHead.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withLocal(getIndexRequest.local());
         params.withHuman(getIndexRequest.humanReadable());
         params.withIndicesOptions(getIndexRequest.indicesOptions());
         params.withIncludeDefaults(getIndexRequest.includeDefaults());
         params.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -461,11 +472,12 @@ final class IndicesRequestConverters {
         String endpoint = RequestConverters.endpoint(getIndexRequest.indices(), "");
         Request request = new Request(HttpHead.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withLocal(getIndexRequest.local());
         params.withHuman(getIndexRequest.humanReadable());
         params.withIndicesOptions(getIndexRequest.indicesOptions());
         params.withIncludeDefaults(getIndexRequest.includeDefaults());
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -473,12 +485,12 @@ final class IndicesRequestConverters {
         String[] indices = updateSettingsRequest.indices() == null ? Strings.EMPTY_ARRAY : updateSettingsRequest.indices();
         Request request = new Request(HttpPut.METHOD_NAME, RequestConverters.endpoint(indices, "_settings"));
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(updateSettingsRequest.timeout());
         parameters.withMasterTimeout(updateSettingsRequest.masterNodeTimeout());
         parameters.withIndicesOptions(updateSettingsRequest.indicesOptions());
         parameters.withPreserveExisting(updateSettingsRequest.isPreserveExisting());
-
+        request.addParameters(parameters.asMap());
         request.setEntity(RequestConverters.createEntity(updateSettingsRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -493,7 +505,7 @@ final class IndicesRequestConverters {
         String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_template")
             .addPathPart(putIndexTemplateRequest.name()).build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withMasterTimeout(putIndexTemplateRequest.masterNodeTimeout());
         if (putIndexTemplateRequest.create()) {
             params.putParam("create", Boolean.TRUE.toString());
@@ -502,6 +514,7 @@ final class IndicesRequestConverters {
             params.putParam("cause", putIndexTemplateRequest.cause());
         }
         params.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
+        request.addParameters(params.asMap());
         request.setEntity(RequestConverters.createEntity(putIndexTemplateRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -510,7 +523,7 @@ final class IndicesRequestConverters {
         String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_template")
             .addPathPart(putIndexTemplateRequest.name()).build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withMasterTimeout(putIndexTemplateRequest.masterNodeTimeout());
         if (putIndexTemplateRequest.create()) {
             params.putParam("create", Boolean.TRUE.toString());
@@ -518,6 +531,7 @@ final class IndicesRequestConverters {
         if (Strings.hasText(putIndexTemplateRequest.cause())) {
             params.putParam("cause", putIndexTemplateRequest.cause());
         }
+        request.addParameters(params.asMap());
         request.setEntity(RequestConverters.createEntity(putIndexTemplateRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -527,11 +541,12 @@ final class IndicesRequestConverters {
         String[] types = validateQueryRequest.types() == null || indices.length <= 0 ? Strings.EMPTY_ARRAY : validateQueryRequest.types();
         String endpoint = RequestConverters.endpoint(indices, types, "_validate/query");
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withIndicesOptions(validateQueryRequest.indicesOptions());
         params.putParam("explain", Boolean.toString(validateQueryRequest.explain()));
         params.putParam("all_shards", Boolean.toString(validateQueryRequest.allShards()));
         params.putParam("rewrite", Boolean.toString(validateQueryRequest.rewrite()));
+        request.addParameters(params.asMap());
         request.setEntity(RequestConverters.createEntity(validateQueryRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -541,9 +556,10 @@ final class IndicesRequestConverters {
         String[] aliases = getAliasesRequest.aliases() == null ? Strings.EMPTY_ARRAY : getAliasesRequest.aliases();
         String endpoint = RequestConverters.endpoint(indices, "_alias", aliases);
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withIndicesOptions(getAliasesRequest.indicesOptions());
         params.withLocal(getAliasesRequest.local());
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -562,12 +578,13 @@ final class IndicesRequestConverters {
             .addCommaSeparatedPathParts(getIndexTemplatesRequest.names())
             .build();
         final Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-        final RequestConverters.Params params = new RequestConverters.Params(request);
+        final RequestConverters.Params params = new RequestConverters.Params();
         params.withLocal(getIndexTemplatesRequest.isLocal());
         params.withMasterTimeout(getIndexTemplatesRequest.getMasterNodeTimeout());
         if (includeTypeName) {
             params.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
         }
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -577,9 +594,10 @@ final class IndicesRequestConverters {
             .addCommaSeparatedPathParts(indexTemplatesExistRequest.names())
             .build();
         final Request request = new Request(HttpHead.METHOD_NAME, endpoint);
-        final RequestConverters.Params params = new RequestConverters.Params(request);
+        final RequestConverters.Params params = new RequestConverters.Params();
         params.withLocal(indexTemplatesExistRequest.isLocal());
         params.withMasterTimeout(indexTemplatesExistRequest.getMasterNodeTimeout());
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -598,22 +616,24 @@ final class IndicesRequestConverters {
     static Request freezeIndex(FreezeIndexRequest freezeIndexRequest) {
         String endpoint = RequestConverters.endpoint(freezeIndexRequest.getIndices(), "_freeze");
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(freezeIndexRequest.timeout());
         parameters.withMasterTimeout(freezeIndexRequest.masterNodeTimeout());
         parameters.withIndicesOptions(freezeIndexRequest.indicesOptions());
         parameters.withWaitForActiveShards(freezeIndexRequest.getWaitForActiveShards());
+        request.addParameters(parameters.asMap());
         return request;
     }
 
     static Request unfreezeIndex(UnfreezeIndexRequest unfreezeIndexRequest) {
         String endpoint = RequestConverters.endpoint(unfreezeIndexRequest.getIndices(), "_unfreeze");
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(unfreezeIndexRequest.timeout());
         parameters.withMasterTimeout(unfreezeIndexRequest.masterNodeTimeout());
         parameters.withIndicesOptions(unfreezeIndexRequest.indicesOptions());
         parameters.withWaitForActiveShards(unfreezeIndexRequest.getWaitForActiveShards());
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -621,8 +641,9 @@ final class IndicesRequestConverters {
         String name = deleteIndexTemplateRequest.name();
         String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_template").addPathPart(name).build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withMasterTimeout(deleteIndexTemplateRequest.masterNodeTimeout());
+        request.addParameters(params.asMap());
         return request;
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IngestRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IngestRequestConverters.java
@@ -41,8 +41,9 @@ final class IngestRequestConverters {
             .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(getPipelineRequest.masterNodeTimeout());
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -53,10 +54,10 @@ final class IngestRequestConverters {
             .build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(putPipelineRequest.timeout());
         parameters.withMasterTimeout(putPipelineRequest.masterNodeTimeout());
-
+        request.addParameters(parameters.asMap());
         request.setEntity(RequestConverters.createEntity(putPipelineRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -68,10 +69,10 @@ final class IngestRequestConverters {
             .build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(deletePipelineRequest.timeout());
         parameters.withMasterTimeout(deletePipelineRequest.masterNodeTimeout());
-
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -83,8 +84,9 @@ final class IngestRequestConverters {
         builder.addPathPartAsIs("_simulate");
         String endpoint = builder.build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.putParam("verbose", Boolean.toString(simulatePipelineRequest.isVerbose()));
+        request.addParameters(params.asMap());
         request.setEntity(RequestConverters.createEntity(simulatePipelineRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;
     }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/LicenseRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/LicenseRequestConverters.java
@@ -36,12 +36,13 @@ final class LicenseRequestConverters {
     static Request putLicense(PutLicenseRequest putLicenseRequest) {
         String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_license").build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(putLicenseRequest.timeout());
         parameters.withMasterTimeout(putLicenseRequest.masterNodeTimeout());
         if (putLicenseRequest.isAcknowledge()) {
             parameters.putParam("acknowledge", "true");
         }
+        request.addParameters(parameters.asMap());
         request.setJsonEntity(putLicenseRequest.getLicenseDefinition());
         return request;
     }
@@ -49,17 +50,19 @@ final class LicenseRequestConverters {
     static Request getLicense(GetLicenseRequest getLicenseRequest) {
         String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_license").build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withLocal(getLicenseRequest.isLocal());
+        request.addParameters(parameters.asMap());
         return request;
     }
 
     static Request deleteLicense(DeleteLicenseRequest deleteLicenseRequest) {
         String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_license").build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(deleteLicenseRequest.timeout());
         parameters.withMasterTimeout(deleteLicenseRequest.masterNodeTimeout());
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -67,11 +70,12 @@ final class LicenseRequestConverters {
         final String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_license", "start_trial").build();
         final Request request = new Request(HttpPost.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.putParam("acknowledge", Boolean.toString(startTrialRequest.isAcknowledge()));
         if (startTrialRequest.getLicenseType() != null) {
             parameters.putParam("type", startTrialRequest.getLicenseType());
         }
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -80,12 +84,13 @@ final class LicenseRequestConverters {
             .addPathPartAsIs("_license", "start_basic")
             .build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(startBasicRequest.timeout());
         parameters.withMasterTimeout(startBasicRequest.masterNodeTimeout());
         if (startBasicRequest.isAcknowledge()) {
             parameters.putParam("acknowledge", "true");
         }
+        request.addParameters(parameters.asMap());
         return request;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/MLRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/MLRequestConverters.java
@@ -105,11 +105,11 @@ final class MLRequestConverters {
             .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         if (getJobRequest.getAllowNoJobs() != null) {
             params.putParam("allow_no_jobs", Boolean.toString(getJobRequest.getAllowNoJobs()));
         }
-
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -122,10 +122,11 @@ final class MLRequestConverters {
                 .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         if (getJobStatsRequest.getAllowNoJobs() != null) {
             params.putParam("allow_no_jobs", Boolean.toString(getJobStatsRequest.getAllowNoJobs()));
         }
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -171,14 +172,14 @@ final class MLRequestConverters {
                 .build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         if (deleteJobRequest.getForce() != null) {
             params.putParam("force", Boolean.toString(deleteJobRequest.getForce()));
         }
         if (deleteJobRequest.getWaitForCompletion() != null) {
             params.putParam("wait_for_completion", Boolean.toString(deleteJobRequest.getWaitForCompletion()));
         }
-
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -249,12 +250,12 @@ final class MLRequestConverters {
                 .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         if (getDatafeedRequest.getAllowNoDatafeeds() != null) {
             params.putParam(GetDatafeedRequest.ALLOW_NO_DATAFEEDS.getPreferredName(),
                     Boolean.toString(getDatafeedRequest.getAllowNoDatafeeds()));
         }
-
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -265,10 +266,11 @@ final class MLRequestConverters {
                 .addPathPart(deleteDatafeedRequest.getDatafeedId())
                 .build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         if (deleteDatafeedRequest.getForce() != null) {
             params.putParam("force", Boolean.toString(deleteDatafeedRequest.getForce()));
         }
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -305,10 +307,11 @@ final class MLRequestConverters {
             .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         if (getDatafeedStatsRequest.getAllowNoDatafeeds() != null) {
             params.putParam("allow_no_datafeeds", Boolean.toString(getDatafeedStatsRequest.getAllowNoDatafeeds()));
         }
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -331,13 +334,14 @@ final class MLRequestConverters {
             .addPathPart(Strings.collectionToCommaDelimitedString(deleteForecastRequest.getForecastIds()))
             .build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         if (deleteForecastRequest.getAllowNoForecasts() != null) {
             params.putParam("allow_no_forecasts", Boolean.toString(deleteForecastRequest.getAllowNoForecasts()));
         }
         if (deleteForecastRequest.timeout() != null) {
             params.putParam("timeout", deleteForecastRequest.timeout().getStringRep());
         }
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -453,7 +457,7 @@ final class MLRequestConverters {
             .build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         if (postDataRequest.getResetStart() != null) {
             params.putParam(PostDataRequest.RESET_START.getPreferredName(), postDataRequest.getResetStart());
         }
@@ -461,6 +465,7 @@ final class MLRequestConverters {
             params.putParam(PostDataRequest.RESET_END.getPreferredName(), postDataRequest.getResetEnd());
         }
         BytesReference content = postDataRequest.getContent();
+        request.addParameters(params.asMap());
         if (content != null) {
             BytesRef source = postDataRequest.getContent().toBytesRef();
             HttpEntity byteEntity = new NByteArrayEntity(source.bytes,
@@ -594,13 +599,14 @@ final class MLRequestConverters {
             .addPathPart(getFiltersRequest.getFilterId())
             .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         if (getFiltersRequest.getSize() != null) {
             params.putParam(PageParams.SIZE.getPreferredName(), getFiltersRequest.getSize().toString());
         }
         if (getFiltersRequest.getFrom() != null) {
             params.putParam(PageParams.FROM.getPreferredName(), getFiltersRequest.getFrom().toString());
         }
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -628,11 +634,12 @@ final class MLRequestConverters {
     static Request setUpgradeMode(SetUpgradeModeRequest setUpgradeModeRequest) {
         String endpoint = new EndpointBuilder().addPathPartAsIs("_ml", "set_upgrade_mode").build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.putParam(SetUpgradeModeRequest.ENABLED.getPreferredName(), Boolean.toString(setUpgradeModeRequest.isEnabled()));
         if (setUpgradeModeRequest.getTimeout() != null) {
             params.putParam(SetUpgradeModeRequest.TIMEOUT.getPreferredName(), setUpgradeModeRequest.getTimeout().toString());
         }
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -650,7 +657,7 @@ final class MLRequestConverters {
             .build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
 
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         if (findFileStructureRequest.getLinesToSample() != null) {
             params.putParam(FindFileStructureRequest.LINES_TO_SAMPLE.getPreferredName(),
                 findFileStructureRequest.getLinesToSample().toString());
@@ -695,7 +702,7 @@ final class MLRequestConverters {
         if (findFileStructureRequest.getExplain() != null) {
             params.putParam(FindFileStructureRequest.EXPLAIN.getPreferredName(), findFileStructureRequest.getExplain().toString());
         }
-
+        request.addParameters(params.asMap());
         BytesReference sample = findFileStructureRequest.getSample();
         BytesRef source = sample.toBytesRef();
         HttpEntity byteEntity = new NByteArrayEntity(source.bytes, source.offset, source.length, createContentType(XContentType.JSON));

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -88,8 +88,10 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.StringJoiner;
 
 final class RequestConverters {
@@ -103,7 +105,7 @@ final class RequestConverters {
         String endpoint = endpoint(deleteRequest.index(), deleteRequest.type(), deleteRequest.id());
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
 
-        Params parameters = new Params(request);
+        Params parameters = new Params();
         parameters.withRouting(deleteRequest.routing());
         parameters.withTimeout(deleteRequest.timeout());
         parameters.withVersion(deleteRequest.version());
@@ -112,6 +114,7 @@ final class RequestConverters {
         parameters.withIfPrimaryTerm(deleteRequest.ifPrimaryTerm());
         parameters.withRefreshPolicy(deleteRequest.getRefreshPolicy());
         parameters.withWaitForActiveShards(deleteRequest.waitForActiveShards());
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -122,7 +125,7 @@ final class RequestConverters {
     static Request bulk(BulkRequest bulkRequest) throws IOException {
         Request request = new Request(HttpPost.METHOD_NAME, "/_bulk");
 
-        Params parameters = new Params(request);
+        Params parameters = new Params();
         parameters.withTimeout(bulkRequest.timeout());
         parameters.withRefreshPolicy(bulkRequest.getRefreshPolicy());
         parameters.withPipeline(bulkRequest.pipeline());
@@ -249,6 +252,7 @@ final class RequestConverters {
                 content.write(separator);
             }
         }
+        request.addParameters(parameters.asMap());
         request.setEntity(new NByteArrayEntity(content.toByteArray(), 0, content.size(), requestContentType));
         return request;
     }
@@ -264,7 +268,7 @@ final class RequestConverters {
     private static Request getStyleRequest(String method, GetRequest getRequest) {
         Request request = new Request(method, endpoint(getRequest.index(), getRequest.type(), getRequest.id()));
 
-        Params parameters = new Params(request);
+        Params parameters = new Params();
         parameters.withPreference(getRequest.preference());
         parameters.withRouting(getRequest.routing());
         parameters.withRefresh(getRequest.refresh());
@@ -273,7 +277,7 @@ final class RequestConverters {
         parameters.withVersion(getRequest.version());
         parameters.withVersionType(getRequest.versionType());
         parameters.withFetchSourceContext(getRequest.fetchSourceContext());
-
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -286,23 +290,24 @@ final class RequestConverters {
             endpoint = endpoint(getRequest.index(), optionalType, getRequest.id(), "_source");
         }
         Request request = new Request(HttpHead.METHOD_NAME, endpoint);
-        Params parameters = new Params(request);
+        Params parameters = new Params();
         parameters.withPreference(getRequest.preference());
         parameters.withRouting(getRequest.routing());
         parameters.withRefresh(getRequest.refresh());
         parameters.withRealtime(getRequest.realtime());
         // Version params are not currently supported by the source exists API so are not passed
+        request.addParameters(parameters.asMap());
         return request;
     }
 
     static Request multiGet(MultiGetRequest multiGetRequest) throws IOException {
         Request request = new Request(HttpPost.METHOD_NAME, "/_mget");
 
-        Params parameters = new Params(request);
+        Params parameters = new Params();
         parameters.withPreference(multiGetRequest.preference());
         parameters.withRealtime(multiGetRequest.realtime());
         parameters.withRefresh(multiGetRequest.refresh());
-
+        request.addParameters(parameters.asMap());
         request.setEntity(createEntity(multiGetRequest, REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -321,7 +326,7 @@ final class RequestConverters {
 
         Request request = new Request(method, endpoint);
 
-        Params parameters = new Params(request);
+        Params parameters = new Params();
         parameters.withRouting(indexRequest.routing());
         parameters.withTimeout(indexRequest.timeout());
         parameters.withVersion(indexRequest.version());
@@ -334,6 +339,7 @@ final class RequestConverters {
 
         BytesRef source = indexRequest.source().toBytesRef();
         ContentType contentType = createContentType(indexRequest.getContentType());
+        request.addParameters(parameters.asMap());
         request.setEntity(new NByteArrayEntity(source.bytes, source.offset, source.length, contentType));
         return request;
     }
@@ -348,7 +354,7 @@ final class RequestConverters {
             : endpoint(updateRequest.index(), updateRequest.type(), updateRequest.id(), "_update");
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
 
-        Params parameters = new Params(request);
+        Params parameters = new Params();
         parameters.withRouting(updateRequest.routing());
         parameters.withTimeout(updateRequest.timeout());
         parameters.withRefreshPolicy(updateRequest.getRefreshPolicy());
@@ -379,6 +385,7 @@ final class RequestConverters {
         if (xContentType == null) {
             xContentType = Requests.INDEX_CONTENT_TYPE;
         }
+        request.addParameters(parameters.asMap());
         request.setEntity(createEntity(updateRequest, xContentType));
         return request;
     }
@@ -393,12 +400,13 @@ final class RequestConverters {
     static Request search(SearchRequest searchRequest, String searchEndpoint) throws IOException {
         Request request = new Request(HttpPost.METHOD_NAME, endpoint(searchRequest.indices(), searchRequest.types(), searchEndpoint));
 
-        Params params = new Params(request);
+        Params params = new Params();
         addSearchRequestParams(params, searchRequest);
 
         if (searchRequest.source() != null) {
             request.setEntity(createEntity(searchRequest.source(), REQUEST_BODY_CONTENT_TYPE));
         }
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -436,7 +444,7 @@ final class RequestConverters {
     static Request multiSearch(MultiSearchRequest multiSearchRequest) throws IOException {
         Request request = new Request(HttpPost.METHOD_NAME, "/_msearch");
 
-        Params params = new Params(request);
+        Params params = new Params();
         params.putParam(RestSearchAction.TYPED_KEYS_PARAM, "true");
         if (multiSearchRequest.maxConcurrentSearchRequests() != MultiSearchRequest.MAX_CONCURRENT_SEARCH_REQUESTS_DEFAULT) {
             params.putParam("max_concurrent_searches", Integer.toString(multiSearchRequest.maxConcurrentSearchRequests()));
@@ -444,6 +452,7 @@ final class RequestConverters {
 
         XContent xContent = REQUEST_BODY_CONTENT_TYPE.xContent();
         byte[] source = MultiSearchRequest.writeMultiLineFormat(multiSearchRequest, xContent);
+        request.addParameters(params.asMap());
         request.setEntity(new NByteArrayEntity(source, createContentType(xContent.type())));
         return request;
     }
@@ -458,8 +467,9 @@ final class RequestConverters {
             String endpoint = endpoint(searchRequest.indices(), searchRequest.types(), "_search/template");
             request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-            Params params = new Params(request);
+            Params params = new Params();
             addSearchRequestParams(params, searchRequest);
+            request.addParameters(params.asMap());
         }
 
         request.setEntity(createEntity(searchTemplateRequest, REQUEST_BODY_CONTENT_TYPE));
@@ -469,7 +479,7 @@ final class RequestConverters {
     static Request multiSearchTemplate(MultiSearchTemplateRequest multiSearchTemplateRequest) throws IOException {
         Request request = new Request(HttpPost.METHOD_NAME, "/_msearch/template");
 
-        Params params = new Params(request);
+        Params params = new Params();
         params.putParam(RestSearchAction.TYPED_KEYS_PARAM, "true");
         if (multiSearchTemplateRequest.maxConcurrentSearchRequests() != MultiSearchRequest.MAX_CONCURRENT_SEARCH_REQUESTS_DEFAULT) {
             params.putParam("max_concurrent_searches", Integer.toString(multiSearchTemplateRequest.maxConcurrentSearchRequests()));
@@ -483,10 +493,11 @@ final class RequestConverters {
 
     static Request count(CountRequest countRequest) throws IOException {
         Request request = new Request(HttpPost.METHOD_NAME, endpoint(countRequest.indices(), countRequest.types(), "_count"));
-        Params params = new Params(request);
+        Params params = new Params();
         params.withRouting(countRequest.routing());
         params.withPreference(countRequest.preference());
         params.withIndicesOptions(countRequest.indicesOptions());
+        request.addParameters(params.asMap());
         request.setEntity(createEntity(countRequest.source(), REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -497,11 +508,12 @@ final class RequestConverters {
             : endpoint(explainRequest.index(), explainRequest.type(), explainRequest.id(), "_explain");
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        Params params = new Params(request);
+        Params params = new Params();
         params.withStoredFields(explainRequest.storedFields());
         params.withFetchSourceContext(explainRequest.fetchSourceContext());
         params.withRouting(explainRequest.routing());
         params.withPreference(explainRequest.preference());
+        request.addParameters(params.asMap());
         request.setEntity(createEntity(explainRequest, REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -509,18 +521,19 @@ final class RequestConverters {
     static Request fieldCaps(FieldCapabilitiesRequest fieldCapabilitiesRequest) {
         Request request = new Request(HttpGet.METHOD_NAME, endpoint(fieldCapabilitiesRequest.indices(), "_field_caps"));
 
-        Params params = new Params(request);
+        Params params = new Params();
         params.withFields(fieldCapabilitiesRequest.fields());
         params.withIndicesOptions(fieldCapabilitiesRequest.indicesOptions());
+        request.addParameters(params.asMap());
         return request;
     }
 
     static Request rankEval(RankEvalRequest rankEvalRequest) throws IOException {
         Request request = new Request(HttpGet.METHOD_NAME, endpoint(rankEvalRequest.indices(), Strings.EMPTY_ARRAY, "_rank_eval"));
 
-        Params params = new Params(request);
+        Params params = new Params();
         params.withIndicesOptions(rankEvalRequest.indicesOptions());
-
+        request.addParameters(params.asMap());
         request.setEntity(createEntity(rankEvalRequest.getRankEvalSpec(), REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -536,7 +549,7 @@ final class RequestConverters {
     private static Request prepareReindexRequest(ReindexRequest reindexRequest, boolean waitForCompletion) throws IOException {
         String endpoint = new EndpointBuilder().addPathPart("_reindex").build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-        Params params = new Params(request)
+        Params params = new Params()
             .withWaitForCompletion(waitForCompletion)
             .withRefresh(reindexRequest.isRefresh())
             .withTimeout(reindexRequest.getTimeout())
@@ -546,6 +559,7 @@ final class RequestConverters {
         if (reindexRequest.getScrollTime() != null) {
             params.putParam("scroll", reindexRequest.getScrollTime());
         }
+        request.addParameters(params.asMap());
         request.setEntity(createEntity(reindexRequest, REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -554,7 +568,7 @@ final class RequestConverters {
         String endpoint =
             endpoint(updateByQueryRequest.indices(), updateByQueryRequest.getDocTypes(), "_update_by_query");
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-        Params params = new Params(request)
+        Params params = new Params()
             .withRouting(updateByQueryRequest.getRouting())
             .withPipeline(updateByQueryRequest.getPipeline())
             .withRefresh(updateByQueryRequest.isRefresh())
@@ -574,6 +588,7 @@ final class RequestConverters {
         if (updateByQueryRequest.getSize() > 0) {
             params.putParam("size", Integer.toString(updateByQueryRequest.getSize()));
         }
+        request.addParameters(params.asMap());
         request.setEntity(createEntity(updateByQueryRequest, REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -582,7 +597,7 @@ final class RequestConverters {
         String endpoint =
             endpoint(deleteByQueryRequest.indices(), deleteByQueryRequest.getDocTypes(), "_delete_by_query");
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-        Params params = new Params(request)
+        Params params = new Params()
             .withRouting(deleteByQueryRequest.getRouting())
             .withRefresh(deleteByQueryRequest.isRefresh())
             .withTimeout(deleteByQueryRequest.getTimeout())
@@ -601,6 +616,7 @@ final class RequestConverters {
         if (deleteByQueryRequest.getSize() > 0) {
             params.putParam("size", Integer.toString(deleteByQueryRequest.getSize()));
         }
+        request.addParameters(params.asMap());
         request.setEntity(createEntity(deleteByQueryRequest, REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -621,22 +637,24 @@ final class RequestConverters {
         String endpoint = new EndpointBuilder().addPathPart(firstPathPart).addPathPart(rethrottleRequest.getTaskId().toString())
                 .addPathPart("_rethrottle").build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-        Params params = new Params(request)
+        Params params = new Params()
                 .withRequestsPerSecond(rethrottleRequest.getRequestsPerSecond());
         // we set "group_by" to "none" because this is the response format we can parse back
         params.putParam("group_by", "none");
+        request.addParameters(params.asMap());
         return request;
     }
 
     static Request putScript(PutStoredScriptRequest putStoredScriptRequest) throws IOException {
         String endpoint = new EndpointBuilder().addPathPartAsIs("_scripts").addPathPart(putStoredScriptRequest.id()).build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-        Params params = new Params(request);
+        Params params = new Params();
         params.withTimeout(putStoredScriptRequest.timeout());
         params.withMasterTimeout(putStoredScriptRequest.masterNodeTimeout());
         if (Strings.hasText(putStoredScriptRequest.context())) {
             params.putParam("context", putStoredScriptRequest.context());
         }
+        request.addParameters(params.asMap());
         request.setEntity(createEntity(putStoredScriptRequest, REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -667,11 +685,12 @@ final class RequestConverters {
         }
 
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-        Params params = new Params(request);
+        Params params = new Params();
         params.withRouting(tvrequest.getRouting());
         params.withPreference(tvrequest.getPreference());
         params.withFields(tvrequest.getFields());
         params.withRealtime(tvrequest.getRealtime());
+        request.addParameters(params.asMap());
         request.setEntity(createEntity(tvrequest, REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -686,17 +705,19 @@ final class RequestConverters {
     static Request getScript(GetStoredScriptRequest getStoredScriptRequest) {
         String endpoint = new EndpointBuilder().addPathPartAsIs("_scripts").addPathPart(getStoredScriptRequest.id()).build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-        Params params = new Params(request);
+        Params params = new Params();
         params.withMasterTimeout(getStoredScriptRequest.masterNodeTimeout());
+        request.addParameters(params.asMap());
         return request;
     }
 
     static Request deleteScript(DeleteStoredScriptRequest deleteStoredScriptRequest) {
         String endpoint = new EndpointBuilder().addPathPartAsIs("_scripts").addPathPart(deleteStoredScriptRequest.id()).build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
-        Params params = new Params(request);
+        Params params = new Params();
         params.withTimeout(deleteStoredScriptRequest.timeout());
         params.withMasterTimeout(deleteStoredScriptRequest.masterNodeTimeout());
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -756,15 +777,14 @@ final class RequestConverters {
      * a {@link Request} and adds the parameters to it directly.
      */
     static class Params {
-        private final Request request;
+        private final Map<String,String> parameters = new HashMap<>();
 
-        Params(Request request) {
-            this.request = request;
+        Params() {
         }
 
         Params putParam(String name, String value) {
             if (Strings.hasLength(value)) {
-                request.addParameter(name, value);
+                parameters.put(name,value);
             }
             return this;
         }
@@ -774,6 +794,10 @@ final class RequestConverters {
                 return putParam(key, value.getStringRep());
             }
             return this;
+        }
+
+        Map<String, String> asMap(){
+            return parameters;
         }
 
         Params withDocAsUpsert(boolean docAsUpsert) {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RollupRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RollupRequestConverters.java
@@ -68,11 +68,12 @@ final class RollupRequestConverters {
             .build();
 
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(stopRollupJobRequest.timeout());
         if (stopRollupJobRequest.waitForCompletion() != null) {
             parameters.withWaitForCompletion(stopRollupJobRequest.waitForCompletion());
         }
+        request.addParameters(parameters.asMap());
         return request;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/SecurityRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/SecurityRequestConverters.java
@@ -66,8 +66,9 @@ final class SecurityRequestConverters {
             .build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
         request.setEntity(createEntity(changePasswordRequest, REQUEST_BODY_CONTENT_TYPE));
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withRefreshPolicy(changePasswordRequest.getRefreshPolicy());
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -87,8 +88,9 @@ final class SecurityRequestConverters {
             .build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
         request.setEntity(createEntity(putUserRequest, REQUEST_BODY_CONTENT_TYPE));
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withRefreshPolicy(putUserRequest.getRefreshPolicy());
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -98,8 +100,9 @@ final class SecurityRequestConverters {
             .addPathPart(deleteUserRequest.getName())
             .build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withRefreshPolicy(deleteUserRequest.getRefreshPolicy());
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -110,8 +113,9 @@ final class SecurityRequestConverters {
             .build();
         final Request request = new Request(HttpPut.METHOD_NAME, endpoint);
         request.setEntity(createEntity(putRoleMappingRequest, REQUEST_BODY_CONTENT_TYPE));
-        final RequestConverters.Params params = new RequestConverters.Params(request);
+        final RequestConverters.Params params = new RequestConverters.Params();
         params.withRefreshPolicy(putRoleMappingRequest.getRefreshPolicy());
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -139,8 +143,9 @@ final class SecurityRequestConverters {
             .addPathPart(setUserEnabledRequest.isEnabled() ? "_enable" : "_disable")
             .build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withRefreshPolicy(setUserEnabledRequest.getRefreshPolicy());
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -161,8 +166,9 @@ final class SecurityRequestConverters {
         final String endpoint = builder.addPathPartAsIs("_clear_cache").build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
         if (clearRealmCacheRequest.getUsernames().isEmpty() == false) {
-            RequestConverters.Params params = new RequestConverters.Params(request);
+            RequestConverters.Params params = new RequestConverters.Params();
             params.putParam("usernames", Strings.collectionToCommaDelimitedString(clearRealmCacheRequest.getUsernames()));
+            request.addParameters(params.asMap());
         }
         return request;
     }
@@ -182,8 +188,9 @@ final class SecurityRequestConverters {
             .addPathPart(deleteRoleMappingRequest.getName())
             .build();
         final Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
-        final RequestConverters.Params params = new RequestConverters.Params(request);
+        final RequestConverters.Params params = new RequestConverters.Params();
         params.withRefreshPolicy(deleteRoleMappingRequest.getRefreshPolicy());
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -193,8 +200,9 @@ final class SecurityRequestConverters {
             .addPathPart(deleteRoleRequest.getName())
             .build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withRefreshPolicy(deleteRoleRequest.getRefreshPolicy());
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -231,8 +239,9 @@ final class SecurityRequestConverters {
     static Request putPrivileges(final PutPrivilegesRequest putPrivilegesRequest) throws IOException {
         Request request = new Request(HttpPut.METHOD_NAME, "/_security/privilege");
         request.setEntity(createEntity(putPrivilegesRequest, REQUEST_BODY_CONTENT_TYPE));
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withRefreshPolicy(putPrivilegesRequest.getRefreshPolicy());
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -243,8 +252,9 @@ final class SecurityRequestConverters {
             .addCommaSeparatedPathParts(deletePrivilegeRequest.getPrivileges())
             .build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withRefreshPolicy(deletePrivilegeRequest.getRefreshPolicy());
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -255,16 +265,18 @@ final class SecurityRequestConverters {
             .build();
         final Request request = new Request(HttpPut.METHOD_NAME, endpoint);
         request.setEntity(createEntity(putRoleRequest, REQUEST_BODY_CONTENT_TYPE));
-        final RequestConverters.Params params = new RequestConverters.Params(request);
+        final RequestConverters.Params params = new RequestConverters.Params();
         params.withRefreshPolicy(putRoleRequest.getRefreshPolicy());
+        request.addParameters(params.asMap());
         return request;
     }
 
     static Request createApiKey(final CreateApiKeyRequest createApiKeyRequest) throws IOException {
         final Request request = new Request(HttpPost.METHOD_NAME, "/_security/api_key");
         request.setEntity(createEntity(createApiKeyRequest, REQUEST_BODY_CONTENT_TYPE));
-        final RequestConverters.Params params = new RequestConverters.Params(request);
+        final RequestConverters.Params params = new RequestConverters.Params();
         params.withRefreshPolicy(createApiKeyRequest.getRefreshPolicy());
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -282,13 +294,13 @@ final class SecurityRequestConverters {
         if (Strings.hasText(getApiKeyRequest.getRealmName())) {
             request.addParameter("realm_name", getApiKeyRequest.getRealmName());
         }
+
         return request;
     }
 
     static Request invalidateApiKey(final InvalidateApiKeyRequest invalidateApiKeyRequest) throws IOException {
         final Request request = new Request(HttpDelete.METHOD_NAME, "/_security/api_key");
         request.setEntity(createEntity(invalidateApiKeyRequest, REQUEST_BODY_CONTENT_TYPE));
-        final RequestConverters.Params params = new RequestConverters.Params(request);
         return request;
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/SnapshotRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/SnapshotRequestConverters.java
@@ -46,9 +46,10 @@ final class SnapshotRequestConverters {
             .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(getRepositoriesRequest.masterNodeTimeout());
         parameters.withLocal(getRepositoriesRequest.local());
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -56,11 +57,11 @@ final class SnapshotRequestConverters {
         String endpoint = new RequestConverters.EndpointBuilder().addPathPart("_snapshot").addPathPart(putRepositoryRequest.name()).build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(putRepositoryRequest.masterNodeTimeout());
         parameters.withTimeout(putRepositoryRequest.timeout());
         parameters.withVerify(putRepositoryRequest.verify());
-
+        request.addParameters(parameters.asMap());
         request.setEntity(RequestConverters.createEntity(putRepositoryRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -70,9 +71,10 @@ final class SnapshotRequestConverters {
             .build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(deleteRepositoryRequest.masterNodeTimeout());
         parameters.withTimeout(deleteRepositoryRequest.timeout());
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -83,9 +85,10 @@ final class SnapshotRequestConverters {
             .build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(verifyRepositoryRequest.masterNodeTimeout());
         parameters.withTimeout(verifyRepositoryRequest.timeout());
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -95,9 +98,10 @@ final class SnapshotRequestConverters {
             .addPathPart(createSnapshotRequest.snapshot())
             .build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withMasterTimeout(createSnapshotRequest.masterNodeTimeout());
         params.withWaitForCompletion(createSnapshotRequest.waitForCompletion());
+        request.addParameters(params.asMap());
         request.setEntity(RequestConverters.createEntity(createSnapshotRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -114,11 +118,11 @@ final class SnapshotRequestConverters {
 
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(getSnapshotsRequest.masterNodeTimeout());
         parameters.putParam("ignore_unavailable", Boolean.toString(getSnapshotsRequest.ignoreUnavailable()));
         parameters.putParam("verbose", Boolean.toString(getSnapshotsRequest.verbose()));
-
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -130,9 +134,10 @@ final class SnapshotRequestConverters {
             .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(snapshotsStatusRequest.masterNodeTimeout());
         parameters.withIgnoreUnavailable(snapshotsStatusRequest.ignoreUnavailable());
+        request.addParameters(parameters.asMap());
         return request;
     }
 
@@ -143,9 +148,10 @@ final class SnapshotRequestConverters {
             .addPathPartAsIs("_restore")
             .build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(restoreSnapshotRequest.masterNodeTimeout());
         parameters.withWaitForCompletion(restoreSnapshotRequest.waitForCompletion());
+        request.addParameters(parameters.asMap());
         request.setEntity(RequestConverters.createEntity(restoreSnapshotRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
@@ -157,8 +163,9 @@ final class SnapshotRequestConverters {
             .build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
 
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(deleteSnapshotRequest.masterNodeTimeout());
+        request.addParameters(parameters.asMap());
         return request;
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/TasksRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/TasksRequestConverters.java
@@ -32,12 +32,13 @@ final class TasksRequestConverters {
 
     static Request cancelTasks(CancelTasksRequest cancelTasksRequest) {
         Request request = new Request(HttpPost.METHOD_NAME, "/_tasks/_cancel");
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withTimeout(cancelTasksRequest.getTimeout())
             .withTaskId(cancelTasksRequest.getTaskId())
             .withNodes(cancelTasksRequest.getNodes())
             .withParentTaskId(cancelTasksRequest.getParentTaskId())
             .withActions(cancelTasksRequest.getActions());
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -46,7 +47,7 @@ final class TasksRequestConverters {
             throw new IllegalArgumentException("TaskId cannot be used for list tasks request");
         }
         Request request  = new Request(HttpGet.METHOD_NAME, "/_tasks");
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withTimeout(listTaskRequest.getTimeout())
             .withDetailed(listTaskRequest.getDetailed())
             .withWaitForCompletion(listTaskRequest.getWaitForCompletion())
@@ -54,6 +55,7 @@ final class TasksRequestConverters {
             .withNodes(listTaskRequest.getNodes())
             .withActions(listTaskRequest.getActions())
             .putParam("group_by", "none");
+        request.addParameters(params.asMap());
         return request;
     }
 
@@ -62,9 +64,10 @@ final class TasksRequestConverters {
                 .addPathPartAsIs(getTaskRequest.getNodeId() + ":" + Long.toString(getTaskRequest.getTaskId()))
                 .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         params.withTimeout(getTaskRequest.getTimeout())
             .withWaitForCompletion(getTaskRequest.getWaitForCompletion());
+        request.addParameters(params.asMap());
         return request;
     }
     

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/WatcherRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/WatcherRequestConverters.java
@@ -69,12 +69,13 @@ final class WatcherRequestConverters {
             .build();
 
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request)
+        RequestConverters.Params params = new RequestConverters.Params()
             .withIfSeqNo(putWatchRequest.ifSeqNo())
             .withIfPrimaryTerm(putWatchRequest.ifPrimaryTerm());
         if (putWatchRequest.isActive() == false) {
             params.putParam("active", "false");
         }
+        request.addParameters(params.asMap());
         ContentType contentType = RequestConverters.createContentType(putWatchRequest.xContentType());
         BytesReference source = putWatchRequest.getSource();
         request.setEntity(new NByteArrayEntity(source.toBytesRef().bytes, 0, source.length(), contentType));
@@ -118,7 +119,7 @@ final class WatcherRequestConverters {
             .addPathPartAsIs("_execute").build();
 
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params(request);
+        RequestConverters.Params params = new RequestConverters.Params();
         if (executeWatchRequest.isDebug()) {
             params.putParam("debug", "true");
         }
@@ -128,7 +129,7 @@ final class WatcherRequestConverters {
         if (executeWatchRequest.recordExecution()) {
             params.putParam("record_execution", "true");
         }
-
+        request.addParameters(params.asMap());
         request.setEntity(RequestConverters.createEntity(executeWatchRequest, XContentType.JSON));
         return request;
     }
@@ -158,7 +159,7 @@ final class WatcherRequestConverters {
         RequestConverters.EndpointBuilder builder = new RequestConverters.EndpointBuilder().addPathPartAsIs("_watcher", "stats");
         String endpoint = builder.build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         StringBuilder metric = new StringBuilder();
         if (watcherStatsRequest.includeCurrentWatches()) {
             metric.append("current_watches");
@@ -172,6 +173,7 @@ final class WatcherRequestConverters {
         if (metric.length() > 0) {
             parameters.putParam("metric", metric.toString());
         }
+        request.addParameters(parameters.asMap());
         return request;
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/XPackRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/XPackRequestConverters.java
@@ -46,8 +46,9 @@ final class XPackRequestConverters {
 
     static Request usage(XPackUsageRequest usageRequest) {
         Request request = new Request(HttpGet.METHOD_NAME, "/_xpack/usage");
-        RequestConverters.Params parameters = new RequestConverters.Params(request);
+        RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withMasterTimeout(usageRequest.masterNodeTimeout());
+        request.addParameters(parameters.asMap());
         return request;
     }
 }

--- a/client/rest/src/main/java/org/elasticsearch/client/Request.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/Request.java
@@ -81,6 +81,10 @@ public final class Request {
         }
     }
 
+    public void addParameters(Map<String, String> paramSource){
+        paramSource.forEach(this::addParameter);
+    }
+
     /**
      * Query string parameters. The returned map is an unmodifiable view of the
      * map in the request so calls to {@link #addParameter(String, String)}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Refactor HLRC RequestConverters parameters to be more explicit  (#42128)