### PR TITLE
Re-enable token bwc tests

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TokenBackwardsCompatibilityIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TokenBackwardsCompatibilityIT.java
@@ -7,7 +7,6 @@ package org.elasticsearch.upgrades;
 
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpHost;
-import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
@@ -26,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@AwaitsFix(bugUrl = "need to backport #42651")
 public class TokenBackwardsCompatibilityIT extends AbstractUpgradeTestCase {
 
     private Collection<RestClient> twoClients = null;

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/50_token_auth.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/50_token_auth.yml
@@ -2,8 +2,6 @@
 "Get the indexed token and use if to authenticate":
   - skip:
       features: headers
-      version: " - 7.99.99"
-      reason: "Need to backport PR #42651"
 
   - do:
       cluster.health:
@@ -61,8 +59,6 @@
 "Get the indexed refreshed access token and use if to authenticate":
   - skip:
       features: headers
-      version: " - 7.99.99"
-      reason: "Need to backport PR #42651"
 
   - do:
       get:
@@ -115,8 +111,6 @@
 "Get the indexed refresh token and use it to get another access token and authenticate":
   - skip:
       features: headers
-      version: " - 7.99.99"
-      reason: "Need to backport PR #42651"
 
   - do:
       get:

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/50_token_auth.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/50_token_auth.yml
@@ -2,8 +2,6 @@
 "Get the indexed token and use if to authenticate":
   - skip:
       features: headers
-      version: " - 8.0.0"
-      reason: "Need to backport PR #42651"
 
   - do:
       cluster.health:
@@ -51,8 +49,6 @@
 "Get the indexed refresh token and use if to get another access token and authenticate":
   - skip:
       features: headers
-      version: " - 8.0.0"
-      reason: "Need to backport PR #42651"
 
   - do:
       get:


### PR DESCRIPTION
This commit re-enables token bwc tests that run as part of the rolling
upgrade tests. These tests were muted while #42651 was being
backported.