### PR TITLE
[DOCS] Remove 8.1.0 Lucene upgrade from 7.2.0 release notes

### DIFF
--- a/docs/reference/release-notes/7.2.asciidoc
+++ b/docs/reference/release-notes/7.2.asciidoc
@@ -462,9 +462,6 @@ Suggesters::
 [float]
 === Upgrades
 
-Engine::
-* Upgrade to Lucene 8.1.0 {pull}42214[#42214]
-
 Features/Watcher::
 * Replace javax activation with jakarta activation {pull}40247[#40247]
 * Replace java mail with jakarta mail {pull}40088[#40088]


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/42214 was erroneously included in
the 7.2.0 release notes. We plan to include this update in the 7.3.0 release.