### PR TITLE
Fix NetworkUtilsTests (#43295)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/network/NetworkUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/network/NetworkUtils.java
@@ -200,10 +200,14 @@ public abstract class NetworkUtils {
     static InetAddress[] getAllAddresses() throws IOException {
         return filterAllAddresses(address -> true, "no up-and-running addresses found");
     }
-    
+
+    static Optional<NetworkInterface> maybeGetInterfaceByName(List<NetworkInterface> networkInterfaces, String name) {
+        return networkInterfaces.stream().filter(netIf -> name.equals(netIf.getName())).findFirst();
+    }
+
     /** Returns addresses for the given interface (it must be marked up) */
     static InetAddress[] getAddressesForInterface(String name) throws SocketException {
-        Optional<NetworkInterface> networkInterface = getInterfaces().stream().filter((netIf) -> name.equals(netIf.getName())).findFirst();
+        Optional<NetworkInterface> networkInterface = maybeGetInterfaceByName(getInterfaces(), name);
 
         if (networkInterface.isPresent() == false) {
             throw new IllegalArgumentException("No interface named '" + name + "' found, got " + getInterfaces());

--- a/server/src/test/java/org/elasticsearch/common/network/NetworkUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/network/NetworkUtilsTests.java
@@ -20,12 +20,15 @@
 package org.elasticsearch.common.network;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.hamcrest.OptionalMatchers;
 
 import java.net.InetAddress;
 import java.net.NetworkInterface;
-import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
 /**
  * Tests for network utils. Please avoid using any methods that cause DNS lookups!
@@ -79,23 +82,14 @@ public class NetworkUtilsTests extends ESTestCase {
         assertArrayEquals(new InetAddress[] { InetAddress.getByName("::1") }, NetworkUtils.filterIPV6(addresses));
     }
 
-    /**
-     * Test that selecting by name is possible and properly matches the addresses on all interfaces and virtual
-     * interfaces.
-     *
-     * Note that to avoid that this test fails when interfaces are down or they do not have addresses assigned to them,
-     * they are ignored.
-     */
-    public void testAddressInterfaceLookup() throws Exception {
-        for (NetworkInterface netIf : NetworkUtils.getInterfaces()) {
-            if (!netIf.isUp() || Collections.list(netIf.getInetAddresses()).isEmpty()) {
-                continue;
-            }
-
-            String name = netIf.getName();
-            InetAddress[] expectedAddresses = Collections.list(netIf.getInetAddresses()).toArray(new InetAddress[0]);
-            InetAddress[] foundAddresses = NetworkUtils.getAddressesForInterface(name);
-            assertArrayEquals(expectedAddresses, foundAddresses);
+    // test that selecting by name is possible
+    public void testMaybeGetInterfaceByName() throws Exception {
+        final List<NetworkInterface> networkInterfaces = NetworkUtils.getInterfaces();
+        for (NetworkInterface netIf : networkInterfaces) {
+            final Optional<NetworkInterface> maybeNetworkInterface =
+                NetworkUtils.maybeGetInterfaceByName(networkInterfaces, netIf.getName());
+            assertThat(maybeNetworkInterface, OptionalMatchers.isPresent());
+            assertThat(maybeNetworkInterface.get().getName(), equalTo(netIf.getName()));
         }
     }
 


### PR DESCRIPTION
* Follow up to #42109:
   * Adjust test to only check that interface lookup by name works not actually lookup IPs which is brittle since virtual interfaces can be destroyed/created by Docker while the tests are running

backport of #43295 

Co-authored-by:  Jason Tedor <jason@tedor.me>
