### PR TITLE
Prune _id of only docs below local checkpoint of safe commit

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/CombinedDeletionPolicy.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/CombinedDeletionPolicy.java
@@ -29,6 +29,7 @@ import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.index.translog.TranslogDeletionPolicy;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
@@ -211,6 +212,15 @@ public final class CombinedDeletionPolicy extends IndexDeletionPolicy {
             }
         }
         return false;
+    }
+
+    long localCheckpointOfSafeCommit() {
+        try {
+            assert safeCommit != null;
+            return Long.parseLong(safeCommit.getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.codecs.blocktree.BlockTreeTermsReader;
 import org.apache.lucene.codecs.blocktree.BlockTreeTermsReader.FSTLoadMode;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexCommit;
@@ -2177,7 +2178,8 @@ public class InternalEngine extends Engine {
         if (softDeleteEnabled) {
             mergePolicy = new RecoverySourcePruneMergePolicy(SourceFieldMapper.RECOVERY_SOURCE_NAME, softDeletesPolicy::getRetentionQuery,
                 new SoftDeletesRetentionMergePolicy(Lucene.SOFT_DELETES_FIELD, softDeletesPolicy::getRetentionQuery,
-                    new PrunePostingsMergePolicy(mergePolicy, IdFieldMapper.NAME)));
+                    new PrunePostingsMergePolicy(mergePolicy, IdFieldMapper.NAME, () -> LongPoint.newRangeQuery(
+                        SeqNoFieldMapper.NAME, combinedDeletionPolicy.localCheckpointOfSafeCommit() + 1, Long.MAX_VALUE))));
         }
         iwc.setMergePolicy(new ElasticsearchMergePolicy(mergePolicy));
         iwc.setSimilarity(engineConfig.getSimilarity());

--- a/server/src/main/java/org/elasticsearch/index/engine/PrunePostingsMergePolicy.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/PrunePostingsMergePolicy.java
@@ -273,10 +273,13 @@ final class PrunePostingsMergePolicy extends OneMergeWrappingMergePolicy {
         } else {
             final FixedBitSet liveDocs = FixedBitSet.copyOf(reader.getLiveDocs());
             final DocIdSetIterator iterator = scorer.iterator();
+            int numDocs = reader.numDocs();
             while (iterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-                liveDocs.set(iterator.docID());
+                if (liveDocs.getAndSet(iterator.docID()) == false) {
+                    numDocs++;
+                }
             }
-            return Tuple.tuple(liveDocs, false);
+            return Tuple.tuple(liveDocs, numDocs == 0);
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/engine/PrunePostingsMergePolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/PrunePostingsMergePolicyTests.java
@@ -50,7 +50,7 @@ public class PrunePostingsMergePolicyTests extends ESTestCase {
             IndexWriterConfig iwc = newIndexWriterConfig();
             iwc.setSoftDeletesField("_soft_deletes");
             MergePolicy mp = new SoftDeletesRetentionMergePolicy("_soft_deletes", MatchAllDocsQuery::new,
-                new PrunePostingsMergePolicy(newLogMergePolicy(), "id"));
+                new PrunePostingsMergePolicy(newLogMergePolicy(), "id", MatchAllDocsQuery::new));
             iwc.setMergePolicy(mp);
             boolean sorted = randomBoolean();
             if (sorted) {

--- a/server/src/test/java/org/elasticsearch/index/engine/PrunePostingsMergePolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/PrunePostingsMergePolicyTests.java
@@ -35,6 +35,7 @@ import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.store.Directory;
@@ -50,7 +51,7 @@ public class PrunePostingsMergePolicyTests extends ESTestCase {
             IndexWriterConfig iwc = newIndexWriterConfig();
             iwc.setSoftDeletesField("_soft_deletes");
             MergePolicy mp = new SoftDeletesRetentionMergePolicy("_soft_deletes", MatchAllDocsQuery::new,
-                new PrunePostingsMergePolicy(newLogMergePolicy(), "id", MatchAllDocsQuery::new));
+                new PrunePostingsMergePolicy(newLogMergePolicy(), "id", MatchNoDocsQuery::new));
             iwc.setMergePolicy(mp);
             boolean sorted = randomBoolean();
             if (sorted) {


### PR DESCRIPTION
Today we use _id of soft-deleted documents to resolve the indexing strategy on replicas. This lookup requires PrunePostingsMergePolicy to keep _id of soft-deleted documents after the local checkpoint of the safe commit. 

Relates #40741
Closes #42979