### PR TITLE
[7.x] [ML][Data Frame] Add support for allow_no_match for endpoints (#43490)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/DataFrameRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/DataFrameRequestConverters.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 
 import static org.elasticsearch.client.RequestConverters.REQUEST_BODY_CONTENT_TYPE;
 import static org.elasticsearch.client.RequestConverters.createEntity;
+import static org.elasticsearch.client.dataframe.GetDataFrameTransformRequest.ALLOW_NO_MATCH;
 
 final class DataFrameRequestConverters {
 
@@ -63,6 +64,9 @@ final class DataFrameRequestConverters {
         }
         if (getRequest.getPageParams() != null && getRequest.getPageParams().getSize() != null) {
             request.addParameter(PageParams.SIZE.getPreferredName(), getRequest.getPageParams().getSize().toString());
+        }
+        if (getRequest.getAllowNoMatch() != null) {
+            request.addParameter(ALLOW_NO_MATCH, getRequest.getAllowNoMatch().toString());
         }
         return request;
     }
@@ -91,21 +95,24 @@ final class DataFrameRequestConverters {
     }
 
     static Request stopDataFrameTransform(StopDataFrameTransformRequest stopRequest) {
-            String endpoint = new RequestConverters.EndpointBuilder()
-                    .addPathPartAsIs("_data_frame", "transforms")
-                    .addPathPart(stopRequest.getId())
-                    .addPathPartAsIs("_stop")
-                    .build();
-            Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-            RequestConverters.Params params = new RequestConverters.Params();
-            if (stopRequest.getWaitForCompletion() != null) {
-                params.withWaitForCompletion(stopRequest.getWaitForCompletion());
-            }
-            if (stopRequest.getTimeout() != null) {
-                params.withTimeout(stopRequest.getTimeout());
-            }
-            request.addParameters(params.asMap());
-            return request;
+        String endpoint = new RequestConverters.EndpointBuilder()
+            .addPathPartAsIs("_data_frame", "transforms")
+            .addPathPart(stopRequest.getId())
+            .addPathPartAsIs("_stop")
+            .build();
+        Request request = new Request(HttpPost.METHOD_NAME, endpoint);
+        RequestConverters.Params params = new RequestConverters.Params();
+        if (stopRequest.getWaitForCompletion() != null) {
+            params.withWaitForCompletion(stopRequest.getWaitForCompletion());
+        }
+        if (stopRequest.getTimeout() != null) {
+            params.withTimeout(stopRequest.getTimeout());
+        }
+        if (stopRequest.getAllowNoMatch() != null) {
+            request.addParameter(ALLOW_NO_MATCH, stopRequest.getAllowNoMatch().toString());
+        }
+        request.addParameters(params.asMap());
+        return request;
     }
 
     static Request previewDataFrameTransform(PreviewDataFrameTransformRequest previewRequest) throws IOException {
@@ -129,6 +136,9 @@ final class DataFrameRequestConverters {
         }
         if (statsRequest.getPageParams() != null && statsRequest.getPageParams().getSize() != null) {
             request.addParameter(PageParams.SIZE.getPreferredName(), statsRequest.getPageParams().getSize().toString());
+        }
+        if (statsRequest.getAllowNoMatch() != null) {
+            request.addParameter(ALLOW_NO_MATCH, statsRequest.getAllowNoMatch().toString());
         }
         return request;
     }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/GetDataFrameTransformRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/GetDataFrameTransformRequest.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 
 public class GetDataFrameTransformRequest implements Validatable {
 
+    public static final String ALLOW_NO_MATCH = "allow_no_match";
     /**
      * Helper method to create a request that will get ALL Data Frame Transforms
      * @return new {@link GetDataFrameTransformRequest} object for the id "_all"
@@ -40,6 +41,7 @@ public class GetDataFrameTransformRequest implements Validatable {
 
     private final List<String> ids;
     private PageParams pageParams;
+    private Boolean allowNoMatch;
 
     public GetDataFrameTransformRequest(String... ids) {
         this.ids = Arrays.asList(ids);
@@ -57,6 +59,14 @@ public class GetDataFrameTransformRequest implements Validatable {
         this.pageParams = pageParams;
     }
 
+    public Boolean getAllowNoMatch() {
+        return allowNoMatch;
+    }
+
+    public void setAllowNoMatch(Boolean allowNoMatch) {
+        this.allowNoMatch = allowNoMatch;
+    }
+
     @Override
     public Optional<ValidationException> validate() {
         if (ids == null || ids.isEmpty()) {
@@ -70,7 +80,7 @@ public class GetDataFrameTransformRequest implements Validatable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(ids, pageParams);
+        return Objects.hash(ids, pageParams, allowNoMatch);
     }
 
     @Override
@@ -83,6 +93,8 @@ public class GetDataFrameTransformRequest implements Validatable {
             return false;
         }
         GetDataFrameTransformRequest other = (GetDataFrameTransformRequest) obj;
-        return Objects.equals(ids, other.ids) && Objects.equals(pageParams, other.pageParams);
+        return Objects.equals(ids, other.ids)
+            && Objects.equals(pageParams, other.pageParams)
+            && Objects.equals(allowNoMatch, other.allowNoMatch);
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/GetDataFrameTransformStatsRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/GetDataFrameTransformStatsRequest.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 public class GetDataFrameTransformStatsRequest implements Validatable {
     private final String id;
     private PageParams pageParams;
+    private Boolean allowNoMatch;
 
     public GetDataFrameTransformStatsRequest(String id) {
         this.id = id;
@@ -46,6 +47,14 @@ public class GetDataFrameTransformStatsRequest implements Validatable {
         this.pageParams = pageParams;
     }
 
+    public Boolean getAllowNoMatch() {
+        return allowNoMatch;
+    }
+
+    public void setAllowNoMatch(Boolean allowNoMatch) {
+        this.allowNoMatch = allowNoMatch;
+    }
+
     @Override
     public Optional<ValidationException> validate() {
         if (id == null) {
@@ -59,7 +68,7 @@ public class GetDataFrameTransformStatsRequest implements Validatable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, pageParams);
+        return Objects.hash(id, pageParams, allowNoMatch);
     }
 
     @Override
@@ -72,6 +81,8 @@ public class GetDataFrameTransformStatsRequest implements Validatable {
             return false;
         }
         GetDataFrameTransformStatsRequest other = (GetDataFrameTransformStatsRequest) obj;
-        return Objects.equals(id, other.id) && Objects.equals(pageParams, other.pageParams);
+        return Objects.equals(id, other.id)
+            && Objects.equals(pageParams, other.pageParams)
+            && Objects.equals(allowNoMatch, other.allowNoMatch);
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/StopDataFrameTransformRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/StopDataFrameTransformRequest.java
@@ -31,6 +31,7 @@ public class StopDataFrameTransformRequest implements Validatable {
     private final String id;
     private Boolean waitForCompletion;
     private TimeValue timeout;
+    private Boolean allowNoMatch;
 
     public StopDataFrameTransformRequest(String id) {
         this.id = id;
@@ -64,6 +65,14 @@ public class StopDataFrameTransformRequest implements Validatable {
         return timeout;
     }
 
+    public Boolean getAllowNoMatch() {
+        return allowNoMatch;
+    }
+
+    public void setAllowNoMatch(Boolean allowNoMatch) {
+        this.allowNoMatch = allowNoMatch;
+    }
+
     @Override
     public Optional<ValidationException> validate() {
         if (id == null) {
@@ -77,7 +86,7 @@ public class StopDataFrameTransformRequest implements Validatable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, waitForCompletion, timeout);
+        return Objects.hash(id, waitForCompletion, timeout, allowNoMatch);
     }
 
     @Override
@@ -92,7 +101,8 @@ public class StopDataFrameTransformRequest implements Validatable {
         StopDataFrameTransformRequest other = (StopDataFrameTransformRequest) obj;
         return Objects.equals(this.id, other.id)
                 && Objects.equals(this.waitForCompletion, other.waitForCompletion)
-                && Objects.equals(this.timeout, other.timeout);
+                && Objects.equals(this.timeout, other.timeout)
+                && Objects.equals(this.allowNoMatch, other.allowNoMatch);
     }
 
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/DataFrameRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/DataFrameRequestConvertersTests.java
@@ -46,6 +46,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
+import static org.elasticsearch.client.dataframe.GetDataFrameTransformRequest.ALLOW_NO_MATCH;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
@@ -114,7 +115,6 @@ public class DataFrameRequestConvertersTests extends ESTestCase {
         }
         StopDataFrameTransformRequest stopRequest = new StopDataFrameTransformRequest(id, waitForCompletion, timeValue);
 
-
         Request request = DataFrameRequestConverters.stopDataFrameTransform(stopRequest);
         assertEquals(HttpPost.METHOD_NAME, request.getMethod());
         assertThat(request.getEndpoint(), equalTo("/_data_frame/transforms/" + stopRequest.getId() + "/_stop"));
@@ -132,6 +132,11 @@ public class DataFrameRequestConvertersTests extends ESTestCase {
         } else {
             assertFalse(request.getParameters().containsKey("timeout"));
         }
+
+        assertFalse(request.getParameters().containsKey(ALLOW_NO_MATCH));
+        stopRequest.setAllowNoMatch(randomBoolean());
+        request = DataFrameRequestConverters.stopDataFrameTransform(stopRequest);
+        assertEquals(stopRequest.getAllowNoMatch(), Boolean.parseBoolean(request.getParameters().get(ALLOW_NO_MATCH)));
     }
 
     public void testPreviewDataFrameTransform() throws IOException {
@@ -157,6 +162,7 @@ public class DataFrameRequestConvertersTests extends ESTestCase {
 
         assertFalse(request.getParameters().containsKey("from"));
         assertFalse(request.getParameters().containsKey("size"));
+        assertFalse(request.getParameters().containsKey(ALLOW_NO_MATCH));
 
         getStatsRequest.setPageParams(new PageParams(0, null));
         request = DataFrameRequestConverters.getDataFrameTransformStats(getStatsRequest);
@@ -171,6 +177,10 @@ public class DataFrameRequestConvertersTests extends ESTestCase {
         getStatsRequest.setPageParams(new PageParams(0, 10));
         request = DataFrameRequestConverters.getDataFrameTransformStats(getStatsRequest);
         assertThat(request.getParameters(), allOf(hasEntry("from", "0"), hasEntry("size", "10")));
+
+        getStatsRequest.setAllowNoMatch(false);
+        request = DataFrameRequestConverters.getDataFrameTransformStats(getStatsRequest);
+        assertThat(request.getParameters(), hasEntry("allow_no_match", "false"));
     }
 
     public void testGetDataFrameTransform() {
@@ -182,6 +192,7 @@ public class DataFrameRequestConvertersTests extends ESTestCase {
 
         assertFalse(request.getParameters().containsKey("from"));
         assertFalse(request.getParameters().containsKey("size"));
+        assertFalse(request.getParameters().containsKey(ALLOW_NO_MATCH));
 
         getRequest.setPageParams(new PageParams(0, null));
         request = DataFrameRequestConverters.getDataFrameTransform(getRequest);
@@ -196,6 +207,10 @@ public class DataFrameRequestConvertersTests extends ESTestCase {
         getRequest.setPageParams(new PageParams(0, 10));
         request = DataFrameRequestConverters.getDataFrameTransform(getRequest);
         assertThat(request.getParameters(), allOf(hasEntry("from", "0"), hasEntry("size", "10")));
+
+        getRequest.setAllowNoMatch(false);
+        request = DataFrameRequestConverters.getDataFrameTransform(getRequest);
+        assertThat(request.getParameters(), hasEntry("allow_no_match", "false"));
     }
 
     public void testGetDataFrameTransform_givenMulitpleIds() {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/DataFrameTransformDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/DataFrameTransformDocumentationIT.java
@@ -263,6 +263,7 @@ public class DataFrameTransformDocumentationIT extends ESRestHighLevelClientTest
             // tag::stop-data-frame-transform-request-options
             request.setWaitForCompletion(Boolean.TRUE);  // <1>
             request.setTimeout(TimeValue.timeValueSeconds(30));  // <2>
+            request.setAllowNoMatch(true); // <3>
             // end::stop-data-frame-transform-request-options
 
             // tag::stop-data-frame-transform-execute
@@ -506,6 +507,11 @@ public class DataFrameTransformDocumentationIT extends ESRestHighLevelClientTest
                 new GetDataFrameTransformStatsRequest(id); // <1>
         // end::get-data-frame-transform-stats-request
 
+        // tag::get-data-frame-transform-stats-request-options
+        request.setPageParams(new PageParams(0, 100)); // <1>
+        request.setAllowNoMatch(true); // <2>
+        // end::get-data-frame-transform-stats-request-params
+
         {
             // tag::get-data-frame-transform-stats-execute
             GetDataFrameTransformStatsResponse response =
@@ -597,6 +603,7 @@ public class DataFrameTransformDocumentationIT extends ESRestHighLevelClientTest
 
             // tag::get-data-frame-transform-request-options
             request.setPageParams(new PageParams(0, 100)); // <1>
+            request.setAllowNoMatch(true); // <2>
             // end::get-data-frame-transform-request-options
 
             // tag::get-data-frame-transform-execute

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/DataFrameTransformDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/DataFrameTransformDocumentationIT.java
@@ -510,7 +510,7 @@ public class DataFrameTransformDocumentationIT extends ESRestHighLevelClientTest
         // tag::get-data-frame-transform-stats-request-options
         request.setPageParams(new PageParams(0, 100)); // <1>
         request.setAllowNoMatch(true); // <2>
-        // end::get-data-frame-transform-stats-request-params
+        // end::get-data-frame-transform-stats-request-options
 
         {
             // tag::get-data-frame-transform-stats-execute

--- a/docs/java-rest/high-level/dataframe/get_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/get_data_frame.asciidoc
@@ -32,6 +32,7 @@ include-tagged::{doc-tests-file}[{api}-request-options]
 <1> The page parameters `from` and `size`. `from` specifies the number of
 {dataframe-transforms} to skip. `size` specifies the maximum number of
 {dataframe-transforms} to get. Defaults to `0` and `100` respectively.
+<2> Whether to ignore if a wildcard expression matches no transforms.
 
 
 include::../execution.asciidoc[]

--- a/docs/java-rest/high-level/dataframe/get_data_frame_stats.asciidoc
+++ b/docs/java-rest/high-level/dataframe/get_data_frame_stats.asciidoc
@@ -22,6 +22,19 @@ include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> Constructing a new GET Stats request referencing an existing {dataframe-transform}
 
+==== Optional Arguments
+
+The following arguments are optional.
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests-file}[{api}-request-options]
+--------------------------------------------------
+<1> The page parameters `from` and `size`. `from` specifies the number of data frame transform stats to skip.
+`size` specifies the maximum number of data frame transform stats to get.
+Defaults to `0` and `100` respectively.
+<2> Whether to ignore if a wildcard expression matches no transforms.
+
 
 include::../execution.asciidoc[]
 

--- a/docs/java-rest/high-level/dataframe/stop_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/stop_data_frame.asciidoc
@@ -32,6 +32,7 @@ include-tagged::{doc-tests-file}[{api}-request-options]
 --------------------------------------------------
 <1> If true wait for the data frame task to stop before responding
 <2> Controls the amount of time to wait until the {dataframe-job} stops.
+<3> Whether to ignore if a wildcard expression matches no transforms.
 
 include::../execution.asciidoc[]
 

--- a/docs/reference/data-frames/apis/get-transform-stats.asciidoc
+++ b/docs/reference/data-frames/apis/get-transform-stats.asciidoc
@@ -36,12 +36,18 @@ Retrieves usage information for {dataframe-transforms}.
   specify one of these options, the API returns information for all
   {dataframe-transforms}.
 
+==== Query Parameters
+
 `from`::
     (integer) Skips the specified number of {dataframe-transforms}. The
     default value is `0`.
 
 `size`::
     (integer) Specifies the maximum number of {dataframe-transforms} to obtain. The default value is `100`.
+
+`allow_no_match`::
+  (boolean) Whether to ignore if a wildcard expression matches no data frame transforms.
+  This includes `_all` string or when no transforms have been specified. The default is `true`.
 
 ==== Results
 

--- a/docs/reference/data-frames/apis/get-transform.asciidoc
+++ b/docs/reference/data-frames/apis/get-transform.asciidoc
@@ -35,12 +35,18 @@ Retrieves configuration information for {dataframe-transforms}.
   specify one of these options, the API returns information for all
   {dataframe-transforms}.
 
+==== Query Parameters
+
 `from`::
       (integer) Skips the specified number of {dataframe-transforms}. The
       default value is `0`.
 
 `size`::
       (integer) Specifies the maximum number of {dataframe-transforms} to obtain. The default value is `100`.
+
+`allow_no_match`::
+  (boolean) Whether to ignore if a wildcard expression matches no data frame transforms.
+  This includes `_all` string or when no transforms have been specified. The default is `true`.
 
 ==== Results
 

--- a/docs/reference/data-frames/apis/stop-transform.asciidoc
+++ b/docs/reference/data-frames/apis/stop-transform.asciidoc
@@ -45,7 +45,11 @@ All {dataframe-transforms} can be stopped by using `_all` or `*` as the `<data_f
    timeout exception is thrown, the stop request is still processing and
    eventually moves the transform to `STOPPED`. The timeout simply means the API
    call itself timed out while waiting for the status change. Defaults to `30s`
-    
+
+ `allow_no_match`::
+   (boolean) Whether to ignore if a wildcard expression matches no data frame transforms.
+   This includes `_all` string or when no transforms have been specified. The default is `true`.
+
 //==== Request Body
 ==== Authorization
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameField.java
@@ -33,6 +33,7 @@ public final class DataFrameField {
     public static final ParseField TIME_BASED_SYNC = new ParseField("time");
     public static final ParseField DELAY = new ParseField("delay");
 
+    public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match");
     /**
      * Fields for checkpointing
      */

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/action/GetDataFrameTransformsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/action/GetDataFrameTransformsStatsAction.java
@@ -56,6 +56,7 @@ public class GetDataFrameTransformsStatsAction extends Action<GetDataFrameTransf
     public static class Request extends BaseTasksRequest<Request> {
         private final String id;
         private PageParams pageParams = PageParams.defaultParams();
+        private boolean allowNoMatch = true;
 
         public static final int MAX_SIZE_RETURN = 1000;
         // used internally to expand the queried id expression
@@ -75,6 +76,9 @@ public class GetDataFrameTransformsStatsAction extends Action<GetDataFrameTransf
             id = in.readString();
             expandedIds = Collections.unmodifiableList(in.readStringList());
             pageParams = new PageParams(in);
+            if (in.getVersion().onOrAfter(Version.V_7_3_0)) {
+                allowNoMatch = in.readBoolean();
+            }
         }
 
         @Override
@@ -104,12 +108,23 @@ public class GetDataFrameTransformsStatsAction extends Action<GetDataFrameTransf
             return pageParams;
         }
 
+        public boolean isAllowNoMatch() {
+            return allowNoMatch;
+        }
+
+        public void setAllowNoMatch(boolean allowNoMatch) {
+            this.allowNoMatch = allowNoMatch;
+        }
+
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeString(id);
             out.writeStringCollection(expandedIds);
             pageParams.writeTo(out);
+            if (out.getVersion().onOrAfter(Version.V_7_3_0)) {
+                out.writeBoolean(allowNoMatch);
+            }
         }
 
         @Override
