### PR TITLE
Fix IpFilteringIntegrationTests

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/filter/IpFilteringIntegrationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/filter/IpFilteringIntegrationTests.java
@@ -70,7 +70,7 @@ public class IpFilteringIntegrationTests extends SecurityIntegTestCase {
     @SuppressForbidden(reason = "Allow opening socket for test")
     private void trySocketConnection(Socket socket, InetSocketAddress address) throws IOException {
         logger.info("connecting to {}", address);
-        SocketAccess.doPrivileged(() -> socket.connect(address, 500));
+        SocketAccess.doPrivileged(() -> socket.connect(address, 5000));
 
         assertThat(socket.isConnected(), is(true));
         try (OutputStream os = socket.getOutputStream()) {


### PR DESCRIPTION
* Increase timeout to 5s since we saw 500ms+ GC pauses on CI
* closes #40689
  * Note: the test failure hasn't happened since that issue was reported, but imo just upping the timeout to 5s instead of simply closing it still makes sense to stabilize slower systems