### PR TITLE
[DOCS] Adds dataframe authorization details

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -1137,3 +1137,12 @@ buildRestTests.setups['seats'] = '''
             {"theatre": "Graye", "cost": 33, "row": 2, "number": 6, "sold": false}
             {"index":{"_id": "4"}}
             {"theatre": "Skyline", "cost": 20, "row": 5, "number": 2, "sold": false}'''
+buildRestTests.setups['kibana_sample_data_ecommerce'] = '''
+  - do:
+        indices.create:
+          index: kibana_sample_data_ecommerce
+          body:
+            settings:
+              number_of_shards: 1
+              number_of_replicas: 0
+'''

--- a/docs/reference/data-frames/apis/delete-transform.asciidoc
+++ b/docs/reference/data-frames/apis/delete-transform.asciidoc
@@ -8,6 +8,8 @@
 <titleabbrev>Delete {dataframe-transforms}</titleabbrev>
 ++++
 
+beta[]
+
 Deletes an existing {dataframe-transform}.
 
 
@@ -22,7 +24,11 @@ Deletes an existing {dataframe-transform}.
 `data_frame_transform_id` (required)::
   (string) Identifier for the {dataframe-transform}.
 
-//===== Authorization
+==== Authorization
+
+If the {es} {security-features} are enabled, you must have
+`manage_data_frame_transforms` cluster privileges to use this API.
+For more information, see {stack-ov}/security-privileges.html[Security privileges].
 
 ==== Examples
 
@@ -30,10 +36,10 @@ The following example deletes the `ecommerce_transform` {dataframe-transform}:
 
 [source,js]
 --------------------------------------------------
-DELETE _data_frame/transforms/ecommerce_transform
+DELETE _data_frame/transforms/airline-transform
 --------------------------------------------------
 // CONSOLE
-// TEST[skip:setup kibana sample data]
+// TEST[setup:setup kibana sample data]
 
 When the {dataframe-transform} is deleted, you receive the following results:
 [source,js]

--- a/docs/reference/data-frames/apis/delete-transform.asciidoc
+++ b/docs/reference/data-frames/apis/delete-transform.asciidoc
@@ -17,7 +17,9 @@ Deletes an existing {dataframe-transform}.
 
 `DELETE _data_frame/transforms/<data_frame_transform_id>`
 
-//==== Description
+==== Description
+
+NOTE: Before you can delete the {dataframe-transform}, you must stop it.
 
 ==== Path Parameters
 

--- a/docs/reference/data-frames/apis/delete-transform.asciidoc
+++ b/docs/reference/data-frames/apis/delete-transform.asciidoc
@@ -36,10 +36,10 @@ The following example deletes the `ecommerce_transform` {dataframe-transform}:
 
 [source,js]
 --------------------------------------------------
-DELETE _data_frame/transforms/airline-transform
+DELETE _data_frame/transforms/ecommerce_transform
 --------------------------------------------------
 // CONSOLE
-// TEST[setup:setup kibana sample data]
+// TEST[skip:setup kibana sample data]
 
 When the {dataframe-transform} is deleted, you receive the following results:
 [source,js]

--- a/docs/reference/data-frames/apis/delete-transform.asciidoc
+++ b/docs/reference/data-frames/apis/delete-transform.asciidoc
@@ -27,8 +27,10 @@ Deletes an existing {dataframe-transform}.
 ==== Authorization
 
 If the {es} {security-features} are enabled, you must have
-`manage_data_frame_transforms` cluster privileges to use this API.
-For more information, see {stack-ov}/security-privileges.html[Security privileges].
+`manage_data_frame_transforms` cluster privileges to use this API. The built-in
+`data_frame_transforms_admin` role has these privileges. For more information,
+see {stack-ov}/security-privileges.html[Security privileges] and
+{stack-ov}/built-in-roles.html[Built-in roles].
 
 ==== Examples
 

--- a/docs/reference/data-frames/apis/get-transform-stats.asciidoc
+++ b/docs/reference/data-frames/apis/get-transform-stats.asciidoc
@@ -47,8 +47,10 @@ The API returns the following information:
 ==== Authorization
 
 If the {es} {security-features} are enabled, you must have
-`data_frame_transforms_user` cluster privileges to use this API. For more
-information, see {stack-ov}/security-privileges.html[Security privileges].
+`monitor_data_frame_transforms` cluster privileges to use this API. The built-in
+`data_frame_transforms_user` role has these privileges. For more information,
+see {stack-ov}/security-privileges.html[Security privileges] and
+{stack-ov}/built-in-roles.html[Built-in roles].
 
 ==== Examples
 

--- a/docs/reference/data-frames/apis/get-transform-stats.asciidoc
+++ b/docs/reference/data-frames/apis/get-transform-stats.asciidoc
@@ -8,6 +8,8 @@
 <titleabbrev>Get {dataframe-transform} statistics</titleabbrev>
 ++++
 
+beta[]
+
 Retrieves usage information for {dataframe-transforms}.
 
 
@@ -42,7 +44,11 @@ The API returns the following information:
 `transforms`::
   (array) An array of statistics objects for {dataframe-transforms}.
 
