### PR TITLE
[ML][Data Frame] Removes slice specification from DBQ. See #42996

### DIFF
--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/persistence/DataFrameTransformsConfigManager.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/persistence/DataFrameTransformsConfigManager.java
@@ -249,8 +249,7 @@ public class DataFrameTransformsConfigManager {
      */
     public void deleteTransform(String transformId, ActionListener<Boolean> listener) {
         DeleteByQueryRequest request = new DeleteByQueryRequest()
-                .setAbortOnVersionConflict(false) //since these documents are not updated, a conflict just means it was deleted previously
-                .setSlices(5);
+                .setAbortOnVersionConflict(false); //since these documents are not updated, a conflict just means it was deleted previously
 
         request.indices(DataFrameInternalIndex.INDEX_NAME);
         QueryBuilder query = QueryBuilders.termQuery(DataFrameField.ID.getPreferredName(), transformId);


### PR DESCRIPTION
Setting `slice` to a value that is not a multiple of the `shard` number can result in an NPE. This change removes our setting of a specific slice value. If performance gets hit hard enough, we will have to see about adjusting the slice to match a multiple of the shards. 

Relates to #42996 