### PR TITLE
Enable tests failing due to java-joda warnings

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
@@ -284,7 +284,7 @@ setup:
                       "date_histogram": {
                         "field": "date",
                         "interval": "1d",
-                        "format": "yyyy-MM-dd"
+                        "format": "strict_date"
                       }
                     }
                   }
@@ -316,7 +316,7 @@ setup:
                         "date_histogram": {
                           "field": "date",
                           "interval": "1d",
-                          "format": "yyyy-MM-dd"
+                          "format": "strict_date"
                         }
                       }
                     }
@@ -347,7 +347,7 @@ setup:
                       "date_histogram": {
                         "field": "date",
                         "calendar_interval": "1d",
-                        "format": "yyyy-MM-dd"
+                        "format": "strict_date"
                       }
                     }
                   }
@@ -377,7 +377,7 @@ setup:
                         "date_histogram": {
                           "field": "date",
                           "calendar_interval": "1d",
-                          "format": "yyyy-MM-dd"
+                          "format": "strict_date"
                         }
                       }
                     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/140_pre_filter_search_shards.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/140_pre_filter_search_shards.yml
@@ -9,7 +9,7 @@ setup:
               properties:
                 created_at:
                    type: date
-                   format: "yyyy-MM-dd"
+                   format: "strict_date"
   - do:
       indices.create:
           index: index_2
@@ -20,7 +20,7 @@ setup:
               properties:
                 created_at:
                    type: date
-                   format: "yyyy-MM-dd"
+                   format: "strict_date"
   - do:
       indices.create:
           index: index_3
@@ -31,14 +31,11 @@ setup:
               properties:
                 created_at:
                    type: date
-                   format: "yyyy-MM-dd"
+                   format: "strict_date"
 
 
 ---
 "pre_filter_shard_size with invalid parameter":
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/42679"
   - do:
       catch: /preFilterShardSize must be >= 1/
       search:
@@ -48,9 +45,6 @@ setup:
 
 ---
 "pre_filter_shard_size with shards that have no hit":
-  - skip:
-        version: "all"
-        reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/42679"
   - do:
       index:
         index: index_1


### PR DESCRIPTION
Tests were failing in mixed cluster after more broad warnings were introduced
in 6.x These tests were using `yyyy-MM-dd` pattern which is now warning about
the change of `y` to `u`. However, using predefined pattern
`strict_date` which uses the same format prevents the warning from being
generate and allow smooth upgrade/work in mixed cluster.
relates #42679
