### PR TITLE
[Backport] Enable krb5kdc-fixture, kerberos tests  mount urandom for kdc contain…

### DIFF
--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -86,7 +86,7 @@ for (String fixtureName : ['hdfsFixture', 'haHdfsFixture', 'secureHdfsFixture', 
       // the hdfs.MiniHDFS fixture writes the ports file when
       // it's ready, so we can just wait for the file to exist
       return fixture.portsFile.exists()
-    }    
+    }
 
     final List<String> miniHDFSArgs = []
 
@@ -118,20 +118,29 @@ for (String fixtureName : ['hdfsFixture', 'haHdfsFixture', 'secureHdfsFixture', 
   }
 }
 
+Set disabledIntegTestTaskNames = ['integTestSecure', 'integTestSecureHa']
+
 for (String integTestTaskName : ['integTestHa', 'integTestSecure', 'integTestSecureHa']) {
   task "${integTestTaskName}"(type: RestIntegTestTask) {
     description = "Runs rest tests against an elasticsearch cluster with HDFS."
     dependsOn(project.bundlePlugin)
+
+    if (disabledIntegTestTaskNames.contains(integTestTaskName)) {
+      enabled = false;
+    }
+
     runner {
       if (integTestTaskName.contains("Secure")) {
-        dependsOn secureHdfsFixture
-        systemProperty "test.krb5.principal.es", "elasticsearch@${realm}"
-        systemProperty "test.krb5.principal.hdfs", "hdfs/hdfs.build.elastic.co@${realm}"
-        jvmArgs "-Djava.security.krb5.conf=${krb5conf}"
-        systemProperty (
-                "test.krb5.keytab.hdfs",
-                project(':test:fixtures:krb5kdc-fixture').ext.krb5Keytabs("hdfs","hdfs_hdfs.build.elastic.co.keytab")
-        )
+        if (disabledIntegTestTaskNames.contains(integTestTaskName) == false) {
+            dependsOn secureHdfsFixture
+            nonInputProperties.systemProperty "test.krb5.principal.es", "elasticsearch@${realm}"
+            nonInputProperties.systemProperty "test.krb5.principal.hdfs", "hdfs/hdfs.build.elastic.co@${realm}"
+            jvmArgs "-Djava.security.krb5.conf=${krb5conf}"
+            nonInputProperties.systemProperty (
+                    "test.krb5.keytab.hdfs",
+                    project(':test:fixtures:krb5kdc-fixture').ext.krb5Keytabs("hdfs","hdfs_hdfs.build.elastic.co.keytab")
+            )
+        }
       }
     }
   }

--- a/test/fixtures/hdfs-fixture/src/main/java/hdfs/MiniHDFS.java
+++ b/test/fixtures/hdfs-fixture/src/main/java/hdfs/MiniHDFS.java
@@ -19,18 +19,6 @@
 
 package hdfs;
 
-import java.io.File;
-import java.lang.management.ManagementFactory;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
@@ -44,6 +32,18 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.MiniDFSNNTopology;
 import org.apache.hadoop.hdfs.server.namenode.ha.HATestUtil;
 import org.apache.hadoop.security.UserGroupInformation;
+
+import java.io.File;
+import java.lang.management.ManagementFactory;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * MiniHDFS test fixture. There is a CLI tool, but here we can
@@ -174,4 +174,5 @@ public class MiniHDFS {
         Files.write(tmp, portFileContent.getBytes(StandardCharsets.UTF_8));
         Files.move(tmp, baseDir.resolve(PORT_FILE_NAME), StandardCopyOption.ATOMIC_MOVE);
     }
+
 }

--- a/test/fixtures/krb5kdc-fixture/build.gradle
+++ b/test/fixtures/krb5kdc-fixture/build.gradle
@@ -47,8 +47,7 @@ postProcessFixture {
     }
 }
 
-// https://github.com/elastic/elasticsearch/issues/40624
-buildFixture.enabled = false
+buildFixture.enabled = true
 
 project.ext.krb5Conf = { service -> file("$buildDir/shared/${service}/krb5.conf") }
 project.ext.krb5Keytabs = { service, fileName -> file("$buildDir/shared/${service}/keytabs/${fileName}") }

--- a/test/fixtures/krb5kdc-fixture/docker-compose.yml
+++ b/test/fixtures/krb5kdc-fixture/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     command: "bash /fixture/src/main/resources/provision/peppa.sh"
     volumes:
       - ./build/shared/peppa:/fixture/build
+      # containers have bad entropy so mount /dev/urandom. Less secure but this is a test fixture.
+      - /dev/urandom:/dev/random
     ports:
       - "4444"
       - "88/udp"
@@ -19,6 +21,8 @@ services:
     command: "bash /fixture/src/main/resources/provision/hdfs.sh"
     volumes:
       - ./build/shared/hdfs:/fixture/build
+      # containers have bad entropy so mount /dev/urandom. Less secure but this is a test fixture.
+      - /dev/urandom:/dev/random
     ports:
       - "4444"
       - "88/udp"

--- a/x-pack/qa/kerberos-tests/build.gradle
+++ b/x-pack/qa/kerberos-tests/build.gradle
@@ -8,8 +8,7 @@ apply plugin: 'elasticsearch.test.fixtures'
 
 testFixtures.useFixture ":test:fixtures:krb5kdc-fixture"
 
-// https://github.com/elastic/elasticsearch/issues/40624
-integTest.enabled = false
+integTest.enabled = true
 
 dependencies {
     testCompile "org.elasticsearch.plugin:x-pack-core:${version}"
@@ -56,9 +55,9 @@ integTestCluster {
 String realm = "BUILD.ELASTIC.CO"
 integTestRunner {
     Path peppaKeytab = Paths.get("${project.buildDir}", "generated-resources", "keytabs", "peppa.keytab")
-    systemProperty 'test.userkt', "peppa@${realm}"
-    systemProperty 'test.userkt.keytab', "${peppaKeytab}"
-    systemProperty 'test.userpwd', "george@${realm}"
+    nonInputProperties.systemProperty 'test.userkt', "peppa@${realm}"
+    nonInputProperties.systemProperty 'test.userkt.keytab', "${peppaKeytab}"
+    nonInputProperties.systemProperty 'test.userpwd', "george@${realm}"
     systemProperty 'test.userpwd.password', "dino"
     systemProperty 'tests.security.manager', 'true'
     jvmArgs([


### PR DESCRIPTION
…er (#41710)

Infra has fixed #10462 by installing `haveged` on CI workers.
This commit enables the disabled fixture and tests, and mounts
`/dev/urandom` for the container so there is enough
entropy required for kdc.
Note: hdfs-repository tests have been disabled, will raise a separate issue for it.

Closes #40624 Closes #40678
