### PR TITLE
[ML][Data Frame] fixing tag end for df doc tests

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/DataFrameTransformDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/DataFrameTransformDocumentationIT.java
@@ -510,7 +510,7 @@ public class DataFrameTransformDocumentationIT extends ESRestHighLevelClientTest
         // tag::get-data-frame-transform-stats-request-options
         request.setPageParams(new PageParams(0, 100)); // <1>
         request.setAllowNoMatch(true); // <2>
-        // end::get-data-frame-transform-stats-request-params
+        // end::get-data-frame-transform-stats-request-options
 
         {
             // tag::get-data-frame-transform-stats-execute


### PR DESCRIPTION
the closing tag for the stats callout in the HRLC is incorrect and causing doc build failures. 