-//==== Authorization
+==== Authorization
+
+If the {es} {security-features} are enabled, you must have
+`data_frame_transforms_user` cluster privileges to use this API. For more
+information, see {stack-ov}/security-privileges.html[Security privileges].
 
 ==== Examples
 

--- a/docs/reference/data-frames/apis/get-transform.asciidoc
+++ b/docs/reference/data-frames/apis/get-transform.asciidoc
@@ -8,6 +8,8 @@
 <titleabbrev>Get {dataframe-transforms}</titleabbrev>
 ++++
 
+beta[]
+
 Retrieves configuration information for {dataframe-transforms}.
 
 
@@ -53,7 +55,11 @@ The API returns the following information:
 `transforms`::
   (array) An array of transform resources.
 
-//==== Authorization
+==== Authorization
+
+If the {es} {security-features} are enabled, you must have
+`data_frame_transforms_user` cluster privileges to use this API. For more
+information, see {stack-ov}/security-privileges.html[Security privileges].
 
 ==== Examples
 

--- a/docs/reference/data-frames/apis/get-transform.asciidoc
+++ b/docs/reference/data-frames/apis/get-transform.asciidoc
@@ -58,8 +58,10 @@ The API returns the following information:
 ==== Authorization
 
 If the {es} {security-features} are enabled, you must have
-`data_frame_transforms_user` cluster privileges to use this API. For more
-information, see {stack-ov}/security-privileges.html[Security privileges].
+`monitor_data_frame_transforms` cluster privileges to use this API. The built-in
+`data_frame_transforms_user` role has these privileges. For more information,
+see {stack-ov}/security-privileges.html[Security privileges] and
+{stack-ov}/built-in-roles.html[Built-in roles].
 
 ==== Examples
 

--- a/docs/reference/data-frames/apis/preview-transform.asciidoc
+++ b/docs/reference/data-frames/apis/preview-transform.asciidoc
@@ -30,10 +30,12 @@ reduce the data.
 ==== Authorization
 
 If the {es} {security-features} are enabled, you must have
-`manage_data_frame_transforms` cluster privileges to use this API. You must also
-have `view_index_metadata` privileges on the source index for the
+`manage_data_frame_transforms` cluster privileges to use this API. The built-in
+`data_frame_transforms_admin` role has these privileges. You must also have
+`read` and `view_index_metadata` privileges on the source index for the
 {dataframe-transform}. For more information, see
-{stack-ov}/security-privileges.html[Security privileges].
+{stack-ov}/security-privileges.html[Security privileges] and
+{stack-ov}/built-in-roles.html[Built-in roles].
 
 ==== Examples
 

--- a/docs/reference/data-frames/apis/preview-transform.asciidoc
+++ b/docs/reference/data-frames/apis/preview-transform.asciidoc
@@ -8,6 +8,8 @@
 <titleabbrev>Preview {dataframe-transforms}</titleabbrev>
 ++++
 
+beta[]
+
 Previews a {dataframe-transform}.
 
 
@@ -17,7 +19,6 @@ Previews a {dataframe-transform}.
 
 //==== Description
 //==== Path Parameters
-//==== Authorization
 
 ==== Request Body
 
@@ -26,6 +27,13 @@ Previews a {dataframe-transform}.
 `pivot`:: Defines the pivot function `group by` fields and the aggregation to
 reduce the data.
 
+==== Authorization
+
+If the {es} {security-features} are enabled, you must have
+`manage_data_frame_transforms` cluster privileges to use this API. You must also
+have `view_index_metadata` privileges on the source index for the
+{dataframe-transform}. For more information, see
+{stack-ov}/security-privileges.html[Security privileges].
 
 ==== Examples
 

--- a/docs/reference/data-frames/apis/put-transform.asciidoc
+++ b/docs/reference/data-frames/apis/put-transform.asciidoc
@@ -8,6 +8,8 @@
 <titleabbrev>Create {dataframe-transforms}</titleabbrev>
 ++++
 
+beta[]
+
 Instantiates a {dataframe-transform}.
 
 
@@ -44,7 +46,13 @@ reduce the data. See <<data-frame-transform-pivot, data frame transform pivot ob
 `description`:: Optional free text description of the data frame transform
 
 
-//==== Authorization
+==== Authorization
+
+If the {es} {security-features} are enabled, you must have
+`manage_data_frame_transforms` cluster privileges to use this API. You must also
+have `read` privileges on the source index and `read`, `create_index`, and
+`index` privileges on the destination index. For more information, see
+{stack-ov}/security-privileges.html[Security privileges].
 
 ==== Examples
 
@@ -88,7 +96,7 @@ PUT _data_frame/transforms/ecommerce_transform
 }
 --------------------------------------------------
 // CONSOLE
-// TEST[skip:add sample kibana data]
+// TEST[setup:kibana_sample_data_ecommerce]
 
 When the transform is created, you receive the following results:
 [source,js]
@@ -97,4 +105,4 @@ When the transform is created, you receive the following results:
   "acknowledged" : true
 }
 ----
