### PR TITLE
Enable tests failing due to java-joda warnings

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
@@ -284,7 +284,7 @@ setup:
                       "date_histogram": {
                         "field": "date",
                         "interval": "1d",
-                        "format": "yyyy-MM-dd"
+                        "format": "strict_date"
                       }
                     }
                   }
@@ -316,7 +316,7 @@ setup:
                         "date_histogram": {
                           "field": "date",
                           "interval": "1d",
-                          "format": "yyyy-MM-dd"
+                          "format": "strict_date"
                         }
                       }
                     }
@@ -347,7 +347,7 @@ setup:
                       "date_histogram": {
                         "field": "date",
                         "calendar_interval": "1d",
-                        "format": "yyyy-MM-dd"
+                        "format": "strict_date"
                       }
                     }
                   }
@@ -377,7 +377,7 @@ setup:
                         "date_histogram": {
                           "field": "date",
                           "calendar_interval": "1d",
-                          "format": "yyyy-MM-dd"
+                          "format": "strict_date"
                         }
                       }
                     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/140_pre_filter_search_shards.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/140_pre_filter_search_shards.yml
@@ -9,7 +9,7 @@ setup:
               properties:
                 created_at:
                    type: date
-                   format: "yyyy-MM-dd"
+                   format: "strict_date"
   - do:
       indices.create:
           index: index_2
@@ -20,7 +20,7 @@ setup:
               properties:
                 created_at:
                    type: date
-                   format: "yyyy-MM-dd"
+                   format: "strict_date"
   - do:
       indices.create:
           index: index_3
@@ -31,7 +31,7 @@ setup:
               properties:
                 created_at:
                    type: date
-                   format: "yyyy-MM-dd"
+                   format: "strict_date"
 
 
 ---


### PR DESCRIPTION
Tests were failing in mixed cluster after more broad warnings were
introduced in 6.x These tests were using `yyyy-MM-dd` pattern which
is now warning about the change of `y` to `u`. However, using predefined pattern
`strict_date` which uses the same format prevents the warning from being
generate and allow smooth upgrade/work in mixed cluster.
relates #42679

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
