### PR TITLE
[DOCS] Remove unneeded `ifdef::asciidoctor[]` conditionals

### DIFF
--- a/docs/reference/settings/notification-settings.asciidoc
+++ b/docs/reference/settings/notification-settings.asciidoc
@@ -37,14 +37,8 @@ required. For more information, see
 {xpack-ref}/encrypting-data.html[Encrypting sensitive data in {watcher}].
 
 `xpack.watcher.history.cleaner_service.enabled`::
-ifdef::asciidoctor[]
 added:[6.3.0,Default changed to `true`.]
 deprecated:[7.0.0,Watcher history indices are now managed by the `watch-history-ilm-policy` ILM policy]
-endif::[]
-ifndef::asciidoctor[]
-added[6.3.0,Default changed to `true`.]
-deprecated[7.0.0,Watcher history indices are now managed by the `watch-history-ilm-policy` ILM policy]
-endif::[]
 +
 Set to `true` (default) to enable the cleaner service. If this setting is
 `true`, the `xpack.monitoring.enabled` setting must also be set to `true` with

--- a/docs/reference/settings/ssl-settings.asciidoc
+++ b/docs/reference/settings/ssl-settings.asciidoc
@@ -38,13 +38,8 @@ endif::verifies[]
 Supported cipher suites can be found in Oracle's http://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html[
 Java Cryptography Architecture documentation]. Defaults to ``.
 
-ifdef::asciidoctor[]
 [#{ssl-context}-tls-ssl-key-trusted-certificate-settings]
 ===== {component} TLS/SSL Key and Trusted Certificate Settings
-endif::[]
-ifndef::asciidoctor[]
-===== anchor:{ssl-context}-tls-ssl-key-trusted-certificate-settings[] {component} TLS/SSL Key and Trusted Certificate Settings
-endif::[]
 
 The following settings are used to specify a private key, certificate, and the
 trusted certificates that should be used when communicating over an SSL/TLS connection.
@@ -110,13 +105,8 @@ Password to the truststore.
 +{ssl-prefix}.ssl.truststore.secure_password+ (<<secure-settings,Secure>>)::
 Password to the truststore.
 
-ifdef::asciidoctor[]
 [#{ssl-context}-pkcs12-files]
 ===== PKCS#12 Files
-endif::[]
-ifndef::asciidoctor[]
-===== anchor:{ssl-context}-pkcs12-files[] PKCS#12 Files
-endif::[]
 
 {es} can be configured to use PKCS#12 container files (`.p12` or `.pfx` files)
 that contain the private key, certificate and certificates that should be trusted.
@@ -154,13 +144,8 @@ Password to the PKCS#12 file.
 +{ssl-prefix}.ssl.truststore.secure_password+ (<<secure-settings,Secure>>)::
 Password to the PKCS#12 file.
 
-ifdef::asciidoctor[]
 [#{ssl-context}-pkcs11-tokens]
 ===== PKCS#11 Tokens
-endif::[]
-ifndef::asciidoctor[]
-===== anchor:{ssl-context}-pkcs11-tokens[] PKCS#11 Tokens
-endif::[]
 
 {es} can be configured to use a PKCS#11 token that contains the private key,
 certificate and certificates that should be trusted.


### PR DESCRIPTION
To prepare for the Asciidoctor migration, several `ifdef::asciidoctor` conditionals were added so that AsciiDoc and Asciidoctor doc builds rendered consistently.

With https://github.com/elastic/docs/pull/827 merged, the Elasticsearch Reference book migrated completely to Asciidoctor. This PR removes those conditionals as we no longer need to support AsciiDoc.

Resolves #41722