### PR TITLE
Add missing GCP update

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -3523,6 +3523,9 @@ public class IndexShardTests extends IndexShardTestCase {
         // In order to instruct the merge policy not to keep a fully deleted segment,
         // we need to flush and make that commit safe so that the SoftDeletesPolicy can drop everything.
         if (IndexSettings.INDEX_SOFT_DELETES_SETTING.get(settings)) {
+            primary.updateGlobalCheckpointForShard(
+                primary.routingEntry().allocationId().getId(),
+                primary.getLastSyncedGlobalCheckpoint());
             primary.advancePeerRecoveryRetentionLeasesToGlobalCheckpoints();
             primary.sync();
             flushShard(primary);


### PR DESCRIPTION
The changes in #43205 and friends mean that the GCP of the local shard is not advanced as expected any more, causing this test to fail.