### PR TITLE
Fix versions for reindex max_docs tests

### DIFF
--- a/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/10_basic.yml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/10_basic.yml
@@ -282,8 +282,8 @@
 ---
 "Limit by size":
   - skip:
-      version: " - 7.1.99"
-      reason: "deprecation warnings only emitted on 7.2+"
+      version: " - 7.2.99"
+      reason: "deprecation warnings only emitted on 7.3+"
       features: warnings
 
   - do:
@@ -326,10 +326,10 @@
   - match: {count: 1}
 
 ---
-"Limit by size pre 7.2":
+"Limit by size pre 7.3":
   - skip:
-      version: "7.2.0 - "
-      reason: "7.2 should use max_docs or get deprecation warning"
+      version: "7.3.0 - "
+      reason: "7.3 should use max_docs or get deprecation warning"
 
   - do:
       index:
@@ -371,8 +371,8 @@
 ---
 "Limit by max_docs in URL":
   - skip:
-      version: " - 7.1.99"
-      reason: "max_docs introduced in 7.2.0"
+      version: " - 7.2.99"
+      reason: "max_docs introduced in 7.3.0"
 
   - do:
       index:
@@ -414,8 +414,8 @@
 ---
 "Limit by max_docs in body":
   - skip:
-      version: " - 7.1.99"
-      reason: "max_docs introduced in 7.2.0"
+      version: " - 7.2.99"
+      reason: "max_docs introduced in 7.3.0"
 
   - do:
       index:

--- a/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/20_validation.yml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/20_validation.yml
@@ -49,8 +49,8 @@
 ---
 "invalid max_docs fails":
   - skip:
-      version: " - 7.1.99"
-      reason: "max_docs introduced in 7.2.0"
+      version: " - 7.2.99"
+      reason: "max_docs introduced in 7.3.0"
 
   - do:
       index:
@@ -69,8 +69,8 @@
 ---
 "both max_docs and size fails":
   - skip:
-      version: " - 7.1.99"
-      reason: "max_docs introduced in 7.2.0"
+      version: " - 7.2.99"
+      reason: "max_docs introduced in 7.3.0"
 
   - do:
       index:

--- a/modules/reindex/src/test/resources/rest-api-spec/test/reindex/20_validation.yml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/reindex/20_validation.yml
@@ -114,8 +114,8 @@
 ---
 "invalid max_docs in body fails":
   - skip:
-      version: " - 7.1.99"
-      reason: "max_docs introduced in 7.2.0"
+      version: " - 7.2.99"
+      reason: "max_docs introduced in 7.3.0"
 
   - do:
       index:
@@ -135,8 +135,8 @@
 ---
 "invalid max_docs in URL fails":
   - skip:
-      version: " - 7.1.99"
-      reason: "max_docs introduced in 7.2.0"
+      version: " - 7.2.99"
+      reason: "max_docs introduced in 7.3.0"
 
   - do:
       index:
@@ -156,8 +156,8 @@
 ---
 "inconsistent max_docs and size fails":
   - skip:
-      version: " - 7.1.99"
-      reason: "max_docs introduced in 7.2.0"
+      version: " - 7.2.99"
+      reason: "max_docs introduced in 7.3.0"
 
   - do:
       index:
@@ -178,8 +178,8 @@
 ---
 "inconsistent max_docs in body and max_docs in URL fails":
   - skip:
-      version: " - 7.1.99"
-      reason: "max_docs introduced in 7.2.0"
+      version: " - 7.2.99"
+      reason: "max_docs introduced in 7.3.0"
 
   - do:
       index:

--- a/modules/reindex/src/test/resources/rest-api-spec/test/reindex/30_search.yml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/reindex/30_search.yml
@@ -34,8 +34,8 @@
 ---
 "Sorting and size combined":
   - skip:
-      version: " - 7.1.99"
-      reason: "deprecation warnings only emitted on 7.2+"
+      version: " - 7.2.99"
+      reason: "deprecation warnings only emitted on 7.3+"
       features: warnings
 
   - do:
@@ -78,10 +78,10 @@
   - match: { hits.total: 1 }
 
 ---
-"Sorting and size combined pre 7.2":
+"Sorting and size combined pre 7.3":
   - skip:
-      version: "7.2.0 - "
-      reason: "7.2 should use max_docs or get deprecation warning"
+      version: "7.3.0 - "
+      reason: "7.3 should use max_docs or get deprecation warning"
 
   - do:
       index:
