### PR TITLE
[ML] Unmute NetworkDisruptionIT.testJobRelocation

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/NetworkDisruptionIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/NetworkDisruptionIT.java
@@ -38,12 +38,6 @@ public class NetworkDisruptionIT extends BaseMlIntegTestCase {
         return plugins;
     }
 
-    // Remove this once the AwaitsFix below has been resolved
-    public void testDummy() {
-        assertTrue(true);
-    }
-
-    @AwaitsFix( bugUrl = "https://github.com/elastic/elasticsearch/issues/39858")
     public void testJobRelocation() throws Exception {
         internalCluster().ensureAtLeastNumDataNodes(5);
         ensureStableCluster(5);


### PR DESCRIPTION
Reenable the test muted in #39858. The failure was due to the cluster failing to form and a related issue has been closed so this is to test whether the issue is resolved or not.  

This reverts commit 27346a076b5f3ca9a81dabbf1796182d3ffc7e00.
