### PR TITLE
ignore_malformed does not work on TEXT datatypes.

### DIFF
--- a/docs/reference/mapping/params/ignore-malformed.asciidoc
+++ b/docs/reference/mapping/params/ignore-malformed.asciidoc
@@ -98,6 +98,7 @@ You can't use `ignore_malformed` with the following datatypes:
 * <<nested, Nested datatype>>
 * <<object, Object datatype>>
 * <<range, Range datatypes>>
+* <<text, Text datatype>>
 
 You also can't use `ignore_malformed` to ignore JSON objects submitted to fields
 of the wrong datatype. A JSON object is any data surrounded by curly brackets


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/issues/12366

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? Yes
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)? Yes
