### PR TITLE
[ML][Data Frame] validate the format is appropriate for interval on PUT

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_crud.yml
@@ -52,6 +52,21 @@ setup:
             }
           }
 ---
+"Test put transform with invalid format":
+  - do:
+      catch: /\[hour\] has invalid format \[yyyy-MM-dd\] for interval \[1h\]/
+      data_frame.put_data_frame_transform:
+        transform_id: "invalid-date_histogram-format"
+        body: >
+          {
+            "source": { "index": "airline-transform" },
+            "dest": { "index": "invalid-date_histogram-format-idx" },
+            "pivot": {
+              "group_by": { "hour": {"date_histogram": {"field": "time", "calendar_interval": "1h", "format":"yyyy-MM-dd"}}},
+              "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+            }
+          }
+---
 "Test basic transform crud":
   - do:
       data_frame.put_data_frame_transform:
@@ -61,7 +76,10 @@ setup:
             "source": { "index": "airline-data" },
             "dest": { "index": "airline-data-by-airline" },
             "pivot": {
-              "group_by": { "airline": {"terms": {"field": "airline"}}},
+              "group_by": {
+                "airline": {"terms": {"field": "airline"}},
+                "hour": {"date_histogram": {"field":"time", "calendar_interval": "1h", "format": "yyyy-MM-dd HH:00"}}
+              },
               "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
             },
             "description": "yaml test transform on airline-data"
@@ -91,6 +109,7 @@ setup:
   - match: { transforms.0.dest.index: "airline-data-by-airline" }
   - is_true: transforms.0.source.query.match_all
   - match: { transforms.0.pivot.group_by.airline.terms.field: "airline" }
+  - match: { transforms.0.pivot.group_by.hour.date_histogram.field: "time" }
   - match: { transforms.0.pivot.aggregations.avg_response.avg.field: "responsetime" }
   - match: { transforms.0.description: "yaml test transform on airline-data" }
 


### PR DESCRIPTION
This PR validates that the format of the `date_histogram` pivot is not a lower fidelity than that the interval.

NOTES:

* This validation is only done on PUT, and will prevent the transform creation
* This validation does not handle situations where the interval is actually a multiple of the next calendar value type(e.g. `24h` instead of `1d`).
   * The reason for this decision is because what if somebody puts in an interval of `720h` ? That is approximately a month, and jumps into a non-deterministic time value. If it is considered important for usability, I can try to revisit that logic. It can get pretty tricky to validate if this is allowed. Certain values (like 25 days) won't see a repeated bucket for a long time, but eventually will depending on the format.

closes https://github.com/elastic/elasticsearch/issues/43068