### PR TITLE
[DOCS] Adds size and from parameters to data frame APIs

### DIFF
--- a/docs/reference/data-frames/apis/get-transform-stats.asciidoc
+++ b/docs/reference/data-frames/apis/get-transform-stats.asciidoc
@@ -36,6 +36,12 @@ Retrieves usage information for {dataframe-transforms}.
   specify one of these options, the API returns information for all
   {dataframe-transforms}.
 
+`from`::
+    (integer) Skips the specified number of {dataframe-transforms}. The
+    default value is `0`.
+
+`size`::
+    (integer) Specifies the maximum number of {dataframe-transforms} to obtain. The default value is `100`.
 
 ==== Results
 
@@ -53,6 +59,16 @@ see {stack-ov}/security-privileges.html[Security privileges] and
 {stack-ov}/built-in-roles.html[Built-in roles].
 
 ==== Examples
+
+The following example skips for the first five {dataframe-transforms} and
+gets usage information for a maximum of ten results: 
+
+[source,js]
+--------------------------------------------------
+GET _data_frame/transforms/_stats?from=5;size=10
+--------------------------------------------------
+// CONSOLE
+// TEST[skip:todo]
 
 The following example gets usage information for the `ecommerce_transform`
 {dataframe-transform}:

--- a/docs/reference/data-frames/apis/get-transform-stats.asciidoc
+++ b/docs/reference/data-frames/apis/get-transform-stats.asciidoc
@@ -65,7 +65,7 @@ gets usage information for a maximum of ten results:
 
 [source,js]
 --------------------------------------------------
-GET _data_frame/transforms/_stats?from=5;size=10
+GET _data_frame/transforms/_stats?from=5&size=10
 --------------------------------------------------
 // CONSOLE
 // TEST[skip:todo]

--- a/docs/reference/data-frames/apis/get-transform-stats.asciidoc
+++ b/docs/reference/data-frames/apis/get-transform-stats.asciidoc
@@ -48,7 +48,8 @@ Retrieves usage information for {dataframe-transforms}.
 The API returns the following information:
 
 `transforms`::
-  (array) An array of statistics objects for {dataframe-transforms}.
+  (array) An array of statistics objects for {dataframe-transforms}, which are
+  sorted by the `id` value in ascending order.
 
 ==== Authorization
 

--- a/docs/reference/data-frames/apis/get-transform.asciidoc
+++ b/docs/reference/data-frames/apis/get-transform.asciidoc
@@ -35,18 +35,12 @@ Retrieves configuration information for {dataframe-transforms}.
   specify one of these options, the API returns information for all
   {dataframe-transforms}.
 
-////
-==== Request Body
-
-  `page`::
-  `from`:::
+`from`::
       (integer) Skips the specified number of {dataframe-transforms}. The
       default value is `0`.
 
-  `size`:::
-      (integer) Specifies the maximum number of {dataframe-transforms} to obtain.
-      The default value is `100`.
-////
+`size`::
+      (integer) Specifies the maximum number of {dataframe-transforms} to obtain. The default value is `100`.
 
 ==== Results
 
@@ -64,6 +58,15 @@ see {stack-ov}/security-privileges.html[Security privileges] and
 {stack-ov}/built-in-roles.html[Built-in roles].
 
 ==== Examples
+
+The following example retrieves information about a maximum of ten transforms:
+
+[source,js]
+--------------------------------------------------
+GET _data_frame/transforms?size=10
+--------------------------------------------------
+// CONSOLE
+// TEST[skip:setup kibana sample data]
 
 The following example gets configuration information for the
 `ecommerce_transform` {dataframe-transform}:

--- a/docs/reference/data-frames/apis/get-transform.asciidoc
+++ b/docs/reference/data-frames/apis/get-transform.asciidoc
@@ -47,7 +47,8 @@ Retrieves configuration information for {dataframe-transforms}.
 The API returns the following information:
 
 `transforms`::
-  (array) An array of transform resources.
+  (array) An array of transform resources, which are sorted by the `id` value in
+  ascending order.
 
 ==== Authorization
 


### PR DESCRIPTION
This PR adds "from" and "size" parameters to the "get data frame transforms" API and "get data frame transform statistics" API.

The descriptions are copied from https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/java-rest-high-dataframe-get-data-frame-transform.html