### PR TITLE
Remove Confusing Comment

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
@@ -70,7 +70,6 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
                 .withTimeout(recoverySettings.internalActionLongTimeout())
                 .build();
         this.fileChunkRequestOptions = TransportRequestOptions.builder()
-                // we are saving the cpu for other things
                 .withType(TransportRequestOptions.Type.RECOVERY)
                 .withTimeout(recoverySettings.internalActionTimeout())
                 .build();


### PR DESCRIPTION
I was looking to see if ES6.8 had compression for recovery disabled by default and came across [this comment](https://github.com/elastic/elasticsearch/commit/8bc2332d9ab028a5415a9606cd349790d3f5dc99#diff-fba6bfac4311a6801e0df6116d86bdecR68) where it was forced to false in ES5.

Looks like in ES6.6 it was [changed](https://github.com/elastic/elasticsearch/pull/36522/files#diff-0adb05ce3100b3dfbffb25daf3021c12L71) so that the `tcp.transport.compress` setting is respected instead of false being the default. In that commit the original comment seems to only have been partially deleted resulting in a now confusing half comment about cpu usage (unless I am missing something?)

