### PR TITLE
[ML DataFrame] Data Frame Ids with upper case chars are invalid

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/utils/DataFrameStrings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/utils/DataFrameStrings.java
@@ -16,11 +16,11 @@ public final class DataFrameStrings {
 
     /**
      * Valid user id pattern.
-     * Matches a string that contains characters, digits, hyphens, underscores or dots.
+     * Matches a string that contains lowercase characters, digits, hyphens, underscores or dots.
      * The string may start and end only in characters or digits.
      * Note that '.' is allowed but not documented.
      */
-    private static final Pattern VALID_ID_CHAR_PATTERN = Pattern.compile("[a-zA-Z0-9](?:[a-zA-Z0-9_\\-\\.]*[a-zA-Z0-9])?");
+    private static final Pattern VALID_ID_CHAR_PATTERN = Pattern.compile("[a-z0-9](?:[a-z0-9_\\-\\.]*[a-z0-9])?");
 
     public static final int ID_LENGTH_LIMIT = 64;
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/utils/DataFrameStringsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/utils/DataFrameStringsTests.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.dataframe.utils;
+
+import org.elasticsearch.test.ESTestCase;
+
+public class DataFrameStringsTests extends ESTestCase {
+
+    public void testValidId() {
+        assertTrue(DataFrameStrings.isValidId("valid-_id"));
+    }
+
+    public void testValidId_givenUppercase() {
+        assertFalse(DataFrameStrings.isValidId("MiXedCase"));
+    }
+
+    public void testValidId_givenStartsWithUnderScore() {
+        assertFalse(DataFrameStrings.isValidId("_this_bit_is_ok"));
+    }
+
+    public void testKasValidLengthForId_givenTooLong() {
+        assertTrue(DataFrameStrings.hasValidLengthForId("#".repeat(DataFrameStrings.ID_LENGTH_LIMIT )));
+        assertFalse(DataFrameStrings.hasValidLengthForId("#".repeat(DataFrameStrings.ID_LENGTH_LIMIT + 1)));
+    }
+}
+

--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameAuditorIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameAuditorIT.java
@@ -53,7 +53,7 @@ public class DataFrameAuditorIT extends DataFrameRestTestCase {
 
     @SuppressWarnings("unchecked")
     public void testAuditorWritesAudits() throws Exception {
-        String transformId = "simplePivotForAudit";
+        String transformId = "simple_pivot_for_audit";
         String dataFrameIndex = "pivot_reviews_user_id_above_20";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, dataFrameIndex);
         String query = "\"match\": {\"user_id\": \"user_26\"}";
@@ -64,7 +64,7 @@ public class DataFrameAuditorIT extends DataFrameRestTestCase {
 
         // Make sure we wrote to the audit
         final Request request = new Request("GET", DataFrameInternalIndex.AUDIT_INDEX + "/_search");
-        request.setJsonEntity("{\"query\":{\"term\":{\"transform_id\":\"simplePivotForAudit\"}}}");
+        request.setJsonEntity("{\"query\":{\"term\":{\"transform_id\":\"simple_pivot_for_audit\"}}}");
         assertBusy(() -> {
             assertTrue(indexExists(DataFrameInternalIndex.AUDIT_INDEX));
         });

--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameGetAndGetStatsIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameGetAndGetStatsIT.java
@@ -160,7 +160,7 @@ public class DataFrameGetAndGetStatsIT extends DataFrameRestTestCase {
 
     @SuppressWarnings("unchecked")
     public void testGetProgressStatsWithPivotQuery() throws Exception {
-        String transformId = "simpleStatsPivotWithQuery";
+        String transformId = "simple_stats_pivot_with_query";
         String dataFrameIndex = "pivot_stats_reviews_user_id_above_20";
         String query = "\"match\": {\"user_id\": \"user_26\"}";
         createPivotReviewsTransform(transformId, dataFrameIndex, query);
@@ -169,7 +169,7 @@ public class DataFrameGetAndGetStatsIT extends DataFrameRestTestCase {
         // Alternate testing between admin and lowly user, as both should be able to get the configs and stats
         String authHeader = randomFrom(BASIC_AUTH_VALUE_DATA_FRAME_USER, BASIC_AUTH_VALUE_DATA_FRAME_ADMIN);
 
-        Request getRequest = createRequestWithAuth("GET", DATAFRAME_ENDPOINT + "simpleStatsPivotWithQuery/_stats", authHeader);
+        Request getRequest = createRequestWithAuth("GET", DATAFRAME_ENDPOINT + transformId + "/_stats", authHeader);
         Map<String, Object> stats = entityAsMap(client().performRequest(getRequest));
         assertEquals(1, XContentMapValues.extractValue("count", stats));
         List<Map<String, Object>> transformsStats = (List<Map<String, Object>>)XContentMapValues.extractValue("transforms", stats);

--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFramePivotRestIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFramePivotRestIT.java
@@ -51,7 +51,7 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
     }
 
     public void testSimplePivot() throws Exception {
-        String transformId = "simplePivot";
+        String transformId = "simple-pivot";
         String dataFrameIndex = "pivot_reviews";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, dataFrameIndex);
 
@@ -72,7 +72,7 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
     }
 
     public void testSimplePivotWithQuery() throws Exception {
-        String transformId = "simplePivotWithQuery";
+        String transformId = "simple_pivot_with_query";
         String dataFrameIndex = "pivot_reviews_user_id_above_20";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, dataFrameIndex);
         String query = "\"match\": {\"user_id\": \"user_26\"}";
@@ -88,7 +88,7 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
     }
 
     public void testHistogramPivot() throws Exception {
-        String transformId = "simpleHistogramPivot";
+        String transformId = "simple_histogram_pivot";
         String dataFrameIndex = "pivot_reviews_via_histogram";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, dataFrameIndex);
 
@@ -126,7 +126,7 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
     }
 
     public void testBiggerPivot() throws Exception {
-        String transformId = "biggerPivot";
+        String transformId = "bigger_pivot";
         String dataFrameIndex = "bigger_pivot_reviews";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, dataFrameIndex);
 
@@ -201,7 +201,7 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
     }
 
     public void testDateHistogramPivot() throws Exception {
-        String transformId = "simpleDateHistogramPivot";
+        String transformId = "simple_date_histogram_pivot";
         String dataFrameIndex = "pivot_reviews_via_date_histogram";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, dataFrameIndex);
 
@@ -275,7 +275,7 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
     }
 
     public void testPivotWithMaxOnDateField() throws Exception {
-        String transformId = "simpleDateHistogramPivotWithMaxTime";
+        String transformId = "simple_date_histogram_pivot_with_max_time";
         String dataFrameIndex = "pivot_reviews_via_date_histogram_with_max_time";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, dataFrameIndex);
 
