### PR TITLE
Fix DieWithDignity logs assertion backport(#43543)

### DIFF
--- a/qa/die-with-dignity/src/test/java/org/elasticsearch/qa/die_with_dignity/DieWithDignityIT.java
+++ b/qa/die-with-dignity/src/test/java/org/elasticsearch/qa/die_with_dignity/DieWithDignityIT.java
@@ -21,14 +21,10 @@ package org.elasticsearch.qa.die_with_dignity;
 
 import org.apache.http.ConnectionClosedException;
 import org.apache.lucene.util.Constants;
-import org.elasticsearch.cli.Terminal;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.common.io.PathUtils;
-import org.elasticsearch.common.logging.JsonLogLine;
-import org.elasticsearch.common.logging.JsonLogsStream;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -38,12 +34,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.instanceOf;
@@ -91,29 +85,29 @@ public class DieWithDignityIT extends ESRestTestCase {
             }
         });
 
+        // parse the logs and ensure that Elasticsearch died with the expected cause
+        final List<String> lines = Files.readAllLines(PathUtils.get(System.getProperty("log")));
+
+        final Iterator<String> it = lines.iterator();
+
+        boolean fatalError = false;
+        boolean fatalErrorInThreadExiting = false;
         try {
-            // parse the logs and ensure that Elasticsearch died with the expected cause
-            Path path = PathUtils.get(System.getProperty("log"));
-            try (Stream<JsonLogLine> stream = JsonLogsStream.from(path)) {
-                final Iterator<JsonLogLine> it = stream.iterator();
-
-                boolean fatalError = false;
-                boolean fatalErrorInThreadExiting = false;
-
-                while (it.hasNext() && (fatalError == false || fatalErrorInThreadExiting == false)) {
-                    final JsonLogLine line = it.next();
-                    if (isFatalError(line)) {
-                        fatalError = true;
-                    } else if (isFatalErrorInThreadExiting(line) || isWarnExceptionReceived(line)) {
-                        fatalErrorInThreadExiting = true;
-                        assertThat(line.stacktrace(),
-                            hasItem(Matchers.containsString("java.lang.OutOfMemoryError: die with dignity")));
-                    }
+            while (it.hasNext() && (fatalError == false || fatalErrorInThreadExiting == false)) {
+                final String line = it.next();
+                if (line.matches(".*ERROR.*o\\.e\\.ExceptionsHelper.*node-0.*fatal error.*")) {
+                    fatalError = true;
+                } else if (line.matches(".*ERROR.*o\\.e\\.b\\.ElasticsearchUncaughtExceptionHandler.*node-0.*"
+                    + "fatal error in thread \\[Thread-\\d+\\], exiting.*")) {
+                    fatalErrorInThreadExiting = true;
+                    assertTrue(it.hasNext());
+                    assertThat(it.next(), containsString("java.lang.OutOfMemoryError: die with dignity"));
                 }
-
-                assertTrue(fatalError);
-                assertTrue(fatalErrorInThreadExiting);
             }
+
+            assertTrue(fatalError);
+            assertTrue(fatalErrorInThreadExiting);
+
         } catch (AssertionError ae) {
             Path path = PathUtils.get(System.getProperty("log"));
             debugLogs(path);
@@ -121,32 +115,10 @@ public class DieWithDignityIT extends ESRestTestCase {
         }
     }
 
-    private boolean isWarnExceptionReceived(JsonLogLine line) {
-        return line.level().equals("WARN")
-            && line.component().equals("o.e.h.AbstractHttpServerTransport")
-            && line.nodeName().equals("node-0")
-            && line.message().contains("caught exception while handling client http traffic");
-    }
-
     private void debugLogs(Path path) throws IOException {
         try (BufferedReader reader = Files.newBufferedReader(path)) {
-            Terminal terminal = Terminal.DEFAULT;
-            reader.lines().forEach(line -> terminal.println(line));
+            reader.lines().forEach(line -> logger.info(line));
         }
-    }
-
-    private boolean isFatalErrorInThreadExiting(JsonLogLine line) {
-        return line.level().equals("ERROR")
-            && line.component().equals("o.e.b.ElasticsearchUncaughtExceptionHandler")
-            && line.nodeName().equals("node-0")
-            && line.message().matches("fatal error in thread \\[Thread-\\d+\\], exiting$");
-    }
-
-    private boolean isFatalError(JsonLogLine line) {
-        return line.level().equals("ERROR")
-            && line.component().equals("o.e.ExceptionsHelper")
-            && line.nodeName().equals("node-0")
-            && line.message().contains("fatal error");
     }
 
     @Override


### PR DESCRIPTION
This test is likely to kill the server in the middle of writing logs. This means that we can end up with logs with partially written json log lines and standard json parsers would fail on this.
This fix is to use regular expressions on json logs.(just like the previous approach on plain text logs)
closes #43413

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
