### PR TITLE
Update icuj4 (Enable to search Japanese new era U+32FF)

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -11,7 +11,7 @@ jts               = 1.15.0
 # the com.maxmind.geoip2:geoip2 dependency
 jackson           = 2.8.11
 snakeyaml         = 1.17
-icu4j             = 62.1
+icu4j             = 64.2
 supercsv          = 2.4.0
 # when updating log4j, please update also docs/java-api/index.asciidoc
 log4j             = 2.11.1


### PR DESCRIPTION
According icu4j change log,
 ICU 64.2 released. This maintenance update for ICU 64 includes draft Unicode 12.1 update,
 CLDR 35.1 locale data and support for new Japanese era Reiwa (令和).

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- [x] Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- [x] Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- [ ] If submitting code, have you built your formula locally prior to submission with `gradle check`?
- [x] If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- [x] If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- [x] If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
