### PR TITLE
Reject the 'type' key in metadata field mappings.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
@@ -120,7 +120,6 @@ public class DocumentMapperParser {
                 }
                 Map<String, Object> fieldNodeMap = (Map<String, Object>) fieldNode;
                 docBuilder.put(typeParser.parse(fieldName, fieldNodeMap, parserContext));
-                fieldNodeMap.remove("type");
                 checkNoRemainingFields(fieldName, fieldNodeMap, parserContext.indexVersionCreated());
             }
         }


### PR DESCRIPTION
Previously, a 'type' field could be provided in a metadata field mapping, even
when 'type' was not a recognized option. This PR corrects the lenient parsing
logic so that metadata field mappings with an unrecognized 'type' key are
correctly rejected.

Addresses #35389.