### PR TITLE
Skip shadow jar logic for javadoc and sources jars

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -695,8 +695,11 @@ class BuildPlugin implements Plugin<Project> {
             // we put all our distributable files under distributions
             jarTask.destinationDir = new File(project.buildDir, 'distributions')
             project.plugins.withType(ShadowPlugin).whenPluginAdded {
-                // ensure the original jar task places its output in 'libs' so we don't overwrite it with the shadowjar
-                if (jarTask instanceof ShadowJar == false) {
+                /*
+                 * Ensure the original jar task places its output in 'libs' so that we don't overwrite it with the shadow jar. We only do
+                 * this for tasks named jar to exclude javadoc and sources jars.
+                 */
+                if (jarTask instanceof ShadowJar == false && jarTask.name == "jar") {
                     jarTask.destinationDir = new File(project.buildDir, 'libs')
                 }
             }


### PR DESCRIPTION
For shadow jars, we place the original jar in a build/libs directory. This is to avoid clobbering the original jar when building the shadow jar. However, we need to skip this logic for javadoc and sources jars otherwise they would never be copied to the build/distributions directory during assembly.

Relates #42771