### PR TITLE
Remove compile-time dependency on test fixtures

### DIFF
--- a/x-pack/qa/kerberos-tests/build.gradle
+++ b/x-pack/qa/kerberos-tests/build.gradle
@@ -45,6 +45,12 @@ testClusters.integTest {
     user username: "test_kibana_user", password: "x-pack-test-password", role: "kibana_system"
 }
 
+task copyKeytabToGeneratedResources(type: Copy) {
+    from project(':test:fixtures:krb5kdc-fixture').ext.krb5Keytabs("peppa", "peppa.keytab")
+    into "$buildDir/generated-resources/keytabs"
+    dependsOn project(':test:fixtures:krb5kdc-fixture').postProcessFixture
+}
+
 String realm = "BUILD.ELASTIC.CO"
 integTest.runner {
     Path peppaKeytab = Paths.get("${project.buildDir}", "generated-resources", "keytabs", "peppa.keytab")
@@ -57,12 +63,5 @@ integTest.runner {
             "-Djava.security.krb5.conf=${project(':test:fixtures:krb5kdc-fixture').ext.krb5Conf("peppa")}",
             "-Dsun.security.krb5.debug=true"
     ])
+    classpath += copyKeytabToGeneratedResources.outputs.files
 }
-
-def generatedResources = "$buildDir/generated-resources/keytabs"
-task copyKeytabToGeneratedResources(type: Copy) {
-    from project(':test:fixtures:krb5kdc-fixture').ext.krb5Keytabs("peppa", "peppa.keytab")
-    into generatedResources
-    dependsOn project(':test:fixtures:krb5kdc-fixture').postProcessFixture
-}
-project.sourceSets.test.output.dir(generatedResources, builtBy:copyKeytabToGeneratedResources)


### PR DESCRIPTION
@rjernst reported an odd phenomenon in which simply running `checkstyle` would cause test fixtures to spin up via docker-compose. This PR removes an unnecessary dependency between compilation and test fixtures such that they are only required for test _execution_.