### PR TITLE
Set auto expand replicas after force merge is done.

### DIFF
--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
@@ -228,7 +228,10 @@ public class EnrichPolicyRunner implements Runnable {
     private void prepareAndCreateEnrichIndex() {
         long nowTimestamp = nowSupplier.getAsLong();
         String enrichIndexName = EnrichPolicy.getBaseName(policyName) + "-" + nowTimestamp;
-        CreateIndexRequest createEnrichIndexRequest = new CreateIndexRequest(enrichIndexName);
+        Settings enrichIndexSettings = Settings.builder()
+            .put("index.number_of_replicas", 0)
+            .build();
+        CreateIndexRequest createEnrichIndexRequest = new CreateIndexRequest(enrichIndexName, enrichIndexSettings);
         createEnrichIndexRequest.mapping(MapperService.SINGLE_MAPPING_NAME, resolveEnrichMapping(policy));
         logger.debug("Policy [{}]: Creating new enrich index [{}]", policyName, enrichIndexName);
         client.admin().indices().create(createEnrichIndexRequest, new ActionListener<>() {


### PR DESCRIPTION
Set the auto expand replicas setting after force merge has completed in order to avoid having all nodes performing force merges on the same data. Wait for green status on the index after setting auto expand settings.