### PR TITLE
[ML][Data Frame] forcing that no ptask => STOPPED state

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
@@ -284,6 +284,8 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
         AtomicBoolean callOnStop = new AtomicBoolean(false);
         AtomicBoolean callOnAbort = new AtomicBoolean(false);
         IndexerState updatedState = state.updateAndGet(prev -> {
+            callOnAbort.set(false);
+            callOnStop.set(false);
             switch (prev) {
             case INDEXING:
                 // ready for another job

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
@@ -236,6 +236,10 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
             return;
         }
 
+        if (getIndexer().getState() == IndexerState.STOPPED) {
+            return;
+        }
+
         IndexerState state = getIndexer().stop();
         if (state == IndexerState.STOPPED) {
             getIndexer().doSaveState(state, getIndexer().getPosition(), () -> getIndexer().onStop());

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_start_stop.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_start_stop.yml
@@ -90,9 +90,6 @@ teardown:
   - match: { airline-data-by-airline-start-stop.mappings: {} }
 ---
 "Test start/stop/start transform":
-  - skip:
-      reason: "https://github.com/elastic/elasticsearch/issues/42650"
-      version: "all"
   - do:
       data_frame.start_data_frame_transform:
         transform_id: "airline-transform-start-stop"


### PR DESCRIPTION
While running tests, there is a slight chance that the p-task is removed from cluster state (i.e. cancelled) before the latest state is written to the index. 

We should make sure that the state for a data frame without a p-task is always STOPPED. 

Thinking about potential race conditions:
* Starting the task again before the previous stats have finished writing (not sure this is possible...).
   * This does not seem that big of an issue. The two concerns would be the accuracy of the indexer position and checkpoint. Since document IDs are deterministic, we may write more documents than necessary on the off-chance that a user is spamming stop/start, but this is a small price to pay.
   * A potential concern here is that task start persists the state of it running, and then quickly afterwards the `STOPPED` state finally persists. The positions and state would eventually become in sync, but the call to `_stats` may look strange.
* Stopping the same data frame twice:
   * This cannot happen as the ptask would no longer be in the cluster state

closes https://github.com/elastic/elasticsearch/issues/42650

The initial bug of writing the `STOPPING` state was fixed in: https://github.com/elastic/elasticsearch/pull/42644

But there may still be the chance of the task actually being in `STARTED`