### PR TITLE
[DOCS] Rewrite boosting query

### DIFF
--- a/docs/reference/query-dsl/boosting-query.asciidoc
+++ b/docs/reference/query-dsl/boosting-query.asciidoc
@@ -27,8 +27,7 @@ GET /_search
                      "text" : "pie tart fruit crumble tree"
                 }
             },
-            "negative_boost" : 0.5,
-            "boost" : 1.0 
+            "negative_boost" : 0.5
         }
     }
 }
@@ -59,18 +58,3 @@ for the document as follows:
 Floating point number between `0` and `1.0` used to decrease the
 <<query-filter-context, relevance scores>> of documents matching the `negative`
 query.
-
-`boost`::
-+
---
-Floating point number used to decrease or increase the
-<<query-filter-context, relevance scores>> of a query. Default is `1.0`.
-Optional.
-
-You can use the `boost` parameter to adjust relevance scores for searches
-containing two or more queries.
-
-Boost values are relative to the default value of `1.0`. A boost value between
-`0` and `1.0` decreases the relevance score. A value greater than `1.0`
-increases the relevance score.
---

--- a/docs/reference/query-dsl/boosting-query.asciidoc
+++ b/docs/reference/query-dsl/boosting-query.asciidoc
@@ -1,36 +1,76 @@
 [[query-dsl-boosting-query]]
 === Boosting Query
 
-The `boosting` query can be used to effectively demote results that
-match a given query. Unlike the "NOT" clause in bool query, this still
-selects documents that contain undesirable terms, but reduces their
-overall score.
+Returns documents matching a `positive` query while reducing the
+<<query-filter-context, relevance score>> of documents that also match a
+`negative` query.
 
-It accepts a `positive` query and a `negative` query.
-Only documents that match the `positive` query will be included
-in the results list, but documents that also match the `negative` query
-will be downgraded by multiplying the original `_score` of the document
-with the `negative_boost`.
+You can use the `boosting` query to demote certain documents without
+excluding them from the search results.
+
+[[boosting-query-ex-request]]
+==== Example request
 
 [source,js]
---------------------------------------------------
+----
 GET /_search
 {
     "query": {
         "boosting" : {
             "positive" : {
                 "term" : {
-                    "field1" : "value1"
+                    "text" : "apple"
                 }
             },
             "negative" : {
                  "term" : {
-                     "field2" : "value2"
+                     "text" : "pie tart fruit crumble tree"
                 }
             },
-            "negative_boost" : 0.2
+            "negative_boost" : 0.5,
+            "boost" : 1.0 
         }
     }
 }
---------------------------------------------------
+----
 // CONSOLE
+
+[[boosting-top-level-params]]
+==== Top-level parameters for `boosting`
+
+`positive` (Required)::
+Query you wish to run. Any returned documents must match this query.
+
+`negative` (Required)::
++
+--
+Query used to decrease the <<query-filter-context, relevance score>> of matching
+documents.
+
+If a returned document matches the `positive` query and this query, the
+`boosting` query calculates the final <<query-filter-context, relevance score>>
+for the document as follows:
+
+. Take the original relevance score from the `positive` query.
+. Multiply the score by the `negative_boost` value.
+--
+
+`negative_boost` (Required)::
+Floating point number between `0` and `1.0` used to decrease the
+<<query-filter-context, relevance scores>> of documents matching the `negative`
+query.
+
+`boost`::
++
+--
+Floating point number used to decrease or increase the
+<<query-filter-context, relevance scores>> of a query. Default is `1.0`.
+Optional.
+
+You can use the `boost` parameter to adjust relevance scores for searches
+containing two or more queries.
+
+Boost values are relative to the default value of `1.0`. A boost value between
+`0` and `1.0` decreases the relevance score. A value greater than `1.0`
+increases the relevance score.
+--


### PR DESCRIPTION
Rewrites the `boosting` query to use the new query format.

This is part of #40977, an effort to standardize documentation for query types.

## Before
<details>
 <summary>Before image</summary>
<img width="777" alt="Boosting-before" src="https://user-images.githubusercontent.com/40268737/60191373-364ec800-9802-11e9-9296-98c30a7e8271.png">
</details>


## After
<details>
 <summary>After image</summary>
<img width="777" alt="Boosting-after" src="https://user-images.githubusercontent.com/40268737/60191400-42d32080-9802-11e9-8562-91338b9efb50.png">
</details>