### PR TITLE
Correct Watcher docs for allocation rules

### DIFF
--- a/x-pack/docs/en/watcher/how-watcher-works.asciidoc
+++ b/x-pack/docs/en/watcher/how-watcher-works.asciidoc
@@ -156,7 +156,7 @@ then configure the `.watches` index like this:
 ------------------------
 PUT .watches/_settings
 {
-  "index.routing.allocation.include": "watcher"
+  "index.routing.allocation.include.watcher": true
 }
 ------------------------
 // CONSOLE


### PR DESCRIPTION
The example of how to control the allocation of `.watches` was
incorrect, and it is not tested. This commit corrects that example.