### PR TITLE
[DOCS] Adds ML release highlights

### DIFF
--- a/docs/reference/release-notes/highlights-7.2.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.2.0.asciidoc
@@ -10,5 +10,14 @@ coming[7.2.0]
 //Installation and Upgrade Guide
 
 // tag::notable-highlights[]
+[discrete]
+==== {dataframes-cap}
+
+beta[] You can now transform your data with
+{stack-ov}/ml-dataframes.html[data frames]. There is a new {kib} wizard that
+guides you through the process of creating a {dataframe-transform} job to pivot
+your data and store it in a new index. Alternatively, you can use
+{ref}/data-frame-apis.html[{dataframe} APIs] to preview, create, and maintain
+the transforms.
 
 // end::notable-highlights[]

--- a/docs/reference/release-notes/highlights-7.2.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.2.0.asciidoc
@@ -15,8 +15,8 @@ coming[7.2.0]
 
 beta[] You can now transform your data with
 {stack-ov}/ml-dataframes.html[data frames]. There is a new {kib} wizard that
-guides you through the process of creating a {dataframe-transform} job to pivot
-your data and store it in a new index. Alternatively, you can use
+guides you through the process of creating a {dataframe-transform} to pivot and
+summarize your data and store it in a new index. Alternatively, you can use
 {ref}/data-frame-apis.html[{dataframe} APIs] to preview, create, and maintain
 the transforms.
 

--- a/docs/reference/release-notes/highlights-7.2.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.2.0.asciidoc
@@ -17,7 +17,7 @@ beta[] You can now transform your data with
 {stack-ov}/ml-dataframes.html[data frames]. There is a new {kib} wizard that
 guides you through the process of creating a {dataframe-transform} to pivot and
 summarize your data and store it in a new index. Alternatively, you can use
-{ref}/data-frame-apis.html[{dataframe} APIs] to preview, create, and maintain
+{ref}/data-frame-apis.html[{dataframe} APIs] to preview, create, and manage
 the transforms.
 
 // end::notable-highlights[]


### PR DESCRIPTION
This PR adds information about data frames to the 7.2 Release Highlights (https://www.elastic.co/guide/en/elasticsearch/reference/7.2/release-highlights-7.2.0.html). 