### PR TITLE
Make sibling pipeline agg ctor's protected

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/SiblingPipelineAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/SiblingPipelineAggregator.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 public abstract class SiblingPipelineAggregator extends PipelineAggregator {
-    SiblingPipelineAggregator(String name, String[] bucketsPaths, Map<String, Object> metaData) {
+    protected SiblingPipelineAggregator(String name, String[] bucketsPaths, Map<String, Object> metaData) {
         super(name, bucketsPaths, metaData);
     }
 


### PR DESCRIPTION
SiblingPipelineAggregator is a public interfaces, but the ctor was package-private.  It should instead be protected so that plugin authors can extend and implement their own pipeline aggs.

Closes https://github.com/elastic/elasticsearch/issues/42493