### PR TITLE
Drop dead code for socket permissions for transport

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -363,17 +363,6 @@ final class Security {
     }
 
     /**
-     * Add dynamic {@link SocketPermission} based on transport settings.
-     *
-     * @param policy          the {@link Permissions} instance to apply the dynamic {@link SocketPermission}s to
-     * @param settings        the {@link Settings} instance to read the transport settings from
-     */
-    private static void addSocketPermissionForTransport(final Permissions policy, final Settings settings) {
-        final String transportRange = TransportSettings.PORT.get(settings);
-        addSocketPermissionForPortRange(policy, transportRange);
-    }
-
-    /**
      * Add dynamic {@link SocketPermission} for the specified port range.
      *
      * @param policy the {@link Permissions} instance to apply the dynamic {@link SocketPermission} to.

--- a/server/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -29,7 +29,6 @@ import org.elasticsearch.plugins.PluginInfo;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.secure_sm.SecureSM;
 import org.elasticsearch.transport.TcpTransport;
-import org.elasticsearch.transport.TransportSettings;
 
 import java.io.IOException;
 import java.net.SocketPermission;


### PR DESCRIPTION
This code has not been needed since the removal of tribe nodes, it was left behind when those were dropped (note that regular transport permissions are handled through transport profiles, even if they are not explicitly in use).
