### PR TITLE
[DOCS] Move 'Scripting' section to top-level navigation.

### DIFF
--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -39,6 +39,8 @@ include::cluster.asciidoc[]
 
 include::query-dsl.asciidoc[]
 
+include::scripting.asciidoc[]
+
 include::mapping.asciidoc[]
 
 include::analysis.asciidoc[]

--- a/docs/reference/modules.asciidoc
+++ b/docs/reference/modules.asciidoc
@@ -46,19 +46,9 @@ The modules in this section are:
 
     A Java node client joins the cluster, but doesn't hold data or act as a master node.
 
-<<modules-scripting-painless,Painless>>::
-
-    A built-in scripting language for Elasticsearch that's designed to be as secure as possible.
-
 <<modules-plugins,Plugins>>::
 
     Using plugins to extend Elasticsearch.
-
-<<modules-scripting,Scripting>>::
-
-    Custom scripting available in Lucene Expressions, ad Groovy. You can also
-    write scripts in the built-in scripting language,
-    <<modules-scripting-painless, Painless>>.
 
 <<modules-snapshots,Snapshot/Restore>>::
 
@@ -101,8 +91,6 @@ include::modules/node.asciidoc[]
 
 :edit_url:
 include::modules/plugins.asciidoc[]
-
-include::modules/scripting.asciidoc[]
 
 include::modules/snapshots.asciidoc[]
 

--- a/docs/reference/scripting.asciidoc
+++ b/docs/reference/scripting.asciidoc
@@ -1,9 +1,11 @@
 [[modules-scripting]]
-== Scripting
+= Scripting
 
-The scripting module enables you to use scripts to evaluate custom
-expressions. For example, you could use a script to return "script fields"
-as part of a search request or evaluate a custom score for a query.
+[partintro]
+--
+With scripting, you can evaluate custom expressions in {es}. For example, you
+could use a script to return "script fields" as part of a search request or
+evaluate a custom score for a query.
 
 The default scripting language is <<modules-scripting-painless, `Painless`>>.
 Additional `lang` plugins enable you to run scripts written in other languages.
@@ -11,7 +13,7 @@ Everywhere a script can be used, you can include a `lang` parameter
 to specify the language of the script.
 
 [float]
-=== General-purpose languages:
+== General-purpose languages
 
 These languages can be used for any purpose in the scripting APIs,
 and give the most flexibility.
@@ -29,7 +31,7 @@ and give the most flexibility.
 |=======================================================================
 
 [float]
-=== Special-purpose languages:
+== Special-purpose languages
 
 These languages are less flexible, but typically have higher performance for
 certain tasks.
@@ -67,7 +69,7 @@ sandboxed languages can be a security issue, please read
 <<modules-scripting-security, Scripting and security>> for more details.
 
 =================================================
-
+--
 
 include::scripting/using.asciidoc[]
 

--- a/docs/reference/scripting/engine.asciidoc
+++ b/docs/reference/scripting/engine.asciidoc
@@ -1,5 +1,5 @@
 [[modules-scripting-engine]]
-=== Advanced scripts using script engines
+== Advanced scripts using script engines
 
 A `ScriptEngine` is a backend for implementing a scripting language. It may also
 be used to write scripts that need to use advanced internals of scripting. For example,

--- a/docs/reference/scripting/expression.asciidoc
+++ b/docs/reference/scripting/expression.asciidoc
@@ -1,5 +1,5 @@
 [[modules-scripting-expression]]
-=== Lucene Expressions Language
+== Lucene Expressions Language
 
 Lucene's expressions compile a `javascript` expression to bytecode. They are
 designed for high-performance custom ranking and sorting functions and are

--- a/docs/reference/scripting/expression.asciidoc
+++ b/docs/reference/scripting/expression.asciidoc
@@ -1,5 +1,5 @@
 [[modules-scripting-expression]]
-== Lucene Expressions Language
+== Lucene expressions language
 
 Lucene's expressions compile a `javascript` expression to bytecode. They are
 designed for high-performance custom ranking and sorting functions and are

--- a/docs/reference/scripting/fields.asciidoc
+++ b/docs/reference/scripting/fields.asciidoc
@@ -1,5 +1,5 @@
 [[modules-scripting-fields]]
-=== Accessing document fields and special variables
+== Accessing document fields and special variables
 
 Depending on where a script is used, it will have access to certain special
 variables and document fields.

--- a/docs/reference/scripting/fields.asciidoc
+++ b/docs/reference/scripting/fields.asciidoc
@@ -17,7 +17,7 @@ API will have access to the `ctx` variable which exposes:
 `ctx._index` etc::  Access to <<mapping-fields,document meta-fields>>, some of which may be read-only.
 
 [float]
