### PR TITLE
Fix incorrect node name in docs

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -254,7 +254,7 @@ If everything goes well with installation, you should see a bunch of messages th
 
 --------------------------------------------------
 
-Without going too much into detail, we can see that our node named "localhost.localdomain" (which will be a different set of characters in your case) has started and elected itself as a master in a single cluster. Don't worry yet at the moment what master means. The main thing that is important here is that we have started one node within one cluster.
+Without going too much into detail, we can see that our node named "localhost.localdomain" has started and elected itself as a master in a single cluster. Don't worry yet at the moment what master means. The main thing that is important here is that we have started one node within one cluster.
 
 As mentioned previously, we can override either the cluster or node name. This can be done from the command line when starting Elasticsearch as follows:
 

--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -254,7 +254,7 @@ If everything goes well with installation, you should see a bunch of messages th
 
 --------------------------------------------------
 
-Without going too much into detail, we can see that our node named "6-bjhwl" (which will be a different set of characters in your case) has started and elected itself as a master in a single cluster. Don't worry yet at the moment what master means. The main thing that is important here is that we have started one node within one cluster.
+Without going too much into detail, we can see that our node named "localhost.localdomain" (which will be a different set of characters in your case) has started and elected itself as a master in a single cluster. Don't worry yet at the moment what master means. The main thing that is important here is that we have started one node within one cluster.
 
 As mentioned previously, we can override either the cluster or node name. This can be done from the command line when starting Elasticsearch as follows:
 


### PR DESCRIPTION
After starting up elasticsearch the documentation said that their node
name was "6-bjhwl" but in the documentation's output I did not see that
node name. Instead I saw the node name as `localhost.localdomain`