@@ -123,8 +123,8 @@
 ---
 "Sorting and max_docs in body combined":
   - skip:
-      version: " - 7.1.99"
-      reason: "max_docs introduced in 7.2.0"
+      version: " - 7.2.99"
+      reason: "max_docs introduced in 7.3.0"
 
   - do:
       index:
@@ -166,8 +166,8 @@
 ---
 "max_docs in URL":
   - skip:
-      version: " - 7.1.99"
-      reason: "max_docs introduced in 7.2.0"
+      version: " - 7.2.99"
+      reason: "max_docs introduced in 7.3.0"
 
   - do:
       index:

--- a/modules/reindex/src/test/resources/rest-api-spec/test/reindex/90_remote.yml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/reindex/90_remote.yml
@@ -220,8 +220,8 @@
 ---
 "Reindex from remote with size":
   - skip:
-      version: "7.2.0 - "
-      reason: "7.2 should use max_docs or get deprecation warning"
+      version: "7.3.0 - "
+      reason: "7.3 should use max_docs or get deprecation warning"
 
   - do:
       index:
@@ -286,8 +286,8 @@
 ---
 "Reindex from remote with max_docs":
   - skip:
-      version: " - 7.1.99"
-      reason: "max_docs introduced in 7.2.0"
+      version: " - 7.2.99"
+      reason: "max_docs introduced in 7.3.0"
 
   - do:
       index:

--- a/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/10_basic.yml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/10_basic.yml
@@ -220,8 +220,8 @@
 ---
 "Limit by size":
   - skip:
-      version: " - 7.1.99"
-      reason: "deprecation warnings only emitted on 7.2+"
+      version: " - 7.2.99"
+      reason: "deprecation warnings only emitted on 7.3+"
       features: warnings
 
   - do:
@@ -251,10 +251,10 @@
   - gte: { took: 0 }
 
 ---
-"Limit by size pre 7.2":
+"Limit by size pre 7.3":
   - skip:
-      version: "7.2.0 - "
-      reason: "7.2 should use max_docs or get deprecation warning"
+      version: "7.3.0 - "
+      reason: "7.3 should use max_docs or get deprecation warning"
 
   - do:
       index:
@@ -283,8 +283,8 @@
 ---
 "Limit by max_docs in URL":
   - skip:
-      version: " - 7.1.99"
-      reason: "max_docs introduced in 7.2.0"
+      version: " - 7.2.99"
+      reason: "max_docs introduced in 7.3.0"
 
   - do:
       index:
@@ -313,8 +313,8 @@
 ---
 "Limit by max_docs in body":
   - skip:
-      version: " - 7.1.99"
-      reason: "max_docs introduced in 7.2.0"
+      version: " - 7.2.99"
+      reason: "max_docs introduced in 7.3.0"
 
   - do:
       index:

--- a/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/20_validation.yml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/20_validation.yml
@@ -27,8 +27,8 @@
 ---
 "invalid max_docs in URL fails":
   - skip:
-      version: " - 7.1.99"
-      reason: "max_docs introduced in 7.2.0"
+      version: " - 7.2.99"
+      reason: "max_docs introduced in 7.3.0"
 
   - do:
       index:
@@ -44,8 +44,8 @@
 ---
 "invalid max_docs in body fails":
   - skip:
-      version: " - 7.1.99"
-      reason: "max_docs introduced in 7.2.0"
+      version: " - 7.2.99"
+      reason: "max_docs introduced in 7.3.0"
 
   - do:
       index:
@@ -62,8 +62,8 @@
 ---
 "inconsistent max_docs and size fails":
   - skip:
-      version: " - 7.1.99"
-      reason: "max_docs introduced in 7.2.0"
+      version: " - 7.2.99"
+      reason: "max_docs introduced in 7.3.0"
 
   - do:
       index:
@@ -83,8 +83,8 @@
 ---
 "inconsistent max_docs in body and max_docs in URL fails":
   - skip:
-      version: " - 7.1.99"
-      reason: "max_docs introduced in 7.2.0"
+      version: " - 7.2.99"
+      reason: "max_docs introduced in 7.3.0"
 
   - do:
       index:


### PR DESCRIPTION
Versions were assuming this went into 7.2, but this ended up going into
7.3, updated test versions to reflect that.

Related to #41894