### PR TITLE
Do not close threadpool if termination fails

### DIFF
--- a/server/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/server/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -374,7 +374,14 @@ public abstract class TransportClient extends AbstractClient {
         for (LifecycleComponent plugin : pluginLifecycleComponents) {
             closeables.add(plugin);
         }
-        closeables.add(() -> ThreadPool.terminate(injector.getInstance(ThreadPool.class), 10, TimeUnit.SECONDS));
+        closeables.add(() -> {
+            final ThreadPool pool = injector.getInstance(ThreadPool.class);
+            final boolean terminated = ThreadPool.terminate(pool, 10, TimeUnit.SECONDS);
+            if (terminated == false) {
+                // the pool is only closed if termination succeeds, just close even if termination failed
+                pool.close();
+            }
+        });
         IOUtils.closeWhileHandlingException(closeables);
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/client/NoOpClient.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/client/NoOpClient.java
@@ -57,10 +57,15 @@ public class NoOpClient extends AbstractClient {
 
     @Override
     public void close() {
+        boolean terminated = false;
         try {
-            ThreadPool.terminate(threadPool(), 10, TimeUnit.SECONDS);
+            terminated = ThreadPool.terminate(threadPool(), 10, TimeUnit.SECONDS);
         } catch (Exception e) {
             throw new ElasticsearchException(e.getMessage(), e);
+        }
+
+        if (terminated == false) {
+            throw new IllegalStateException("threadpool was not terminated after waiting for 10 seconds");
         }
     }
 }


### PR DESCRIPTION
This commit changes the code so that the threadpool is not closed
unless termination succeeds. Otherwise there can still be running tasks
that rely on resources that are closed by closing the threadpool.

Additionally, there is a test fix included for the NodeTests that
ensures the submitted task is actually running prior to closing the
node in the test.

Closes #42577