### PR TITLE
[DOCS] Rewrite delete index API to use new API reference format

### DIFF
--- a/docs/reference/indices/delete-index.asciidoc
+++ b/docs/reference/indices/delete-index.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Delete index</titleabbrev>
 ++++
 
-Delete an index.
+Deletes an index.
 
 [float]
 [[indices-delete-index-request]]

--- a/docs/reference/indices/delete-index.asciidoc
+++ b/docs/reference/indices/delete-index.asciidoc
@@ -10,11 +10,7 @@ Deletes an index.
 [[indices-delete-index-request]]
 === {api-request-title}
 
-[source,js]
-----
-DELETE /<index>
-----
-// NOTCONSOLE
+`DELETE /<index>`
 
 [float]
 [[indices-delete-index-desc]]

--- a/docs/reference/indices/delete-index.asciidoc
+++ b/docs/reference/indices/delete-index.asciidoc
@@ -1,22 +1,74 @@
 [[indices-delete-index]]
-== Delete Index
+== Delete index API
+++++
+<titleabbrev>Delete index</titleabbrev>
+++++
 
-The delete index API allows to delete an existing index.
+Delete an index.
+
+[float]
+[[indices-delete-index-request]]
+=== {api-request-title}
 
 [source,js]
---------------------------------------------------
+----
+DELETE /<index>
+----
+// NOTCONSOLE
+
+[float]
+[[indices-delete-index-desc]]
+=== {api-description-title}
+You can use the delete index API to manually delete one or more existing indices
+in {es}.
+
+[float]
+[[indices-delete-index-path-params]]
+=== {api-path-parms-title}
+
+`<index>` (Required)::
++
+--
+(string) Comma-separated list or wildcard expression of index names to delete.
+Aliases cannot be used.
+
+If the `action.destructive_requires_name` setting is `true`, you can use a value
+of `_all` or `*` to delete all indices.
+--
+
+[float]
+[[indices-delete-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/timeoutparms.asciidoc[]
+
+`ignore_unavailable` (Optional)::
+(boolean) Indicates whether unavailable indices are skipped. Defaults to
+`false`.
+
+`allow_no_indices` (Optional)::
+(boolean) Indicates whether the operation is skipped if a wildcard expression
+matches no indices. Defaults to `false`.
+
+`expand_wildcards` (Optional)::
++
+--
+(string) Indicates whether wildcard expressions should expand to open or closed
+indices. Possible values are:
+
+* `open` (Default)
+* `closed`
+* `none`
+* `all`
+--
+
+[float]
+[[indices-delete-index-example]]
+=== {api-example-title}
+
+[source,js]
+----
 DELETE /twitter
---------------------------------------------------
+----
 // CONSOLE
 // TEST[setup:twitter]
-
-The above example deletes an index called `twitter`. Specifying an index or a
-wildcard expression is required. Aliases cannot be used to delete an index.
-Wildcard expressions are resolved to matching concrete indices only.
-
-The delete index API can also be applied to more than one index, by either
-using a comma separated list, or on all indices (be careful!) by using `_all` or `*` as index.
-
-In order to disable allowing to delete indices via wildcards or `_all`,
-set `action.destructive_requires_name` setting in the config to `true`.
-This setting can also be changed via the cluster update settings api.

--- a/docs/reference/indices/delete-index.asciidoc
+++ b/docs/reference/indices/delete-index.asciidoc
@@ -53,8 +53,8 @@ matches no indices. Defaults to `false`.
 `expand_wildcards` (Optional)::
 +
 --
-(string) Indicates whether wildcard expressions should expand to open or closed
-indices. Possible values are:
+(string) Indicates whether wildcard expressions should expand to
+<<indices-open-close, open or closed indices>>. Possible values are:
 
 * `open` (Default)
 * `closed`

--- a/docs/reference/indices/delete-index.asciidoc
+++ b/docs/reference/indices/delete-index.asciidoc
@@ -34,13 +34,9 @@ of `_all` or `*` to delete all indices.
 
 [float]
 [[indices-delete-query-params]]
-==== {api-query-parms-title}
+=== {api-query-parms-title}
 
 include::{docdir}/rest-api/timeoutparms.asciidoc[]
-
-`ignore_unavailable` (Optional)::
-(boolean) Indicates whether unavailable indices are skipped. Defaults to
-`false`.
 
 `allow_no_indices` (Optional)::
 (boolean) Indicates whether the operation is skipped if a wildcard expression
@@ -57,6 +53,10 @@ matches no indices. Defaults to `false`.
 * `none`
 * `all`
 --
+
+`ignore_unavailable` (Optional)::
+(boolean) Indicates whether unavailable indices are skipped. Defaults to
+`false`.
 
 [float]
 [[indices-delete-index-example]]


### PR DESCRIPTION
With https://github.com/elastic/docs/pull/938, we created a standard template
for Elastic API Reference documentation.

This PR rewrites the delete index API to use that template.

Relates to elastic/docs#937

## Before
<details>
 <summary>Before image</summary>
<img width="767" alt="Delete Index - Before" src="https://user-images.githubusercontent.com/40268737/59881664-25bfcd00-937e-11e9-8738-845d08b076d4.png">
</details>


## After
<details>
 <summary>After image</summary>
<img width="796" alt="Delete Index - After " src="https://user-images.githubusercontent.com/40268737/59881656-222c4600-937e-11e9-9e58-9507116e34d5.png">
</details>