### PR TITLE
Better test diag output on OOM

### DIFF
--- a/server/src/test/java/org/elasticsearch/versioning/ConcurrentSeqNoVersioningIT.java
+++ b/server/src/test/java/org/elasticsearch/versioning/ConcurrentSeqNoVersioningIT.java
@@ -454,8 +454,8 @@ public class ConcurrentSeqNoVersioningIT extends AbstractDisruptionTestCase {
                 String serializedHistory = base64Serialize(history);
                 if (linearizable == false) {
                     // we dump base64 encoded data, since the nature of this test is that it does not reproduce even with same seed.
-                    logger.error("Linearizability check failed. Spec: {}, initial version: {}, serialized history: {}", spec, initialVersion,
-                        serializedHistory);
+                    logger.error("Linearizability check failed. Spec: {}, initial version: {}, serialized history: {}",
+                        spec, initialVersion, serializedHistory);
                 }
             }
             return linearizable;

--- a/server/src/test/java/org/elasticsearch/versioning/ConcurrentSeqNoVersioningIT.java
+++ b/server/src/test/java/org/elasticsearch/versioning/ConcurrentSeqNoVersioningIT.java
@@ -446,13 +446,17 @@ public class ConcurrentSeqNoVersioningIT extends AbstractDisruptionTestCase {
             logger.info("--> Linearizability checking history of size: {} for key: {} and initialVersion: {}: {}", history.size(),
                 id, initialVersion, history);
             LinearizabilityChecker.SequentialSpec spec = new CASSequentialSpec(initialVersion);
-            boolean linearizable = new LinearizabilityChecker().isLinearizable(spec, history, missingResponseGenerator());
-            // implicitly test that we can serialize all histories.
-            String serializedHistory = base64Serialize(history);
-            if (linearizable == false) {
-                // we dump base64 encoded data, since the nature of this test is that it does not reproduce even with same seed.
-                logger.error("Linearizability check failed. Spec: {}, initial version: {}, serialized history: {}", spec, initialVersion,
-                    serializedHistory);
+            boolean linearizable = false;
+            try {
+                linearizable = new LinearizabilityChecker().isLinearizable(spec, history, missingResponseGenerator());
+            } finally {
+                // implicitly test that we can serialize all histories.
+                String serializedHistory = base64Serialize(history);
+                if (linearizable == false) {
+                    // we dump base64 encoded data, since the nature of this test is that it does not reproduce even with same seed.
+                    logger.error("Linearizability check failed. Spec: {}, initial version: {}, serialized history: {}", spec, initialVersion,
+                        serializedHistory);
+                }
             }
             return linearizable;
         }


### PR DESCRIPTION
If linearizability checking fails with OOM (or other exception), we did
not get the serialized history written into the log, making it difficult
to debug in cases where the problem is hard to reproduce. Fixed to
always attempt dumping the serialized history.

Related to #42244