@@ -322,7 +322,7 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
     }
 
     public void testPivotWithScriptedMetricAgg() throws Exception {
-        String transformId = "scriptedMetricPivot";
+        String transformId = "scripted_metric_pivot";
         String dataFrameIndex = "scripted_metric_pivot_reviews";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, dataFrameIndex);
 
@@ -375,7 +375,7 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
     }
 
     public void testPivotWithBucketScriptAgg() throws Exception {
-        String transformId = "bucketScriptPivot";
+        String transformId = "bucket_script_pivot";
         String dataFrameIndex = "bucket_script_pivot_reviews";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, dataFrameIndex);
 
@@ -426,7 +426,7 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
     }
 
     public void testPivotWithGeoCentroidAgg() throws Exception {
-        String transformId = "geoCentroidPivot";
+        String transformId = "geo_centroid_pivot";
         String dataFrameIndex = "geo_centroid_pivot_reviews";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, dataFrameIndex);
 
@@ -476,7 +476,7 @@ public class DataFramePivotRestIT extends DataFrameRestTestCase {
     }
 
     public void testPivotWithWeightedAvgAgg() throws Exception {
-        String transformId = "weightedAvgAggTransform";
+        String transformId = "weighted_avg_agg_transform";
         String dataFrameIndex = "weighted_avg_pivot_reviews";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, dataFrameIndex);
 


### PR DESCRIPTION
Follow up the to the validations added in #40534. Upper case characters should not be allowed in the Data Frame ID as defined in #43043

The error message in `DataFrameMessages.INVALID_ID` already states the ID must be lower case so it is not necessary to change.

_"Invalid {0}; ''{1}'' can contain lowercase alphanumeric (a-z and 0-9), hyphens or underscores; must start and end with alphanumeric";_