### PR TITLE
Improove error on waiting for cluster to come up

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/http/WaitForHttpResource.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/http/WaitForHttpResource.java
@@ -129,18 +129,14 @@ public class WaitForHttpResource {
     }
 
     protected void checkResource(SSLContext ssl) throws IOException {
-        try {
-            final HttpURLConnection connection = buildConnection(ssl);
-            connection.connect();
-            final Integer response = connection.getResponseCode();
-            if (validResponseCodes.contains(response)) {
-                logger.info("Got successful response [{}] from URL [{}]", response, url);
-                return;
-            } else {
-                throw new IOException(response + " " + connection.getResponseMessage());
-            }
-        } catch (IOException e) {
-            throw e;
+        final HttpURLConnection connection = buildConnection(ssl);
+        connection.connect();
+        final Integer response = connection.getResponseCode();
+        if (validResponseCodes.contains(response)) {
+            logger.info("Got successful response [{}] from URL [{}]", response, url);
+            return;
+        } else {
+            throw new IOException(response + " " + connection.getResponseMessage());
         }
     }
 

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
@@ -320,7 +320,6 @@ public class ElasticsearchCluster implements TestClusterConfiguration {
 
     private void addWaitForClusterHealth() {
         waitConditions.put("cluster health yellow", (node) -> {
-
             try {
                 boolean httpSslEnabled = getFirstNode().isHttpSslEnabled();
                 WaitForHttpResource wait = new WaitForHttpResource(
@@ -339,7 +338,7 @@ public class ElasticsearchCluster implements TestClusterConfiguration {
                 }
                 return wait.wait(500);
             } catch (IOException e) {
-                throw new IllegalStateException("Connection attempt to " + this + " failed", e);
+                throw new UncheckedIOException("IO error while waiting cluster", e);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new TestClustersException("Interrupted while waiting for " + this, e);

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClusterConfiguration.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClusterConfiguration.java
@@ -122,7 +122,7 @@ public interface TestClusterConfiguration {
                 } catch (TestClustersException e) {
                     throw e;
                 } catch (Exception e) {
-                    throw  e;
+                    lastException = e;
                 }
             }
             if (conditionMet == false) {
@@ -131,7 +131,17 @@ public interface TestClusterConfiguration {
                 if (lastException == null) {
                     throw new TestClustersException(message);
                 } else {
-                    throw new TestClustersException(message + message, lastException);
+                    String extraCause = "";
+                    Throwable cause = lastException;
+                    int ident = 2;
+                    while (cause != null) {
+                        if (cause.getMessage() != null && cause.getMessage().isEmpty() == false) {
+                            extraCause += "\n" + " ".repeat(ident) + cause.getMessage();
+                            ident += 2;
+                        }
+                        cause = cause.getCause();
+                    }
+                    throw new TestClustersException(message + extraCause, lastException);
                 }
             }
             logger.info(


### PR DESCRIPTION
Always include all messages from exceptions to make the reason for
failure more visible.

