### PR TITLE
[Backport 7.2] Don't require TLS for single node clusters

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -40,7 +40,6 @@ import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.http.HttpServerTransport;
@@ -984,35 +983,10 @@ public class Security extends Plugin implements ActionPlugin, IngestPlugin, Netw
     @Override
     public BiConsumer<DiscoveryNode, ClusterState> getJoinValidator() {
         if (enabled) {
-            return new ValidateTLSOnJoin(XPackSettings.TRANSPORT_SSL_ENABLED.get(settings),
-                    DiscoveryModule.DISCOVERY_TYPE_SETTING.get(settings), settings)
-                .andThen(new ValidateUpgradedSecurityIndex())
-                .andThen(new ValidateLicenseCanBeDeserialized())
+            return new ValidateUpgradedSecurityIndex()
                 .andThen(new ValidateLicenseForFIPS(XPackSettings.FIPS_MODE_ENABLED.get(settings)));
         }
         return null;
-    }
-
-    static final class ValidateTLSOnJoin implements BiConsumer<DiscoveryNode, ClusterState> {
-        private final boolean isTLSEnabled;
-        private final String discoveryType;
-        private final Settings settings;
-
-        ValidateTLSOnJoin(boolean isTLSEnabled, String discoveryType, Settings settings) {
-            this.isTLSEnabled = isTLSEnabled;
-            this.discoveryType = discoveryType;
-            this.settings = settings;
-        }
-
-        @Override
-        public void accept(DiscoveryNode node, ClusterState state) {
-            License license = LicenseService.getLicense(state.metaData());
-            if (isTLSEnabled == false && "single-node".equals(discoveryType) == false
-                && XPackLicenseState.isTransportTlsRequired(license, settings)) {
-                throw new IllegalStateException("Transport TLS ([" + XPackSettings.TRANSPORT_SSL_ENABLED.getKey() +
-                    "]) is required for license type [" + license.operationMode().description() + "] when security is enabled");
-            }
-        }
     }
 
     static final class ValidateUpgradedSecurityIndex implements BiConsumer<DiscoveryNode, ClusterState> {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -65,7 +65,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.metadata.IndexMetaData.INDEX_FORMAT_SETTING;
-import static org.elasticsearch.discovery.DiscoveryModule.ZEN2_DISCOVERY_TYPE;
 import static org.elasticsearch.xpack.core.security.index.RestrictedIndicesNames.SECURITY_MAIN_ALIAS;
 import static org.elasticsearch.xpack.security.support.SecurityIndexManager.INTERNAL_MAIN_INDEX_FORMAT;
 import static org.hamcrest.Matchers.containsString;
@@ -241,61 +240,6 @@ public class SecurityTests extends ESTestCase {
         createComponents(disabledSettings);
         BiConsumer<DiscoveryNode, ClusterState> joinValidator = security.getJoinValidator();
         assertNull(joinValidator);
-    }
-
-    public void testTLSJoinValidator() throws Exception {
-        createComponents(Settings.EMPTY);
-        BiConsumer<DiscoveryNode, ClusterState> joinValidator = security.getJoinValidator();
-        assertNotNull(joinValidator);
-        DiscoveryNode node = new DiscoveryNode("foo", buildNewFakeTransportAddress(), Version.CURRENT);
-        joinValidator.accept(node, ClusterState.builder(ClusterName.DEFAULT).build());
-        int numIters = randomIntBetween(1, 10);
-        for (int i = 0; i < numIters; i++) {
-            boolean tlsOn = randomBoolean();
-            boolean securityExplicitlyEnabled = randomBoolean();
-            String discoveryType = randomFrom("single-node", ZEN2_DISCOVERY_TYPE, ZEN2_DISCOVERY_TYPE, randomAlphaOfLength(4));
-
-            final Settings settings;
-            if (securityExplicitlyEnabled) {
-                settings = Settings.builder().put("xpack.security.enabled", true).build();
-            } else {
-                settings = Settings.EMPTY;
-            }
-            Security.ValidateTLSOnJoin validator = new Security.ValidateTLSOnJoin(tlsOn, discoveryType, settings);
-            MetaData.Builder builder = MetaData.builder();
-            License.OperationMode licenseMode = randomFrom(License.OperationMode.values());
-            License license = TestUtils.generateSignedLicense(licenseMode.description(), TimeValue.timeValueHours(24));
-            TestUtils.putLicense(builder, license);
-            ClusterState state = ClusterState.builder(ClusterName.DEFAULT).metaData(builder.build()).build();
-
-            final boolean expectFailure;
-            switch (licenseMode) {
-                case PLATINUM:
-                case GOLD:
-                case STANDARD:
-                    expectFailure = tlsOn == false && "single-node".equals(discoveryType) == false;
-                    break;
-                case BASIC:
-                    expectFailure = tlsOn == false && "single-node".equals(discoveryType) == false && securityExplicitlyEnabled;
-                    break;
-                case MISSING:
-                case TRIAL:
-                    expectFailure = false;
-                    break;
-                default:
-                    throw new AssertionError("unknown operation mode [" + license.operationMode() + "]");
-            }
-            logger.info("Test TLS join; Lic:{} TLS:{} Disco:{} Settings:{}  ; Expect Failure: {}",
-                licenseMode, tlsOn, discoveryType, settings.toDelimitedString(','), expectFailure);
-            if (expectFailure) {
-                IllegalStateException ise = expectThrows(IllegalStateException.class, () -> validator.accept(node, state));
-                assertEquals("Transport TLS ([xpack.security.transport.ssl.enabled]) is required for license type ["
-                    + license.operationMode().description() + "] when security is enabled", ise.getMessage());
-            } else {
-                validator.accept(node, state);
-            }
-            validator.accept(node, ClusterState.builder(ClusterName.DEFAULT).metaData(MetaData.builder().build()).build());
-        }
     }
 
     public void testJoinValidatorForLicenseDeserialization() throws Exception {


### PR DESCRIPTION
This commit removes the TLS cluster join validator.

This validator existed to prevent v6.x nodes (which mandated
TLS) from joining an existing cluster of v5.x nodes (which did
not mandate TLS) unless the 6.x node (and by implication the
5.x nodes) was configured to use TLS.

Since 7.x nodes cannot talk to 5.x nodes, this validator is no longer
needed.

Removing the validator solves a problem where single node clusters
that were bound to local interfaces were incorrectly requiring TLS
when they recovered cluster state and joined their own cluster.

Backport of: #42826