### PR TITLE
Fix hang in test for "too many fields" dep. checks

### DIFF
--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -370,7 +370,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
                 mappingBuilder.startObject("properties");
                 {
                     int subfields = randomIntBetween(1, 10);
-                    while (existingFieldNames.size() < subfields) {
+                    while (existingFieldNames.size() < subfields && fieldCount.get() <= fieldLimit) {
                         addRandomField(existingFieldNames, fieldLimit, mappingBuilder, fieldCount);
                     }
                 }


### PR DESCRIPTION
This commit fixes a rare case where the method to randomly generate a
very large mapping could enter an infinite loop.

Fixes https://github.com/elastic/elasticsearch/issues/41740