### PR TITLE
[ML] Tag destination index with data frame metadata

### DIFF
--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportStartDataFrameTransformAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportStartDataFrameTransformAction.java
@@ -46,6 +46,7 @@ import org.elasticsearch.xpack.dataframe.persistence.DataframeIndex;
 import org.elasticsearch.xpack.dataframe.transforms.pivot.Pivot;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -226,7 +227,9 @@ public class TransportStartDataFrameTransformAction extends
         final Pivot pivot = new Pivot(config.getPivotConfig());
 
         ActionListener<Map<String, String>> deduceMappingsListener = ActionListener.wrap(
-            mappings -> DataframeIndex.createDestinationIndex(client,
+            mappings -> DataframeIndex.createDestinationIndex(
+                client,
+                Clock.systemUTC(),
                 config,
                 mappings,
                 ActionListener.wrap(r -> listener.onResponse(null), listener::onFailure)),

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/persistence/DataframeIndex.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/persistence/DataframeIndex.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.core.dataframe.transforms.pivot.DateHistogramGrou
 import org.elasticsearch.xpack.core.dataframe.transforms.pivot.SingleGroupSource;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -41,8 +42,11 @@ public final class DataframeIndex {
     private DataframeIndex() {
     }
 
-    public static void createDestinationIndex(Client client, DataFrameTransformConfig transformConfig, Map<String, String> mappings,
-            final ActionListener<Boolean> listener) {
+    public static void createDestinationIndex(Client client,
+                                              Clock clock,
+                                              DataFrameTransformConfig transformConfig,
+                                              Map<String, String> mappings,
+                                              ActionListener<Boolean> listener) {
         CreateIndexRequest request = new CreateIndexRequest(transformConfig.getDestination().getIndex());
 
         // TODO: revisit number of shards, number of replicas
@@ -50,9 +54,9 @@ public final class DataframeIndex {
                 .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
                 .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "0-1"));
 
-        request.mapping(SINGLE_MAPPING_NAME, createMappingXContent(mappings,
-            transformConfig.getPivotConfig().getGroupConfig().getGroups(),
-            transformConfig.getId()));
+        request.mapping(
+            SINGLE_MAPPING_NAME,
+            createMappingXContent(mappings, transformConfig.getPivotConfig().getGroupConfig().getGroups(), transformConfig.getId(), clock));
 
         client.execute(CreateIndexAction.INSTANCE, request, ActionListener.wrap(createIndexResponse -> {
             listener.onResponse(true);
@@ -66,29 +70,13 @@ public final class DataframeIndex {
 
     private static XContentBuilder createMappingXContent(Map<String, String> mappings,
                                                          Map<String, SingleGroupSource> groupSources,
-                                                         String id) {
+                                                         String id,
+                                                         Clock clock) {
         try {
             XContentBuilder builder = jsonBuilder().startObject();
             builder.startObject(SINGLE_MAPPING_NAME);
-            addMetaData(builder, id);
-            builder.startObject(PROPERTIES);
-            for (Entry<String, String> field : mappings.entrySet()) {
-                String fieldName = field.getKey();
-                String fieldType = field.getValue();
-
-                builder.startObject(fieldName);
-                builder.field(TYPE, fieldType);
-
-                SingleGroupSource groupSource = groupSources.get(fieldName);
-                if (groupSource instanceof DateHistogramGroupSource) {
-                    String format = ((DateHistogramGroupSource) groupSource).getFormat();
-                    if (format != null) {
-                        builder.field(FORMAT, DEFAULT_TIME_FORMAT + "||" + format);
-                    }
-                }
-                builder.endObject();
-            }
-            builder.endObject(); // properties
+            addProperties(builder, mappings, groupSources);
+            addMetaData(builder, id, clock);
             builder.endObject(); // _doc type
             return builder.endObject();
         } catch (IOException e) {
@@ -96,17 +84,40 @@ public final class DataframeIndex {
         }
     }
 
-    private static XContentBuilder addMetaData(XContentBuilder builder, String id) throws IOException {
-        builder.startObject(META);
-        builder.field(DataFrameField.CREATED_BY, DataFrameField.DATA_FRAME_SIGNATURE);
-        builder.startObject(DataFrameField.META_FIELDNAME);
-        builder.field(DataFrameField.CREATION_DATE_MILLIS, System.currentTimeMillis());
-        builder.startObject(DataFrameField.VERSION);
-        builder.field(DataFrameField.CREATED, Version.CURRENT);
-        builder.endObject();
-        builder.field(DataFrameField.TRANSFORM, id);
-        builder.endObject(); // META_FIELDNAME
-        builder.endObject(); // META
+    private static XContentBuilder addProperties(XContentBuilder builder,
+                                                 Map<String, String> mappings,
+                                                 Map<String, SingleGroupSource> groupSources) throws IOException {
+        builder.startObject(PROPERTIES);
+        for (Entry<String, String> field : mappings.entrySet()) {
+            String fieldName = field.getKey();
+            String fieldType = field.getValue();
+
+            builder.startObject(fieldName);
+            builder.field(TYPE, fieldType);
+
+            SingleGroupSource groupSource = groupSources.get(fieldName);
+            if (groupSource instanceof DateHistogramGroupSource) {
+                String format = ((DateHistogramGroupSource) groupSource).getFormat();
+                if (format != null) {
+                    builder.field(FORMAT, DEFAULT_TIME_FORMAT + "||" + format);
+                }
+            }
+            builder.endObject();
+        }
+        builder.endObject(); // PROPERTIES
         return builder;
+    }
+
+    private static XContentBuilder addMetaData(XContentBuilder builder, String id, Clock clock) throws IOException {
+        return builder.startObject(META)
+            .field(DataFrameField.CREATED_BY, DataFrameField.DATA_FRAME_SIGNATURE)
+            .startObject(DataFrameField.META_FIELDNAME)
+                .field(DataFrameField.CREATION_DATE_MILLIS, clock.millis())
+                .startObject(DataFrameField.VERSION)
+                    .field(DataFrameField.CREATED, Version.CURRENT)
+                .endObject()
+                .field(DataFrameField.TRANSFORM, id)
+            .endObject() // META_FIELDNAME
+        .endObject(); // META
     }
 }

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/persistence/DataframeIndexTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/persistence/DataframeIndexTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.dataframe.persistence;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.create.CreateIndexAction;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfigTests;
+import org.elasticsearch.xpack.core.watcher.watch.ClockMock;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.support.XContentMapValues.extractValue;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class DataframeIndexTests extends ESTestCase {
+
+    private static final String TRANSFORM_ID = "some-random-transform-id";
+    private static final DataFrameTransformConfig TRANSFORM_CONFIG =
+        DataFrameTransformConfigTests.randomDataFrameTransformConfig(TRANSFORM_ID);
+    private static final int CURRENT_TIME_MILLIS = 123456789;
+    private static final String CREATED_BY = "data-frame-transform";
+
+    private Client client = mock(Client.class);
+    private Clock clock = ClockMock.fixed(Instant.ofEpochMilli(CURRENT_TIME_MILLIS), ZoneId.systemDefault());
+
+    public void testCreateDestinationIndex() throws IOException {
+        doAnswer(
+            invocationOnMock -> {
+                @SuppressWarnings("unchecked")
+                ActionListener<CreateIndexResponse> listener = (ActionListener<CreateIndexResponse>) invocationOnMock.getArguments()[2];
+                listener.onResponse(null);
+                return null;
+            })
+            .when(client).execute(any(), any(), any());
+
+        DataframeIndex.createDestinationIndex(
+            client,
+            clock,
+            TRANSFORM_CONFIG,
+            new HashMap<>(),
+            ActionListener.wrap(
+                value -> assertTrue(value),
+                e -> fail(e.getMessage())));
+
+        ArgumentCaptor<CreateIndexRequest> createIndexRequestCaptor = ArgumentCaptor.forClass(CreateIndexRequest.class);
+        verify(client).execute(eq(CreateIndexAction.INSTANCE), createIndexRequestCaptor.capture(), any());
+        verifyNoMoreInteractions(client);
+
+        CreateIndexRequest createIndexRequest = createIndexRequestCaptor.getValue();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, createIndexRequest.mappings().get("_doc"))) {
+            Map<String, Object> map = parser.map();
+            assertThat(extractValue("_doc._meta._data_frame.transform", map), equalTo(TRANSFORM_ID));
+            assertThat(extractValue("_doc._meta._data_frame.creation_date_in_millis", map), equalTo(CURRENT_TIME_MILLIS));
+            assertThat(extractValue("_doc._meta.created_by", map), equalTo(CREATED_BY));
+        }
+    }
+}

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/persistence/DataframeIndexTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/persistence/DataframeIndexTests.java
@@ -13,9 +13,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfigTests;
-import org.elasticsearch.xpack.core.watcher.watch.ClockMock;
 import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
@@ -37,13 +35,11 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 public class DataframeIndexTests extends ESTestCase {
 
     private static final String TRANSFORM_ID = "some-random-transform-id";
-    private static final DataFrameTransformConfig TRANSFORM_CONFIG =
-        DataFrameTransformConfigTests.randomDataFrameTransformConfig(TRANSFORM_ID);
     private static final int CURRENT_TIME_MILLIS = 123456789;
     private static final String CREATED_BY = "data-frame-transform";
 
     private Client client = mock(Client.class);
-    private Clock clock = ClockMock.fixed(Instant.ofEpochMilli(CURRENT_TIME_MILLIS), ZoneId.systemDefault());
+    private Clock clock = Clock.fixed(Instant.ofEpochMilli(CURRENT_TIME_MILLIS), ZoneId.systemDefault());
 
     public void testCreateDestinationIndex() throws IOException {
         doAnswer(
@@ -58,7 +54,7 @@ public class DataframeIndexTests extends ESTestCase {
         DataframeIndex.createDestinationIndex(
             client,
             clock,
-            TRANSFORM_CONFIG,
+            DataFrameTransformConfigTests.randomDataFrameTransformConfig(TRANSFORM_ID),
             new HashMap<>(),
             ActionListener.wrap(
                 value -> assertTrue(value),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsFields.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsFields.java
@@ -9,5 +9,12 @@ public final class DataFrameAnalyticsFields {
 
     public static final String ID = "_id_copy";
 
+    // Metadata fields
+    static final String CREATION_DATE_MILLIS = "creation_date_in_millis";
+    static final String VERSION = "version";
+    static final String CREATED = "created";
+    static final String CREATED_BY = "created_by";
+    static final String ANALYTICS = "analytics";
+
     private DataFrameAnalyticsFields() {}
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsIndex.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsIndex.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.dataframe;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.create.CreateIndexAction;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.IndexSortConfig;
+import org.elasticsearch.search.sort.SortOrder;
+import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
+
+import java.time.Clock;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * {@link DataFrameAnalyticsIndex} class encapsulates logic for creating destination index based on source index metadata.
+ */
+final class DataFrameAnalyticsIndex {
+
+    private static final String PROPERTIES = "properties";
+    private static final String META = "_meta";
+
+    /**
+     * Unfortunately, getting the settings of an index include internal settings that should
+     * not be set explicitly. There is no way to filter those out. Thus, we have to maintain
+     * a list of them and filter them out manually.
+     */
+    private static final List<String> INTERNAL_SETTINGS = Arrays.asList(
+        "index.creation_date",
+        "index.provided_name",
+        "index.uuid",
+        "index.version.created",
+        "index.version.upgraded"
+    );
+
+    /**
+     * Creates destination index based on source index metadata.
+     */
+    public static void createDestinationIndex(Client client,
+                                              Clock clock,
+                                              ClusterState clusterState,
+                                              DataFrameAnalyticsConfig analyticsConfig,
+                                              ActionListener<CreateIndexResponse> listener) {
+        String sourceIndex = analyticsConfig.getSource().getIndex();
+        Map<String, String> headers = analyticsConfig.getHeaders();
+        IndexMetaData sourceIndexMetaData = clusterState.getMetaData().getIndices().get(sourceIndex);
+        if (sourceIndexMetaData == null) {
+            listener.onFailure(new IndexNotFoundException(sourceIndex));
+            return;
+        }
+        CreateIndexRequest createIndexRequest =
+            prepareCreateIndexRequest(sourceIndexMetaData, analyticsConfig.getDest().getIndex(), analyticsConfig.getId(), clock);
+        ClientHelper.executeWithHeadersAsync(
+            headers, ClientHelper.ML_ORIGIN, client, CreateIndexAction.INSTANCE, createIndexRequest, listener);
+    }
+
+    private static CreateIndexRequest prepareCreateIndexRequest(IndexMetaData sourceIndexMetaData,
+                                                                String destinationIndex,
+                                                                String analyticsId,
+                                                                Clock clock) {
+        // Settings
+        Settings.Builder settingsBuilder = Settings.builder().put(sourceIndexMetaData.getSettings());
+        INTERNAL_SETTINGS.forEach(settingsBuilder::remove);
+        settingsBuilder.put(IndexSortConfig.INDEX_SORT_FIELD_SETTING.getKey(), DataFrameAnalyticsFields.ID);
+        settingsBuilder.put(IndexSortConfig.INDEX_SORT_ORDER_SETTING.getKey(), SortOrder.ASC);
+        Settings settings = settingsBuilder.build();
+
+        // Mappings
+        String singleMappingType = sourceIndexMetaData.getMappings().keysIt().next();
+        Map<String, Object> mappingsAsMap = sourceIndexMetaData.getMappings().valuesIt().next().sourceAsMap();
+        addProperties(mappingsAsMap);
+        addMetaData(mappingsAsMap, analyticsId, clock);
+
+        return new CreateIndexRequest(destinationIndex, settings).mapping(singleMappingType, mappingsAsMap);
+    }
+
+    private static void addProperties(Map<String, Object> mappingsAsMap) {
+        Map<String, Object> properties = getOrPutDefault(mappingsAsMap, PROPERTIES, HashMap::new);
+        properties.put(DataFrameAnalyticsFields.ID, Map.of("type", "keyword"));
+    }
+
+    private static void addMetaData(Map<String, Object> mappingsAsMap, String analyticsId, Clock clock) {
+        Map<String, Object> metadata = getOrPutDefault(mappingsAsMap, META, HashMap::new);
+        metadata.put(DataFrameAnalyticsFields.CREATION_DATE_MILLIS, clock.millis());
+        metadata.put(DataFrameAnalyticsFields.CREATED_BY, "data-frame-analytics");
+        metadata.put(DataFrameAnalyticsFields.VERSION, Map.of(DataFrameAnalyticsFields.CREATED, Version.CURRENT));
+        metadata.put(DataFrameAnalyticsFields.ANALYTICS, analyticsId);
+    }
+
+    private static <K, V> V getOrPutDefault(Map<K, Object> map, K key, Supplier<V> valueSupplier) {
+        V value = (V) map.get(key);
+        if (value == null) {
+            value = valueSupplier.get();
+            map.put(key, value);
+        }
+        return value;
+    }
+
+    private DataFrameAnalyticsIndex() {}
+}
+

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsIndexTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsIndexTests.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.dataframe;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.create.CreateIndexAction;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsDest;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsSource;
+import org.elasticsearch.xpack.core.ml.dataframe.analyses.OutlierDetection;
+import org.elasticsearch.xpack.core.watcher.watch.ClockMock;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.support.XContentMapValues.extractValue;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class DataFrameAnalyticsIndexTests extends ESTestCase {
+
+    private static final String CLUSTER_NAME = "some-cluster-name";
+
+    private static final String ANALYTICS_ID = "some-analytics-id";
+    private static final String SOURCE_INDEX = "source-index";
+    private static final String DEST_INDEX = "dest-index";
+    private static final DataFrameAnalyticsConfig ANALYTICS_CONFIG =
+        new DataFrameAnalyticsConfig.Builder(ANALYTICS_ID)
+            .setSource(new DataFrameAnalyticsSource(SOURCE_INDEX, null))
+            .setDest(new DataFrameAnalyticsDest(DEST_INDEX, null))
+            .setAnalysis(new OutlierDetection())
+            .build();
+    private static final int CURRENT_TIME_MILLIS = 123456789;
+    private static final String CREATED_BY = "data-frame-analytics";
+
+    private ThreadPool threadPool = mock(ThreadPool.class);
+    private Client client = mock(Client.class);
+    private Clock clock = ClockMock.fixed(Instant.ofEpochMilli(123456789L), ZoneId.systemDefault());
+
+    public void testCreateDestinationIndex() throws IOException {
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+        doAnswer(
+            invocationOnMock -> {
+                @SuppressWarnings("unchecked")
+                ActionListener<CreateIndexResponse> listener = (ActionListener<CreateIndexResponse>) invocationOnMock.getArguments()[2];
+                listener.onResponse(null);
+                return null;
+            })
+            .when(client).execute(any(), any(), any());
+
+        ClusterState clusterState =
+            ClusterState.builder(new ClusterName(CLUSTER_NAME))
+                .metaData(MetaData.builder()
+                    .put(IndexMetaData.builder(SOURCE_INDEX)
+                        .settings(Settings.builder()
+                            .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+                            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+                            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0))
+                        .putMapping(new MappingMetaData("_doc", Map.of("properties", Map.of())))))
+                .build();
+        DataFrameAnalyticsIndex.createDestinationIndex(
+            client,
+            clock,
+            clusterState,
+            ANALYTICS_CONFIG,
+            ActionListener.wrap(
+                response -> {},
+                e -> fail(e.getMessage())));
+
+        ArgumentCaptor<CreateIndexRequest> createIndexRequestCaptor = ArgumentCaptor.forClass(CreateIndexRequest.class);
+        verify(client, atLeastOnce()).threadPool();
+        verify(client).execute(eq(CreateIndexAction.INSTANCE), createIndexRequestCaptor.capture(), any());
+        verifyNoMoreInteractions(client);
+
+        CreateIndexRequest createIndexRequest = createIndexRequestCaptor.getValue();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, createIndexRequest.mappings().get("_doc"))) {
+            Map<String, Object> map = parser.map();
+            assertThat(extractValue("_doc.properties._id_copy.type", map), equalTo("keyword"));
+            assertThat(extractValue("_doc._meta.analytics", map), equalTo(ANALYTICS_ID));
+            assertThat(extractValue("_doc._meta.creation_date_in_millis", map), equalTo(CURRENT_TIME_MILLIS));
+            assertThat(extractValue("_doc._meta.created_by", map), equalTo(CREATED_BY));
+        }
+    }
+
+    public void testCreateDestinationIndex_IndexNotFound() {
+        ClusterState clusterState =
+            ClusterState.builder(new ClusterName(CLUSTER_NAME))
+                .metaData(MetaData.builder())
+                .build();
+        DataFrameAnalyticsIndex.createDestinationIndex(
+            client,
+            clock,
+            clusterState,
+            ANALYTICS_CONFIG,
+            ActionListener.wrap(
+                response -> fail("IndexNotFoundException should be thrown"),
+                e -> {
+                    assertThat(e, instanceOf(IndexNotFoundException.class));
+                    IndexNotFoundException infe = (IndexNotFoundException) e;
+                    assertThat(infe.getIndex().getName(), equalTo(SOURCE_INDEX));
+                }));
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsIndexTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsIndexTests.java
@@ -27,7 +27,6 @@ import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsDest;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsSource;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.OutlierDetection;
-import org.elasticsearch.xpack.core.watcher.watch.ClockMock;
 import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
@@ -66,7 +65,7 @@ public class DataFrameAnalyticsIndexTests extends ESTestCase {
 
     private ThreadPool threadPool = mock(ThreadPool.class);
     private Client client = mock(Client.class);
-    private Clock clock = ClockMock.fixed(Instant.ofEpochMilli(123456789L), ZoneId.systemDefault());
+    private Clock clock = Clock.fixed(Instant.ofEpochMilli(123456789L), ZoneId.systemDefault());
 
     public void testCreateDestinationIndex() throws IOException {
         when(client.threadPool()).thenReturn(threadPool);


### PR DESCRIPTION
Tag all the destination indices that are created by Data Frame Analytics with metadata: created by, creation time, version and analytics id.

Also:
- extract destination index creation logic into a separate class: DataFrameAnalyticsIndex
- add unit test for DataframeIndex::createDestinationIndex method