### PR TITLE
[DOCS] Remove unneeded options from SQL code blocks

### DIFF
--- a/docs/reference/sql/functions/conditional.asciidoc
+++ b/docs/reference/sql/functions/conditional.asciidoc
@@ -33,17 +33,17 @@ If the condition’s result is true, the value of the result expression that fol
 the subsequent when clauses will be skipped and not processed.
 
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[case]
 ----
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[caseReturnNull]
 ----
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[caseWithElse]
 ----
@@ -70,12 +70,12 @@ CASE WHEN expression = value1 THEN result1
 END
 ----
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[caseWithOperand]
 ----
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[caseWithOperandAndElse]
 ----
@@ -155,12 +155,12 @@ If all arguments are null, then it returns `null`.
 
 
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[coalesceReturnNonNull]
 ----
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[coalesceReturnNull]
 ----
@@ -199,12 +199,12 @@ If all arguments are null, then it returns `null`.
 
 
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[greatestReturnNonNull]
 ----
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[greatestReturnNull]
 ----
@@ -237,12 +237,12 @@ If all arguments are null, then it returns `null`.
 
 
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[ifNullReturnFirst]
 ----
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[ifNullReturnSecond]
 ----
@@ -277,12 +277,12 @@ logic of programming languages. If the 3rd expression is not provided and the co
 `null` is returned.
 
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[iifWithDefaultValue]
 ----
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[iifWithoutDefaultValue]
 ----
@@ -325,12 +325,12 @@ If all arguments are null, then it returns `null`.
 
 
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[isNullReturnFirst]
 ----
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[isNullReturnSecond]
 ----
@@ -370,12 +370,12 @@ If all arguments are null, then it returns `null`.
 
 
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[leastReturnNonNull]
 ----
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[leastReturnNull]
 ----
@@ -407,12 +407,12 @@ Returns `null` when the two input expressions are equal and
 if not, it returns the 1st expression.
 
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[nullIfReturnFirst]
 ----
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[nullIfReturnNull]
 ----
@@ -446,12 +446,12 @@ If all arguments are null, then it returns `null`.
 
 
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[nvlReturnFirst]
 ----
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[nvlReturnSecond]
 ----

--- a/docs/reference/sql/functions/date-time.asciidoc
+++ b/docs/reference/sql/functions/date-time.asciidoc
@@ -57,32 +57,32 @@ s|Description
 
 Basic arithmetic operators (`+`, `-`, etc) support date/time parameters as indicated below:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[dtIntervalPlusInterval]
 --------------------------------------------------
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[dtDateTimePlusInterval]
 --------------------------------------------------
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[dtMinusInterval]
 --------------------------------------------------
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[dtIntervalMinusInterval]
 --------------------------------------------------
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[dtDateTimeMinusInterval]
 --------------------------------------------------
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[dtIntervalMul]
 --------------------------------------------------
@@ -116,17 +116,17 @@ Unlike CURRENT_DATE, `CURDATE()` can only be used as a function with no argument
 
 This method always returns the same value for its every occurrence within the same query.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[currentDate]
 --------------------------------------------------
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[currentDateFunction]
 --------------------------------------------------
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[curDateFunction]
 --------------------------------------------------
@@ -134,7 +134,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[curDateFunction]
 Typically, this function (as well as its twin <<sql-functions-today,TODAY())>> function
 is used for relative date filtering:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[filterToday]
 --------------------------------------------------
@@ -165,29 +165,29 @@ meaning a milliseconds precision current time will be returned.
 
 This method always returns the same value for its every occurrence within the same query.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[currentTime]
 --------------------------------------------------
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[currentTimeFunction]
 --------------------------------------------------
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[curTimeFunction]
 --------------------------------------------------
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[currentTimeFunctionPrecision]
 --------------------------------------------------
 
 Typically, this function is used for relative date/time filtering:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[filterCurrentTime]
 --------------------------------------------------
@@ -221,17 +221,17 @@ meaning a milliseconds precision current date/time will be returned.
 
 This method always returns the same value for its every occurrence within the same query.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[curTs]
 --------------------------------------------------
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[curTsFunction]
 --------------------------------------------------
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[curTsFunctionPrecision]
 --------------------------------------------------