@@ -124,7 +139,7 @@ public class GetDataFrameTransformsStatsAction extends Action<GetDataFrameTransf
 
         @Override
         public int hashCode() {
-            return Objects.hash(id, pageParams);
+            return Objects.hash(id, pageParams, allowNoMatch);
         }
 
         @Override
@@ -136,7 +151,9 @@ public class GetDataFrameTransformsStatsAction extends Action<GetDataFrameTransf
                 return false;
             }
             Request other = (Request) obj;
-            return Objects.equals(id, other.id) && Objects.equals(pageParams, other.pageParams);
+            return Objects.equals(id, other.id)
+                && Objects.equals(pageParams, other.pageParams)
+                && allowNoMatch == other.allowNoMatch;
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/action/StopDataFrameTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/action/StopDataFrameTransformAction.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.core.dataframe.action;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.TaskOperationFailure;
@@ -56,15 +57,17 @@ public class StopDataFrameTransformAction extends Action<StopDataFrameTransformA
         private final String id;
         private final boolean waitForCompletion;
         private final boolean force;
+        private final boolean allowNoMatch;
         private Set<String> expandedIds;
 
-        public Request(String id, boolean waitForCompletion, boolean force, @Nullable TimeValue timeout) {
+        public Request(String id, boolean waitForCompletion, boolean force, @Nullable TimeValue timeout, boolean allowNoMatch) {
             this.id = ExceptionsHelper.requireNonNull(id, DataFrameField.ID.getPreferredName());
             this.waitForCompletion = waitForCompletion;
             this.force = force;
 
             // use the timeout value already present in BaseTasksRequest
             this.setTimeout(timeout == null ? DEFAULT_TIMEOUT : timeout);
+            this.allowNoMatch = allowNoMatch;
         }
 
         public Request(StreamInput in) throws IOException {
@@ -74,6 +77,11 @@ public class StopDataFrameTransformAction extends Action<StopDataFrameTransformA
             force = in.readBoolean();
             if (in.readBoolean()) {
                 expandedIds = new HashSet<>(Arrays.asList(in.readStringArray()));
+            }
+            if (in.getVersion().onOrAfter(Version.V_7_3_0)) {
+                this.allowNoMatch = in.readBoolean();
+            } else {
+                this.allowNoMatch = true;
             }
         }
 
@@ -97,6 +105,10 @@ public class StopDataFrameTransformAction extends Action<StopDataFrameTransformA
             this.expandedIds = expandedIds;
         }
 
