### PR TITLE
Deprecate native code info in xpack info api

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/xpack/XPackInfoResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/xpack/XPackInfoResponse.java
@@ -326,6 +326,11 @@ public class XPackInfoResponse {
                 return enabled;
             }
 
+            /**
+             * Return native code info
+             * @deprecated Use ML info api to find native code info
+             */
+            @Deprecated
             @Nullable
             public Map<String, Object> nativeCodeInfo() {
                 return nativeCodeInfo;


### PR DESCRIPTION
The xpack info api currently returns native code info within each
feature. This commit deprecates retrieving that info, which is now
available directly in the ML info api.