### PR TITLE
Fix score mode of the MinimumScoreCollector

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/lucene/MinimumScoreCollector.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/MinimumScoreCollector.java
@@ -65,6 +65,6 @@ public class MinimumScoreCollector extends SimpleCollector {
 
     @Override
     public ScoreMode scoreMode() {
-        return ScoreMode.COMPLETE;
+        return collector.scoreMode() == ScoreMode.TOP_SCORES ? ScoreMode.TOP_SCORES :  ScoreMode.COMPLETE;
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -681,6 +681,39 @@ public class QueryPhaseTests extends IndexShardTestCase {
         }
     }
 
+    public void testMinScore() throws Exception {
+        Directory dir = newDirectory();
+        IndexWriterConfig iwc = newIndexWriterConfig();
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+        for (int i = 0; i < 10; i++) {
+            Document doc = new Document();
+            doc.add(new StringField("foo", "bar", Store.NO));
+            doc.add(new StringField("filter", "f1", Store.NO));
+            w.addDocument(doc);
+        }
+        w.close();
+
+        IndexReader reader = DirectoryReader.open(dir);
+        IndexSearcher contextSearcher = new IndexSearcher(reader);
+        TestSearchContext context = new TestSearchContext(null, indexShard);
+        context.parsedQuery(new ParsedQuery(
+            new BooleanQuery.Builder()
+                .add(new TermQuery(new Term("foo", "bar")), Occur.MUST)
+                .add(new TermQuery(new Term("filter", "f1")), Occur.SHOULD)
+                .build()
+        ));
+        context.minimumScore(0.01f);
+        context.setTask(new SearchTask(123L, "", "", "", null, Collections.emptyMap()));
+        context.setSize(1);
+        context.trackTotalHitsUpTo(5);
+
+        QueryPhase.execute(context, contextSearcher, checkCancelled -> {});
+        assertEquals(10, context.queryResult().topDocs().topDocs.totalHits.value);
+
+        reader.close();
+        dir.close();
+    }
+
     private static IndexSearcher getAssertingEarlyTerminationSearcher(IndexReader reader, int size) {
         return new IndexSearcher(reader) {
             @Override


### PR DESCRIPTION
This change fixes the score mode of the minimum score collector to
be set based on the score mode of the child collector (top docs).

Closes #43497