### PR TITLE
[ML][Data Frame] change failure count reset logic

### DIFF
--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
@@ -489,8 +489,6 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
 
         @Override
         protected void onStart(long now, ActionListener<Void> listener) {
-            // Reset our failure count as we are starting again
-            failureCount.set(0);
             // On each run, we need to get the total number of docs and reset the count of processed docs
             // Since multiple checkpoints can be executed in the task while it is running on the same node, we need to gather
             // the progress here, and not in the executor.
@@ -609,6 +607,8 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
             try {
                 super.onFinish(listener);
                 long checkpoint = transformTask.currentCheckpoint.incrementAndGet();
+                // Reset our failure count as we have finished and may start again with a new checkpoint
+                failureCount.set(0);
                 auditor.info(transformTask.getTransformId(), "Finished indexing for data frame transform checkpoint [" + checkpoint + "].");
                 logger.info(
                     "Finished indexing for data frame transform [" + transformTask.getTransformId() + "] checkpoint [" + checkpoint + "]");


### PR DESCRIPTION
Resetting the `failureCount` field to `0` onStart does not provide value, and in fact, causes issues. 

Since all failures reset the Indexer back to a `STARTED` state, `onStart` is actually called eventually after every failure. Our counter resets back to `0` and we continue to log failures as they occur. 

I moved the counter reset to `onFinish` as the task can still be alive after the Indexer finishes. For a single checkpoint, > 10 failures indicates some sort of systemic problem as a single checkpoint should not last many days, but should only be, at most, a couple of hours. 

The failureCount is set to `0` in the following conditions:
* The Task is marked as failed
* The onFinish is called on the task
* When the task is created

When the task is marked as failed, it will stop triggering and the user will see what errors occurred up to that state transition so that they can address them as needed. 