### PR TITLE
Fix mutateInstance for SearchTemplateRequestTests

### DIFF
--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/SearchTemplateRequestTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/SearchTemplateRequestTests.java
@@ -63,8 +63,8 @@ public class SearchTemplateRequestTests extends AbstractStreamableTestCase<Searc
         mutators.add(request -> request.setExplain(!request.isExplain()));
         mutators.add(request -> request.setSimulate(!request.isSimulate()));
 
-        mutators.add(request -> request.setRequest(
-            RandomSearchRequestGenerator.randomSearchRequest(SearchSourceBuilder::searchSource)));
+        mutators.add(request -> request.setRequest(randomValueOtherThan(request.getRequest(),
+                () -> RandomSearchRequestGenerator.randomSearchRequest(SearchSourceBuilder::searchSource))));
 
         SearchTemplateRequest mutatedInstance = copyInstance(instance);
         Consumer<SearchTemplateRequest> mutator = randomFrom(mutators);


### PR DESCRIPTION
A seed was hit in (https://github.com/elastic/elasticsearch/issues/43157) that caused mutateInstance to generate an identical instance. This change prevents that.