### PR TITLE
Install unzip in the "create_certs" container

### DIFF
--- a/docs/reference/security/securing-communications/configuring-tls-docker.asciidoc
+++ b/docs/reference/security/securing-communications/configuring-tls-docker.asciidoc
@@ -69,6 +69,7 @@ services:
     image: {docker-image}
     command: >
       bash -c '
+        yum install unzip -y
         if [[ ! -d config/certificates/certs ]]; then
           mkdir config/certificates/certs;
         fi;


### PR DESCRIPTION
the create_certs container don't have the unzip installed and it gave error after installing the certificates.
Added a line to install the unzip package

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
