### PR TITLE
SearchPhaseContext to not extend ActionListener

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -284,8 +284,7 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
         return request;
     }
 
-    @Override
-    public final SearchResponse buildSearchResponse(InternalSearchResponse internalSearchResponse, String scrollId) {
+    protected final SearchResponse buildSearchResponse(InternalSearchResponse internalSearchResponse, String scrollId) {
         ShardSearchFailure[] failures = buildShardFailures();
         Boolean allowPartialResults = request.allowPartialSearchResults();
         assert allowPartialResults != null : "SearchRequest missing setting for allowPartialSearchResults";
@@ -294,6 +293,11 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
         }
         return new SearchResponse(internalSearchResponse, scrollId, getNumShards(), successfulOps.get(),
             skippedOps.get(), buildTookInMillis(), failures, clusters);
+    }
+
+    @Override
+    public void sendSearchResponse(InternalSearchResponse internalSearchResponse, String scrollId) {
+        listener.onResponse(buildSearchResponse(internalSearchResponse, scrollId));
     }
 
     @Override
@@ -314,16 +318,6 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
     @Override
     public final void execute(Runnable command) {
         executor.execute(command);
-    }
-
-    @Override
-    public final void onResponse(SearchResponse response) {
-        listener.onResponse(response);
-    }
-
-    @Override
-    public final void onFailure(Exception e) {
-        listener.onFailure(e);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -301,6 +301,11 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
     }
 
     @Override
+    public void onFailure(Exception e) {
+        listener.onFailure(e);
+    }
+
+    @Override
     public final void onPhaseFailure(SearchPhase phase, String msg, Throwable cause) {
         raisePhaseFailure(new SearchPhaseExecutionException(phase.getName(), msg, cause, buildShardFailures()));
     }

--- a/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -301,11 +301,6 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
     }
 
     @Override
-    public void onFailure(Exception e) {
-        listener.onFailure(e);
-    }
-
-    @Override
     public final void onPhaseFailure(SearchPhase phase, String msg, Throwable cause) {
         raisePhaseFailure(new SearchPhaseExecutionException(phase.getName(), msg, cause, buildShardFailures()));
     }
@@ -323,6 +318,11 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
     @Override
     public final void execute(Runnable command) {
         executor.execute(command);
+    }
+
+    @Override
+    public final void onFailure(Exception e) {
+        listener.onFailure(e);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/search/ExpandSearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ExpandSearchPhase.java
@@ -30,7 +30,6 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.collapse.CollapseBuilder;
 import org.elasticsearch.search.internal.InternalSearchResponse;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -65,7 +64,7 @@ final class ExpandSearchPhase extends SearchPhase {
     }
 
     @Override
-    public void run() throws IOException {
+    public void run() {
         if (isCollapseRequest() && searchResponse.hits().getHits().length > 0) {
             SearchRequest searchRequest = context.getRequest();
             CollapseBuilder collapseBuilder = searchRequest.source().collapse();
@@ -114,7 +113,7 @@ final class ExpandSearchPhase extends SearchPhase {
                         }
                     }
                     context.executeNextPhase(this, nextPhaseFactory.apply(searchResponse));
-                }, context::onFailure)
+                }, e -> context.onPhaseFailure(this, "failed to expand hits", e))
             );
         } else {
             context.executeNextPhase(this, nextPhaseFactory.apply(searchResponse));

--- a/server/src/main/java/org/elasticsearch/action/search/ExpandSearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ExpandSearchPhase.java
@@ -113,7 +113,7 @@ final class ExpandSearchPhase extends SearchPhase {
                         }
                     }
                     context.executeNextPhase(this, nextPhaseFactory.apply(searchResponse));