+        public boolean isAllowNoMatch() {
+            return allowNoMatch;
+        }
+
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
@@ -108,6 +120,9 @@ public class StopDataFrameTransformAction extends Action<StopDataFrameTransformA
             if (hasExpandedIds) {
                 out.writeStringArray(expandedIds.toArray(new String[0]));
             }
+            if (out.getVersion().onOrAfter(Version.V_7_3_0)) {
+                out.writeBoolean(allowNoMatch);
+            }
         }
 
         @Override
@@ -118,7 +133,7 @@ public class StopDataFrameTransformAction extends Action<StopDataFrameTransformA
         @Override
         public int hashCode() {
             // the base class does not implement hashCode, therefore we need to hash timeout ourselves
-            return Objects.hash(id, waitForCompletion, force, expandedIds, this.getTimeout());
+            return Objects.hash(id, waitForCompletion, force, expandedIds, this.getTimeout(), allowNoMatch);
         }
 
         @Override
@@ -140,7 +155,8 @@ public class StopDataFrameTransformAction extends Action<StopDataFrameTransformA
             return Objects.equals(id, other.id) &&
                     Objects.equals(waitForCompletion, other.waitForCompletion) &&
                     Objects.equals(force, other.force) &&
-                    Objects.equals(expandedIds, other.expandedIds);
+                    Objects.equals(expandedIds, other.expandedIds) &&
+                    allowNoMatch == other.allowNoMatch;
         }
 
         @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/action/StopDataFrameTransformActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/action/StopDataFrameTransformActionRequestTests.java
