### PR TITLE
[DOCS] Rewrite `terms_set` query

### DIFF
--- a/docs/reference/query-dsl/terms-set-query.asciidoc
+++ b/docs/reference/query-dsl/terms-set-query.asciidoc
@@ -158,8 +158,6 @@ For an example query using the `minimum_should_match_script` parameter, see
 parameter>>.
 --
 
---
-
 [[terms-set-query-notes]]
 ==== Notes
 

--- a/docs/reference/query-dsl/terms-set-query.asciidoc
+++ b/docs/reference/query-dsl/terms-set-query.asciidoc
@@ -5,17 +5,17 @@ Returns documents that contain a minimum number of *exact* terms in a provided
 field.
 
 The `terms_set` query is the same as the <<query-dsl-terms-query, `terms`
-query>>, except you can define a minimum number of matching terms required to
+query>>, except you can define the number of matching terms required to
 return a document. For example:
-
-* A field, `permissions`, contains a list of possible user permissions for an
-application. You can use the `terms_set` query to return documents that
-match a set of permissions.
 
 * A field, `programming_languages`, contains a list of known programming
 languages, such as `c++`, `java`, or `php` for job candidates. You can use the
 `terms_set` query to return documents that match at least two of these
 languages.
+
+* A field, `permissions`, contains a list of possible user permissions for an
+application. You can use the `terms_set` query to return documents that
+match a subset of these permissions.
 
 [[terms-set-query-ex-request]]
 ==== Example request
@@ -24,7 +24,7 @@ languages.
 ===== Index setup
 In most cases, you'll need to include a <<number, numeric>> field mapping in
 your index to use the `terms_set` query. This numeric field contains the
-minimum number of matching terms required to return a document.
+number of matching terms required to return a document.
 
 To see how you can set up an index for the `terms_set` query, try the
 following example.
@@ -40,7 +40,7 @@ job candidate.
 programming languages known by the job candidate.
 
 * `required_matches`, a <<number, numeric>> `long` field. This field contains
-the minimum number of matching terms required to return a document.
+the number of matching terms required to return a document.
 
 [source,js]
 ----
@@ -115,8 +115,8 @@ PUT /job-candidates/_doc/2?refresh
 
 --
 
-You can now use the `required_matches` field value as a minimum number of
-matching terms required in the `terms_set` query.
+You can now use the `required_matches` field value as the number of
+matching terms required to return a document in the `terms_set` query.
 
 [[terms-set-query-ex-request-query]]
 ===== Example query
@@ -128,7 +128,7 @@ contains at least two of the following terms:
 * `java`
 * `php`
 
-The `minimum_should_match_field` is `required_matches`. This means the minimum
+The `minimum_should_match_field` is `required_matches`. This means the
 number of matching terms required is `2`, the value of the `required_matches`
 field.
 
@@ -161,21 +161,22 @@ Field you wish to search.
 +
 --
 Array of terms you wish to find in the provided `<field>`. To return a document,
-a minimum number of terms must exactly match the field values, including
+a required number of terms must exactly match the field values, including
 whitespace and capitalization.
 
-The minimum number of matching terms is defined in the
+The required number of matching terms is defined in the
 `minimum_should_match_field` or `minimum_should_match_script` parameter.
 --
 
 `minimum_should_match_field`::
-<<number, Numeric>> field containing the minimum number of matching terms
+<<number, Numeric>> field containing the number of matching terms
 required to return a document.
 
 `minimum_should_match_script`::
 +
 --
-Custom script containing the minimum number of terms to match.
+Custom script containing the number of matching terms required to return a
+document.
 
 For parameters and valid values, see <<modules-scripting, Scripting>>.
 
@@ -189,8 +190,8 @@ parameter>>.
 
 [[terms-set-query-script]]
 ===== How to use the `minimum_should_match_script` parameter
-You can use `minimum_should_match_script` to define the minimum number of terms
-to match using a script. This is useful if you need to set the number of
+You can use `minimum_should_match_script` to define the required number of
+matching terms using a script. This is useful if you need to set the number of
 required terms dynamically.
 
 [[terms-set-query-script-ex]]
