### PR TITLE
[ML][Data frame] make sure that fields exist when creating progress

### DIFF
--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameTransformProgressIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameTransformProgressIT.java
@@ -6,7 +6,6 @@
 
 package org.elasticsearch.xpack.dataframe.integration;
 
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
@@ -44,7 +43,6 @@ import static org.elasticsearch.xpack.dataframe.integration.DataFrameRestTestCas
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
-@LuceneTestCase.AwaitsFix( bugUrl = "https://github.com/elastic/elasticsearch/issues/42344")
 public class DataFrameTransformProgressIT extends ESRestTestCase {
     protected void createReviewsIndex() throws Exception {
         final int numDocs = 1000;
@@ -162,6 +160,23 @@ public class DataFrameTransformProgressIT extends ESRestTestCase {
         assertThat(progress.getTotalDocs(), equalTo(35L));
         assertThat(progress.getRemainingDocs(), equalTo(35L));
         assertThat(progress.getPercentComplete(), equalTo(0.0));
+
+        histgramGroupConfig = new GroupConfig(Collections.emptyMap(),
+            Collections.singletonMap("every_50", new HistogramGroupSource("missing_field", 50.0)));
+        pivotConfig = new PivotConfig(histgramGroupConfig, aggregationConfig, null);
+        config = new DataFrameTransformConfig("get_progress_transform",
+            sourceConfig,
+            destConfig,
+            null,
+            pivotConfig,
+            null);
+
+        response = restClient.search(TransformProgressGatherer.getSearchRequest(config), RequestOptions.DEFAULT);
+        progress = TransformProgressGatherer.searchResponseToDataFrameTransformProgressFunction().apply(response);
+
+        assertThat(progress.getTotalDocs(), equalTo(0L));
+        assertThat(progress.getRemainingDocs(), equalTo(0L));
+        assertThat(progress.getPercentComplete(), equalTo(100.0));
 
         deleteIndex(REVIEWS_INDEX_NAME);
     }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
@@ -131,7 +131,7 @@ public class DataFrameTransformPersistentTasksExecutor extends PersistentTasksEx
                     .setInitialPosition(stateAndStats.getTransformState().getPosition())
                     .setProgress(stateAndStats.getTransformState().getProgress())
                     .setIndexerState(currentIndexerState(stateAndStats.getTransformState()));
-                logger.info("[{}] Loading existing state: [{}], position [{}]",
+                logger.debug("[{}] Loading existing state: [{}], position [{}]",
                     transformId,
                     stateAndStats.getTransformState(),
                     stateAndStats.getTransformState().getPosition());


### PR DESCRIPTION
Since we do not yet support `missing_bucket` in our pivot transform, the default behavior in Composite aggregations is to skip that bucket. This causes our total doc count to be inaccurate when there are missing/null fields. To address this, an `exists` query for each of the pivoted fields needs to be done when `missing_bucket: false` (currently, always the case). 