### PR TITLE
Ignore internal SQL methods for Painless API Docs

### DIFF
--- a/modules/lang-painless/src/doc/java/org/elasticsearch/painless/ContextDocGenerator.java
+++ b/modules/lang-painless/src/doc/java/org/elasticsearch/painless/ContextDocGenerator.java
@@ -798,6 +798,7 @@ public final class ContextDocGenerator {
 
     private static boolean isInternalClass(String javaName) {
         return  javaName.equals("org.elasticsearch.script.ScoreScript") ||
+                javaName.equals("org.elasticsearch.xpack.sql.expression.function.scalar.geo.GeoShape") ||
                 javaName.equals("org.elasticsearch.xpack.sql.expression.function.scalar.whitelist.InternalSqlScriptUtils") ||
                 javaName.equals("org.elasticsearch.xpack.sql.expression.literal.IntervalDayTime") ||
                 javaName.equals("org.elasticsearch.xpack.sql.expression.literal.IntervalYearMonth");


### PR DESCRIPTION
This ensures that internal SQL methods continue to be excluded from the public API documentation.