### PR TITLE
Fix version parsing in webhook https tests

### DIFF
--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/webhook/WebhookHttpsIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/webhook/WebhookHttpsIntegrationTests.java
@@ -148,7 +148,8 @@ public class WebhookHttpsIntegrationTests extends AbstractWatcherIntegrationTest
             return List.of("TLSv1.2");
         } else {
             JavaVersion full =
-                AccessController.doPrivileged((PrivilegedAction<JavaVersion>) () -> JavaVersion.parse(System.getProperty("java.version")));
+                AccessController.doPrivileged(
+                        (PrivilegedAction<JavaVersion>) () -> JavaVersion.parse(System.getProperty("java.specification.version")));
             if (full.compareTo(JavaVersion.parse("12.0.1")) < 0) {
                 return List.of("TLSv1.2");
             }


### PR DESCRIPTION
This commit fixes the version parsing in the webhook https integration tests. The issue here is that the parsing was relying on java.version. However, java.version can contain additional characters such as -ea for early access builds. See [JEP 233](https://openjdk.java.net/jeps/223):

```
Name                            Syntax
------------------------------  --------------
java.version                    $VNUM(\-$PRE)?
java.runtime.version            $VSTR
java.vm.version                 $VSTR
java.specification.version      $VNUM
java.vm.specification.version   $VNUM
```

Instead, we want java.specification.version.

Realtes #40829