### PR TITLE
[ML] Add DatafeedTimingStats to datafeed GetDatafeedStatsAction.Response

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/datafeed/DatafeedStats.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/datafeed/DatafeedStats.java
@@ -41,9 +41,12 @@ public class DatafeedStats implements ToXContentObject {
     private final NodeAttributes node;
     @Nullable
     private final String assignmentExplanation;
+    @Nullable
+    private final DatafeedTimingStats timingStats;
 
     public static final ParseField ASSIGNMENT_EXPLANATION = new ParseField("assignment_explanation");
     public static final ParseField NODE = new ParseField("node");
+    public static final ParseField TIMING_STATS = new ParseField("timing_stats");
 
     public static final ConstructingObjectParser<DatafeedStats, Void> PARSER = new ConstructingObjectParser<>("datafeed_stats",
     true,
@@ -52,7 +55,8 @@ public class DatafeedStats implements ToXContentObject {
         DatafeedState datafeedState = DatafeedState.fromString((String)a[1]);
         NodeAttributes nodeAttributes = (NodeAttributes)a[2];
         String assignmentExplanation = (String)a[3];
-        return new DatafeedStats(datafeedId, datafeedState, nodeAttributes, assignmentExplanation);
+        DatafeedTimingStats timingStats = (DatafeedTimingStats)a[4];
+        return new DatafeedStats(datafeedId, datafeedState, nodeAttributes, assignmentExplanation, timingStats);
     } );
 
     static {
@@ -60,14 +64,16 @@ public class DatafeedStats implements ToXContentObject {
         PARSER.declareString(ConstructingObjectParser.constructorArg(), DatafeedState.STATE);
         PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), NodeAttributes.PARSER, NODE);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), ASSIGNMENT_EXPLANATION);
+        PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), DatafeedTimingStats.PARSER, TIMING_STATS);
     }
 
     public DatafeedStats(String datafeedId, DatafeedState datafeedState, @Nullable NodeAttributes node,
-                         @Nullable String assignmentExplanation) {
+                         @Nullable String assignmentExplanation, @Nullable DatafeedTimingStats timingStats) {
         this.datafeedId = Objects.requireNonNull(datafeedId);
         this.datafeedState = Objects.requireNonNull(datafeedState);
         this.node = node;
         this.assignmentExplanation = assignmentExplanation;
+        this.timingStats = timingStats;
     }
 
     public String getDatafeedId() {
@@ -84,6 +90,10 @@ public class DatafeedStats implements ToXContentObject {
 
     public String getAssignmentExplanation() {
         return assignmentExplanation;
+    }
+
+    public DatafeedTimingStats getDatafeedTimingStats() {
+        return timingStats;
     }
 
     @Override
@@ -110,13 +120,16 @@ public class DatafeedStats implements ToXContentObject {
         if (assignmentExplanation != null) {
             builder.field(ASSIGNMENT_EXPLANATION.getPreferredName(), assignmentExplanation);
         }
+        if (timingStats != null) {
+            builder.field(TIMING_STATS.getPreferredName(), timingStats);
+        }
         builder.endObject();
         return builder;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(datafeedId, datafeedState.toString(), node, assignmentExplanation);
+        return Objects.hash(datafeedId, datafeedState.toString(), node, assignmentExplanation, timingStats);
     }
 
     @Override
@@ -131,6 +144,7 @@ public class DatafeedStats implements ToXContentObject {
         return Objects.equals(datafeedId, other.datafeedId) &&
             Objects.equals(this.datafeedState, other.datafeedState) &&
             Objects.equals(this.node, other.node) &&
-            Objects.equals(this.assignmentExplanation, other.assignmentExplanation);
+            Objects.equals(this.assignmentExplanation, other.assignmentExplanation) &&
+            Objects.equals(this.timingStats, other.timingStats);
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/datafeed/DatafeedTimingStats.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/datafeed/DatafeedTimingStats.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.client.ml.datafeed;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+public class DatafeedTimingStats implements ToXContentObject {
+
+    public static final ParseField JOB_ID = new ParseField("job_id");
+    public static final ParseField TOTAL_SEARCH_TIME_MS = new ParseField("total_search_time_ms");
+
+    public static final ParseField TYPE = new ParseField("datafeed_timing_stats");
+
+    public static final ConstructingObjectParser<DatafeedTimingStats, Void> PARSER = createParser();
+
+    private static ConstructingObjectParser<DatafeedTimingStats, Void> createParser() {
+        ConstructingObjectParser<DatafeedTimingStats, Void> parser =
+            new ConstructingObjectParser<>("datafeed_timing_stats", true, a -> new DatafeedTimingStats((String) a[0], (double) a[1]));
+        parser.declareString(constructorArg(), JOB_ID);
+        parser.declareDouble(optionalConstructorArg(), TOTAL_SEARCH_TIME_MS);
+        return parser;
+    }
+
+    private final String jobId;
+    private double totalSearchTimeMs;
+
+    public DatafeedTimingStats(String jobId, double totalSearchTimeMs) {
+        this.jobId = Objects.requireNonNull(jobId);
+        this.totalSearchTimeMs = totalSearchTimeMs;
+    }
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    public double getTotalSearchTimeMs() {
+        return totalSearchTimeMs;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startObject();
+        builder.field(JOB_ID.getPreferredName(), jobId);
+        builder.field(TOTAL_SEARCH_TIME_MS.getPreferredName(), totalSearchTimeMs);
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        DatafeedTimingStats other = (DatafeedTimingStats) obj;
+        return Objects.equals(this.jobId, other.jobId)
+            && Objects.equals(this.totalSearchTimeMs, other.totalSearchTimeMs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(jobId, totalSearchTimeMs);
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/datafeed/DatafeedStatsTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/datafeed/DatafeedStatsTests.java
@@ -50,7 +50,8 @@ public class DatafeedStatsTests extends AbstractXContentTestCase<DatafeedStats> 
                 attributes);
         }
         String assignmentReason = randomBoolean() ? randomAlphaOfLength(10) : null;
-        return new DatafeedStats(datafeedId, datafeedState, nodeAttributes, assignmentReason);
+        DatafeedTimingStats timingStats = DatafeedTimingStatsTests.createRandomInstance();
+        return new DatafeedStats(datafeedId, datafeedState, nodeAttributes, assignmentReason, timingStats);
     }
 
     @Override

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/datafeed/DatafeedTimingStatsTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/datafeed/DatafeedTimingStatsTests.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.client.ml.datafeed;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractXContentTestCase;
+
+import java.io.IOException;
+
+public class DatafeedTimingStatsTests extends AbstractXContentTestCase<DatafeedTimingStats> {
+
+    public static DatafeedTimingStats createRandomInstance() {
+        return new DatafeedTimingStats(randomAlphaOfLength(10), randomDouble());
+    }
+
+    @Override
+    protected DatafeedTimingStats createTestInstance() {
+        return createRandomInstance();
+    }
+
+    @Override
+    protected DatafeedTimingStats doParseInstance(XContentParser parser) throws IOException {
+        return DatafeedTimingStats.PARSER.apply(parser, null);
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return true;
+    }
+}

--- a/docs/reference/ml/apis/datafeedresource.asciidoc
+++ b/docs/reference/ml/apis/datafeedresource.asciidoc
@@ -143,3 +143,9 @@ update their values:
   `started`::: The {dfeed} is actively receiving data.
   `stopped`::: The {dfeed} is stopped and will not receive data until it is
   re-started.
+
+`timing_stats`::
+  (object) An object that provides statistical information about timing aspect of this datafeed. +
+  `job_id`::: A numerical character string that uniquely identifies the job.
+  `total_search_time_ms`::: Total time the datafeed spent searching in milliseconds.
+

--- a/docs/reference/ml/apis/datafeedresource.asciidoc
+++ b/docs/reference/ml/apis/datafeedresource.asciidoc
@@ -147,5 +147,6 @@ update their values:
 `timing_stats`::
   (object) An object that provides statistical information about timing aspect of this datafeed. +
   `job_id`::: A numerical character string that uniquely identifies the job.
+  `search_count`::: Number of searches performed by this datafeed.
   `total_search_time_ms`::: Total time the datafeed spent searching in milliseconds.
 

--- a/docs/reference/ml/apis/get-datafeed-stats.asciidoc
+++ b/docs/reference/ml/apis/get-datafeed-stats.asciidoc
@@ -90,7 +90,11 @@ The API returns the following results:
           "ml.max_open_jobs": "20"
         }
       },
-      "assignment_explanation": ""
+      "assignment_explanation": "",
+      "timing_stats": {
+        "job_id": "job-total-requests",
+        "total_search_time_ms": 120.5
+      }
     }
   ]
 }

--- a/docs/reference/ml/apis/get-datafeed-stats.asciidoc
+++ b/docs/reference/ml/apis/get-datafeed-stats.asciidoc
@@ -93,6 +93,7 @@ The API returns the following results:
       "assignment_explanation": "",
       "timing_stats": {
         "job_id": "job-total-requests",
+        "search_count": 20,
         "total_search_time_ms": 120.5
       }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.elasticsearch.Version.V_7_3_0;
+import static org.elasticsearch.Version.V_7_4_0;
 
 public class GetDatafeedsStatsAction extends StreamableResponseActionType<GetDatafeedsStatsAction.Response> {
 
@@ -148,7 +148,7 @@ public class GetDatafeedsStatsAction extends StreamableResponseActionType<GetDat
                 datafeedState = DatafeedState.fromStream(in);
                 node = in.readOptionalWriteable(DiscoveryNode::new);
                 assignmentExplanation = in.readOptionalString();
-                if (in.getVersion().onOrAfter(V_7_3_0)) {
+                if (in.getVersion().onOrAfter(V_7_4_0)) {
                     timingStats = in.readOptionalWriteable(DatafeedTimingStats::new);
                 } else {
                     timingStats = null;
@@ -212,7 +212,7 @@ public class GetDatafeedsStatsAction extends StreamableResponseActionType<GetDat
                 datafeedState.writeTo(out);
                 out.writeOptionalWriteable(node);
                 out.writeOptionalString(assignmentExplanation);
-                if (out.getVersion().onOrAfter(V_7_3_0)) {
+                if (out.getVersion().onOrAfter(V_7_4_0)) {
                     out.writeOptionalWriteable(timingStats);
                 }
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java
@@ -22,11 +22,14 @@ import org.elasticsearch.xpack.core.action.AbstractGetResourcesResponse;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
+
+import static org.elasticsearch.Version.V_7_3_0;
 
 public class GetDatafeedsStatsAction extends StreamableResponseActionType<GetDatafeedsStatsAction.Response> {
 
@@ -128,13 +131,16 @@ public class GetDatafeedsStatsAction extends StreamableResponseActionType<GetDat
             private DiscoveryNode node;
             @Nullable
             private String assignmentExplanation;
+            @Nullable
+            private DatafeedTimingStats timingStats;
 
             public DatafeedStats(String datafeedId, DatafeedState datafeedState, @Nullable DiscoveryNode node,
-                          @Nullable String assignmentExplanation) {
+                          @Nullable String assignmentExplanation, @Nullable DatafeedTimingStats timingStats) {
                 this.datafeedId = Objects.requireNonNull(datafeedId);
                 this.datafeedState = Objects.requireNonNull(datafeedState);
                 this.node = node;
                 this.assignmentExplanation = assignmentExplanation;
+                this.timingStats = timingStats;
             }
 
             DatafeedStats(StreamInput in) throws IOException {
@@ -142,6 +148,11 @@ public class GetDatafeedsStatsAction extends StreamableResponseActionType<GetDat
                 datafeedState = DatafeedState.fromStream(in);
                 node = in.readOptionalWriteable(DiscoveryNode::new);
                 assignmentExplanation = in.readOptionalString();
+                if (in.getVersion().onOrAfter(V_7_3_0)) {
+                    timingStats = in.readOptionalWriteable(DatafeedTimingStats::new);
+                } else {
+                    timingStats = null;
+                }
             }
 
             public String getDatafeedId() {
@@ -158,6 +169,10 @@ public class GetDatafeedsStatsAction extends StreamableResponseActionType<GetDat
 
             public String getAssignmentExplanation() {
                 return assignmentExplanation;
+            }
+
+            public DatafeedTimingStats getTimingStats() {
+                return timingStats;
             }
 
             @Override
@@ -184,6 +199,9 @@ public class GetDatafeedsStatsAction extends StreamableResponseActionType<GetDat
                 if (assignmentExplanation != null) {
                     builder.field("assignment_explanation", assignmentExplanation);
                 }
+                if (timingStats != null) {
+                    builder.field("timing_stats", timingStats);
+                }
                 builder.endObject();
                 return builder;
             }
@@ -194,11 +212,14 @@ public class GetDatafeedsStatsAction extends StreamableResponseActionType<GetDat
                 datafeedState.writeTo(out);
                 out.writeOptionalWriteable(node);
                 out.writeOptionalString(assignmentExplanation);
+                if (out.getVersion().onOrAfter(V_7_3_0)) {
+                    out.writeOptionalWriteable(timingStats);
+                }
             }
 
             @Override
             public int hashCode() {
-                return Objects.hash(datafeedId, datafeedState, node, assignmentExplanation);
+                return Objects.hash(datafeedId, datafeedState, node, assignmentExplanation, timingStats);
             }
 
             @Override
@@ -210,10 +231,11 @@ public class GetDatafeedsStatsAction extends StreamableResponseActionType<GetDat
                     return false;
                 }
                 DatafeedStats other = (DatafeedStats) obj;
-                return Objects.equals(datafeedId, other.datafeedId) &&
+                return Objects.equals(this.datafeedId, other.datafeedId) &&
                         Objects.equals(this.datafeedState, other.datafeedState) &&
                         Objects.equals(this.node, other.node) &&
-                        Objects.equals(this.assignmentExplanation, other.assignmentExplanation);
+                        Objects.equals(this.assignmentExplanation, other.assignmentExplanation) &&
+                        Objects.equals(this.timingStats, other.timingStats);
             }
         }
 
@@ -232,5 +254,4 @@ public class GetDatafeedsStatsAction extends StreamableResponseActionType<GetDat
             return DatafeedStats::new;
         }
     }
-
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -682,7 +682,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
             if (!MlStrings.isValidId(id)) {
                 throw ExceptionsHelper.badRequestException(Messages.getMessage(Messages.INVALID_ID, ID.getPreferredName(), id));
             }
