### PR TITLE
Better support for unmapped fields in AggregatorTestCase

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -86,6 +86,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -161,6 +162,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
         when(searchContext.getQueryShardContext()).thenReturn(queryShardContext);
         Map<String, MappedFieldType> fieldNameToType = new HashMap<>();
         fieldNameToType.putAll(Arrays.stream(fieldTypes)
+            .filter(Objects::nonNull)
             .collect(Collectors.toMap(MappedFieldType::name, Function.identity())));
         fieldNameToType.putAll(getFieldAliases(fieldTypes));
 


### PR DESCRIPTION
AggregatorTestCase will NPE if only a single, null MappedFieldType is provided (which is required to simulate an unmapped field).  While it's possible to test unmapped fields by supplying other, non-related field types... that's clunky and unnecessary.  AggregatorTestCase just needs to filter out null field types when setting up.

Adjusts an unmapped terms test, and adds one for max aggregation as proof that it works.  We should probably also add unmapped tests across the board but I wanted to get this in so other PRs could use it.

/cc @not-napoleon 

Related to https://github.com/elastic/elasticsearch/issues/42893
