### PR TITLE
[7.x] Prevent NullPointerException in TransportRolloverAction (#43353)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -44,6 +44,7 @@ import org.elasticsearch.cluster.metadata.MetaDataCreateIndexService;
 import org.elasticsearch.cluster.metadata.MetaDataIndexAliasesService;
 import org.elasticsearch.cluster.metadata.MetaDataIndexTemplateService;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.shard.DocsStats;
@@ -55,6 +56,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -238,7 +240,11 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
     }
 
     static Map<String, Boolean> evaluateConditions(final Collection<Condition<?>> conditions,
-                                                   final DocsStats docsStats, final IndexMetaData metaData) {
+                                                   @Nullable final DocsStats docsStats,
+                                                   @Nullable final IndexMetaData metaData) {
+        if (metaData == null) {
+            return conditions.stream().collect(Collectors.toMap(Condition::toString, cond -> false));
+        }
         final long numDocs = docsStats == null ? 0 : docsStats.getCount();
         final long indexSize = docsStats == null ? 0 : docsStats.getTotalSizeInBytes();
         final Condition.Stats stats = new Condition.Stats(numDocs, metaData.getCreationDate(), new ByteSizeValue(indexSize));
@@ -247,9 +253,18 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
             .collect(Collectors.toMap(result -> result.condition.toString(), result -> result.matched));
     }
 
-    static Map<String, Boolean> evaluateConditions(final Collection<Condition<?>> conditions, final IndexMetaData metaData,
-                                                    final IndicesStatsResponse statsResponse) {
-        return evaluateConditions(conditions, statsResponse.getIndex(metaData.getIndex().getName()).getPrimaries().getDocs(), metaData);
+    static Map<String, Boolean> evaluateConditions(final Collection<Condition<?>> conditions,
+                                                   @Nullable final IndexMetaData metaData,
+                                                   @Nullable final IndicesStatsResponse statsResponse) {
+        if (metaData == null) {
+            return conditions.stream().collect(Collectors.toMap(Condition::toString, cond -> false));
+        } else {
+            final DocsStats docsStats = Optional.ofNullable(statsResponse)
+                .map(stats -> stats.getIndex(metaData.getIndex().getName()))
+                .map(indexStats -> indexStats.getPrimaries().getDocs())
+                .orElse(null);
+            return evaluateConditions(conditions, docsStats, metaData);
+        }
     }
 
     static void validate(MetaData metaData, RolloverRequest request) {

--- a/server/src/test/java/org/elasticsearch/rest/action/cat/RestIndicesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/cat/RestIndicesActionTests.java
@@ -151,7 +151,7 @@ public class RestIndicesActionTests extends ESTestCase {
         }
     }
 
-    private IndicesStatsResponse randomIndicesStatsResponse(final IndexMetaData[] indices) {
+    public static IndicesStatsResponse randomIndicesStatsResponse(final IndexMetaData[] indices) {
         List<ShardStats> shardStats = new ArrayList<>();
         for (final IndexMetaData index : indices) {
             int numShards = randomIntBetween(1, 3);


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Prevent NullPointerException in TransportRolloverAction  (#43353)