### PR TITLE
Add native code info to ML info api

### DIFF
--- a/docs/reference/ml/apis/get-ml-info.asciidoc
+++ b/docs/reference/ml/apis/get-ml-info.asciidoc
@@ -57,7 +57,13 @@ This is a possible response:
     }
   },
   "upgrade_mode": false,
+  "native_code" : {
+    "version": "7.0.0",
+    "build_hash": "99a07c016d5a73"
+  },
   "limits" : { }
 }
 ----
 // TESTRESPONSE[s/"upgrade_mode": false/"upgrade_mode": $body.upgrade_mode/]
+// TESTRESPONSE[s/"version": "7.0.0",/"version": "$body.native_code.version",/]
+// TESTRESPONSE[s/"build_hash": "99a07c016d5a73"/"build_hash": "$body.native_code.build_hash"/]

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportMlInfoAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportMlInfoAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xpack.ml.process.NativeController;
 import org.elasticsearch.xpack.ml.process.NativeControllerHolder;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
@@ -43,8 +44,13 @@ public class TransportMlInfoAction extends HandledTransportAction<MlInfoAction.R
 
         try {
             NativeController nativeController = NativeControllerHolder.getNativeController(clusterService.getNodeName(), env);
-            assert nativeController != null;
-            nativeCodeInfo = nativeController.getNativeCodeInfo();
+            // TODO: this leniency is only for tests. it can be removed when NativeController is created as a component and
+            // becomes a ctor arg to this action
+            if (nativeController != null) {
+                nativeCodeInfo = nativeController.getNativeCodeInfo();
+            } else {
+                nativeCodeInfo = Collections.emptyMap();
+            }
         } catch (IOException e) {
             // this should not be possible since this action is only registered when ML is enabled,
             // and the MachineLearning plugin would have failed to create components

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportMlInfoAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportMlInfoAction.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.env.Environment;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ml.MachineLearningField;
@@ -20,19 +21,37 @@ import org.elasticsearch.xpack.core.ml.action.MlInfoAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisLimits;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.ml.process.NativeController;
+import org.elasticsearch.xpack.ml.process.NativeControllerHolder;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
 public class TransportMlInfoAction extends HandledTransportAction<MlInfoAction.Request, MlInfoAction.Response> {
 
     private final ClusterService clusterService;
+    private final Map<String, Object> nativeCodeInfo;
 
     @Inject
-    public TransportMlInfoAction(TransportService transportService, ActionFilters actionFilters, ClusterService clusterService) {
+    public TransportMlInfoAction(TransportService transportService, ActionFilters actionFilters,
+                                 ClusterService clusterService, Environment env) {
         super(MlInfoAction.NAME, transportService, actionFilters, (Supplier<MlInfoAction.Request>) MlInfoAction.Request::new);
         this.clusterService = clusterService;
+
+        try {
+            NativeController nativeController = NativeControllerHolder.getNativeController(clusterService.getNodeName(), env);
+            assert nativeController != null;
+            nativeCodeInfo = nativeController.getNativeCodeInfo();
+        } catch (IOException e) {
+            // this should not be possible since this action is only registered when ML is enabled,
+            // and the MachineLearning plugin would have failed to create components
+            throw new IllegalStateException("native controller failed to load", e);
+        } catch (TimeoutException e) {
+            throw new RuntimeException("Could not get native code info from native controller", e);
+        }
     }
 
     @Override
@@ -40,6 +59,7 @@ public class TransportMlInfoAction extends HandledTransportAction<MlInfoAction.R
         Map<String, Object> info = new HashMap<>();
         info.put("defaults", defaults());
         info.put("limits", limits());
+        info.put("native_code", nativeCodeInfo);
         info.put(MlMetadata.UPGRADE_MODE.getPreferredName(), upgradeMode());
         listener.onResponse(new MlInfoAction.Response(info));
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityFeatureSetTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityFeatureSetTests.java
@@ -160,6 +160,7 @@ public class SecurityFeatureSetTests extends ESTestCase {
             assertThat(usage.enabled(), is(enabled));
             assertThat(usage.available(), is(authcAuthzAvailable));
             XContentSource source = getXContentSource(usage);
+            
             if (enabled) {
                 if (authcAuthzAvailable) {
                     for (int i = 0; i < 5; i++) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityFeatureSetTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityFeatureSetTests.java
@@ -160,7 +160,7 @@ public class SecurityFeatureSetTests extends ESTestCase {
             assertThat(usage.enabled(), is(enabled));
             assertThat(usage.available(), is(authcAuthzAvailable));
             XContentSource source = getXContentSource(usage);
-            
+
             if (enabled) {
                 if (authcAuthzAvailable) {
                     for (int i = 0; i < 5; i++) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityFeatureSetTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityFeatureSetTests.java
@@ -160,7 +160,6 @@ public class SecurityFeatureSetTests extends ESTestCase {
             assertThat(usage.enabled(), is(enabled));
             assertThat(usage.available(), is(authcAuthzAvailable));
             XContentSource source = getXContentSource(usage);
-
             if (enabled) {
                 if (authcAuthzAvailable) {
                     for (int i = 0; i < 5; i++) {


### PR DESCRIPTION
The machine learning feature of xpack has native binaries with a
different commit id than the rest of code. It is currently exposed in
the xpack info api. This commit adds that commit information to the ML
info api, so that it may be removed from the info api.