-// NOTCONSOLE
+// TESTRESPONSE

--- a/docs/reference/data-frames/apis/put-transform.asciidoc
+++ b/docs/reference/data-frames/apis/put-transform.asciidoc
@@ -50,9 +50,9 @@ reduce the data. See <<data-frame-transform-pivot, data frame transform pivot ob
 
 If the {es} {security-features} are enabled, you must have
 `manage_data_frame_transforms` cluster privileges to use this API. You must also
-have `read` privileges on the source index and `read`, `create_index`, and
-`index` privileges on the destination index. For more information, see
-{stack-ov}/security-privileges.html[Security privileges].
+have `read` and `view_index_metadata` privileges on the source index and `read`,
+`create_index`, and `index` privileges on the destination index. For more
+information, see {stack-ov}/security-privileges.html[Security privileges].
 
 ==== Examples
 

--- a/docs/reference/data-frames/apis/put-transform.asciidoc
+++ b/docs/reference/data-frames/apis/put-transform.asciidoc
@@ -49,10 +49,12 @@ reduce the data. See <<data-frame-transform-pivot, data frame transform pivot ob
 ==== Authorization
 
 If the {es} {security-features} are enabled, you must have
-`manage_data_frame_transforms` cluster privileges to use this API. You must also
+`manage_data_frame_transforms` cluster privileges to use this API. The built-in
+`data_frame_transforms_admin` role has these privileges. You must also
 have `read` and `view_index_metadata` privileges on the source index and `read`,
 `create_index`, and `index` privileges on the destination index. For more
-information, see {stack-ov}/security-privileges.html[Security privileges].
+information, see {stack-ov}/security-privileges.html[Security privileges] and
+{stack-ov}/built-in-roles.html[Built-in roles].
 
 ==== Examples
 

--- a/docs/reference/data-frames/apis/start-transform.asciidoc
+++ b/docs/reference/data-frames/apis/start-transform.asciidoc
@@ -8,6 +8,8 @@
 <titleabbrev>Start {dataframe-transforms}</titleabbrev>
 ++++
 
+beta[]
+
 Starts one or more {dataframe-transforms}.
 
 ==== Request
@@ -24,7 +26,13 @@ Starts one or more {dataframe-transforms}.
   must start and end with alphanumeric characters.
 
 //==== Request Body
-//==== Authorization
+==== Authorization
+
+If the {es} {security-features} are enabled, you must have
+`manage_data_frame_transforms` cluster privileges to use this API. You must also
+have `view_index_metadata` privileges on the source index for the
+{dataframe-transform}. For more information, see
+{stack-ov}/security-privileges.html[Security privileges].
 
 ==== Examples
 

--- a/docs/reference/data-frames/apis/start-transform.asciidoc
+++ b/docs/reference/data-frames/apis/start-transform.asciidoc
@@ -32,7 +32,8 @@ If the {es} {security-features} are enabled, you must have
 `manage_data_frame_transforms` cluster privileges to use this API. You must also
 have `view_index_metadata` privileges on the source index for the
 {dataframe-transform}. For more information, see
-{stack-ov}/security-privileges.html[Security privileges].
+{stack-ov}/security-privileges.html[Security privileges] and
+{stack-ov}/built-in-roles.html[Built-in roles].
 
 ==== Examples
 

--- a/docs/reference/data-frames/apis/stop-transform.asciidoc
+++ b/docs/reference/data-frames/apis/stop-transform.asciidoc
@@ -8,6 +8,8 @@
 <titleabbrev>Stop {dataframe-transforms}</titleabbrev>
 ++++
 
+beta[]
+
 Stops one or more {dataframe-transforms}.
 
 ==== Request
@@ -44,7 +46,11 @@ All {dataframe-transforms} can be stopped by using `_all` or `*` as the `<data_f
    eventually moves the job to `STOPPED`. The timeout simply means the API call itself timed out while waiting for the status change. Defaults to `30s`
     
 //==== Request Body
-//==== Authorization
+==== Authorization
+
+If the {es} {security-features} are enabled, you must have
+`manage_data_frame_transforms` cluster privileges to use this API. For more
+information, see {stack-ov}/security-privileges.html[Security privileges].
 
 ==== Examples
 

--- a/docs/reference/data-frames/apis/stop-transform.asciidoc
+++ b/docs/reference/data-frames/apis/stop-transform.asciidoc
@@ -49,8 +49,10 @@ All {dataframe-transforms} can be stopped by using `_all` or `*` as the `<data_f
 ==== Authorization
 
 If the {es} {security-features} are enabled, you must have
-`manage_data_frame_transforms` cluster privileges to use this API. For more
-information, see {stack-ov}/security-privileges.html[Security privileges].
+`manage_data_frame_transforms` cluster privileges to use this API. The built-in
+`data_frame_transforms_admin` role has these privileges. For more information,
+see {stack-ov}/security-privileges.html[Security privileges] and
+{stack-ov}/built-in-roles.html[Built-in roles].
 
 ==== Examples
 


### PR DESCRIPTION
This PR adds authorization details for the data frame APIs.

It also enables testing for the examples in the create data frame transform API.