### PR TITLE
Just to improve Exception message as adding which indices includes wi…

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
@@ -178,7 +178,7 @@ class IndicesAndAliasesResolver {
         } else {
             if (containsWildcards(indicesRequest)) {
                 throw new IllegalStateException("There are no external requests known to support wildcards that don't support replacing " +
-                        "their indices");
+                    "their indices." + "(This indicesRequest includes indices which name has wildcards(*) : " + Arrays.toString(indicesRequest.indices()) + ") \nPlesae remove wildcards from index name.";
             }
             //NOTE: shard level requests do support wildcards (as they hold the original indices options) but don't support
             // replacing their indices.


### PR DESCRIPTION
…ldcards in the name. So that we can do analysis more easily when we get this error.

(For example)
 In a case of using Logstash, it can happen the new index names are decided dynamically by a Logstash pipeline processing.
 It is better for error analysis to know which index name is requested by ES client.

