### PR TITLE
Add missing dependencies so we can build in parallel 

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -167,6 +167,7 @@ buildDefaultLog4jConfig.doLast(writeLog4jProperties)
 
 // copy log4j2.properties from modules that have it
 void copyLog4jProperties(Task buildTask, Project module) {
+  buildTask.dependsOn { module.bundlePlugin }
   buildTask.doFirst {
     FileTree tree = zipTree(module.bundlePlugin.outputs.files.singleFile)
     FileTree filtered = tree.matching {

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -117,7 +117,7 @@ task buildTransportModules {
 
 void copyModule(Sync copyTask, Project module) {
   copyTask.configure {
-    dependsOn { module.bundlePlugin }
+    dependsOn "${module.path}:bundlePlugin"
     from({ zipTree(module.bundlePlugin.outputs.files.singleFile) }) {
       includeEmptyDirs false
 
@@ -167,7 +167,7 @@ buildDefaultLog4jConfig.doLast(writeLog4jProperties)
 
 // copy log4j2.properties from modules that have it
 void copyLog4jProperties(Task buildTask, Project module) {
-  buildTask.dependsOn { module.bundlePlugin }
+  buildTask.dependsOn "${module.path}:bundlePlugin"
   buildTask.doFirst {
     FileTree tree = zipTree(module.bundlePlugin.outputs.files.singleFile)
     FileTree filtered = tree.matching {

--- a/x-pack/plugin/sql/sql-cli/build.gradle
+++ b/x-pack/plugin/sql/sql-cli/build.gradle
@@ -51,10 +51,9 @@ dependencyLicenses {
  * can be easily shipped around and used.
  */
 jar {
-    dependsOn configurations.compile, configurations.runtime
+    dependsOn configurations.runtimeClasspath
     from({
-        configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
-        configurations.runtime.collect { it.isDirectory() ? it : zipTree(it) }
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }) {
         // We don't need the META-INF from the things we bundle. For now.
         exclude 'META-INF/*'

--- a/x-pack/plugin/sql/sql-cli/build.gradle
+++ b/x-pack/plugin/sql/sql-cli/build.gradle
@@ -51,6 +51,7 @@ dependencyLicenses {
  * can be easily shipped around and used.
  */
 jar {
+    dependsOn configurations.compile, configurations.runtime
     from({
         configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
         configurations.runtime.collect { it.isDirectory() ? it : zipTree(it) }


### PR DESCRIPTION
This PR adds a couple of missing dependencies.
These happened to execute in the right order so we didn't notice them, but running with `--parallel` quickly uncovered them. 