@@ -205,9 +206,9 @@ contains at least two of the following terms:
 
 The `source` parameter of this query indicates:
 
-* The minimum number of terms to match cannot exceed `params.num_terms`, the
+* The required number of terms to match cannot exceed `params.num_terms`, the
 number of terms provided in the `terms` field.
-* The minimum number of terms to match is `2`, the value of the
+* The required number of terms to match is `2`, the value of the
 `required_matches` field.
 
 [source,js]

--- a/docs/reference/query-dsl/terms-set-query.asciidoc
+++ b/docs/reference/query-dsl/terms-set-query.asciidoc
@@ -5,7 +5,17 @@ Returns documents that contain a minimum number of *exact* terms in a provided
 field.
 
 The `terms_set` query is the same as the <<query-dsl-terms-query, `terms`
-query>>, except you can define a minimum number of matching terms.
+query>>, except you can define a minimum number of matching terms required to
+return a document. For example:
+
+* A field, `permissions`, contains a list of possible user permissions for an
+application. You can use the `terms_set` query to return documents that
+match a set of permissions.
+
+* A field, `programming_languages`, contains a list of known programming
+languages, such as `c++`, `java`, or `php` for job candidates. You can use the
+`terms_set` query to return documents that match at least two of these
+languages.
 
 [[terms-set-query-ex-request]]
 ==== Example request
@@ -13,27 +23,35 @@ query>>, except you can define a minimum number of matching terms.
 [[terms-set-query-ex-request-index-setup]]
 ===== Index setup
 In most cases, you'll need to include a <<number, numeric>> field mapping in
-your index to use the `terms_set` query. This numeric field will contain the
+your index to use the `terms_set` query. This numeric field contains the
 minimum number of matching terms required to return a document.
 
 To see how you can set up an index for the `terms_set` query, try the
 following example.
 
-. Create an index with the following field mappings:
+. Create an index, `job-candidates`, with the following field mappings:
 +
 --
 
-* `color`, a <<keyword, `keyword`>> field.
-* `required_matches`, a <<number, numeric>> `long` field. This field will
-contain the minimum number of matching terms required to return a document.
+* `name`, a <<keyword, `keyword`>> field. This field contains the name of the
+job candidate.
+
+* `programming_languages`, a <<keyword, `keyword`>> field. This field contains
+programming languages known by the job candidate.
+
+* `required_matches`, a <<number, numeric>> `long` field. This field contains
+the minimum number of matching terms required to return a document.
 
 [source,js]
 ----
