### PR TITLE
Correct "term_vector" option with documented one

### DIFF
--- a/docs/reference/docs/termvectors.asciidoc
+++ b/docs/reference/docs/termvectors.asciidoc
@@ -130,13 +130,13 @@ PUT /twitter
     "properties": {
       "text": {
         "type": "text",
-        "term_vector": "with_positions_offsets_payloads",
+        "term_vector": "with_positions_offsets",
         "store" : true,
         "analyzer" : "fulltext_analyzer"
        },
        "fullname": {
         "type": "text",
-        "term_vector": "with_positions_offsets_payloads",
+        "term_vector": "with_positions_offsets",
         "analyzer" : "fulltext_analyzer"
       }
     }


### PR DESCRIPTION
In [term_vector reference doc](https://www.elastic.co/guide/en/elasticsearch/reference/7.1/term-vector.html#term-vector), `with_positions_offsets_payloads` is not existed and `payloads` seems useless. 
Let's change it to `with_positions_offsets` as it was mentioned in the reference doc to avoid confusion. `with_positions_offsets_payloads` is not searchable in 7.1 doc.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

