### PR TITLE
Make the ignore_above docs tests more robust.

### DIFF
--- a/docs/reference/mapping/params/ignore-above.asciidoc
+++ b/docs/reference/mapping/params/ignore-above.asciidoc
@@ -30,7 +30,7 @@ PUT my_index/_doc/2 <3>
   "message": "Syntax error with some long stacktrace"
 }
 
-GET _search <4>
+GET my_index/_search <4>
 {
   "aggs": {
     "messages": {


### PR DESCRIPTION
It is possible for internal ML indices like `.data-frame-notifications-1` to leak,
causing other docs tests to fail when they accidentally search over these
indices. This PR updates the ignore_above tests to only search a specific index.

The index leaking issue is tracked in #43271.

Addresses #43347.