### PR TITLE
[DOCS] Rewrite create index API to test new API reference format

### DIFF
--- a/docs/reference/indices/create-index.asciidoc
+++ b/docs/reference/indices/create-index.asciidoc
@@ -48,7 +48,7 @@ include the following characters: `\`, `/`, `*`, `?`, `"`, `<`, `>`, `|`, ` `
 `wait_for_active_shards` (Optional)::
 (integer) Number of active shard copies required to start before returning a
 response. See
-<<index-wait-for-active-shards, Wait For active shards>>.
+<<index-wait-for-active-shards>>.
 
 include::{docdir}/rest-api/timeoutparms.asciidoc[]
 

--- a/docs/reference/indices/create-index.asciidoc
+++ b/docs/reference/indices/create-index.asciidoc
@@ -54,12 +54,7 @@ include the following characters: `\`, `/`, `*`, `?`, `"`, `<`, `>`, `|`, ` `
 response. See
 <<index-wait-for-active-shards, Wait For active shards>>.
 
-`timeout` (Optional)::
-(<<time-units,time value>>) Maximum time to wait for the operation before
-providing a response.  Defaults to `30s`.
-
-`master_timeout` (Optional)::
-(<<time-units,time value>>) Maximum time to wait to discover the master node in the cluster. If not provided, defaults to the `timeout` value.
+include::{docdir}/rest-api/timeoutparms.asciidoc[]
 
 [float]
 [[indices-create-index-request-body]]

--- a/docs/reference/indices/create-index.asciidoc
+++ b/docs/reference/indices/create-index.asciidoc
@@ -8,7 +8,7 @@ Create an index.
 
 [float]
 [[indices-create-index-request]]
-=== Request
+=== {api-request-title}
 
 [source,js]
 ----
@@ -18,12 +18,12 @@ PUT <index>
 
 [float]
 [[sample-api-desc]]
-=== Description
+=== {api-description-title}
 You can use the create index API to manually create an index in {es}.
 
 [float]
 [[indices-create-index-path-params]]
-=== Path parameters
+=== {api-path-parms-title}
 
 `<index>` (Required)::
 +
@@ -46,7 +46,7 @@ include the following characters: `\`, `/`, `*`, `?`, `"`, `<`, `>`, `|`, ` `
 
 [float]
 [[indices-create-index-query-params]]
-=== Query parameters
+=== {api-query-parms-title}
 
 [[create-index-wait-for-active-shards]]
 `wait_for_active_shards` (Optional)::
@@ -58,7 +58,7 @@ include::{docdir}/rest-api/timeoutparms.asciidoc[]
 
 [float]
 [[indices-create-index-request-body]]
-=== Request body
+=== {api-request-body-title}
 
 [[create-index-settings]]
 `settings` (Optional)::
@@ -77,7 +77,7 @@ aliases>>.
 
 [float]
 [[indices-create-index-response-body]]
-=== Response body
+=== {api-response-body-title}
 
 `acknowledged`::
 +
@@ -104,7 +104,7 @@ If `false`, it is possible that {es} still successfully created the index. A
 
 [float]
 [[indices-create-index-example]]
-=== Example
+=== {api-example-title}
 
 [source,js]
 ----

--- a/docs/reference/indices/create-index.asciidoc
+++ b/docs/reference/indices/create-index.asciidoc
@@ -10,11 +10,7 @@ Creates an index.
 [[indices-create-index-request]]
 === {api-request-title}
 
-[source,js]
-----
-PUT <index>
-----
-// NOTCONSOLE
+`PUT <index>`
 
 [float]
 [[sample-api-desc]]

--- a/docs/reference/indices/create-index.asciidoc
+++ b/docs/reference/indices/create-index.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Create index</titleabbrev>
 ++++
 
-Create an index.
+Creates an index.
 
 [float]
 [[indices-create-index-request]]