@@ -239,7 +239,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[curTsFunctionPrecision]
 Typically, this function (as well as its twin <<sql-functions-now,NOW())>> function is used for
 relative date/time filtering:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[filterNow]
 --------------------------------------------------
@@ -267,7 +267,7 @@ DAY_OF_MONTH(datetime_exp) <1>
 
 Extract the day of the month from a date/datetime.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[dayOfMonth]
 --------------------------------------------------
@@ -291,7 +291,7 @@ DAY_OF_WEEK(datetime_exp) <1>
 
 Extract the day of the week from a date/datetime. Sunday is `1`, Monday is `2`, etc.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[dayOfWeek]
 --------------------------------------------------
@@ -315,7 +315,7 @@ DAY_OF_YEAR(datetime_exp) <1>
 
 Extract the day of the year from a date/datetime.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[dayOfYear]
 --------------------------------------------------
@@ -339,7 +339,7 @@ DAY_NAME(datetime_exp) <1>
 
 Extract the day of the week from a date/datetime in text format (`Monday`, `Tuesday`...).
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[dayName]
 --------------------------------------------------
@@ -363,7 +363,7 @@ HOUR_OF_DAY(datetime_exp) <1>
 
 Extract the hour of the day from a date/datetime.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[hourOfDay]
 --------------------------------------------------
@@ -388,7 +388,7 @@ ISO_DAY_OF_WEEK(datetime_exp) <1>
 Extract the day of the week from a date/datetime, following the https://en.wikipedia.org/wiki/ISO_week_date[ISO 8601 standard].
 Monday is `1`, Tuesday is `2`, etc.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[isoDayOfWeek]
 --------------------------------------------------
@@ -413,7 +413,7 @@ ISO_WEEK_OF_YEAR(datetime_exp) <1>
 Extract the week of the year from a date/datetime, following https://en.wikipedia.org/wiki/ISO_week_date[ISO 8601 standard]. The first week
 of a year is the first week with a majority (4 or more) of its days in January.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[isoWeekOfYear]
 --------------------------------------------------
@@ -437,7 +437,7 @@ MINUTE_OF_DAY(datetime_exp) <1>
 
 Extract the minute of the day from a date/datetime.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[minuteOfDay]
 --------------------------------------------------
@@ -461,7 +461,7 @@ MINUTE_OF_HOUR(datetime_exp) <1>
 
 Extract the minute of the hour from a date/datetime.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[minuteOfHour]
 --------------------------------------------------
@@ -485,7 +485,7 @@ MONTH(datetime_exp) <1>
 
 Extract the month of the year from a date/datetime.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[monthOfYear]
 --------------------------------------------------
@@ -509,7 +509,7 @@ MONTH_NAME(datetime_exp) <1>
 
 Extract the month from a date/datetime in text format (`January`, `February`...).
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[monthName]
 --------------------------------------------------
@@ -533,7 +533,7 @@ This function offers the same functionality as <<sql-functions-current-timestamp
 the datetime when the current query reached the server. This method always returns the same value for its every
 occurrence within the same query.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[nowFunction]
 --------------------------------------------------
@@ -541,7 +541,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[nowFunction]
 Typically, this function (as well as its twin <<sql-functions-current-timestamp,CURRENT_TIMESTAMP())>> function is used
 for relative date/time filtering:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[filterNow]
 --------------------------------------------------
@@ -565,7 +565,7 @@ SECOND_OF_MINUTE(datetime_exp) <1>
 
 Extract the second of the minute from a date/datetime.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[secondOfMinute]
 --------------------------------------------------
@@ -589,7 +589,7 @@ QUARTER(datetime_exp) <1>
 
 Extract the year quarter the date/datetime falls in.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[quarter]
 --------------------------------------------------
@@ -613,7 +613,7 @@ This function offers the same functionality as <<sql-functions-current-date,CURR
 the date when the current query reached the server. This method always returns the same value for its every occurrence
 within the same query.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[todayFunction]
 --------------------------------------------------
@@ -621,7 +621,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[todayFunction]
 Typically, this function (as well as its twin <<sql-functions-current-timestamp,CURRENT_TIMESTAMP())>> function is used
 for relative date filtering:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[filterToday]
 --------------------------------------------------
