### PR TITLE
Add UnknownRole#equals, hashCode, toString

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeRole.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeRole.java
@@ -113,7 +113,7 @@ public abstract class DiscoveryNodeRole {
      * Represents an unknown role. This can occur if a newer version adds a role that an older version does not know about, or a newer
      * version removes a role that an older version knows about.
      */
-    public static class UnknownRole extends DiscoveryNodeRole {
+    static class UnknownRole extends DiscoveryNodeRole {
 
         /**
          * Construct an unknown role with the specified role name and role name abbreviation.

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeRole.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeRole.java
@@ -113,7 +113,7 @@ public abstract class DiscoveryNodeRole {
      * Represents an unknown role. This can occur if a newer version adds a role that an older version does not know about, or a newer
      * version removes a role that an older version knows about.
      */
-    static class UnknownRole extends DiscoveryNodeRole {
+    public static class UnknownRole extends DiscoveryNodeRole {
 
         /**
          * Construct an unknown role with the specified role name and role name abbreviation.
@@ -132,6 +132,27 @@ public abstract class DiscoveryNodeRole {
             return Setting.boolSetting("node. " + roleName(), false, Setting.Property.NodeScope);
         }
 
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            UnknownRole that = (UnknownRole) o;
+            return Objects.equals(roleName(), that.roleName()) &&
+                Objects.equals(roleNameAbbreviation(), that.roleNameAbbreviation());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(roleName(), roleNameAbbreviation());
+        }
+
+        @Override
+        public String toString() {
+            return "UnknownRole{" +
+                "roleName='" + roleName() + '\'' +
+                ", roleAbbreviation='" + roleNameAbbreviation() + '\'' +
+                '}';
+        }
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeRoleTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeRoleTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.cluster.node;
 
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.EqualsHashCodeTestUtils;
 
 import java.util.Set;
 
@@ -75,4 +76,15 @@ public class DiscoveryNodeRoleTests extends ESTestCase {
         assertThat(e, hasToString(containsString("Duplicate key")));
     }
 
+    public void testUnknownDiscoveryNodeRoleEqualsHashCode() {
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(new DiscoveryNodeRole.UnknownRole(randomAlphaOfLength(10), randomAlphaOfLength(1)),
+            r -> new DiscoveryNodeRole.UnknownRole(r.roleName(), r.roleNameAbbreviation()),
+            r -> {
+                if (randomBoolean()) {
+                    return new DiscoveryNodeRole.UnknownRole(randomAlphaOfLength(21 - r.roleName().length()), r.roleNameAbbreviation());
+                } else {
+                    return new DiscoveryNodeRole.UnknownRole(r.roleName(), randomAlphaOfLength(3 - r.roleNameAbbreviation().length()));
+                }
+            });
+    }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.EqualsHashCodeTestUtils;
 
 import java.net.InetAddress;
 

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.EqualsHashCodeTestUtils;
 
 import java.net.InetAddress;
 


### PR DESCRIPTION
Adds methods to `DiscoveryNodeRole.UnknownRole` to compare these objects'
values for equality, and adds a specialized `toString()` implementation for
clearer test failures.

Relates #43175