### PR TITLE
[FEATURE][ML] Fetch from source when fields are more then docvalue limit

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
@@ -6,6 +6,8 @@
 package org.elasticsearch.xpack.ml.integration;
 
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequest;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.get.GetResponse;
@@ -13,6 +15,8 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsStatsAction;
@@ -145,6 +149,71 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
             .setTrackTotalHits(true)
             .setQuery(QueryBuilders.existsQuery("custom_ml.outlier_score")).get();
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo((long) docCount));
+    }
+
+    public void testOutlierDetectionWithMoreFieldsThanDocValueFieldLimit() throws Exception {
+        String sourceIndex = "test-outlier-detection-with-more-fields-than-docvalue-limit";
+
+        client().admin().indices().prepareCreate(sourceIndex).get();
+
+        GetSettingsRequest getSettingsRequest = new GetSettingsRequest();
+        getSettingsRequest.indices(sourceIndex);
+        getSettingsRequest.names(IndexSettings.MAX_DOCVALUE_FIELDS_SEARCH_SETTING.getKey());
+        getSettingsRequest.includeDefaults(true);
+
+        GetSettingsResponse docValueLimitSetting = client().admin().indices().getSettings(getSettingsRequest).actionGet();
+        int docValueLimit = IndexSettings.MAX_DOCVALUE_FIELDS_SEARCH_SETTING.get(
+            docValueLimitSetting.getIndexToSettings().values().iterator().next().value);
+
+        BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
+        bulkRequestBuilder.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        for (int i = 0; i < 100; i++) {
+
+            StringBuilder source = new StringBuilder("{");
+            for (int fieldCount = 0; fieldCount < docValueLimit + 1; fieldCount++) {
+                source.append("\"field_").append(fieldCount).append("\":").append(randomDouble());
+                if (fieldCount < docValueLimit) {
+                    source.append(",");
+                }
+            }
+            source.append("}");
+
+            IndexRequest indexRequest = new IndexRequest(sourceIndex);
+            indexRequest.source(source.toString(), XContentType.JSON);
+            bulkRequestBuilder.add(indexRequest);
+        }
+        BulkResponse bulkResponse = bulkRequestBuilder.get();
+        if (bulkResponse.hasFailures()) {
+            fail("Failed to index data: " + bulkResponse.buildFailureMessage());
+        }
+
+        String id = "test_outlier_detection_with_more_fields_than_docvalue_limit";
+        DataFrameAnalyticsConfig config = buildOutlierDetectionAnalytics(id, sourceIndex, null);
+        registerAnalytics(config);
+        putAnalytics(config);
+
+        assertState(id, DataFrameAnalyticsState.STOPPED);
+
+        startAnalytics(id);
+        waitUntilAnalyticsIsStopped(id);
+
+        SearchResponse sourceData = client().prepareSearch(sourceIndex).get();
+        for (SearchHit hit : sourceData.getHits()) {
+            GetResponse destDocGetResponse = client().prepareGet().setIndex(config.getDest().getIndex()).setId(hit.getId()).get();
+            assertThat(destDocGetResponse.isExists(), is(true));
+            Map<String, Object> sourceDoc = hit.getSourceAsMap();
+            Map<String, Object> destDoc = destDocGetResponse.getSource();
+            for (String field : sourceDoc.keySet()) {
+                assertThat(destDoc.containsKey(field), is(true));
+                assertThat(destDoc.get(field), equalTo(sourceDoc.get(field)));
+            }
+            assertThat(destDoc.containsKey("ml"), is(true));
+            Map<String, Object> resultsObject = (Map<String, Object>) destDoc.get("ml");
+            assertThat(resultsObject.containsKey("outlier_score"), is(true));
+            double outlierScore = (double) resultsObject.get("outlier_score");
+            assertThat(outlierScore, allOf(greaterThanOrEqualTo(0.0), lessThanOrEqualTo(100.0)));
+        }
     }
 
     public void testStopOutlierDetectionWithEnoughDocumentsToScroll() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/fields/ExtractedField.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/fields/ExtractedField.java
