### PR TITLE
[Docs] Move mentions of updateable synonyms flag

### DIFF
--- a/docs/reference/analysis/tokenfilters/synonym-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/synonym-tokenfilter.asciidoc
@@ -41,9 +41,6 @@ appear before it in the chain.
 Additional settings are:
 
 * `expand` (defaults to `true`).
-* `updateable` (defaults to false). If `true`, this marks the filter to be updateable using the 
-<<indices-reload-analyzers,analyzer reload API>>, but it will also restrict the filter to only be usable in 
-<<search-analyzer,search analyzers>>.
 * `lenient` (defaults to `false`). If `true` ignores exceptions while parsing the synonym configuration. It is important
 to note that only those synonym rules which cannot get parsed are ignored. For instance consider the following request:
  
@@ -186,41 +183,3 @@ error.
 If you need to build analyzers that include both multi-token filters and synonym
 filters, consider using the <<analysis-multiplexer-tokenfilter,multiplexer>> filter,
 with the multi-token filters in one branch and the synonym filter in the other.
-
-=== Updateability of search time synonyms
-
-Synonym filters that are used in <<search-analyzer,search analyzers>> can be marked
-as updateable using the `updateable` flag:
-
-[source,js]
---------------------------------------------------
-PUT /test_index
-{
-    "settings": {
-        "index" : {
-            "analysis" : {
-                "analyzer" : {
-                    "synonym" : {
-                        "tokenizer" : "whitespace",
-                        "filter" : ["synonym"]
-                    }
-                },
-                "filter" : {
-                    "synonym" : {
-                        "type" : "synonym",
-                        "synonyms_path" : "analysis/synonym.txt",
-                        "updateable" : true
-                    }
-                }
-            }
-        }
-    }
-}
---------------------------------------------------
-// CONSOLE
-
-Using the <<indices-reload-analyzers,analyzer reload API>>, you can trigger reloading of the
-synonym definition. The contents of the configured synonyms file will be reloaded and the
-synonyms definition the filter uses will be updated. 
-
-NOTE: Trying to use the above analyzer as an index analyzer will result in an error.

--- a/docs/reference/indices.asciidoc
+++ b/docs/reference/indices.asciidoc
@@ -56,7 +56,6 @@ index settings, aliases, mappings, and index templates.
 * <<indices-refresh>>
 * <<indices-flush>>
 * <<indices-forcemerge>>
-* <<indices-reload-analyzers>>
 
 --
 
@@ -109,6 +108,4 @@ include::indices/flush.asciidoc[]
 include::indices/refresh.asciidoc[]
 
 include::indices/forcemerge.asciidoc[]
-
-include::indices/reload-analyzers.asciidoc[]
 

--- a/docs/reference/indices/apis/reload-analyzers.asciidoc
+++ b/docs/reference/indices/apis/reload-analyzers.asciidoc
@@ -1,3 +1,5 @@
+[role="xpack"]
+[testenv="basic"]
 [[indices-reload-analyzers]]
 == Reload Search Analyzers
 
@@ -5,10 +7,9 @@ experimental[]
 
 Reloads search analyzers and its resources.
 
-The `_reload_search_analyzers` API can be run on one or more indices and will
-reload all search analyzers that contain components that were marked as
-updateable when they were created, such as 
-<<analysis-synonym-tokenfilter,synonym token filters>>:
+Synonym filters (both `synonym` and `synonym_graph`) can be declared as
+updateable if they are only used in <<search-analyzer,search analyzers>> 
+with the `updateable` flag:
 
 [source,js]
 --------------------------------------------------
@@ -49,8 +50,14 @@ PUT /test_index
 <1> Mark the synonym filter as updateable.
 <2> Synonym analyzer is usable as a search_analyzer.
 
-Calling the `_reload_search_analyzers` endpoint will now trigger reloading of the
-synonyms from the configured "synonym.txt" file.
+NOTE: Trying to use the above analyzer as an index analyzer will result in an error.
+
+Using the <<indices-reload-analyzers,analyzer reload API>>, you can trigger reloading of the
+synonym definition. The contents of the configured synonyms file will be reloaded and the
+synonyms definition the filter uses will be updated. 
+
+The `_reload_search_analyzers` API can be run on one or more indices and will trigger 
+reloading of the synonyms from the configured file.
 
 NOTE: Reloading will happen on every node the index has shards, so its important
 to update the synonym file contents on every data node (even the ones that don't currently

--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -12,6 +12,7 @@ directly to configure and access {xpack} features.
 * <<data-frame-apis,{dataframe-cap} APIs>>
 * <<graph-explore-api,Graph Explore API>>
 * <<freeze-index-api>>, <<unfreeze-index-api>>
+* <<indices-reload-analyzers,Reload Search Analyzers API>>
 * <<index-lifecycle-management-api,Index lifecycle management APIs>>
 * <<licensing-apis,Licensing APIs>>
 * <<ml-apis,Machine Learning APIs>>
@@ -35,4 +36,5 @@ include::{es-repo-dir}/rollup/rollup-api.asciidoc[]
 include::{xes-repo-dir}/rest-api/security.asciidoc[]
 include::{es-repo-dir}/indices/apis/unfreeze.asciidoc[]
 include::{xes-repo-dir}/rest-api/watcher.asciidoc[]
+include::{es-repo-dir}/indices/apis/reload-analyzers.asciidoc[]
 include::defs.asciidoc[]


### PR DESCRIPTION
The new "updateable" flag used with synonym and synonym_graph should be
mentioned with the reload API endpoint which I also moved under the x-pack basic
role with this change.