### PR TITLE
[DOCS] Backports discovery.type #42823

### DIFF
--- a/docs/reference/modules/discovery/zen.asciidoc
+++ b/docs/reference/modules/discovery/zen.asciidoc
@@ -224,3 +224,13 @@ cluster.
 The `discovery.zen.no_master_block` setting doesn't apply to nodes-based apis
 (for example cluster stats, node info and node stats apis).  Requests to these
 apis will not be blocked and can run on any available node.
+
+[float]
+[[single-node]]
+==== Single-node discovery
+
+The `discovery.type` setting specifies whether {es} should form a multiple-node
+cluster. By default, {es} discovers other nodes when forming a cluster and
+allows other nodes to join the cluster later. If `discovery.type` is set to
+`single-node`, {es} forms a single-node cluster. For more information about when
+you might use this setting, see <<single-node-discovery,Bootstrap checks>>.


### PR DESCRIPTION
This PR backports https://github.com/elastic/elasticsearch/pull/42823

In particular, it adds information about the `discovery.type` setting at the bottom of this page: https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-discovery-zen.html