@@ -58,6 +58,8 @@ public abstract class ExtractedField {
 
     public abstract Object[] value(SearchHit hit);
 
+    protected abstract boolean supportsFromSource();
+
     public String getDocValueFormat() {
         return null;
     }
@@ -93,6 +95,14 @@ public abstract class ExtractedField {
         }
     }
 
+    public ExtractedField newFromSource() {
+        if (supportsFromSource() == false) {
+            throw new IllegalStateException("Field (alias [" + alias + "], name [" + name + "]) should be extracted via ["
+                + extractionMethod + "] and cannot be extracted from source");
+        }
+        return new FromSource(alias, name);
+    }
+
     private static class FromFields extends ExtractedField {
 
         FromFields(String alias, String name, ExtractionMethod extractionMethod) {
@@ -107,6 +117,11 @@ public abstract class ExtractedField {
                 return values.toArray(new Object[0]);
             }
             return new Object[0];
+        }
+
+        @Override
+        protected boolean supportsFromSource() {
+            return getExtractionMethod() == ExtractionMethod.DOC_VALUE;
         }
     }
 
@@ -255,6 +270,11 @@ public abstract class ExtractedField {
                 }
             }
             return new Object[0];
+        }
+
+        @Override
+        protected boolean supportsFromSource() {
+            return true;
         }
 
         @SuppressWarnings("unchecked")

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/fields/ExtractedField.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/fields/ExtractedField.java
@@ -58,7 +58,7 @@ public abstract class ExtractedField {
 
     public abstract Object[] value(SearchHit hit);
 
-    protected abstract boolean supportsFromSource();
+    public abstract boolean supportsFromSource();
 
     public String getDocValueFormat() {
         return null;
@@ -96,11 +96,11 @@ public abstract class ExtractedField {
     }
 
     public ExtractedField newFromSource() {
-        if (supportsFromSource() == false) {
-            throw new IllegalStateException("Field (alias [" + alias + "], name [" + name + "]) should be extracted via ["
-                + extractionMethod + "] and cannot be extracted from source");
+        if (supportsFromSource()) {
+            return new FromSource(alias, name);
         }
-        return new FromSource(alias, name);
+        throw new IllegalStateException("Field (alias [" + alias + "], name [" + name + "]) should be extracted via ["
+            + extractionMethod + "] and cannot be extracted from source");
     }
 
     private static class FromFields extends ExtractedField {
@@ -120,7 +120,7 @@ public abstract class ExtractedField {
         }
 
         @Override
-        protected boolean supportsFromSource() {
+        public boolean supportsFromSource() {
             return getExtractionMethod() == ExtractionMethod.DOC_VALUE;
         }
     }
@@ -210,6 +210,11 @@ public abstract class ExtractedField {
                 throw new IllegalArgumentException("Unexpected value for a geo_point field: " + geoString);
             }
         }
+
+        @Override
+        public boolean supportsFromSource() {
+            return false;
+        }
     }
 
     private static class TimeField extends FromFields {
@@ -237,6 +242,11 @@ public abstract class ExtractedField {
         @Override
         public String getDocValueFormat() {
             return EPOCH_MILLIS_FORMAT;
+        }
+
+        @Override
+        public boolean supportsFromSource() {
+            return false;
         }
     }
 
@@ -273,7 +283,7 @@ public abstract class ExtractedField {
         }
 
         @Override
-        protected boolean supportsFromSource() {
+        public boolean supportsFromSource() {
             return true;
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorFactory.java
@@ -110,14 +110,7 @@ public class DataFrameDataExtractorFactory {
         ActionListener<FieldCapabilitiesResponse> fieldCapabilitiesHandler = ActionListener.wrap(
             fieldCapabilitiesResponse -> listener.onResponse(new ExtractedFieldsDetector(index, config, isTaskRestarting,
                 docValueFieldsLimitHolder.get(), fieldCapabilitiesResponse).detect()),
-            e -> {
-                if (e instanceof IndexNotFoundException) {
-                    listener.onFailure(new ResourceNotFoundException("cannot retrieve data because index "
-                        + ((IndexNotFoundException) e).getIndex() + " does not exist"));
-                } else {
-                    listener.onFailure(e);
-                }
-            }
+            listener::onFailure
         );
 
         // Step 2. Get field capabilities necessary to build the information of how to extract fields
@@ -156,7 +149,14 @@ public class DataFrameDataExtractorFactory {
                 }
                 docValueFieldsLimitListener.onResponse(minDocValueFieldsLimit);
             },
-            docValueFieldsLimitListener::onFailure
+            e -> {
+                if (e instanceof IndexNotFoundException) {
+                    docValueFieldsLimitListener.onFailure(new ResourceNotFoundException("cannot retrieve data because index "
+                        + ((IndexNotFoundException) e).getIndex() + " does not exist"));
+                } else {
+                    docValueFieldsLimitListener.onFailure(e);
+                }
+            }
         );
 
         GetSettingsRequest getSettingsRequest = new GetSettingsRequest();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorFactory.java
@@ -5,21 +5,29 @@
  */
 package org.elasticsearch.xpack.ml.dataframe.extractor;
 
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesAction;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.ml.datafeed.extractor.fields.ExtractedFields;
 
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class DataFrameDataExtractorFactory {
 
@@ -96,10 +104,12 @@ public class DataFrameDataExtractorFactory {
                                                       DataFrameAnalyticsConfig config,
                                                       boolean isTaskRestarting,
                                                       ActionListener<ExtractedFields> listener) {
-        // Step 2. Extract fields (if possible) and notify listener
+        AtomicInteger docValueFieldsLimitHolder = new AtomicInteger();
+
+        // Step 3. Extract fields (if possible) and notify listener
         ActionListener<FieldCapabilitiesResponse> fieldCapabilitiesHandler = ActionListener.wrap(
-            fieldCapabilitiesResponse -> listener.onResponse(
-                new ExtractedFieldsDetector(index, config, isTaskRestarting, fieldCapabilitiesResponse).detect()),
+            fieldCapabilitiesResponse -> listener.onResponse(new ExtractedFieldsDetector(index, config, isTaskRestarting,
+                docValueFieldsLimitHolder.get(), fieldCapabilitiesResponse).detect()),
             e -> {
                 if (e instanceof IndexNotFoundException) {
                     listener.onFailure(new ResourceNotFoundException("cannot retrieve data because index "
@@ -110,15 +120,49 @@ public class DataFrameDataExtractorFactory {
             }
         );
 
-        // Step 1. Get field capabilities necessary to build the information of how to extract fields
-        FieldCapabilitiesRequest fieldCapabilitiesRequest = new FieldCapabilitiesRequest();
-        fieldCapabilitiesRequest.indices(index);
-        fieldCapabilitiesRequest.fields("*");
-        ClientHelper.executeWithHeaders(config.getHeaders(), ClientHelper.ML_ORIGIN, client, () -> {
-            client.execute(FieldCapabilitiesAction.INSTANCE, fieldCapabilitiesRequest, fieldCapabilitiesHandler);
-            // This response gets discarded - the listener handles the real response
-            return null;
-        });
+        // Step 2. Get field capabilities necessary to build the information of how to extract fields
+        ActionListener<Integer> docValueFieldsLimitListener = ActionListener.wrap(
+            docValueFieldsLimit -> {
+                docValueFieldsLimitHolder.set(docValueFieldsLimit);
+
+                FieldCapabilitiesRequest fieldCapabilitiesRequest = new FieldCapabilitiesRequest();
+                fieldCapabilitiesRequest.indices(index);
+                fieldCapabilitiesRequest.fields("*");
+                ClientHelper.executeWithHeaders(config.getHeaders(), ClientHelper.ML_ORIGIN, client, () -> {
+                    client.execute(FieldCapabilitiesAction.INSTANCE, fieldCapabilitiesRequest, fieldCapabilitiesHandler);
+                    // This response gets discarded - the listener handles the real response
+                    return null;
+                });
+            },
+            listener::onFailure
+        );
+
+        // Step 1. Get doc value fields limit
+        getDocValueFieldsLimit(client, index, docValueFieldsLimitListener);
     }
 
+    private static void getDocValueFieldsLimit(Client client, String index, ActionListener<Integer> docValueFieldsLimitListener) {
+        ActionListener<GetSettingsResponse> settingsListener = ActionListener.wrap(getSettingsResponse -> {
+                Integer minDocValueFieldsLimit = Integer.MAX_VALUE;
+
+                ImmutableOpenMap<String, Settings> indexToSettings = getSettingsResponse.getIndexToSettings();
+                Iterator<ObjectObjectCursor<String, Settings>> iterator = indexToSettings.iterator();
+                while (iterator.hasNext()) {
+                    ObjectObjectCursor<String, Settings> indexSettings = iterator.next();
+                    Integer indexMaxDocValueFields = IndexSettings.MAX_DOCVALUE_FIELDS_SEARCH_SETTING.get(indexSettings.value);
+                    if (indexMaxDocValueFields < minDocValueFieldsLimit) {
+                        minDocValueFieldsLimit = indexMaxDocValueFields;
+                    }
+                }
+                docValueFieldsLimitListener.onResponse(minDocValueFieldsLimit);
+            },
+            docValueFieldsLimitListener::onFailure
+        );
+
+        GetSettingsRequest getSettingsRequest = new GetSettingsRequest();
+        getSettingsRequest.indices(index);
+        getSettingsRequest.includeDefaults(true);
+        getSettingsRequest.names(IndexSettings.MAX_DOCVALUE_FIELDS_SEARCH_SETTING.getKey());
+        client.admin().indices().getSettings(getSettingsRequest, settingsListener);
+    }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetector.java
@@ -57,13 +57,15 @@ public class ExtractedFieldsDetector {
     private final String index;
     private final DataFrameAnalyticsConfig config;
     private final boolean isTaskRestarting;
+    private final int docValueFieldsLimit;
     private final FieldCapabilitiesResponse fieldCapabilitiesResponse;
 
-    ExtractedFieldsDetector(String index, DataFrameAnalyticsConfig config, boolean isTaskRestarting,
+    ExtractedFieldsDetector(String index, DataFrameAnalyticsConfig config, boolean isTaskRestarting, int docValueFieldsLimit,
                             FieldCapabilitiesResponse fieldCapabilitiesResponse) {
         this.index = Objects.requireNonNull(index);
         this.config = Objects.requireNonNull(config);
         this.isTaskRestarting = isTaskRestarting;
+        this.docValueFieldsLimit = docValueFieldsLimit;
         this.fieldCapabilitiesResponse = Objects.requireNonNull(fieldCapabilitiesResponse);
     }
 
@@ -85,6 +87,10 @@ public class ExtractedFieldsDetector {
             .filterFields(ExtractedField.ExtractionMethod.DOC_VALUE);
         if (extractedFields.getAllFields().isEmpty()) {
             throw ExceptionsHelper.badRequestException("No compatible fields could be detected in index [{}]", index);
+        }
+        if (extractedFields.getAllFields().size() > docValueFieldsLimit) {
+            extractedFields = new ExtractedFields(extractedFields.getAllFields().stream().map(ExtractedField::newFromSource)
+                .collect(Collectors.toList()));
         }
         return extractedFields;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManager.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.ml.dataframe.extractor.DataFrameDataExtractor;
 import org.elasticsearch.xpack.ml.dataframe.extractor.DataFrameDataExtractorFactory;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManager.java
@@ -22,7 +22,6 @@ import org.elasticsearch.xpack.ml.dataframe.extractor.DataFrameDataExtractor;
 import org.elasticsearch.xpack.ml.dataframe.extractor.DataFrameDataExtractorFactory;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;


### PR DESCRIPTION
There is an index level setting called `index.max_docvalue_fields_search` which limits the number of doc_value fields that can be returned from a search. This commit changes behaviour of the extractor so that it's now reading the value of that setting and if there are more fields we switch to fetching the fields from `_source`.