### PR TITLE
Skip CAS deprecation tests until all nodes upgraded

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/delete/20_internal_version.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/delete/20_internal_version.yml
@@ -1,8 +1,8 @@
 ---
 "Internal version":
  - skip:
-      version: " - 6.6.99"
-      reason:  versioned operations were deprecated in 6.7
+      version: " - 6.8.0"
+      reason:  versioned operations were deprecated in 6.7 but deprecation warnings are not consistent until all nodes on 6.8.1+
       features: warnings
 
  - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/30_internal_version.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/30_internal_version.yml
@@ -1,8 +1,8 @@
 ---
 "Internal version":
  - skip:
-     version: " - 6.6.99"
-     reason:  versioned operations were deprecated in 6.7
+     version: " - 6.8.0"
+     reason:  versioned operations were deprecated in 6.7 but deprecation warnings are not consistent until all nodes on 6.8.1+
      features: warnings
 
  - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/30_internal_version.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/30_internal_version.yml
@@ -1,8 +1,8 @@
 ---
 "Internal version":
  - skip:
-      version: " - 6.6.99"
-      reason:  versioned operations were deprecated in 6.7
+      version: " - 6.8.0"
+      reason:  versioned operations were deprecated in 6.7 but deprecation warnings are not consistent until all nodes on 6.8.1+
       features: warnings
 
  - do:


### PR DESCRIPTION
After we moved CAS deprecation check to TransportShardBulkAction (#42641), a mixed cluster consisting of 6.7 and 6.8.1 nodes can issue two deprecation warnings for versioning write requests. The way we deduplicate response headers does not work for warning headers from different versions (maybe we need to improve this?). This commit skips CAS deprecation tests until all nodes on 6.8.1+. 

An alternative option is to make `DoSection.checkWarningHeaders` more lenient to accept duplicated warnings (maybe only CAS warnings). 

Some CI instances: 
- https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+6.8+bwc-tests/9/console
- https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+6.8+bwc-tests/8/console
- https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+6.8+default-distro-bwc-tests/5/console

