### PR TITLE
[ML] [Data Frame] Adding supported aggs in docs

### DIFF
--- a/docs/reference/data-frames/apis/pivotresource.asciidoc
+++ b/docs/reference/data-frames/apis/pivotresource.asciidoc
@@ -1,0 +1,26 @@
+[role="xpack"]
+[testenv="basic"]
+[[data-frame-transform-pivot]]
+=== Pivot resources
+
+A pivot configuration object has the following properties:
+
+`group_by` (required):: (object) Defines how to group the data. More than one grouping can be defined per pivot. The following groupings are supported:
+* {ref}/search-aggregations-bucket-composite-aggregation.html#_terms[Terms]
+* {ref}/search-aggregations-bucket-composite-aggregation.html#_histogram[Histogram]
+* {ref}/search-aggregations-bucket-composite-aggregation.html#_date_histogram[Date Histogram]
+
+`aggregations` (required):: (object) Defines how to aggregate the grouped data.
+The following aggregations are supported:
+* {ref}/search-aggregations-metrics-avg-aggregation.html[Average]
+* {ref}/search-aggregations-metrics-weight-avg-aggregation.html[Weighted Average]
+* {ref}/search-aggregations-metrics-cardinality-aggregation.html[Cardinality]
+* {ref}/search-aggregations-metrics-geocentroid-aggregation.html[Geo Centroid]
+* {ref}/search-aggregations-metrics-max-aggregation.html[Max]
+* {ref}/search-aggregations-metrics-min-aggregation.html[Min]
+* {ref}/search-aggregations-metrics-scripted-metric-aggregation.html[Scripted Metric]
+* {ref}/search-aggregations-metrics-sum-aggregation.html[Sum]
+* {ref}/search-aggregations-metrics-valuecount-aggregation.html[Value Count]
+* {ref}/search-aggregations-metrics-bucket_script-aggregation.html[Bucket Script]
+
+//For more information, see {stack-ov}/ml-dataframes.html[dataframes-cap}].

--- a/docs/reference/data-frames/apis/put-transform.asciidoc
+++ b/docs/reference/data-frames/apis/put-transform.asciidoc
@@ -39,7 +39,7 @@ a `query`.
 `dest` (required):: (object) The destination configuration, consisting of `index`.
 
 `pivot`:: (object) Defines the pivot function `group by` fields and the aggregation to
-reduce the data.
+reduce the data. See <<data-frame-transform-pivot, data frame transform pivot objects>>.
 
 `description`:: Optional free text description of the data frame transform
 
@@ -98,3 +98,27 @@ When the transform is created, you receive the following results:
 }
 ----
 // NOTCONSOLE
+
+[[data-frame-transform-pivot]]
+==== Data Frame Transform Pivot Objects
+
+A pivot configuration object has the following properties:
+
+`group_by` (required):: (object) Defines how to group the data. More than one grouping can be defined
+per pivot. The following groupings are supported:
+* {ref}/search-aggregations-bucket-composite-aggregation.html#_terms[Terms]
+* {ref}/search-aggregations-bucket-composite-aggregation.html#_histogram[Histogram]
+* {ref}/search-aggregations-bucket-composite-aggregation.html#_date_histogram[Date Histogram]
+
+`aggregations` (required):: (object) Defines how to aggregate the grouped data.
+The following aggregations are supported:
+* {ref}/search-aggregations-metrics-avg-aggregation.html[Average]
+* {ref}/search-aggregations-metrics-weight-avg-aggregation.html[Weighted Average]
+* {ref}/search-aggregations-metrics-cardinality-aggregation.html[Cardinality]
+* {ref}/search-aggregations-metrics-geocentroid-aggregation.html[Geo Centroid]
+* {ref}/search-aggregations-metrics-max-aggregation.html[Max]
+* {ref}/search-aggregations-metrics-min-aggregation.html[Min]
+* {ref}/search-aggregations-metrics-scripted-metric-aggregation.html[Scripted Metric]
+* {ref}/search-aggregations-metrics-sum-aggregation.html[Sum]
+* {ref}/search-aggregations-metrics-valuecount-aggregation.html[Value Count]
+* {ref}/search-aggregations-metrics-bucket_script-aggregation.html[Bucket Script]

--- a/docs/reference/data-frames/apis/put-transform.asciidoc
+++ b/docs/reference/data-frames/apis/put-transform.asciidoc
@@ -98,27 +98,3 @@ When the transform is created, you receive the following results:
 }
 ----
 // NOTCONSOLE
-
-[[data-frame-transform-pivot]]
-==== Data Frame Transform Pivot Objects
-
-A pivot configuration object has the following properties:
-
-`group_by` (required):: (object) Defines how to group the data. More than one grouping can be defined
-per pivot. The following groupings are supported:
-* {ref}/search-aggregations-bucket-composite-aggregation.html#_terms[Terms]
-* {ref}/search-aggregations-bucket-composite-aggregation.html#_histogram[Histogram]
-* {ref}/search-aggregations-bucket-composite-aggregation.html#_date_histogram[Date Histogram]
-
-`aggregations` (required):: (object) Defines how to aggregate the grouped data.
-The following aggregations are supported:
-* {ref}/search-aggregations-metrics-avg-aggregation.html[Average]
-* {ref}/search-aggregations-metrics-weight-avg-aggregation.html[Weighted Average]
-* {ref}/search-aggregations-metrics-cardinality-aggregation.html[Cardinality]
-* {ref}/search-aggregations-metrics-geocentroid-aggregation.html[Geo Centroid]
-* {ref}/search-aggregations-metrics-max-aggregation.html[Max]
-* {ref}/search-aggregations-metrics-min-aggregation.html[Min]
-* {ref}/search-aggregations-metrics-scripted-metric-aggregation.html[Scripted Metric]
-* {ref}/search-aggregations-metrics-sum-aggregation.html[Sum]
-* {ref}/search-aggregations-metrics-valuecount-aggregation.html[Value Count]
-* {ref}/search-aggregations-metrics-bucket_script-aggregation.html[Bucket Script]

--- a/docs/reference/rest-api/defs.asciidoc
+++ b/docs/reference/rest-api/defs.asciidoc
@@ -12,6 +12,7 @@ These resource definitions are used in APIs related to {ml-features} and
 * <<ml-job-resource,Jobs>>
 * <<ml-jobstats,Job statistics>>
 * <<ml-snapshot-resource,Model snapshots>>
+* <<data-frame-transform-pivot,Pivots>>
 * <<ml-results-resource,Results>>
 * <<role-mapping-resources,Role mappings>>
 * <<ml-event-resource,Scheduled Events>>
@@ -22,6 +23,7 @@ include::{es-repo-dir}/ml/apis/filterresource.asciidoc[]
 include::{es-repo-dir}/ml/apis/jobresource.asciidoc[]
 include::{es-repo-dir}/ml/apis/jobcounts.asciidoc[]
 include::{es-repo-dir}/ml/apis/snapshotresource.asciidoc[]
+include::{es-repo-dir}/data-frames/apis/pivotresource.asciidoc[]
 include::{xes-repo-dir}/rest-api/security/role-mapping-resources.asciidoc[]
 include::{es-repo-dir}/ml/apis/resultsresource.asciidoc[]
 include::{es-repo-dir}/ml/apis/eventresource.asciidoc[]


### PR DESCRIPTION
This adds a list of supported aggregations for the `group_by` and for the `aggs` in the `pivot` data frame transform. 