### PR TITLE
Remove description from xpack feature sets

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/xpack/XPackInfoResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/xpack/XPackInfoResponse.java
@@ -318,11 +318,6 @@ public class XPackInfoResponse {
                 return name;
             }
 
-            @Nullable
-            public String description() {
-                return description;
-            }
-
             public boolean available() {
                 return available;
             }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/PingAndInfoIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/PingAndInfoIT.java
@@ -71,17 +71,14 @@ public class PingAndInfoIT extends ESRestHighLevelClientTestCase {
         assertEquals(LicenseStatus.ACTIVE, info.getLicenseInfo().getStatus());
 
         FeatureSet graph = info.getFeatureSetsInfo().getFeatureSets().get("graph");
-        assertNotNull(graph.description());
         assertTrue(graph.available());
         assertTrue(graph.enabled());
         assertNull(graph.nativeCodeInfo());
         FeatureSet monitoring = info.getFeatureSetsInfo().getFeatureSets().get("monitoring");
-        assertNotNull(monitoring.description());
         assertTrue(monitoring.available());
         assertTrue(monitoring.enabled());
         assertNull(monitoring.nativeCodeInfo());
         FeatureSet ml = info.getFeatureSetsInfo().getFeatureSets().get("ml");
-        assertNotNull(ml.description());
         assertTrue(ml.available());
         assertTrue(ml.enabled());
         assertEquals(mainResponse.getVersion().getNumber(), ml.nativeCodeInfo().get("version").toString());

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/XPackInfoResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/XPackInfoResponseTests.java
@@ -70,8 +70,7 @@ public class XPackInfoResponseTests extends
     private FeatureSetsInfo convertHlrcToInternal(org.elasticsearch.client.xpack.XPackInfoResponse.FeatureSetsInfo featureSetsInfo) {
         return featureSetsInfo != null
             ? new FeatureSetsInfo(featureSetsInfo.getFeatureSets().values().stream()
-            .map(fs -> new FeatureSet(fs.name(), fs.description(), fs.available(), fs.enabled(),
-                fs.nativeCodeInfo()))
+            .map(fs -> new FeatureSet(fs.name(), fs.available(), fs.enabled(), fs.nativeCodeInfo()))
             .collect(Collectors.toSet()))
             : null;
     }
@@ -169,7 +168,6 @@ public class XPackInfoResponseTests extends
     private FeatureSet randomFeatureSet() {
         return new FeatureSet(
             randomAlphaOfLength(5),
-            randomBoolean() ? null : randomAlphaOfLength(20),
             randomBoolean(),
             randomBoolean(),
             randomNativeCodeInfo());

--- a/docs/reference/rest-api/info.asciidoc
+++ b/docs/reference/rest-api/info.asciidoc
@@ -64,32 +64,26 @@ Example response:
    },
    "features" : {
       "ccr" : {
-        "description" : "Cross Cluster Replication",
         "available" : true,
         "enabled" : true
       },
       "data_frame" : {
-          "description" : "Data Frame for the Elastic Stack",
           "available" : true,
           "enabled" : true
       },
       "graph" : {
-         "description" : "Graph Data Exploration for the Elastic Stack",
          "available" : true,
          "enabled" : true
       },
       "ilm" : {
-         "description" : "Index lifecycle management for the Elastic Stack",
          "available" : true,
          "enabled" : true
       },
       "logstash" : {
-         "description" : "Logstash management component for X-Pack",
          "available" : true,
          "enabled" : true
       },
       "ml" : {
-         "description" : "Machine Learning for the Elastic Stack",
          "available" : true,
          "enabled" : true,
          "native_code_info" : {
@@ -98,27 +92,22 @@ Example response:
         }
       },
       "monitoring" : {
-         "description" : "Monitoring for the Elastic Stack",
          "available" : true,
          "enabled" : true
       },
       "rollup": {
-        "description": "Time series pre-aggregation and rollup",
          "available": true,
          "enabled": true
       },
       "security" : {
-         "description" : "Security for the Elastic Stack",
          "available" : true,
          "enabled" : false
       },
       "sql" : {
-         "description" : "SQL access to Elasticsearch",
          "available" : true,
          "enabled" : true
       },
       "watcher" : {
-         "description" : "Alerting, Notification and Automation for the Elastic Stack",
          "available" : true,
          "enabled" : true
       }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/EmptyXPackFeatureSet.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/EmptyXPackFeatureSet.java
@@ -17,11 +17,6 @@ public class EmptyXPackFeatureSet implements XPackFeatureSet {
     }
 
     @Override
-    public String description() {
-        return "Core will not function without this empty featureset compliments of the way the TransportXPackInfoAction Guice works";
-    }
-
-    @Override
     public boolean available() {
         return false;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackFeatureSet.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackFeatureSet.java
@@ -19,8 +19,6 @@ public interface XPackFeatureSet {
 
     String name();
 
-    String description();
-
     boolean available();
 
     boolean enabled();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportXPackInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportXPackInfoAction.java
@@ -58,7 +58,7 @@ public class TransportXPackInfoAction extends HandledTransportAction<XPackInfoRe
         XPackInfoResponse.FeatureSetsInfo featureSetsInfo = null;
         if (request.getCategories().contains(XPackInfoRequest.Category.FEATURES)) {
             Set<FeatureSet> featureSets = this.featureSets.stream().map(fs ->
-                    new FeatureSet(fs.name(), request.isVerbose() ? fs.description() : null, fs.available(), fs.enabled(),
+                    new FeatureSet(fs.name(), fs.available(), fs.enabled(),
                             request.isVerbose() ? fs.nativeCodeInfo() : null))
                     .collect(Collectors.toSet());
             featureSetsInfo = new XPackInfoResponse.FeatureSetsInfo(featureSets);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/CCRFeatureSet.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/CCRFeatureSet.java
@@ -44,11 +44,6 @@ public class CCRFeatureSet implements XPackFeatureSet {
     }
 
     @Override
-    public String description() {
-        return "Cross Cluster Replication";
-    }
-
-    @Override
     public boolean available() {
         return licenseState != null && licenseState.isCcrAllowed();
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/action/TransportXPackInfoActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/action/TransportXPackInfoActionTests.java
@@ -49,7 +49,6 @@ public class TransportXPackInfoActionTests extends ESTestCase {
         for (int i = 0; i < featureSetCount; i++) {
             XPackFeatureSet fs = mock(XPackFeatureSet.class);
             when(fs.name()).thenReturn(randomAlphaOfLength(5));
-            when(fs.description()).thenReturn(randomAlphaOfLength(10));
             when(fs.available()).thenReturn(randomBoolean());
             when(fs.enabled()).thenReturn(randomBoolean());
             featureSets.add(fs);
@@ -131,11 +130,6 @@ public class TransportXPackInfoActionTests extends ESTestCase {
             for (XPackFeatureSet fs : featureSets) {
                 assertThat(features, hasKey(fs.name()));
                 assertThat(features.get(fs.name()).name(), equalTo(fs.name()));
-                if (!request.isVerbose()) {
-                    assertThat(features.get(fs.name()).description(), is(nullValue()));
-                } else {
-                    assertThat(features.get(fs.name()).description(), is(fs.description()));
-                }
                 assertThat(features.get(fs.name()).available(), equalTo(fs.available()));
                 assertThat(features.get(fs.name()).enabled(), equalTo(fs.enabled()));
             }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/DataFrameFeatureSet.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/DataFrameFeatureSet.java
@@ -85,11 +85,6 @@ public class DataFrameFeatureSet implements XPackFeatureSet {
     }
 
     @Override
-    public String description() {
-        return "Data Frame for the Elastic Stack";
-    }
-
-    @Override
     public boolean available() {
         return licenseState != null && licenseState.isDataFrameAllowed();
     }

--- a/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/GraphFeatureSet.java
+++ b/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/GraphFeatureSet.java
@@ -34,11 +34,6 @@ public class GraphFeatureSet implements XPackFeatureSet {
     }
 
     @Override
-    public String description() {
-        return "Graph Data Exploration for the Elastic Stack";
-    }
-
-    @Override
     public boolean available() {
         return licenseState != null && licenseState.isGraphAllowed();
     }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleFeatureSet.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleFeatureSet.java
@@ -46,11 +46,6 @@ public class IndexLifecycleFeatureSet implements XPackFeatureSet {
     }
 
     @Override
-    public String description() {
-        return "Index lifecycle management for the Elastic Stack";
-    }
-
-    @Override
     public boolean available() {
         return licenseState != null && licenseState.isIndexLifecycleAllowed();
     }

--- a/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/LogstashFeatureSet.java
+++ b/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/LogstashFeatureSet.java
@@ -35,11 +35,6 @@ public class LogstashFeatureSet implements XPackFeatureSet {
     }
 
     @Override
-    public String description() {
-        return "Logstash management component for X-Pack";
-    }
-
-    @Override
     public boolean available() {
         return licenseState != null && licenseState.isLogstashAllowed();
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSet.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSet.java
@@ -113,11 +113,6 @@ public class MachineLearningFeatureSet implements XPackFeatureSet {
     }
 
     @Override
-    public String description() {
-        return "Machine Learning for the Elastic Stack";
-    }
-
-    @Override
     public boolean available() {
         return licenseState != null && licenseState.isMachineLearningAllowed();
     }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringFeatureSet.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringFeatureSet.java
@@ -44,11 +44,6 @@ public class MonitoringFeatureSet implements XPackFeatureSet {
     }
 
     @Override
-    public String description() {
-        return "Monitoring for the Elastic Stack";
-    }
-
-    @Override
     public boolean available() {
         return licenseState != null && licenseState.isMonitoringAllowed();
     }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/RollupFeatureSet.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/RollupFeatureSet.java
@@ -34,11 +34,6 @@ public class RollupFeatureSet implements XPackFeatureSet {
     }
 
     @Override
-    public String description() {
-        return "Time series pre-aggregation and rollup";
-    }
-
-    @Override
     public boolean available() {
         return licenseState != null && licenseState.isRollupAllowed();
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityFeatureSet.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityFeatureSet.java
@@ -69,11 +69,6 @@ public class SecurityFeatureSet implements XPackFeatureSet {
     }
 
     @Override
-    public String description() {
-        return "Security for the Elastic Stack";
-    }
-
-    @Override
     public boolean available() {
         return licenseState != null && licenseState.isSecurityAvailable();
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/tool/SetupPasswordToolTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/tool/SetupPasswordToolTests.java
@@ -236,8 +236,8 @@ public class SetupPasswordToolTests extends CommandTestCase {
         URL xpackSecurityPluginQueryURL = queryXPackSecurityFeatureConfigURL(url);
 
         Set<FeatureSet> featureSets = new HashSet<>();
-        featureSets.add(new FeatureSet("logstash", null, true, true, null));
-        featureSets.add(new FeatureSet("security", null, true, true, null));
+        featureSets.add(new FeatureSet("logstash", true, true, null));
+        featureSets.add(new FeatureSet("security", true, true, null));
         FeatureSetsInfo featureInfos = new FeatureSetsInfo(featureSets);
         XPackInfoResponse xpackInfo = new XPackInfoResponse(null, null, featureInfos);
         String securityPluginQueryResponseBody = null;
@@ -267,8 +267,8 @@ public class SetupPasswordToolTests extends CommandTestCase {
                 any(CheckedFunction.class))).thenReturn(httpResponse);
 
         Set<FeatureSet> featureSets = new HashSet<>();
-        featureSets.add(new FeatureSet("logstash", null, true, true, null));
-        featureSets.add(new FeatureSet("security", null, false, false, null));
+        featureSets.add(new FeatureSet("logstash", true, true, null));
+        featureSets.add(new FeatureSet("security", false, false, null));
         FeatureSetsInfo featureInfos = new FeatureSetsInfo(featureSets);
         XPackInfoResponse xpackInfo = new XPackInfoResponse(null, null, featureInfos);
         String securityPluginQueryResponseBody = null;
@@ -298,8 +298,8 @@ public class SetupPasswordToolTests extends CommandTestCase {
                 any(CheckedFunction.class))).thenReturn(httpResponse);
 
         Set<FeatureSet> featureSets = new HashSet<>();
-        featureSets.add(new FeatureSet("logstash", null, true, true, null));
-        featureSets.add(new FeatureSet("security", null, true, false, null));
+        featureSets.add(new FeatureSet("logstash", true, true, null));
+        featureSets.add(new FeatureSet("security", true, false, null));
         FeatureSetsInfo featureInfos = new FeatureSetsInfo(featureSets);
         XPackInfoResponse xpackInfo = new XPackInfoResponse(null, null, featureInfos);
         String securityPluginQueryResponseBody = null;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/SqlFeatureSet.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/SqlFeatureSet.java
@@ -46,11 +46,6 @@ public class SqlFeatureSet implements XPackFeatureSet {
     }
 
     @Override
-    public String description() {
-        return "SQL access to Elasticsearch";
-    }
-
-    @Override
     public boolean available() {
         return licenseState != null && licenseState.isSqlAllowed();
     }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/xpack/15_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/xpack/15_basic.yml
@@ -68,19 +68,15 @@
   - is_true:    features.watcher
   - is_true:    features.watcher.enabled
   - is_true:    features.watcher.available
-  - is_true:    features.watcher.description
   - is_true:    features.security
   - is_true:    features.security.enabled
   - is_true:    features.security.available
-  - is_true:    features.security.description
   - is_true:    features.graph
   - is_true:    features.graph.enabled
   - is_true:    features.graph.available
-  - is_true:    features.graph.description
   - is_true:    features.monitoring
   - is_true:    features.monitoring.enabled
   - is_true:    features.monitoring.available
-  - is_true:    features.monitoring.description
   - is_true:    tagline
 
   - do:
@@ -152,19 +148,15 @@
   - is_true:    features.watcher
   - is_true:    features.watcher.enabled
   - is_true:    features.watcher.available
-  - is_false:   features.watcher.description
   - is_true:    features.security
   - is_true:    features.security.enabled
   - is_true:    features.security.available
-  - is_false:   features.security.description
   - is_true:    features.graph
   - is_true:    features.graph.enabled
   - is_true:    features.graph.available
-  - is_false:   features.graph.description
   - is_true:    features.monitoring
   - is_true:    features.monitoring.enabled
   - is_true:    features.monitoring.available
-  - is_false:   features.monitoring.description
   - is_false:   tagline
 
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherFeatureSet.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherFeatureSet.java
@@ -48,11 +48,6 @@ public class WatcherFeatureSet implements XPackFeatureSet {
     }
 
     @Override
-    public String description() {
-        return "Alerting, Notification and Automation for the Elastic Stack";
-    }
-
-    @Override
     public boolean available() {
         return licenseState != null && licenseState.isWatcherAllowed();
     }


### PR DESCRIPTION
The description field of xpack featuresets is optionally part of the
xpack info api, when using the verbose flag. However, this information
is unnecessary, as it is better left for documentation (and the existing
descriptions describe anything meaningful). This commit removes the
description field from feature sets.