### PR TITLE
Fix Stuck IO Thread Logging Time Precision

### DIFF
--- a/test/framework/src/test/java/org/elasticsearch/transport/nio/TestEventHandlerTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/transport/nio/TestEventHandlerTests.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.nio.ServerChannelContext;
 import org.elasticsearch.nio.SocketChannelContext;
 import org.elasticsearch.test.ESTestCase;
@@ -57,7 +58,7 @@ public class TestEventHandlerTests extends ESTestCase {
 
     public void testLogOnElapsedTime() throws Exception {
         long start = System.nanoTime();
-        long end = start + TimeUnit.MILLISECONDS.toNanos(200);
+        long end = start + TimeUnit.MILLISECONDS.toNanos(400);
         AtomicBoolean isStart = new AtomicBoolean(true);
         LongSupplier timeSupplier = () -> {
             if (isStart.compareAndSet(true, false)) {
@@ -70,7 +71,7 @@ public class TestEventHandlerTests extends ESTestCase {
         final ThreadPool threadPool = mock(ThreadPool.class);
         doAnswer(i -> timeSupplier.getAsLong()).when(threadPool).relativeTimeInNanos();
         TestEventHandler eventHandler =
-            new TestEventHandler((e) -> {}, () -> null, new MockNioTransport.TransportThreadWatchdog(threadPool));
+            new TestEventHandler(e -> {}, () -> null, new MockNioTransport.TransportThreadWatchdog(threadPool, Settings.EMPTY));
 
         ServerChannelContext serverChannelContext = mock(ServerChannelContext.class);
         SocketChannelContext socketChannelContext = mock(SocketChannelContext.class);


### PR DESCRIPTION
* The precision of the timestamps we get from the cached time thread is only 200ms by default resulting in a number of needless ~200ms slow network thread execution logs
  * Fixed by making the warn threshold a function of the precision of the cached time thread found in the settings
