### PR TITLE
[7.x] [ML] BWC tests for job_stats.timing_stats field (#43267)

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/30_ml_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/30_ml_jobs_crud.yml
@@ -39,10 +39,10 @@
 "Test get old cluster job's timing stats":
   - do:
       ml.get_job_stats:
-        job_id: old-cluster-job
-  - match: { jobs.0.job_id: old-cluster-job }
+        job_id: old-cluster-job-with-ts
+  - match: { jobs.0.job_id: old-cluster-job-with-ts }
   - match: { jobs.0.state: "closed" }
-  - match: { jobs.0.timing_stats.job_id: old-cluster-job }
+  - match: { jobs.0.timing_stats.job_id: old-cluster-job-with-ts }
   - match: { jobs.0.timing_stats.bucket_count: 1 }
   - gte:   { jobs.0.timing_stats.minimum_bucket_processing_time_ms: 0.0 }
   - gte:   { jobs.0.timing_stats.maximum_bucket_processing_time_ms: 0.0 }

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/30_ml_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/30_ml_jobs_crud.yml
@@ -36,6 +36,20 @@
   - match: { count: 1 }
 
 ---
+"Test get old cluster job's timing stats":
+  - do:
+      ml.get_job_stats:
+        job_id: old-cluster-job
+  - match: { jobs.0.job_id: old-cluster-job }
+  - match: { jobs.0.state: "closed" }
+  - match: { jobs.0.timing_stats.job_id: old-cluster-job }
+  - match: { jobs.0.timing_stats.bucket_count: 1 }
+  - gte:   { jobs.0.timing_stats.minimum_bucket_processing_time_ms: 0.0 }
+  - gte:   { jobs.0.timing_stats.maximum_bucket_processing_time_ms: 0.0 }
+  - gte:   { jobs.0.timing_stats.average_bucket_processing_time_ms: 0.0 }
+  - gte:   { jobs.0.timing_stats.exponential_average_bucket_processing_time_ms: 0.0 }
+
+---
 "Test get old cluster categorization job":
   - do:
       ml.get_jobs:

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/30_ml_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/30_ml_jobs_crud.yml
@@ -37,17 +37,16 @@
 
 ---
 "Test get old cluster job's timing stats":
+  - skip:
+      version: " - 7.2.99"
+      reason: timing_stats was introduced in 7.3.0
   - do:
       ml.get_job_stats:
         job_id: old-cluster-job-with-ts
   - match: { jobs.0.job_id: old-cluster-job-with-ts }
   - match: { jobs.0.state: "closed" }
   - match: { jobs.0.timing_stats.job_id: old-cluster-job-with-ts }
-  - match: { jobs.0.timing_stats.bucket_count: 1 }
-  - gte:   { jobs.0.timing_stats.minimum_bucket_processing_time_ms: 0.0 }
-  - gte:   { jobs.0.timing_stats.maximum_bucket_processing_time_ms: 0.0 }
-  - gte:   { jobs.0.timing_stats.average_bucket_processing_time_ms: 0.0 }
-  - gte:   { jobs.0.timing_stats.exponential_average_bucket_processing_time_ms: 0.0 }
+  - gte:   { jobs.0.timing_stats.bucket_count: 0 }
 
 ---
 "Test get old cluster categorization job":

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/30_ml_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/30_ml_jobs_crud.yml
@@ -170,6 +170,64 @@
        wait_for_status: green
 
 ---
+"Put job with timing stats checking on the old cluster and post some data":
+
+  - do:
+      ml.put_job:
+        job_id: old-cluster-job-with-ts
+        body:  >
+          {
+            "description":"Cluster upgrade with timing stats checking",
+            "analysis_config" : {
+                "bucket_span": "60s",
+                "detectors" :[{"function":"metric","field_name":"responsetime","by_field_name":"airline"}]
+            },
+            "analysis_limits" : {
+                "model_memory_limit": "50mb"
+            },
+            "data_description" : {
+                "format":"xcontent",
+                "time_field":"time",
+                "time_format":"epoch"
+            }
+          }
+  - match: { job_id: old-cluster-job-with-ts }
+
+  - do:
+      ml.open_job:
+        job_id: old-cluster-job-with-ts
+
+  - do:
+      ml.post_data:
+        job_id: old-cluster-job-with-ts
+        body:
+          - airline: AAL
+            responsetime: 132.2046
+            sourcetype: post-data-job
+            time: 1403481600
+          - airline: JZA
+            responsetime: 990.4628
+            sourcetype: post-data-job
+            time: 1403481700
+  - match: { processed_record_count: 2 }
+
+  - do:
+      ml.close_job:
+        job_id: old-cluster-job-with-ts
+
+  - do:
+      ml.get_buckets:
+        job_id: old-cluster-job-with-ts
+  - match: { count: 1 }
+
+  # Wait for indices to be fully allocated before
+  # killing the node
+  - do:
+      cluster.health:
+        index: [".ml-state", ".ml-anomalies-shared"]
+        wait_for_status: green
+
+---
 "Put job with empty strings in the configuration":
   - do:
       ml.put_job:

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/30_ml_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/30_ml_jobs_crud.yml
@@ -110,6 +110,20 @@ setup:
   - is_true: ''
 
 ---
+"Test get old cluster job's timing stats":
+  - do:
+      ml.get_job_stats:
+        job_id: old-cluster-job
+  - match: { jobs.0.job_id: old-cluster-job }
+  - match: { jobs.0.state: "closed" }
+  - match: { jobs.0.timing_stats.job_id: old-cluster-job }
+  - match: { jobs.0.timing_stats.bucket_count: 1 }
+  - gte:   { jobs.0.timing_stats.minimum_bucket_processing_time_ms: 0.0 }
+  - gte:   { jobs.0.timing_stats.maximum_bucket_processing_time_ms: 0.0 }
+  - gte:   { jobs.0.timing_stats.average_bucket_processing_time_ms: 0.0 }
+  - gte:   { jobs.0.timing_stats.exponential_average_bucket_processing_time_ms: 0.0 }
+
+---
 "Test job with pre 6.4 rules":
 
   - do:

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/30_ml_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/30_ml_jobs_crud.yml
@@ -113,15 +113,25 @@ setup:
 "Test get old cluster job's timing stats":
   - do:
       ml.get_job_stats:
-        job_id: old-cluster-job
-  - match: { jobs.0.job_id: old-cluster-job }
+        job_id: old-cluster-job-with-ts
+  - match: { jobs.0.job_id: old-cluster-job-with-ts }
   - match: { jobs.0.state: "closed" }
-  - match: { jobs.0.timing_stats.job_id: old-cluster-job }
+  - match: { jobs.0.timing_stats.job_id: old-cluster-job-with-ts }
   - match: { jobs.0.timing_stats.bucket_count: 1 }
   - gte:   { jobs.0.timing_stats.minimum_bucket_processing_time_ms: 0.0 }
   - gte:   { jobs.0.timing_stats.maximum_bucket_processing_time_ms: 0.0 }
   - gte:   { jobs.0.timing_stats.average_bucket_processing_time_ms: 0.0 }
   - gte:   { jobs.0.timing_stats.exponential_average_bucket_processing_time_ms: 0.0 }
+
+  - do:
+      ml.delete_job:
+        job_id: old-cluster-job-with-ts
+  - match: { acknowledged: true }
+
+  - do:
+      catch: missing
+      ml.get_jobs:
+        job_id: old-cluster-job-with-ts
 
 ---
 "Test job with pre 6.4 rules":

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/30_ml_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/30_ml_jobs_crud.yml
@@ -117,11 +117,7 @@ setup:
   - match: { jobs.0.job_id: old-cluster-job-with-ts }
   - match: { jobs.0.state: "closed" }
   - match: { jobs.0.timing_stats.job_id: old-cluster-job-with-ts }
-  - match: { jobs.0.timing_stats.bucket_count: 1 }
-  - gte:   { jobs.0.timing_stats.minimum_bucket_processing_time_ms: 0.0 }
-  - gte:   { jobs.0.timing_stats.maximum_bucket_processing_time_ms: 0.0 }
-  - gte:   { jobs.0.timing_stats.average_bucket_processing_time_ms: 0.0 }
-  - gte:   { jobs.0.timing_stats.exponential_average_bucket_processing_time_ms: 0.0 }
+  - gte:   { jobs.0.timing_stats.bucket_count: 0 }
 
   - do:
       ml.delete_job:


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] BWC tests for job_stats.timing_stats field  (#43267)