### PR TITLE
[Ml Data Frame] Size the GET stats search by number of Ids requested

### DIFF
--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/persistence/DataFrameTransformsConfigManager.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/persistence/DataFrameTransformsConfigManager.java
@@ -335,7 +335,7 @@ public class DataFrameTransformsConfigManager {
         SearchRequest searchRequest = client.prepareSearch(DataFrameInternalIndex.INDEX_NAME)
                 .addSort(DataFrameField.ID.getPreferredName(), SortOrder.ASC)
                 .setQuery(builder)
-                .setSize(transformIds.size() > 10_000 ? 10_000 : transformIds.size())
+                .setSize(Math.min(transformIds.size(), 10_000))
                 .request();
 
         executeAsyncWithOrigin(client.threadPool().getThreadContext(), DATA_FRAME_ORIGIN, searchRequest,

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/persistence/DataFrameTransformsConfigManager.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/persistence/DataFrameTransformsConfigManager.java
@@ -335,6 +335,7 @@ public class DataFrameTransformsConfigManager {
         SearchRequest searchRequest = client.prepareSearch(DataFrameInternalIndex.INDEX_NAME)
                 .addSort(DataFrameField.ID.getPreferredName(), SortOrder.ASC)
                 .setQuery(builder)
+                .setSize(transformIds.size() > 10_000 ? 10_000 : transformIds.size())
                 .request();
 
         executeAsyncWithOrigin(client.threadPool().getThreadContext(), DATA_FRAME_ORIGIN, searchRequest,

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/persistence/DataFrameTransformsConfigManagerTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/persistence/DataFrameTransformsConfigManagerTests.java
@@ -239,7 +239,7 @@ public class DataFrameTransformsConfigManagerTests extends DataFrameSingleNodeTe
     }
 
     public void testGetStateAndStatsMultiple() throws InterruptedException {
-        int numStats = randomInt(5);
+        int numStats = randomIntBetween(10, 15);
         List<DataFrameTransformStateAndStats> expectedStats = new ArrayList<>();
         for (int i=0; i<numStats; i++) {
             DataFrameTransformStateAndStats stat =


### PR DESCRIPTION
Set the size of the search request to the number of terms limited by 10,00. The default size of 10 is not appropriate.

Closes #43203