### PR TITLE
[ML][Data Frame] fixing some data frame hlrc tests

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/DataFrameTransformIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/DataFrameTransformIT.java
@@ -356,6 +356,10 @@ public class DataFrameTransformIT extends ESRestHighLevelClientTestCase {
             DataFrameTransformStateAndStats stateAndStats = response.getTransformsStateAndStats().get(0);
             assertNotEquals(zeroIndexerStats, stateAndStats.getTransformStats());
             assertNotNull(stateAndStats.getTransformState().getProgress());
+            assertThat(stateAndStats.getTransformState().getTaskState(),
+                is(oneOf(DataFrameTransformTaskState.STARTED, DataFrameTransformTaskState.STOPPED)));
+            assertThat(stateAndStats.getTransformState().getIndexerState(),
+                is(oneOf(IndexerState.STARTED, IndexerState.STOPPED)));
             assertThat(stateAndStats.getTransformState().getProgress().getPercentComplete(), equalTo(100.0));
             assertThat(stateAndStats.getTransformState().getProgress().getTotalDocs(), greaterThan(0L));
             assertThat(stateAndStats.getTransformState().getProgress().getRemainingDocs(), equalTo(0L));

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/DataFrameTransformIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/DataFrameTransformIT.java
@@ -66,6 +66,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -186,9 +187,7 @@ public class DataFrameTransformIT extends ESRestHighLevelClientTestCase {
         DataFrameTransformConfig transform = validDataFrameTransformConfig(id, sourceIndex, "pivot-dest");
 
         DataFrameClient client = highLevelClient().dataFrame();
-        AcknowledgedResponse ack = execute(new PutDataFrameTransformRequest(transform), client::putDataFrameTransform,
-                client::putDataFrameTransformAsync);
-        assertTrue(ack.isAcknowledged());
+        putTransform(transform);
 
         GetDataFrameTransformRequest getRequest = new GetDataFrameTransformRequest(id);
         GetDataFrameTransformResponse getResponse = execute(getRequest, client::getDataFrameTransform,
@@ -205,14 +204,10 @@ public class DataFrameTransformIT extends ESRestHighLevelClientTestCase {
         DataFrameClient client = highLevelClient().dataFrame();
 
         DataFrameTransformConfig transform = validDataFrameTransformConfig("test-get-all-1", sourceIndex, "pivot-dest-1");
-        AcknowledgedResponse ack = execute(new PutDataFrameTransformRequest(transform), client::putDataFrameTransform,
-                client::putDataFrameTransformAsync);
-        assertTrue(ack.isAcknowledged());
+        putTransform(transform);
 
         transform = validDataFrameTransformConfig("test-get-all-2", sourceIndex, "pivot-dest-2");
-        ack = execute(new PutDataFrameTransformRequest(transform), client::putDataFrameTransform,
-                client::putDataFrameTransformAsync);
-        assertTrue(ack.isAcknowledged());
+        putTransform(transform);
 
         GetDataFrameTransformRequest getRequest = new GetDataFrameTransformRequest("_all");
         GetDataFrameTransformResponse getResponse = execute(getRequest, client::getDataFrameTransform,
@@ -251,10 +246,7 @@ public class DataFrameTransformIT extends ESRestHighLevelClientTestCase {
         DataFrameTransformConfig transform = validDataFrameTransformConfig(id, sourceIndex, "pivot-dest");
 
         DataFrameClient client = highLevelClient().dataFrame();
-        AcknowledgedResponse ack = execute(new PutDataFrameTransformRequest(transform), client::putDataFrameTransform,
-                client::putDataFrameTransformAsync);
-        assertTrue(ack.isAcknowledged());
-        transformsToClean.add(id);
+        putTransform(transform);
 
         StartDataFrameTransformRequest startRequest = new StartDataFrameTransformRequest(id);
         StartDataFrameTransformResponse startResponse =
@@ -318,7 +310,7 @@ public class DataFrameTransformIT extends ESRestHighLevelClientTestCase {
             .build();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/43324")
+    // TODO add tests to cover continuous situations
     public void testGetStats() throws Exception {
         String sourceIndex = "transform-source";
         createIndex(sourceIndex);
@@ -340,10 +332,7 @@ public class DataFrameTransformIT extends ESRestHighLevelClientTestCase {
             .build();
 
         DataFrameClient client = highLevelClient().dataFrame();
-        AcknowledgedResponse ack = execute(new PutDataFrameTransformRequest(transform), client::putDataFrameTransform,
-                client::putDataFrameTransformAsync);
-        assertTrue(ack.isAcknowledged());
-        transformsToClean.add(id);
+        putTransform(transform);
 
         GetDataFrameTransformStatsResponse statsResponse = execute(new GetDataFrameTransformStatsRequest(id),
                 client::getDataFrameTransformStats, client::getDataFrameTransformStatsAsync);
@@ -365,15 +354,21 @@ public class DataFrameTransformIT extends ESRestHighLevelClientTestCase {
             GetDataFrameTransformStatsResponse response = execute(new GetDataFrameTransformStatsRequest(id),
                     client::getDataFrameTransformStats, client::getDataFrameTransformStatsAsync);
             DataFrameTransformStateAndStats stateAndStats = response.getTransformsStateAndStats().get(0);
-            assertEquals(IndexerState.STARTED, stateAndStats.getTransformState().getIndexerState());
-            assertEquals(DataFrameTransformTaskState.STARTED, stateAndStats.getTransformState().getTaskState());
-            assertEquals(null, stateAndStats.getTransformState().getReason());
             assertNotEquals(zeroIndexerStats, stateAndStats.getTransformStats());
             assertNotNull(stateAndStats.getTransformState().getProgress());
             assertThat(stateAndStats.getTransformState().getProgress().getPercentComplete(), equalTo(100.0));
             assertThat(stateAndStats.getTransformState().getProgress().getTotalDocs(), greaterThan(0L));
             assertThat(stateAndStats.getTransformState().getProgress().getRemainingDocs(), equalTo(0L));
+            assertThat(stateAndStats.getTransformState().getReason(), is(nullValue()));
         });
+    }
+
+    void putTransform(DataFrameTransformConfig config) throws IOException {
+        DataFrameClient client = highLevelClient().dataFrame();
+        AcknowledgedResponse ack = execute(new PutDataFrameTransformRequest(config), client::putDataFrameTransform,
+            client::putDataFrameTransformAsync);
+        assertTrue(ack.isAcknowledged());
+        transformsToClean.add(config.getId());
     }
 }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/DataFrameTransformDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/DataFrameTransformDocumentationIT.java
@@ -171,6 +171,7 @@ public class DataFrameTransformDocumentationIT extends ESRestHighLevelClientTest
                     client.dataFrame().putDataFrameTransform(
                             request, RequestOptions.DEFAULT);
             // end::put-data-frame-transform-execute
+            transformsToClean.add(request.getConfig().getId());
 
             assertTrue(response.isAcknowledged());
         }
@@ -208,6 +209,7 @@ public class DataFrameTransformDocumentationIT extends ESRestHighLevelClientTest
             // end::put-data-frame-transform-execute-async
 
             assertTrue(latch.await(30L, TimeUnit.SECONDS));
+            transformsToClean.add(request.getConfig().getId());
         }
     }
 
@@ -497,6 +499,7 @@ public class DataFrameTransformDocumentationIT extends ESRestHighLevelClientTest
             .setPivotConfig(pivotConfig)
             .build();
         client.dataFrame().putDataFrameTransform(new PutDataFrameTransformRequest(transformConfig), RequestOptions.DEFAULT);
+        transformsToClean.add(id);
 
         // tag::get-data-frame-transform-stats-request
         GetDataFrameTransformStatsRequest request =


### PR DESCRIPTION

The issue with `DataFrameTransformIT#testGetStats` that we have `assertBusy` waiting on a many things that do not have a consistent end state. The task COULD transition to STARTED, but the progress is not 100%. Since we STOP on finish, the next time we assert when the progress is 100% the state would then be STOPPED. Asserting on the `STARTED` state for a transform should wait until we have continuous data frame transforms.

I also made sure that all transforms that are PUT but not deleted within the same test are added to the `transformsToClean` `ArrayList`. 

closes https://github.com/elastic/elasticsearch/issues/43324