--- a/docs/reference/indices/create-index.asciidoc
+++ b/docs/reference/indices/create-index.asciidoc
@@ -83,7 +83,7 @@ aliases>>.
 +
 --
 (boolean) Indicates whether the index was successfully created in the cluster
-before timing out. Possible values are `true` and `false`.
+before timing out.
 
 If `false`, it is possible that {es} still successfully created the index. A
 `false` value only indicates the operation timed out before the response.
@@ -93,7 +93,7 @@ If `false`, it is possible that {es} still successfully created the index. A
 +
 --
 (boolean) Indicates whether the required number of active shard copies started
-before timing out. Possible values are `true` and `false`.
+before timing out.
 
 If `false`, it is possible that {es} still successfully created the index. A
 `false` value only indicates the operation timed out before the response.

--- a/docs/reference/indices/create-index.asciidoc
+++ b/docs/reference/indices/create-index.asciidoc
@@ -1,87 +1,118 @@
 [[indices-create-index]]
-== Create Index
+== Create index API
+++++
+<titleabbrev>Create index</titleabbrev>
+++++
 
-The Create Index API is used to manually create an index in Elasticsearch.  All documents in Elasticsearch
-are stored inside of one index or another.
-
-The most basic command is the following:
-
-[source,js]
---------------------------------------------------
-PUT twitter
---------------------------------------------------
-// CONSOLE
-
-This creates an index named `twitter` with all default setting.
-
-[NOTE]
-.Index name limitations
-======================================================
-There are several limitations to what you can name your index.  The complete list of limitations are:
-
-- Lowercase only
-- Cannot include `\`, `/`, `*`, `?`, `"`, `<`, `>`, `|`, ` ` (space character), `,`, `#`
-- Indices prior to 7.0 could contain a colon (`:`), but that's been deprecated and won't be supported in 7.0+
-- Cannot start with `-`, `_`, `+`
-- Cannot be `.` or `..`
-- Cannot be longer than 255 bytes (note it is bytes, so multi-byte characters will count towards the 255 limit faster)
-
-======================================================
+Create an index.
 
 [float]
+[[indices-create-index-request]]
+=== Request
+
+[source,js]
+----
+PUT <index>
+----
+// NOTCONSOLE
+
+[float]
+[[sample-api-desc]]
+=== Description
+You can use the create index API to manually create an index in {es}.
+
+[float]
+[[indices-create-index-path-params]]
+=== Path parameters
+
+`<index>` (Required)::
++
+--
+(string) Name of the index.
+
+[NOTE]
+====
+Index names must meet the following criteria:
+
+* Must be lowercase only
+* deprecated:[7.0, "Index names can no longer include a colon (`:`)."] Cannot
+include the following characters: `\`, `/`, `*`, `?`, `"`, `<`, `>`, `|`, ` `
+(space character), `,`, `#`, or `:`.
+* Cannot begin with the following characters: `-`, `_`, `+`.
+* Cannot be named `.` or `..`.
+* Cannot be longer than 255 bytes, including multi-byte characters.
+====
+--
+
+[float]
+[[indices-create-index-query-params]]
+=== Query parameters
+
+[[create-index-wait-for-active-shards]]
+`wait_for_active_shards` (Optional)::
+(integer) Number of active shard copies required to start before returning a
+response. See
+<<index-wait-for-active-shards, Wait For active shards>>.
+
+`timeout` (Optional)::
+(<<time-units,time value>>) Maximum time to wait for the operation before
+providing a response.  Defaults to `30s`.
+
+`master_timeout` (Optional)::
+(<<time-units,time value>>) Maximum time to wait to discover the master node in the cluster. If not provided, defaults to the `timeout` value.
+
+[float]
+[[indices-create-index-request-body]]
+=== Request body
+
 [[create-index-settings]]
-=== Index Settings
+`settings` (Optional)::
+(object) Configuration options for the index. See <<index-modules-settings,
+Index settings>>.
 
-Each index created can have specific settings
-associated with it, defined in the body:
+[[mappings]]
+`mappings` (Optional)::
+(object) Describes fields in the index and their datatypes. See <<mapping-types,
+Field datatypes>>.
 
