### PR TITLE
Fix failing LicensingDocumentationIT test

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/LicensingDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/LicensingDocumentationIT.java
@@ -180,7 +180,6 @@ public class LicensingDocumentationIT extends ESRestHighLevelClientTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/43504")
     public void testGetLicense() throws Exception {
         RestHighLevelClient client = highLevelClient();
         {
@@ -195,7 +194,7 @@ public class LicensingDocumentationIT extends ESRestHighLevelClientTestCase {
             //end::get-license-response
 
             assertThat(currentLicense, containsString("trial"));
-            assertThat(currentLicense, containsString("client_rest-high-level_integTestCluster"));
+            assertThat(currentLicense, containsString("integTest"));
         }
         {
             GetLicenseRequest request = new GetLicenseRequest();
@@ -234,7 +233,7 @@ public class LicensingDocumentationIT extends ESRestHighLevelClientTestCase {
             String currentLicense = response.getLicenseDefinition();
             assertThat(currentLicense, startsWith("{"));
             assertThat(currentLicense, containsString("trial"));
-            assertThat(currentLicense, containsString("client_rest-high-level_integTestCluster"));
+            assertThat(currentLicense, containsString("integTest"));
             assertThat(currentLicense, endsWith("}"));
         }
     }


### PR DESCRIPTION
This PR brings corrections for cluster name after migrating to testclusters.
Not sure how this slipped trough the cracks when converting.

Closes #43504

