### PR TITLE
Check message instead of toString for DS_Store test

### DIFF
--- a/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -171,7 +171,7 @@ public class PluginsServiceTests extends ESTestCase {
             if (Constants.WINDOWS) {
                 assertThat(e.getCause(), instanceOf(NoSuchFileException.class));
             } else {
-                assertThat(e.getCause(), hasToString(containsString("Not a directory")));
+                assertThat(e.getCause().getMessage(), containsString("Not a directory"));
             }
         }
     }


### PR DESCRIPTION
The plugin service special cases .DS_Store on MacOS, to not think it is
a plugin. The tests for this behavior also check an appropriate error
occurs on non macos systems. On Linux, the test checks the exception
message, but uses toString(), which uses a localized version of the
exception message. This commit changes the test to instead check the
exception message directly, so as not to depend on the locale.

closes #41689