### PR TITLE
shrink may full copy when using multi data paths

### DIFF
--- a/docs/reference/indices/shrink-index.asciidoc
+++ b/docs/reference/indices/shrink-index.asciidoc
@@ -17,7 +17,10 @@ Shrinking works as follows:
 
 * Then it hard-links segments from the source index into the target index. (If
   the file system doesn't support hard-linking, then all segments are copied
-  into the new index, which is a much more time consuming process.)
+  into the new index, which is a much more time consuming process. Also if using 
+  multiple data paths, shards on different data paths require a full copy of 
+  segment files if they are not on the same disk since hardlinks don’t work across
+  disks)
 
 * Finally, it recovers the target index as though it were a closed index which
   had just been re-opened.


### PR DESCRIPTION
Additional scenario for full segment copy as hard linking
cannot work across disks.