### PR TITLE
[ML] Lock down extraction method when possible

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/fields/ExtractedField.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/fields/ExtractedField.java
@@ -69,12 +69,12 @@ public abstract class ExtractedField {
         return new TimeField(name, extractionMethod);
     }
 
-    public static ExtractedField newGeoShapeField(String alias, String name, ExtractionMethod extractionMethod) {
-        return new GeoShapeField(alias, name, extractionMethod);
+    public static ExtractedField newGeoShapeField(String alias, String name) {
+        return new GeoShapeField(alias, name);
     }
 
-    public static ExtractedField newGeoPointField(String alias, String name, ExtractionMethod extractionMethod) {
-        return new GeoPointField(alias, name, extractionMethod);
+    public static ExtractedField newGeoPointField(String alias, String name) {
+        return new GeoPointField(alias, name);
     }
 
     public static ExtractedField newField(String name, ExtractionMethod extractionMethod) {
@@ -87,7 +87,7 @@ public abstract class ExtractedField {
             case SCRIPT_FIELD:
                 return new FromFields(alias, name, extractionMethod);
             case SOURCE:
-                return new FromSource(alias, name, extractionMethod);
+                return new FromSource(alias, name);
             default:
                 throw new IllegalArgumentException("Invalid extraction method [" + extractionMethod + "]");
         }
@@ -113,8 +113,8 @@ public abstract class ExtractedField {
     private static class GeoShapeField extends FromSource {
         private static final WellKnownText wkt = new WellKnownText();
 
-        GeoShapeField(String alias, String name, ExtractionMethod extractionMethod) {
-            super(alias, name, extractionMethod);
+        GeoShapeField(String alias, String name) {
+            super(alias, name);
         }
 
         @Override
@@ -170,11 +170,8 @@ public abstract class ExtractedField {
 
     private static class GeoPointField extends FromFields {
 
-        GeoPointField(String alias, String name, ExtractionMethod extractionMethod) {
-            super(alias, name, extractionMethod);
-            if (extractionMethod != ExtractionMethod.DOC_VALUE) {
-                throw new IllegalArgumentException("cannot use [geo_point] field with disabled doc values");
-            }
+        GeoPointField(String alias, String name) {
+            super(alias, name, ExtractionMethod.DOC_VALUE);
         }
 
         @Override
@@ -232,8 +229,8 @@ public abstract class ExtractedField {
 
         private String[] namePath;
 
-        FromSource(String alias, String name, ExtractionMethod extractionMethod) {
-            super(alias, name, extractionMethod);
+        FromSource(String alias, String name) {
+            super(alias, name, ExtractionMethod.SOURCE);
             namePath = name.split("\\.");
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/fields/ExtractedFields.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/fields/ExtractedFields.java
@@ -87,12 +87,17 @@ public class ExtractedFields {
                             : ExtractedField.ExtractionMethod.SOURCE;
                 }
             }
+
             if (isFieldOfType(field, "geo_point")) {
-                return ExtractedField.newGeoPointField(field, internalField, method);
+                if (method != ExtractedField.ExtractionMethod.DOC_VALUE) {
+                    throw new IllegalArgumentException("cannot use [geo_point] field with disabled doc values");
+                }
+                return ExtractedField.newGeoPointField(field, internalField);
             }
             if (isFieldOfType(field, "geo_shape")) {
-                return ExtractedField.newGeoShapeField(field, internalField, method);
+                return ExtractedField.newGeoShapeField(field, internalField);
             }
+
             return ExtractedField.newField(field, internalField, method);
         }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/fields/ExtractedFieldTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/fields/ExtractedFieldTests.java
@@ -68,7 +68,7 @@ public class ExtractedFieldTests extends ESTestCase {
         String[] expected = new String[] {lat + "," + lon};
 
         // doc_value field
-        ExtractedField geo = ExtractedField.newGeoPointField("geo", "geo", ExtractedField.ExtractionMethod.DOC_VALUE);
+        ExtractedField geo = ExtractedField.newGeoPointField("geo", "geo");
         SearchHit hit = new SearchHitBuilder(42).addField("geo", lat + ", " + lon).build();
         assertThat(geo.value(hit), equalTo(expected));
     }
@@ -81,12 +81,12 @@ public class ExtractedFieldTests extends ESTestCase {
         SearchHit hit = new SearchHitBuilder(42)
             .setSource("{\"geo\":{\"type\":\"point\", \"coordinates\": [" + lon + ", " + lat + "]}}")
             .build();
-        ExtractedField geo = ExtractedField.newGeoShapeField("geo", "geo", ExtractedField.ExtractionMethod.SOURCE);
+        ExtractedField geo = ExtractedField.newGeoShapeField("geo", "geo");
         assertThat(geo.value(hit), equalTo(expected));
 
         // WKT format
         hit = new SearchHitBuilder(42).setSource("{\"geo\":\"POINT ("+ lon + " " + lat + ")\"}").build();
-        geo = ExtractedField.newGeoShapeField("geo", "geo", ExtractedField.ExtractionMethod.SOURCE);
+        geo = ExtractedField.newGeoShapeField("geo", "geo");
         assertThat(geo.value(hit), equalTo(expected));
     }
 


### PR DESCRIPTION
In certain implementations of `ExtractedField` we can expect a single type of extraction method. Forcing that makes the code clearer and less error prone.