### PR TITLE
[DOCS] Rewrite `constant_score` query

### DIFF
--- a/docs/reference/query-dsl/constant-score-query.asciidoc
+++ b/docs/reference/query-dsl/constant-score-query.asciidoc
@@ -1,12 +1,12 @@
 [[query-dsl-constant-score-query]]
 === Constant Score Query
 
-A query that wraps another query and simply returns a
-constant score equal to the query boost for every document in the
-filter. Maps to Lucene `ConstantScoreQuery`.
+Wraps a <<query-dsl-bool-query, filter query>> and returns every matching
+document with a <<query-filter-context, relevance score>> equal to the `boost`
+parameter value.
 
 [source,js]
---------------------------------------------------
+----
 GET /_search
 {
     "query": {
@@ -18,8 +18,22 @@ GET /_search
         }
     }
 }
---------------------------------------------------
+----
 // CONSOLE
 
-Filter clauses are executed in <<query-filter-context,filter context>>,
-meaning that scoring is ignored and clauses are considered for caching.
+[[constant-score-top-level-params]]
+==== Top-level parameters for `constant_score`
+`filter`::
++
+--
+<<query-dsl-bool-query, Filter query>> you wish to run. Any returned documents
+must match this query. Required.
+
+Filter queries do not calculate <<query-filter-context, relevance scores>>. To
+speed up performance, {es} automatically caches frequently used filter queries.
+--
+
+`boost`::
+Floating point number used as the constant <<query-filter-context, relevance
+score>> for every document matching the `filter` query. Default is `1.0`.
+Optional.


### PR DESCRIPTION
## Changes
* Rewrites description of `constant_score` query
* Adds parameters section

This is part of #40977, an effort to standardize documentation for query types.

## Before
<details>
 <summary>Before image</summary>
<img width="784" alt="Before image" src="https://user-images.githubusercontent.com/40268737/59772629-22dbb400-927a-11e9-8729-74eec5a03378.png">
</details>


## After
<details>
 <summary>After image</summary>
<img width="770" alt="After image" src="https://user-images.githubusercontent.com/40268737/59772642-2707d180-927a-11e9-8dcb-40591da7bb59.png">
</details>
