### PR TITLE
Fix mustache search template test

### DIFF
--- a/modules/lang-mustache/src/test/resources/rest-api-spec/test/lang_mustache/30_search_template.yml
+++ b/modules/lang-mustache/src/test/resources/rest-api-spec/test/lang_mustache/30_search_template.yml
@@ -128,16 +128,12 @@
 
 ---
 "Test with new response format":
-
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/42664"
-
   - do:
       index:
         index:  test
         id:     1
         body:   {}
+        refresh: true
 
   - do:
       put_script:
@@ -150,5 +146,5 @@
       search_template:
         body: { "id": "template_1", "params": {} }
 
-  - match: { hits.total.value: 0 }
+  - match: { hits.total.value: 1 }
   - match: { hits.total.relation: eq }


### PR DESCRIPTION
This commit fixes a race in the test for the new response format with
search templates. The test indexes a document and then executes a
search with the expectation of 0 results. In some instances, the index
will refresh prior to the search execution and 1 hit will be found
causing the test fail.

Closes #42664