### PR TITLE
Make unwrapCorrupt Check Suppressed Ex. (#41889) (#42605)

### DIFF
--- a/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -175,12 +175,42 @@ public final class ExceptionsHelper {
         return first;
     }
 
+    private static final List<Class<? extends IOException>> CORRUPTION_EXCEPTIONS =
+        Arrays.asList(CorruptIndexException.class, IndexFormatTooOldException.class, IndexFormatTooNewException.class);
+
+    /**
+     * Looks at the given Throwable's and its cause(s) as well as any suppressed exceptions on the Throwable as well as its causes
+     * and returns the first corruption indicating exception (as defined by {@link #CORRUPTION_EXCEPTIONS}) it finds.
+     * @param t Throwable
+     * @return Corruption indicating exception if one is found, otherwise {@code null}
+     */
     public static IOException unwrapCorruption(Throwable t) {
-        return (IOException) unwrap(t, CorruptIndexException.class,
-                                       IndexFormatTooOldException.class,
-                                       IndexFormatTooNewException.class);
+        if (t != null) {
+            do {
+                for (Class<?> clazz : CORRUPTION_EXCEPTIONS) {
+                    if (clazz.isInstance(t)) {
+                        return (IOException) t;
+                    }
+                }
+                for (Throwable suppressed : t.getSuppressed()) {
+                    IOException corruptionException = unwrapCorruption(suppressed);
+                    if (corruptionException != null) {
+                        return corruptionException;
+                    }
+                }
+            } while ((t = t.getCause()) != null);
+        }
+        return null;
     }
 
+    /**
+     * Looks at the given Throwable and its cause(s) and returns the first Throwable that is of one of the given classes or {@code null}
+     * if no matching Throwable is found. Unlike {@link #unwrapCorruption} this method does only check the given Throwable and its causes
+     * but does not look at any suppressed exceptions.
+     * @param t Throwable
+     * @param clazzes Classes to look for
+     * @return Matching Throwable if one is found, otherwise {@code null}
+     */
     public static Throwable unwrap(Throwable t, Class<?>... clazzes) {
         if (t != null) {
             do {

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -436,10 +436,12 @@ public class RecoverySourceHandlerTests extends ESTestCase {
             handler.sendFiles(store, metas.toArray(new StoreFileMetaData[0]), () -> 0);
             fail("exception index");
         } catch (RuntimeException ex) {
-            assertNull(ExceptionsHelper.unwrapCorruption(ex));
+            final IOException unwrappedCorruption = ExceptionsHelper.unwrapCorruption(ex);
             if (throwCorruptedIndexException) {
+                assertNotNull(unwrappedCorruption);
                 assertEquals(ex.getMessage(), "[File corruption occurred on recovery but checksums are ok]");
             } else {
+                assertNull(unwrappedCorruption);
                 assertEquals(ex.getMessage(), "boom");
             }
         } catch (CorruptIndexException ex) {


### PR DESCRIPTION
* Make unwrapCorrupt Check Suppressed Ex. (#41889)
* As discussed in #24800 we want to check for suppressed corruption
indicating exceptions here as well to more reliably categorize
corruption related exceptions
* Closes #24800, #41201

backport of #41889