### PR TITLE
Get snapshots response example for the breaking change

### DIFF
--- a/docs/reference/migration/migrate_8_0/snapshots.asciidoc
+++ b/docs/reference/migration/migrate_8_0/snapshots.asciidoc
@@ -26,6 +26,7 @@ GET _snapshot/repo1/snap1
 produces the following response
 
 [source,js]
+-----------------------------------
 {
     "responses": [
         {
@@ -55,6 +56,9 @@ produces the following response
         }
     ]
 }
+-----------------------------------
+// TESTRESPONSE
+// TEST[skip:no repo and snapshots are created]
 
 See <<modules-snapshots>> for more information.
 

--- a/docs/reference/migration/migrate_8_0/snapshots.asciidoc
+++ b/docs/reference/migration/migrate_8_0/snapshots.asciidoc
@@ -12,7 +12,51 @@
 [float]
 === Get snapshots response format is changed
 It's possible to get snapshots from multiple repositories in one go. The response format has changed
-and now contains separate response for each repository. See <<modules-snapshots>> for more information.
+and now contains separate response for each repository.
+
+For example, requesting one snapshot from particular repository
+
+[source,js]
+-----------------------------------
+GET _snapshot/repo1/snap1
+-----------------------------------
+// CONSOLE
+// TEST[skip:no repo and snapshots are created]
+
+produces the following response
+
+[source,js]
+{
+    "responses": [
+        {
+            "repository": "repo1",
+            "snapshots": [
+                {
+                    "snapshot": "snap1",
+                    "uuid": "cEzdqUKxQ5G6MyrJAcYwmA",
+                    "version_id": 8000099,
+                    "version": "8.0.0",
+                    "indices": [],
+                    "include_global_state": true,
+                    "state": "SUCCESS",
+                    "start_time": "2019-05-10T17:01:57.868Z",
+                    "start_time_in_millis": 1557507717868,
+                    "end_time": "2019-05-10T17:01:57.909Z",
+                    "end_time_in_millis": 1557507717909,
+                    "duration_in_millis": 41,
+                    "failures": [],
+                    "shards": {
+                        "total": 0,
+                        "failed": 0,
+                        "successful": 0
+                    }
+                }
+            ]
+        }
+    ]
+}
+
+See <<modules-snapshots>> for more information.
 
 [float]
 ==== Deprecated node level compress setting removed


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/42090 PR added support
for requesting snapshots from multiple repositories. And it has changed
the response format in a non-BwC way.
There is a mentioning of a response format change in the breaking
changes docs, however, there is no example of how new format looks
like. Pointed out by @dakrone.
This PR adds the missing example.