### PR TITLE
[ML] Improve message when native controller cannot connect

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -485,8 +485,8 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                 // only log this at the lowest level of detail.  It's almost always "file not found" on a named pipe we expect to be
                 // able to connect to, but the thing we really need to know is what stopped the native process creating the named pipe.
                 logger.trace("Failed to connect to ML native controller", e);
-                throw new ElasticsearchException("Failure running machine learning native code. This could be due to running"
-                    + "on an unsupported OS or distribution, missing OS libraries or a problem with the temp directory. To "
+                throw new ElasticsearchException("Failure running machine learning native code. This could be due to running "
+                    + "on an unsupported OS or distribution, missing OS libraries, or a problem with the temp directory. To "
                     + "bypass this problem by running Elasticsearch without machine learning functionality set ["
                     + XPackSettings.MACHINE_LEARNING_ENABLED.getKey() + ": false].");
             }


### PR DESCRIPTION
The error message if the native controller failed to run
(for example due to running Elasticsearch on an unsupported
platform) was not easy to understand.  This change removes
pointless detail from the message and adds some hints about
likely causes.

Fixes #42341