### PR TITLE
Set document on script when using Bytes.WithScript

### DIFF
--- a/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/100_terms_agg.yml
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/100_terms_agg.yml
@@ -1,0 +1,104 @@
+setup:
+  - do:
+      indices.create:
+          index: test_1
+          body:
+            settings:
+              number_of_replicas: 0
+            mappings:
+              properties:
+                str:
+                   type: keyword
+                double:
+                  type: double
+                number:
+                  type: long
+
+  - do:
+      cluster.health:
+        wait_for_status: green
+
+  - do:
+      index:
+        index: test_1
+        id: 1
+        body:
+          str: "abc"
+          double: 1.0
+          number: 1
+
+  - do:
+      index:
+        index: test_1
+        id: 2
+        body:
+          str: "abc"
+          double: 1.0
+          number: 1
+
+  - do:
+      index:
+        index: test_1
+        id: 3
+        body:
+          str: "bcd"
+          double: 2.0
+          number: 2
+
+  - do:
+      indices.refresh: {}
+
+---
+"String Value Script with doc notation":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body: { "size" : 0, "aggs" : { "str_terms" : { "terms" : { "field" : "str", "script": { "source": "return doc.str[0] + \"1\""} } } } }
+
+  - match: { hits.total: 3 }
+
+  - length: { aggregations.str_terms.buckets: 2 }
+  - match: { aggregations.str_terms.buckets.0.key: "abc1" }
+  - is_false: aggregations.str_terms.buckets.0.key_as_string
+  - match: { aggregations.str_terms.buckets.0.doc_count: 2 }
+  - match: { aggregations.str_terms.buckets.1.key: "bcd1" }
+  - is_false: aggregations.str_terms.buckets.1.key_as_string
+  - match: { aggregations.str_terms.buckets.1.doc_count: 1 }
+
+---
+"Long Value Script with doc notation":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body: { "size" : 0, "aggs" : { "long_terms" : { "terms" : { "field" : "number", "script": { "source": "return doc.number[0] + 1"} } } } }
+
+  - match: { hits.total: 3 }
+
+  - length: { aggregations.long_terms.buckets: 2 }
+  - match: { aggregations.long_terms.buckets.0.key: 2.0 }
+  - is_false: aggregations.long_terms.buckets.0.key_as_string
+  - match: { aggregations.long_terms.buckets.0.doc_count: 2 }
+  - match: { aggregations.long_terms.buckets.1.key: 3.0 }
+  - is_false: aggregations.long_terms.buckets.1.key_as_string
+  - match: { aggregations.long_terms.buckets.1.doc_count: 1 }
+
+---
+"Double Value Script with doc notation":
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body: { "size" : 0, "aggs" : { "double_terms" : { "terms" : { "field" : "double", "script": { "source": "return doc.double[0] + 1"} } } } }
+
+  - match: { hits.total: 3 }
+
+  - length: { aggregations.double_terms.buckets: 2 }
+  - match: { aggregations.double_terms.buckets.0.key: 2.0 }
+  - is_false: aggregations.double_terms.buckets.0.key_as_string
+  - match: { aggregations.double_terms.buckets.0.doc_count: 2 }
+  - match: { aggregations.double_terms.buckets.1.key: 3.0 }
+  - is_false: aggregations.double_terms.buckets.1.key_as_string
+  - match: { aggregations.double_terms.buckets.1.doc_count: 1 }
+

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
@@ -452,6 +452,7 @@ public abstract class ValuesSource {
                 if (bytesValues.advanceExact(doc)) {
                     count = bytesValues.docValueCount();
                     grow();
+                    script.setDocument(doc);
                     for (int i = 0; i < count; ++i) {
                         final BytesRef value = bytesValues.nextValue();
                         script.setNextAggregationValue(value.utf8ToString());


### PR DESCRIPTION
Long and Double ValuesSource set the current document on the script before executing, but Bytes was missing this method call.  That meant it was possible to generate an OutOfBoundsException when using a "value" script (`field` + `script`) on keyword or other bytes fields.  Because it was never set, the doc remained unintialized at -1 and when the script asked for the doc value it'd blow up from an illegal doc ordinal.

This adds in the method call, and a few yaml tests to verify correct behavior.

/cc @jdconrad because I want to make sure this is ok use of setDocument and i'm not misunderstanding, @not-napoleon because you're now our resident ValuesSource expert :)

*As a side note, the exception is entirely avoided by using a "regular script" (`script` only, no `field`)*
