### PR TITLE
[ML][Data Frame] have sum map to a double to prevent overflows

### DIFF
--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/pivot/Aggregations.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/pivot/Aggregations.java
@@ -34,7 +34,7 @@ public final class Aggregations {
         VALUE_COUNT("value_count", "long"),
         MAX("max", SOURCE),
         MIN("min", SOURCE),
-        SUM("sum", SOURCE),
+        SUM("sum", "double"),
         GEO_CENTROID("geo_centroid", "geo_point"),
         SCRIPTED_METRIC("scripted_metric", DYNAMIC),
         WEIGHTED_AVG("weighted_avg", DYNAMIC),

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/pivot/AggregationsTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/pivot/AggregationsTests.java
@@ -34,9 +34,9 @@ public class AggregationsTests extends ESTestCase {
         assertEquals("half_float", Aggregations.resolveTargetMapping("min", "half_float"));
 
         // sum
-        assertEquals("int", Aggregations.resolveTargetMapping("sum", "int"));
         assertEquals("double", Aggregations.resolveTargetMapping("sum", "double"));
-        assertEquals("half_float", Aggregations.resolveTargetMapping("sum", "half_float"));
+        assertEquals("double", Aggregations.resolveTargetMapping("sum", "half_float"));
+        assertEquals("double", Aggregations.resolveTargetMapping("sum", null));
 
         // geo_centroid
         assertEquals("geo_point", Aggregations.resolveTargetMapping("geo_centroid", "geo_point"));


### PR DESCRIPTION
It can be pretty easy for `sum` in significantly large buckets to overflow the `source` index mapping value. Especially when that source mapping is something small, like `byte` or `short`.

Making the default mapping a `double` accounts for this as best as we can.