### PR TITLE
Correct versions limits for snapshot metadata field

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get/10_basic.yml
@@ -154,8 +154,8 @@ setup:
 ---
 "Get snapshot info with metadata":
   - skip:
-      version: " - 7.9.99"
-      reason: "https://github.com/elastic/elasticsearch/pull/41281 not yet backported to 7.x"
+      version: " - 7.2.99"
+      reason: "metadata field was added in 7.3"
 
   - do:
       indices.create:

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -52,7 +52,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
 
     public static final String CONTEXT_MODE_PARAM = "context_mode";
     public static final String CONTEXT_MODE_SNAPSHOT = "SNAPSHOT";
-    public static final Version METADATA_FIELD_INTRODUCED = Version.V_8_0_0; // TODO Set this to the earliest version this is backported to
+    public static final Version METADATA_FIELD_INTRODUCED = Version.V_7_3_0;
     private static final DateFormatter DATE_TIME_FORMATTER = DateFormatter.forPattern("strictDateOptionalTime");
     private static final String SNAPSHOT = "snapshot";
     private static final String UUID = "uuid";


### PR DESCRIPTION
Now that the snapshot metadata field has been backported, the version
restrictions used in tests and for serialization need to corrected.

---

This is a draft PR for now because I want to be sure it passes CI.