### PR TITLE
Report MaxDirectMemorySize for newer JDKs

### DIFF
--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
@@ -57,11 +57,14 @@ public class JvmInfo implements Writeable, ToXContentFragment {
         long nonHeapInit = memoryMXBean.getNonHeapMemoryUsage().getInit() < 0 ? 0 : memoryMXBean.getNonHeapMemoryUsage().getInit();
         long nonHeapMax = memoryMXBean.getNonHeapMemoryUsage().getMax() < 0 ? 0 : memoryMXBean.getNonHeapMemoryUsage().getMax();
         long directMemoryMax = 0;
-        try {
-            Class<?> vmClass = Class.forName("sun.misc.VM");
-            directMemoryMax = (Long) vmClass.getMethod("maxDirectMemory").invoke(null);
-        } catch (Exception t) {
-            // ignore
+        for (String vmClassName : new String[] { "sun.misc.VM", "jdk.internal.misc.VM" }) {
+            try {
+                Class<?> vmClass = Class.forName(vmClassName);
+                directMemoryMax = (Long) vmClass.getMethod("maxDirectMemory").invoke(null);
+                break;
+            } catch (Exception t) {
+                // ignore
+            }
         }
         String[] inputArguments = runtimeMXBean.getInputArguments().toArray(new String[runtimeMXBean.getInputArguments().size()]);
         Mem mem = new Mem(heapInit, heapMax, nonHeapInit, nonHeapMax, directMemoryMax);


### PR DESCRIPTION
Newer JDKs have moved the `VM` class from the `sun.misc` to the `jdk.internal.misc` package. With the default-bundled JDK, we currently don't report stats on MaxDirectMemorySize.