### PR TITLE
[7.x] Remove unused mapStringsOrdered method (#42513)

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
@@ -136,11 +136,9 @@ public interface XContentParser extends Closeable {
 
     Map<String, String> mapStrings() throws IOException;
 
-    Map<String, String> mapStringsOrdered() throws IOException;
-
     /**
      * Returns an instance of {@link Map} holding parsed map.
-     * Serves as a replacement for the "map", "mapOrdered", "mapStrings" and "mapStringsOrdered" methods above.
+     * Serves as a replacement for the "map", "mapOrdered" and "mapStrings" methods above.
      *
      * @param mapFactory factory for creating new {@link Map} objects
      * @param mapValueParser parser for parsing a single map value

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentSubParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentSubParser.java
@@ -109,11 +109,6 @@ public class XContentSubParser implements XContentParser {
     }
 
     @Override
-    public Map<String, String> mapStringsOrdered() throws IOException {
-        return parser.mapStringsOrdered();
-    }
-
-    @Override
     public <T> Map<String, T> map(
             Supplier<Map<String, T>> mapFactory, CheckedFunction<XContentParser, T, IOException> mapValueParser) throws IOException {
         return parser.map(mapFactory, mapValueParser);

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
@@ -277,11 +277,6 @@ public abstract class AbstractXContentParser implements XContentParser {
     }
 
     @Override
-    public Map<String, String> mapStringsOrdered() throws IOException {
-        return readOrderedMapStrings(this);
-    }
-
-    @Override
     public <T> Map<String, T> map(
             Supplier<Map<String, T>> mapFactory, CheckedFunction<XContentParser, T, IOException> mapValueParser) throws IOException {
         return readGenericMap(this, mapFactory, mapValueParser);
@@ -303,8 +298,6 @@ public abstract class AbstractXContentParser implements XContentParser {
 
     static final Supplier<Map<String, String>> SIMPLE_MAP_STRINGS_FACTORY = HashMap::new;
 
-    static final Supplier<Map<String, String>> ORDERED_MAP_STRINGS_FACTORY = LinkedHashMap::new;
-
     static Map<String, Object> readMap(XContentParser parser) throws IOException {
         return readMap(parser, SIMPLE_MAP_FACTORY);
     }
@@ -314,11 +307,7 @@ public abstract class AbstractXContentParser implements XContentParser {
     }
 
     static Map<String, String> readMapStrings(XContentParser parser) throws IOException {
-        return readMapStrings(parser, SIMPLE_MAP_STRINGS_FACTORY);
-    }
-
-    static Map<String, String> readOrderedMapStrings(XContentParser parser) throws IOException {
-        return readMapStrings(parser, ORDERED_MAP_STRINGS_FACTORY);
+        return readGenericMap(parser, SIMPLE_MAP_STRINGS_FACTORY, XContentParser::text);
     }
 
     static List<Object> readList(XContentParser parser) throws IOException {
@@ -331,10 +320,6 @@ public abstract class AbstractXContentParser implements XContentParser {
 
     static Map<String, Object> readMap(XContentParser parser, Supplier<Map<String, Object>> mapFactory) throws IOException {
         return readGenericMap(parser, mapFactory, p -> readValue(p, mapFactory));
-    }
-
-    static Map<String, String> readMapStrings(XContentParser parser, Supplier<Map<String, String>> mapFactory) throws IOException {
-        return readGenericMap(parser, mapFactory, XContentParser::text);
     }
 
     static <T> Map<String, T> readGenericMap(

--- a/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/XContentParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/XContentParserTests.java
@@ -189,7 +189,7 @@ public class XContentParserTests extends ESTestCase {
             assertThat(parser.currentName(), equalTo("foo"));
             token = parser.nextToken();
             assertThat(token, equalTo(XContentParser.Token.START_OBJECT));
-            return randomBoolean() ? parser.mapStringsOrdered() : parser.mapStrings();
+            return parser.mapStrings();
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/xcontent/WatcherXContentParser.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/xcontent/WatcherXContentParser.java
@@ -121,11 +121,6 @@ public class WatcherXContentParser implements XContentParser {
     }
 
     @Override
-    public Map<String, String> mapStringsOrdered() throws IOException {
-        return parser.mapStringsOrdered();
-    }
-
-    @Override
     public <T> Map<String, T> map(
             Supplier<Map<String, T>> mapFactory, CheckedFunction<XContentParser, T, IOException> mapValueParser) throws IOException {
         return parser.map(mapFactory, mapValueParser);


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Remove unused mapStringsOrdered method  (#42513)