### PR TITLE
Fix dockerfile for non-local builds

### DIFF
--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN groupadd -g 1000 elasticsearch && \
 
 WORKDIR /usr/share/elasticsearch
 
-COPY ${elasticsearch} /opt/
+${source_elasticsearch}
 
 RUN tar zxf /opt/${elasticsearch} --strip-components=1
 RUN grep ES_DISTRIBUTION_TYPE=tar /usr/share/elasticsearch/bin/elasticsearch-env \


### PR DESCRIPTION
Use the `source_elasticsearch` variable to conditionally get the command
needed for release builds for the [dockerfiles repository][0].

Fixes https://github.com/elastic/elasticsearch/issues/43590

[0]: https://github.com/elastic/dockerfiles