### PR TITLE
[ML] Close sample stream in find_file_structure endpoint

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFindFileStructureAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFindFileStructureAction.java
@@ -18,6 +18,8 @@ import org.elasticsearch.xpack.ml.filestructurefinder.FileStructureFinder;
 import org.elasticsearch.xpack.ml.filestructurefinder.FileStructureFinderManager;
 import org.elasticsearch.xpack.ml.filestructurefinder.FileStructureOverrides;
 
+import java.io.InputStream;
+
 public class TransportFindFileStructureAction
     extends HandledTransportAction<FindFileStructureAction.Request, FindFileStructureAction.Response> {
 
@@ -48,9 +50,11 @@ public class TransportFindFileStructureAction
 
         FileStructureFinderManager structureFinderManager = new FileStructureFinderManager(threadPool.scheduler());
 
-        FileStructureFinder fileStructureFinder = structureFinderManager.findFileStructure(request.getLinesToSample(),
-            request.getLineMergeSizeLimit(), request.getSample().streamInput(), new FileStructureOverrides(request), request.getTimeout());
+        try (InputStream sampleStream = request.getSample().streamInput()) {
+            FileStructureFinder fileStructureFinder = structureFinderManager.findFileStructure(request.getLinesToSample(),
+                request.getLineMergeSizeLimit(), sampleStream, new FileStructureOverrides(request), request.getTimeout());
 
-        return new FindFileStructureAction.Response(fileStructureFinder.getStructure());
+            return new FindFileStructureAction.Response(fileStructureFinder.getStructure());
+        }
     }
 }


### PR DESCRIPTION
A static code analysis revealed that we are not closing
the input stream in the find_file_structure endpoint.
This actually makes no difference in practice, as the
particular InputStream implementation in this case is
org.elasticsearch.common.bytes.BytesReferenceStreamInput
and its close() method is a no-op.  However, it is good
practice to close the stream anyway.