-== Search and Aggregation scripts
+== Search and aggregation scripts
 
 With the exception of <<search-request-script-fields,script fields>> which are
 executed once per search hit, scripts used in search and aggregations will be
@@ -80,7 +80,7 @@ GET my_index/_search
 
 [float]
 [[modules-scripting-doc-vals]]
-=== Doc Values
+=== Doc values
 
 By far the fastest most efficient way to access a field value from a
 script is to use the `doc['field_name']` syntax, which retrieves the field
@@ -140,7 +140,7 @@ access `text` fields from scripts.
 
 [float]
 [[modules-scripting-stored]]
-=== Stored Fields and `_source`
+=== Stored fields and `_source`
 
 _Stored fields_ -- fields explicitly marked as
 <<mapping-store,`"store": true`>> -- can be accessed using the

--- a/docs/reference/scripting/painless.asciidoc
+++ b/docs/reference/scripting/painless.asciidoc
@@ -1,5 +1,5 @@
 [[modules-scripting-painless]]
-=== Painless Scripting Language
+== Painless Scripting Language
 
 _Painless_ is a simple, secure scripting language designed specifically for use
 with Elasticsearch. It is the default scripting language for Elasticsearch and

--- a/docs/reference/scripting/painless.asciidoc
+++ b/docs/reference/scripting/painless.asciidoc
@@ -1,5 +1,5 @@
 [[modules-scripting-painless]]
-== Painless Scripting Language
+== Painless scripting language
 
 _Painless_ is a simple, secure scripting language designed specifically for use
 with Elasticsearch. It is the default scripting language for Elasticsearch and

--- a/docs/reference/scripting/security.asciidoc
+++ b/docs/reference/scripting/security.asciidoc
@@ -1,5 +1,5 @@
 [[modules-scripting-security]]
-=== Scripting and security
+== Scripting and security
 
 While Elasticsearch contributors make every effort to prevent scripts from
 running amok, security is something best done in

--- a/docs/reference/scripting/using.asciidoc
+++ b/docs/reference/scripting/using.asciidoc
@@ -45,7 +45,7 @@ GET my_index/_search
 // CONSOLE
 
 [float]
-=== Script Parameters
+=== Script parameters
 
 `lang`::
 
@@ -107,7 +107,7 @@ minute will be compiled. You can change this setting dynamically by setting
 
 [float]
 [[modules-scripting-short-script-form]]
-=== Short Script Form
+=== Short script form
 A short script form can be used for brevity. In the short form, `script` is represented
 by a string instead of an object. This string contains the source of the script.
 
@@ -131,13 +131,13 @@ The same script in the normal form:
 
 [float]
 [[modules-scripting-stored-scripts]]
-=== Stored Scripts
+=== Stored scripts
 
 Scripts may be stored in and retrieved from the cluster state using the
 `_scripts` end-point.
 
 [float]
-==== Request Examples
+==== Request examples
 
 The following are examples of using a stored script that lives at
 `/_scripts/{id}`.
@@ -197,7 +197,7 @@ DELETE _scripts/calculate-score
 
 [float]
 [[modules-scripting-using-caching]]
-=== Script Caching
+=== Script caching
 
 All scripts are cached by default so that they only need to be recompiled
 when updates occur. By default, scripts do not have a time-based expiration, but

--- a/docs/reference/scripting/using.asciidoc
+++ b/docs/reference/scripting/using.asciidoc
@@ -1,5 +1,5 @@
 [[modules-scripting-using]]
-=== How to use scripts
+== How to use scripts
 
 Wherever scripting is supported in the Elasticsearch API, the syntax follows
 the same pattern:
@@ -136,6 +136,7 @@ The same script in the normal form:
 Scripts may be stored in and retrieved from the cluster state using the
 `_scripts` end-point.
 
+[float]
 ==== Request Examples
 
 The following are examples of using a stored script that lives at


### PR DESCRIPTION
Relocates 'Scripting' from the 'Modules' section to its own section in the top-level navigation of the Elasticsearch Reference.

Aside from a few edits to the introduction, there are no changes outside of navigation. Anchors and page URLs will remain the same.

## Before
<details>
 <summary>Before image</summary>
<img width="757" alt="scripting nav before" src="https://user-images.githubusercontent.com/40268737/59033322-74298380-8836-11e9-853f-6b970c7d3245.png">
</details>


## After
<details>
 <summary>After image</summary>
<img width="762" alt="scripting nav after" src="https://user-images.githubusercontent.com/40268737/59033333-7855a100-8836-11e9-8ccc-18fd2e304d09.png">
</details>