### PR TITLE
Remove unreleased 7.1.2 version from 2 previous minors ago

### DIFF
--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -51,7 +51,6 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_7_0_1 = new Version(7000199, org.apache.lucene.util.Version.LUCENE_8_0_0);
     public static final Version V_7_1_0 = new Version(7010099, org.apache.lucene.util.Version.LUCENE_8_0_0);
     public static final Version V_7_1_1 = new Version(7010199, org.apache.lucene.util.Version.LUCENE_8_0_0);
-    public static final Version V_7_1_2 = new Version(7010299, org.apache.lucene.util.Version.LUCENE_8_0_0);
     public static final Version V_7_2_0 = new Version(7020099, org.apache.lucene.util.Version.LUCENE_8_0_0);
     public static final Version V_7_2_1 = new Version(7020199, org.apache.lucene.util.Version.LUCENE_8_0_0);
     public static final Version V_7_3_0 = new Version(7030099, org.apache.lucene.util.Version.LUCENE_8_1_0);


### PR DESCRIPTION
The code in `BwcVersions` to list the unreleased versions only includes the tip of the previous minor.

https://github.com/elastic/elasticsearch/blob/42e19b78fca61ddd096d80f542199755a02c498c/buildSrc/src/main/java/org/elasticsearch/gradle/BwcVersions.java#L258

Now that 7.x has been bumped to version 7.3.0 the tip of the minor version 7.1.x is not considered as an unreleased version, only 7.2.x is included. This makes sense with the 7.2.0 release as it is very unlikely there will be a 7.1.2 

Remove the 7.1.2 version constant. 

Closes #43624