### PR TITLE
Avoid clobbering shared testcluster JAR files when installing modules

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -23,6 +23,7 @@ import org.elasticsearch.gradle.Distribution;
 import org.elasticsearch.gradle.FileSupplier;
 import org.elasticsearch.gradle.OS;
 import org.elasticsearch.gradle.Version;
+import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 
@@ -398,6 +399,9 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     private void installModules() {
         if (distribution == Distribution.INTEG_TEST) {
             modules.forEach(module -> services.copy(spec -> {
+                // ensure we don't override any existing JARs, since these are hardlinks other clusters might be using those files
+                spec.setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE);
+
                 if (module.getName().toLowerCase().endsWith(".zip")) {
                     spec.from(services.zipTree(module));
                 } else if (module.isDirectory()) {


### PR DESCRIPTION
This addresses #42532 which is the result of parallel test clusters test runners mutating JAR files in the shared integ-test distribution. Because we use hardlinks here to avoid copying the test distribution multiple times, any modifications to hardlinked files will be reflected everywhere they are used. 

In this case what was happening is that when we installed the `transport-netty` module, we were inadvertently overriding the existing Netty JAR files which we already bundle in the integ-test distribution. If this was done while another cluster was attempting to read from those JARs, we start getting odd IO exceptions.

@atorok we should do a scrub of some of this logic to ensure we aren't doing any other mutations to anything on the filesystem that is hardlinked across clusters. For example does [installing plugins](https://github.com/elastic/elasticsearch/blob/b00728d28f1d997d0ef0a334d9cbd4330bd34f0a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java#L322-L325) also potentially touch shared files?