@@ -645,7 +645,7 @@ WEEK_OF_YEAR(datetime_exp) <1>
 
 Extract the week of the year from a date/datetime.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[weekOfYear]
 --------------------------------------------------
@@ -669,7 +669,7 @@ YEAR(datetime_exp) <1>
 
 Extract the year from a date/datetime.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[year]
 --------------------------------------------------
@@ -697,14 +697,14 @@ EXTRACT(
 Extract fields from a date/datetime by specifying the name of a <<sql-functions-datetime,datetime function>>.
 The following
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[extractDayOfYear]
 --------------------------------------------------
 
 is the equivalent to
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[dayOfYear]
 --------------------------------------------------

--- a/docs/reference/sql/functions/grouping.asciidoc
+++ b/docs/reference/sql/functions/grouping.asciidoc
@@ -44,14 +44,14 @@ NOTE:: The histogram in SQL does *NOT* return empty buckets for missing interval
 `Histogram` can be applied on either numeric fields:
 
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[histogramNumeric]
 ----
 
 or date/time fields:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[histogramDateTime]
 ----
@@ -59,14 +59,14 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[histogramDateTime]
 Expressions inside the histogram are also supported as long as the
 return type is numeric:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[histogramNumericExpression]
 ----
 
 Do note that histograms (and grouping functions in general) allow custom expressions but cannot have any functions applied to them in the `GROUP BY`. In other words, the following statement is *NOT* allowed:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[expressionOnHistogramNotAllowed]
 ----
@@ -75,7 +75,7 @@ as it requires two groupings (one for histogram followed by a second for applyin
 
 Instead one can rewrite the query to move the expression on the histogram _inside_ of it:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[histogramDateTimeExpression]
 ----

--- a/docs/reference/sql/functions/like-rlike.asciidoc
+++ b/docs/reference/sql/functions/like-rlike.asciidoc
@@ -38,7 +38,7 @@ with the `LIKE` operator:
 The percent sign represents zero, one or multiple characters. The underscore represents a single number or character. These symbols can be
 used in combinations.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[simpleLike]
 ----
@@ -75,7 +75,7 @@ and underscore (`_`); the pattern in this case is a regular expression which all
 For more details about the regular expressions syntax, https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html[Java's Pattern class javadoc]
 is a good starting point.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[simpleRLike]
 ----

--- a/docs/reference/sql/functions/operators.asciidoc
+++ b/docs/reference/sql/functions/operators.asciidoc
@@ -8,7 +8,7 @@ Boolean operator for comparing against one or multiple expressions.
 [[sql-operators-equality]]
 ==== `Equality (=)`
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/filter.sql-spec[whereFieldEquality]
 --------------------------------------------------
@@ -16,12 +16,12 @@ include-tagged::{sql-specs}/filter.sql-spec[whereFieldEquality]
 [[sql-operators-null-safe-equality]]
 ==== `Null safe Equality (<=>)`
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[nullEqualsCompareWithNull]
 --------------------------------------------------
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[nullEqualsCompareTwoNulls]
 --------------------------------------------------
@@ -29,7 +29,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[nullEqualsCompareTwoNulls]
 [[sql-operators-inequality]]
 ==== `Inequality (<> or !=)`
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/filter.sql-spec[whereFieldNonEquality]
 --------------------------------------------------
@@ -37,7 +37,7 @@ include-tagged::{sql-specs}/filter.sql-spec[whereFieldNonEquality]
 [[sql-operators-comparison]]
 ==== `Comparison (<, <=, >, >=)`
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/filter.sql-spec[whereFieldLessThan]
 --------------------------------------------------
@@ -45,7 +45,7 @@ include-tagged::{sql-specs}/filter.sql-spec[whereFieldLessThan]
 [[sql-operators-between]]
 ==== `BETWEEN`
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/filter.sql-spec[whereBetween]
 --------------------------------------------------
@@ -53,7 +53,7 @@ include-tagged::{sql-specs}/filter.sql-spec[whereBetween]
 [[sql-operators-is-null]]
 ==== `IS NULL/IS NOT NULL`
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/filter.sql-spec[whereIsNotNullAndIsNull]
 --------------------------------------------------
@@ -61,7 +61,7 @@ include-tagged::{sql-specs}/filter.sql-spec[whereIsNotNullAndIsNull]
 [[sql-operators-in]]
 ==== `IN (<value1>, <value2>, ...)`
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/filter.sql-spec[whereWithInAndMultipleValues]
 --------------------------------------------------
@@ -74,7 +74,7 @@ Boolean operator for evaluating one or two expressions.
 [[sql-operators-and]]
 ==== `AND`
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/filter.sql-spec[whereFieldAndComparison]
 --------------------------------------------------
@@ -82,7 +82,7 @@ include-tagged::{sql-specs}/filter.sql-spec[whereFieldAndComparison]
 [[sql-operators-or]]
 ==== `OR`
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/filter.sql-spec[whereFieldOrComparison]
 --------------------------------------------------
@@ -90,7 +90,7 @@ include-tagged::{sql-specs}/filter.sql-spec[whereFieldOrComparison]
 [[sql-operators-not]]
 ==== `NOT`
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/filter.sql-spec[whereFieldEqualityNot]
 --------------------------------------------------
@@ -104,7 +104,7 @@ The result is a value of numeric type.
 [[sql-operators-plus]]
 ==== `Add (+)`
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/arithmetic.sql-spec[plus]
 --------------------------------------------------
@@ -112,7 +112,7 @@ include-tagged::{sql-specs}/arithmetic.sql-spec[plus]
 [[sql-operators-subtract]]
 ==== `Subtract (infix -)`
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/arithmetic.sql-spec[minus]
 --------------------------------------------------
@@ -120,7 +120,7 @@ include-tagged::{sql-specs}/arithmetic.sql-spec[minus]
 [[sql-operators-negate]]
 ==== `Negate (unary -)`
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/arithmetic.sql-spec[unaryMinus]
 --------------------------------------------------
@@ -128,7 +128,7 @@ include-tagged::{sql-specs}/arithmetic.sql-spec[unaryMinus]
 [[sql-operators-multiply]]
 ==== `Multiply (*)`
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/arithmetic.sql-spec[multiply]
 --------------------------------------------------
@@ -136,7 +136,7 @@ include-tagged::{sql-specs}/arithmetic.sql-spec[multiply]
 [[sql-operators-divide]]
 ==== `Divide (/)`
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/arithmetic.sql-spec[divide]
 --------------------------------------------------
@@ -144,7 +144,7 @@ include-tagged::{sql-specs}/arithmetic.sql-spec[divide]
 [[sql-operators-remainder]]
 ==== `Modulo or Remainder(%)`
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/arithmetic.sql-spec[mod]
 --------------------------------------------------
@@ -157,7 +157,7 @@ include-tagged::{sql-specs}/arithmetic.sql-spec[mod]
 
 `::` provides an alternative syntax to the <<sql-functions-type-conversion-cast>> function.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[conversionStringToLongCastOperator]
 --------------------------------------------------

--- a/docs/reference/sql/functions/search.asciidoc
+++ b/docs/reference/sql/functions/search.asciidoc
@@ -33,7 +33,7 @@ and <<query-dsl-multi-match-query,multi_match>> {es} queries.
 
 The first parameter is the field or fields to match against. In case it receives one value only, {es-sql} will use a `match` query to perform the search:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[simpleMatch]
 ----
@@ -41,7 +41,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[simpleMatch]
 However, it can also receive a list of fields and their corresponding optional `boost` value. In this case, {es-sql} will use a
 `multi_match` query to match the documents:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[multiFieldsMatch]
 ----
@@ -53,7 +53,7 @@ the final score than the `author` field when searching for `frank dune` text in 
 Both options above can be used in combination with the optional third parameter of the `MATCH()` predicate, where one can specify
 additional configuration parameters (separated by semicolon `;`) for either `match` or `multi_match` queries. For example:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[optionalParamsForMatch]
 ----
@@ -95,14 +95,14 @@ Just like `MATCH`, `QUERY` is a full-text search predicate that gives the user c
 The first parameter is basically the input that will be passed as is to the `query_string` query, which means that anything that `query_string`
 accepts in its `query` field can be used here as well:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[simpleQueryQuery]
 ----
 
 A more advanced example, showing more of the features that `query_string` supports, of course possible with {es-sql}:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[advancedQueryQuery]
 ----
@@ -113,7 +113,7 @@ regex and fuzziness queries for the `name` field.
 If one needs to customize various configuration options that `query_string` exposes, this can be done using the second _optional_ parameter.
 Multiple settings can be specified separated by a semicolon `;`:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[optionalParameterQuery]
 ----
@@ -149,14 +149,14 @@ combined using the same rules as {es}'s
 
 Typically `SCORE` is used for ordering the results of a query based on their relevance:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[orderByScore]
 ----
 
 However, it is perfectly fine to return the score without sorting by it:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[scoreWithMatch]
 ----

--- a/docs/reference/sql/functions/string.asciidoc
+++ b/docs/reference/sql/functions/string.asciidoc
@@ -24,7 +24,7 @@ ASCII(string_exp) <1>
 
 Returns the ASCII code value of the leftmost character of `string_exp` as an integer.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[stringAscii]
 --------------------------------------------------
@@ -47,7 +47,7 @@ BIT_LENGTH(string_exp) <1>
 
 Returns the length in bits of the `string_exp` input expression.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[stringBitLength]
 --------------------------------------------------
@@ -70,7 +70,7 @@ CHAR(code) <1>
 
 Returns the character that has the ASCII code value specified by the numeric input. The value should be between 0 and 255; otherwise, the return value is data source–dependent.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[stringChar]
 --------------------------------------------------
@@ -93,7 +93,7 @@ CHAR_LENGTH(string_exp) <1>
 
 Returns the length in characters of the input, if the string expression is of a character data type; otherwise, returns the length in bytes of the string expression (the smallest integer not less than the number of bits divided by 8).
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[stringCharLength]
 --------------------------------------------------
@@ -119,7 +119,7 @@ CONCAT(
 
 Returns a character string that is the result of concatenating `string_exp1` to `string_exp2`. If one of the string is `NULL`, the other string will be returned.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[stringConcat]
 --------------------------------------------------
@@ -149,7 +149,7 @@ INSERT(
 
 Returns a string where `length` characters have been deleted from `source`, beginning at `start`, and where `replacement` has been inserted into `source`, beginning at `start`.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[stringInsert]
 --------------------------------------------------
@@ -172,7 +172,7 @@ LCASE(string_exp) <1>
 
 Returns a string equal to that in `string_exp`, with all uppercase characters converted to lowercase.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[stringLCase]
 --------------------------------------------------
@@ -198,7 +198,7 @@ LEFT(
 
 Returns the leftmost count characters of `string_exp`.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[stringLeft]
 --------------------------------------------------
@@ -221,7 +221,7 @@ LENGTH(string_exp) <1>
 
 Returns the number of characters in `string_exp`, excluding trailing blanks.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[stringLength]
 --------------------------------------------------
@@ -250,12 +250,12 @@ LOCATE(
 
 Returns the starting position of the first occurrence of `pattern` within `source`. The search for the first occurrence of `pattern` begins with the first character position in `source` unless the optional argument, `start`, is specified. If `start` is specified, the search begins with the character position indicated by the value of `start`. The first character position in `source` is indicated by the value 1. If `pattern` is not found within `source`, the value 0 is returned.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[stringLocateWoStart]
 --------------------------------------------------
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[stringLocateWithStart]
 --------------------------------------------------
@@ -278,7 +278,7 @@ LTRIM(string_exp) <1>
 
 Returns the characters of `string_exp`, with leading blanks removed.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[stringLTrim]
 --------------------------------------------------
@@ -301,7 +301,7 @@ OCTET_LENGTH(string_exp) <1>
 
 Returns the length in bytes of the `string_exp` input expression.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[stringOctetLength]
 --------------------------------------------------
@@ -327,7 +327,7 @@ POSITION(
 
 Returns the position of the `string_exp1` in `string_exp2`. The result is an exact numeric.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[stringPosition]
 --------------------------------------------------
@@ -353,7 +353,7 @@ REPEAT(
 
 Returns a character string composed of `string_exp` repeated `count` times.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[stringRepeat]
 --------------------------------------------------
@@ -381,7 +381,7 @@ REPLACE(
 
 Search `source` for occurrences of `pattern`, and replace with `replacement`.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[stringReplace]
 --------------------------------------------------
@@ -407,7 +407,7 @@ RIGHT(
 
 Returns the rightmost count characters of `string_exp`.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[stringRight]
 --------------------------------------------------
@@ -430,7 +430,7 @@ RTRIM(string_exp) <1>
 
 Returns the characters of `string_exp` with trailing blanks removed.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[stringRTrim]
 --------------------------------------------------
@@ -453,7 +453,7 @@ SPACE(count) <1>
 
 Returns a character string consisting of `count` spaces.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[stringSpace]
 --------------------------------------------------
@@ -481,7 +481,7 @@ SUBSTRING(
 
 Returns a character string that is derived from `source`, beginning at the character position specified by `start` for `length` characters.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[stringSubString]
 --------------------------------------------------
@@ -504,7 +504,7 @@ UCASE(string_exp) <1>
 
 Returns a string equal to that of the input, with all lowercase characters converted to uppercase.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[stringUCase]
 --------------------------------------------------

--- a/docs/reference/sql/functions/system.asciidoc
+++ b/docs/reference/sql/functions/system.asciidoc
@@ -24,7 +24,7 @@ Returns the name of the database being queried. In the case of Elasticsearch SQL
 is the name of the Elasticsearch cluster. This function should always return a non-null
 value.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[database]
 --------------------------------------------------
@@ -46,7 +46,7 @@ USER()
 Returns the username of the authenticated user executing the query. This function can
 return `null` in case {stack-ov}/elasticsearch-security.html[Security] is disabled.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[user]
 --------------------------------------------------

--- a/docs/reference/sql/functions/type-conversion.asciidoc
+++ b/docs/reference/sql/functions/type-conversion.asciidoc
@@ -25,17 +25,17 @@ Casts the result of the given expression to the target <<sql-data-types, data ty
 If the cast is not possible (for example because of target type is too narrow or because
 the value itself cannot be converted), the query fails.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[conversionStringToIntCast]
 ----
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[conversionIntToStringCast]
 ----
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[conversionStringToDateTimeCast]
 ----
@@ -66,12 +66,12 @@ Works exactly like <<sql-functions-type-conversion-cast>> with slightly differen
 Moreover, apart from the standard <<sql-data-types, data types>> it supports the corresponding
 https://docs.microsoft.com/en-us/sql/odbc/reference/appendixes/explicit-data-type-conversion-function?view=sql-server-2017[ODBC data types].
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[conversionStringToIntConvertODBCDataType]
 ----
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[conversionStringToIntConvertESDataType]
 ----

--- a/docs/reference/sql/language/indices.asciidoc
+++ b/docs/reference/sql/language/indices.asciidoc
@@ -14,7 +14,7 @@ is supported _as long_ as it is quoted or escaped as a table identifier.
 
 For example:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[showTablesEsMultiIndex]
 ----
@@ -28,7 +28,7 @@ The same kind of patterns can also be used to query multiple indices or tables.
 
 For example:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[fromTablePatternQuoted]
 ----
@@ -44,7 +44,7 @@ or multiple `%` characters.
 
 Using `SHOW TABLES` command again:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[showTablesLikeWildcard]
 ----
@@ -53,7 +53,7 @@ The pattern matches all tables that start with `emp`.
 
 This command supports _escaping_ as well, for example:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[showTablesLikeEscape]
 ----
@@ -101,13 +101,13 @@ Set to `true` properties `index_include_frozen` in the <<sql-rest>> or `index.in
 dedicated keyword::
 Explicitly perform the inclusion through the dedicated `FROZEN` keyword in the `FROM` clause or `INCLUDE FROZEN` in the `SHOW` commands:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[showTablesIncludeFrozen]
 ----
 
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[fromTableIncludeFrozen]
 ----

--- a/docs/reference/sql/language/syntax/commands/describe-table.asciidoc
+++ b/docs/reference/sql/language/syntax/commands/describe-table.asciidoc
@@ -30,7 +30,7 @@ DESC
 
 `DESC` and `DESCRIBE` are aliases to <<sql-syntax-show-columns>>.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[describeTable]
 ----

--- a/docs/reference/sql/language/syntax/commands/select.asciidoc
+++ b/docs/reference/sql/language/syntax/commands/select.asciidoc
@@ -36,7 +36,7 @@ The general execution of `SELECT` is as follows:
 
 As with a table, every output column of a `SELECT` has a name which can be either specified per column through the `AS` keyword :
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[selectColumnAlias]
 ----
@@ -46,14 +46,14 @@ which is why it is recommended to specify it.
 
 assigned by {es-sql} if no name is given:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[selectInline]
 ----
 
 or if it's a simple column reference, use its name as the column name:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[selectColumn]
 ----
@@ -63,7 +63,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[selectColumn]
 
 To select all the columns in the source, one can use `*`:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[wildcardWithOrder]
 ----
@@ -89,14 +89,14 @@ Represents the name (optionally qualified) of an existing table, either a concre
 
 If the table name contains special SQL characters (such as `.`,`-`,`*`,etc...) use double quotes to escape them:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[fromTableQuoted]
 ----
 
 The name can be a <<multi-index, pattern>> pointing to multiple indices (likely requiring quoting as mentioned above) with the restriction that *all* resolved concrete tables have **exact mapping**.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[fromTablePatternQuoted]
 ----
@@ -104,7 +104,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[fromTablePatternQuoted]
 `alias`::
 A substitute name for the `FROM` item containing the alias. An alias is used for brevity or to eliminate ambiguity. When an alias is provided, it completely hides the actual name of the table and must be used in its place.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[fromTableAlias]
 ----
@@ -125,7 +125,7 @@ where:
 
 Represents an expression that evaluates to a `boolean`. Only the rows that match the condition (to `true`) are returned.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[basicWhere]
 ----
@@ -148,34 +148,34 @@ Represents an expression on which rows are being grouped _on_. It can be a colum
 
 A common, group by column name:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[groupByColumn]
 ----
 
 Grouping by output ordinal:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[groupByOrdinal]
 ----
 
 Grouping by alias:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[groupByAlias]
 ----
 
 And grouping by column expression (typically used along-side an alias):
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[groupByExpression]
 ----
 
 Or a mixture of the above:
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[groupByMulti]
 ----
@@ -185,21 +185,21 @@ When a `GROUP BY` clause is used in a `SELECT`, _all_ output expressions must be
 
 To wit:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[groupByAndAgg]
 ----
 
 Expressions over aggregates used in output:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[groupByAndAggExpression]
 ----
 
 Multiple aggregates used:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[groupByAndMultipleAggs]
 ----
@@ -216,14 +216,14 @@ As such, the query emits only a single row (as there is only a single group).
 
 A common example is counting the number of records:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[groupByImplicitCount]
 ----
 
 Of course, multiple aggregations can be applied:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[groupByImplicitMultipleAggs]
 ----
@@ -249,14 +249,14 @@ Both `WHERE` and `HAVING` are used for filtering however there are several signi
 . `WHERE` works on individual *rows*, `HAVING` works on the *groups* created by ``GROUP BY``
 . `WHERE` is evaluated *before* grouping, `HAVING` is evaluated *after* grouping
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[groupByHaving]
 ----
 
 Further more, one can use multiple aggregate expressions inside `HAVING` even ones that are not used in the output (`SELECT`):
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[groupByHavingMultiple]
 ----
@@ -269,14 +269,14 @@ As such, the query emits only a single row (as there is only a single group) and
 
 In this example, `HAVING` matches:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[groupByHavingImplicitMatch]
 ----
 
 //However `HAVING` can also not match, in which case an empty result is returned:
 //
-//["source","sql",subs="attributes,callouts,macros"]
+//[source, sql]
 //----
 //include-tagged::{sql-specs}/docs/docs.csv-spec[groupByHavingImplicitNoMatch]
 //----
@@ -304,7 +304,7 @@ IMPORTANT: When used along-side, `GROUP BY` expression can point _only_ to the c
 
 For example, the following query sorts by an arbitrary input field (`page_count`):
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[orderByBasic]
 ----
@@ -318,20 +318,20 @@ NOTE: With `GROUP BY`, make sure the ordering targets the resulting group - appl
 
 For example, to order groups simply indicate the grouping key:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[orderByGroup]
 ----
 
 Multiple keys can be specified of course:
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[groupByMulti]
 ----
 
 Further more, it is possible to order groups based on aggregations of their values:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[orderByAgg]
 ----
@@ -352,7 +352,7 @@ combined using the same rules as {es}'s
 
 To sort based on the `score`, use the special function `SCORE()`:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[orderByScore]
 ----
@@ -360,7 +360,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[orderByScore]
 Note that you can return `SCORE()` by using a full-text search predicate in the `WHERE` clause.
 This is possible even if `SCORE()` is not used for sorting:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[orderByScoreWithMatch]
 ----
@@ -387,7 +387,7 @@ ALL:: indicates there is no limit and thus all results are being returned.
 
 To return 
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[limitBasic]
 ----

--- a/docs/reference/sql/language/syntax/commands/show-columns.asciidoc
+++ b/docs/reference/sql/language/syntax/commands/show-columns.asciidoc
@@ -21,7 +21,7 @@ patterns.
 
 List the columns in table and their data type (and other attributes).
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[showColumns]
 ----

--- a/docs/reference/sql/language/syntax/commands/show-functions.asciidoc
+++ b/docs/reference/sql/language/syntax/commands/show-functions.asciidoc
@@ -15,7 +15,7 @@ SHOW FUNCTIONS [LIKE pattern?]? <1>
 
 List all the SQL functions and their type. The `LIKE` clause can be used to restrict the list of names to the given pattern.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[showFunctions]
 ----
@@ -23,25 +23,25 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[showFunctions]
 The list of functions returned can be customized based on the pattern.
 
 It can be an exact match:
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[showFunctionsLikeExact]
 ----
 
 A wildcard for exactly one character:
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[showFunctionsLikeChar]
 ----
 
 A wildcard matching zero or more characters:
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[showFunctionsLikeWildcard]
 ----
 
 Or of course, a variation of the above:
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[showFunctionsWithPattern]
 ----

--- a/docs/reference/sql/language/syntax/commands/show-tables.asciidoc
+++ b/docs/reference/sql/language/syntax/commands/show-tables.asciidoc
@@ -24,7 +24,7 @@ patterns.
 
 List the tables available to the current user and their type.
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[showTables]
 ----
@@ -32,7 +32,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[showTables]
 Match multiple indices by using {es} <<multi-index,multi index syntax>>
 notation:
 
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[showTablesEsMultiIndex]
 ----
@@ -40,26 +40,26 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[showTablesEsMultiIndex]
 One can also use the `LIKE` clause to restrict the list of names to the given pattern.
 
 The pattern can be an exact match:
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[showTablesLikeExact]
 ----
 
 Multiple chars:
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[showTablesLikeWildcard]
 ----
 
 A single char:
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[showTablesLikeOneChar]
 ----
 
 
 Or a mixture of single and multiple chars:
-["source","sql",subs="attributes,callouts,macros"]
+[source, sql]
 ----
 include-tagged::{sql-specs}/docs/docs.csv-spec[showTablesLikeMixed]
 ----

--- a/docs/reference/sql/security.asciidoc
+++ b/docs/reference/sql/security.asciidoc
@@ -33,7 +33,7 @@ the API require `cluster:monitor/main`.
 The following example configures a role that can run SQL in JDBC querying the `test` and `bort`
 indices:
 
-["source","yaml",subs="attributes,callouts,macros"]
+[source, yaml]
 --------------------------------------------------
 include-tagged::{sql-tests}/security/roles.yml[cli_drivers]
 --------------------------------------------------

--- a/x-pack/plugin/sql/qa/src/main/resources/docs/docs.csv-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/docs/docs.csv-spec
@@ -643,9 +643,9 @@ M              |57
 ;
 
 groupByAndAggExpression
-// tag::groupByAndAggExpression
 schema::g:s|salary:i
-SELECT gender AS g, ROUND( (MIN(salary) / 100) ) AS salary FROM emp GROUP BY gender;
+// tag::groupByAndAggExpression
+SELECT gender AS g, ROUND((MIN(salary) / 100)) AS salary FROM emp GROUP BY gender;
 
        g       |    salary     
 ---------------+---------------


### PR DESCRIPTION
In AsciiDoc, `subs="attributes,callouts,macros"` options were required
to render `include-tagged::` in a code block.

With elastic/docs#827, Elasticsearch Reference documentation migrated
from AsciiDoc to Asciidoctor.

In Asciidoctor, the `subs="attributes,callouts,macros"` options are no
longer needed to render `include-tagged::` in a code block. This PR
removes those unneeded options.

Resolves #41589