-            if (indices == null || indices.isEmpty() || indices.contains(null) || indices.contains("")) {
+            if (indices == null || indices.isEmpty() || indices.contains("")) {
                 throw invalidOptionValue(INDICES.getPreferredName(), indices);
             }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -682,7 +682,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
             if (!MlStrings.isValidId(id)) {
                 throw ExceptionsHelper.badRequestException(Messages.getMessage(Messages.INVALID_ID, ID.getPreferredName(), id));
             }
-            if (indices == null || indices.isEmpty() || indices.contains("")) {
+            if (indices == null || indices.isEmpty() || indices.contains(null) || indices.contains("")) {
                 throw invalidOptionValue(INDICES.getPreferredName(), indices);
             }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedTimingStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedTimingStats.java
@@ -57,7 +57,7 @@ public class DatafeedTimingStats implements ToXContentObject, Writeable {
 
     public DatafeedTimingStats(StreamInput in) throws IOException {
         jobId = in.readString();
-        totalSearchTimeMs = in.readOptionalDouble();
+        totalSearchTimeMs = in.readDouble();
     }
 
     public DatafeedTimingStats(DatafeedTimingStats other) {
@@ -79,7 +79,7 @@ public class DatafeedTimingStats implements ToXContentObject, Writeable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(jobId);
-        out.writeOptionalDouble(totalSearchTimeMs);
+        out.writeDouble(totalSearchTimeMs);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedTimingStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedTimingStats.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ml.datafeed;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+public class DatafeedTimingStats implements ToXContentObject, Writeable {
+
+    public static final ParseField JOB_ID = new ParseField("job_id");
+    public static final ParseField TOTAL_SEARCH_TIME_MS = new ParseField("total_search_time_ms");
+
+    public static final ParseField TYPE = new ParseField("datafeed_timing_stats");
+
+    public static final ConstructingObjectParser<DatafeedTimingStats, Void> PARSER = createParser();
+
+    private static ConstructingObjectParser<DatafeedTimingStats, Void> createParser() {
+        ConstructingObjectParser<DatafeedTimingStats, Void> parser =
+            new ConstructingObjectParser<>(
+                "datafeed_timing_stats", true, args -> new DatafeedTimingStats((String) args[0], (double) args[1]));
+        parser.declareString(constructorArg(), JOB_ID);
+        parser.declareDouble(optionalConstructorArg(), TOTAL_SEARCH_TIME_MS);
+        return parser;
+    }
+
+    public static String documentId(String jobId) {
+        return jobId + "_datafeed_timing_stats";
+    }
+
+    private final String jobId;
+    private double totalSearchTimeMs;
+
+    public DatafeedTimingStats(String jobId, double totalSearchTimeMs) {
+        this.jobId = Objects.requireNonNull(jobId);
+        this.totalSearchTimeMs = totalSearchTimeMs;
+    }
+
+    public DatafeedTimingStats(String jobId) {
+        this(jobId, 0);
+    }
+
+    public DatafeedTimingStats(StreamInput in) throws IOException {
+        jobId = in.readString();
+        totalSearchTimeMs = in.readOptionalDouble();
+    }
+
+    public DatafeedTimingStats(DatafeedTimingStats other) {
+        this(other.jobId, other.totalSearchTimeMs);
+    }
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    public double getTotalSearchTimeMs() {
+        return totalSearchTimeMs;
+    }
+
+    public void incrementTotalSearchTimeMs(double totalSearchTimeMs) {
+        this.totalSearchTimeMs += totalSearchTimeMs;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(jobId);
+        out.writeOptionalDouble(totalSearchTimeMs);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startObject();
+        builder.field(JOB_ID.getPreferredName(), jobId);
+        builder.field(TOTAL_SEARCH_TIME_MS.getPreferredName(), totalSearchTimeMs);
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        DatafeedTimingStats other = (DatafeedTimingStats) obj;
+        return Objects.equals(this.jobId, other.jobId)
+            && Objects.equals(this.totalSearchTimeMs, other.totalSearchTimeMs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(jobId, totalSearchTimeMs);
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
+    }
+
+    /**
+     * Returns true if given stats objects differ from each other by more than 10% for at least one of the statistics.
+     */
+    public static boolean differSignificantly(DatafeedTimingStats stats1, DatafeedTimingStats stats2) {
+        return differSignificantly(stats1.totalSearchTimeMs, stats2.totalSearchTimeMs);
+    }
+
+    /**
+     * Returns {@code true} if one of the ratios { value1 / value2, value2 / value1 } is smaller than MIN_VALID_RATIO.
+     * This can be interpreted as values { value1, value2 } differing significantly from each other.
+     */
+    private static boolean differSignificantly(double value1, double value2) {
+        return (value2 / value1 < MIN_VALID_RATIO) || (value1 / value2 < MIN_VALID_RATIO);
+    }
+
+    /**
+     * Minimum ratio of values that is interpreted as values being similar.
+     * If the values ratio is less than MIN_VALID_RATIO, the values are interpreted as significantly different.
+     */
+    private static final double MIN_VALID_RATIO = 0.9;
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedTimingStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedTimingStats.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.core.ml.datafeed;
 
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -24,6 +25,7 @@ import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optiona
 public class DatafeedTimingStats implements ToXContentObject, Writeable {
 
     public static final ParseField JOB_ID = new ParseField("job_id");
+    public static final ParseField SEARCH_COUNT = new ParseField("search_count");
     public static final ParseField TOTAL_SEARCH_TIME_MS = new ParseField("total_search_time_ms");
 
     public static final ParseField TYPE = new ParseField("datafeed_timing_stats");
@@ -33,8 +35,16 @@ public class DatafeedTimingStats implements ToXContentObject, Writeable {
     private static ConstructingObjectParser<DatafeedTimingStats, Void> createParser() {
         ConstructingObjectParser<DatafeedTimingStats, Void> parser =
             new ConstructingObjectParser<>(
-                "datafeed_timing_stats", true, args -> new DatafeedTimingStats((String) args[0], (double) args[1]));
+                "datafeed_timing_stats",
+                true,
+                args -> {
+                    String jobId = (String) args[0];
+                    Long searchCount = (Long) args[1];
+                    Double totalSearchTimeMs = (Double) args[2];
+                    return new DatafeedTimingStats(jobId, getOrDefault(searchCount, 0L), getOrDefault(totalSearchTimeMs, 0.0));
+                });
         parser.declareString(constructorArg(), JOB_ID);
+        parser.declareLong(optionalConstructorArg(), SEARCH_COUNT);
         parser.declareDouble(optionalConstructorArg(), TOTAL_SEARCH_TIME_MS);
         return parser;
     }
@@ -44,28 +54,35 @@ public class DatafeedTimingStats implements ToXContentObject, Writeable {
     }
 
     private final String jobId;
+    private long searchCount;
     private double totalSearchTimeMs;
 
-    public DatafeedTimingStats(String jobId, double totalSearchTimeMs) {
+    public DatafeedTimingStats(String jobId, long searchCount, double totalSearchTimeMs) {
         this.jobId = Objects.requireNonNull(jobId);
+        this.searchCount = searchCount;
         this.totalSearchTimeMs = totalSearchTimeMs;
     }
 
     public DatafeedTimingStats(String jobId) {
-        this(jobId, 0);
+        this(jobId, 0, 0);
     }
 
     public DatafeedTimingStats(StreamInput in) throws IOException {
         jobId = in.readString();
+        searchCount = in.readLong();
         totalSearchTimeMs = in.readDouble();
     }
 
     public DatafeedTimingStats(DatafeedTimingStats other) {
-        this(other.jobId, other.totalSearchTimeMs);
+        this(other.jobId, other.searchCount, other.totalSearchTimeMs);
     }
 
     public String getJobId() {
         return jobId;
+    }
+
+    public long getSearchCount() {
+        return searchCount;
     }
 
     public double getTotalSearchTimeMs() {
@@ -73,12 +90,14 @@ public class DatafeedTimingStats implements ToXContentObject, Writeable {
     }
 
     public void incrementTotalSearchTimeMs(double searchTimeMs) {
+        this.searchCount++;
         this.totalSearchTimeMs += searchTimeMs;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(jobId);
+        out.writeLong(searchCount);
         out.writeDouble(totalSearchTimeMs);
     }
 
@@ -86,6 +105,7 @@ public class DatafeedTimingStats implements ToXContentObject, Writeable {
     public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
         builder.startObject();
         builder.field(JOB_ID.getPreferredName(), jobId);
+        builder.field(SEARCH_COUNT.getPreferredName(), searchCount);
         builder.field(TOTAL_SEARCH_TIME_MS.getPreferredName(), totalSearchTimeMs);
         builder.endObject();
         return builder;
@@ -102,16 +122,21 @@ public class DatafeedTimingStats implements ToXContentObject, Writeable {
 
         DatafeedTimingStats other = (DatafeedTimingStats) obj;
         return Objects.equals(this.jobId, other.jobId)
-            && Objects.equals(this.totalSearchTimeMs, other.totalSearchTimeMs);
+            && this.searchCount == other.searchCount
+            && this.totalSearchTimeMs == other.totalSearchTimeMs;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(jobId, totalSearchTimeMs);
+        return Objects.hash(jobId, searchCount, totalSearchTimeMs);
     }
 
     @Override
     public String toString() {
         return Strings.toString(this);
+    }
+
+    private static <T> T getOrDefault(@Nullable T value, T defaultValue) {
+        return value != null ? value : defaultValue;
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedTimingStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedTimingStats.java
@@ -114,25 +114,4 @@ public class DatafeedTimingStats implements ToXContentObject, Writeable {
     public String toString() {
         return Strings.toString(this);
     }
-
-    /**
-     * Returns true if given stats objects differ from each other by more than 10% for at least one of the statistics.
-     */
-    public static boolean differSignificantly(DatafeedTimingStats stats1, DatafeedTimingStats stats2) {
-        return differSignificantly(stats1.totalSearchTimeMs, stats2.totalSearchTimeMs);
-    }
-
-    /**
-     * Returns {@code true} if one of the ratios { value1 / value2, value2 / value1 } is smaller than MIN_VALID_RATIO.
-     * This can be interpreted as values { value1, value2 } differing significantly from each other.
-     */
-    private static boolean differSignificantly(double value1, double value2) {
-        return (value2 / value1 < MIN_VALID_RATIO) || (value1 / value2 < MIN_VALID_RATIO);
-    }
-
-    /**
-     * Minimum ratio of values that is interpreted as values being similar.
-     * If the values ratio is less than MIN_VALID_RATIO, the values are interpreted as significantly different.
-     */
-    private static final double MIN_VALID_RATIO = 0.9;
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedTimingStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedTimingStats.java
@@ -72,8 +72,8 @@ public class DatafeedTimingStats implements ToXContentObject, Writeable {
         return totalSearchTimeMs;
     }
 
-    public void incrementTotalSearchTimeMs(double totalSearchTimeMs) {
-        this.totalSearchTimeMs += totalSearchTimeMs;
+    public void incrementTotalSearchTimeMs(double searchTimeMs) {
+        this.totalSearchTimeMs += searchTimeMs;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
@@ -420,57 +420,69 @@ public class DatafeedUpdate implements Writeable, ToXContentObject {
             this.delayedDataCheckConfig = config.delayedDataCheckConfig;
         }
 
-        public void setId(String datafeedId) {
+        public Builder setId(String datafeedId) {
             id = ExceptionsHelper.requireNonNull(datafeedId, DatafeedConfig.ID.getPreferredName());
+            return this;
         }
 
-        public void setJobId(String jobId) {
+        public Builder setJobId(String jobId) {
             this.jobId = jobId;
+            return this;
         }
 
-        public void setIndices(List<String> indices) {
+        public Builder setIndices(List<String> indices) {
             this.indices = indices;
+            return this;
         }
 
-        public void setQueryDelay(TimeValue queryDelay) {
+        public Builder setQueryDelay(TimeValue queryDelay) {
             this.queryDelay = queryDelay;
+            return this;
         }
 
-        public void setFrequency(TimeValue frequency) {
+        public Builder setFrequency(TimeValue frequency) {
             this.frequency = frequency;
+            return this;
         }
 
-        public void setQuery(QueryProvider queryProvider) {
+        public Builder setQuery(QueryProvider queryProvider) {
             this.queryProvider = queryProvider;
+            return this;
         }
 
-        private void setAggregationsSafe(AggProvider aggProvider) {
+        private Builder setAggregationsSafe(AggProvider aggProvider) {
             if (this.aggProvider != null) {
                 throw ExceptionsHelper.badRequestException("Found two aggregation definitions: [aggs] and [aggregations]");
             }
             setAggregations(aggProvider);
+            return this;
         }
 
-        public void setAggregations(AggProvider aggProvider) {
+        public Builder setAggregations(AggProvider aggProvider) {
             this.aggProvider = aggProvider;
+            return this;
         }
 
-        public void setScriptFields(List<SearchSourceBuilder.ScriptField> scriptFields) {
+        public Builder setScriptFields(List<SearchSourceBuilder.ScriptField> scriptFields) {
             List<SearchSourceBuilder.ScriptField> sorted = new ArrayList<>(scriptFields);
             sorted.sort(Comparator.comparing(SearchSourceBuilder.ScriptField::fieldName));
             this.scriptFields = sorted;
+            return this;
         }
 
-        public void setDelayedDataCheckConfig(DelayedDataCheckConfig delayedDataCheckConfig) {
+        public Builder setDelayedDataCheckConfig(DelayedDataCheckConfig delayedDataCheckConfig) {
             this.delayedDataCheckConfig = delayedDataCheckConfig;
+            return this;
         }
 
-        public void setScrollSize(int scrollSize) {
+        public Builder setScrollSize(int scrollSize) {
             this.scrollSize = scrollSize;
+            return this;
         }
 
-        public void setChunkingConfig(ChunkingConfig chunkingConfig) {
+        public Builder setChunkingConfig(ChunkingConfig chunkingConfig) {
             this.chunkingConfig = chunkingConfig;
+            return this;
         }
 
         public DatafeedUpdate build() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/AnomalyDetectorsIndex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/AnomalyDetectorsIndex.java
@@ -38,6 +38,14 @@ public final class AnomalyDetectorsIndex {
     }
 
     /**
+     * The name of the alias pointing to the indices where the jobs' results are stored
+     * @return The read alias
+     */
+    public static String jobResultsIndexName() {
+        return AnomalyDetectorsIndexFields.RESULTS_INDEX_PREFIX + AnomalyDetectorsIndexFields.RESULTS_INDEX_DEFAULT;
+    }
+
+    /**
      * The name of the alias pointing to the indices where the job's results are stored
      * @param jobId Job Id
      * @return The read alias

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/AnomalyDetectorsIndex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/AnomalyDetectorsIndex.java
@@ -38,14 +38,6 @@ public final class AnomalyDetectorsIndex {
     }
 
     /**
-     * The name of the alias pointing to the indices where the jobs' results are stored
-     * @return The read alias
-     */
-    public static String jobResultsIndexName() {
-        return AnomalyDetectorsIndexFields.RESULTS_INDEX_PREFIX + AnomalyDetectorsIndexFields.RESULTS_INDEX_DEFAULT;
-    }
-
-    /**
      * The name of the alias pointing to the indices where the job's results are stored
      * @param jobId Job Id
      * @return The read alias

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
@@ -25,6 +25,7 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.xpack.core.ml.datafeed.ChunkingConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.core.ml.datafeed.DelayedDataCheckConfig;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsDest;
@@ -510,6 +511,7 @@ public class ElasticsearchMappings {
         addCategoryDefinitionMapping(builder);
         addDataCountsMapping(builder);
         addTimingStatsExceptBucketCountMapping(builder);
+        addDatafeedTimingStats(builder);
         addModelSnapshotMapping(builder);
 
         addTermFields(builder, extraTermFields);
@@ -924,6 +926,18 @@ public class ElasticsearchMappings {
                 .field(TYPE, DOUBLE)
             .endObject()
             .startObject(TimingStats.EXPONENTIAL_AVG_BUCKET_PROCESSING_TIME_MS.getPreferredName())
+                .field(TYPE, DOUBLE)
+            .endObject();
+    }
+
+    /**
+     * {@link DatafeedTimingStats} mapping.
+     *
+     * @throws IOException On builder write error
+     */
+    private static void addDatafeedTimingStats(XContentBuilder builder) throws IOException {
+        builder
+            .startObject(DatafeedTimingStats.TOTAL_SEARCH_TIME_MS.getPreferredName())
                 .field(TYPE, DOUBLE)
             .endObject();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
@@ -937,6 +937,9 @@ public class ElasticsearchMappings {
      */
     private static void addDatafeedTimingStats(XContentBuilder builder) throws IOException {
         builder
+            .startObject(DatafeedTimingStats.SEARCH_COUNT.getPreferredName())
+                .field(TYPE, LONG)
+            .endObject()
             .startObject(DatafeedTimingStats.TOTAL_SEARCH_TIME_MS.getPreferredName())
                 .field(TYPE, DOUBLE)
             .endObject();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ReservedFieldNames.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ReservedFieldNames.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.core.ml.job.results;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.xpack.core.ml.datafeed.ChunkingConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.core.ml.datafeed.DelayedDataCheckConfig;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsDest;
@@ -184,6 +185,8 @@ public final class ReservedFieldNames {
             TimingStats.MAX_BUCKET_PROCESSING_TIME_MS.getPreferredName(),
             TimingStats.AVG_BUCKET_PROCESSING_TIME_MS.getPreferredName(),
             TimingStats.EXPONENTIAL_AVG_BUCKET_PROCESSING_TIME_MS.getPreferredName(),
+
+            DatafeedTimingStats.TOTAL_SEARCH_TIME_MS.getPreferredName(),
 
             GetResult._ID,
             GetResult._INDEX,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ReservedFieldNames.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ReservedFieldNames.java
@@ -186,6 +186,7 @@ public final class ReservedFieldNames {
             TimingStats.AVG_BUCKET_PROCESSING_TIME_MS.getPreferredName(),
             TimingStats.EXPONENTIAL_AVG_BUCKET_PROCESSING_TIME_MS.getPreferredName(),
 
+            DatafeedTimingStats.SEARCH_COUNT.getPreferredName(),
             DatafeedTimingStats.TOTAL_SEARCH_TIME_MS.getPreferredName(),
 
             GetResult._ID,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedStatsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedStatsActionResponseTests.java
@@ -77,7 +77,7 @@ public class GetDatafeedStatsActionResponseTests extends AbstractStreamableTestC
                 Set.of(),
                 Version.CURRENT);
 
-        DatafeedTimingStats timingStats = new DatafeedTimingStats("my-job-id", 123.456);
+        DatafeedTimingStats timingStats = new DatafeedTimingStats("my-job-id", 5, 123.456);
 
         Response.DatafeedStats stats = new Response.DatafeedStats("df-id", DatafeedState.STARTED, node, null, timingStats);
 
@@ -110,6 +110,7 @@ public class GetDatafeedStatsActionResponseTests extends AbstractStreamableTestC
         Map<String, Object> timingStatsMap = (Map<String, Object>) dfStatsMap.get("timing_stats");
         assertThat(timingStatsMap.size(), is(equalTo(2)));
         assertThat(timingStatsMap, hasEntry("job_id", "my-job-id"));
+        assertThat(timingStatsMap, hasEntry("search_count", 5));
         assertThat(timingStatsMap, hasEntry("total_search_time_ms", 123.456));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedStatsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedStatsActionResponseTests.java
@@ -18,6 +18,8 @@ import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.action.GetDatafeedsStatsAction.Response;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStatsTests;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -43,16 +45,13 @@ public class GetDatafeedStatsActionResponseTests extends AbstractStreamableTestC
         for (int j = 0; j < listSize; j++) {
             String datafeedId = randomAlphaOfLength(10);
             DatafeedState datafeedState = randomFrom(DatafeedState.values());
-
-            DiscoveryNode node = null;
-            if (randomBoolean()) {
-                node = new DiscoveryNode("_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.CURRENT);
-            }
-            String explanation = null;
-            if (randomBoolean()) {
-                explanation = randomAlphaOfLength(3);
-            }
-            Response.DatafeedStats datafeedStats = new Response.DatafeedStats(datafeedId, datafeedState, node, explanation);
+            DiscoveryNode node =
+                randomBoolean()
+                    ? null
+                    : new DiscoveryNode("_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.CURRENT);
+            String explanation = randomBoolean() ? null : randomAlphaOfLength(3);
+            DatafeedTimingStats timingStats = randomBoolean() ? null : DatafeedTimingStatsTests.createRandom();
+            Response.DatafeedStats datafeedStats = new Response.DatafeedStats(datafeedId, datafeedState, node, explanation, timingStats);
             datafeedStatsList.add(datafeedStats);
         }
 
@@ -78,7 +77,9 @@ public class GetDatafeedStatsActionResponseTests extends AbstractStreamableTestC
                 Set.of(),
                 Version.CURRENT);
 
-        Response.DatafeedStats stats = new Response.DatafeedStats("df-id", DatafeedState.STARTED, node, null);
+        DatafeedTimingStats timingStats = new DatafeedTimingStats("my-job-id", 123.456);
+
+        Response.DatafeedStats stats = new Response.DatafeedStats("df-id", DatafeedState.STARTED, node, null, timingStats);
 
         XContentType xContentType = randomFrom(XContentType.values());
         BytesReference bytes;
@@ -89,7 +90,7 @@ public class GetDatafeedStatsActionResponseTests extends AbstractStreamableTestC
 
         Map<String, Object> dfStatsMap = XContentHelper.convertToMap(bytes, randomBoolean(), xContentType).v2();
 
-        assertThat(dfStatsMap.size(), is(equalTo(3)));
+        assertThat(dfStatsMap.size(), is(equalTo(4)));
         assertThat(dfStatsMap, hasEntry("datafeed_id", "df-id"));
         assertThat(dfStatsMap, hasEntry("state", "started"));
         assertThat(dfStatsMap, hasKey("node"));
@@ -105,5 +106,10 @@ public class GetDatafeedStatsActionResponseTests extends AbstractStreamableTestC
         assertThat(nodeAttributes.size(), is(equalTo(2)));
         assertThat(nodeAttributes, hasEntry("ml.enabled", "true"));
         assertThat(nodeAttributes, hasEntry("ml.max_open_jobs", "5"));
+
+        Map<String, Object> timingStatsMap = (Map<String, Object>) dfStatsMap.get("timing_stats");
+        assertThat(timingStatsMap.size(), is(equalTo(2)));
+        assertThat(timingStatsMap, hasEntry("job_id", "my-job-id"));
+        assertThat(timingStatsMap, hasEntry("total_search_time_ms", 123.456));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedStatsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedStatsActionResponseTests.java
@@ -94,6 +94,7 @@ public class GetDatafeedStatsActionResponseTests extends AbstractStreamableTestC
         assertThat(dfStatsMap, hasEntry("datafeed_id", "df-id"));
         assertThat(dfStatsMap, hasEntry("state", "started"));
         assertThat(dfStatsMap, hasKey("node"));
+        assertThat(dfStatsMap, hasKey("timing_stats"));
 
         Map<String, Object> nodeMap = (Map<String, Object>) dfStatsMap.get("node");
         assertThat(nodeMap, hasEntry("id", "df-node-id"));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedStatsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedStatsActionResponseTests.java
@@ -108,7 +108,7 @@ public class GetDatafeedStatsActionResponseTests extends AbstractStreamableTestC
         assertThat(nodeAttributes, hasEntry("ml.max_open_jobs", "5"));
 
         Map<String, Object> timingStatsMap = (Map<String, Object>) dfStatsMap.get("timing_stats");
-        assertThat(timingStatsMap.size(), is(equalTo(2)));
+        assertThat(timingStatsMap.size(), is(equalTo(3)));
         assertThat(timingStatsMap, hasEntry("job_id", "my-job-id"));
         assertThat(timingStatsMap, hasEntry("search_count", 5));
         assertThat(timingStatsMap, hasEntry("total_search_time_ms", 123.456));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedTimingStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedTimingStatsTests.java
@@ -12,7 +12,6 @@ import org.elasticsearch.test.AbstractSerializingTestCase;
 import java.io.IOException;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 
 public class DatafeedTimingStatsTests extends AbstractSerializingTestCase<DatafeedTimingStats> {
 
@@ -92,17 +91,5 @@ public class DatafeedTimingStatsTests extends AbstractSerializingTestCase<Datafe
 
     public void testDocumentId() {
         assertThat(DatafeedTimingStats.documentId("my-job-id"), equalTo("my-job-id_datafeed_timing_stats"));
-    }
-
-    public void testTimingStatsDifferSignificantly() {
-        assertThat(
-            DatafeedTimingStats.differSignificantly(new DatafeedTimingStats(JOB_ID, 1000.0), new DatafeedTimingStats(JOB_ID, 1000.0)),
-            is(false));
-        assertThat(
-            DatafeedTimingStats.differSignificantly(new DatafeedTimingStats(JOB_ID, 1000.0), new DatafeedTimingStats(JOB_ID, 1100.0)),
-            is(false));
-        assertThat(
-            DatafeedTimingStats.differSignificantly(new DatafeedTimingStats(JOB_ID, 1000.0), new DatafeedTimingStats(JOB_ID, 1120.0)),
-            is(true));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedTimingStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedTimingStatsTests.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ml.datafeed;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class DatafeedTimingStatsTests extends AbstractSerializingTestCase<DatafeedTimingStats> {
+
+    private static final String JOB_ID = "my-job-id";
+
+    public static DatafeedTimingStats createRandom() {
+        return new DatafeedTimingStats(randomAlphaOfLength(10), randomDouble());
+    }
+
+    @Override
+    protected DatafeedTimingStats createTestInstance(){
+        return createRandom();
+    }
+
+    @Override
+    protected Writeable.Reader<DatafeedTimingStats> instanceReader() {
+        return DatafeedTimingStats::new;
+    }
+
+    @Override
+    protected DatafeedTimingStats doParseInstance(XContentParser parser) {
+        return DatafeedTimingStats.PARSER.apply(parser, null);
+    }
+
+    @Override
+    protected DatafeedTimingStats mutateInstance(DatafeedTimingStats instance) throws IOException {
+        String jobId = instance.getJobId();
+        double totalSearchTimeMs = instance.getTotalSearchTimeMs();
+        return new DatafeedTimingStats(
+            jobId + randomAlphaOfLength(5),
+            totalSearchTimeMs + randomDoubleBetween(1.0, 100.0, true));
+    }
+
+    public void testEquals() {
+        DatafeedTimingStats stats1 = new DatafeedTimingStats(JOB_ID, 100.0);
+        DatafeedTimingStats stats2 = new DatafeedTimingStats(JOB_ID, 100.0);
+        DatafeedTimingStats stats3 = new DatafeedTimingStats(JOB_ID, 200.0);
+
+        assertTrue(stats1.equals(stats1));
+        assertTrue(stats1.equals(stats2));
+        assertFalse(stats2.equals(stats3));
+    }
+
+    public void testHashCode() {
+        DatafeedTimingStats stats1 = new DatafeedTimingStats(JOB_ID, 100.0);
+        DatafeedTimingStats stats2 = new DatafeedTimingStats(JOB_ID, 100.0);
+        DatafeedTimingStats stats3 = new DatafeedTimingStats(JOB_ID, 200.0);
+
+        assertEquals(stats1.hashCode(), stats1.hashCode());
+        assertEquals(stats1.hashCode(), stats2.hashCode());
+        assertNotEquals(stats2.hashCode(), stats3.hashCode());
+    }
+
+    public void testConstructorsAndGetters() {
+        DatafeedTimingStats stats = new DatafeedTimingStats(JOB_ID, 123.456);
+        assertThat(stats.getJobId(), equalTo(JOB_ID));
+        assertThat(stats.getTotalSearchTimeMs(), equalTo(123.456));
+
+        stats = new DatafeedTimingStats(JOB_ID);
+        assertThat(stats.getJobId(), equalTo(JOB_ID));
+        assertThat(stats.getTotalSearchTimeMs(), equalTo(0.0));
+    }
+
+    public void testCopyConstructor() {
+        DatafeedTimingStats stats1 = new DatafeedTimingStats(JOB_ID, 123.456);
+        DatafeedTimingStats stats2 = new DatafeedTimingStats(stats1);
+
+        assertThat(stats2.getJobId(), equalTo(JOB_ID));
+        assertThat(stats2.getTotalSearchTimeMs(), equalTo(123.456));
+    }
+
+    public void testIncrementTotalSearchTimeMs() {
+        DatafeedTimingStats stats = new DatafeedTimingStats(JOB_ID, 100.0);
+        stats.incrementTotalSearchTimeMs(200.0);
+        assertThat(stats.getTotalSearchTimeMs(), equalTo(300.0));
+    }
+
+    public void testDocumentId() {
+        assertThat(DatafeedTimingStats.documentId("my-job-id"), equalTo("my-job-id_datafeed_timing_stats"));
+    }
+
+    public void testTimingStatsDifferSignificantly() {
+        assertThat(
+            DatafeedTimingStats.differSignificantly(new DatafeedTimingStats(JOB_ID, 1000.0), new DatafeedTimingStats(JOB_ID, 1000.0)),
+            is(false));
+        assertThat(
+            DatafeedTimingStats.differSignificantly(new DatafeedTimingStats(JOB_ID, 1000.0), new DatafeedTimingStats(JOB_ID, 1100.0)),
+            is(false));
+        assertThat(
+            DatafeedTimingStats.differSignificantly(new DatafeedTimingStats(JOB_ID, 1000.0), new DatafeedTimingStats(JOB_ID, 1120.0)),
+            is(true));
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedTimingStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedTimingStatsTests.java
@@ -6,7 +6,10 @@
 package org.elasticsearch.xpack.core.ml.datafeed;
 
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 
 import java.io.IOException;
@@ -18,7 +21,7 @@ public class DatafeedTimingStatsTests extends AbstractSerializingTestCase<Datafe
     private static final String JOB_ID = "my-job-id";
 
     public static DatafeedTimingStats createRandom() {
-        return new DatafeedTimingStats(randomAlphaOfLength(10), randomDouble());
+        return new DatafeedTimingStats(randomAlphaOfLength(10), randomLong(), randomDouble());
     }
 
     @Override
@@ -39,16 +42,30 @@ public class DatafeedTimingStatsTests extends AbstractSerializingTestCase<Datafe
     @Override
     protected DatafeedTimingStats mutateInstance(DatafeedTimingStats instance) throws IOException {
         String jobId = instance.getJobId();
+        long searchCount = instance.getSearchCount();
         double totalSearchTimeMs = instance.getTotalSearchTimeMs();
         return new DatafeedTimingStats(
             jobId + randomAlphaOfLength(5),
+            searchCount + 1,
             totalSearchTimeMs + randomDoubleBetween(1.0, 100.0, true));
     }
 
+    public void testParse_OptionalFieldsAbsent() throws IOException {
+        String json = "{\"job_id\": \"my-job-id\"}";
+        try (XContentParser parser =
+                 XContentFactory.xContent(XContentType.JSON).createParser(
+                     xContentRegistry(), DeprecationHandler.THROW_UNSUPPORTED_OPERATION, json)) {
+            DatafeedTimingStats stats = DatafeedTimingStats.PARSER.apply(parser, null);
+            assertThat(stats.getJobId(), equalTo(JOB_ID));
+            assertThat(stats.getSearchCount(), equalTo(0L));
+            assertThat(stats.getTotalSearchTimeMs(), equalTo(0.0));
+        }
+    }
+
     public void testEquals() {
-        DatafeedTimingStats stats1 = new DatafeedTimingStats(JOB_ID, 100.0);
-        DatafeedTimingStats stats2 = new DatafeedTimingStats(JOB_ID, 100.0);
-        DatafeedTimingStats stats3 = new DatafeedTimingStats(JOB_ID, 200.0);
+        DatafeedTimingStats stats1 = new DatafeedTimingStats(JOB_ID, 5, 100.0);
+        DatafeedTimingStats stats2 = new DatafeedTimingStats(JOB_ID, 5, 100.0);
+        DatafeedTimingStats stats3 = new DatafeedTimingStats(JOB_ID, 5, 200.0);
 
         assertTrue(stats1.equals(stats1));
         assertTrue(stats1.equals(stats2));
@@ -56,9 +73,9 @@ public class DatafeedTimingStatsTests extends AbstractSerializingTestCase<Datafe
     }
 
     public void testHashCode() {
-        DatafeedTimingStats stats1 = new DatafeedTimingStats(JOB_ID, 100.0);
-        DatafeedTimingStats stats2 = new DatafeedTimingStats(JOB_ID, 100.0);
-        DatafeedTimingStats stats3 = new DatafeedTimingStats(JOB_ID, 200.0);
+        DatafeedTimingStats stats1 = new DatafeedTimingStats(JOB_ID, 5, 100.0);
+        DatafeedTimingStats stats2 = new DatafeedTimingStats(JOB_ID, 5, 100.0);
+        DatafeedTimingStats stats3 = new DatafeedTimingStats(JOB_ID, 5, 200.0);
 
         assertEquals(stats1.hashCode(), stats1.hashCode());
         assertEquals(stats1.hashCode(), stats2.hashCode());
@@ -66,26 +83,31 @@ public class DatafeedTimingStatsTests extends AbstractSerializingTestCase<Datafe
     }
 
     public void testConstructorsAndGetters() {
-        DatafeedTimingStats stats = new DatafeedTimingStats(JOB_ID, 123.456);
+        DatafeedTimingStats stats = new DatafeedTimingStats(JOB_ID, 5, 123.456);
         assertThat(stats.getJobId(), equalTo(JOB_ID));
+        assertThat(stats.getSearchCount(), equalTo(5L));
         assertThat(stats.getTotalSearchTimeMs(), equalTo(123.456));
 
         stats = new DatafeedTimingStats(JOB_ID);
         assertThat(stats.getJobId(), equalTo(JOB_ID));
+        assertThat(stats.getSearchCount(), equalTo(0L));
         assertThat(stats.getTotalSearchTimeMs(), equalTo(0.0));
     }
 
     public void testCopyConstructor() {
-        DatafeedTimingStats stats1 = new DatafeedTimingStats(JOB_ID, 123.456);
+        DatafeedTimingStats stats1 = new DatafeedTimingStats(JOB_ID, 5, 123.456);
         DatafeedTimingStats stats2 = new DatafeedTimingStats(stats1);
 
         assertThat(stats2.getJobId(), equalTo(JOB_ID));
+        assertThat(stats2.getSearchCount(), equalTo(5L));
         assertThat(stats2.getTotalSearchTimeMs(), equalTo(123.456));
     }
 
     public void testIncrementTotalSearchTimeMs() {
-        DatafeedTimingStats stats = new DatafeedTimingStats(JOB_ID, 100.0);
+        DatafeedTimingStats stats = new DatafeedTimingStats(JOB_ID, 5, 100.0);
         stats.incrementTotalSearchTimeMs(200.0);
+        assertThat(stats.getJobId(), equalTo(JOB_ID));
+        assertThat(stats.getSearchCount(), equalTo(6L));
         assertThat(stats.getTotalSearchTimeMs(), equalTo(300.0));
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappingsTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.ModelPlotConfig;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
@@ -82,6 +83,7 @@ public class ElasticsearchMappingsTests extends ESTestCase {
         overridden.add(ModelSnapshot.TYPE.getPreferredName());
         overridden.add(Quantiles.TYPE.getPreferredName());
         overridden.add(TimingStats.TYPE.getPreferredName());
+        overridden.add(DatafeedTimingStats.TYPE.getPreferredName());
 
         Set<String> expected = collectResultsDocFieldNames();
         expected.removeAll(overridden);

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlNativeAutodetectIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlNativeAutodetectIntegTestCase.java
@@ -43,11 +43,13 @@ import org.elasticsearch.xpack.core.ml.action.PutJobAction;
 import org.elasticsearch.xpack.core.ml.action.RevertModelSnapshotAction;
 import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.StopDatafeedAction;
+import org.elasticsearch.xpack.core.ml.action.UpdateDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateJobAction;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.ml.calendars.Calendar;
 import org.elasticsearch.xpack.core.ml.calendars.ScheduledEvent;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedUpdate;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.config.JobUpdate;
@@ -173,6 +175,11 @@ abstract class MlNativeAutodetectIntegTestCase extends MlNativeIntegTestCase {
     protected StopDatafeedAction.Response stopDatafeed(String datafeedId) {
         StopDatafeedAction.Request request = new StopDatafeedAction.Request(datafeedId);
         return client().execute(StopDatafeedAction.INSTANCE, request).actionGet();
+    }
+
+    protected PutDatafeedAction.Response updateDatafeed(DatafeedUpdate update) {
+        UpdateDatafeedAction.Request request = new UpdateDatafeedAction.Request(update);
+        return client().execute(UpdateDatafeedAction.INSTANCE, request).actionGet();
     }
 
     protected AcknowledgedResponse deleteDatafeed(String datafeedId) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -448,12 +448,15 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
 
         Auditor auditor = new Auditor(client, clusterService.getNodeName());
         JobResultsProvider jobResultsProvider = new JobResultsProvider(client, settings);
+        JobResultsPersister jobResultsPersister = new JobResultsPersister(client);
+        JobDataCountsPersister jobDataCountsPersister = new JobDataCountsPersister(client);
         JobConfigProvider jobConfigProvider = new JobConfigProvider(client, xContentRegistry);
         DatafeedConfigProvider datafeedConfigProvider = new DatafeedConfigProvider(client, xContentRegistry);
         UpdateJobProcessNotifier notifier = new UpdateJobProcessNotifier(client, clusterService, threadPool);
         JobManager jobManager = new JobManager(env,
             settings,
             jobResultsProvider,
+            jobResultsPersister,
             clusterService,
             auditor,
             threadPool,
@@ -463,9 +466,6 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
 
         // special holder for @link(MachineLearningFeatureSetUsage) which needs access to job manager if ML is enabled
         JobManagerHolder jobManagerHolder = new JobManagerHolder(jobManager);
-
-        JobDataCountsPersister jobDataCountsPersister = new JobDataCountsPersister(client);
-        JobResultsPersister jobResultsPersister = new JobResultsPersister(client);
 
         NativeStorageProvider nativeStorageProvider = new NativeStorageProvider(environment, MIN_DISK_SPACE_OFF_HEAP.get(settings));
 
@@ -509,8 +509,16 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                 xContentRegistry, auditor, clusterService, jobManager, jobResultsProvider, jobResultsPersister, jobDataCountsPersister,
                 autodetectProcessFactory, normalizerFactory, nativeStorageProvider);
         this.autodetectProcessManager.set(autodetectProcessManager);
-        DatafeedJobBuilder datafeedJobBuilder = new DatafeedJobBuilder(client, settings, xContentRegistry,
-                auditor, System::currentTimeMillis);
+        DatafeedJobBuilder datafeedJobBuilder =
+            new DatafeedJobBuilder(
+                client,
+                xContentRegistry,
+                auditor,
+                System::currentTimeMillis,
+                jobConfigProvider,
+                jobResultsProvider,
+                datafeedConfigProvider,
+                jobResultsPersister);
         DatafeedManager datafeedManager = new DatafeedManager(threadPool, client, clusterService, datafeedJobBuilder,
                 System::currentTimeMillis, auditor, autodetectProcessManager);
         this.datafeedManager.set(datafeedManager);
@@ -542,6 +550,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                 mlLifeCycleService,
                 new MlControllerHolder(mlController),
                 jobResultsProvider,
+                jobResultsPersister,
                 jobConfigProvider,
                 datafeedConfigProvider,
                 jobManager,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteDatafeedAction.java
@@ -151,19 +151,18 @@ public class TransportDeleteDatafeedAction extends TransportMasterNodeAction<Del
             return;
         }
 
-        // Get datafeed config document
+        String datafeedId = request.getDatafeedId();
+
         datafeedConfigProvider.getDatafeedConfig(
-            request.getDatafeedId(),
+            datafeedId,
             ActionListener.wrap(
                 datafeedConfigBuilder -> {
-                    // Delete datafeed timing stats document
                     deleteDatafeedTimingStats(
                         datafeedConfigBuilder.build().getJobId(),
                         ActionListener.wrap(
                             unused1 -> {
-                                // Delete datafeed config document
                                 datafeedConfigProvider.deleteDatafeedConfig(
-                                    request.getDatafeedId(),
+                                    datafeedId,
                                     ActionListener.wrap(
                                         unused2 -> listener.onResponse(new AcknowledgedResponse(true)),
                                         listener::onFailure));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsStatsAction.java
@@ -77,8 +77,13 @@ public class TransportGetDatafeedsStatsAction extends TransportMasterNodeReadAct
                         timingStatsByJobId -> {
                             PersistentTasksCustomMetaData tasksInProgress = state.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
                             List<GetDatafeedsStatsAction.Response.DatafeedStats> results = datafeedBuilders.stream()
-                                .map(datafeedBuilder -> getDatafeedStats(
-                                    datafeedBuilder.getId(), state, tasksInProgress, jobIdByDatafeedId, timingStatsByJobId))
+                                .map(
+                                    datafeedBuilder -> getDatafeedStats(
+                                        datafeedBuilder.getId(),
+                                        state,
+                                        tasksInProgress,
+                                        jobIdByDatafeedId.get(datafeedBuilder.getId()),
+                                        timingStatsByJobId))
                                 .collect(Collectors.toList());
                             QueryPage<GetDatafeedsStatsAction.Response.DatafeedStats> statsPage =
                                 new QueryPage<>(results, results.size(), DatafeedConfig.RESULTS_FIELD);
@@ -93,7 +98,7 @@ public class TransportGetDatafeedsStatsAction extends TransportMasterNodeReadAct
     private static GetDatafeedsStatsAction.Response.DatafeedStats getDatafeedStats(String datafeedId,
                                                                                    ClusterState state,
                                                                                    PersistentTasksCustomMetaData tasks,
-                                                                                   Map<String, String> jobIdByDatafeedId,
+                                                                                   String jobId,
                                                                                    Map<String, DatafeedTimingStats> timingStatsByJobId) {
         PersistentTasksCustomMetaData.PersistentTask<?> task = MlTasks.getDatafeedTask(datafeedId, tasks);
         DatafeedState datafeedState = MlTasks.getDatafeedState(datafeedId, tasks);
@@ -104,7 +109,6 @@ public class TransportGetDatafeedsStatsAction extends TransportMasterNodeReadAct
             explanation = task.getAssignment().getExplanation();
         }
         DatafeedTimingStats timingStats = null;
-        String jobId = jobIdByDatafeedId.get(datafeedId);
         if (jobId != null) {
             timingStats = timingStatsByJobId.get(jobId);
             if (timingStats == null) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
@@ -31,7 +31,6 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.time.Clock;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -86,7 +85,7 @@ public class TransportPreviewDatafeedAction extends HandledTransportAction<Previ
                                     previewDatafeed.build(),
                                     jobBuilder.build(),
                                     xContentRegistry,
-                                    new DatafeedTimingStatsReporter(timingStats, Clock.systemUTC(), jobResultsPersister),
+                                    new DatafeedTimingStatsReporter(timingStats, jobResultsPersister),
                                     new ActionListener<>() {
                                         @Override
                                         public void onResponse(DataExtractorFactory dataExtractorFactory) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
@@ -20,14 +20,18 @@ import org.elasticsearch.xpack.core.ml.action.PreviewDatafeedAction;
 import org.elasticsearch.xpack.core.ml.datafeed.ChunkingConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.extractor.DataExtractor;
+import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter;
 import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractorFactory;
 import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
+import org.elasticsearch.xpack.ml.job.persistence.JobResultsPersister;
+import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
 
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -39,56 +43,68 @@ public class TransportPreviewDatafeedAction extends HandledTransportAction<Previ
     private final Client client;
     private final JobConfigProvider jobConfigProvider;
     private final DatafeedConfigProvider datafeedConfigProvider;
+    private final JobResultsProvider jobResultsProvider;
+    private final JobResultsPersister jobResultsPersister;
     private final NamedXContentRegistry xContentRegistry;
 
     @Inject
     public TransportPreviewDatafeedAction(ThreadPool threadPool, TransportService transportService,
                                           ActionFilters actionFilters, Client client, JobConfigProvider jobConfigProvider,
-                                          DatafeedConfigProvider datafeedConfigProvider, NamedXContentRegistry xContentRegistry) {
+                                          DatafeedConfigProvider datafeedConfigProvider, JobResultsProvider jobResultsProvider,
+                                          JobResultsPersister jobResultsPersister, NamedXContentRegistry xContentRegistry) {
         super(PreviewDatafeedAction.NAME, transportService, actionFilters,
             (Supplier<PreviewDatafeedAction.Request>) PreviewDatafeedAction.Request::new);
         this.threadPool = threadPool;
         this.client = client;
         this.jobConfigProvider = jobConfigProvider;
         this.datafeedConfigProvider = datafeedConfigProvider;
+        this.jobResultsProvider = jobResultsProvider;
+        this.jobResultsPersister = jobResultsPersister;
         this.xContentRegistry = xContentRegistry;
     }
 
     @Override
     protected void doExecute(Task task, PreviewDatafeedAction.Request request, ActionListener<PreviewDatafeedAction.Response> listener) {
-
         datafeedConfigProvider.getDatafeedConfig(request.getDatafeedId(), ActionListener.wrap(
-                datafeedConfigBuilder -> {
-                    DatafeedConfig datafeedConfig = datafeedConfigBuilder.build();
-                    jobConfigProvider.getJob(datafeedConfig.getJobId(), ActionListener.wrap(
-                            jobBuilder -> {
-                                DatafeedConfig.Builder previewDatafeed = buildPreviewDatafeed(datafeedConfig);
-                                Map<String, String> headers = threadPool.getThreadContext().getHeaders().entrySet().stream()
-                                        .filter(e -> ClientHelper.SECURITY_HEADER_FILTERS.contains(e.getKey()))
-                                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-                                previewDatafeed.setHeaders(headers);
+            datafeedConfigBuilder -> {
+                DatafeedConfig datafeedConfig = datafeedConfigBuilder.build();
+                jobConfigProvider.getJob(datafeedConfig.getJobId(), ActionListener.wrap(
+                    jobBuilder -> {
+                        DatafeedConfig.Builder previewDatafeed = buildPreviewDatafeed(datafeedConfig);
+                        Map<String, String> headers = threadPool.getThreadContext().getHeaders().entrySet().stream()
+                            .filter(e -> ClientHelper.SECURITY_HEADER_FILTERS.contains(e.getKey()))
+                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                        previewDatafeed.setHeaders(headers);
+                        jobResultsProvider.datafeedTimingStats(
+                            jobBuilder.getId(),
+                            timingStats -> {
                                 // NB: this is using the client from the transport layer, NOT the internal client.
                                 // This is important because it means the datafeed search will fail if the user
                                 // requesting the preview doesn't have permission to search the relevant indices.
-                                DataExtractorFactory.create(client, previewDatafeed.build(), jobBuilder.build(), xContentRegistry,
-                                        new ActionListener<DataExtractorFactory>() {
-                                    @Override
-                                    public void onResponse(DataExtractorFactory dataExtractorFactory) {
-                                        DataExtractor dataExtractor = dataExtractorFactory.newExtractor(0, Long.MAX_VALUE);
-                                        threadPool.generic().execute(() -> previewDatafeed(dataExtractor, listener));
-                                    }
+                                DataExtractorFactory.create(
+                                    client,
+                                    previewDatafeed.build(),
+                                    jobBuilder.build(),
+                                    xContentRegistry,
+                                    new DatafeedTimingStatsReporter(timingStats, Clock.systemUTC(), jobResultsPersister),
+                                    new ActionListener<>() {
+                                        @Override
+                                        public void onResponse(DataExtractorFactory dataExtractorFactory) {
+                                            DataExtractor dataExtractor = dataExtractorFactory.newExtractor(0, Long.MAX_VALUE);
+                                            threadPool.generic().execute(() -> previewDatafeed(dataExtractor, listener));
+                                        }
 
-                                    @Override
-                                    public void onFailure(Exception e) {
-                                        listener.onFailure(e);
-                                    }
-                                });
+                                        @Override
+                                        public void onFailure(Exception e) {
+                                            listener.onFailure(e);
+                                        }
+                                    });
                             },
-                            listener::onFailure
-                    ));
-                },
-                listener::onFailure
-        ));
+                            listener::onFailure);
+                    },
+                    listener::onFailure));
+            },
+            listener::onFailure));
     }
 
     /** Visible for testing */

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -44,6 +44,7 @@ import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedJobValidator;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
@@ -51,12 +52,15 @@ import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.MlConfigMigrationEligibilityCheck;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedManager;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedNodeSelector;
+import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter;
 import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractorFactory;
 import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
+import org.elasticsearch.xpack.ml.job.persistence.JobResultsPersister;
 import org.elasticsearch.xpack.ml.notifications.Auditor;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -80,6 +84,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
     private final PersistentTasksService persistentTasksService;
     private final JobConfigProvider jobConfigProvider;
     private final DatafeedConfigProvider datafeedConfigProvider;
+    private final JobResultsPersister jobResultsPersister;
     private final Auditor auditor;
     private final MlConfigMigrationEligibilityCheck migrationEligibilityCheck;
     private final NamedXContentRegistry xContentRegistry;
@@ -90,7 +95,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
                                         PersistentTasksService persistentTasksService,
                                         ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
                                         Client client, JobConfigProvider jobConfigProvider, DatafeedConfigProvider datafeedConfigProvider,
-                                        Auditor auditor, NamedXContentRegistry xContentRegistry) {
+                                        JobResultsPersister jobResultsPersister, Auditor auditor, NamedXContentRegistry xContentRegistry) {
         super(StartDatafeedAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver,
                 StartDatafeedAction.Request::new);
         this.licenseState = licenseState;
@@ -98,6 +103,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
         this.client = client;
         this.jobConfigProvider = jobConfigProvider;
         this.datafeedConfigProvider = datafeedConfigProvider;
+        this.jobResultsPersister = jobResultsPersister;
         this.auditor = auditor;
         this.migrationEligibilityCheck = new MlConfigMigrationEligibilityCheck(settings, clusterService);
         this.xContentRegistry = xContentRegistry;
@@ -242,14 +248,22 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
         datafeedConfigProvider.getDatafeedConfig(params.getDatafeedId(), datafeedListener);
     }
 
+    /** Creates {@link DataExtractorFactory} solely for the purpose of validation i.e. verifying that it can be created. */
     private void createDataExtractor(Job job, DatafeedConfig datafeed, StartDatafeedAction.DatafeedParams params,
                                      ActionListener<PersistentTasksCustomMetaData.PersistentTask<StartDatafeedAction.DatafeedParams>>
                                              listener) {
-        DataExtractorFactory.create(client, datafeed, job, xContentRegistry, ActionListener.wrap(
-                dataExtractorFactory ->
-                        persistentTasksService.sendStartRequest(MlTasks.datafeedTaskId(params.getDatafeedId()),
-                                MlTasks.DATAFEED_TASK_NAME, params, listener)
-                , listener::onFailure));
+        DataExtractorFactory.create(
+            client,
+            datafeed,
+            job,
+            xContentRegistry,
+            // Creating fake {@link TimingStatsReporter} so that search API call is not needed.
+            new DatafeedTimingStatsReporter(new DatafeedTimingStats(job.getId()), Clock.systemUTC(), jobResultsPersister),
+            ActionListener.wrap(
+                unused ->
+                    persistentTasksService.sendStartRequest(
+                        MlTasks.datafeedTaskId(params.getDatafeedId()), MlTasks.DATAFEED_TASK_NAME, params, listener),
+                listener::onFailure));
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -60,7 +60,6 @@ import org.elasticsearch.xpack.ml.job.persistence.JobResultsPersister;
 import org.elasticsearch.xpack.ml.notifications.Auditor;
 
 import java.io.IOException;
-import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -258,7 +257,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
             job,
             xContentRegistry,
             // Creating fake {@link TimingStatsReporter} so that search API call is not needed.
-            new DatafeedTimingStatsReporter(new DatafeedTimingStats(job.getId()), Clock.systemUTC(), jobResultsPersister),
+            new DatafeedTimingStatsReporter(new DatafeedTimingStats(job.getId()), jobResultsPersister),
             ActionListener.wrap(
                 unused ->
                     persistentTasksService.sendStartRequest(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilder.java
@@ -29,7 +29,6 @@ import org.elasticsearch.xpack.ml.job.persistence.JobResultsPersister;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
 import org.elasticsearch.xpack.ml.notifications.Auditor;
 
-import java.time.Clock;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
@@ -98,7 +97,7 @@ public class DatafeedJobBuilder {
                 datafeedConfigHolder.get(),
                 jobHolder.get(),
                 xContentRegistry,
-                new DatafeedTimingStatsReporter(timingStats, Clock.systemUTC(), jobResultsPersister),
+                new DatafeedTimingStatsReporter(timingStats, jobResultsPersister),
                 dataExtractorFactoryHandler);
         };
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilder.java
@@ -8,12 +8,12 @@ package org.elasticsearch.xpack.ml.datafeed;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedJobValidator;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
@@ -25,9 +25,11 @@ import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractorFactory;
 import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.BucketsQueryBuilder;
 import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
+import org.elasticsearch.xpack.ml.job.persistence.JobResultsPersister;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
 import org.elasticsearch.xpack.ml.notifications.Auditor;
 
+import java.time.Clock;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
@@ -37,36 +39,28 @@ import java.util.function.Supplier;
 public class DatafeedJobBuilder {
 
     private final Client client;
-    private final Settings settings;
     private final NamedXContentRegistry xContentRegistry;
     private final Auditor auditor;
     private final Supplier<Long> currentTimeSupplier;
+    private final JobConfigProvider jobConfigProvider;
+    private final JobResultsProvider jobResultsProvider;
+    private final DatafeedConfigProvider datafeedConfigProvider;
+    private final JobResultsPersister jobResultsPersister;
 
-    public DatafeedJobBuilder(Client client, Settings settings, NamedXContentRegistry xContentRegistry,
-                              Auditor auditor, Supplier<Long> currentTimeSupplier) {
+    public DatafeedJobBuilder(Client client, NamedXContentRegistry xContentRegistry, Auditor auditor, Supplier<Long> currentTimeSupplier,
+                              JobConfigProvider jobConfigProvider, JobResultsProvider jobResultsProvider,
+                              DatafeedConfigProvider datafeedConfigProvider, JobResultsPersister jobResultsPersister) {
         this.client = client;
-        this.settings = Objects.requireNonNull(settings);
         this.xContentRegistry = Objects.requireNonNull(xContentRegistry);
         this.auditor = Objects.requireNonNull(auditor);
         this.currentTimeSupplier = Objects.requireNonNull(currentTimeSupplier);
+        this.jobConfigProvider = Objects.requireNonNull(jobConfigProvider);
+        this.jobResultsProvider = Objects.requireNonNull(jobResultsProvider);
+        this.datafeedConfigProvider = Objects.requireNonNull(datafeedConfigProvider);
+        this.jobResultsPersister = Objects.requireNonNull(jobResultsPersister);
     }
 
     void build(String datafeedId, ActionListener<DatafeedJob> listener) {
-
-        JobResultsProvider jobResultsProvider = new JobResultsProvider(client, settings);
-        JobConfigProvider jobConfigProvider = new JobConfigProvider(client, xContentRegistry);
-        DatafeedConfigProvider datafeedConfigProvider = new DatafeedConfigProvider(client, xContentRegistry);
-
-        build(datafeedId, jobResultsProvider, jobConfigProvider, datafeedConfigProvider, listener);
-    }
-
-    /**
-     * For testing only.
-     * Use {@link #build(String, ActionListener)} instead
-     */
-    void build(String datafeedId, JobResultsProvider jobResultsProvider, JobConfigProvider jobConfigProvider,
-               DatafeedConfigProvider datafeedConfigProvider, ActionListener<DatafeedJob> listener) {
-
         AtomicReference<Job> jobHolder = new AtomicReference<>();
         AtomicReference<DatafeedConfig> datafeedConfigHolder = new AtomicReference<>();
 
@@ -98,11 +92,21 @@ public class DatafeedJobBuilder {
         );
 
         // Create data extractor factory
+        Consumer<DatafeedTimingStats> datafeedTimingStatsHandler = timingStats -> {
+            DataExtractorFactory.create(
+                client,
+                datafeedConfigHolder.get(),
+                jobHolder.get(),
+                xContentRegistry,
+                new DatafeedTimingStatsReporter(timingStats, Clock.systemUTC(), jobResultsPersister),
+                dataExtractorFactoryHandler);
+        };
+
         Consumer<DataCounts> dataCountsHandler = dataCounts -> {
             if (dataCounts.getLatestRecordTimeStamp() != null) {
                 context.latestRecordTimeMs = dataCounts.getLatestRecordTimeStamp().getTime();
             }
-            DataExtractorFactory.create(client, datafeedConfigHolder.get(), jobHolder.get(), xContentRegistry, dataExtractorFactoryHandler);
+            jobResultsProvider.datafeedTimingStats(jobHolder.get().getId(), datafeedTimingStatsHandler, listener::onFailure);
         };
 
         // Collect data counts
@@ -118,7 +122,8 @@ public class DatafeedJobBuilder {
         Consumer<String> jobIdConsumer = jobId -> {
             BucketsQueryBuilder latestBucketQuery = new BucketsQueryBuilder()
                     .sortField(Result.TIMESTAMP.getPreferredName())
-                    .sortDescending(true).size(1)
+                    .sortDescending(true)
+                    .size(1)
                     .includeInterim(false);
             jobResultsProvider.bucketsViaInternalClient(jobId, latestBucketQuery, bucketsHandler, e -> {
                 if (e instanceof ResourceNotFoundException) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporter.java
@@ -49,10 +49,13 @@ public class DatafeedTimingStatsReporter {
         double searchDurationMs = searchDuration.toMillis();
         currentTimingStats.incrementTotalSearchTimeMs(searchDurationMs);
         if (differSignificantly(currentTimingStats, persistedTimingStats)) {
-            jobResultsPersister.persistDatafeedTimingStats(currentTimingStats);
-            persistedTimingStats = currentTimingStats;
-            currentTimingStats = new DatafeedTimingStats(persistedTimingStats);
+            flush();
         }
+    }
+
+    private void flush() {
+        persistedTimingStats = new DatafeedTimingStats(currentTimingStats);
+        jobResultsPersister.persistDatafeedTimingStats(persistedTimingStats);
     }
 
     /**
@@ -82,5 +85,5 @@ public class DatafeedTimingStatsReporter {
      * Maximum absolute difference of values that is interpreted as values being similar.
      * If the values absolute difference is greater than MAX_VALID_ABS_DIFFERENCE, the values are interpreted as significantly different.
      */
-    private static final double MAX_VALID_ABS_DIFFERENCE_MS = 10000.0;
+    private static final double MAX_VALID_ABS_DIFFERENCE_MS = 10000.0;  // 10s
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.datafeed;
+
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
+import org.elasticsearch.xpack.ml.job.persistence.JobResultsPersister;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.function.Function;
+
+public class DatafeedTimingStatsReporter {
+
+    private final Clock clock;
+    private final JobResultsPersister jobResultsPersister;
+    private DatafeedTimingStats persistedTimingStats;
+    private volatile DatafeedTimingStats currentTimingStats;
+
+    public DatafeedTimingStatsReporter(DatafeedTimingStats timingStats, Clock clock, JobResultsPersister jobResultsPersister) {
+        Objects.requireNonNull(timingStats);
+        this.persistedTimingStats = new DatafeedTimingStats(timingStats);
+        this.currentTimingStats = new DatafeedTimingStats(timingStats);
+        this.clock = Objects.requireNonNull(clock);
+        this.jobResultsPersister = Objects.requireNonNull(jobResultsPersister);
+    }
+
+    public DatafeedTimingStats getCurrentTimingStats() {
+        return new DatafeedTimingStats(currentTimingStats);
+    }
+
+    /**
+     * Executes the given function and reports how much time did the execution take.
+     */
+    public <T, R> R executeWithReporting(Function<T, R> function, T argument) {
+        Instant before = clock.instant();
+        R result = function.apply(argument);
+        Instant after = clock.instant();
+        Duration duration = Duration.between(before, after);
+        reportSearchDuration(duration);
+        return result;
+    }
+
+    private void reportSearchDuration(Duration searchDuration) {
+        double searchDurationMs = searchDuration.toMillis();
+        currentTimingStats.incrementTotalSearchTimeMs(searchDurationMs);
+        if (DatafeedTimingStats.differSignificantly(currentTimingStats, persistedTimingStats)) {
+            jobResultsPersister.persistDatafeedTimingStats(currentTimingStats);
+            persistedTimingStats = currentTimingStats;
+            currentTimingStats = new DatafeedTimingStats(persistedTimingStats);
+        }
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporter.java
@@ -67,7 +67,9 @@ public class DatafeedTimingStatsReporter {
      * This can be interpreted as values { value1, value2 } differing significantly from each other.
      */
     private static boolean differSignificantly(double value1, double value2) {
-        return (value2 / value1 < MIN_VALID_RATIO) || (value1 / value2 < MIN_VALID_RATIO);
+        return (value2 / value1 < MIN_VALID_RATIO)
+            || (value1 / value2 < MIN_VALID_RATIO)
+            || Math.abs(value1 - value2) > MAX_VALID_ABS_DIFFERENCE_MS;
     }
 
     /**
@@ -75,4 +77,10 @@ public class DatafeedTimingStatsReporter {
      * If the values ratio is less than MIN_VALID_RATIO, the values are interpreted as significantly different.
      */
     private static final double MIN_VALID_RATIO = 0.9;
+
+    /**
+     * Maximum absolute difference of values that is interpreted as values being similar.
+     * If the values absolute difference is greater than MAX_VALID_ABS_DIFFERENCE, the values are interpreted as significantly different.
+     */
+    private static final double MAX_VALID_ABS_DIFFERENCE_MS = 10000.0;
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporter.java
@@ -11,11 +11,20 @@ import org.elasticsearch.xpack.ml.job.persistence.JobResultsPersister;
 
 import java.util.Objects;
 
+/**
+ * {@link DatafeedTimingStatsReporter} class handles the logic of persisting {@link DatafeedTimingStats} if they changed significantly
+ * since the last time they were persisted.
+ *
+ * This class is not thread-safe.
+ */
 public class DatafeedTimingStatsReporter {
 
-    private final JobResultsPersister jobResultsPersister;
+    /** Persisted timing stats. May be stale. */
     private DatafeedTimingStats persistedTimingStats;
+    /** Current timing stats. */
     private volatile DatafeedTimingStats currentTimingStats;
+    /** Object used to persist current timing stats. */
+    private final JobResultsPersister jobResultsPersister;
 
     public DatafeedTimingStatsReporter(DatafeedTimingStats timingStats, JobResultsPersister jobResultsPersister) {
         Objects.requireNonNull(timingStats);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporter.java
@@ -48,10 +48,31 @@ public class DatafeedTimingStatsReporter {
     private void reportSearchDuration(Duration searchDuration) {
         double searchDurationMs = searchDuration.toMillis();
         currentTimingStats.incrementTotalSearchTimeMs(searchDurationMs);
-        if (DatafeedTimingStats.differSignificantly(currentTimingStats, persistedTimingStats)) {
+        if (differSignificantly(currentTimingStats, persistedTimingStats)) {
             jobResultsPersister.persistDatafeedTimingStats(currentTimingStats);
             persistedTimingStats = currentTimingStats;
             currentTimingStats = new DatafeedTimingStats(persistedTimingStats);
         }
     }
+
+    /**
+     * Returns true if given stats objects differ from each other by more than 10% for at least one of the statistics.
+     */
+    public static boolean differSignificantly(DatafeedTimingStats stats1, DatafeedTimingStats stats2) {
+        return differSignificantly(stats1.getTotalSearchTimeMs(), stats2.getTotalSearchTimeMs());
+    }
+
+    /**
+     * Returns {@code true} if one of the ratios { value1 / value2, value2 / value1 } is smaller than MIN_VALID_RATIO.
+     * This can be interpreted as values { value1, value2 } differing significantly from each other.
+     */
+    private static boolean differSignificantly(double value1, double value2) {
+        return (value2 / value1 < MIN_VALID_RATIO) || (value1 / value2 < MIN_VALID_RATIO);
+    }
+
+    /**
+     * Minimum ratio of values that is interpreted as values being similar.
+     * If the values ratio is less than MIN_VALID_RATIO, the values are interpreted as significantly different.
+     */
+    private static final double MIN_VALID_RATIO = 0.9;
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporter.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.ml.datafeed;
 
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsPersister;
@@ -46,13 +47,14 @@ public class DatafeedTimingStatsReporter {
         }
         currentTimingStats.incrementTotalSearchTimeMs(searchDuration.millis());
         if (differSignificantly(currentTimingStats, persistedTimingStats)) {
-            flush();
+            // TODO: Consider changing refresh policy to NONE here and only do IMMEDIATE on datafeed _stop action
+            flush(WriteRequest.RefreshPolicy.IMMEDIATE);
         }
     }
 
-    private void flush() {
+    private void flush(WriteRequest.RefreshPolicy refreshPolicy) {
         persistedTimingStats = new DatafeedTimingStats(currentTimingStats);
-        jobResultsPersister.persistDatafeedTimingStats(persistedTimingStats);
+        jobResultsPersister.persistDatafeedTimingStats(persistedTimingStats, refreshPolicy);
     }
 
     /**

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AbstractAggregationDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AbstractAggregationDataExtractor.java
@@ -109,8 +109,9 @@ abstract class AbstractAggregationDataExtractor<T extends ActionRequestBuilder<S
 
     private Aggregations search() throws IOException {
         LOGGER.debug("[{}] Executing aggregated search", context.jobId);
-        SearchResponse searchResponse = executeSearchRequestWithReporting(buildSearchRequest(buildBaseSearchSource()));
+        SearchResponse searchResponse = executeSearchRequest(buildSearchRequest(buildBaseSearchSource()));
         LOGGER.debug("[{}] Search response was obtained", context.jobId);
+        timingStatsReporter.reportSearchDuration(searchResponse.getTook());
         ExtractorUtils.checkSearchWasSuccessful(context.jobId, searchResponse);
         return validateAggs(searchResponse.getAggregations());
     }
@@ -119,10 +120,6 @@ abstract class AbstractAggregationDataExtractor<T extends ActionRequestBuilder<S
         aggregationToJsonProcessor = new AggregationToJsonProcessor(context.timeField, context.fields, context.includeDocCount,
             context.start);
         aggregationToJsonProcessor.process(aggs);
-    }
-
-    private SearchResponse executeSearchRequestWithReporting(T searchRequestBuilder) {
-        return timingStatsReporter.executeWithReporting(this::executeSearchRequest, searchRequestBuilder);
     }
 
     protected SearchResponse executeSearchRequest(T searchRequestBuilder) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AbstractAggregationDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AbstractAggregationDataExtractor.java
@@ -18,6 +18,7 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ml.datafeed.extractor.DataExtractor;
 import org.elasticsearch.xpack.core.ml.datafeed.extractor.ExtractorUtils;
+import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -50,17 +51,20 @@ abstract class AbstractAggregationDataExtractor<T extends ActionRequestBuilder<S
 
     protected final Client client;
     protected final AggregationDataExtractorContext context;
+    private final DatafeedTimingStatsReporter timingStatsReporter;
     private boolean hasNext;
     private boolean isCancelled;
     private AggregationToJsonProcessor aggregationToJsonProcessor;
     private ByteArrayOutputStream outputStream;
 
-    AbstractAggregationDataExtractor(Client client, AggregationDataExtractorContext dataExtractorContext) {
+    AbstractAggregationDataExtractor(
+            Client client, AggregationDataExtractorContext dataExtractorContext, DatafeedTimingStatsReporter timingStatsReporter) {
         this.client = Objects.requireNonNull(client);
-        context = Objects.requireNonNull(dataExtractorContext);
-        hasNext = true;
-        isCancelled = false;
-        outputStream = new ByteArrayOutputStream();
+        this.context = Objects.requireNonNull(dataExtractorContext);
+        this.timingStatsReporter = Objects.requireNonNull(timingStatsReporter);
+        this.hasNext = true;
+        this.isCancelled = false;
+        this.outputStream = new ByteArrayOutputStream();
     }
 
     @Override
@@ -105,7 +109,7 @@ abstract class AbstractAggregationDataExtractor<T extends ActionRequestBuilder<S
 
     private Aggregations search() throws IOException {
         LOGGER.debug("[{}] Executing aggregated search", context.jobId);
-        SearchResponse searchResponse = executeSearchRequest(buildSearchRequest(buildBaseSearchSource()));
+        SearchResponse searchResponse = executeSearchRequestWithReporting(buildSearchRequest(buildBaseSearchSource()));
         LOGGER.debug("[{}] Search response was obtained", context.jobId);
         ExtractorUtils.checkSearchWasSuccessful(context.jobId, searchResponse);
         return validateAggs(searchResponse.getAggregations());
@@ -115,6 +119,10 @@ abstract class AbstractAggregationDataExtractor<T extends ActionRequestBuilder<S
         aggregationToJsonProcessor = new AggregationToJsonProcessor(context.timeField, context.fields, context.includeDocCount,
             context.start);
         aggregationToJsonProcessor.process(aggs);
+    }
+
+    private SearchResponse executeSearchRequestWithReporting(T searchRequestBuilder) {
+        return timingStatsReporter.executeWithReporting(this::executeSearchRequest, searchRequestBuilder);
     }
 
     protected SearchResponse executeSearchRequest(T searchRequestBuilder) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractor.java
@@ -9,6 +9,7 @@ import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter;
 
 /**
  * An implementation that extracts data from elasticsearch using search with aggregations on a client.
@@ -18,8 +19,9 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
  */
 class AggregationDataExtractor extends AbstractAggregationDataExtractor<SearchRequestBuilder> {
 
-    AggregationDataExtractor(Client client, AggregationDataExtractorContext dataExtractorContext) {
-        super(client, dataExtractorContext);
+    AggregationDataExtractor(
+            Client client, AggregationDataExtractorContext dataExtractorContext, DatafeedTimingStatsReporter timingStatsReporter) {
+        super(client, dataExtractorContext, timingStatsReporter);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorFactory.java
@@ -9,9 +9,10 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.extractor.DataExtractor;
-import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractorFactory;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.utils.Intervals;
+import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter;
+import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractorFactory;
 
 import java.util.Objects;
 
@@ -21,12 +22,19 @@ public class AggregationDataExtractorFactory implements DataExtractorFactory {
     private final DatafeedConfig datafeedConfig;
     private final Job job;
     private final NamedXContentRegistry xContentRegistry;
+    private final DatafeedTimingStatsReporter timingStatsReporter;
 
-    public AggregationDataExtractorFactory(Client client, DatafeedConfig datafeedConfig, Job job, NamedXContentRegistry xContentRegistry) {
+    public AggregationDataExtractorFactory(
+            Client client,
+            DatafeedConfig datafeedConfig,
+            Job job,
+            NamedXContentRegistry xContentRegistry,
+            DatafeedTimingStatsReporter timingStatsReporter) {
         this.client = Objects.requireNonNull(client);
         this.datafeedConfig = Objects.requireNonNull(datafeedConfig);
         this.job = Objects.requireNonNull(job);
         this.xContentRegistry = xContentRegistry;
+        this.timingStatsReporter = Objects.requireNonNull(timingStatsReporter);
     }
 
     @Override
@@ -43,6 +51,6 @@ public class AggregationDataExtractorFactory implements DataExtractorFactory {
                 Intervals.alignToFloor(end, histogramInterval),
                 job.getAnalysisConfig().getSummaryCountFieldName().equals(DatafeedConfig.DOC_COUNT),
                 datafeedConfig.getHeaders());
-        return new AggregationDataExtractor(client, dataExtractorContext);
+        return new AggregationDataExtractor(client, dataExtractorContext, timingStatsReporter);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/RollupDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/RollupDataExtractor.java
@@ -9,6 +9,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.xpack.core.rollup.action.RollupSearchAction;
+import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter;
 
 /**
  * An implementation that extracts data from elasticsearch using search with aggregations against rollup indexes on a client.
@@ -18,8 +19,9 @@ import org.elasticsearch.xpack.core.rollup.action.RollupSearchAction;
  */
 class RollupDataExtractor extends AbstractAggregationDataExtractor<RollupSearchAction.RequestBuilder> {
 
-    RollupDataExtractor(Client client, AggregationDataExtractorContext dataExtractorContext) {
-        super(client, dataExtractorContext);
+    RollupDataExtractor(
+            Client client, AggregationDataExtractorContext dataExtractorContext, DatafeedTimingStatsReporter timingStatsReporter) {
+        super(client, dataExtractorContext, timingStatsReporter);
     }
 
     @Override
@@ -28,5 +30,4 @@ class RollupDataExtractor extends AbstractAggregationDataExtractor<RollupSearchA
 
         return new RollupSearchAction.RequestBuilder(client, searchRequest);
     }
-
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorFactory.java
@@ -9,6 +9,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.extractor.DataExtractor;
+import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter;
 import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractorFactory;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.utils.Intervals;
@@ -22,17 +23,20 @@ public class ChunkedDataExtractorFactory implements DataExtractorFactory {
     private final Job job;
     private final DataExtractorFactory dataExtractorFactory;
     private final NamedXContentRegistry xContentRegistry;
+    private final DatafeedTimingStatsReporter timingStatsReporter;
 
     public ChunkedDataExtractorFactory(Client client,
                                        DatafeedConfig datafeedConfig,
                                        Job job,
                                        NamedXContentRegistry xContentRegistry,
-                                       DataExtractorFactory dataExtractorFactory) {
+                                       DataExtractorFactory dataExtractorFactory,
+                                       DatafeedTimingStatsReporter timingStatsReporter) {
         this.client = Objects.requireNonNull(client);
         this.datafeedConfig = Objects.requireNonNull(datafeedConfig);
         this.job = Objects.requireNonNull(job);
         this.dataExtractorFactory = Objects.requireNonNull(dataExtractorFactory);
         this.xContentRegistry = xContentRegistry;
+        this.timingStatsReporter = Objects.requireNonNull(timingStatsReporter);
     }
 
     @Override
@@ -52,7 +56,7 @@ public class ChunkedDataExtractorFactory implements DataExtractorFactory {
                 datafeedConfig.hasAggregations(),
                 datafeedConfig.hasAggregations() ? datafeedConfig.getHistogramIntervalMillis(xContentRegistry) : null
             );
-        return new ChunkedDataExtractor(client, dataExtractorFactory, dataExtractorContext);
+        return new ChunkedDataExtractor(client, dataExtractorFactory, dataExtractorContext, timingStatsReporter);
     }
 
     private ChunkedDataExtractorContext.TimeAligner newTimeAligner() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorFactory.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.core.ml.datafeed.extractor.DataExtractor;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.ml.utils.MlStrings;
+import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter;
 import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractorFactory;
 import org.elasticsearch.xpack.ml.datafeed.extractor.fields.TimeBasedExtractedFields;
 
@@ -31,14 +32,16 @@ public class ScrollDataExtractorFactory implements DataExtractorFactory {
     private final Job job;
     private final TimeBasedExtractedFields extractedFields;
     private final NamedXContentRegistry xContentRegistry;
+    private final DatafeedTimingStatsReporter timingStatsReporter;
 
     private ScrollDataExtractorFactory(Client client, DatafeedConfig datafeedConfig, Job job, TimeBasedExtractedFields extractedFields,
-                                       NamedXContentRegistry xContentRegistry) {
+                                       NamedXContentRegistry xContentRegistry, DatafeedTimingStatsReporter timingStatsReporter) {
         this.client = Objects.requireNonNull(client);
         this.datafeedConfig = Objects.requireNonNull(datafeedConfig);
         this.job = Objects.requireNonNull(job);
         this.extractedFields = Objects.requireNonNull(extractedFields);
         this.xContentRegistry = xContentRegistry;
+        this.timingStatsReporter = Objects.requireNonNull(timingStatsReporter);
     }
 
     @Override
@@ -53,30 +56,33 @@ public class ScrollDataExtractorFactory implements DataExtractorFactory {
                 start,
                 end,
                 datafeedConfig.getHeaders());
-        return new ScrollDataExtractor(client, dataExtractorContext);
+        return new ScrollDataExtractor(client, dataExtractorContext, timingStatsReporter);
     }
 
     public static void create(Client client,
                               DatafeedConfig datafeed,
                               Job job,
                               NamedXContentRegistry xContentRegistry,
-                              ActionListener<DataExtractorFactory> listener ) {
+                              DatafeedTimingStatsReporter timingStatsReporter,
+                              ActionListener<DataExtractorFactory> listener) {
 
         // Step 2. Contruct the factory and notify listener
         ActionListener<FieldCapabilitiesResponse> fieldCapabilitiesHandler = ActionListener.wrap(
-                fieldCapabilitiesResponse -> {
-                    TimeBasedExtractedFields extractedFields = TimeBasedExtractedFields.build(job, datafeed, fieldCapabilitiesResponse);
-                    listener.onResponse(new ScrollDataExtractorFactory(client, datafeed, job, extractedFields, xContentRegistry));
-                }, e -> {
-                    if (e instanceof IndexNotFoundException) {
-                        listener.onFailure(new ResourceNotFoundException("datafeed [" + datafeed.getId()
-                                + "] cannot retrieve data because index " + ((IndexNotFoundException) e).getIndex() + " does not exist"));
-                    } else if (e instanceof IllegalArgumentException) {
-                        listener.onFailure(ExceptionsHelper.badRequestException("[" + datafeed.getId() + "] " + e.getMessage()));
-                    } else {
-                        listener.onFailure(e);
-                    }
+            fieldCapabilitiesResponse -> {
+                TimeBasedExtractedFields extractedFields = TimeBasedExtractedFields.build(job, datafeed, fieldCapabilitiesResponse);
+                listener.onResponse(
+                    new ScrollDataExtractorFactory(client, datafeed, job, extractedFields, xContentRegistry, timingStatsReporter));
+            },
+            e -> {
+                if (e instanceof IndexNotFoundException) {
+                    listener.onFailure(new ResourceNotFoundException("datafeed [" + datafeed.getId()
+                            + "] cannot retrieve data because index " + ((IndexNotFoundException) e).getIndex() + " does not exist"));
+                } else if (e instanceof IllegalArgumentException) {
+                    listener.onFailure(ExceptionsHelper.badRequestException("[" + datafeed.getId() + "] " + e.getMessage()));
+                } else {
+                    listener.onFailure(e);
                 }
+            }
         );
 
         // Step 1. Get field capabilities necessary to build the information of how to extract fields

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleter.java
@@ -122,8 +122,7 @@ public class JobDataDeleter {
             LOGGER.error("[" + jobId + "] An error occurred while deleting interim results", e);
         }
     }
-
-
+    
     /**
      * Delete the datafeed timing stats document from all the job results indices
      *

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
@@ -23,6 +23,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSizeStats;
@@ -323,6 +324,18 @@ public class JobResultsPersister {
         try (ThreadContext.StoredContext ignore = client.threadPool().getThreadContext().stashWithOrigin(ML_ORIGIN)) {
             client.admin().indices().refresh(refreshRequest).actionGet();
         }
+    }
+
+    /**
+     * Persist datafeed timing stats
+     *
+     * @param timingStats datafeed timing stats to persist
+     */
+    public IndexResponse persistDatafeedTimingStats(DatafeedTimingStats timingStats) {
+        String jobId = timingStats.getJobId();
+        logger.trace("[{}] Persisting datafeed timing stats", jobId);
+        Persistable persistable = new Persistable(jobId, timingStats, DatafeedTimingStats.documentId(timingStats.getJobId()));
+        return persistable.persist(AnomalyDetectorsIndex.resultsWriteAlias(jobId)).actionGet();
     }
 
     private XContentBuilder toXContentBuilder(ToXContent obj) throws IOException {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
@@ -330,11 +330,13 @@ public class JobResultsPersister {
      * Persist datafeed timing stats
      *
      * @param timingStats datafeed timing stats to persist
+     * @param refreshPolicy refresh policy to apply
      */
-    public IndexResponse persistDatafeedTimingStats(DatafeedTimingStats timingStats) {
+    public IndexResponse persistDatafeedTimingStats(DatafeedTimingStats timingStats, WriteRequest.RefreshPolicy refreshPolicy) {
         String jobId = timingStats.getJobId();
         logger.trace("[{}] Persisting datafeed timing stats", jobId);
         Persistable persistable = new Persistable(jobId, timingStats, DatafeedTimingStats.documentId(timingStats.getJobId()));
+        persistable.setRefreshPolicy(refreshPolicy);
         return persistable.persist(AnomalyDetectorsIndex.resultsWriteAlias(jobId)).actionGet();
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
@@ -448,6 +448,10 @@ public class JobResultsProvider {
 
     public void datafeedTimingStats(List<String> jobIds, Consumer<Map<String, DatafeedTimingStats>> handler,
                                     Consumer<Exception> errorHandler) {
+        if (jobIds.isEmpty()) {
+            handler.accept(Map.of());
+            return;
+        }
         MultiSearchRequestBuilder msearchRequestBuilder = client.prepareMultiSearch();
         for (String jobId : jobIds) {
             String indexName = AnomalyDetectorsIndex.jobResultsAliasedName(jobId);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/TimingStatsReporter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/TimingStatsReporter.java
@@ -20,9 +20,9 @@ public class TimingStatsReporter {
     /** Persisted timing stats. May be stale. */
     private TimingStats persistedTimingStats;
     /** Current timing stats. */
-    private TimingStats currentTimingStats;
+    private volatile TimingStats currentTimingStats;
     /** Object used to persist current timing stats. */
-    private JobResultsPersister.Builder bulkResultsPersister;
+    private final JobResultsPersister.Builder bulkResultsPersister;
 
     public TimingStatsReporter(TimingStats timingStats, JobResultsPersister.Builder jobResultsPersister) {
         Objects.requireNonNull(timingStats);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/TimingStatsReporter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/TimingStatsReporter.java
@@ -50,7 +50,7 @@ public class TimingStatsReporter {
         flush();
     }
 
-    public void flush() {
+    private void flush() {
         persistedTimingStats = new TimingStats(currentTimingStats);
         bulkResultsPersister.persistTimingStats(persistedTimingStats);
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporterTests.java
@@ -30,56 +30,56 @@ public class DatafeedTimingStatsReporterTests extends ESTestCase {
     }
 
     public void testReportSearchDuration() {
-        DatafeedTimingStats timingStats = new DatafeedTimingStats(JOB_ID, 10000.0);
+        DatafeedTimingStats timingStats = new DatafeedTimingStats(JOB_ID, 3, 10000.0);
         DatafeedTimingStatsReporter timingStatsReporter = new DatafeedTimingStatsReporter(timingStats, jobResultsPersister);
-        assertThat(timingStatsReporter.getCurrentTimingStats(), equalTo(new DatafeedTimingStats(JOB_ID, 10000.0)));
+        assertThat(timingStatsReporter.getCurrentTimingStats(), equalTo(new DatafeedTimingStats(JOB_ID, 3, 10000.0)));
 
         timingStatsReporter.reportSearchDuration(ONE_SECOND);
-        assertThat(timingStatsReporter.getCurrentTimingStats(), equalTo(new DatafeedTimingStats(JOB_ID, 11000.0)));
+        assertThat(timingStatsReporter.getCurrentTimingStats(), equalTo(new DatafeedTimingStats(JOB_ID, 4, 11000.0)));
 
         timingStatsReporter.reportSearchDuration(ONE_SECOND);
-        assertThat(timingStatsReporter.getCurrentTimingStats(), equalTo(new DatafeedTimingStats(JOB_ID, 12000.0)));
+        assertThat(timingStatsReporter.getCurrentTimingStats(), equalTo(new DatafeedTimingStats(JOB_ID, 5, 12000.0)));
 
         timingStatsReporter.reportSearchDuration(ONE_SECOND);
-        assertThat(timingStatsReporter.getCurrentTimingStats(), equalTo(new DatafeedTimingStats(JOB_ID, 13000.0)));
+        assertThat(timingStatsReporter.getCurrentTimingStats(), equalTo(new DatafeedTimingStats(JOB_ID, 6, 13000.0)));
 
         timingStatsReporter.reportSearchDuration(ONE_SECOND);
-        assertThat(timingStatsReporter.getCurrentTimingStats(), equalTo(new DatafeedTimingStats(JOB_ID, 14000.0)));
+        assertThat(timingStatsReporter.getCurrentTimingStats(), equalTo(new DatafeedTimingStats(JOB_ID, 7, 14000.0)));
 
         InOrder inOrder = inOrder(jobResultsPersister);
-        inOrder.verify(jobResultsPersister).persistDatafeedTimingStats(new DatafeedTimingStats(JOB_ID, 12000.0));
-        inOrder.verify(jobResultsPersister).persistDatafeedTimingStats(new DatafeedTimingStats(JOB_ID, 14000.0));
+        inOrder.verify(jobResultsPersister).persistDatafeedTimingStats(new DatafeedTimingStats(JOB_ID, 5, 12000.0));
+        inOrder.verify(jobResultsPersister).persistDatafeedTimingStats(new DatafeedTimingStats(JOB_ID, 7, 14000.0));
         inOrder.verifyNoMoreInteractions();
     }
 
     public void testTimingStatsDifferSignificantly() {
         assertThat(
             DatafeedTimingStatsReporter.differSignificantly(
-                new DatafeedTimingStats(JOB_ID, 1000.0), new DatafeedTimingStats(JOB_ID, 1000.0)),
+                new DatafeedTimingStats(JOB_ID, 5, 1000.0), new DatafeedTimingStats(JOB_ID, 5, 1000.0)),
             is(false));
         assertThat(
             DatafeedTimingStatsReporter.differSignificantly(
-                new DatafeedTimingStats(JOB_ID, 1000.0), new DatafeedTimingStats(JOB_ID, 1100.0)),
+                new DatafeedTimingStats(JOB_ID, 5, 1000.0), new DatafeedTimingStats(JOB_ID, 5, 1100.0)),
             is(false));
         assertThat(
             DatafeedTimingStatsReporter.differSignificantly(
-                new DatafeedTimingStats(JOB_ID, 1000.0), new DatafeedTimingStats(JOB_ID, 1120.0)),
+                new DatafeedTimingStats(JOB_ID, 5, 1000.0), new DatafeedTimingStats(JOB_ID, 5, 1120.0)),
             is(true));
         assertThat(
             DatafeedTimingStatsReporter.differSignificantly(
-                new DatafeedTimingStats(JOB_ID, 10000.0), new DatafeedTimingStats(JOB_ID, 11000.0)),
+                new DatafeedTimingStats(JOB_ID, 5, 10000.0), new DatafeedTimingStats(JOB_ID, 5, 11000.0)),
             is(false));
         assertThat(
             DatafeedTimingStatsReporter.differSignificantly(
-                new DatafeedTimingStats(JOB_ID, 10000.0), new DatafeedTimingStats(JOB_ID, 11200.0)),
+                new DatafeedTimingStats(JOB_ID, 5, 10000.0), new DatafeedTimingStats(JOB_ID, 5, 11200.0)),
             is(true));
         assertThat(
             DatafeedTimingStatsReporter.differSignificantly(
-                new DatafeedTimingStats(JOB_ID, 100000.0), new DatafeedTimingStats(JOB_ID, 110000.0)),
+                new DatafeedTimingStats(JOB_ID, 5, 100000.0), new DatafeedTimingStats(JOB_ID, 5, 110000.0)),
             is(false));
         assertThat(
             DatafeedTimingStatsReporter.differSignificantly(
-                new DatafeedTimingStats(JOB_ID, 100000.0), new DatafeedTimingStats(JOB_ID, 110001.0)),
+                new DatafeedTimingStats(JOB_ID, 5, 100000.0), new DatafeedTimingStats(JOB_ID, 5, 110001.0)),
             is(true));
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporterTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.datafeed;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
+import org.elasticsearch.xpack.core.watcher.watch.ClockMock;
+import org.elasticsearch.xpack.ml.job.persistence.JobResultsPersister;
+import org.junit.Before;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+public class DatafeedTimingStatsReporterTests extends ESTestCase {
+
+    private static final String JOB_ID = "my-job-id";
+
+    private ClockMock clock;
+    private JobResultsPersister jobResultsPersister;
+
+    @Before
+    public void setUpTests() {
+        clock = new ClockMock();
+        jobResultsPersister = mock(JobResultsPersister.class);
+    }
+
+    public void testExecuteWithReporting() {
+        DatafeedTimingStats timingStats = new DatafeedTimingStats(JOB_ID, 10000.0);
+        DatafeedTimingStatsReporter timingStatsReporter = new DatafeedTimingStatsReporter(timingStats, clock, jobResultsPersister);
+        assertThat(timingStatsReporter.getCurrentTimingStats(), equalTo(new DatafeedTimingStats(JOB_ID, 10000.0)));
+
+        timingStatsReporter.executeWithReporting(this::advanceTime, 1);
+        assertThat(timingStatsReporter.getCurrentTimingStats(), equalTo(new DatafeedTimingStats(JOB_ID, 11000.0)));
+        verifyZeroInteractions(jobResultsPersister);
+
+        timingStatsReporter.executeWithReporting(this::advanceTime, 1);
+        assertThat(timingStatsReporter.getCurrentTimingStats(), equalTo(new DatafeedTimingStats(JOB_ID, 12000.0)));
+        verify(jobResultsPersister).persistDatafeedTimingStats(new DatafeedTimingStats(JOB_ID, 12000.0));
+        verifyNoMoreInteractions(jobResultsPersister);
+
+        timingStatsReporter.executeWithReporting(this::advanceTime, 1);
+        assertThat(timingStatsReporter.getCurrentTimingStats(), equalTo(new DatafeedTimingStats(JOB_ID, 13000.0)));
+        verifyZeroInteractions(jobResultsPersister);
+
+        timingStatsReporter.executeWithReporting(this::advanceTime, 1);
+        assertThat(timingStatsReporter.getCurrentTimingStats(), equalTo(new DatafeedTimingStats(JOB_ID, 14000.0)));
+        verify(jobResultsPersister).persistDatafeedTimingStats(new DatafeedTimingStats(JOB_ID, 14000.0));
+        verifyNoMoreInteractions(jobResultsPersister);
+    }
+
+    private Void advanceTime(int seconds) {
+        clock.fastForwardSeconds(seconds);
+        return null;
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporterTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.xpack.ml.job.persistence.JobResultsPersister;
 import org.junit.Before;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -57,5 +58,20 @@ public class DatafeedTimingStatsReporterTests extends ESTestCase {
     private Void advanceTime(int seconds) {
         clock.fastForwardSeconds(seconds);
         return null;
+    }
+
+    public void testTimingStatsDifferSignificantly() {
+        assertThat(
+            DatafeedTimingStatsReporter.differSignificantly(
+                new DatafeedTimingStats(JOB_ID, 1000.0), new DatafeedTimingStats(JOB_ID, 1000.0)),
+            is(false));
+        assertThat(
+            DatafeedTimingStatsReporter.differSignificantly(
+                new DatafeedTimingStats(JOB_ID, 1000.0), new DatafeedTimingStats(JOB_ID, 1100.0)),
+            is(false));
+        assertThat(
+            DatafeedTimingStatsReporter.differSignificantly(
+                new DatafeedTimingStats(JOB_ID, 1000.0), new DatafeedTimingStats(JOB_ID, 1120.0)),
+            is(true));
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporterTests.java
@@ -7,9 +7,13 @@ package org.elasticsearch.xpack.ml.datafeed;
 
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
-import org.elasticsearch.xpack.core.watcher.watch.ClockMock;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsPersister;
 import org.junit.Before;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -21,13 +25,14 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 public class DatafeedTimingStatsReporterTests extends ESTestCase {
 
     private static final String JOB_ID = "my-job-id";
+    private static final Duration ONE_SECOND = Duration.ofSeconds(1);
 
-    private ClockMock clock;
+    private FakeClock clock;
     private JobResultsPersister jobResultsPersister;
 
     @Before
     public void setUpTests() {
-        clock = new ClockMock();
+        clock = new FakeClock();
         jobResultsPersister = mock(JobResultsPersister.class);
     }
 
@@ -36,28 +41,49 @@ public class DatafeedTimingStatsReporterTests extends ESTestCase {
         DatafeedTimingStatsReporter timingStatsReporter = new DatafeedTimingStatsReporter(timingStats, clock, jobResultsPersister);
         assertThat(timingStatsReporter.getCurrentTimingStats(), equalTo(new DatafeedTimingStats(JOB_ID, 10000.0)));
 
-        timingStatsReporter.executeWithReporting(this::advanceTime, 1);
+        timingStatsReporter.executeWithReporting(clock::advanceTime, ONE_SECOND);
         assertThat(timingStatsReporter.getCurrentTimingStats(), equalTo(new DatafeedTimingStats(JOB_ID, 11000.0)));
         verifyZeroInteractions(jobResultsPersister);
 
-        timingStatsReporter.executeWithReporting(this::advanceTime, 1);
+        timingStatsReporter.executeWithReporting(clock::advanceTime, ONE_SECOND);
         assertThat(timingStatsReporter.getCurrentTimingStats(), equalTo(new DatafeedTimingStats(JOB_ID, 12000.0)));
         verify(jobResultsPersister).persistDatafeedTimingStats(new DatafeedTimingStats(JOB_ID, 12000.0));
         verifyNoMoreInteractions(jobResultsPersister);
 
-        timingStatsReporter.executeWithReporting(this::advanceTime, 1);
+        timingStatsReporter.executeWithReporting(clock::advanceTime, ONE_SECOND);
         assertThat(timingStatsReporter.getCurrentTimingStats(), equalTo(new DatafeedTimingStats(JOB_ID, 13000.0)));
         verifyZeroInteractions(jobResultsPersister);
 
-        timingStatsReporter.executeWithReporting(this::advanceTime, 1);
+        timingStatsReporter.executeWithReporting(clock::advanceTime, ONE_SECOND);
         assertThat(timingStatsReporter.getCurrentTimingStats(), equalTo(new DatafeedTimingStats(JOB_ID, 14000.0)));
         verify(jobResultsPersister).persistDatafeedTimingStats(new DatafeedTimingStats(JOB_ID, 14000.0));
         verifyNoMoreInteractions(jobResultsPersister);
     }
 
-    private Void advanceTime(int seconds) {
-        clock.fastForwardSeconds(seconds);
-        return null;
+    /** Mutable clock that allows advancing current time. */
+    private static final class FakeClock extends Clock {
+
+        private Instant instant = Instant.EPOCH;
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+
+        Void advanceTime(Duration duration) {
+            instant = instant.plus(duration);
+            return null;
+        }
+
+        @Override
+        public ZoneId getZone() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            throw new UnsupportedOperationException();
+        }
     }
 
     public void testTimingStatsDifferSignificantly() {
@@ -72,6 +98,22 @@ public class DatafeedTimingStatsReporterTests extends ESTestCase {
         assertThat(
             DatafeedTimingStatsReporter.differSignificantly(
                 new DatafeedTimingStats(JOB_ID, 1000.0), new DatafeedTimingStats(JOB_ID, 1120.0)),
+            is(true));
+        assertThat(
+            DatafeedTimingStatsReporter.differSignificantly(
+                new DatafeedTimingStats(JOB_ID, 10000.0), new DatafeedTimingStats(JOB_ID, 11000.0)),
+            is(false));
+        assertThat(
+            DatafeedTimingStatsReporter.differSignificantly(
+                new DatafeedTimingStats(JOB_ID, 10000.0), new DatafeedTimingStats(JOB_ID, 11200.0)),
+            is(true));
+        assertThat(
+            DatafeedTimingStatsReporter.differSignificantly(
+                new DatafeedTimingStats(JOB_ID, 100000.0), new DatafeedTimingStats(JOB_ID, 110000.0)),
+            is(false));
+        assertThat(
+            DatafeedTimingStatsReporter.differSignificantly(
+                new DatafeedTimingStats(JOB_ID, 100000.0), new DatafeedTimingStats(JOB_ID, 110001.0)),
             is(true));
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/DataExtractorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/DataExtractorFactoryTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.xpack.core.rollup.job.MetricConfig;
 import org.elasticsearch.xpack.core.rollup.job.RollupJobConfig;
 import org.elasticsearch.xpack.core.rollup.job.TermsGroupConfig;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedManagerTests;
+import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter;
 import org.elasticsearch.xpack.ml.datafeed.extractor.aggregation.AggregationDataExtractorFactory;
 import org.elasticsearch.xpack.ml.datafeed.extractor.chunked.ChunkedDataExtractorFactory;
 import org.elasticsearch.xpack.ml.datafeed.extractor.aggregation.RollupDataExtractorFactory;
@@ -62,6 +63,7 @@ public class DataExtractorFactoryTests extends ESTestCase {
     private GetRollupIndexCapsAction.Response getRollupIndexResponse;
 
     private Client client;
+    private DatafeedTimingStatsReporter timingStatsReporter;
 
     @Override
     protected NamedXContentRegistry xContentRegistry() {
@@ -72,6 +74,7 @@ public class DataExtractorFactoryTests extends ESTestCase {
     @Before
     public void setUpTests() {
         client = mock(Client.class);
+        timingStatsReporter = mock(DatafeedTimingStatsReporter.class);
         ThreadPool threadPool = mock(ThreadPool.class);
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
@@ -109,7 +112,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
                 e -> fail()
         );
 
-        DataExtractorFactory.create(client, datafeedConfig, jobBuilder.build(new Date()), xContentRegistry(), listener);
+        DataExtractorFactory.create(
+            client, datafeedConfig, jobBuilder.build(new Date()), xContentRegistry(), timingStatsReporter, listener);
     }
 
     public void testCreateDataExtractorFactoryGivenScrollWithAutoChunk() {
@@ -125,7 +129,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
                 e -> fail()
         );
 
-        DataExtractorFactory.create(client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), listener);
+        DataExtractorFactory.create(
+            client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), timingStatsReporter, listener);
     }
 
     public void testCreateDataExtractorFactoryGivenScrollWithOffChunk() {
@@ -141,7 +146,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
                 e -> fail()
         );
 
-        DataExtractorFactory.create(client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), listener);
+        DataExtractorFactory.create(
+            client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), timingStatsReporter, listener);
     }
 
     public void testCreateDataExtractorFactoryGivenDefaultAggregation() {
@@ -159,7 +165,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
                 e -> fail()
         );
 
-        DataExtractorFactory.create(client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), listener);
+        DataExtractorFactory.create(
+            client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), timingStatsReporter, listener);
     }
 
     public void testCreateDataExtractorFactoryGivenAggregationWithOffChunk() {
@@ -178,7 +185,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
                 e -> fail()
         );
 
-        DataExtractorFactory.create(client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), listener);
+        DataExtractorFactory.create(
+            client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), timingStatsReporter, listener);
     }
 
     public void testCreateDataExtractorFactoryGivenDefaultAggregationWithAutoChunk() {
@@ -197,7 +205,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
                 e -> fail()
         );
 
-        DataExtractorFactory.create(client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), listener);
+        DataExtractorFactory.create(
+            client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), timingStatsReporter, listener);
     }
 
     public void testCreateDataExtractorFactoryGivenRollupAndValidAggregation() {
@@ -220,7 +229,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
             },
             e -> fail()
         );
-        DataExtractorFactory.create(client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), listener);
+        DataExtractorFactory.create(
+            client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), timingStatsReporter, listener);
     }
 
     public void testCreateDataExtractorFactoryGivenRollupAndRemoteIndex() {
@@ -297,7 +307,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
             },
             e -> fail()
         );
-        DataExtractorFactory.create(client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), listener);
+        DataExtractorFactory.create(
+            client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), timingStatsReporter, listener);
     }
 
     public void testCreateDataExtractorFactoryGivenRollupButNoAggregations() {
@@ -317,7 +328,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
             }
         );
 
-        DataExtractorFactory.create(client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), listener);
+        DataExtractorFactory.create(
+            client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), timingStatsReporter, listener);
     }
 
     public void testCreateDataExtractorFactoryGivenRollupWithBadInterval() {
@@ -343,7 +355,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
                 assertWarnings("[interval] on [date_histogram] is deprecated, use [fixed_interval] or [calendar_interval] in the future.");
             }
         );
-        DataExtractorFactory.create(client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), listener);
+        DataExtractorFactory.create(
+            client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), timingStatsReporter, listener);
     }
 
     public void testCreateDataExtractorFactoryGivenRollupMissingTerms() {
@@ -368,7 +381,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
                 assertWarnings("[interval] on [date_histogram] is deprecated, use [fixed_interval] or [calendar_interval] in the future.");
             }
         );
-        DataExtractorFactory.create(client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), listener);
+        DataExtractorFactory.create(
+            client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), timingStatsReporter, listener);
     }
 
     public void testCreateDataExtractorFactoryGivenRollupMissingMetric() {
@@ -393,7 +407,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
                 assertWarnings("[interval] on [date_histogram] is deprecated, use [fixed_interval] or [calendar_interval] in the future.");
             }
         );
-        DataExtractorFactory.create(client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), listener);
+        DataExtractorFactory.create(
+            client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), timingStatsReporter, listener);
     }
 
     private void givenAggregatableRollup(String field, String type, int minuteInterval, String... groupByTerms) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/DataExtractorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/DataExtractorFactoryTests.java
@@ -256,7 +256,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
             },
             e -> fail()
         );
-        DataExtractorFactory.create(client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), listener);
+        DataExtractorFactory.create(
+            client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), timingStatsReporter, listener);
 
         // Test with remote index, aggregation, and chunking
         datafeedConfig.setChunkingConfig(ChunkingConfig.newAuto());
@@ -264,7 +265,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
             dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(ChunkedDataExtractorFactory.class)),
             e -> fail()
         );
-        DataExtractorFactory.create(client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), listener);
+        DataExtractorFactory.create(
+            client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), timingStatsReporter, listener);
 
         // Test with remote index, no aggregation, and no chunking
         datafeedConfig = DatafeedManagerTests.createDatafeedConfig("datafeed1", "foo");
@@ -276,7 +278,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
             e -> fail()
         );
 
-        DataExtractorFactory.create(client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), listener);
+        DataExtractorFactory.create(
+            client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), timingStatsReporter, listener);
 
         // Test with remote index, no aggregation, and chunking
         datafeedConfig.setChunkingConfig(ChunkingConfig.newAuto());
@@ -284,7 +287,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
             dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(ChunkedDataExtractorFactory.class)),
             e -> fail()
         );
-        DataExtractorFactory.create(client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), listener);
+        DataExtractorFactory.create(
+            client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), timingStatsReporter, listener);
     }
 
     public void testCreateDataExtractorFactoryGivenRollupAndValidAggregationAndAutoChunk() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorFactoryTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
 import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
 import org.elasticsearch.xpack.core.ml.job.config.Detector;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter;
 import org.junit.Before;
 
 import java.util.Arrays;
@@ -29,10 +30,12 @@ import static org.mockito.Mockito.mock;
 public class AggregationDataExtractorFactoryTests extends ESTestCase {
 
     private Client client;
+    private DatafeedTimingStatsReporter timingStatsReporter;
 
     @Before
     public void setUpMocks() {
         client = mock(Client.class);
+        timingStatsReporter = mock(DatafeedTimingStatsReporter.class);
     }
 
     @Override
@@ -76,6 +79,7 @@ public class AggregationDataExtractorFactoryTests extends ESTestCase {
         DatafeedConfig.Builder datafeedConfigBuilder = new DatafeedConfig.Builder("foo-feed", jobBuilder.getId());
         datafeedConfigBuilder.setParsedAggregations(aggs);
         datafeedConfigBuilder.setIndices(Arrays.asList("my_index"));
-        return new AggregationDataExtractorFactory(client, datafeedConfigBuilder.build(), jobBuilder.build(new Date()), xContentRegistry());
+        return new AggregationDataExtractorFactory(
+            client, datafeedConfigBuilder.build(), jobBuilder.build(new Date()), xContentRegistry(), timingStatsReporter);
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorTests.java
@@ -9,6 +9,7 @@ import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.rest.RestStatus;
@@ -28,7 +29,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -93,8 +93,7 @@ public class AggregationDataExtractorTests extends ESTestCase {
                 .addAggregator(AggregationBuilders.histogram("time").field("time").interval(1000).subAggregation(
                         AggregationBuilders.terms("airline").field("airline").subAggregation(
                                 AggregationBuilders.avg("responsetime").field("responsetime"))));
-        timingStatsReporter =
-            new DatafeedTimingStatsReporter(new DatafeedTimingStats(jobId), Clock.systemUTC(), mock(JobResultsPersister.class));
+        timingStatsReporter = new DatafeedTimingStatsReporter(new DatafeedTimingStats(jobId), mock(JobResultsPersister.class));
     }
 
     public void testExtraction() throws IOException {
@@ -291,6 +290,7 @@ public class AggregationDataExtractorTests extends ESTestCase {
         when(searchResponse.status()).thenReturn(RestStatus.OK);
         when(searchResponse.getScrollId()).thenReturn(randomAlphaOfLength(1000));
         when(searchResponse.getAggregations()).thenReturn(aggregations);
+        when(searchResponse.getTook()).thenReturn(TimeValue.timeValueMillis(randomNonNegativeLong()));
         return searchResponse;
     }
 
@@ -313,6 +313,7 @@ public class AggregationDataExtractorTests extends ESTestCase {
         when(searchResponse.status()).thenReturn(RestStatus.OK);
         when(searchResponse.getSuccessfulShards()).thenReturn(3);
         when(searchResponse.getTotalShards()).thenReturn(3 + unavailableShards);
+        when(searchResponse.getTook()).thenReturn(TimeValue.timeValueMillis(randomNonNegativeLong()));
         return searchResponse;
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorFactoryTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter;
 import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractorFactory;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
 import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
@@ -31,6 +32,7 @@ public class ChunkedDataExtractorFactoryTests extends ESTestCase {
 
     private Client client;
     private DataExtractorFactory dataExtractorFactory;
+    private DatafeedTimingStatsReporter timingStatsReporter;
 
     @Override
     protected NamedXContentRegistry xContentRegistry() {
@@ -42,6 +44,7 @@ public class ChunkedDataExtractorFactoryTests extends ESTestCase {
     public void setUpMocks() {
         client = mock(Client.class);
         dataExtractorFactory = mock(DataExtractorFactory.class);
+        timingStatsReporter = mock(DatafeedTimingStatsReporter.class);
     }
 
     public void testNewExtractor_GivenAlignedTimes() {
@@ -103,7 +106,12 @@ public class ChunkedDataExtractorFactoryTests extends ESTestCase {
         DatafeedConfig.Builder datafeedConfigBuilder = new DatafeedConfig.Builder("foo-feed", jobBuilder.getId());
         datafeedConfigBuilder.setParsedAggregations(aggs);
         datafeedConfigBuilder.setIndices(Arrays.asList("my_index"));
-        return new ChunkedDataExtractorFactory(client, datafeedConfigBuilder.build(), jobBuilder.build(new Date()),
-            xContentRegistry(), dataExtractorFactory);
+        return new ChunkedDataExtractorFactory(
+            client,
+            datafeedConfigBuilder.build(),
+            jobBuilder.build(new Date()),
+            xContentRegistry(),
+            dataExtractorFactory,
+            timingStatsReporter);
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorTests.java
@@ -32,7 +32,6 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -94,8 +93,7 @@ public class ChunkedDataExtractorTests extends ESTestCase {
         scrollSize = 1000;
         chunkSpan = null;
         dataExtractorFactory = mock(DataExtractorFactory.class);
-        timingStatsReporter =
-            new DatafeedTimingStatsReporter(new DatafeedTimingStats(jobId), Clock.systemUTC(), mock(JobResultsPersister.class));
+        timingStatsReporter = new DatafeedTimingStatsReporter(new DatafeedTimingStats(jobId), mock(JobResultsPersister.class));
     }
 
     public void testExtractionGivenNoData() throws IOException {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -41,7 +42,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -145,8 +145,7 @@ public class ScrollDataExtractorTests extends ESTestCase {
         clearScrollFuture = mock(ActionFuture.class);
         capturedClearScrollRequests = ArgumentCaptor.forClass(ClearScrollRequest.class);
         when(client.execute(same(ClearScrollAction.INSTANCE), capturedClearScrollRequests.capture())).thenReturn(clearScrollFuture);
-        timingStatsReporter =
-            new DatafeedTimingStatsReporter(new DatafeedTimingStats(jobId), Clock.systemUTC(), mock(JobResultsPersister.class));
+        timingStatsReporter = new DatafeedTimingStatsReporter(new DatafeedTimingStats(jobId), mock(JobResultsPersister.class));
     }
 
     public void testSinglePageExtraction() throws IOException {
@@ -513,6 +512,7 @@ public class ScrollDataExtractorTests extends ESTestCase {
         SearchHits searchHits = new SearchHits(hits.toArray(new SearchHit[0]),
             new TotalHits(hits.size(), TotalHits.Relation.EQUAL_TO), 1);
         when(searchResponse.getHits()).thenReturn(searchHits);
+        when(searchResponse.getTook()).thenReturn(TimeValue.timeValueMillis(randomNonNegativeLong()));
         return searchResponse;
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
@@ -58,6 +58,7 @@ import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.MlConfigMigrationEligibilityCheck;
 import org.elasticsearch.xpack.ml.job.categorization.CategorizationAnalyzerTests;
+import org.elasticsearch.xpack.ml.job.persistence.JobResultsPersister;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
 import org.elasticsearch.xpack.ml.job.persistence.MockClientBuilder;
 import org.elasticsearch.xpack.ml.job.process.autodetect.UpdateParams;
@@ -103,6 +104,7 @@ public class JobManagerTests extends ESTestCase {
     private ClusterService clusterService;
     private ThreadPool threadPool;
     private JobResultsProvider jobResultsProvider;
+    private JobResultsPersister jobResultsPersister;
     private Auditor auditor;
     private UpdateJobProcessNotifier updateJobProcessNotifier;
 
@@ -123,6 +125,7 @@ public class JobManagerTests extends ESTestCase {
         givenClusterSettings(settings);
 
         jobResultsProvider = mock(JobResultsProvider.class);
+        jobResultsPersister = mock(JobResultsPersister.class);
         auditor = mock(Auditor.class);
         updateJobProcessNotifier = mock(UpdateJobProcessNotifier.class);
 
@@ -593,8 +596,17 @@ public class JobManagerTests extends ESTestCase {
     }
 
     private JobManager createJobManager(Client client) {
-        return new JobManager(environment, environment.settings(), jobResultsProvider, clusterService,
-                auditor, threadPool, client, updateJobProcessNotifier, xContentRegistry());
+        return new JobManager(
+            environment,
+            environment.settings(),
+            jobResultsProvider,
+            jobResultsPersister,
+            clusterService,
+            auditor,
+            threadPool,
+            client,
+            updateJobProcessNotifier,
+            xContentRegistry());
     }
 
     private ClusterState createClusterState() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleterTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.job.persistence;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.index.reindex.DeleteByQueryAction;
+import org.elasticsearch.index.reindex.DeleteByQueryRequest;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class JobDataDeleterTests extends ESTestCase {
+
+    private static final String JOB_ID = "my-job-id";
+
+    private Client client;
+
+    @Before
+    public void setUpTests() {
+        client = mock(Client.class);
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+    }
+
+    public void testDeleteDatafeedTimingStats() {
+        JobDataDeleter jobDataDeleter = new JobDataDeleter(client, JOB_ID);
+        jobDataDeleter.deleteDatafeedTimingStats(ActionListener.wrap(
+            deleteResponse -> {},
+            e -> fail(e.toString())
+        ));
+
+        ArgumentCaptor<DeleteByQueryRequest> deleteRequestCaptor = ArgumentCaptor.forClass(DeleteByQueryRequest.class);
+        verify(client).threadPool();
+        verify(client).execute(eq(DeleteByQueryAction.INSTANCE), deleteRequestCaptor.capture(), any(ActionListener.class));
+        verifyNoMoreInteractions(client);
+
+        DeleteByQueryRequest deleteRequest = deleteRequestCaptor.getValue();
+        assertThat(deleteRequest.indices(), arrayContaining(AnomalyDetectorsIndex.jobResultsAliasedName(JOB_ID)));
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
@@ -244,7 +244,7 @@ public class JobResultsPersisterTests extends ESTestCase {
             .when(client).index(any(), any(ActionListener.class));
 
         JobResultsPersister persister = new JobResultsPersister(client);
-        DatafeedTimingStats timingStats = new DatafeedTimingStats("foo", 666.0);
+        DatafeedTimingStats timingStats = new DatafeedTimingStats("foo", 6, 666.0);
         persister.persistDatafeedTimingStats(timingStats);
 
         ArgumentCaptor<IndexRequest> indexRequestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
@@ -257,6 +257,7 @@ public class JobResultsPersisterTests extends ESTestCase {
             equalTo(
                 Map.of(
                     "job_id", "foo",
+                    "search_count", 6,
                     "total_search_time_ms", 666.0)));
 
         verify(client, times(1)).threadPool();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -245,13 +246,14 @@ public class JobResultsPersisterTests extends ESTestCase {
 
         JobResultsPersister persister = new JobResultsPersister(client);
         DatafeedTimingStats timingStats = new DatafeedTimingStats("foo", 6, 666.0);
-        persister.persistDatafeedTimingStats(timingStats);
+        persister.persistDatafeedTimingStats(timingStats, WriteRequest.RefreshPolicy.IMMEDIATE);
 
         ArgumentCaptor<IndexRequest> indexRequestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
         verify(client, times(1)).index(indexRequestCaptor.capture(), any(ActionListener.class));
         IndexRequest indexRequest = indexRequestCaptor.getValue();
         assertThat(indexRequest.index(), equalTo(".ml-anomalies-.write-foo"));
         assertThat(indexRequest.id(), equalTo("foo_datafeed_timing_stats"));
+        assertThat(indexRequest.getRefreshPolicy(), equalTo(WriteRequest.RefreshPolicy.IMMEDIATE));
         assertThat(
             indexRequest.sourceAsMap(),
             equalTo(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
@@ -6,15 +6,18 @@
 package org.elasticsearch.xpack.ml.job.persistence;
 
 import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.TimingStats;
 import org.elasticsearch.xpack.core.ml.job.results.AnomalyRecord;
 import org.elasticsearch.xpack.core.ml.job.results.Bucket;
@@ -32,6 +35,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -222,6 +226,38 @@ public class JobResultsPersisterTests extends ESTestCase {
                     "maximum_bucket_processing_time_ms", 2.0,
                     "average_bucket_processing_time_ms", 1.23,
                     "exponential_average_bucket_processing_time_ms", 7.89)));
+
+        verify(client, times(1)).threadPool();
+        verifyNoMoreInteractions(client);
+    }
+
+    public void testPersistDatafeedTimingStats() {
+        Client client = mockClient(ArgumentCaptor.forClass(BulkRequest.class));
+        doAnswer(
+            invocationOnMock -> {
+                // Take the listener passed to client::index as 2nd argument
+                ActionListener listener = (ActionListener) invocationOnMock.getArguments()[1];
+                // Handle the response on the listener
+                listener.onResponse(new IndexResponse());
+                return null;
+            })
+            .when(client).index(any(), any(ActionListener.class));
+
+        JobResultsPersister persister = new JobResultsPersister(client);
+        DatafeedTimingStats timingStats = new DatafeedTimingStats("foo", 666.0);
+        persister.persistDatafeedTimingStats(timingStats);
+
+        ArgumentCaptor<IndexRequest> indexRequestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
+        verify(client, times(1)).index(indexRequestCaptor.capture(), any(ActionListener.class));
+        IndexRequest indexRequest = indexRequestCaptor.getValue();
+        assertThat(indexRequest.index(), equalTo(".ml-anomalies-.write-foo"));
+        assertThat(indexRequest.id(), equalTo("foo_datafeed_timing_stats"));
+        assertThat(
+            indexRequest.sourceAsMap(),
+            equalTo(
+                Map.of(
+                    "job_id", "foo",
+                    "total_search_time_ms", 666.0)));
 
         verify(client, times(1)).threadPool();
         verifyNoMoreInteractions(client);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
@@ -79,6 +79,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class JobResultsProviderTests extends ESTestCase {
@@ -881,6 +882,18 @@ public class JobResultsProviderTests extends ESTestCase {
         verify(client).threadPool();
         verify(client).search(any(SearchRequest.class), any(ActionListener.class));
         verifyNoMoreInteractions(client);
+    }
+
+    public void testDatafeedTimingStats_EmptyJobList() throws IOException {
+        Client client = getBasicMockedClient();
+
+        JobResultsProvider provider = createProvider(client);
+        provider.datafeedTimingStats(
+            List.of(),
+            statsByJobId -> assertThat(statsByJobId, equalTo(Map.of())),
+            e -> { throw new AssertionError(); });
+
+        verifyZeroInteractions(client);
     }
 
     public void testDatafeedTimingStats_MultipleDocumentsAtOnce() throws IOException {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
@@ -902,11 +902,13 @@ public class JobResultsProviderTests extends ESTestCase {
             Arrays.asList(
                 Map.of(
                     Job.ID.getPreferredName(), "foo",
+                    DatafeedTimingStats.SEARCH_COUNT.getPreferredName(), 6,
                     DatafeedTimingStats.TOTAL_SEARCH_TIME_MS.getPreferredName(), 666.0));
         List<Map<String, Object>> sourceBar =
             Arrays.asList(
                 Map.of(
                     Job.ID.getPreferredName(), "bar",
+                    DatafeedTimingStats.SEARCH_COUNT.getPreferredName(), 7,
                     DatafeedTimingStats.TOTAL_SEARCH_TIME_MS.getPreferredName(), 777.0));
         SearchResponse responseFoo = createSearchResponse(sourceFoo);
         SearchResponse responseBar = createSearchResponse(sourceBar);
@@ -941,7 +943,7 @@ public class JobResultsProviderTests extends ESTestCase {
             statsByJobId ->
                 assertThat(
                     statsByJobId,
-                    equalTo(Map.of("foo", new DatafeedTimingStats("foo", 666.0), "bar", new DatafeedTimingStats("bar", 777.0)))),
+                    equalTo(Map.of("foo", new DatafeedTimingStats("foo", 6, 666.0), "bar", new DatafeedTimingStats("bar", 7, 777.0)))),
             e -> { throw new AssertionError(); });
 
         verify(client).threadPool();
@@ -958,6 +960,7 @@ public class JobResultsProviderTests extends ESTestCase {
             Arrays.asList(
                 Map.of(
                     Job.ID.getPreferredName(), "foo",
+                    DatafeedTimingStats.SEARCH_COUNT.getPreferredName(), 6,
                     DatafeedTimingStats.TOTAL_SEARCH_TIME_MS.getPreferredName(), 666.0));
         SearchResponse response = createSearchResponse(source);
         Client client = getMockedClient(
@@ -968,7 +971,7 @@ public class JobResultsProviderTests extends ESTestCase {
         JobResultsProvider provider = createProvider(client);
         provider.datafeedTimingStats(
             "foo",
-            stats -> assertThat(stats, equalTo(new DatafeedTimingStats("foo", 666.0))),
+            stats -> assertThat(stats, equalTo(new DatafeedTimingStats("foo", 6, 666.0))),
             e -> { throw new AssertionError(); });
 
         verify(client).prepareSearch(indexName);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
@@ -70,6 +70,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import static org.elasticsearch.xpack.core.ml.job.config.JobTests.buildJobBuilder;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Matchers.any;
@@ -884,13 +885,13 @@ public class JobResultsProviderTests extends ESTestCase {
         verifyNoMoreInteractions(client);
     }
 
-    public void testDatafeedTimingStats_EmptyJobList() throws IOException {
+    public void testDatafeedTimingStats_EmptyJobList() {
         Client client = getBasicMockedClient();
 
         JobResultsProvider provider = createProvider(client);
         provider.datafeedTimingStats(
             List.of(),
-            statsByJobId -> assertThat(statsByJobId, equalTo(Map.of())),
+            statsByJobId -> assertThat(statsByJobId, anEmptyMap()),
             e -> { throw new AssertionError(); });
 
         verifyZeroInteractions(client);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/TimingStatsReporterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/TimingStatsReporterTests.java
@@ -55,7 +55,7 @@ public class TimingStatsReporterTests extends ESTestCase {
         inOrder.verifyNoMoreInteractions();
     }
 
-    public void testFlush() {
+    public void testFinishReporting() {
         TimingStatsReporter reporter = new TimingStatsReporter(new TimingStats(JOB_ID), bulkResultsPersister);
         assertThat(reporter.getCurrentTimingStats(), equalTo(new TimingStats(JOB_ID)));
 
@@ -68,7 +68,7 @@ public class TimingStatsReporterTests extends ESTestCase {
         reporter.reportBucketProcessingTime(10);
         assertThat(reporter.getCurrentTimingStats(), equalTo(new TimingStats(JOB_ID, 3, 10.0, 10.0, 10.0, 10.0)));
 
-        reporter.flush();
+        reporter.finishReporting();
         assertThat(reporter.getCurrentTimingStats(), equalTo(new TimingStats(JOB_ID, 3, 10.0, 10.0, 10.0, 10.0)));
 
         InOrder inOrder = inOrder(bulkResultsPersister);

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_datafeed_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_datafeed_stats.yml
@@ -126,16 +126,18 @@ setup:
   - do:
       ml.get_datafeed_stats:
         datafeed_id: datafeed-1
-  - match: { datafeeds.0.datafeed_id: "datafeed-1"}
-  - match: { datafeeds.0.state: "stopped"}
+  - match:  { datafeeds.0.datafeed_id: "datafeed-1"}
+  - match:  { datafeeds.0.state: "stopped"}
   - is_false: datafeeds.0.node
+  - match:  { datafeeds.0.timing_stats.job_id: "get-datafeed-stats-1" }
 
   - do:
       ml.get_datafeed_stats:
         datafeed_id: datafeed-2
-  - match: { datafeeds.0.datafeed_id: "datafeed-2"}
-  - match: { datafeeds.0.state: "stopped"}
+  - match:  { datafeeds.0.datafeed_id: "datafeed-2"}
+  - match:  { datafeeds.0.state: "stopped"}
   - is_false: datafeeds.0.node
+  - match:  { datafeeds.0.timing_stats.job_id: "get-datafeed-stats-2" }
 
 ---
 "Test get stats for started datafeed":
@@ -157,6 +159,40 @@ setup:
   - is_true: datafeeds.0.node.name
   - is_true: datafeeds.0.node.transport_address
   - match: { datafeeds.0.node.attributes.ml\.max_open_jobs: "20"}
+
+---
+"Test get stats for started datafeed contains timing stats":
+
+  - do:
+      ml.open_job:
+        job_id: get-datafeed-stats-1
+
+  - do:
+      ml.start_datafeed:
+        "datafeed_id": "datafeed-1"
+        "start": 0
+
+  - do:
+      ml.get_datafeed_stats:
+        datafeed_id: datafeed-1
+  - match: { datafeeds.0.datafeed_id: "datafeed-1"}
+  - match: { datafeeds.0.state: "started"}
+  - match: { datafeeds.0.timing_stats.job_id: "get-datafeed-stats-1"}
+  # Datafeed did not perform any search yet, hence 0.0
+  - match: { datafeeds.0.timing_stats.total_search_time_ms: 0.0}
+
+  - do:
+      ml.stop_datafeed:
+        "datafeed_id": "datafeed-1"
+
+  - do:
+      ml.get_datafeed_stats:
+        datafeed_id: datafeed-1
+  - match: { datafeeds.0.datafeed_id: "datafeed-1"}
+  - match: { datafeeds.0.state: "stopped"}
+  - match: { datafeeds.0.timing_stats.job_id: "get-datafeed-stats-1"}
+  # Datafeed did perform at least one search
+  - gt:    { datafeeds.0.timing_stats.total_search_time_ms: 0.0}
 
 ---
 "Test implicit get all datafeed stats given started datafeeds":

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_datafeed_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_datafeed_stats.yml
@@ -130,6 +130,8 @@ setup:
   - match:  { datafeeds.0.state: "stopped"}
   - is_false: datafeeds.0.node
   - match:  { datafeeds.0.timing_stats.job_id: "get-datafeed-stats-1" }
+  - match:  { datafeeds.0.timing_stats.search_count: 0 }
+  - match:  { datafeeds.0.timing_stats.total_search_time_ms: 0.0}
 
   - do:
       ml.get_datafeed_stats:
@@ -138,6 +140,8 @@ setup:
   - match:  { datafeeds.0.state: "stopped"}
   - is_false: datafeeds.0.node
   - match:  { datafeeds.0.timing_stats.job_id: "get-datafeed-stats-2" }
+  - match:  { datafeeds.0.timing_stats.search_count: 0 }
+  - match:  { datafeeds.0.timing_stats.total_search_time_ms: 0.0}
 
 ---
 "Test get stats for started datafeed":
@@ -178,7 +182,7 @@ setup:
   - match: { datafeeds.0.datafeed_id: "datafeed-1"}
   - match: { datafeeds.0.state: "started"}
   - match: { datafeeds.0.timing_stats.job_id: "get-datafeed-stats-1"}
-  # Datafeed did not perform any search yet, hence 0.0
+  - match: { datafeeds.0.timing_stats.search_count: 0}
   - match: { datafeeds.0.timing_stats.total_search_time_ms: 0.0}
 
   - do:
@@ -191,8 +195,8 @@ setup:
   - match: { datafeeds.0.datafeed_id: "datafeed-1"}
   - match: { datafeeds.0.state: "stopped"}
   - match: { datafeeds.0.timing_stats.job_id: "get-datafeed-stats-1"}
-  # Datafeed did perform at least one search
-  - gt:    { datafeeds.0.timing_stats.total_search_time_ms: 0.0}
+  - match: { datafeeds.0.timing_stats.search_count: 0}
+  - match: { datafeeds.0.timing_stats.total_search_time_ms: 0.0}
 
 ---
 "Test implicit get all datafeed stats given started datafeeds":

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_datafeed_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_datafeed_stats.yml
@@ -148,8 +148,8 @@ setup:
 
   - do:
       ml.start_datafeed:
-        "datafeed_id": "datafeed-1"
-        "start": 0
+        datafeed_id: "datafeed-1"
+        start: 0
 
   - do:
       ml.get_datafeed_stats:
@@ -169,8 +169,8 @@ setup:
 
   - do:
       ml.start_datafeed:
-        "datafeed_id": "datafeed-1"
-        "start": 0
+        datafeed_id: "datafeed-1"
+        start: 0
 
   - do:
       ml.get_datafeed_stats:
@@ -183,7 +183,7 @@ setup:
 
   - do:
       ml.stop_datafeed:
-        "datafeed_id": "datafeed-1"
+        datafeed_id: "datafeed-1"
 
   - do:
       ml.get_datafeed_stats:
@@ -203,8 +203,8 @@ setup:
 
   - do:
       ml.start_datafeed:
-        "datafeed_id": "datafeed-1"
-        "start": 0
+        datafeed_id: "datafeed-1"
+        start: 0
 
   - do:
       ml.open_job:
@@ -212,8 +212,8 @@ setup:
 
   - do:
       ml.start_datafeed:
-        "datafeed_id": "datafeed-2"
-        "start": 0
+        datafeed_id: "datafeed-2"
+        start: 0
 
   - do:
       ml.get_datafeed_stats: {}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_datafeed_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_datafeed_stats.yml
@@ -195,8 +195,8 @@ setup:
   - match: { datafeeds.0.datafeed_id: "datafeed-1"}
   - match: { datafeeds.0.state: "stopped"}
   - match: { datafeeds.0.timing_stats.job_id: "get-datafeed-stats-1"}
-  - match: { datafeeds.0.timing_stats.search_count: 0}
-  - match: { datafeeds.0.timing_stats.total_search_time_ms: 0.0}
+  - match: { datafeeds.0.timing_stats.search_count: 1}
+  - gte:   { datafeeds.0.timing_stats.total_search_time_ms: 0.0}
 
 ---
 "Test implicit get all datafeed stats given started datafeeds":


### PR DESCRIPTION
This PR introduces DatafeedTimingStats class which will hold various timing-related metrics useful for debugging.
Initially, the only metric available is totalSearchTimeMs which accumulates total time spent by datafeed searching indices.

Related issue: #29857