### PR TITLE
Remove Redundant Delete from Shard Snapshot Delete

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1039,12 +1039,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         BlobStoreIndexShardSnapshots snapshots = tuple.v1();
         int fileListGeneration = tuple.v2();
 
-        try {
-            indexShardSnapshotFormat.delete(shardContainer, snapshotId.getUUID());
-        } catch (IOException e) {
-            logger.warn(new ParameterizedMessage("[{}] [{}] failed to delete shard snapshot file", snapshotShardId, snapshotId), e);
-        }
-
         // Build a list of snapshots that should be preserved
         List<SnapshotFiles> newSnapshotsList = new ArrayList<>();
         for (SnapshotFiles point : snapshots) {


### PR DESCRIPTION
* There is no point (and some harm) in deleting the snap- blob before writing the updated index-N blob in the shard folder:
   * We will delete it in `finalizeShard` anyway where we list the shard folders contents and clean them up (in a bulk delete) so we're just wasting an RPC call here
   * Deleting it before writing the updated index-N blob actually could leave a broken index-(N-1) blob if writing index-N fails and index-(N-1) still references the now deleted snap- blob
