### PR TITLE
Clarify heap setting in Docker docs

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -369,6 +369,12 @@ host.
 . Use the `ES_JAVA_OPTS` environment variable to set heap size. For example, to
 use 16GB use `-e ES_JAVA_OPTS="-Xms16g -Xmx16g"` with `docker run`.
 +
+--
+NOTE: You still need to <<heap-size,configure the heap size>> even if you are
+https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory[limiting
+memory access] to the container.
+--
+
 . Pin your deployments to a specific version of the {es} Docker image. For
 example, +docker.elastic.co/elasticsearch/elasticsearch:{version}+.
 +


### PR DESCRIPTION
Add note in the Docker docs that even when container memory is limited,
we still require specifying -Xms/-Xmx using one of the supported
methods.

Backport of #42754 