### PR TITLE
Log Blocked IO Thread State (#43424)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/MockNioTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/MockNioTransport.java
@@ -373,7 +373,9 @@ public class MockNioTransport extends TcpTransport {
                 final long elapsedTimeInNanos = threadPool.relativeTimeInNanos() - entry.getValue();
                 if (elapsedTimeInNanos > warnThreshold) {
                     final Thread thread = entry.getKey();
-                    logger.warn("Potentially blocked execution on network thread [{}] [{} milliseconds]: \n{}", thread.getName(),
+                    logger.warn("Potentially blocked execution on network thread [{}] [{}] [{} milliseconds]: \n{}",
+                        thread.getName(),
+                        thread.getState(),
                         TimeUnit.NANOSECONDS.toMillis(elapsedTimeInNanos),
                         Arrays.stream(thread.getStackTrace()).map(Object::toString).collect(Collectors.joining("\n")));
                 }


### PR DESCRIPTION
* Let's log the state of the thread to find out if it's dead-locked or just stuck after being suspended
* Relates #43392

backport of #43424