### PR TITLE
Fix testPendingTasks test failure

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
@@ -330,8 +330,10 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
                 fail(e.getMessage());
             }
         });
-        assertThat(indicesService.hasUncompletedPendingDeletes(), equalTo(hasBogus)); // "bogus" index has not been removed
-        assertFalse(shardPath.exists());
+        assertBusy(() -> {
+            assertThat(indicesService.hasUncompletedPendingDeletes(), equalTo(hasBogus)); // "bogus" index has not been removed
+            assertFalse(shardPath.exists());
+        });
     }
 
     public void testVerifyIfIndexContentDeleted() throws Exception {


### PR DESCRIPTION
Fixes a race in the test which can be reliably reproduced by adding `Thread.sleep(100)` to the end of
`IndicesService.processPendingDeletes`

Closes #18747