### PR TITLE
[Docs] Remove boost parameter from intervals-query example

### DIFF
--- a/docs/reference/query-dsl/intervals-query.asciidoc
+++ b/docs/reference/query-dsl/intervals-query.asciidoc
@@ -40,7 +40,6 @@ POST _search
             }
           ]
         },
-        "boost" : 2.0,
         "_name" : "favourite_food"
       }
     }


### PR DESCRIPTION
The boost factor doesn't seem to be needed and can possibly be removed. To me it
raised the question of why it was there in the example. If it is important for
the example to work it should be explained why instead.