-                }, e -> context.onPhaseFailure(this, "failed to expand hits", e))
+                }, context::onFailure)
             );
         } else {
             context.executeNextPhase(this, nextPhaseFactory.apply(searchResponse));

--- a/server/src/main/java/org/elasticsearch/action/search/SearchPhaseContext.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchPhaseContext.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.action.search;
 
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.search.SearchShardTarget;
@@ -32,7 +31,7 @@ import java.util.concurrent.Executor;
 /**
  * This class provide contextual state and access to resources across multiple search phases.
  */
-interface SearchPhaseContext extends ActionListener<SearchResponse>, Executor {
+interface SearchPhaseContext extends Executor {
     // TODO maybe we can make this concrete later - for now we just implement this in the base class for all initial phases
 
     /**
@@ -56,11 +55,11 @@ interface SearchPhaseContext extends ActionListener<SearchResponse>, Executor {
     SearchRequest getRequest();
 
     /**
-     * Builds the final search response that should be send back to the user.
+     * Builds and sends the final search response back to the user.
      * @param internalSearchResponse the internal search response
      * @param scrollId an optional scroll ID if this search is a scroll search
      */
-    SearchResponse buildSearchResponse(InternalSearchResponse internalSearchResponse, String scrollId);
+    void sendSearchResponse(InternalSearchResponse internalSearchResponse, String scrollId);
 
     /**
      * This method will communicate a fatal phase failure back to the user. In contrast to a shard failure
@@ -113,5 +112,4 @@ interface SearchPhaseContext extends ActionListener<SearchResponse>, Executor {
      * a response is returned to the user indicating that all shards have failed.
      */
     void executeNextPhase(SearchPhase currentPhase, SearchPhase nextPhase);
-
 }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchPhaseContext.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchPhaseContext.java
@@ -62,6 +62,11 @@ interface SearchPhaseContext extends Executor {
     void sendSearchResponse(InternalSearchResponse internalSearchResponse, String scrollId);
 
     /**
+     * Notifies the top-level listener of the provided exception
+     */
+    void onFailure(Exception e);
+
+    /**
      * This method will communicate a fatal phase failure back to the user. In contrast to a shard failure
      * will this method immediately fail the search request and return the failure to the issuer of the request
      * @param phase the phase that failed

--- a/server/src/test/java/org/elasticsearch/action/search/MockSearchPhaseContext.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MockSearchPhaseContext.java
@@ -49,6 +49,7 @@ public final class MockSearchPhaseContext implements SearchPhaseContext {
     Set<Long> releasedSearchContexts = new HashSet<>();
     SearchRequest searchRequest = new SearchRequest();
     AtomicInteger phasesExecuted = new AtomicInteger();
+    AtomicReference<SearchResponse> searchResponse = new AtomicReference<>();
 
     public MockSearchPhaseContext(int numShards) {
         this.numShards = numShards;
@@ -82,9 +83,9 @@ public final class MockSearchPhaseContext implements SearchPhaseContext {
     }
 
     @Override
-    public SearchResponse buildSearchResponse(InternalSearchResponse internalSearchResponse, String scrollId) {
-        return new SearchResponse(internalSearchResponse, scrollId, numShards, numSuccess.get(), 0, 0,
-            failures.toArray(new ShardSearchFailure[failures.size()]), SearchResponse.Clusters.EMPTY);
+    public void sendSearchResponse(InternalSearchResponse internalSearchResponse, String scrollId) {
+        searchResponse.set(new SearchResponse(internalSearchResponse, scrollId, numShards, numSuccess.get(), 0, 0,
+            failures.toArray(ShardSearchFailure.EMPTY_ARRAY), SearchResponse.Clusters.EMPTY));
     }
 
     @Override
@@ -128,16 +129,6 @@ public final class MockSearchPhaseContext implements SearchPhaseContext {
     @Override
     public void execute(Runnable command) {
         command.run();
-    }
-
-    @Override
-    public void onResponse(SearchResponse response) {
-        Assert.fail("should not be called");
-    }
-
-    @Override
-    public void onFailure(Exception e) {
-        Assert.fail("should not be called");
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/search/MockSearchPhaseContext.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MockSearchPhaseContext.java
@@ -89,11 +89,6 @@ public final class MockSearchPhaseContext implements SearchPhaseContext {
     }
 
     @Override
-    public void onFailure(Exception e) {
-        Assert.fail("should not be called");
-    }
-
-    @Override
     public void onPhaseFailure(SearchPhase phase, String msg, Throwable cause) {
         phaseFailure.set(cause);
     }
@@ -134,6 +129,11 @@ public final class MockSearchPhaseContext implements SearchPhaseContext {
     @Override
     public void execute(Runnable command) {
         command.run();
+    }
+
+    @Override
+    public void onFailure(Exception e) {
+        Assert.fail("should not be called");
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/search/MockSearchPhaseContext.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MockSearchPhaseContext.java
@@ -89,6 +89,11 @@ public final class MockSearchPhaseContext implements SearchPhaseContext {
     }
 
     @Override
+    public void onFailure(Exception e) {
+        Assert.fail("should not be called");
+    }
+
+    @Override
     public void onPhaseFailure(SearchPhase phase, String msg, Throwable cause) {
         phaseFailure.set(cause);
     }


### PR DESCRIPTION
The fact that SearchPhaseContext extends ActionListener makes it hard
to reason about when the original listener is notified and to trace
those calls. Also, the corresponding onFailure and onResponse were
only needed in two places, one each, where they can be replaced by a
more intuitive call, like sendSearchResponse for onResponse.