### PR TITLE
Add support for s390x seccomp

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/SystemCallFilter.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/SystemCallFilter.java
@@ -240,7 +240,8 @@ final class SystemCallFilter {
     static {
         ARCHITECTURES = Map.of(
                 "amd64", new Arch(0xC000003E, 0x3FFFFFFF, 57, 58, 59, 322, 317),
-                "aarch64", new Arch(0xC00000B7, 0xFFFFFFFF, 1079, 1071, 221, 281, 277));
+                "aarch64", new Arch(0xC00000B7, 0xFFFFFFFF, 1079, 1071, 221, 281, 277),
+ 		"s390x",  new Arch(0x80000016, 0xFFFFFFFF, 2, 190, 6, 354, 348));
     }
 
     /** invokes prctl() from linux libc library */


### PR DESCRIPTION
s390x fails basic checks because it has no support for seccomp. This PR adds s390x as a supported architecture. 

If you need a s390x host for use in your CI setup let me know as I have access to Z resources that could be used.
