### PR TITLE
Add release highlight for replicated closed indices on 7.2.0

### DIFF
--- a/docs/reference/release-notes/highlights-7.2.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.2.0.asciidoc
@@ -40,11 +40,8 @@ the <<modules-snapshots,Snapshot/Restore API>>. To include a closed index
 when creating a snapshot on Elasticsearch 7.2+, the `expand_wildcards`
 parameter must be explicitly set to either `all` or `closed` .
 
-To snapshot closed indices,
-setting the expand_wildcards option either to all or closed (see https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-index.html).
-
 Note that only indices closed in Elasticsearch 7.2+ are automatically
 replicated. Indices closed on previous versions of Elasticsearch will
-remain non replicated unless they are opened and closed again in 7.2.0.
+remain non replicated unless they are opened and closed again in 7.2+.
 
 // end::notable-highlights[]

--- a/docs/reference/release-notes/highlights-7.2.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.2.0.asciidoc
@@ -26,14 +26,24 @@ the transforms.
 [float]
 ==== Closed indices are now replicated
 
-Elasticsearch 7.2.0 brings a better support for closed indices by allowing
+Elasticsearch 7.2.0 brings better support for closed indices by allowing
 shards of closed indices to be replicated. As soon as an index is closed,
-Elasticsearch takes care of tearing down the "opened" shards before
+Elasticsearch takes care of safely tearing down the "opened" shards before
 reinitializing them as "closed" shards, which require much less resources
 while still providing the ability for shards to be promoted as primaries or
-to be recovered from peer.
+to be recovered from peer. The data is also automatically replicated by the
+cluster to ensure that enough shard copies are safely kept around at all
+times (configurable with `index.number_of_replicas`).
 
-Note that only indices closed in Elasticsearch 7.2.0 are automatically
+In addition to that, it is now possible to snapshot closed indices using
+the <<modules-snapshots,Snapshot/Restore API>>. To include a closed index
+when creating a snapshot on Elasticsearch 7.2+, the `expand_wildcards`
+parameter must be explicitly set to either `all` or `closed` .
+
+To snapshot closed indices,
+setting the expand_wildcards option either to all or closed (see https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-index.html).
+
+Note that only indices closed in Elasticsearch 7.2+ are automatically
 replicated. Indices closed on previous versions of Elasticsearch will
 remain non replicated unless they are opened and closed again in 7.2.0.
 

--- a/docs/reference/release-notes/highlights-7.2.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.2.0.asciidoc
@@ -21,3 +21,20 @@ summarize your data and store it in a new index. Alternatively, you can use
 the transforms.
 
 // end::notable-highlights[]
+
+// tag::notable-highlights[]
+[float]
+==== Closed indices are now replicated
+
+Elasticsearch 7.2.0 brings a better support for closed indices by allowing
+shards of closed indices to be replicated. As soon as an index is closed,
+Elasticsearch takes care of tearing down the "opened" shards before
+reinitializing them as "closed" shards, which require much less resources
+while still providing the ability for shards to be promoted as primaries or
+to be recovered from peer.
+
+Note that only indices closed in Elasticsearch 7.2.0 are automatically
+replicated. Indices closed on previous versions of Elasticsearch will
+remain non replicated unless they are opened and closed again in 7.2.0.
+
+// end::notable-highlights[]


### PR DESCRIPTION
Note: pull request against `7.2` branch

This pull request adds a small release highlight for the support of replicated closed indices released in 7.2.0. Suggestions welcome