### PR TITLE
[6.8] Fix hang in test for "too many fields" dep. check (#42909)

### DIFF
--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -614,8 +614,8 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             if (rarely()) {
                 mappingBuilder.startObject("properties");
                 {
-                    int subfields = randomIntBetween(1,10);
-                    while (existingFieldNames.size() < subfields) {
+                    int subfields = randomIntBetween(1, 10);
+                    while (existingFieldNames.size() < subfields && fieldCount.get() <= fieldLimit) {
                         addRandomField(existingFieldNames, fieldLimit, mappingBuilder, fieldCount);
                     }
                 }


### PR DESCRIPTION
Backports the following commits to 6.8:
 - Fix hang in test for "too many fields" dep. check (#42909) (e35b240)