### PR TITLE
[DOCS] Fixing backquote in fail_on_unsupported_field

### DIFF
--- a/docs/reference/query-dsl/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/mlt-query.asciidoc
@@ -232,9 +232,8 @@ The syntax is the same as the <<query-dsl-minimum-should-match,minimum should ma
 `fail_on_unsupported_field`::
 Controls whether the query should fail (throw an exception) if any of the 
 specified fields are not of the supported types
-(`text` or `keyword'). Set this to `false` to ignore the field and continue
-processing. Defaults to
-`true`.
+(`text` or `keyword`). Set this to `false` to ignore the field and continue
+processing. Defaults to `true`.
 
 `boost_terms`::
 Each term in the formed query could be further boosted by their tf-idf score.


### PR DESCRIPTION
Terminating backquote was missing on "keyword".