### PR TITLE
Backport 7.2 - NPE when creating a watch with Jira action (#41922)(#42081)

### DIFF
--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/Scheme.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/Scheme.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.watcher.common.http;
 
 import java.util.Locale;
+import java.util.Objects;
 
 public enum Scheme {
 
@@ -29,6 +30,7 @@ public enum Scheme {
     }
 
     public static Scheme parse(String value) {
+        Objects.requireNonNull(value, "Scheme should not be Null");
         value = value.toLowerCase(Locale.ROOT);
         switch (value) {
             case "http":

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/jira/JiraAccount.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/jira/JiraAccount.java
@@ -61,6 +61,9 @@ public class JiraAccount {
         String url = getSetting(name, settings, SECURE_URL_SETTING);
         try {
             URI uri = new URI(url);
+            if (uri.getScheme() == null) {
+                throw new URISyntaxException("null", "No scheme defined in url");
+            }
             Scheme protocol = Scheme.parse(uri.getScheme());
             if ((protocol == Scheme.HTTP) && (Booleans.isTrue(settings.get(ALLOW_HTTP_SETTING)) == false)) {
                 throw new SettingsException("invalid jira [" + name + "] account settings. unsecure scheme [" + protocol + "]");
@@ -68,7 +71,7 @@ public class JiraAccount {
             this.url = uri;
         } catch (URISyntaxException | IllegalArgumentException e) {
             throw new SettingsException(
-                    "invalid jira [" + name + "] account settings. invalid [" + SECURE_URL_SETTING.getKey() + "] setting", e);
+                "invalid jira [" + name + "] account settings. invalid [" + SECURE_URL_SETTING.getKey() + "] setting", e);
         }
         this.user = getSetting(name, settings, SECURE_USER_SETTING);
         this.password = getSetting(name, settings, SECURE_PASSWORD_SETTING);

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/jira/JiraAccountTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/jira/JiraAccountTests.java
@@ -80,6 +80,16 @@ public class JiraAccountTests extends ESTestCase {
         assertThat(e.getMessage(), containsString("invalid jira [test] account settings. missing required [secure_password] setting"));
     }
 
+    public void testInvalidSchemeUrl() throws Exception{
+        MockSecureSettings secureSettings = new MockSecureSettings();
+        secureSettings.setString(JiraAccount.SECURE_URL_SETTING.getKey(),"test"); //Setting test as invalid scheme url
+        secureSettings.setString(JiraAccount.SECURE_USER_SETTING.getKey(), "foo");
+        secureSettings.setString(JiraAccount.SECURE_PASSWORD_SETTING.getKey(), "password");
+        Settings settings = Settings.builder().setSecureSettings(secureSettings).build();
+        SettingsException e = expectThrows(SettingsException.class, () -> new JiraAccount("test", settings, null));
+        assertThat(e.getMessage(), containsString("invalid jira [test] account settings. invalid [secure_url] setting"));
+    }
+
     public void testUnsecureAccountUrl() throws Exception {
         final MockSecureSettings secureSettings = new MockSecureSettings();
         secureSettings.setString(JiraAccount.SECURE_USER_SETTING.getKey(), "foo");


### PR DESCRIPTION
Backport of #42081

NullPointerException when secured_url does not use proper scheme in jira action. 
This commit will handle Expection and display proper message.
