### PR TITLE
Eclipse libs projects setup fix

### DIFF
--- a/libs/core/src/test/eclipse-build.gradle
+++ b/libs/core/src/test/eclipse-build.gradle
@@ -2,5 +2,5 @@
 apply from: '../../build.gradle'
 
 dependencies {
-  testCompile project(':libs:core')
+  testCompile project(':libs:elasticsearch-core')
 }

--- a/libs/dissect/src/test/eclipse-build.gradle
+++ b/libs/dissect/src/test/eclipse-build.gradle
@@ -3,5 +3,5 @@
 apply from: '../../build.gradle'
 
 dependencies {
-  testCompile project(':libs:dissect')
+  testCompile project(':libs:elasticsearch-dissect')
 }

--- a/libs/grok/src/test/eclipse-build.gradle
+++ b/libs/grok/src/test/eclipse-build.gradle
@@ -3,5 +3,5 @@
 apply from: '../../build.gradle'
 
 dependencies {
-  testCompile project(':libs:grok')
+  testCompile project(':libs:elasticsearch-grok')
 }

--- a/libs/nio/src/test/eclipse-build.gradle
+++ b/libs/nio/src/test/eclipse-build.gradle
@@ -3,5 +3,5 @@
 apply from: '../../build.gradle'
 
 dependencies {
-  testCompile project(':libs:nio')
+  testCompile project(':libs:elasticsearch-nio')
 }

--- a/libs/secure-sm/src/test/eclipse-build.gradle
+++ b/libs/secure-sm/src/test/eclipse-build.gradle
@@ -3,5 +3,5 @@
 apply from: '../../build.gradle'
 
 dependencies {
-  testCompile project(':libs:secure-sm')
+  testCompile project(':libs:elasticsearch-secure-sm')
 }

--- a/libs/x-content/src/test/eclipse-build.gradle
+++ b/libs/x-content/src/test/eclipse-build.gradle
@@ -3,5 +3,5 @@
 apply from: '../../build.gradle'
 
 dependencies {
-  testCompile project(':libs:x-content')
+  testCompile project(':libs:elasticsearch-x-content')
 }


### PR DESCRIPTION
Fallout from https://github.com/elastic/elasticsearch/pull/42773 for eclipse users.

Sample error for `./gradlew eclipse` :
```
FAILURE: Build failed with an exception.

* Where:
Settings file '/Users/albert/workspace/elasticsearch/settings.gradle' line: 134

* What went wrong:
A problem occurred evaluating settings 'elasticsearch'.
> Project with path ':libs:elasticsearch-core-tests' could not be found.
```