-PUT /my-index
+PUT /job-candidates
 {
     "mappings": {
         "properties": {
-            "color": {
+            "name": {
+                "type": "keyword"
+            },
+            "programming_languages": {
                 "type": "keyword"
             },
             "required_matches": {
@@ -52,18 +70,21 @@ PUT /my-index
 +
 --
 
-* `["blue", "green"]` in the `color` field.
-* `2` in the `required_matches` field. This is the minimum number of matching
-terms required to return a document.
+* `Jane Smith` in the `name` field.
+
+* `["c++", "java"]` in the `programming_languages` field.
+
+* `2` in the `required_matches` field.
 
 Include the `?refresh` parameter so the document is immediately available for
 search.
 
 [source,js]
 ----
-PUT /my-index/_doc/1?refresh
+PUT /job-candidates/_doc/1?refresh
 {
-    "color": ["blue", "green"],
+    "name": "Jane Smith",
+    "programming_languages": ["c++", "java"],
     "required_matches": 2
 }
 ----
@@ -75,14 +96,18 @@ PUT /my-index/_doc/1?refresh
 +
 --
 
-* `["blue", "red"]` in the `color` field.
+* `Jason Response` in the `name` field.
+
+* `["java", "php"]` in the `programming_languages` field.
+
 * `2` in the `required_matches` field.
 
 [source,js]
 ----
-PUT /my-index/_doc/2?refresh
+PUT /job-candidates/_doc/2?refresh
 {
-    "color": ["blue", "red"],
+    "name": "Jason Response",
+    "programming_languages": ["java", "php"],
     "required_matches": 2
 }
 ----
@@ -96,12 +121,12 @@ matching terms required in the `terms_set` query.
 [[terms-set-query-ex-request-query]]
 ===== Example query
 
-The following search returns documents where the `color` field contains at least
-two of the following terms:
+The following search returns documents where the `programming_languages` field
+contains at least two of the following terms:
 
-* `blue`
-* `green`
-* `red`
+* `c++`
+* `java`
+* `php`
 
 The `minimum_should_match_field` is `required_matches`. This means the minimum
 number of matching terms required is `2`, the value of the `required_matches`
@@ -109,12 +134,12 @@ field.
 
 [source,js]
 ----
-GET /my-index/_search
+GET /job-candidates/_search
 {
     "query": {
         "terms_set": {
-            "color": {
-                "terms": ["blue", "green", "red"],
+            "programming_languages": {
+                "terms": ["c++", "java", "php"],
                 "minimum_should_match_field": "required_matches"
             }
         }
@@ -139,7 +164,8 @@ Array of terms you wish to find in the provided `<field>`. To return a document,
 a minimum number of terms must exactly match the field values, including
 whitespace and capitalization.
 
-The minimum number of matching terms is defined in the `minimum_should_match_field` or `minimum_should_match_script` parameter.
+The minimum number of matching terms is defined in the
+`minimum_should_match_field` or `minimum_should_match_script` parameter.
 --
 
 `minimum_should_match_field`::
@@ -170,12 +196,12 @@ required terms dynamically.
 [[terms-set-query-script-ex]]
 ====== Example query using `minimum_should_match_script`
 
-The following search returns documents where the `color` field contains at least
-two of the following terms:
+The following search returns documents where the `programming_languages` field
+contains at least two of the following terms:
 
-* `blue`
-* `green`
-* `red`
+* `c++`
+* `java`
+* `php`
 
 The `source` parameter of this query indicates:
 
@@ -186,12 +212,12 @@ number of terms provided in the `terms` field.
 
 [source,js]
 ----
-GET /my-index/_search
+GET /job-candidates/_search
 {
     "query": {
         "terms_set": {
-            "color": {
-                "terms": ["blue", "green", "red"],
+            "programming_languages": {
+                "terms": ["c++", "java", "php"],
                 "minimum_should_match_script": {
                    "source": "Math.min(params.num_terms, doc['required_matches'].value)"
                 },

--- a/docs/reference/query-dsl/terms-set-query.asciidoc
+++ b/docs/reference/query-dsl/terms-set-query.asciidoc
@@ -115,8 +115,7 @@ GET /my-index/_search
         "terms_set": {
             "color": {
                 "terms": ["blue", "green", "red"],
-                "minimum_should_match_field": "required_matches",
-                "boost": 1.0
+                "minimum_should_match_field": "required_matches"
             }
         }
     }
@@ -159,19 +158,6 @@ For an example query using the `minimum_should_match_script` parameter, see
 parameter>>.
 --
 
-`boost`::
-+
---
-Floating point number used to decrease or increase the
-<<query-filter-context, relevance scores>> of a query. Default is `1.0`.
-Optional.
-
-You can use the `boost` parameter to adjust relevance scores for searches
-containing two or more queries.
-
-Boost values are relative to the default value of `1.0`. A boost value between
-`0` and `1.0` decreases the relevance score. A value greater than `1.0`
-increases the relevance score.
 --
 
 [[terms-set-query-notes]]

--- a/docs/reference/query-dsl/terms-set-query.asciidoc
+++ b/docs/reference/query-dsl/terms-set-query.asciidoc
@@ -1,121 +1,220 @@
 [[query-dsl-terms-set-query]]
 === Terms Set Query
 
-Returns any documents that match with at least one or more of the
-provided terms. The terms are not analyzed and thus must match exactly.
-The number of terms that must match varies per document and is either
-controlled by a minimum should match field or computed per document in
-a minimum should match script.
+Returns documents that contain a minimum number of *exact* terms in a provided
+field.
 
-The field that controls the number of required terms that must match must
-be a number field:
+The `terms_set` query is the same as the <<query-dsl-terms-query, `terms`
+query>>, except you can define a minimum number of matching terms.
+
+[[terms-set-query-ex-request]]
+==== Example request
+
+[[terms-set-query-ex-request-index-setup]]
+===== Index setup
+In most cases, you'll need to include a <<number, numeric>> field mapping in
+your index to use the `terms_set` query. This numeric field will contain the
+minimum number of matching terms required to return a document.
+
+To see how you can set up an index for the `terms_set` query, try the
+following example.
+
+. Create an index with the following field mappings:
++
+--
+
+* `color`, a <<keyword, `keyword`>> field.
+* `required_matches`, a <<number, numeric>> `long` field. This field will
+contain the minimum number of matching terms required to return a document.
 
 [source,js]
---------------------------------------------------
+----
 PUT /my-index
 {
     "mappings": {
         "properties": {
+            "color": {
+                "type": "keyword"
+            },
             "required_matches": {
                 "type": "long"
             }
         }
     }
 }
-
-PUT /my-index/_doc/1?refresh
-{
-    "codes": ["ghi", "jkl"],
-    "required_matches": 2
-}
-
-PUT /my-index/_doc/2?refresh
-{
-    "codes": ["def", "ghi"],
-    "required_matches": 2
-}
---------------------------------------------------
+----
 // CONSOLE
 // TESTSETUP
 
-An example that uses the minimum should match field:
+--
+
+. Index a document with an ID of `1` and the following values:
++
+--
+
+* `["blue", "green"]` in the `color` field.
+* `2` in the `required_matches` field. This is the minimum number of matching
+terms required to return a document.
+
+Include the `?refresh` parameter so the document is immediately available for
+search.
 
 [source,js]
---------------------------------------------------
-GET /my-index/_search
+----
+PUT /my-index/_doc/1?refresh
 {
-    "query": {
-        "terms_set": {
-            "codes" : {
-                "terms" : ["abc", "def", "ghi"],
-                "minimum_should_match_field": "required_matches"
-            }
-        }
-    }
+    "color": ["blue", "green"],
+    "required_matches": 2
 }
---------------------------------------------------
+----
 // CONSOLE
 
-Response:
+--
+
+. Index another document with an ID of `2` and the following values:
++
+--
+
+* `["blue", "red"]` in the `color` field.
+* `2` in the `required_matches` field.
 
 [source,js]
---------------------------------------------------
+----
+PUT /my-index/_doc/2?refresh
 {
-  "took": 13,
-  "timed_out": false,
-  "_shards": {
-    "total": 1,
-    "successful": 1,
-    "skipped" : 0,
-    "failed": 0
-  },
-  "hits": {
-    "total" : {
-        "value": 1,
-        "relation": "eq"
-    },
-    "max_score": 0.87546873,
-    "hits": [
-      {
-        "_index": "my-index",
-        "_type": "_doc",
-        "_id": "2",
-        "_score": 0.87546873,
-        "_source": {
-          "codes": ["def", "ghi"],
-          "required_matches": 2
-        }
-      }
-    ]
-  }
+    "color": ["blue", "red"],
+    "required_matches": 2
 }
---------------------------------------------------
-// TESTRESPONSE[s/"took": 13,/"took": "$body.took",/]
+----
+// CONSOLE
 
-Scripts can also be used to control how many terms are required to match
-in a more dynamic way. For example a create date or a popularity field
-can be used as basis for the number of required terms to match.
+--
 
-Also the `params.num_terms` parameter is available in the script to indicate the
-number of terms that have been specified.
+You can now use the `required_matches` field value as a minimum number of
+matching terms required in the `terms_set` query.
 
-An example that always limits the number of required terms to match to never
-become larger than the number of terms specified:
+[[terms-set-query-ex-request-query]]
+===== Example query
+
+The following search returns documents where the `color` field contains at least
+two of the following terms:
+
+* `blue`
+* `green`
+* `red`
+
+The `minimum_should_match_field` is `required_matches`. This means the minimum
+number of matching terms required is `2`, the value of the `required_matches`
+field.
 
 [source,js]
---------------------------------------------------
+----
 GET /my-index/_search
 {
     "query": {
         "terms_set": {
-            "codes" : {
-                "terms" : ["abc", "def", "ghi"],
-                "minimum_should_match_script": {
-                   "source": "Math.min(params.num_terms, doc['required_matches'].value)"
-                }
+            "color": {
+                "terms": ["blue", "green", "red"],
+                "minimum_should_match_field": "required_matches",
+                "boost": 1.0
             }
         }
     }
 }
---------------------------------------------------
+----
+// CONSOLE
+
+[[terms-set-top-level-params]]
+==== Top-level parameters for `terms_set`
+
+`<field>`::
+Field you wish to search.
+
+[[terms-set-field-params]]
+==== Parameters for `<field>`
+
+`terms`::
++
+--
+Array of terms you wish to find in the provided `<field>`. To return a document,
+a minimum number of terms must exactly match the field values, including
+whitespace and capitalization.
+
+The minimum number of matching terms is defined in the `minimum_should_match_field` or `minimum_should_match_script` parameter.
+--
+
+`minimum_should_match_field`::
+<<number, Numeric>> field containing the minimum number of matching terms
+required to return a document.
+
+`minimum_should_match_script`::
++
+--
+Custom script containing the minimum number of terms to match.
+
+For parameters and valid values, see <<modules-scripting, Scripting>>.
+
+For an example query using the `minimum_should_match_script` parameter, see
+<<terms-set-query-script, How to use the `minimum_should_match_script`
+parameter>>.
+--
+
+`boost`::
++
+--
+Floating point number used to decrease or increase the
+<<query-filter-context, relevance scores>> of a query. Default is `1.0`.
+Optional.
+
+You can use the `boost` parameter to adjust relevance scores for searches
+containing two or more queries.
+
+Boost values are relative to the default value of `1.0`. A boost value between
+`0` and `1.0` decreases the relevance score. A value greater than `1.0`
+increases the relevance score.
+--
+
+[[terms-set-query-notes]]
+==== Notes
+
+[[terms-set-query-script]]
+===== How to use the `minimum_should_match_script` parameter
+You can use `minimum_should_match_script` to define the minimum number of terms
+to match using a script. This is useful if you need to set the number of
+required terms dynamically.
+
+[[terms-set-query-script-ex]]
+====== Example query using `minimum_should_match_script`
+
+The following search returns documents where the `color` field contains at least
+two of the following terms:
+
+* `blue`
+* `green`
+* `red`
+
+The `source` parameter of this query indicates:
+
+* The minimum number of terms to match cannot exceed `params.num_terms`, the
+number of terms provided in the `terms` field.
+* The minimum number of terms to match is `2`, the value of the
+`required_matches` field.
+
+[source,js]
+----
+GET /my-index/_search
+{
+    "query": {
+        "terms_set": {
+            "color": {
+                "terms": ["blue", "green", "red"],
+                "minimum_should_match_script": {
+                   "source": "Math.min(params.num_terms, doc['required_matches'].value)"
+                },
+                "boost": 1.0
+            }
+        }
+    }
+}
+----
 // CONSOLE


### PR DESCRIPTION
## Changes
* Rewrites description of `terms_set` query
* Adds example request section
* Adds parameters sections
* Adds notes section

This is part of #40977, an effort to standardize documentation for query types.

## Before
<details>
 <summary>Before image</summary>
<img width="774" alt="Before image" src="https://user-images.githubusercontent.com/40268737/59195661-85d29a00-8b5a-11e9-9a77-bc1e1c516036.png">
</details>


## After
<details>
 <summary>After image</summary>
<img width="774" alt="Before image" src="https://user-images.githubusercontent.com/40268737/60353493-20730b80-9998-11e9-9555-b6a16ace2e45.png">
</details>
