### PR TITLE
Docs: Add description of the coerce parameter in geo_shape mapper

### DIFF
--- a/docs/reference/mapping/types/geo-shape.asciidoc
+++ b/docs/reference/mapping/types/geo-shape.asciidoc
@@ -108,6 +108,8 @@ geo-points containing any more than latitude and longitude (two dimensions) valu
 and reject the whole document.
 | `true`
 
+|`coerce` |If `true` unclosed linear rings in polygons will be automatically closed.
+| `false`
 
 |=======================================================================
 


### PR DESCRIPTION
Explains the effect of the coerce parameter on the geo_shape field.

Relates #35059

