### PR TITLE
Fixes a bug in AnalyzeRequest.toXContent()

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
@@ -1656,6 +1656,17 @@ public class RequestConvertersTests extends ESTestCase {
         assertThat(RequestConverters.analyze(analyzeRequest).getEndpoint(), equalTo("/_analyze"));
     }
 
+    public void testAnalyzeRequestWithCustomAnalyzer() throws IOException {
+        AnalyzeRequest ar = new AnalyzeRequest()
+            .text("Here is some text")
+            .index("test_index")
+            .tokenizer("standard");
+
+        Request request = RequestConverters.analyze(ar);
+        assertThat(request.getEndpoint(), equalTo("/test_index/_analyze"));
+        assertToXContentBody(ar, request.getEntity());
+    }
+
     public void testGetScriptRequest() {
         GetStoredScriptRequest getStoredScriptRequest = new GetStoredScriptRequest("x-script");
         Map<String, String> expectedParams = new HashMap<>();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
@@ -281,7 +281,7 @@ public class AnalyzeRequest extends SingleShardRequest<AnalyzeRequest> implement
             builder.field("analyzer", analyzer);
         }
         if (tokenizer != null) {
-            tokenizer.toXContent(builder, params);
+            builder.field("tokenizer", tokenizer);
         }
         if (tokenFilters.size() > 0) {
             builder.field("filter", tokenFilters);


### PR DESCRIPTION
Fix for #39670, for 7.2 branch only as this has been fixed separately in 7.3 by the refactoring in #42197 