-[source,js]
---------------------------------------------------
-PUT twitter
-{
-    "settings" : {
-        "index" : {
-            "number_of_shards" : 3, <1>
-            "number_of_replicas" : 2 <2>
-        }
-    }
-}
---------------------------------------------------
-// CONSOLE
-<1> Default for `number_of_shards` is 1
-<2> Default for `number_of_replicas` is 1 (ie one replica for each primary shard)
-
-or more simplified
-
-[source,js]
---------------------------------------------------
-PUT twitter
-{
-    "settings" : {
-        "number_of_shards" : 3,
-        "number_of_replicas" : 2
-    }
-}
---------------------------------------------------
-// CONSOLE
-
-[NOTE]
-You do not have to explicitly specify `index` section inside the
-`settings` section.
-
-For more information regarding all the different index level settings
-that can be set when creating an index, please check the
-<<index-modules,index modules>> section.
-
+[[create-index-aliases]]
+`aliases` (Optional)::
+(object) Index aliases which include the index. See <<indices-aliases, Index
+aliases>>.
 
 [float]
-[[mappings]]
-=== Mappings
+[[indices-create-index-response-body]]
+=== Response body
 
-The create index API allows for providing a mapping definition:
+`acknowledged`::
++
+--
+(boolean) Indicates whether the index was successfully created in the cluster
+before timing out. Possible values are `true` and `false`.
+
+If `false`, it is possible that {es} still successfully created the index. A
+`false` value only indicates the operation timed out before the response.
+--
+
+`shards_acknowledged`::
++
+--
+(boolean) Indicates whether the required number of active shard copies started
+before timing out. Possible values are `true` and `false`.
+
+If `false`, it is possible that {es} still successfully created the index. A
+`false` value only indicates the operation timed out before the response.
+--
+
+`index`::
+(string) Name of the index.
+
+[float]
+[[indices-create-index-example]]
+=== Example
 
 [source,js]
---------------------------------------------------
+----
 PUT test
 {
     "settings" : {
@@ -91,25 +122,7 @@ PUT test
         "properties" : {
             "field1" : { "type" : "text" }
         }
-    }
-}
---------------------------------------------------
-// CONSOLE
-
-NOTE: Before 7.0.0, the 'mappings' definition used to include a type name. Although specifying
-types in requests is now deprecated, a type can still be provided if the request parameter
-include_type_name is set. For more details, please see <<removal-of-types>>.
-
-[float]
-[[create-index-aliases]]
-=== Aliases
-
-The create index API allows also to provide a set of <<indices-aliases,aliases>>:
-
-[source,js]
---------------------------------------------------
-PUT test
-{
+    },
     "aliases" : {
         "alias_1" : {},
         "alias_2" : {
@@ -120,62 +133,17 @@ PUT test
         }
     }
 }
---------------------------------------------------
+----
 // CONSOLE
 
-[float]
-[[create-index-wait-for-active-shards]]
-=== Wait For Active Shards
-
-By default, index creation will only return a response to the client when the primary copies of
-each shard have been started, or the request times out. The index creation response will indicate
-what happened:
+The API returns the following result:
 
 [source,js]
---------------------------------------------------
+----
 {
     "acknowledged": true,
     "shards_acknowledged": true,
     "index": "test"
 }
---------------------------------------------------
+----
 // TESTRESPONSE
