### PR TITLE
Fix GeoIP custom database directory in docs

### DIFF
--- a/docs/reference/ingest/processors/geoip.asciidoc
+++ b/docs/reference/ingest/processors/geoip.asciidoc
@@ -10,7 +10,7 @@ under the CCA-ShareAlike 4.0 license. For more details see, http://dev.maxmind.c
 
 The `geoip` processor can run with other GeoIP2 databases from Maxmind. The files must be copied into the `ingest-geoip` config directory,
 and the `database_file` option should be used to specify the filename of the custom database. Custom database files must be stored
-uncompressed. The `ingest-geoip` config directory is located at `$ES_HOME/config/ingest-geoip`.
+uncompressed. The `ingest-geoip` config directory is located at `$ES_CONFIG/ingest-geoip`.
 
 [[using-ingest-geoip]]
 ==== Using the `geoip` Processor in a Pipeline


### PR DESCRIPTION
These docs were misleading for package installations of Elasticsearch. Instead, we should refer to $ES_CONFIG/ingest-geoip asthe path to place the custom database files. For non-package installations, this is the same as $ES_HOME/config, but for package installations this is not the case as the config directory for package installations is /etc/elasticsearch, and is not relative to $ES_HOME. This commit corrects the docs.

Closes #43376