### PR TITLE
[DOCS] Rewrite get index API to use new API reference format

### DIFF
--- a/docs/reference/indices/get-index.asciidoc
+++ b/docs/reference/indices/get-index.asciidoc
@@ -8,19 +8,19 @@ Returns information about an index.
 
 [float]
 [[indices-get-request]]
-==== {api-request-title}
+=== {api-request-title}
 
 `GET /<index>`
 
 [float]
 [[indices-get-index-desc]]
-==== {api-description-title}
+=== {api-description-title}
 
 You can use the get index API to retrieve information about one or more indices.
 
 [float]
 [[indices-get-index-path-params]]
-==== {api-path-parms-title}
+=== {api-path-parms-title}
 
 `<index>` (Required)::
 +
@@ -32,7 +32,7 @@ You can use a value of `_all` or `*` to retrieve all indices.
 
 [float]
 [[indices-get-index-query-params]]
-==== {api-query-parms-title}
+=== {api-query-parms-title}
 
 `allow_no_indices` (Optional)::
 (boolean) Indicates whether the operation is skipped if a wildcard expression

--- a/docs/reference/indices/get-index.asciidoc
+++ b/docs/reference/indices/get-index.asciidoc
@@ -54,11 +54,6 @@ matches no indices. Defaults to `false`.
 (boolean) Indicates whether settings are returned in a flat format. Defaults to
 `false`.
 
-`local` (Optional)::
-(boolean) Indicates whether only local node information is included in the
-response. Defaults to `false`. If `true`, state information is not retrieved
-from the master node.
-
 `ignore_unavailable` (Optional)::
 (boolean) Indicates whether unavailable indices are skipped. Defaults to
 `false`.
@@ -78,6 +73,11 @@ Although mappings in responses no longer contain a type name by default, you can
 still request the old format through the parameter include_type_name. For more
 details, please see <<removal-of-types>>.
 --
+
+`local` (Optional)::
+(boolean) Indicates whether only local node information is included in the
+response. Defaults to `false`. If `true`, state information is not retrieved
+from the master node.
 
 include::{docdir}/rest-api/timeoutparms.asciidoc[tag=master_timeout]
 

--- a/docs/reference/indices/get-index.asciidoc
+++ b/docs/reference/indices/get-index.asciidoc
@@ -1,21 +1,85 @@
 [[indices-get-index]]
-== Get Index
+== Get index API
+++++
+<titleabbrev>Get index</titleabbrev>
+++++
 
-The get index API allows to retrieve information about one or more indexes.
+Returns information about an index.
+
+[float]
+[[indices-get-request]]
+==== {api-request-title}
+
+`GET /<index>`
+
+[float]
+[[indices-get-index-desc]]
+==== {api-description-title}
+
+You can use the get index API to retrieve information about one or more indices.
+
+[float]
+[[indices-get-index-path-params]]
+==== {api-path-parms-title}
+
+`<index>` (Required)::
++
+--
+(string) Comma-separated list or wildcard expression of index names to retrieve.
+
+You can use a value of `_all` or `*` to retrieve all indices.
+--
+
+[float]
+[[indices-get-index-query-params]]
+==== {api-query-parms-title}
+
+`allow_no_indices` (Optional)::
+(boolean) Indicates whether the operation is skipped if a wildcard expression
+matches no indices. Defaults to `false`.
+
+`expand_wildcards` (Optional)::
++
+--
+(string) Indicates whether wildcard expressions should expand to
+<<indices-open-close, open or closed indices>>. Possible values are:
+
+* `open` (Default)
+* `closed`
+* `none`
+* `all`
+--
+
+`flat_settings` (Optional)::
+(boolean) Indicates whether settings are returned in a flat format. Defaults to
+`false`.
+
+`local` (Optional)::
+(boolean) Indicates whether only local node information is included in the
+response. Defaults to `false`. If `true`, state information is not retrieved
+from the master node.
+
+`ignore_unavailable` (Optional)::
+(boolean) Indicates whether unavailable indices are skipped. Defaults to
+`false`.
+
+`include_defaults` (Optional)::
+(boolean) Indicates whether default settings are included in the response.
+Defaults to `false`.
+
+`include_type_name` (Optional)::
+(boolean) Indicates whether the type name is included in the response. Defaults
+to `false`.
+
+include::{docdir}/rest-api/timeoutparms.asciidoc[tag=master_timeout]
+
+[float]
+[[indices-get-index-example]]
+=== {api-example-title}
 
 [source,js]
---------------------------------------------------
+----
 GET /twitter
---------------------------------------------------
+----
 // CONSOLE
 // TEST[setup:twitter]
-
-The above example gets the information for an index called `twitter`. Specifying an index,
-alias or wildcard expression is required.
-
-The get index API can also be applied to more than one index, or on
-all indices by using `_all` or `*` as index.
-
-NOTE: Before 7.0.0, the 'mappings' definition used to include a type name. Although mappings
-in responses no longer contain a type name by default, you can still request the old format
-through the parameter include_type_name. For more details, please see <<removal-of-types>>.

--- a/docs/reference/indices/get-index.asciidoc
+++ b/docs/reference/indices/get-index.asciidoc
@@ -68,8 +68,16 @@ from the master node.
 Defaults to `false`.
 
 `include_type_name` (Optional)::
++
+--
 (boolean) Indicates whether the type name is included in the response. Defaults
 to `false`.
+
+NOTE: Before 7.0.0, the 'mappings' definition used to include a type name.
+Although mappings in responses no longer contain a type name by default, you can
+still request the old format through the parameter include_type_name. For more
+details, please see <<removal-of-types>>.
+--
 
 include::{docdir}/rest-api/timeoutparms.asciidoc[tag=master_timeout]
 

--- a/docs/reference/rest-api/timeoutparms.asciidoc
+++ b/docs/reference/rest-api/timeoutparms.asciidoc
@@ -4,8 +4,10 @@
   returns an error. Defaults to `30s`. For more information about
   time units, see <<time-units>>.
 
+// tag::master_timeout[]
 `master_timeout`::
   (time units) Specifies the period of time to wait for a connection to the
   master node. If no response is received before the timeout expires, the request
   fails and returns an error. Defaults to `30s`. For more information about
   time units, see <<time-units>>.
+// end::master_timeout[]


### PR DESCRIPTION
With https://github.com/elastic/docs/pull/938, we created a standard template
for Elastic API Reference documentation.

This PR rewrites the get index API to using that template.

Relates to https://github.com/elastic/docs/issues/937.

## Before
<details>
 <summary>Before image</summary>
<img width="775" alt="Get index API - Before" src="https://user-images.githubusercontent.com/40268737/59951294-78fd5280-9446-11e9-8de9-eb8fb9a63248.png">
</details>


## After
<details>
 <summary>After image</summary>
<img width="775" alt="Get index API - After" src="https://user-images.githubusercontent.com/40268737/59951299-7e5a9d00-9446-11e9-9170-a810320128d0.png">
</details>