### PR TITLE
[DOCS] remove mentions of "fields with the same name in the same index"

### DIFF
--- a/docs/reference/mapping/params/coerce.asciidoc
+++ b/docs/reference/mapping/params/coerce.asciidoc
@@ -47,8 +47,7 @@ PUT my_index/_doc/2
 <1> The `number_one` field will contain the integer `10`.
 <2> This document will be rejected because coercion is disabled.
 
-TIP: The `coerce` setting is allowed to have different settings for fields of
-the same name in the same index.  Its value can be updated on existing fields
+TIP: The `coerce` setting value can be updated on existing fields
 using the <<indices-put-mapping,PUT mapping API>>.
 
 [[coerce-setting]]

--- a/docs/reference/mapping/params/ignore-malformed.asciidoc
+++ b/docs/reference/mapping/params/ignore-malformed.asciidoc
@@ -46,8 +46,7 @@ PUT my_index/_doc/2
 <1> This document will have the `text` field indexed, but not the `number_one` field.
 <2> This document will be rejected because `number_two` does not allow malformed values.
 
-TIP: The `ignore_malformed` setting is allowed to have different settings for
-fields of the same name in the same index.  Its value can be updated on
+TIP: The `ignore_malformed` setting value can be updated on
 existing fields using the <<indices-put-mapping,PUT mapping API>>.
 
 

--- a/docs/reference/mapping/params/multi-fields.asciidoc
+++ b/docs/reference/mapping/params/multi-fields.asciidoc
@@ -60,8 +60,7 @@ GET my_index/_search
 
 NOTE: Multi-fields do not change the original `_source` field.
 
-TIP: The `fields` setting is allowed to have different settings for fields of
-the same name in the same index.  New multi-fields can be added to existing
+TIP: New multi-fields can be added to existing
 fields using the <<indices-put-mapping,PUT mapping API>>.
 
 ==== Multi-fields with multiple analyzers

--- a/docs/reference/mapping/params/norms.asciidoc
+++ b/docs/reference/mapping/params/norms.asciidoc
@@ -11,11 +11,10 @@ don't need scoring on a specific field, you should disable norms on that
 field. In  particular, this is the case for fields that are used solely for
 filtering or aggregations.
 
-TIP: The `norms` setting must have the same setting for fields of the
-same name in the same index.  Norms can be disabled on existing fields using
+TIP: Norms can be disabled on existing fields using
 the <<indices-put-mapping,PUT mapping API>>.
 
-Norms can be disabled (but not reenabled) after the fact, using the
+Norms can be disabled (but not reenabled after the fact), using the
 <<indices-put-mapping,PUT mapping API>> like so:
 
 [source,js]


### PR DESCRIPTION
As part of [types removal](https://github.com/elastic/elasticsearch/issues/41059) in 8.0, it doesn't make sense to keep around any mention of "fields with the same name in the same index" around in the documentation.