### PR TITLE
[ML] Resolve NetworkDisruptionIT failures

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/NetworkDisruptionIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/NetworkDisruptionIT.java
@@ -38,7 +38,6 @@ public class NetworkDisruptionIT extends BaseMlIntegTestCase {
         return plugins;
     }
 
-    @AwaitsFix( bugUrl = "https://github.com/elastic/elasticsearch/issues/39858")
     public void testJobRelocation() throws Exception {
         internalCluster().ensureAtLeastNumDataNodes(5);
         ensureStableCluster(5);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/support/BaseMlIntegTestCase.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/support/BaseMlIntegTestCase.java
@@ -334,7 +334,7 @@ public abstract class BaseMlIntegTestCase extends ESIntegTestCase {
     protected String awaitJobOpenedAndAssigned(String jobId, String queryNode) throws Exception {
 
         PersistentTasksClusterService persistentTasksClusterService =
-            internalCluster().getInstance(PersistentTasksClusterService.class, internalCluster().getMasterName());
+            internalCluster().getInstance(PersistentTasksClusterService.class, internalCluster().getMasterName(queryNode));
         // Speed up rechecks to a rate that is quicker than what settings would allow.
         // The check would work eventually without doing this, but the assertBusy() below
         // would need to wait 30 seconds, which would make the test run very slowly.


### PR DESCRIPTION
Calls to `internalCluster().getMasterName()` select a random node to make the request. In the case of this network partition test sometimes that random node is on the wrong side of the partition, i.e. the side that is unable to form a cluster. This fails the test as there is no master node. The fix is to specify a node from the other side of the partition where a cluster has formed. 

Closes #39858