### PR TITLE
SQL: Increase hard limit for sorting on aggregates

### DIFF
--- a/docs/reference/sql/language/syntax/commands/select.asciidoc
+++ b/docs/reference/sql/language/syntax/commands/select.asciidoc
@@ -336,7 +336,7 @@ Further more, it is possible to order groups based on aggregations of their valu
 include-tagged::{sql-specs}/docs/docs.csv-spec[orderByAgg]
 ----
 
-IMPORTANT: Ordering by aggregation is possible for up to 512 entries for memory consumption reasons.
+IMPORTANT: Ordering by aggregation is possible for up to *10000* entries for memory consumption reasons.
 In cases where the results pass this threshold, use <<sql-syntax-limit,`LIMIT`>> to reduce the number
 of results.
 

--- a/docs/reference/sql/limitations.asciidoc
+++ b/docs/reference/sql/limitations.asciidoc
@@ -87,8 +87,8 @@ It is recommended to use `LIMIT` for queries that use sorting by aggregation, es
 SELECT * FROM test GROUP BY age ORDER BY COUNT(*) LIMIT 100;
 --------------------------------------------------
 
-It is possible to run the same queries without a `LIMIT` however in that case if the maximum size (*512*) is passed, an exception will be
-returned as {es-sql} is unable to track (and sort) all the results returned.
+It is possible to run the same queries without a `LIMIT` however in that case if the maximum size (*10000*) is passed,
+an exception will be returned as {es-sql} is unable to track (and sort) all the results returned.
 
 [float]
 === Using aggregation functions on top of scalar functions

--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/cli/ErrorsTestCase.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/cli/ErrorsTestCase.java
@@ -100,8 +100,8 @@ public abstract class ErrorsTestCase extends CliIntegrationTestCase implements o
     @Override
     public void testHardLimitForSortOnAggregate() throws Exception {
         index("test", body -> body.field("a", 1).field("b", 2));
-        String commandResult = command("SELECT max(a) max FROM test GROUP BY b ORDER BY max LIMIT 10000");
-        assertEquals(START + "Bad request [[3;33;22mThe maximum LIMIT for aggregate sorting is [512], received [10000]" + END,
+        String commandResult = command("SELECT max(a) max FROM test GROUP BY b ORDER BY max LIMIT 12000");
+        assertEquals(START + "Bad request [[3;33;22mThe maximum LIMIT for aggregate sorting is [10000], received [12000]" + END,
             commandResult);
     }
 

--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ErrorsTestCase.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ErrorsTestCase.java
@@ -122,8 +122,8 @@ public class ErrorsTestCase extends JdbcIntegrationTestCase implements org.elast
         index("test", body -> body.field("a", 1).field("b", 2));
         try (Connection c = esJdbc()) {
             SQLException e = expectThrows(SQLException.class, () ->
-                c.prepareStatement("SELECT max(a) max FROM test GROUP BY b ORDER BY max LIMIT 10000").executeQuery());
-            assertEquals("The maximum LIMIT for aggregate sorting is [512], received [10000]", e.getMessage());
+                c.prepareStatement("SELECT max(a) max FROM test GROUP BY b ORDER BY max LIMIT 12000").executeQuery());
+            assertEquals("The maximum LIMIT for aggregate sorting is [10000], received [12000]", e.getMessage());
         }
     }
 }

--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
@@ -317,8 +317,8 @@ public abstract class RestSqlTestCase extends ESRestTestCase implements ErrorsTe
     @Override
     public void testHardLimitForSortOnAggregate() throws Exception {
         index("{\"a\": 1, \"b\": 2}");
-        expectBadRequest(() -> runSql(randomMode(), "SELECT max(a) max FROM test GROUP BY b ORDER BY max LIMIT 10000"),
-            containsString("The maximum LIMIT for aggregate sorting is [512], received [10000]"));
+        expectBadRequest(() -> runSql(randomMode(), "SELECT max(a) max FROM test GROUP BY b ORDER BY max LIMIT 12000"),
+            containsString("The maximum LIMIT for aggregate sorting is [10000], received [12000]"));
     }
 
     public void testUseColumnarForUnsupportedFormats() throws Exception {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
@@ -23,6 +23,7 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
 import org.elasticsearch.search.aggregations.bucket.filter.Filters;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -160,7 +161,10 @@ public class Querier {
         private final AtomicInteger counter = new AtomicInteger();
         private volatile Schema schema;
 
-        private static final int MAXIMUM_SIZE = 512;
+        /**
+         * Match the default value for {@link MultiBucketConsumerService#MAX_BUCKET_SETTING}
+         */
+        private static final int MAXIMUM_SIZE = 10_000;
         private final boolean noLimit;
 
         LocalAggregationSorterListener(ActionListener<SchemaRowSet> listener, List<Tuple<Integer, Comparator>> sortingColumns, int limit) {


### PR DESCRIPTION
To be consistent with the `search.max_buckets` default setting,
set the hard limit of the PriorityQueue used for in memory sorting,
when sorting on an aggregate function, to 10000.

Fixes: #43168
