### PR TITLE
Clarify heap setting in Docker docs

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -372,6 +372,10 @@ published ports with `--publish-all`, unless you are pinning one container per h
 
 . Use the `ES_JAVA_OPTS` environment variable to set heap size. For example, to
 use 16GB, use `-e ES_JAVA_OPTS="-Xms16g -Xmx16g"` with `docker run`.
++
+--
+NOTE: You still need to configure the heap size even if you are https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory[limiting memory access] to the container.
+--
 
 . Pin your deployments to a specific version of the {es} Docker image, for
 example +docker.elastic.co/elasticsearch/elasticsearch:{version}+.

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -374,7 +374,9 @@ published ports with `--publish-all`, unless you are pinning one container per h
 use 16GB, use `-e ES_JAVA_OPTS="-Xms16g -Xmx16g"` with `docker run`.
 +
 --
-NOTE: You still need to configure the heap size even if you are https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory[limiting memory access] to the container.
+NOTE: You still need to <<heap-size,configure the heap size>> even if you are
+https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory[limiting
+memory access] to the container.
 --
 
 . Pin your deployments to a specific version of the {es} Docker image, for


### PR DESCRIPTION
Add note in the Docker docs that even when container memory is limited,
we still require specifying -Xms/-Xmx using one of the supported
methods.

Closes #42660 