### PR TITLE
Mute LicenseDocumentationIT#testGetLicense

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/LicensingDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/LicensingDocumentationIT.java
@@ -180,6 +180,7 @@ public class LicensingDocumentationIT extends ESRestHighLevelClientTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/43504")
     public void testGetLicense() throws Exception {
         RestHighLevelClient client = highLevelClient();
         {


### PR DESCRIPTION
Muting this test due to https://github.com/elastic/elasticsearch/issues/43504.