### PR TITLE
Rename processor test fix

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RenameProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RenameProcessorTests.java
@@ -132,7 +132,11 @@ public class RenameProcessorTests extends ESTestCase {
         String newFieldName = randomValueOtherThanMany(ingestDocument::hasField, () -> RandomDocumentPicks.randomFieldName(random()));
         Processor processor = createRenameProcessor(fieldName, newFieldName, false);
         processor.execute(ingestDocument);
-        assertThat(ingestDocument.hasField(fieldName), equalTo(false));
+        if (newFieldName.startsWith(fieldName + '.')) {
+            assertThat(ingestDocument.getFieldValue(fieldName, Object.class), instanceOf(Map.class));
+        } else {
+            assertThat(ingestDocument.hasField(fieldName), equalTo(false));
+        }
         assertThat(ingestDocument.hasField(newFieldName), equalTo(true));
         assertThat(ingestDocument.getFieldValue(newFieldName, Object.class), nullValue());
     }


### PR DESCRIPTION
If the source field name is a prefix of the target field name, the
source field still exists after rename processor has run. Adjusted test
case to handle that case.

Fix for https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+multijob-unix-compatibility/os=opensuse/22/testReport/org.elasticsearch.ingest.common/RenameProcessorTests/testRenameExistingFieldNullValue/