### PR TITLE
Omit JDK sources archive from bundled JDK

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -381,6 +381,9 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
           if (details.relativePath.segments[-2] == 'bin' || details.relativePath.segments[-1] == 'jspawnhelper') {
             details.mode = 0755
           }
+          if (details.name == 'src.zip') {
+            details.exclude()
+          }
         }
       }
     }


### PR DESCRIPTION
One side-effect of bundling the JDK in our distributions by default is it increases their size considerably. Once thing we could do the defer some of this cost is to exclude the `src.zip` file which is included in the JDK distributions. This weighs in at about 60MB or nearly 20% of the total JDK distribution size.

I looked into the licensing concerns here and it's not _completely_ clear if this will be a problem. Everything _in_ the OpenJDK distribution is GPLv2 licensed which is pretty permissive. It's not completely clear whether the archive itself is considered "the program" and modifications to its contents merit a "change to the software". I'm leaning towards no, and even if it were, the source to the "change" in effectively public (our build is open source). In terms of precedent, anyone is open to build their own JDK distributions (i.e. AdoptOpenJDK) from the OpenJDK sources which may or may not include any subset of the OpenJDK sources. In fact, AdoptOpenJDK JRE distributions obviously omit the `src.zip` file.