### PR TITLE
[Docs] Add note for date patterns used for index search.

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -86,12 +86,10 @@ Where:
 `date_format`:: is the optional format in which the computed date should be rendered. Defaults to `yyyy.MM.dd`. Format should be compatible with java-time https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html
 `time_zone`:: is the optional time zone. Defaults to `utc`.
 
----
 NOTE: Pay attention on the usage of small vs capital letters used in the `date_format`. For example:
 `mm` denotes minute of hour, where `MM` denotes month of year. Similarly `hh` denotes the hour in the
 `1-12` range used in combination with the `AM/PM` information, where `HH` denotes the hour in the 24-Hour
 format (0-24 range).
-----
 
 Date math expressions are resolved locale-independent. Consequently, it is not possible to use any other
 calendars than the Gregorian calendar.

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -86,6 +86,13 @@ Where:
 `date_format`:: is the optional format in which the computed date should be rendered. Defaults to `yyyy.MM.dd`. Format should be compatible with java-time https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html
 `time_zone`:: is the optional time zone. Defaults to `utc`.
 
+---
+NOTE: Pay attention on the usage of small vs capital letters used in the `date_format`. For example:
+`mm` denotes minute of hour, where `MM` denotes month of year. Similarly `hh` denotes the hour in the
+`1-12` range used in combination with the `AM/PM` information, where `HH` denotes the hour in the 24-Hour
+format (0-24 range).
+----
+
 Date math expressions are resolved locale-independent. Consequently, it is not possible to use any other
 calendars than the Gregorian calendar.
 

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -86,10 +86,9 @@ Where:
 `date_format`:: is the optional format in which the computed date should be rendered. Defaults to `yyyy.MM.dd`. Format should be compatible with java-time https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html
 `time_zone`:: is the optional time zone. Defaults to `utc`.
 
-NOTE: Pay attention on the usage of small vs capital letters used in the `date_format`. For example:
-`mm` denotes minute of hour, where `MM` denotes month of year. Similarly `hh` denotes the hour in the
-`1-12` range used in combination with the `AM/PM` information, where `HH` denotes the hour in the 24-Hour
-format (0-24 range).
+NOTE: Pay attention to the usage of small vs capital letters used in the `date_format`. For example:
+`mm` denotes minute of hour, while `MM` denotes month of year. Similarly `hh` denotes the hour in the
+`1-12` range in combination with `AM/PM`, while `HH` denotes the hour in the `0-23` 24-hour range.
 
 Date math expressions are resolved locale-independent. Consequently, it is not possible to use any other
 calendars than the Gregorian calendar.

--- a/docs/reference/ingest/processors/date-index-name.asciidoc
+++ b/docs/reference/ingest/processors/date-index-name.asciidoc
@@ -140,6 +140,6 @@ understands this to mean `2016-04-01` as is explained in the <<date-math-index-n
 | `date_formats`         | no        | yyyy-MM-dd+++'T'+++HH:mm:ss.SSSXX  | An array of the expected date formats for parsing dates / timestamps in the document being preprocessed. Can be a java time pattern or one of the following formats: ISO8601, UNIX, UNIX_MS, or TAI64N.
 | `timezone`             | no        | UTC                          | The timezone to use when parsing the date and when date math index supports resolves expressions into concrete index names.
 | `locale`               | no        | ENGLISH                      | The locale to use when parsing the date from the document being preprocessed, relevant when parsing month names or week days.
-| `index_name_format`    | no        | yyyy-MM-dd                   | The format to be used when printing the parsed date into the index name. An valid java time pattern is expected here. Supports <<accessing-template-fields,template snippets>>.
+| `index_name_format`    | no        | yyyy-MM-dd                   | The format to be used when printing the parsed date into the index name. A valid java time pattern is expected here. Supports <<accessing-template-fields,template snippets>>.
 include::common-options.asciidoc[]
 |======


### PR DESCRIPTION
Add an explanatory NOTE section to draw attention to the difference
between small and capital letters used for the index date patterns.
e.g.: `HH` vs`hh`, `MM` vs `mm`.

Closes: #22322
