### PR TITLE
Testclusters: Convert additional projects

### DIFF
--- a/qa/ccs-unavailable-clusters/build.gradle
+++ b/qa/ccs-unavailable-clusters/build.gradle
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 apply plugin: 'elasticsearch.test-with-dependencies'

--- a/qa/die-with-dignity/build.gradle
+++ b/qa/die-with-dignity/build.gradle
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.esplugin'
 
 esplugin {
@@ -24,12 +25,15 @@ esplugin {
     classname 'org.elasticsearch.DieWithDignityPlugin'
 }
 
-integTestRunner {
+integTest.runner {
     systemProperty 'tests.security.manager', 'false'
     systemProperty 'tests.system_call_filter', 'false'
-    nonInputProperties.systemProperty 'pidfile', "${-> integTest.getNodes().get(0).pidFile}"
-    nonInputProperties.systemProperty 'log', "${-> integTest.getNodes().get(0).homeDir}/logs/${-> integTest.getNodes().get(0).clusterName}_server.json"
+    nonInputProperties.systemProperty 'log', "${-> testClusters.integTest.singleNode().getServerLog()}"
     systemProperty 'runtime.java.home', "${project.runtimeJavaHome}"
+}
+
+testClusters.integTest {
+    systemProperty "die.with.dignity.test", "whatever"
 }
 
 test.enabled = false

--- a/qa/die-with-dignity/src/main/java/org/elasticsearch/DieWithDignityPlugin.java
+++ b/qa/die-with-dignity/src/main/java/org/elasticsearch/DieWithDignityPlugin.java
@@ -36,6 +36,10 @@ import java.util.function.Supplier;
 
 public class DieWithDignityPlugin extends Plugin implements ActionPlugin {
 
+    public DieWithDignityPlugin() {
+        assert System.getProperty("die.with.dignity.test") != null : "test should pass the `die.with.dignity.test` property";
+    }
+
     @Override
     public List<RestHandler> getRestHandlers(
             final Settings settings,

--- a/qa/die-with-dignity/src/test/java/org/elasticsearch/qa/die_with_dignity/DieWithDignityIT.java
+++ b/qa/die-with-dignity/src/test/java/org/elasticsearch/qa/die_with_dignity/DieWithDignityIT.java
@@ -62,6 +62,9 @@ public class DieWithDignityIT extends ESRestTestCase {
             failureMatcher = either(failureMatcher)
                 .or(hasToString(containsString("An existing connection was forcibly closed by the remote host")));
         }
+        failureMatcher = either(failureMatcher).or(
+            hasToString(containsString("Connection reset by peer"))
+        );
         assertThat(e, failureMatcher);
 
         // the Elasticsearch process should die and disappear from the output of jps

--- a/qa/evil-tests/build.gradle
+++ b/qa/evil-tests/build.gradle
@@ -23,6 +23,7 @@
  * threads, etc.
  */
 
+apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {

--- a/qa/multi-cluster-search/build.gradle
+++ b/qa/multi-cluster-search/build.gradle
@@ -19,42 +19,43 @@
 
 import org.elasticsearch.gradle.test.RestIntegTestTask
 
+apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
   testCompile project(":client:rest-high-level")
 }
 
-task remoteClusterTest(type: RestIntegTestTask) {
+task 'remote-cluster'(type: RestIntegTestTask) {
   mustRunAfter(precommit)
+  runner {
+    systemProperty 'tests.rest.suite', 'remote_cluster'
+  }
 }
 
-remoteClusterTestCluster {
-  numNodes = 2
-  clusterName = 'remote-cluster'
-  setting 'cluster.remote.connect', false
+testClusters.'remote-cluster' {
+  numberOfNodes = 2
+  setting 'cluster.remote.connect', 'false'
 }
 
-remoteClusterTestRunner {
-  systemProperty 'tests.rest.suite', 'remote_cluster'
+task mixedClusterTest(type: RestIntegTestTask) {
+  useCluster testClusters.'remote-cluster'
+  runner {
+    dependsOn 'remote-cluster'
+    systemProperty 'tests.rest.suite', 'multi_cluster'
+  }
 }
 
-task mixedClusterTest(type: RestIntegTestTask) {}
-
-mixedClusterTestCluster {
-  dependsOn remoteClusterTestRunner
-  setting 'cluster.remote.my_remote_cluster.seeds', "\"${-> remoteClusterTest.nodes.get(0).transportUri()}\""
-  setting 'cluster.remote.connections_per_cluster', 1
-  setting 'cluster.remote.connect', true
+testClusters.mixedClusterTest {
+  setting 'cluster.remote.my_remote_cluster.seeds',
+          { "\"${testClusters.'remote-cluster'.getAllTransportPortURI().get(0)}\"" }
+  setting 'cluster.remote.connections_per_cluster', '1'
+  setting 'cluster.remote.connect', 'true'
 }
 
-mixedClusterTestRunner {
-  systemProperty 'tests.rest.suite', 'multi_cluster'
-  finalizedBy 'remoteClusterTestCluster#node0.stop','remoteClusterTestCluster#node1.stop'
-}
 
 task integTest {
-  dependsOn = [mixedClusterTest]
+  dependsOn mixedClusterTest
 }
 
 test.enabled = false // no unit tests for multi-cluster-search, only integration tests

--- a/qa/smoke-test-http/build.gradle
+++ b/qa/smoke-test-http/build.gradle
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 apply plugin: 'elasticsearch.test-with-dependencies'
@@ -26,7 +27,7 @@ dependencies {
     testCompile project(path: ':plugins:transport-nio', configuration: 'runtime') // for http
 }
 
-integTestRunner {
+integTest.runner {
     /*
      * We have to disable setting the number of available processors as tests in the same JVM randomize processors and will step on each
      * other if we allow them to set the number of available processors as it's set-once in Netty.

--- a/qa/smoke-test-ingest-with-all-dependencies/build.gradle
+++ b/qa/smoke-test-ingest-with-all-dependencies/build.gradle
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 


### PR DESCRIPTION
Found some more that were not using testclusters from elasticsearch-ci/1

Testclusters doesn't use a pidfie so the die with dignity test now uses a system property to identify it's node and assert that it's not running. 