### PR TITLE
Clarify storage location of ML Snapshots

### DIFF
--- a/docs/reference/ml/apis/snapshotresource.asciidoc
+++ b/docs/reference/ml/apis/snapshotresource.asciidoc
@@ -3,7 +3,7 @@
 [[ml-snapshot-resource]]
 === Model snapshot resources
 
-Model snapshots are saved to disk periodically.
+Model snapshots are saved to an internal index within the Elasticsearch cluster.
 By default, this is occurs approximately every 3 hours to 4 hours and is
 configurable with the `background_persist_interval` property.
 


### PR DESCRIPTION
The existing language was misleading about the model snapshots and where they are located. Saying "to disk" sounds like files external to Elasticsearch IMO. It raises the obvious question, where on disk? which node? Is it in the Elasticsearch snapshot repo? The model snapshots are held in an internal index.





