### PR TITLE
Do not use runtime Java when starting BWC nodes

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -657,8 +657,8 @@ class ClusterFormationTasks {
     static Task configureExecTask(String name, Project project, Task setup, NodeInfo node, Object[] execArgs) {
         return project.tasks.create(name: name, type: LoggedExec, dependsOn: setup) { Exec exec ->
             exec.workingDir node.cwd
-            if (project.isRuntimeJavaHomeSet || node.nodeVersion.before(Version.fromString("7.0.0")) ||
-                node.config.distribution == 'integ-test-zip') {
+            if ((project.isRuntimeJavaHomeSet && node.isBwcNode == false) // runtime Java might not be compatible with old nodes
+                    || node.config.distribution == 'integ-test-zip') {
                 exec.environment.put('JAVA_HOME', project.runtimeJavaHome)
             } else {
                 // force JAVA_HOME to *not* be set
@@ -683,8 +683,8 @@ class ClusterFormationTasks {
             ant.exec(executable: node.executable, spawn: node.config.daemonize, newenvironment: true,
                      dir: node.cwd, taskname: 'elasticsearch') {
                 node.env.each { key, value -> env(key: key, value: value) }
-                if (project.isRuntimeJavaHomeSet || node.nodeVersion.before(Version.fromString("7.0.0")) ||
-                    node.config.distribution == 'integ-test-zip') {
+                if ((project.isRuntimeJavaHomeSet && node.isBwcNode == false) // runtime Java might not be compatible with old nodes
+                        || node.config.distribution == 'integ-test-zip') {
                     env(key: 'JAVA_HOME', value: project.runtimeJavaHome)
                 }
                 node.args.each { arg(value: it) }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
@@ -23,6 +23,7 @@ import com.sun.jna.Native
 import com.sun.jna.WString
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.elasticsearch.gradle.Version
+import org.elasticsearch.gradle.VersionProperties
 import org.gradle.api.Project
 
 import java.nio.file.Files
@@ -107,6 +108,9 @@ class NodeInfo {
     /** the version of elasticsearch that this node runs */
     Version nodeVersion
 
+    /** true if the node is not the current version */
+    boolean isBwcNode
+
     /** Holds node configuration for part of a test cluster. */
     NodeInfo(ClusterConfiguration config, int nodeNum, Project project, String prefix, String nodeVersion, File sharedDir) {
         this.config = config
@@ -121,6 +125,7 @@ class NodeInfo {
         baseDir = new File(project.buildDir, "cluster/${prefix} node${nodeNum}")
         pidFile = new File(baseDir, 'es.pid')
         this.nodeVersion = Version.fromString(nodeVersion)
+        this.isBwcNode = this.nodeVersion.before(VersionProperties.elasticsearch)
         homeDir = new File(baseDir, "elasticsearch-${nodeVersion}")
         pathConf = new File(homeDir, 'config')
         if (config.dataDir != null) {


### PR DESCRIPTION
When starting BWC nodes, it could be that runtime Java home is set. Yet, runtime Java home can advance beyond what a BWC node might be compatible with. For example, if runtime Java home is set to JDK 13 and we are starting a 7.1.2 node, we do not have any guarantees that 7.1.2 is compatible with JDK 13 (since we never did any work to make it so). This will continue to be the case as JDK releases advance, but we still need to test against BWC nodes. This commit stops applying runtime Java home when starting a BWC node. Instead, we would use the bundled JDK.

Closes #43024