### PR TITLE
Clarify unsupported secure settings behavior

### DIFF
--- a/docs/reference/setup/secure-settings.asciidoc
+++ b/docs/reference/setup/secure-settings.asciidoc
@@ -7,8 +7,11 @@ keystore and the `elasticsearch-keystore` tool to manage the settings in the key
 
 NOTE: All commands here should be run as the user which will run Elasticsearch.
 
-NOTE: Only some settings are designed to be read from the keystore. See
-documentation for each setting to see if it is supported as part of the keystore.
+IMPORTANT: Only some settings are designed to be read from the keystore. However,
+the keystore currently has no validation to block adding settings not supported.
+Additional unsupported settings being added to the keystore will cause Elasticsearch
+to fail to start. See documentation for each setting to see if it is supported
+as part of the keystore.
 
 NOTE: All the modifications to the keystore take affect only after restarting
 Elasticsearch.

--- a/docs/reference/setup/secure-settings.asciidoc
+++ b/docs/reference/setup/secure-settings.asciidoc
@@ -8,7 +8,8 @@ keystore and the `elasticsearch-keystore` tool to manage the settings in the key
 NOTE: All commands here should be run as the user which will run Elasticsearch.
 
 IMPORTANT: Only some settings are designed to be read from the keystore. However,
-the keystore currently has no validation to block adding settings not supported.
+the keystore has no validation to block unsupported settings.
+Adding unsupported settings to the keystore will cause {es}
 Additional unsupported settings being added to the keystore will cause Elasticsearch
 to fail to start. See documentation for each setting to see if it is supported
 as part of the keystore.


### PR DESCRIPTION
This commit tweaks the docs for secure settings to ensure the user is
aware adding non secure settings to the keystore will result in
elasticsearch not starting.

fixes #43328