### PR TITLE
Update removal_of_types.asciidoc

### DIFF
--- a/docs/reference/mapping/removal_of_types.asciidoc
+++ b/docs/reference/mapping/removal_of_types.asciidoc
@@ -416,8 +416,6 @@ POST _reindex
   },
   "script": {
     "source": """
-      ctx._source.type = ctx._type;
-      ctx._id = ctx._type + '-' + ctx._id;
       ctx._type = '_doc';
     """
   }


### PR DESCRIPTION
Suggest to delete these two lines:
     ``ctx._source.type = ctx._type;`` - In case you have old index with field `type` this line will corrupt data and field `type`. 
      ``ctx._id = ctx._type + '-' + ctx._id;`` - in case you have old document for instance with id `50`, after re index will be changed to `ctx._type + '-' + ctx._id;`. And then I want to update this record by id, it won't find id `50` and just create a new one with id `ctx._type + '-' + ctx._id;`

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

