### PR TITLE
[7.x] Fixing handling of auto slices in bulk scroll requests (#43050)

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/BulkByScrollParallelizationHelper.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/BulkByScrollParallelizationHelper.java
@@ -112,7 +112,7 @@ class BulkByScrollParallelizationHelper {
             (sum, term) -> sum + term
         ));
         Set<Integer> counts = new HashSet<>(countsByIndex.values());
-        int leastShards = Collections.min(counts);
+        int leastShards = counts.isEmpty() ? 1 : Collections.min(counts);
         return Math.min(leastShards, AUTO_SLICE_CEILING);
     }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/DeleteByQueryBasicTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/DeleteByQueryBasicTests.java
@@ -306,4 +306,13 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
 
     }
 
+    public void testMissingSources() {
+        BulkByScrollResponse response = updateByQuery()
+            .source("missing-index-*")
+            .refresh(true)
+            .setSlices(AbstractBulkByScrollRequest.AUTO_SLICES)
+            .get();
+        assertThat(response, matcher().deleted(0).slices(hasSize(0)));
+    }
+
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexBasicTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexBasicTests.java
@@ -157,5 +157,13 @@ public class ReindexBasicTests extends ReindexTestCase {
         assertHitCount(client().prepareSearch("dest").setSize(0).get(), allDocs.size());
     }
 
+    public void testMissingSources() {
+        BulkByScrollResponse response = updateByQuery()
+            .source("missing-index-*")
+            .refresh(true)
+            .setSlices(AbstractBulkByScrollRequest.AUTO_SLICES)
+            .get();
+        assertThat(response, matcher().created(0).slices(hasSize(0)));
+    }
 
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/UpdateByQueryBasicTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/UpdateByQueryBasicTests.java
@@ -160,4 +160,13 @@ public class UpdateByQueryBasicTests extends ReindexTestCase {
             assertEquals(2, client().prepareGet(index, "test", Integer.toString(randomDoc)).get().getVersion());
         }
     }
+
+    public void testMissingSources() {
+        BulkByScrollResponse response = updateByQuery()
+            .source("missing-index-*")
+            .refresh(true)
+            .setSlices(AbstractBulkByScrollRequest.AUTO_SLICES)
+            .get();
+        assertThat(response, matcher().updated(0).slices(hasSize(0)));
+    }
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fixing handling of auto slices in bulk scroll requests  (#43050)