### PR TITLE
[FEATURE][ML] Ignore `index.version.upgraded` index setting

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
@@ -60,7 +60,8 @@ public class DataFrameAnalyticsManager {
         "index.creation_date",
         "index.provided_name",
         "index.uuid",
-        "index.version.created"
+        "index.version.created",
+        "index.version.upgraded"
     );
 
     private final ClusterService clusterService;


### PR DESCRIPTION
When a data frame analytics job reindexes the source index into the
dest index, we try to preserve settings. However, some settings are
internal and are not valid during index creation. This commit
adds `index.version.upgraded` to the list of ignored settings.