@@ -23,7 +23,7 @@ public class StopDataFrameTransformActionRequestTests extends AbstractWireSerial
     @Override
     protected Request createTestInstance() {
         TimeValue timeout = randomBoolean() ? TimeValue.timeValueMinutes(randomIntBetween(1, 10)) : null;
-        Request request = new Request(randomAlphaOfLengthBetween(1, 10), randomBoolean(), randomBoolean(), timeout);
+        Request request = new Request(randomAlphaOfLengthBetween(1, 10), randomBoolean(), randomBoolean(), timeout, randomBoolean());
         if (randomBoolean()) {
             request.setExpandedIds(new HashSet<>(Arrays.asList(generateRandomStringArray(5, 6, false))));
         }
@@ -39,9 +39,10 @@ public class StopDataFrameTransformActionRequestTests extends AbstractWireSerial
         String id = randomAlphaOfLengthBetween(1, 10);
         boolean waitForCompletion = randomBoolean();
         boolean force = randomBoolean();
+        boolean allowNoMatch = randomBoolean();
 
-        Request r1 = new Request(id, waitForCompletion, force, TimeValue.timeValueSeconds(10));
-        Request r2 = new Request(id, waitForCompletion, force, TimeValue.timeValueSeconds(20));
+        Request r1 = new Request(id, waitForCompletion, force, TimeValue.timeValueSeconds(10), allowNoMatch);
+        Request r2 = new Request(id, waitForCompletion, force, TimeValue.timeValueSeconds(20), allowNoMatch);
 
         assertNotEquals(r1,r2);
         assertNotEquals(r1.hashCode(),r2.hashCode());
@@ -54,11 +55,11 @@ public class StopDataFrameTransformActionRequestTests extends AbstractWireSerial
                 DataFrameField.PERSISTENT_TASK_DESCRIPTION_PREFIX + dataFrameId,
                 TaskId.EMPTY_TASK_ID, Collections.emptyMap());
 
