### PR TITLE
Enable backwards compatibility with Java 8 for build-tools

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -121,9 +121,12 @@ if (project != rootProject) {
   apply plugin: 'nebula.maven-base-publish'
   apply plugin: 'nebula.maven-scm'
 
-  // we need to apply these again to override the build plugin
-  targetCompatibility = "10"
-  sourceCompatibility = "10"
+  // instruct the build plugin to omit the --release compiler flag so we can still compile against Java 9+ APIs
+  ext.useReleaseArg = false
+
+  // Keep compatibility with Java 8 for external users of build-tools that haven't migrated to Java 11
+  targetCompatibility = "8"
+  sourceCompatibility = "8"
 
   // groovydoc succeeds, but has some weird internal exception...
   groovydoc.enabled = false

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -592,6 +592,7 @@ class BuildPlugin implements Plugin<Project> {
     static void configureCompile(Project project) {
         ExtraPropertiesExtension ext = project.extensions.getByType(ExtraPropertiesExtension)
         ext.set('compactProfile', 'full')
+        ext.set('useReleaseArg', true)
 
         project.extensions.getByType(JavaPluginExtension).sourceCompatibility = ext.get('minimumRuntimeVersion') as JavaVersion
         project.extensions.getByType(JavaPluginExtension).targetCompatibility = ext.get('minimumRuntimeVersion') as JavaVersion
@@ -626,7 +627,9 @@ class BuildPlugin implements Plugin<Project> {
                 compileTask.options.incremental = true
 
                 // TODO: use native Gradle support for --release when available (cf. https://github.com/gradle/gradle/issues/2510)
-                compileTask.options.compilerArgs << '--release' << targetCompatibilityVersion.majorVersion
+                if (ext.get('useReleaseArg')) {
+                    compileTask.options.compilerArgs << '--release' << targetCompatibilityVersion.majorVersion
+                }
             }
             // also apply release flag to groovy, which is used in build-tools
             project.tasks.withType(GroovyCompile) { GroovyCompile compileTask ->
@@ -636,7 +639,9 @@ class BuildPlugin implements Plugin<Project> {
                 } else {
                     compileTask.options.fork = true
                     compileTask.options.forkOptions.javaHome = compilerJavaHome
-                    compileTask.options.compilerArgs << '--release' << JavaVersion.toVersion(compileTask.targetCompatibility).majorVersion
+                    if (ext.get('useReleaseArg')) {
+                        compileTask.options.compilerArgs << '--release' << JavaVersion.toVersion(compileTask.targetCompatibility).majorVersion
+                    }
                 }
             }
         }


### PR DESCRIPTION
The elasticsearch-hadoop project is still on Java 8 for a number reasons but requires the use of the `build-tools` project built from the elasticseach source. A previous attempt to make this compatible didn't actually work and we are still publishing JDK 10 target source to artifactory for this project. This PR changes the build-tools project target compatibility to Java 8, and introduces a flag to disable the `--release` compiler argument so that we can still use the configured compiler Java home bootstrap classpath. This is because we rely on JDK9+ APIs in `buildSrc` but `elasticsearch-hadoop` and others don't actually use any of those classes.