### PR TITLE
[ML] Get resources action should be lenient when sort field is unmapped

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/AbstractTransportGetResourcesAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/AbstractTransportGetResourcesAction.java
@@ -30,6 +30,7 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.action.util.ExpandedIdsMatcher;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
@@ -70,7 +71,10 @@ public abstract class AbstractTransportGetResourcesAction<Resource extends ToXCo
     protected void searchResources(AbstractGetResourcesRequest request, ActionListener<QueryPage<Resource>> listener) {
         String[] tokens = Strings.tokenizeToStringArray(request.getResourceId(), ",");
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
-            .sort(request.getResourceIdField())
+            .sort(SortBuilders.fieldSort(request.getResourceIdField())
+                // If there are no resources, there might be no mapping for the id field.
+                // This makes sure we don't get an error if that happens.
+                .unmappedType("long"))
             .query(buildQuery(tokens, request.getResourceIdField()));
         if (request.getPageParams() != null) {
             sourceBuilder.from(request.getPageParams().getFrom())

--- a/x-pack/plugin/ml/qa/ml-with-security/build.gradle
+++ b/x-pack/plugin/ml/qa/ml-with-security/build.gradle
@@ -47,6 +47,7 @@ integTestRunner {
     'ml/filter_crud/Test invalid param combinations',
     'ml/filter_crud/Test non-existing filter',
     'ml/filter_crud/Test update filter given remove item is not present',
+    'ml/filter_crud/Test get all filter given index exists but no mapping for filter_id',
     'ml/get_datafeed_stats/Test get datafeed stats given missing datafeed_id',
     'ml/get_datafeeds/Test get datafeed given missing datafeed_id',
     'ml/jobs_crud/Test cannot create job with existing categorizer state document',

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/filter_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/filter_crud.yml
@@ -328,3 +328,18 @@ setup:
       ml.get_filters: {}
   - match: { count: 0 }
   - match: { filters: [] }
+
+---
+"Test get all filter given index exists but no mapping for filter_id":
+
+  - do:
+      indices.delete:
+        index: ".ml-meta"
+  - do:
+      indices.create:
+        index: ".ml-meta"
+
+  - do:
+      ml.get_filters: {}
+  - match: { count: 0 }
+  - match: { filters: [] }


### PR DESCRIPTION
Get resources action sorts on the resource id. When there are no resources at
all, then it is possible the index does not contain a mapping for the resource
id field. In that case, the search api fails by default.

This commit adjusts the search request to ignore unmapped fields.

Closes elastic/kibana#37870
