### PR TITLE
[TEST] Embed msearch samples in MultiSearchRequestTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
@@ -60,7 +60,7 @@ public class MultiSearchRequestTests extends ESTestCase {
         LogManager.getLogger(MultiSearchRequestTests.class));
 
     public void testSimpleAdd() throws Exception {
-        MultiSearchRequest request = parseMultiSearchRequest("/org/elasticsearch/action/search/simple-msearch1.json");
+        MultiSearchRequest request = parseMultiSearchRequestFromFile("/org/elasticsearch/action/search/simple-msearch1.json");
         assertThat(request.requests().size(),
                 equalTo(8));
         assertThat(request.requests().get(0).indices()[0],
@@ -136,7 +136,7 @@ public class MultiSearchRequestTests extends ESTestCase {
     }
 
     public void testSimpleAdd2() throws Exception {
-        MultiSearchRequest request = parseMultiSearchRequest("/org/elasticsearch/action/search/simple-msearch2.json");
+        MultiSearchRequest request = parseMultiSearchRequestFromFile("/org/elasticsearch/action/search/simple-msearch2.json");
         assertThat(request.requests().size(), equalTo(5));
         assertThat(request.requests().get(0).indices()[0], equalTo("test"));
         assertThat(request.requests().get(0).types().length, equalTo(0));
@@ -152,7 +152,7 @@ public class MultiSearchRequestTests extends ESTestCase {
     }
 
     public void testSimpleAdd3() throws Exception {
-        MultiSearchRequest request = parseMultiSearchRequest("/org/elasticsearch/action/search/simple-msearch3.json");
+        MultiSearchRequest request = parseMultiSearchRequestFromFile("/org/elasticsearch/action/search/simple-msearch3.json");
         assertThat(request.requests().size(), equalTo(4));
         assertThat(request.requests().get(0).indices()[0], equalTo("test0"));
         assertThat(request.requests().get(0).indices()[1], equalTo("test1"));
@@ -169,7 +169,7 @@ public class MultiSearchRequestTests extends ESTestCase {
     }
 
     public void testSimpleAdd4() throws Exception {
-        MultiSearchRequest request = parseMultiSearchRequest("/org/elasticsearch/action/search/simple-msearch4.json");
+        MultiSearchRequest request = parseMultiSearchRequestFromFile("/org/elasticsearch/action/search/simple-msearch4.json");
         assertThat(request.requests().size(), equalTo(3));
         assertThat(request.requests().get(0).indices()[0], equalTo("test0"));
         assertThat(request.requests().get(0).indices()[1], equalTo("test1"));
@@ -187,9 +187,17 @@ public class MultiSearchRequestTests extends ESTestCase {
         assertThat(request.requests().get(2).routing(), equalTo("123"));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/43464")
     public void testEmptyFirstLine1() throws Exception {
-        MultiSearchRequest request = parseMultiSearchRequest("/org/elasticsearch/action/search/msearch-empty-first-line1.json");
+        MultiSearchRequest request = parseMultiSearchRequestFromString(
+            "\n" +
+            "\n" +
+            "{ \"query\": {\"match_all\": {}}}\n" +
+            "{}\n" +
+            "{ \"query\": {\"match_all\": {}}}\n" +
+            "\n" +
+            "{ \"query\": {\"match_all\": {}}}\n" +
+            "{}\n" +
+            "{ \"query\": {\"match_all\": {}}}\n");
         assertThat(request.requests().size(), equalTo(4));
         for (SearchRequest searchRequest : request.requests()) {
             assertThat(searchRequest.indices().length, equalTo(0));
@@ -199,9 +207,17 @@ public class MultiSearchRequestTests extends ESTestCase {
             "in the next major version");
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/43464")
     public void testEmptyFirstLine2() throws Exception {
-        MultiSearchRequest request = parseMultiSearchRequest("/org/elasticsearch/action/search/msearch-empty-first-line2.json");
+        MultiSearchRequest request = parseMultiSearchRequestFromString(
+            "\n" +
+            "{}\n" +
+            "{ \"query\": {\"match_all\": {}}}\n" +
+            "\n" +
+            "{ \"query\": {\"match_all\": {}}}\n" +
+            "{}\n" +
+            "{ \"query\": {\"match_all\": {}}}\n" +
+            "\n" +
+            "{ \"query\": {\"match_all\": {}}}\n");
         assertThat(request.requests().size(), equalTo(4));
         for (SearchRequest searchRequest : request.requests()) {
             assertThat(searchRequest.indices().length, equalTo(0));
@@ -256,11 +272,19 @@ public class MultiSearchRequestTests extends ESTestCase {
         assertEquals(3, msearchRequest.requests().size());
     }
 
-    private MultiSearchRequest parseMultiSearchRequest(String sample) throws IOException {
-        byte[] data = StreamsUtils.copyToBytesFromClasspath(sample);
-        RestRequest restRequest = new FakeRestRequest.Builder(xContentRegistry())
-            .withContent(new BytesArray(data), XContentType.JSON).build();
+    private MultiSearchRequest parseMultiSearchRequestFromString(String request) throws IOException {
+        return parseMultiSearchRequest(new FakeRestRequest.Builder(xContentRegistry())
+            .withContent(new BytesArray(request), XContentType.JSON).build());
+    }
 
+    private MultiSearchRequest parseMultiSearchRequestFromFile(String sample) throws IOException {
+        byte[] data = StreamsUtils.copyToBytesFromClasspath(sample);
+        return parseMultiSearchRequest(new FakeRestRequest.Builder(xContentRegistry())
+            .withContent(new BytesArray(data), XContentType.JSON).build());
+
+    }
+
+    private MultiSearchRequest parseMultiSearchRequest(RestRequest restRequest) throws IOException {
         MultiSearchRequest request = new MultiSearchRequest();
         RestMultiSearchAction.parseMultiLineRequest(restRequest, SearchRequest.DEFAULT_INDICES_OPTIONS, true,
             (searchRequest, parser) -> {

--- a/server/src/test/resources/org/elasticsearch/action/search/msearch-empty-first-line1.json
+++ b/server/src/test/resources/org/elasticsearch/action/search/msearch-empty-first-line1.json
@@ -1,9 +1,0 @@
-
-
-{ "query": {"match_all": {}}}
-{}
-{ "query": {"match_all": {}}}
-
-{ "query": {"match_all": {}}}
-{}
-{ "query": {"match_all": {}}}

--- a/server/src/test/resources/org/elasticsearch/action/search/msearch-empty-first-line2.json
+++ b/server/src/test/resources/org/elasticsearch/action/search/msearch-empty-first-line2.json
@@ -1,9 +1,0 @@
-
-{}
-{ "query": {"match_all": {}}}
-
-{ "query": {"match_all": {}}}
-{}
-{ "query": {"match_all": {}}}
-
-{ "query": {"match_all": {}}}


### PR DESCRIPTION
Depending on git configuration, line feed on checked out files may be
platform dependent, which causes problems to some msearch tests as the
line separator must always be `/n`. With this change we move two files
to the test code so that we control exactly what line separator is used,
given that the corresponding tests fail on windows.

Closes #43464