-
-`acknowledged` indicates whether the index was successfully created in the cluster, while
-`shards_acknowledged` indicates whether the requisite number of shard copies were started for
-each shard in the index before timing out. Note that it is still possible for either
-`acknowledged` or `shards_acknowledged` to be `false`, but the index creation was successful.
-These values simply indicate whether the operation completed before the timeout. If
-`acknowledged` is `false`, then we timed out before the cluster state was updated with the
-newly created index, but it probably will be created sometime soon. If `shards_acknowledged`
-is `false`, then we timed out before the requisite number of shards were started (by default
-just the primaries), even if the cluster state was successfully updated to reflect the newly
-created index (i.e. `acknowledged=true`).
-
-We can change the default of only waiting for the primary shards to start through the index
-setting `index.write.wait_for_active_shards` (note that changing this setting will also affect
-the `wait_for_active_shards` value on all subsequent write operations):
-
-[source,js]
---------------------------------------------------
-PUT test
-{
-    "settings": {
-        "index.write.wait_for_active_shards": "2"
-    }
-}
---------------------------------------------------
-// CONSOLE
-// TEST[skip:requires two nodes]
-
-or through the request parameter `wait_for_active_shards`:
-
-[source,js]
---------------------------------------------------
-PUT test?wait_for_active_shards=2
---------------------------------------------------
-// CONSOLE
-// TEST[skip:requires two nodes]
-
-A detailed explanation of `wait_for_active_shards` and its possible values can be found
-<<index-wait-for-active-shards,here>>.

--- a/docs/reference/indices/create-index.asciidoc
+++ b/docs/reference/indices/create-index.asciidoc
@@ -56,20 +56,21 @@ include::{docdir}/rest-api/timeoutparms.asciidoc[]
 [[indices-create-index-request-body]]
 === {api-request-body-title}
 
-[[create-index-settings]]
-`settings` (Optional)::
-(object) Configuration options for the index. See <<index-modules-settings,
-Index settings>>.
+[[create-index-aliases]]
+`aliases` (Optional)::
+(object) Index aliases which include the index. See <<indices-aliases, Index
+aliases>>.
 
 [[mappings]]
 `mappings` (Optional)::
 (object) Describes fields in the index and their datatypes. See <<mapping-types,
 Field datatypes>>.
 
-[[create-index-aliases]]
-`aliases` (Optional)::
-(object) Index aliases which include the index. See <<indices-aliases, Index
-aliases>>.
+[[create-index-settings]]
+`settings` (Optional)::
+(object) Configuration options for the index. See <<index-modules-settings,
+Index settings>>.
+
 
 [float]
 [[indices-create-index-response-body]]
@@ -106,14 +107,6 @@ If `false`, it is possible that {es} still successfully created the index. A
 ----
 PUT test
 {
-    "settings" : {
-        "number_of_shards" : 1
-    },
-    "mappings" : {
-        "properties" : {
-            "field1" : { "type" : "text" }
-        }
-    },
     "aliases" : {
         "alias_1" : {},
         "alias_2" : {
@@ -122,6 +115,14 @@ PUT test
             },
             "routing" : "kimchy"
         }
+    },
+    "mappings" : {
+        "properties" : {
+            "field1" : { "type" : "text" }
+        }
+    },
+    "settings" : {
+        "number_of_shards" : 1
     }
 }
 ----

--- a/docs/reference/rest-api/timeoutparms.asciidoc
+++ b/docs/reference/rest-api/timeoutparms.asciidoc
@@ -1,11 +1,9 @@
 `timeout`::
-  (time units) Specifies the period of time to wait for a response. If no
+  (<<time-units, time units>>) Specifies the period of time to wait for a response. If no
   response is received before the timeout expires, the request fails and
-  returns an error. Defaults to `30s`. For more information about
-  time units, see <<time-units>>.
+  returns an error. Defaults to `30s`.
 
 `master_timeout`::
-  (time units) Specifies the period of time to wait for a connection to the
+  (<<time-units, time units>>) Specifies the period of time to wait for a connection to the
   master node. If no response is received before the timeout expires, the request
-  fails and returns an error. Defaults to `30s`. For more information about
-  time units, see <<time-units>>.
+  fails and returns an error. Defaults to `30s`.


### PR DESCRIPTION
With https://github.com/elastic/docs/pull/938, we created a standard template
for Elastic API Reference documentation.

This PR rewrites the create index API to use that template.

Relates to elastic/docs#937

FYI @lcawl @KOTungseth 