### PR TITLE
IndexAnalyzers doesn't need to extend AbstractIndexComponent

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
@@ -44,7 +44,6 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.index.analysis.CharFilterFactory;
 import org.elasticsearch.index.analysis.CustomAnalyzer;
-import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NameOrDefinition;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.analysis.TokenFilterFactory;
@@ -124,11 +123,11 @@ public class TransportAnalyzeAction extends TransportSingleShardAction<AnalyzeAc
     public static AnalyzeAction.Response analyze(AnalyzeAction.Request request, AnalysisRegistry analysisRegistry,
                                           IndexService indexService, int maxTokenCount) throws IOException {
 
-        IndexAnalyzers indexAnalyzers = indexService == null ? null : indexService.getIndexAnalyzers();
+        IndexSettings settings = indexService == null ? null : indexService.getIndexSettings();
 
         // First, we check to see if the request requires a custom analyzer.  If so, then we
         // need to build it and then close it after use.
-        try (Analyzer analyzer = buildCustomAnalyzer(request, analysisRegistry, indexAnalyzers)) {
+        try (Analyzer analyzer = buildCustomAnalyzer(request, analysisRegistry, settings)) {
             if (analyzer != null) {
                 return analyze(request, analyzer, maxTokenCount);
             }
@@ -194,8 +193,7 @@ public class TransportAnalyzeAction extends TransportSingleShardAction<AnalyzeAc
     }
 
     private static Analyzer buildCustomAnalyzer(AnalyzeAction.Request request, AnalysisRegistry analysisRegistry,
-                                                IndexAnalyzers indexAnalyzers) throws IOException {
-        final IndexSettings indexSettings = indexAnalyzers == null ? null : indexAnalyzers.getIndexSettings();
+                                                IndexSettings indexSettings) throws IOException {
         if (request.tokenizer() != null) {
             return analysisRegistry.buildCustomAnalyzer(indexSettings, false,
                 request.tokenizer(), request.charFilters(), request.tokenFilters());

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
@@ -195,7 +195,7 @@ public class MetaDataIndexUpgradeService {
                 }
             };
             try (IndexAnalyzers fakeIndexAnalzyers =
-                     new IndexAnalyzers(indexSettings, analyzerMap, analyzerMap, analyzerMap)) {
+                     new IndexAnalyzers(analyzerMap, analyzerMap, analyzerMap)) {
                 MapperService mapperService = new MapperService(indexSettings, fakeIndexAnalzyers, xContentRegistry, similarityService,
                         mapperRegistry, () -> null);
                 mapperService.merge(indexMetaData, MapperService.MergeReason.MAPPING_RECOVERY);

--- a/server/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
@@ -558,7 +558,7 @@ public final class AnalysisRegistry implements Closeable {
                 throw new IllegalArgumentException("analyzer name must not start with '_'. got \"" + analyzer.getKey() + "\"");
             }
         }
-        return new IndexAnalyzers(indexSettings, analyzers, normalizers, whitespaceNormalizers);
+        return new IndexAnalyzers(analyzers, normalizers, whitespaceNormalizers);
     }
 
     private static NamedAnalyzer produceAnalyzer(String name, AnalyzerProvider<?> analyzerFactory,

--- a/server/src/main/java/org/elasticsearch/index/analysis/IndexAnalyzers.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/IndexAnalyzers.java
@@ -19,8 +19,6 @@
 package org.elasticsearch.index.analysis;
 
 import org.elasticsearch.core.internal.io.IOUtils;
-import org.elasticsearch.index.AbstractIndexComponent;
-import org.elasticsearch.index.IndexSettings;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -40,14 +38,13 @@ import static org.elasticsearch.index.analysis.AnalysisRegistry.DEFAULT_SEARCH_Q
  *
  * @see AnalysisRegistry
  */
-public final class IndexAnalyzers extends AbstractIndexComponent implements Closeable {
+public final class IndexAnalyzers implements Closeable {
     private final Map<String, NamedAnalyzer> analyzers;
     private final Map<String, NamedAnalyzer> normalizers;
     private final Map<String, NamedAnalyzer> whitespaceNormalizers;
 
-    public IndexAnalyzers(IndexSettings indexSettings, Map<String, NamedAnalyzer> analyzers, Map<String, NamedAnalyzer> normalizers,
+    public IndexAnalyzers(Map<String, NamedAnalyzer> analyzers, Map<String, NamedAnalyzer> normalizers,
             Map<String, NamedAnalyzer> whitespaceNormalizers) {
-        super(indexSettings);
         Objects.requireNonNull(analyzers.get(DEFAULT_ANALYZER_NAME), "the default analyzer must be set");
         if (analyzers.get(DEFAULT_ANALYZER_NAME).name().equals(DEFAULT_ANALYZER_NAME) == false) {
             throw new IllegalStateException(

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/TransportAnalyzeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/TransportAnalyzeActionTests.java
@@ -58,7 +58,6 @@ import static java.util.Collections.singletonMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-
 /**
  * Tests for {@link TransportAnalyzeAction}. See the rest tests in the {@code analysis-common} module for places where this code gets a ton
  * more exercise.
@@ -66,6 +65,7 @@ import static org.mockito.Mockito.when;
 public class TransportAnalyzeActionTests extends ESTestCase {
 
     private IndexAnalyzers indexAnalyzers;
+    private IndexSettings indexSettings;
     private AnalysisRegistry registry;
     private int maxTokenCount;
     private int idxMaxTokenCount;
@@ -85,7 +85,7 @@ public class TransportAnalyzeActionTests extends ESTestCase {
                 .put("index.analysis.char_filter.my_append.suffix", "baz")
                 .put("index.analyze.max_token_count", 100)
                 .putList("index.analysis.normalizer.my_normalizer.filter", "lowercase").build();
-        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", indexSettings);
+        this.indexSettings = IndexSettingsModule.newIndexSettings("index", indexSettings);
         Environment environment = TestEnvironment.newEnvironment(settings);
         AnalysisPlugin plugin = new AnalysisPlugin() {
             class MockFactory extends AbstractTokenFilterFactory {
@@ -145,14 +145,15 @@ public class TransportAnalyzeActionTests extends ESTestCase {
             }
         };
         registry = new AnalysisModule(environment, singletonList(plugin)).getAnalysisRegistry();
-        indexAnalyzers = registry.build(idxSettings);
+        indexAnalyzers = registry.build(this.indexSettings);
         maxTokenCount = IndexSettings.MAX_TOKEN_COUNT_SETTING.getDefault(settings);
-        idxMaxTokenCount = idxSettings.getMaxTokenCount();
+        idxMaxTokenCount = this.indexSettings.getMaxTokenCount();
     }
 
     private IndexService mockIndexService() {
         IndexService is = mock(IndexService.class);
         when(is.getIndexAnalyzers()).thenReturn(indexAnalyzers);
+        when(is.getIndexSettings()).thenReturn(indexSettings);
         return is;
     }
 

--- a/server/src/test/java/org/elasticsearch/index/analysis/IndexAnalyzersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/IndexAnalyzersTests.java
@@ -20,9 +20,7 @@
 package org.elasticsearch.index.analysis;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.IndexSettingsModule;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -38,16 +36,14 @@ public class IndexAnalyzersTests extends ESTestCase {
         Map<String, NamedAnalyzer> analyzers = new HashMap<>();
         {
             NullPointerException ex = expectThrows(NullPointerException.class,
-                    () -> new IndexAnalyzers(IndexSettingsModule.newIndexSettings("index", Settings.EMPTY), analyzers,
-                            Collections.emptyMap(), Collections.emptyMap()));
+                    () -> new IndexAnalyzers(analyzers, Collections.emptyMap(), Collections.emptyMap()));
             assertEquals("the default analyzer must be set", ex.getMessage());
         }
         {
             analyzers.put(AnalysisRegistry.DEFAULT_ANALYZER_NAME,
                     new NamedAnalyzer("otherName", AnalyzerScope.INDEX, new StandardAnalyzer()));
             IllegalStateException ex = expectThrows(IllegalStateException.class,
-                    () -> new IndexAnalyzers(IndexSettingsModule.newIndexSettings("index", Settings.EMPTY), analyzers,
-                            Collections.emptyMap(), Collections.emptyMap()));
+                    () -> new IndexAnalyzers(analyzers, Collections.emptyMap(), Collections.emptyMap()));
             assertEquals("default analyzer must have the name [default] but was: [otherName]", ex.getMessage());
         }
     }
@@ -58,8 +54,7 @@ public class IndexAnalyzersTests extends ESTestCase {
         analyzers.put(AnalysisRegistry.DEFAULT_ANALYZER_NAME, analyzer);
 
         // if only "default" is set in the map, all getters should return the same analyzer
-        try (IndexAnalyzers indexAnalyzers = new IndexAnalyzers(IndexSettingsModule.newIndexSettings("index", Settings.EMPTY), analyzers,
-                Collections.emptyMap(), Collections.emptyMap())) {
+        try (IndexAnalyzers indexAnalyzers = new IndexAnalyzers(analyzers, Collections.emptyMap(), Collections.emptyMap())) {
             assertSame(analyzer, indexAnalyzers.getDefaultIndexAnalyzer());
             assertSame(analyzer, indexAnalyzers.getDefaultSearchAnalyzer());
             assertSame(analyzer, indexAnalyzers.getDefaultSearchQuoteAnalyzer());
@@ -67,8 +62,7 @@ public class IndexAnalyzersTests extends ESTestCase {
 
         analyzers.put(AnalysisRegistry.DEFAULT_SEARCH_ANALYZER_NAME,
                 new NamedAnalyzer("my_search_analyzer", AnalyzerScope.INDEX, new StandardAnalyzer()));
-        try (IndexAnalyzers indexAnalyzers = new IndexAnalyzers(IndexSettingsModule.newIndexSettings("index", Settings.EMPTY), analyzers,
-                Collections.emptyMap(), Collections.emptyMap())) {
+        try (IndexAnalyzers indexAnalyzers = new IndexAnalyzers(analyzers, Collections.emptyMap(), Collections.emptyMap())) {
             assertSame(analyzer, indexAnalyzers.getDefaultIndexAnalyzer());
             assertEquals("my_search_analyzer", indexAnalyzers.getDefaultSearchAnalyzer().name());
             assertEquals("my_search_analyzer", indexAnalyzers.getDefaultSearchQuoteAnalyzer().name());
@@ -76,8 +70,7 @@ public class IndexAnalyzersTests extends ESTestCase {
 
         analyzers.put(AnalysisRegistry.DEFAULT_SEARCH_QUOTED_ANALYZER_NAME,
                 new NamedAnalyzer("my_search_quote_analyzer", AnalyzerScope.INDEX, new StandardAnalyzer()));
-        try (IndexAnalyzers indexAnalyzers = new IndexAnalyzers(IndexSettingsModule.newIndexSettings("index", Settings.EMPTY), analyzers,
-                Collections.emptyMap(), Collections.emptyMap())) {
+        try (IndexAnalyzers indexAnalyzers = new IndexAnalyzers(analyzers, Collections.emptyMap(), Collections.emptyMap())) {
             assertSame(analyzer, indexAnalyzers.getDefaultIndexAnalyzer());
             assertEquals("my_search_analyzer", indexAnalyzers.getDefaultSearchAnalyzer().name());
             assertEquals("my_search_quote_analyzer", indexAnalyzers.getDefaultSearchQuoteAnalyzer().name());

--- a/server/src/test/java/org/elasticsearch/index/mapper/TypeParsersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TypeParsersTests.java
@@ -71,7 +71,7 @@ public class TypeParsersTests extends ESTestCase {
         analyzers.put("my_analyzer",
                 new NamedAnalyzer("my_named_analyzer", AnalyzerScope.INDEX, createAnalyzerWithMode("my_analyzer", AnalysisMode.ALL)));
 
-        IndexAnalyzers indexAnalyzers = new IndexAnalyzers(indexSettings, analyzers, Collections.emptyMap(), Collections.emptyMap());
+        IndexAnalyzers indexAnalyzers = new IndexAnalyzers(analyzers, Collections.emptyMap(), Collections.emptyMap());
         when(parserContext.getIndexAnalyzers()).thenReturn(indexAnalyzers);
         TypeParsers.parseTextField(builder, "name", new HashMap<>(fieldNode), parserContext);
 
@@ -80,7 +80,7 @@ public class TypeParsersTests extends ESTestCase {
         analyzers = defaultAnalyzers();
         analyzers.put("my_analyzer", new NamedAnalyzer("my_named_analyzer", AnalyzerScope.INDEX,
                 createAnalyzerWithMode("my_analyzer", mode)));
-        indexAnalyzers = new IndexAnalyzers(indexSettings, analyzers, Collections.emptyMap(), Collections.emptyMap());
+        indexAnalyzers = new IndexAnalyzers(analyzers, Collections.emptyMap(), Collections.emptyMap());
         when(parserContext.getIndexAnalyzers()).thenReturn(indexAnalyzers);
         MapperException ex = expectThrows(MapperException.class,
                 () -> TypeParsers.parseTextField(builder, "name", new HashMap<>(fieldNode), parserContext));
@@ -114,7 +114,7 @@ public class TypeParsersTests extends ESTestCase {
                     new NamedAnalyzer("my_named_analyzer", AnalyzerScope.INDEX, createAnalyzerWithMode("my_analyzer", mode)));
             analyzers.put("standard", new NamedAnalyzer("standard", AnalyzerScope.INDEX, new StandardAnalyzer()));
 
-            IndexAnalyzers indexAnalyzers = new IndexAnalyzers(indexSettings, analyzers, Collections.emptyMap(), Collections.emptyMap());
+            IndexAnalyzers indexAnalyzers = new IndexAnalyzers(analyzers, Collections.emptyMap(), Collections.emptyMap());
             when(parserContext.getIndexAnalyzers()).thenReturn(indexAnalyzers);
             TypeParsers.parseTextField(builder, "name", new HashMap<>(fieldNode), parserContext);
 
@@ -124,7 +124,7 @@ public class TypeParsersTests extends ESTestCase {
             analyzers.put("my_analyzer",
                     new NamedAnalyzer("my_named_analyzer", AnalyzerScope.INDEX, createAnalyzerWithMode("my_analyzer", mode)));
             analyzers.put("standard", new NamedAnalyzer("standard", AnalyzerScope.INDEX, new StandardAnalyzer()));
-            indexAnalyzers = new IndexAnalyzers(indexSettings, analyzers, Collections.emptyMap(), Collections.emptyMap());
+            indexAnalyzers = new IndexAnalyzers(analyzers, Collections.emptyMap(), Collections.emptyMap());
             when(parserContext.getIndexAnalyzers()).thenReturn(indexAnalyzers);
             MapperException ex = expectThrows(MapperException.class,
                     () -> TypeParsers.parseTextField(builder, "name", new HashMap<>(fieldNode), parserContext));
@@ -144,7 +144,7 @@ public class TypeParsersTests extends ESTestCase {
         Map<String, NamedAnalyzer> analyzers = defaultAnalyzers();
         analyzers.put("my_analyzer",
                 new NamedAnalyzer("my_named_analyzer", AnalyzerScope.INDEX, createAnalyzerWithMode("my_analyzer", mode)));
-        IndexAnalyzers indexAnalyzers = new IndexAnalyzers(indexSettings, analyzers, Collections.emptyMap(), Collections.emptyMap());
+        IndexAnalyzers indexAnalyzers = new IndexAnalyzers(analyzers, Collections.emptyMap(), Collections.emptyMap());
         when(parserContext.getIndexAnalyzers()).thenReturn(indexAnalyzers);
         MapperException ex = expectThrows(MapperException.class,
                 () -> TypeParsers.parseTextField(builder, "name", new HashMap<>(fieldNode), parserContext));
@@ -159,7 +159,7 @@ public class TypeParsersTests extends ESTestCase {
                 new NamedAnalyzer("my_named_analyzer", AnalyzerScope.INDEX, createAnalyzerWithMode("my_analyzer", mode)));
         analyzers.put("standard", new NamedAnalyzer("standard", AnalyzerScope.INDEX, new StandardAnalyzer()));
 
-        indexAnalyzers = new IndexAnalyzers(indexSettings, analyzers, Collections.emptyMap(), Collections.emptyMap());
+        indexAnalyzers = new IndexAnalyzers(analyzers, Collections.emptyMap(), Collections.emptyMap());
         when(parserContext.getIndexAnalyzers()).thenReturn(indexAnalyzers);
         TypeParsers.parseTextField(builder, "name", new HashMap<>(fieldNode), parserContext);
     }

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/TranslogHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/TranslogHandler.java
@@ -63,7 +63,7 @@ public class TranslogHandler implements Engine.TranslogRecoveryRunner {
     public TranslogHandler(NamedXContentRegistry xContentRegistry, IndexSettings indexSettings) {
         Map<String, NamedAnalyzer> analyzers = new HashMap<>();
         analyzers.put(AnalysisRegistry.DEFAULT_ANALYZER_NAME, new NamedAnalyzer("default", AnalyzerScope.INDEX, new StandardAnalyzer()));
-        IndexAnalyzers indexAnalyzers = new IndexAnalyzers(indexSettings, analyzers, emptyMap(), emptyMap());
+        IndexAnalyzers indexAnalyzers = new IndexAnalyzers(analyzers, emptyMap(), emptyMap());
         SimilarityService similarityService = new SimilarityService(indexSettings, null, emptyMap());
         MapperRegistry mapperRegistry = new IndicesModule(emptyList()).getMapperRegistry();
         mapperService = new MapperService(indexSettings, indexAnalyzers, xContentRegistry, similarityService, mapperRegistry,


### PR DESCRIPTION
AIC doesn't add anything here, and it removes the need to pass index settings
to the constructor.