### PR TITLE
Analysis enhancement - better plural stemmer than minimal_english.

### DIFF
--- a/docs/reference/analysis/tokenfilters/stemmer-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/stemmer-tokenfilter.asciidoc
@@ -84,6 +84,7 @@ English::
 http://snowball.tartarus.org/algorithms/porter/stemmer.html[*`english`*],
 http://ciir.cs.umass.edu/pubfiles/ir-35.pdf[`light_english`],
 http://www.researchgate.net/publication/220433848_How_effective_is_suffixing[`minimal_english`],
+https://github.com/elastic/elasticsearch/issues/42892[`plural_english`],
 http://lucene.apache.org/core/4_9_0/analyzers-common/org/apache/lucene/analysis/en/EnglishPossessiveFilter.html[`possessive_english`],
 http://snowball.tartarus.org/algorithms/english/stemmer.html[`porter2`],
 http://snowball.tartarus.org/algorithms/lovins/stemmer.html[`lovins`]

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/EnglishPluralStemFilter.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/EnglishPluralStemFilter.java
@@ -132,7 +132,7 @@ public final class EnglishPluralStemFilter extends TokenFilter {
             }
         }
 
-        private final boolean isOesException(char[] s, int len) {
+        private boolean isOesException(char[] s, int len) {
             for (char[] oesRule : oesExceptions) {
                 int rulePos = oesRule.length - 1;
                 int sPos = len - 1;

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/EnglishPluralStemFilter.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/EnglishPluralStemFilter.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.analysis.common;
+
+import org.apache.lucene.analysis.TokenFilter;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.en.EnglishMinimalStemFilter;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.KeywordAttribute;
+
+import java.io.IOException;
+
+public final class EnglishPluralStemFilter extends TokenFilter {
+    private final EnglishPlurallStemmer stemmer = new EnglishPlurallStemmer();
+    private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+    private final KeywordAttribute keywordAttr = addAttribute(KeywordAttribute.class);
+
+    public EnglishPluralStemFilter(TokenStream input) {
+        super(input);
+    }
+
+    @Override
+    public boolean incrementToken() throws IOException {
+        if (input.incrementToken()) {
+            if (!keywordAttr.isKeyword()) {
+                final int newlen = stemmer.stem(termAtt.buffer(), termAtt.length());
+                termAtt.setLength(newlen);
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Plural stemmer for English based on the {@link EnglishMinimalStemFilter}
+     * <p>
+     * This stemmer removes plurals but beyond EnglishMinimalStemFilter adds
+     * four new suffix rules to remove dangling e characters:
+     * <ul>
+     * <li>xes - "boxes" becomes "box"</li>
+     * <li>sses - "dresses" becomes "dress"</li>
+     * <li>shes - "dishes" becomes "dish"</li>
+     * <li>tches - "watches" becomes "watch"</li>
+     * </ul>
+     * See https://github.com/elastic/elasticsearch/issues/42892
+     */
+    public static class EnglishPlurallStemmer {
+        @SuppressWarnings("fallthrough")
+        public int stem(char s[], int len) {
+            if (len < 3 || s[len - 1] != 's')
+                return len;
+
+            switch (s[len - 2]) {
+            case 'u':
+            case 's':
+                return len;
+            case 'e':
+                if (len > 3 && s[len - 3] == 'i' && s[len - 4] != 'a' && s[len - 4] != 'e') {
+                    s[len - 3] = 'y';
+                    return len - 2;
+                }
+                
+                // Suffix rules to remove any dangling "e"                
+                if (len > 3) {
+                    // xes (but >1 prefix so we can stem "boxes->box" but keep "axes->axe")
+                    if (len > 4 && s[len -3] == 'x') {
+                        return len - 2;
+                    }
+                    // shes/sses
+                    if (len > 4) {
+                        if (s[len -4] == 's' && (s[len -3] == 'h' || s[len -3] == 's')){
+                            return len - 2;
+                        }
+                        // tches
+                        if (len > 5) {
+                            if (s[len -5] == 't' && s[len -4] == 'c' && s[len -3] == 'h' ){
+                                return len - 2;
+                            }                            
+                        }                        
+                    }
+                }
+                
+                if (s[len - 3] == 'i' || s[len - 3] == 'a' || s[len - 3] == 'o' || s[len - 3] == 'e')
+                    return len; /* intentional fallthrough */
+                if (s[len - 3] == 'i' || s[len - 3] == 'a' || s[len - 3] == 'o' || s[len - 3] == 'e')
+                    return len; /* intentional fallthrough */
+            default:
+                return len - 1;
+            }
+        }
+    }
+
+}

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/EnglishPluralStemFilter.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/EnglishPluralStemFilter.java
@@ -77,6 +77,19 @@ public final class EnglishPluralStemFilter extends TokenFilter {
                 "canoes".toCharArray(), 
                 "oboes".toCharArray() 
                 }; 
+        // Words ending in ches that retain the e when stemmed 
+        public static final char [][] chesExceptions = { 
+                "cliches".toCharArray(), 
+                "avalanches".toCharArray(), 
+                "mustaches".toCharArray(), 
+                "moustaches".toCharArray(), 
+                "quiches".toCharArray(), 
+                "headaches".toCharArray(), 
+                "heartaches".toCharArray(), 
+                "porsches".toCharArray(), 
+                "tranches".toCharArray(), 
+                "caches".toCharArray() 
+                }; 
         
         @SuppressWarnings("fallthrough")
         public int stem(char s[], int len) {
@@ -105,7 +118,7 @@ public final class EnglishPluralStemFilter extends TokenFilter {
                     }
                     // oes
                     if (len > 3 && s[len -3] == 'o') {
-                        if (isOesException(s, len)) {
+                        if (isException(s, len, oesExceptions)) {
                             // Only remove the S
                             return len -1;
                         }
@@ -118,10 +131,16 @@ public final class EnglishPluralStemFilter extends TokenFilter {
                             return len - 2;
                         }
                         
-                        // tches (TODO consider just ches? Gains: lunches == lunch, losses: moustaches!= moustache
-                        if (len > 5) {
-                            if (s[len -5] == 't' && s[len -4] == 'c' && s[len -3] == 'h' ){
+                        // ches
+                        if (len > 4) {
+                            if (s[len -4] == 'c' && s[len -3] == 'h' ){
+                                if (isException(s, len, chesExceptions)) {
+                                    // Only remove the S
+                                    return len -1;
+                                }
+                                // Remove the es 
                                 return len - 2;
+
                             }                            
                         }                        
                     }
@@ -132,8 +151,8 @@ public final class EnglishPluralStemFilter extends TokenFilter {
             }
         }
 
-        private boolean isOesException(char[] s, int len) {
-            for (char[] oesRule : oesExceptions) {
+        private boolean isException(char[] s, int len, char [][] exceptionsList) {
+            for (char[] oesRule : exceptionsList) {
                 int rulePos = oesRule.length - 1;
                 int sPos = len - 1;
                 boolean matched = true;

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/EnglishPluralStemFilter.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/EnglishPluralStemFilter.java
@@ -64,8 +64,8 @@ public final class EnglishPluralStemFilter extends TokenFilter {
      * <p>
      * In addition the s stemmer logic is amended so that
      * <ul>
-     * <li>ees->ee so that bees matches bee</li>
-     * <li>ies->y only on longer words to that ties matches tie</li>
+     * <li>ees-&gt;ee so that bees matches bee</li>
+     * <li>ies-&gt;y only on longer words to that ties matches tie</li>
      * </ul>
      */
     public static class EnglishPlurallStemmer {

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/StemmerTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/StemmerTokenFilterFactory.java
@@ -139,6 +139,8 @@ public class StemmerTokenFilterFactory extends AbstractTokenFilterFactory {
             return new SnowballFilter(tokenStream, new EnglishStemmer());
         } else if ("minimal_english".equalsIgnoreCase(language) || "minimalEnglish".equalsIgnoreCase(language)) {
             return new EnglishMinimalStemFilter(tokenStream);
+        } else if ("plural_english".equalsIgnoreCase(language) || "pluralEnglish".equalsIgnoreCase(language)) {
+            return new EnglishPluralStemFilter(tokenStream);
         } else if ("possessive_english".equalsIgnoreCase(language) || "possessiveEnglish".equalsIgnoreCase(language)) {
             return new EnglishPossessiveFilter(tokenStream);
 

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/StemmerTokenFilterFactoryTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/StemmerTokenFilterFactoryTests.java
@@ -127,12 +127,16 @@ public class StemmerTokenFilterFactoryTests extends ESTokenStreamTestCase {
             assertAnalyzesTo(analyzer, "horses", new String[]{"horse"});
             assertAnalyzesTo(analyzer, "cameras", new String[]{"camera"});
             
-            // TODO The orginal s stemmer gives up on stemming oes words because English has no fixed rule for the stem
+            // The orginal s stemmer gives up on stemming oes words because English has no fixed rule for the stem
             // (see https://howtospell.co.uk/making-O-words-plural )
-            // Would be good to find a heuristic for stemming oes words.
-            assertAnalyzesTo(analyzer, "toes", new String[]{"toes"});
-            assertAnalyzesTo(analyzer, "shoes", new String[]{"shoes"});
-            assertAnalyzesTo(analyzer, "heroes", new String[]{"heroes"});
+            // This stemmer removes the es but retains e for a small number of exceptions 
+            assertAnalyzesTo(analyzer, "mosquitoes", new String[]{"mosquito"});
+            assertAnalyzesTo(analyzer, "heroes", new String[]{"hero"});
+            // oes exceptions that retain the e.
+            assertAnalyzesTo(analyzer, "shoes", new String[]{"shoe"});
+            assertAnalyzesTo(analyzer, "horseshoes", new String[]{"horseshoe"});
+            assertAnalyzesTo(analyzer, "canoes", new String[]{"canoe"});
+            assertAnalyzesTo(analyzer, "oboes", new String[]{"oboe"});
 
             // Check improved EnglishPluralStemFilter logic
             //sses

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/StemmerTokenFilterFactoryTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/StemmerTokenFilterFactoryTests.java
@@ -121,15 +121,49 @@ public class StemmerTokenFilterFactoryTests extends ESTokenStreamTestCase {
             IndexAnalyzers indexAnalyzers = analysis.indexAnalyzers;
             NamedAnalyzer analyzer = indexAnalyzers.get("my_plurals");
             assertThat(create, instanceOf(EnglishPluralStemFilter.class));
+
+            // Check old EnglishMinimalStemmer ("S" stemmer) logic
             assertAnalyzesTo(analyzer, "phones", new String[]{"phone"});
             assertAnalyzesTo(analyzer, "horses", new String[]{"horse"});
+            assertAnalyzesTo(analyzer, "cameras", new String[]{"camera"});
+            
+            // TODO The orginal s stemmer gives up on stemming oes words because English has no fixed rule for the stem
+            // (see https://howtospell.co.uk/making-O-words-plural )
+            // Would be good to find a heuristic for stemming oes words.
+            assertAnalyzesTo(analyzer, "toes", new String[]{"toes"});
+            assertAnalyzesTo(analyzer, "shoes", new String[]{"shoes"});
+            assertAnalyzesTo(analyzer, "heroes", new String[]{"heroes"});
+
+            // Check improved EnglishPluralStemFilter logic
+            //sses
             assertAnalyzesTo(analyzer, "dresses", new String[]{"dress"});
-            assertAnalyzesTo(analyzer, "watches", new String[]{"watch"});
             assertAnalyzesTo(analyzer, "possess", new String[]{"possess"});
             assertAnalyzesTo(analyzer, "possesses", new String[]{"possess"});
+            // xes
             assertAnalyzesTo(analyzer, "boxes", new String[]{"box"});
             assertAnalyzesTo(analyzer, "axes", new String[]{"axe"});
+            //shes
             assertAnalyzesTo(analyzer, "dishes", new String[]{"dish"});
+            assertAnalyzesTo(analyzer, "washes", new String[]{"wash"});
+            //ees
+            assertAnalyzesTo(analyzer, "employees", new String[]{"employee"});
+            assertAnalyzesTo(analyzer, "bees", new String[]{"bee"});
+            //tch
+            assertAnalyzesTo(analyzer, "watches", new String[]{"watch"});
+            assertAnalyzesTo(analyzer, "itches", new String[]{"itch"});
+            // ies->y but only for length >4
+            assertAnalyzesTo(analyzer, "spies", new String[]{"spy"});
+            assertAnalyzesTo(analyzer, "ties", new String[]{"tie"});
+            assertAnalyzesTo(analyzer, "lies", new String[]{"lie"});
+            assertAnalyzesTo(analyzer, "pies", new String[]{"pie"});
+            assertAnalyzesTo(analyzer, "dies", new String[]{"die"});
+
+            
+            // *CHES - would be good to find a simple rule that solves lunches, churches but doesn't break aches
+            // documenting current behaviour here as a known issue:
+            assertAnalyzesTo(analyzer, "lunches", new String[]{"lunche"});
+            assertAnalyzesTo(analyzer, "avalanches", new String[]{"avalanche"});
+            assertAnalyzesTo(analyzer, "headaches", new String[]{"headache"});
         }
     }    
 

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/StemmerTokenFilterFactoryTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/StemmerTokenFilterFactoryTests.java
@@ -163,11 +163,16 @@ public class StemmerTokenFilterFactoryTests extends ESTokenStreamTestCase {
             assertAnalyzesTo(analyzer, "dies", new String[]{"die"});
 
             
-            // *CHES - would be good to find a simple rule that solves lunches, churches but doesn't break aches
-            // documenting current behaviour here as a known issue:
-            assertAnalyzesTo(analyzer, "lunches", new String[]{"lunche"});
+            assertAnalyzesTo(analyzer, "lunches", new String[]{"lunch"});
             assertAnalyzesTo(analyzer, "avalanches", new String[]{"avalanche"});
             assertAnalyzesTo(analyzer, "headaches", new String[]{"headache"});
+            assertAnalyzesTo(analyzer, "caches", new String[]{"cache"});
+            assertAnalyzesTo(analyzer, "beaches", new String[]{"beach"});
+            assertAnalyzesTo(analyzer, "britches", new String[]{"britch"});
+            assertAnalyzesTo(analyzer, "cockroaches", new String[]{"cockroach"});
+            assertAnalyzesTo(analyzer, "cliches", new String[]{"cliche"});
+            assertAnalyzesTo(analyzer, "quiches", new String[]{"quiche"});
+            
         }
     }    
 


### PR DESCRIPTION
Drops the trailing “e” in taxes, dresses, watches, dishes etc that otherwise cause mismatches with plural and singular forms.
See the issue for recall benchmarking results on typical data.
Closes #42892