### PR TITLE
Version bump to 6 8 2

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -1,4 +1,4 @@
-elasticsearch     = 6.8.1
+elasticsearch     = 6.8.2
 lucene            = 7.7.0
 
 # optional dependencies

--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -1,4 +1,4 @@
-:version:               6.8.0
+:version:               6.8.1
 :major-version:         6.x
 :lucene_version:        7.7.0
 :lucene_version_path:   7_7_0

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -145,8 +145,9 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_6_7_2 = new Version(6070299, org.apache.lucene.util.Version.LUCENE_7_7_0);
     public static final Version V_6_8_0 = new Version(6080099, org.apache.lucene.util.Version.LUCENE_7_7_0);
     public static final Version V_6_8_1 = new Version(6080199, org.apache.lucene.util.Version.LUCENE_7_7_0);
+    public static final Version V_6_8_2 = new Version(6080299, org.apache.lucene.util.Version.LUCENE_7_7_0);
 
-    public static final Version CURRENT = V_6_8_1;
+    public static final Version CURRENT = V_6_8_2;
 
 
     private static final ImmutableOpenIntMap<Version> idToVersion;


### PR DESCRIPTION
This PR is shorter then normal thanks to https://github.com/elastic/elasticsearch/pull/42668 ! 

(also includes the docs bump, per @lcawl )