### PR TITLE
[7.2] Fix hang in test for "too many fields" dep. check (#42909)

### DIFF
--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -132,7 +132,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
                 mappingBuilder.startObject("properties");
                 {
                     int subfields = randomIntBetween(1, 10);
-                    while (existingFieldNames.size() < subfields) {
+                    while (existingFieldNames.size() < subfields && fieldCount.get() <= fieldLimit) {
                         addRandomField(existingFieldNames, fieldLimit, mappingBuilder, fieldCount);
                     }
                 }


### PR DESCRIPTION
Backports the following commits to 7.2:
 - Fix hang in test for "too many fields" dep. check (#42909) (e35b240)