### PR TITLE
Fixing handling of auto slices in bulk scroll requests

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/BulkByScrollParallelizationHelper.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/BulkByScrollParallelizationHelper.java
@@ -112,7 +112,7 @@ class BulkByScrollParallelizationHelper {
             (sum, term) -> sum + term
         ));
         Set<Integer> counts = new HashSet<>(countsByIndex.values());
-        int leastShards = Collections.min(counts);
+        int leastShards = counts.isEmpty() ? 1 : Collections.min(counts);
         return Math.min(leastShards, AUTO_SLICE_CEILING);
     }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/DeleteByQueryBasicTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/DeleteByQueryBasicTests.java
@@ -306,4 +306,13 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
 
     }
 
+    public void testMissingSources() {
+        BulkByScrollResponse response = updateByQuery()
+            .source("missing-index-*")
+            .refresh(true)
+            .setSlices(AbstractBulkByScrollRequest.AUTO_SLICES)
+            .get();
+        assertThat(response, matcher().updated(0).slices(hasSize(0)));
+    }
+
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/DeleteByQueryBasicTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/DeleteByQueryBasicTests.java
@@ -312,7 +312,7 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
             .refresh(true)
             .setSlices(AbstractBulkByScrollRequest.AUTO_SLICES)
             .get();
-        assertThat(response, matcher().updated(0).slices(hasSize(0)));
+        assertThat(response, matcher().deleted(0).slices(hasSize(0)));
     }
 
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexBasicTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexBasicTests.java
@@ -163,7 +163,7 @@ public class ReindexBasicTests extends ReindexTestCase {
             .refresh(true)
             .setSlices(AbstractBulkByScrollRequest.AUTO_SLICES)
             .get();
-        assertThat(response, matcher().updated(0).slices(hasSize(0)));
+        assertThat(response, matcher().created(0).slices(hasSize(0)));
     }
 
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexBasicTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexBasicTests.java
@@ -157,5 +157,13 @@ public class ReindexBasicTests extends ReindexTestCase {
         assertHitCount(client().prepareSearch("dest").setSize(0).get(), allDocs.size());
     }
 
+    public void testMissingSources() {
+        BulkByScrollResponse response = updateByQuery()
+            .source("missing-index-*")
+            .refresh(true)
+            .setSlices(AbstractBulkByScrollRequest.AUTO_SLICES)
+            .get();
+        assertThat(response, matcher().updated(0).slices(hasSize(0)));
+    }
 
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/UpdateByQueryBasicTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/UpdateByQueryBasicTests.java
@@ -160,4 +160,13 @@ public class UpdateByQueryBasicTests extends ReindexTestCase {
             assertEquals(2, client().prepareGet(index, "test", Integer.toString(randomDoc)).get().getVersion());
         }
     }
+
+    public void testMissingSources() {
+        BulkByScrollResponse response = updateByQuery()
+            .source("missing-index-*")
+            .refresh(true)
+            .setSlices(AbstractBulkByScrollRequest.AUTO_SLICES)
+            .get();
+        assertThat(response, matcher().updated(0).slices(hasSize(0)));
+    }
 }


### PR DESCRIPTION
When using `auto` and referencing an index pattern that expands to no indices, a cryptic error message is returned:

```
POST missing-index-*/_update_by_query?slices=auto
>{
  "error": {
    "root_cause": [
      {
        "type": "no_such_element_exception",
        "reason": null
      }
    ],
    "type": "no_such_element_exception",
    "reason": null
  },
  "status": 500
}
```
However, when specifying a `slices=1`
```
POST missing-index-*/_update_by_query?slices=1
>{
  "took" : 0,
  "timed_out" : false,
  "total" : 0,
  "updated" : 0,
  "deleted" : 0,
  "batches" : 0,
  "version_conflicts" : 0,
  "noops" : 0,
  "retries" : {
    "bulk" : 0,
    "search" : 0
  },
  "throttled_millis" : 0,
  "requests_per_second" : -1.0,
  "throttled_until_millis" : 0,
  "failures" : [ ]
}
```

This PR puts the two requests into parity so that `auto` does not throw an error when the index pattern expands to a non-existing concrete indices. 