### PR TITLE
[DOCS] Add explicit `articles_case` parameter to Elision Token Filter example

### DIFF
--- a/docs/reference/analysis/tokenfilters/elision-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/elision-tokenfilter.asciidoc
@@ -22,6 +22,7 @@ PUT /elision_example
             "filter" : {
                 "elision" : {
                     "type" : "elision",
+                    "articles_case": true,
                     "articles" : ["l", "m", "t", "qu", "n", "s", "j"]
                 }
             }

--- a/docs/reference/analysis/tokenfilters/elision-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/elision-tokenfilter.asciidoc
@@ -4,8 +4,11 @@
 A token filter which removes elisions. For example, "l'avion" (the
 plane) will tokenized as "avion" (plane).
 
-Accepts `articles` setting which is a set of stop words articles. For
-example:
+Accepts `articles` parameter which is a set of stop words articles. Also accepts
+`articles_case`, which indicates whether the filter treats those articles as
+case sensitive.
+
+For example:
 
 [source,js]
 --------------------------------------------------


### PR DESCRIPTION
Adds the `articles_case` parameter to the Elision Token Filter example.

While the `articles_cases` parameter is included in other [examples](https://www.elastic.co/guide/en/elasticsearch/reference/master/analysis-lang-analyzer.html), it is currently missing from the [Elision Token Filter documentation](https://www.elastic.co/guide/en/elasticsearch/reference/master/analysis-elision-tokenfilter.html).

Resolves #41015.