### PR TITLE
Properly format reproduction lines for test methods that contain periods

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -84,8 +84,14 @@ public class ReproduceInfoPrinter extends RunListener {
         b.append(failure.getDescription().getClassName());
         final String methodName = failure.getDescription().getMethodName();
         if (methodName != null) {
-            b.append(".");
-            b.append(failure.getDescription().getMethodName());
+            // fallback to system property filter when tests contain "."
+            if (methodName.contains(".")) {
+                b.append("\" -Dtests.method=\"");
+                b.append(methodName);
+            } else {
+                b.append(".");
+                b.append(methodName);
+            }
         }
         b.append("\"");
 


### PR DESCRIPTION
The Gradle `Test` task's `--tests` option doesn't handle test include patterns where the test method name includes a period (`.`). The parser assumes that everything before the last occurrence of `.` is the test _class_. To get around this we update the `ReproduceInfoPrinter` to fallback to the old system property method (i.e. `-Dtests.method=`) when it encounters a failed test method that contains `.`.