### PR TITLE
Permit API Keys on Basic License

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -454,12 +454,12 @@ public class XPackLicenseState {
     }
 
     /**
-     * @return whether the Elasticsearch {@code ApiKeyService} is allowed based on the license {@link OperationMode}
+     * @return whether the Elasticsearch {@code ApiKeyService} is allowed based on the current node/cluster state
      */
     public synchronized boolean isApiKeyServiceAllowed() {
         final OperationMode mode = status.mode;
         final boolean isSecurityCurrentlyEnabled = isSecurityEnabled(mode, isSecurityExplicitlyEnabled, isSecurityEnabled);
-        return isSecurityCurrentlyEnabled && (mode == OperationMode.GOLD || mode == OperationMode.PLATINUM || mode == OperationMode.TRIAL);
+        return isSecurityCurrentlyEnabled;
     }
 
     /**

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
@@ -107,6 +107,8 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isDocumentAndFieldLevelSecurityAllowed(), is(false));
         assertThat(licenseState.allowedRealmType(), is(XPackLicenseState.AllowedRealmType.NONE));
         assertThat(licenseState.isCustomRoleProvidersAllowed(), is(false));
+        assertThat(licenseState.isTokenServiceAllowed(), is(false));
+        assertThat(licenseState.isApiKeyServiceAllowed(), is(false));
 
         assertThat(licenseState.isSecurityAvailable(), is(true));
         assertThat(licenseState.isSecurityDisabledByLicenseDefaults(), is(true));
@@ -124,6 +126,8 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isDocumentAndFieldLevelSecurityAllowed(), is(false));
         assertThat(licenseState.allowedRealmType(), is(XPackLicenseState.AllowedRealmType.NATIVE));
         assertThat(licenseState.isCustomRoleProvidersAllowed(), is(false));
+        assertThat(licenseState.isTokenServiceAllowed(), is(false));
+        assertThat(licenseState.isApiKeyServiceAllowed(), is(true));
 
         assertThat(licenseState.isSecurityAvailable(), is(true));
         assertThat(licenseState.isSecurityDisabledByLicenseDefaults(), is(false));
@@ -140,6 +144,8 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isDocumentAndFieldLevelSecurityAllowed(), is(false));
         assertThat(licenseState.allowedRealmType(), is(XPackLicenseState.AllowedRealmType.NONE));
         assertThat(licenseState.isCustomRoleProvidersAllowed(), is(false));
+        assertThat(licenseState.isTokenServiceAllowed(), is(false));
+        assertThat(licenseState.isApiKeyServiceAllowed(), is(false));
     }
 
     public void testSecurityEnabledBasicExpired() {
@@ -154,6 +160,8 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isDocumentAndFieldLevelSecurityAllowed(), is(false));
         assertThat(licenseState.allowedRealmType(), is(XPackLicenseState.AllowedRealmType.NATIVE));
         assertThat(licenseState.isCustomRoleProvidersAllowed(), is(false));
+        assertThat(licenseState.isTokenServiceAllowed(), is(false));
+        assertThat(licenseState.isApiKeyServiceAllowed(), is(true));
     }
 
     public void testSecurityStandard() {
@@ -196,6 +204,8 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isDocumentAndFieldLevelSecurityAllowed(), is(false));
         assertThat(licenseState.allowedRealmType(), is(XPackLicenseState.AllowedRealmType.DEFAULT));
         assertThat(licenseState.isCustomRoleProvidersAllowed(), is(false));
+        assertThat(licenseState.isTokenServiceAllowed(), is(true));
+        assertThat(licenseState.isApiKeyServiceAllowed(), is(true));
     }
 
     public void testSecurityGoldExpired() {
@@ -210,6 +220,8 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isDocumentAndFieldLevelSecurityAllowed(), is(false));
         assertThat(licenseState.allowedRealmType(), is(XPackLicenseState.AllowedRealmType.DEFAULT));
         assertThat(licenseState.isCustomRoleProvidersAllowed(), is(false));
+        assertThat(licenseState.isTokenServiceAllowed(), is(true));
+        assertThat(licenseState.isApiKeyServiceAllowed(), is(true));
     }
 
     public void testSecurityPlatinum() {
@@ -224,6 +236,8 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isDocumentAndFieldLevelSecurityAllowed(), is(true));
         assertThat(licenseState.allowedRealmType(), is(XPackLicenseState.AllowedRealmType.ALL));
         assertThat(licenseState.isCustomRoleProvidersAllowed(), is(true));
+        assertThat(licenseState.isTokenServiceAllowed(), is(true));
+        assertThat(licenseState.isApiKeyServiceAllowed(), is(true));
     }
 
     public void testSecurityPlatinumExpired() {
@@ -238,6 +252,8 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isDocumentAndFieldLevelSecurityAllowed(), is(true));
         assertThat(licenseState.allowedRealmType(), is(XPackLicenseState.AllowedRealmType.ALL));
         assertThat(licenseState.isCustomRoleProvidersAllowed(), is(false));
+        assertThat(licenseState.isTokenServiceAllowed(), is(true));
+        assertThat(licenseState.isApiKeyServiceAllowed(), is(true));
     }
 
     public void testNewTrialDefaultsSecurityOff() {

--- a/x-pack/plugin/security/qa/security-basic/src/test/java/org/elasticsearch/xpack/security/SecurityWithBasicLicenseIT.java
+++ b/x-pack/plugin/security/qa/security-basic/src/test/java/org/elasticsearch/xpack/security/SecurityWithBasicLicenseIT.java
@@ -54,8 +54,11 @@ public class SecurityWithBasicLicenseIT extends ESRestTestCase {
         checkAuthentication();
         checkHasPrivileges();
         checkIndexWrite();
+
+        final Tuple<String, String> keyAndId = getApiKeyAndId();
+        assertAuthenticateWithApiKey(keyAndId, true);
+
         assertFailToGetToken();
-        assertFailToGetApiKey();
         assertAddRoleWithDLS(false);
         assertAddRoleWithFLS(false);
     }
@@ -79,9 +82,8 @@ public class SecurityWithBasicLicenseIT extends ESRestTestCase {
         } finally {
             revertTrial();
             assertAuthenticateWithToken(accessToken, false);
-            assertAuthenticateWithApiKey(keyAndId, false);
+            assertAuthenticateWithApiKey(keyAndId, true);
             assertFailToGetToken();
-            assertFailToGetApiKey();
             assertAddRoleWithDLS(false);
             assertAddRoleWithFLS(false);
         }
@@ -197,12 +199,6 @@ public class SecurityWithBasicLicenseIT extends ESRestTestCase {
         ResponseException e = expectThrows(ResponseException.class, () -> adminClient().performRequest(buildGetTokenRequest()));
         assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(403));
         assertThat(e.getMessage(), containsString("current license is non-compliant for [security tokens]"));
-    }
-
-    private void assertFailToGetApiKey() {
-        ResponseException e = expectThrows(ResponseException.class, () -> adminClient().performRequest(buildGetApiKeyRequest()));
-        assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(403));
-        assertThat(e.getMessage(), containsString("current license is non-compliant for [api keys]"));
     }
 
     private void assertAuthenticateWithToken(String accessToken, boolean shouldSucceed) throws IOException {


### PR DESCRIPTION
Kibana alerting is going to be built using API Keys, and should be
permitted on a basic license.

This commit moves API Keys (but not Tokens) to the Basic license

Relates: https://github.com/elastic/kibana/issues/36836