-        Request request = new Request("unrelated", false, false, null);
+        Request request = new Request("unrelated", false, false, null, false);
         request.setExpandedIds(new HashSet<>(Arrays.asList("foo", "bar")));
         assertFalse(request.match(dataFrameTask));
 
-        Request matchingRequest = new Request(dataFrameId, false, false, null);
+        Request matchingRequest = new Request(dataFrameId, false, false, null, false);
         matchingRequest.setExpandedIds(Collections.singleton(dataFrameId));
         assertTrue(matchingRequest.match(dataFrameTask));
 

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportGetDataFrameTransformsStatsAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportGetDataFrameTransformsStatsAction.java
@@ -105,8 +105,10 @@ public class TransportGetDataFrameTransformsStatsAction extends
 
     @Override
     protected void doExecute(Task task, Request request, ActionListener<Response> finalListener) {
-        dataFrameTransformsConfigManager.expandTransformIds(request.getId(), request.getPageParams(), ActionListener.wrap(
-            hitsAndIds -> {
+        dataFrameTransformsConfigManager.expandTransformIds(request.getId(),
+            request.getPageParams(),
+            request.isAllowNoMatch(),
+            ActionListener.wrap(hitsAndIds -> {
                 request.setExpandedIds(hitsAndIds.v2());
                 request.setNodes(DataFrameNodes.dataFrameTaskNodes(hitsAndIds.v2(), clusterService.state()));
                 super.doExecute(task, request, ActionListener.wrap(

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportStopDataFrameTransformAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportStopDataFrameTransformAction.java
@@ -84,8 +84,10 @@ public class TransportStopDataFrameTransformAction extends
                 finalListener = listener;
             }
 
-            dataFrameTransformsConfigManager.expandTransformIds(request.getId(), new PageParams(0, 10_000), ActionListener.wrap(
-                hitsAndIds -> {
+            dataFrameTransformsConfigManager.expandTransformIds(request.getId(),
+                new PageParams(0, 10_000),
+                request.isAllowNoMatch(),
+                ActionListener.wrap(hitsAndIds -> {
                     request.setExpandedIds(new HashSet<>(hitsAndIds.v2()));
                     request.setNodes(DataFrameNodes.dataFrameTaskNodes(hitsAndIds.v2(), clusterService.state()));
                     super.doExecute(task, request, finalListener);

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/persistence/DataFrameTransformsConfigManager.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/persistence/DataFrameTransformsConfigManager.java
@@ -199,6 +199,7 @@ public class DataFrameTransformsConfigManager {
      */
     public void expandTransformIds(String transformIdsExpression,
                                    PageParams pageParams,
+                                   boolean allowNoMatch,
                                    ActionListener<Tuple<Long, List<String>>> foundIdsListener) {
         String[] idTokens = ExpandedIdsMatcher.tokenizeExpression(transformIdsExpression);
         QueryBuilder queryBuilder = buildQueryFromTokenizedIds(idTokens, DataFrameTransformConfig.NAME);
@@ -213,7 +214,7 @@ public class DataFrameTransformsConfigManager {
             .setFetchSource(DataFrameField.ID.getPreferredName(), "")
             .request();
 
-        final ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(idTokens, true);
+        final ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(idTokens, allowNoMatch);
 
         executeAsyncWithOrigin(client.threadPool().getThreadContext(), DATA_FRAME_ORIGIN, request,
             ActionListener.<SearchResponse>wrap(

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestGetDataFrameTransformsAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestGetDataFrameTransformsAction.java
@@ -16,6 +16,8 @@ import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.dataframe.action.GetDataFrameTransformsAction;
 
+import static org.elasticsearch.xpack.core.dataframe.DataFrameField.ALLOW_NO_MATCH;
+
 public class RestGetDataFrameTransformsAction extends BaseRestHandler {
 
     public RestGetDataFrameTransformsAction(Settings settings, RestController controller) {
@@ -30,6 +32,7 @@ public class RestGetDataFrameTransformsAction extends BaseRestHandler {
 
         String id = restRequest.param(DataFrameField.ID.getPreferredName());
         request.setResourceId(id);
+        request.setAllowNoResources(restRequest.paramAsBoolean(ALLOW_NO_MATCH.getPreferredName(), true));
         if (restRequest.hasParam(PageParams.FROM.getPreferredName()) || restRequest.hasParam(PageParams.SIZE.getPreferredName())) {
             request.setPageParams(
                 new PageParams(restRequest.paramAsInt(PageParams.FROM.getPreferredName(), PageParams.DEFAULT_FROM),

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestGetDataFrameTransformsStatsAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestGetDataFrameTransformsStatsAction.java
@@ -15,6 +15,8 @@ import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.dataframe.action.GetDataFrameTransformsStatsAction;
 
+import static org.elasticsearch.xpack.core.dataframe.DataFrameField.ALLOW_NO_MATCH;
+
 public class RestGetDataFrameTransformsStatsAction extends BaseRestHandler {
 
     public RestGetDataFrameTransformsStatsAction(Settings settings, RestController controller) {
@@ -27,6 +29,7 @@ public class RestGetDataFrameTransformsStatsAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
         String id = restRequest.param(DataFrameField.ID.getPreferredName());
         GetDataFrameTransformsStatsAction.Request request = new GetDataFrameTransformsStatsAction.Request(id);
+        request.setAllowNoMatch(restRequest.paramAsBoolean(ALLOW_NO_MATCH.getPreferredName(), true));
         if (restRequest.hasParam(PageParams.FROM.getPreferredName()) || restRequest.hasParam(PageParams.SIZE.getPreferredName())) {
             request.setPageParams(
                 new PageParams(restRequest.paramAsInt(PageParams.FROM.getPreferredName(), PageParams.DEFAULT_FROM),

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestStopDataFrameTransformAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/rest/action/RestStopDataFrameTransformAction.java
@@ -30,8 +30,14 @@ public class RestStopDataFrameTransformAction extends BaseRestHandler {
                 StopDataFrameTransformAction.DEFAULT_TIMEOUT);
         boolean waitForCompletion = restRequest.paramAsBoolean(DataFrameField.WAIT_FOR_COMPLETION.getPreferredName(), false);
         boolean force = restRequest.paramAsBoolean(DataFrameField.FORCE.getPreferredName(), false);
+        boolean allowNoMatch = restRequest.paramAsBoolean(DataFrameField.ALLOW_NO_MATCH.getPreferredName(), false);
 
-        StopDataFrameTransformAction.Request request = new StopDataFrameTransformAction.Request(id, waitForCompletion, force, timeout);
+
+        StopDataFrameTransformAction.Request request = new StopDataFrameTransformAction.Request(id,
+            waitForCompletion,
+            force,
+            timeout,
+            allowNoMatch);
 
         return channel -> client.execute(StopDataFrameTransformAction.INSTANCE, request,
                 new BaseTasksResponseToXContentListener<>(channel));

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/persistence/DataFrameTransformsConfigManagerTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/persistence/DataFrameTransformsConfigManagerTests.java
@@ -159,6 +159,7 @@ public class DataFrameTransformsConfigManagerTests extends DataFrameSingleNodeTe
         assertAsync(listener ->
                 transformsConfigManager.expandTransformIds(transformConfig1.getId(),
                     PageParams.defaultParams(),
+                    true,
                     listener),
             new Tuple<>(1L, Collections.singletonList("transform1_expand")),
             null,
@@ -168,6 +169,7 @@ public class DataFrameTransformsConfigManagerTests extends DataFrameSingleNodeTe
         assertAsync(listener ->
                 transformsConfigManager.expandTransformIds("transform1_expand,transform2_expand",
                     PageParams.defaultParams(),
+                    true,
                     listener),
             new Tuple<>(2L, Arrays.asList("transform1_expand", "transform2_expand")),
             null,
@@ -177,6 +179,7 @@ public class DataFrameTransformsConfigManagerTests extends DataFrameSingleNodeTe
         assertAsync(listener ->
                 transformsConfigManager.expandTransformIds("transform1*,transform2_expand,transform3_expand",
                     PageParams.defaultParams(),
+                    true,
                     listener),
             new Tuple<>(3L, Arrays.asList("transform1_expand", "transform2_expand", "transform3_expand")),
             null,
@@ -186,6 +189,7 @@ public class DataFrameTransformsConfigManagerTests extends DataFrameSingleNodeTe
         assertAsync(listener ->
                 transformsConfigManager.expandTransformIds("_all",
                     PageParams.defaultParams(),
+                    true,
                     listener),
             new Tuple<>(3L, Arrays.asList("transform1_expand", "transform2_expand", "transform3_expand")),
             null,
@@ -195,6 +199,7 @@ public class DataFrameTransformsConfigManagerTests extends DataFrameSingleNodeTe
         assertAsync(listener ->
                 transformsConfigManager.expandTransformIds("_all",
                     new PageParams(0, 1),
+                    true,
                     listener),
             new Tuple<>(3L, Collections.singletonList("transform1_expand")),
             null,
@@ -204,6 +209,7 @@ public class DataFrameTransformsConfigManagerTests extends DataFrameSingleNodeTe
         assertAsync(listener ->
                 transformsConfigManager.expandTransformIds("_all",
                     new PageParams(1, 2),
+                    true,
                     listener),
             new Tuple<>(3L, Arrays.asList("transform2_expand", "transform3_expand")),
             null,
@@ -213,6 +219,7 @@ public class DataFrameTransformsConfigManagerTests extends DataFrameSingleNodeTe
         assertAsync(listener ->
                 transformsConfigManager.expandTransformIds("unknown,unknown2",
                     new PageParams(1, 2),
+                    true,
                     listener),
             (Tuple<Long, List<String>>)null,
             null,
@@ -220,6 +227,20 @@ public class DataFrameTransformsConfigManagerTests extends DataFrameSingleNodeTe
                 assertThat(e, instanceOf(ResourceNotFoundException.class));
                 assertThat(e.getMessage(),
                     equalTo(DataFrameMessages.getMessage(DataFrameMessages.REST_DATA_FRAME_UNKNOWN_TRANSFORM, "unknown,unknown2")));
+            });
+
+        // expand 1 id implicitly that does not exist
+        assertAsync(listener ->
+                transformsConfigManager.expandTransformIds("unknown*",
+                    new PageParams(1, 2),
+                    false,
+                    listener),
+            (Tuple<Long, List<String>>)null,
+            null,
+            e -> {
+                assertThat(e, instanceOf(ResourceNotFoundException.class));
+                assertThat(e.getMessage(),
+                    equalTo(DataFrameMessages.getMessage(DataFrameMessages.REST_DATA_FRAME_UNKNOWN_TRANSFORM, "unknown*")));
             });
 
     }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.get_data_frame_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.get_data_frame_transform.json
@@ -22,6 +22,11 @@
           "type": "int",
           "required": false,
           "description": "specifies a max number of transforms to get, defaults to 100"
+        },
+        "allow_no_match": {
+          "type": "boolean",
+          "required": false,
+          "description": "Whether to ignore if a wildcard expression matches no data frame transforms. (This includes `_all` string or when no data frame transforms have been specified)"
         }
       }
     },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.get_data_frame_transform_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.get_data_frame_transform_stats.json
@@ -22,6 +22,11 @@
           "type": "number",
           "required": false,
           "description": "specifies a max number of transform stats to get, defaults to 100"
+        },
+        "allow_no_match": {
+          "type": "boolean",
+          "required": false,
+          "description": "Whether to ignore if a wildcard expression matches no data frame transforms. (This includes `_all` string or when no data frame transforms have been specified)"
         }
       }
     },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.stop_data_frame_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame.stop_data_frame_transform.json
@@ -22,6 +22,11 @@
           "type": "time",
           "required": false,
           "description": "Controls the time to wait until the transform has stopped. Default to 30 seconds"
+        },
+        "allow_no_match": {
+          "type": "boolean",
+          "required": false,
+          "description": "Whether to ignore if a wildcard expression matches no data frame transforms. (This includes `_all` string or when no data frame transforms have been specified)"
         }
       }
     },

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_crud.yml
@@ -22,6 +22,12 @@ setup:
   - match: { count: 0 }
   - match: { transforms: [] }
 
+  - do:
+      catch: missing
+      data_frame.get_data_frame_transform:
+        transform_id: "*"
+        allow_no_match: false
+
 ---
 "Test get transform when it does not exist":
   - do:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_start_stop.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_start_stop.yml
@@ -138,6 +138,19 @@ teardown:
         transform_id: "missing-transform"
 
 ---
+"Test stop missing transform by expression":
+  - do:
+      data_frame.stop_data_frame_transform:
+        allow_no_match: true
+        transform_id: "missing-transform*"
+
+  - do:
+      catch: missing
+      data_frame.stop_data_frame_transform:
+        allow_no_match: false
+        transform_id: "missing-transform*"
+
+---
 "Test stop already stopped transform":
   - do:
       data_frame.stop_data_frame_transform:


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML][Data Frame] Add support for allow_no_match for endpoints  (#43490)