### PR TITLE
[DOCS] Adds discovery.type

### DIFF
--- a/docs/reference/modules/discovery/discovery-settings.asciidoc
+++ b/docs/reference/modules/discovery/discovery-settings.asciidoc
@@ -30,7 +30,13 @@ Discovery and cluster formation are affected by the following settings:
     If set to `single-node`, the node elects itself master and does not join a
     cluster with any other node. For more information about when you might use
     this setting, see <<single-node-discovery>>.
-
+ 
+    Specifies whether {es} should form a multiple-node cluster or not. By
+    default {es} will discover other nodes when forming a cluster and will allow
+    other nodes to join the cluster later.  If `discovery.type` is set to
+    `single-node` then {es} will form a single-node cluster. For more
+    information about when you might use this setting, see
+    <<single-node-discovery>>.
 [float]
 ==== Expert settings
 

--- a/docs/reference/modules/discovery/discovery-settings.asciidoc
+++ b/docs/reference/modules/discovery/discovery-settings.asciidoc
@@ -5,7 +5,7 @@ Discovery and cluster formation are affected by the following settings:
 
 `cluster.initial_master_nodes`::
 
-    Sets a list of the <<node.name,node names>> or transport addresses of the
+    Sets the
     initial set of master-eligible nodes in a brand-new cluster. By default
     this list is empty, meaning that this node expects to join a cluster that
     has already been bootstrapped. See <<initial_master_nodes>>.

--- a/docs/reference/modules/discovery/discovery-settings.asciidoc
+++ b/docs/reference/modules/discovery/discovery-settings.asciidoc
@@ -3,13 +3,6 @@
 
 Discovery and cluster formation are affected by the following settings:
 
-`cluster.initial_master_nodes`::
-
-    Sets the
-    initial set of master-eligible nodes in a brand-new cluster. By default
-    this list is empty, meaning that this node expects to join a cluster that
-    has already been bootstrapped. See <<initial_master_nodes>>.
-
 `discovery.seed_hosts`::
 
     Provides a list of master-eligible nodes in the cluster. Each value has the
@@ -25,18 +18,19 @@ Discovery and cluster formation are affected by the following settings:
     <<settings-based-hosts-provider,settings-based seed hosts provider>>.
     
 `discovery.type`::
-
-    Specifies whether to use the default discovery and cluster formation (`zen`).
-    If set to `single-node`, the node elects itself master and does not join a
-    cluster with any other node. For more information about when you might use
-    this setting, see <<single-node-discovery>>.
  
-    Specifies whether {es} should form a multiple-node cluster or not. By
-    default {es} will discover other nodes when forming a cluster and will allow
-    other nodes to join the cluster later.  If `discovery.type` is set to
-    `single-node` then {es} will form a single-node cluster. For more
-    information about when you might use this setting, see
-    <<single-node-discovery>>.
+    Specifies whether {es} should form a multiple-node cluster. By default, {es}
+    discovers other nodes when forming a cluster and allows other nodes to join
+    the cluster later. If `discovery.type` is set to `single-node`, {es} forms a
+    single-node cluster. For more information about when you might use this
+    setting, see <<single-node-discovery>>.
+    
+`cluster.initial_master_nodes`::
+
+    Sets the initial set of master-eligible nodes in a brand-new cluster. By
+    default this list is empty, meaning that this node expects to join a cluster
+    that has already been bootstrapped. See <<initial_master_nodes>>.
+            
 [float]
 ==== Expert settings
 

--- a/docs/reference/modules/discovery/discovery-settings.asciidoc
+++ b/docs/reference/modules/discovery/discovery-settings.asciidoc
@@ -3,6 +3,13 @@
 
 Discovery and cluster formation are affected by the following settings:
 
+`cluster.initial_master_nodes`::
+
+    Sets a list of the <<node.name,node names>> or transport addresses of the
+    initial set of master-eligible nodes in a brand-new cluster. By default
+    this list is empty, meaning that this node expects to join a cluster that
+    has already been bootstrapped. See <<initial_master_nodes>>.
+
 `discovery.seed_hosts`::
 
     Provides a list of master-eligible nodes in the cluster. Each value has the
@@ -16,13 +23,13 @@ Discovery and cluster formation are affected by the following settings:
     to use to obtain the addresses of the seed nodes used to start the
     discovery process. By default, it is the
     <<settings-based-hosts-provider,settings-based seed hosts provider>>.
+    
+`discovery.type`::
 
-`cluster.initial_master_nodes`::
-
-    Sets a list of the <<node.name,node names>> or transport addresses of the
-    initial set of master-eligible nodes in a brand-new cluster. By default
-    this list is empty, meaning that this node expects to join a cluster that
-    has already been bootstrapped. See <<initial_master_nodes>>.
+    Specifies whether to use the default discovery and cluster formation (`zen`).
+    If set to `single-node`, the node elects itself master and does not join a
+    cluster with any other node. For more information about when you might use
+    this setting, see <<single-node-discovery>>.
 
 [float]
 ==== Expert settings


### PR DESCRIPTION
This PR adds the discovery.type setting to https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-discovery-settings.html
It also sorts the initial list of settings alphabetically.