### PR TITLE
Remove alpha/beta/rc from version constants

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,10 +104,7 @@ subprojects {
 
 /* Introspect all versions of ES that may be tested against for backwards
  * compatibility. It is *super* important that this logic is the same as the
- * logic in VersionUtils.java, throwing out alphas because they don't have any
- * backwards compatibility guarantees and only keeping the latest beta or rc
- * in a branch if there are only betas and rcs in the branch so we have
- * *something* to test against. */
+ * logic in VersionUtils.java. */
 BwcVersions versions = new BwcVersions(file('server/src/main/java/org/elasticsearch/Version.java').readLines('UTF-8'))
 
 // build metadata from previous build, contains eg hashes for bwc builds

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -284,7 +284,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
 
             for (int i = DeclaredVersionsHolder.DECLARED_VERSIONS.size() - 1; i >= 0; i--) {
                 final Version candidateVersion = DeclaredVersionsHolder.DECLARED_VERSIONS.get(i);
-                if (candidateVersion.major == major - 1 && candidateVersion.isRelease() && after(candidateVersion)) {
+                if (candidateVersion.major == major - 1 && after(candidateVersion)) {
                     if (bwcVersion != null && candidateVersion.minor < bwcVersion.minor) {
                         break;
                     }
@@ -340,27 +340,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(major).append('.').append(minor).append('.').append(revision);
-        if (isAlpha()) {
-            sb.append("-alpha");
-            sb.append(build);
-        } else if (isBeta()) {
-            if (major >= 2) {
-                sb.append("-beta");
-            } else {
-                sb.append(".Beta");
-            }
-            sb.append(major < 5 ? build : build-25);
-        } else if (build < 99) {
-            if (major >= 2) {
-                sb.append("-rc");
-            } else {
-                sb.append(".RC");
-            }
-            sb.append(build - 50);
-        }
-        return sb.toString();
+        return major + "." + minor + "." + revision;
     }
 
     @Override
@@ -386,27 +366,6 @@ public class Version implements Comparable<Version>, ToXContentFragment {
         return id;
     }
 
-    public boolean isBeta() {
-        return major < 5 ? build < 50 : build >= 25 && build < 50;
-    }
-
-    /**
-     * Returns true iff this version is an alpha version
-     * Note: This has been introduced in elasticsearch version 5. Previous versions will never
-     * have an alpha version.
-     */
-    public boolean isAlpha() {
-        return major < 5 ? false :  build < 25;
-    }
-
-    public boolean isRC() {
-        return build > 50 && build < 99;
-    }
-
-    public boolean isRelease() {
-        return build == 99;
-    }
-
     /**
      * Extracts a sorted list of declared version constants from a class.
      * The argument would normally be Version.class but is exposed for
@@ -428,7 +387,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
                 case "V_EMPTY":
                     continue;
             }
-            assert field.getName().matches("V(_\\d+)+(_(alpha|beta|rc)\\d+)?") : field.getName();
+            assert field.getName().matches("V(_\\d+){3}?") : field.getName();
             try {
                 versions.add(((Version) field.get(null)));
             } catch (final IllegalAccessException e) {

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -169,7 +169,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
             version = version.substring(0, version.length() - 9);
         }
         String[] parts = version.split("[.-]");
-        if (parts.length < 3 || parts.length > 4) {
+        if (parts.length != 3) {
             throw new IllegalArgumentException(
                     "the version needs to contain major, minor, and revision, and optionally the build: " + version);
         }
@@ -182,31 +182,13 @@ public class Version implements Comparable<Version>, ToXContentFragment {
             if (rawMajor >=7 && parts.length == 4) { // we don't support qualifier as part of the version anymore
                 throw new IllegalArgumentException("illegal version format - qualifiers are only supported until version 6.x");
             }
-            final int betaOffset = rawMajor < 5 ? 0 : 25;
             //we reverse the version id calculation based on some assumption as we can't reliably reverse the modulo
             final int major = rawMajor * 1000000;
             final int minor = Integer.parseInt(parts[1]) * 10000;
             final int revision = Integer.parseInt(parts[2]) * 100;
 
-
-            int build = 99;
-            if (parts.length == 4) {
-                String buildStr = parts[3];
-                if (buildStr.startsWith("alpha")) {
-                    assert rawMajor >= 5 : "major must be >= 5 but was " + major;
-                    build = Integer.parseInt(buildStr.substring(5));
-                    assert build < 25 : "expected a alpha build but " + build + " >= 25";
-                } else if (buildStr.startsWith("Beta") || buildStr.startsWith("beta")) {
-                    build = betaOffset + Integer.parseInt(buildStr.substring(4));
-                    assert build < 50 : "expected a beta build but " + build + " >= 50";
-                } else if (buildStr.startsWith("RC") || buildStr.startsWith("rc")) {
-                    build = Integer.parseInt(buildStr.substring(2)) + 50;
-                } else {
-                    throw new IllegalArgumentException("unable to parse version " + version);
-                }
-            }
-
-            return fromId(major + minor + revision + build);
+            // TODO: 99 is leftover from alpha/beta/rc, it should be removed
+            return fromId(major + minor + revision + 99);
 
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("unable to parse version " + version, e);

--- a/server/src/test/java/org/elasticsearch/BuildTests.java
+++ b/server/src/test/java/org/elasticsearch/BuildTests.java
@@ -60,16 +60,6 @@ public class BuildTests extends ESTestCase {
 
         assertFalse(new Build(
             Build.CURRENT.flavor(), Build.CURRENT.type(), Build.CURRENT.shortHash(), Build.CURRENT.date(),
-            Build.CURRENT.isSnapshot(), "7.0.0-alpha1"
-        ).isProductionRelease());
-
-        assertFalse(new Build(
-            Build.CURRENT.flavor(), Build.CURRENT.type(), Build.CURRENT.shortHash(), Build.CURRENT.date(),
-            Build.CURRENT.isSnapshot(), "7.0.0-alpha1-SNAPSHOT"
-        ).isProductionRelease());
-
-        assertFalse(new Build(
-            Build.CURRENT.flavor(), Build.CURRENT.type(), Build.CURRENT.shortHash(), Build.CURRENT.date(),
             Build.CURRENT.isSnapshot(), "7.0.0-SNAPSHOT"
         ).isProductionRelease());
 

--- a/server/src/test/java/org/elasticsearch/VersionTests.java
+++ b/server/src/test/java/org/elasticsearch/VersionTests.java
@@ -66,11 +66,6 @@ public class VersionTests extends ESTestCase {
         assertThat(V_7_2_0.onOrAfter(V_7_2_0), is(true));
         assertThat(V_8_0_0.onOrAfter(V_7_2_0), is(true));
 
-        assertTrue(Version.fromString("5.0.0-alpha2").onOrAfter(Version.fromString("5.0.0-alpha1")));
-        assertTrue(Version.fromString("5.0.0").onOrAfter(Version.fromString("5.0.0-beta2")));
-        assertTrue(Version.fromString("5.0.0-rc1").onOrAfter(Version.fromString("5.0.0-beta24")));
-        assertTrue(Version.fromString("5.0.0-alpha24").before(Version.fromString("5.0.0-beta0")));
-
         assertThat(V_7_2_0, is(lessThan(V_8_0_0)));
         assertThat(V_7_2_0.compareTo(V_7_2_0), is(0));
         assertThat(V_8_0_0, is(greaterThan(V_7_2_0)));

--- a/server/src/test/java/org/elasticsearch/VersionTests.java
+++ b/server/src/test/java/org/elasticsearch/VersionTests.java
@@ -194,41 +194,12 @@ public class VersionTests extends ESTestCase {
     }
 
     public void testToString() {
-        // with 2.0.beta we lowercase
-        assertEquals("2.0.0-beta1", Version.fromString("2.0.0-beta1").toString());
-        assertEquals("5.0.0-alpha1", Version.fromId(5000001).toString());
+        assertEquals("5.0.0", Version.fromId(5000099).toString());
         assertEquals("2.3.0", Version.fromString("2.3.0").toString());
-        assertEquals("0.90.0.Beta1", Version.fromString("0.90.0.Beta1").toString());
-        assertEquals("1.0.0.Beta1", Version.fromString("1.0.0.Beta1").toString());
-        assertEquals("2.0.0-beta1", Version.fromString("2.0.0-beta1").toString());
-        assertEquals("5.0.0-beta1", Version.fromString("5.0.0-beta1").toString());
-        assertEquals("5.0.0-alpha1", Version.fromString("5.0.0-alpha1").toString());
-    }
-
-    public void testIsBeta() {
-        assertTrue(Version.fromString("2.0.0-beta1").isBeta());
-        assertTrue(Version.fromString("1.0.0.Beta1").isBeta());
-        assertTrue(Version.fromString("0.90.0.Beta1").isBeta());
-    }
-
-
-    public void testIsAlpha() {
-        assertTrue(new Version(5000001, org.apache.lucene.util.Version.LUCENE_7_0_0).isAlpha());
-        assertFalse(new Version(4000002, org.apache.lucene.util.Version.LUCENE_7_0_0).isAlpha());
-        assertTrue(new Version(4000002, org.apache.lucene.util.Version.LUCENE_7_0_0).isBeta());
-        assertTrue(Version.fromString("5.0.0-alpha14").isAlpha());
-        assertEquals(5000014, Version.fromString("5.0.0-alpha14").id);
-        assertTrue(Version.fromId(5000015).isAlpha());
-
-        for (int i = 0 ; i < 25; i++) {
-            assertEquals(Version.fromString("5.0.0-alpha" + i).id, Version.fromId(5000000 + i).id);
-            assertEquals("5.0.0-alpha" + i, Version.fromId(5000000 + i).toString());
-        }
-
-        for (int i = 0 ; i < 25; i++) {
-            assertEquals(Version.fromString("5.0.0-beta" + i).id, Version.fromId(5000000 + i + 25).id);
-            assertEquals("5.0.0-beta" + i, Version.fromId(5000000 + i + 25).toString());
-        }
+        assertEquals("0.90.0", Version.fromString("0.90.0").toString());
+        assertEquals("1.0.0", Version.fromString("1.0.0").toString());
+        assertEquals("2.0.0", Version.fromString("2.0.0").toString());
+        assertEquals("5.0.0", Version.fromString("5.0.0").toString());
     }
 
     public void testParseVersion() {
@@ -288,19 +259,8 @@ public class VersionTests extends ESTestCase {
                 }
                 assertEquals("Version id " + field.getName() + " does not point to " + constantName, v, Version.fromId(versionId));
                 assertEquals("Version " + constantName + " does not have correct id", versionId, v.id);
-                if (v.major >= 2) {
-                    String number = v.toString();
-                    if (v.isBeta()) {
-                        number = number.replace("-beta", "_beta");
-                    } else if (v.isRC()) {
-                        number = number.replace("-rc", "_rc");
-                    } else if (v.isAlpha()) {
-                        number = number.replace("-alpha", "_alpha");
-                    }
-                    assertEquals("V_" + number.replace('.', '_'), constantName);
-                } else {
-                    assertEquals("V_" + v.toString().replace('.', '_'), constantName);
-                }
+                String number = v.toString();
+                assertEquals("V_" + number.replace('.', '_'), constantName);
 
                 // only the latest version for a branch should be a snapshot (ie unreleased)
                 String branchName = "" + v.major + "." + v.minor;
@@ -328,8 +288,7 @@ public class VersionTests extends ESTestCase {
                     assertTrue("lucene versions must be "  + other + " >= " + version,
                         other.luceneVersion.onOrAfter(version.luceneVersion));
                 }
-                if (other.isAlpha() == false && version.isAlpha() == false
-                        && other.major == version.major && other.minor == version.minor) {
+                if (other.major == version.major && other.minor == version.minor) {
                     assertEquals(version + " vs. " + other, other.luceneVersion.major, version.luceneVersion.major);
                     assertEquals(version + " vs. " + other, other.luceneVersion.minor, version.luceneVersion.minor);
                     // should we also assert the lucene bugfix version?

--- a/server/src/test/java/org/elasticsearch/persistent/PersistentTasksCustomMetaDataTests.java
+++ b/server/src/test/java/org/elasticsearch/persistent/PersistentTasksCustomMetaDataTests.java
@@ -259,7 +259,7 @@ public class PersistentTasksCustomMetaDataTests extends AbstractDiffableSerializ
     public void testMinVersionSerialization() throws IOException {
         PersistentTasksCustomMetaData.Builder tasks = PersistentTasksCustomMetaData.builder();
 
-        Version minVersion = allReleasedVersions().stream().filter(Version::isRelease).findFirst().orElseThrow(NoSuchElementException::new);
+        Version minVersion = allReleasedVersions().stream().findFirst().orElseThrow(NoSuchElementException::new);
         final Version streamVersion = randomVersionBetween(random(), minVersion, getPreviousVersion(Version.CURRENT));
         tasks.addTask("test_compatible_version", TestPersistentTasksExecutor.NAME,
             new TestParams(null, randomVersionBetween(random(), minVersion, streamVersion),

--- a/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
@@ -190,10 +190,8 @@ public class VersionUtilsTests extends ESTestCase {
         public static final Version V_5_3_1 = Version.fromString("5.3.1");
         public static final Version V_5_3_2 = Version.fromString("5.3.2");
         public static final Version V_5_4_0 = Version.fromString("5.4.0");
-        public static final Version V_6_0_0_alpha1 = Version.fromString("6.0.0-alpha1");
-        public static final Version V_6_0_0_alpha2 = Version.fromString("6.0.0-alpha2");
-        public static final Version V_6_0_0_beta1 = Version.fromString("6.0.0-beta1");
-        public static final Version CURRENT = V_6_0_0_beta1;
+        public static final Version V_6_0_0 = Version.fromString("6.0.0-beta1");
+        public static final Version CURRENT = V_6_0_0;
     }
 
     public void testResolveReleasedVersionsForUnstableBranch() {
@@ -204,23 +202,17 @@ public class VersionUtilsTests extends ESTestCase {
 
         assertThat(released, equalTo(Arrays.asList(
             TestUnstableBranch.V_5_3_0,
-            TestUnstableBranch.V_5_3_1,
-            TestUnstableBranch.V_6_0_0_alpha1,
-            TestUnstableBranch.V_6_0_0_alpha2)));
+            TestUnstableBranch.V_5_3_1)));
         assertThat(unreleased, equalTo(Arrays.asList(
             TestUnstableBranch.V_5_3_2,
             TestUnstableBranch.V_5_4_0,
-            TestUnstableBranch.V_6_0_0_beta1)));
+            TestUnstableBranch.V_6_0_0)));
     }
 
     public static class TestNewMajorRelease {
         public static final Version V_5_6_0 = Version.fromString("5.6.0");
         public static final Version V_5_6_1 = Version.fromString("5.6.1");
         public static final Version V_5_6_2 = Version.fromString("5.6.2");
-        public static final Version V_6_0_0_alpha1 = Version.fromString("6.0.0-alpha1");
-        public static final Version V_6_0_0_alpha2 = Version.fromString("6.0.0-alpha2");
-        public static final Version V_6_0_0_beta1 = Version.fromString("6.0.0-beta1");
-        public static final Version V_6_0_0_beta2 = Version.fromString("6.0.0-beta2");
         public static final Version V_6_0_0 = Version.fromString("6.0.0");
         public static final Version V_6_0_1 = Version.fromString("6.0.1");
         public static final Version CURRENT = V_6_0_1;
@@ -235,10 +227,6 @@ public class VersionUtilsTests extends ESTestCase {
         assertThat(released, equalTo(Arrays.asList(
             TestNewMajorRelease.V_5_6_0,
             TestNewMajorRelease.V_5_6_1,
-            TestNewMajorRelease.V_6_0_0_alpha1,
-            TestNewMajorRelease.V_6_0_0_alpha2,
-            TestNewMajorRelease.V_6_0_0_beta1,
-            TestNewMajorRelease.V_6_0_0_beta2,
             TestNewMajorRelease.V_6_0_0)));
         assertThat(unreleased, equalTo(Arrays.asList(
             TestNewMajorRelease.V_5_6_2,
@@ -249,10 +237,6 @@ public class VersionUtilsTests extends ESTestCase {
         public static final Version V_5_6_0 = Version.fromString("5.6.0");
         public static final Version V_5_6_1 = Version.fromString("5.6.1");
         public static final Version V_5_6_2 = Version.fromString("5.6.2");
-        public static final Version V_6_0_0_alpha1 = Version.fromString("6.0.0-alpha1");
-        public static final Version V_6_0_0_alpha2 = Version.fromString("6.0.0-alpha2");
-        public static final Version V_6_0_0_beta1 = Version.fromString("6.0.0-beta1");
-        public static final Version V_6_0_0_beta2 = Version.fromString("6.0.0-beta2");
         public static final Version V_6_0_0 = Version.fromString("6.0.0");
         public static final Version V_6_0_1 = Version.fromString("6.0.1");
         public static final Version V_6_1_0 = Version.fromString("6.1.0");
@@ -268,10 +252,6 @@ public class VersionUtilsTests extends ESTestCase {
         assertThat(released, equalTo(Arrays.asList(
             TestVersionBumpIn6x.V_5_6_0,
             TestVersionBumpIn6x.V_5_6_1,
-            TestVersionBumpIn6x.V_6_0_0_alpha1,
-            TestVersionBumpIn6x.V_6_0_0_alpha2,
-            TestVersionBumpIn6x.V_6_0_0_beta1,
-            TestVersionBumpIn6x.V_6_0_0_beta2,
             TestVersionBumpIn6x.V_6_0_0)));
         assertThat(unreleased, equalTo(Arrays.asList(
             TestVersionBumpIn6x.V_5_6_2,
@@ -283,10 +263,6 @@ public class VersionUtilsTests extends ESTestCase {
         public static final Version V_5_6_0 = Version.fromString("5.6.0");
         public static final Version V_5_6_1 = Version.fromString("5.6.1");
         public static final Version V_5_6_2 = Version.fromString("5.6.2");
-        public static final Version V_6_0_0_alpha1 = Version.fromString("6.0.0-alpha1");
-        public static final Version V_6_0_0_alpha2 = Version.fromString("6.0.0-alpha2");
-        public static final Version V_6_0_0_beta1 = Version.fromString("6.0.0-beta1");
-        public static final Version V_6_0_0_beta2 = Version.fromString("6.0.0-beta2");
         public static final Version V_6_0_0 = Version.fromString("6.0.0");
         public static final Version V_6_0_1 = Version.fromString("6.0.1");
         public static final Version V_6_1_0 = Version.fromString("6.1.0");
@@ -305,10 +281,6 @@ public class VersionUtilsTests extends ESTestCase {
         assertThat(released, equalTo(Arrays.asList(
             TestNewMinorBranchIn6x.V_5_6_0,
             TestNewMinorBranchIn6x.V_5_6_1,
-            TestNewMinorBranchIn6x.V_6_0_0_alpha1,
-            TestNewMinorBranchIn6x.V_6_0_0_alpha2,
-            TestNewMinorBranchIn6x.V_6_0_0_beta1,
-            TestNewMinorBranchIn6x.V_6_0_0_beta2,
             TestNewMinorBranchIn6x.V_6_0_0,
             TestNewMinorBranchIn6x.V_6_0_1,
             TestNewMinorBranchIn6x.V_6_1_0,
@@ -330,11 +302,6 @@ public class VersionUtilsTests extends ESTestCase {
                 /* Java lists all versions from the 5.x series onwards, but we only want to consider
                  * ones that we're supposed to be compatible with. */
                 .filter(v -> v.onOrAfter(Version.CURRENT.minimumIndexCompatibilityVersion()))
-                /* Gradle will never include *released* alphas or betas because it will prefer
-                 * the unreleased branch head. Gradle is willing to use branch heads that are
-                 * beta or rc so that we have *something* to test against even though we
-                 * do not offer backwards compatibility for alphas, betas, or rcs. */
-                .filter(Version::isRelease)
                 .collect(toList());
 
         List<String> releasedIndexCompatible = released.stream()
@@ -347,14 +314,6 @@ public class VersionUtilsTests extends ESTestCase {
                 /* Java lists all versions from the 5.x series onwards, but we only want to consider
                  * ones that we're supposed to be compatible with. */
                 .filter(v -> v.onOrAfter(Version.CURRENT.minimumIndexCompatibilityVersion()))
-                /* Note that gradle skips alphas because they don't have any backwards
-                 * compatibility guarantees but keeps the last beta and rc in a branch
-                 * on when there are only betas an RCs in that branch so that we have
-                 * *something* to test that branch against. There is no need to recreate
-                 * that logic here because allUnreleasedVersions already only contains
-                 * the heads of branches so it should be good enough to just keep all
-                 * the non-alphas.*/
-                .filter(v -> false == v.isAlpha())
                 .map(Object::toString)
                 .collect(toCollection(LinkedHashSet::new)));
         assertEquals(unreleasedIndexCompatible, indexCompatible.unreleased);

--- a/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
@@ -190,7 +190,7 @@ public class VersionUtilsTests extends ESTestCase {
         public static final Version V_5_3_1 = Version.fromString("5.3.1");
         public static final Version V_5_3_2 = Version.fromString("5.3.2");
         public static final Version V_5_4_0 = Version.fromString("5.4.0");
-        public static final Version V_6_0_0 = Version.fromString("6.0.0-beta1");
+        public static final Version V_6_0_0 = Version.fromString("6.0.0");
         public static final Version CURRENT = V_6_0_0;
     }
 


### PR DESCRIPTION
Prerelease qualifiers were moved outside of Version logic within
Elasticsearch for 7.0.0, where they are now just an external modifier on
the filename. However, they still existed inside code to support 6.x
constants. Now that those constants have been removed in master, the
prerelease logic can be removed.
