### PR TITLE
specifies which index to search in docs for various queries

### DIFF
--- a/docs/reference/query-dsl/geo-bounding-box-query.asciidoc
+++ b/docs/reference/query-dsl/geo-bounding-box-query.asciidoc
@@ -39,7 +39,7 @@ Then the following simple query can be executed with a
 
 [source,js]
 --------------------------------------------------
-GET /_search
+GET my_locations/_search
 {
     "query": {
         "bool" : {
@@ -94,7 +94,7 @@ representations of the geo point, the filter can accept it as well:
 
 [source,js]
 --------------------------------------------------
-GET /_search
+GET my_locations/_search
 {
     "query": {
         "bool" : {
@@ -129,7 +129,7 @@ conform with http://geojson.org/[GeoJSON].
 
 [source,js]
 --------------------------------------------------
-GET /_search
+GET my_locations/_search
 {
     "query": {
         "bool" : {
@@ -157,7 +157,7 @@ Format in `lat,lon`.
 
 [source,js]
 --------------------------------------------------
-GET /_search
+GET my_locations/_search
 {
     "query": {
         "bool" : {
@@ -183,7 +183,7 @@ GET /_search
 
 [source,js]
 --------------------------------------------------
-GET /_search
+GET my_locations/_search
 {
     "query": {
         "bool" : {
@@ -208,7 +208,7 @@ GET /_search
 
 [source,js]
 --------------------------------------------------
-GET /_search
+GET my_locations/_search
 {
     "query": {
         "bool" : {
@@ -243,7 +243,7 @@ geohash the geohash can be specified in both `top_left` and
 
 [source,js]
 --------------------------------------------------
-GET /_search
+GET my_locations/_search
 {
     "query": {
         "geo_bounding_box" : {
@@ -273,7 +273,7 @@ values separately.
 
 [source,js]
 --------------------------------------------------
-GET /_search
+GET my_locations/_search
 {
     "query": {
         "bool" : {
@@ -323,7 +323,7 @@ are not supported. Here is an example:
 
 [source,js]
 --------------------------------------------------
-GET /_search
+GET my_locations/_search
 {
     "query": {
         "bool" : {

--- a/docs/reference/search/suggesters/phrase-suggest.asciidoc
+++ b/docs/reference/search/suggesters/phrase-suggest.asciidoc
@@ -224,7 +224,7 @@ The response contains suggestions scored by the most likely spell correction fir
 
 [source,js]
 --------------------------------------------------
-POST _search
+POST test/_search
 {
   "suggest": {
     "text" : "noble prize",
@@ -293,7 +293,7 @@ properties that can be configured.
 
 [source,js]
 --------------------------------------------------
-POST _search
+POST test/_search
 {
   "suggest": {
     "text" : "obel prize",
@@ -414,7 +414,7 @@ accept ordinary analyzer names.
 
 [source,js]
 --------------------------------------------------
-POST _search
+POST test/_search
 {
   "suggest": {
     "text" : "obel prize",


### PR DESCRIPTION
the geo-bounding-box and phrase-suggest docs were susceptible to
failing due to other indices in the cluster. This change restricts
the queries to the index that is set up for the test.

relates to #43271.