### PR TITLE
[ML][Data Frame] re-ordering format priorities in dest mapping

### DIFF
--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/persistence/DataframeIndex.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/persistence/DataframeIndex.java
@@ -83,7 +83,7 @@ public final class DataframeIndex {
                 if (groupSource instanceof DateHistogramGroupSource) {
                     String format = ((DateHistogramGroupSource) groupSource).getFormat();
                     if (format != null) {
-                        builder.field(FORMAT, DEFAULT_TIME_FORMAT + "||" + format);
+                        builder.field(FORMAT, format + "||" + DEFAULT_TIME_FORMAT);
                     }
                 }
                 builder.endObject();


### PR DESCRIPTION
There is a bug around formatting (see https://github.com/elastic/kibana/issues/38926). 

This re-orders the multiple `format` entry supplied for `date_histogram` time fields when a user `format` is provided.