### PR TITLE
Docs enhancement for quote_field_suffix.

### DIFF
--- a/docs/reference/how-to/recipes/stemming.asciidoc
+++ b/docs/reference/how-to/recipes/stemming.asciidoc
@@ -228,3 +228,5 @@ In the above case, since `ski` was in-between quotes, it was searched on the
 `body.exact` field due to the `quote_field_suffix` parameter, so only document
 `1` matched. This allows users to mix exact search with stemmed search as they
 like.
+Note that if the choice of field passed in `quote_field_suffix` does not exist 
+the search will fall back to using the default field for the query string.

--- a/docs/reference/how-to/recipes/stemming.asciidoc
+++ b/docs/reference/how-to/recipes/stemming.asciidoc
@@ -228,5 +228,6 @@ In the above case, since `ski` was in-between quotes, it was searched on the
 `body.exact` field due to the `quote_field_suffix` parameter, so only document
 `1` matched. This allows users to mix exact search with stemmed search as they
 like.
-Note that if the choice of field passed in `quote_field_suffix` does not exist 
+
+NOTE: If the choice of field passed in `quote_field_suffix` does not exist 
 the search will fall back to using the default field for the query string.


### PR DESCRIPTION
Mentions the use of a fall-back field when specified field is missing.
Closes #40778