### PR TITLE
Add version and create_time to data frame analytics config

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/PutDataFrameAnalyticsRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/PutDataFrameAnalyticsRequest.java
@@ -22,6 +22,7 @@ package org.elasticsearch.client.ml;
 import org.elasticsearch.client.Validatable;
 import org.elasticsearch.client.ValidationException;
 import org.elasticsearch.client.ml.dataframe.DataFrameAnalyticsConfig;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -66,5 +67,10 @@ public class PutDataFrameAnalyticsRequest implements ToXContentObject, Validatab
     @Override
     public int hashCode() {
         return Objects.hash(config);
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/dataframe/DataFrameAnalyticsConfigTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/dataframe/DataFrameAnalyticsConfigTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.client.ml.dataframe;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -29,6 +30,7 @@ import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.test.AbstractXContentTestCase;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -53,6 +55,12 @@ public class DataFrameAnalyticsConfigTests extends AbstractXContentTestCase<Data
         }
         if (randomBoolean()) {
             builder.setModelMemoryLimit(new ByteSizeValue(randomIntBetween(1, 16), randomFrom(ByteSizeUnit.MB, ByteSizeUnit.GB)));
+        }
+        if (randomBoolean()) {
+            builder.setCreateTime(Instant.now());
+        }
+        if (randomBoolean()) {
+            builder.setVersion(Version.CURRENT);
         }
         return builder.build();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -19,7 +19,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
-import org.elasticsearch.xpack.core.common.time.TimeUtils;
+import org.elasticsearch.xpack.core.dataframe.utils.TimeUtils;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.DataFrameAnalysis;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -19,7 +19,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
-import org.elasticsearch.xpack.core.dataframe.utils.TimeUtils;
+import org.elasticsearch.xpack.core.common.time.TimeUtils;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.DataFrameAnalysis;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -5,7 +5,9 @@
  */
 package org.elasticsearch.xpack.core.ml.dataframe;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -17,12 +19,14 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
+import org.elasticsearch.xpack.core.dataframe.utils.TimeUtils;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.DataFrameAnalysis;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -47,6 +51,8 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
     public static final ParseField ANALYZED_FIELDS = new ParseField("analyzed_fields");
     public static final ParseField MODEL_MEMORY_LIMIT = new ParseField("model_memory_limit");
     public static final ParseField HEADERS = new ParseField("headers");
+    public static final ParseField CREATE_TIME = new ParseField("create_time");
+    public static final ParseField VERSION = new ParseField("version");
 
     public static final ObjectParser<Builder, Void> STRICT_PARSER = createParser(false);
     public static final ObjectParser<Builder, Void> LENIENT_PARSER = createParser(true);
@@ -69,6 +75,18 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
             // Headers are not parsed by the strict (config) parser, so headers supplied in the _body_ of a REST request will be rejected.
             // (For config, headers are explicitly transferred from the auth headers by code in the put data frame actions.)
             parser.declareObject(Builder::setHeaders, (p, c) -> p.mapStrings(), HEADERS);
+            // Creation time is set automatically during PUT, so create_time supplied in the _body_ of a REST request will be rejected.
+            parser.declareField(Builder::setCreateTime,
+                p -> TimeUtils.parseTimeFieldToInstant(p, CREATE_TIME.getPreferredName()),
+                CREATE_TIME,
+                ObjectParser.ValueType.VALUE);
+            // Version is set automatically during PUT, so version supplied in the _body_ of a REST request will be rejected.
+            parser.declareField(Builder::setVersion, p -> {
+                if (p.currentToken() == XContentParser.Token.VALUE_STRING) {
+                    return Version.fromString(p.text());
+                }
+                throw new IllegalArgumentException("Unsupported token [" + p.currentToken() + "]");
+            }, VERSION, ObjectParser.ValueType.STRING);
         }
         return parser;
     }
@@ -96,10 +114,12 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
      */
     private final ByteSizeValue modelMemoryLimit;
     private final Map<String, String> headers;
+    private final Instant createTime;
+    private final Version version;
 
     public DataFrameAnalyticsConfig(String id, DataFrameAnalyticsSource source, DataFrameAnalyticsDest dest,
                                     DataFrameAnalysis analysis, Map<String, String> headers, ByteSizeValue modelMemoryLimit,
-                                    FetchSourceContext analyzedFields) {
+                                    FetchSourceContext analyzedFields, Instant createTime, Version version) {
         this.id = ExceptionsHelper.requireNonNull(id, ID);
         this.source = ExceptionsHelper.requireNonNull(source, SOURCE);
         this.dest = ExceptionsHelper.requireNonNull(dest, DEST);
@@ -107,16 +127,25 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         this.analyzedFields = analyzedFields;
         this.modelMemoryLimit = modelMemoryLimit;
         this.headers = Collections.unmodifiableMap(headers);
+        this.createTime = createTime == null ? null : Instant.ofEpochMilli(createTime.toEpochMilli());;
+        this.version = version;
     }
 
     public DataFrameAnalyticsConfig(StreamInput in) throws IOException {
-        id = in.readString();
-        source = new DataFrameAnalyticsSource(in);
-        dest = new DataFrameAnalyticsDest(in);
-        analysis = in.readNamedWriteable(DataFrameAnalysis.class);
+        this.id = in.readString();
+        this.source = new DataFrameAnalyticsSource(in);
+        this.dest = new DataFrameAnalyticsDest(in);
+        this.analysis = in.readNamedWriteable(DataFrameAnalysis.class);
         this.analyzedFields = in.readOptionalWriteable(FetchSourceContext::new);
         this.modelMemoryLimit = in.readOptionalWriteable(ByteSizeValue::new);
         this.headers = Collections.unmodifiableMap(in.readMap(StreamInput::readString, StreamInput::readString));
+        if (in.getVersion().onOrAfter(Version.V_7_3_0)) {
+            createTime = in.readOptionalInstant();
+            version = in.readBoolean() ? Version.readVersion(in) : null;
+        } else {
+            createTime = null;
+            version = null;
+        }
     }
 
     public String getId() {
@@ -147,6 +176,14 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         return headers;
     }
 
+    public Instant getCreateTime() {
+        return createTime;
+    }
+
+    public Version getVersion() {
+        return version;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
@@ -168,6 +205,12 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         if (headers.isEmpty() == false && params.paramAsBoolean(ToXContentParams.FOR_INTERNAL_STORAGE, false)) {
             builder.field(HEADERS.getPreferredName(), headers);
         }
+        if (createTime != null) {
+            builder.timeField(CREATE_TIME.getPreferredName(), CREATE_TIME.getPreferredName() + "_string", createTime.toEpochMilli());
+        }
+        if (version != null) {
+            builder.field(VERSION.getPreferredName(), version);
+        }
         builder.endObject();
         return builder;
     }
@@ -181,6 +224,15 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         out.writeOptionalWriteable(analyzedFields);
         out.writeOptionalWriteable(modelMemoryLimit);
         out.writeMap(headers, StreamOutput::writeString, StreamOutput::writeString);
+        if (out.getVersion().onOrAfter(Version.V_7_3_0)) {
+            out.writeOptionalInstant(createTime);
+            if (version != null) {
+                out.writeBoolean(true);
+                Version.writeVersion(version, out);
+            } else {
+                out.writeBoolean(false);
+            }
+        }
     }
 
     @Override
@@ -195,12 +247,19 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
             && Objects.equals(analysis, other.analysis)
             && Objects.equals(headers, other.headers)
             && Objects.equals(getModelMemoryLimit(), other.getModelMemoryLimit())
-            && Objects.equals(analyzedFields, other.analyzedFields);
+            && Objects.equals(analyzedFields, other.analyzedFields)
+            && Objects.equals(createTime, other.createTime)
+            && Objects.equals(version, other.version);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, source, dest, analysis, headers, getModelMemoryLimit(), analyzedFields);
+        return Objects.hash(id, source, dest, analysis, headers, getModelMemoryLimit(), analyzedFields, createTime, version);
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
     }
 
     public static String documentId(String id) {
@@ -217,6 +276,8 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         private ByteSizeValue modelMemoryLimit;
         private ByteSizeValue maxModelMemoryLimit;
         private Map<String, String> headers = Collections.emptyMap();
+        private Instant createTime;
+        private Version version;
 
         public Builder() {}
 
@@ -304,9 +365,19 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
             }
         }
 
+        public Builder setCreateTime(Instant createTime) {
+            this.createTime = createTime;
+            return this;
+        }
+
+        public Builder setVersion(Version version) {
+            this.version = version;
+            return this;
+        }
+
         public DataFrameAnalyticsConfig build() {
             applyMaxModelMemoryLimit();
-            return new DataFrameAnalyticsConfig(id, source, dest, analysis, headers, modelMemoryLimit, analyzedFields);
+            return new DataFrameAnalyticsConfig(id, source, dest, analysis, headers, modelMemoryLimit, analyzedFields, createTime, version);
         }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -304,6 +304,8 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
             if (config.analyzedFields != null) {
                 this.analyzedFields = new FetchSourceContext(true, config.analyzedFields.includes(), config.analyzedFields.excludes());
             }
+            this.createTime = config.createTime;
+            this.version = config.version;
         }
 
         public String getId() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
@@ -391,6 +391,10 @@ public class ElasticsearchMappings {
         .endObject();
     }
 
+    /**
+     * {@link DataFrameAnalyticsConfig} mapping.
+     * Does not include mapping for CREATE_TIME as this mapping is added by {@link #addJobConfigFields} method.
+     */
     public static void addDataFrameAnalyticsFields(XContentBuilder builder) throws IOException {
         builder.startObject(DataFrameAnalyticsConfig.ID.getPreferredName())
             .field(TYPE, KEYWORD)
@@ -434,6 +438,10 @@ public class ElasticsearchMappings {
                     .endObject()
                 .endObject()
             .endObject()
+        .endObject()
+        // re-used: CREATE_TIME
+        .startObject(DataFrameAnalyticsConfig.VERSION.getPreferredName())
+            .field(TYPE, KEYWORD)
         .endObject();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ReservedFieldNames.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ReservedFieldNames.java
@@ -277,6 +277,8 @@ public final class ReservedFieldNames {
             DataFrameAnalyticsConfig.DEST.getPreferredName(),
             DataFrameAnalyticsConfig.ANALYSIS.getPreferredName(),
             DataFrameAnalyticsConfig.ANALYZED_FIELDS.getPreferredName(),
+            DataFrameAnalyticsConfig.CREATE_TIME.getPreferredName(),
+            DataFrameAnalyticsConfig.VERSION.getPreferredName(),
             DataFrameAnalyticsDest.INDEX.getPreferredName(),
             DataFrameAnalyticsDest.RESULTS_FIELD.getPreferredName(),
             DataFrameAnalyticsSource.INDEX.getPreferredName(),

--- a/x-pack/plugin/ml/qa/ml-with-security/build.gradle
+++ b/x-pack/plugin/ml/qa/ml-with-security/build.gradle
@@ -42,6 +42,8 @@ integTest.runner  {
     'ml/datafeeds_crud/Test put datafeed with security headers in the body',
     'ml/datafeeds_crud/Test update datafeed with missing id',
     'ml/data_frame_analytics_crud/Test put config with security headers in the body',
+    'ml/data_frame_analytics_crud/Test put config with create_time in the body',
+    'ml/data_frame_analytics_crud/Test put config with version in the body',
     'ml/data_frame_analytics_crud/Test put config with inconsistent body/param ids',
     'ml/data_frame_analytics_crud/Test put config with invalid id',
     'ml/data_frame_analytics_crud/Test put config with invalid dest index name',

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.ml.action;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
@@ -41,6 +42,7 @@ import org.elasticsearch.xpack.ml.dataframe.SourceDestValidator;
 import org.elasticsearch.xpack.ml.dataframe.persistence.DataFrameAnalyticsConfigProvider;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -91,7 +93,10 @@ public class TransportPutDataFrameAnalyticsAction
         }
         validateConfig(request.getConfig());
         DataFrameAnalyticsConfig memoryCappedConfig =
-            new DataFrameAnalyticsConfig.Builder(request.getConfig(), maxModelMemoryLimit).build();
+            new DataFrameAnalyticsConfig.Builder(request.getConfig(), maxModelMemoryLimit)
+                .setCreateTime(Instant.now())
+                .setVersion(Version.CURRENT)
+                .build();
         if (licenseState.isAuthAllowed()) {
             final String username = securityContext.getUser().principal();
             RoleDescriptor.IndicesPrivileges sourceIndexPrivileges = RoleDescriptor.IndicesPrivileges.builder()
@@ -156,5 +161,6 @@ public class TransportPutDataFrameAnalyticsAction
         }
         config.getDest().validate();
         new SourceDestValidator(clusterService.state(), indexNameExpressionResolver).check(config);
+
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsIndex.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsIndex.java
@@ -94,7 +94,7 @@ final class DataFrameAnalyticsIndex {
         properties.put(DataFrameAnalyticsFields.ID, Map.of("type", "keyword"));
     }
 
-    private static void addMetaData(Map<String, Object> mappingsAsMap, String analyticsId, Clock clock) {
+    private static voidaddMetaData(Map<String, Object> mappingsAsMap, String analyticsId, Clock clock) {
         Map<String, Object> metadata = getOrPutDefault(mappingsAsMap, META, HashMap::new);
         metadata.put(DataFrameAnalyticsFields.CREATION_DATE_MILLIS, clock.millis());
         metadata.put(DataFrameAnalyticsFields.CREATED_BY, "data-frame-analytics");

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsIndex.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsIndex.java
@@ -94,7 +94,7 @@ final class DataFrameAnalyticsIndex {
         properties.put(DataFrameAnalyticsFields.ID, Map.of("type", "keyword"));
     }
 
-    private static voidaddMetaData(Map<String, Object> mappingsAsMap, String analyticsId, Clock clock) {
+    private static void addMetaData(Map<String, Object> mappingsAsMap, String analyticsId, Clock clock) {
         Map<String, Object> metadata = getOrPutDefault(mappingsAsMap, META, HashMap::new);
         metadata.put(DataFrameAnalyticsFields.CREATION_DATE_MILLIS, clock.millis());
         metadata.put(DataFrameAnalyticsFields.CREATED_BY, "data-frame-analytics");

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_crud.yml
@@ -453,3 +453,41 @@ setup:
               "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
             }
           }
+
+---
+"Test put valid config with create_time in the body":
+
+  - do:
+      catch: /Found \[create_time\], not allowed for strict parsing/
+      data_frame.put_data_frame_transform:
+        transform_id: "airline-transform-with-create-time"
+        body: >
+          {
+            "source": { "index": "airline-data" },
+            "dest": { "index": "airline-data-by-airline" },
+            "pivot": {
+              "group_by": { "airline": {"terms": {"field": "airline"}}},
+              "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+            },
+            "description": "yaml test transform on airline-data",
+            "create_time": 123456789
+          }
+
+---
+"Test put valid config with version in the body":
+
+  - do:
+      catch: /Found \[version\], not allowed for strict parsing/
+      data_frame.put_data_frame_transform:
+        transform_id: "airline-transform-with-version"
+        body: >
+          {
+            "source": { "index": "airline-data" },
+            "dest": { "index": "airline-data-by-airline" },
+            "pivot": {
+              "group_by": { "airline": {"terms": {"field": "airline"}}},
+              "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+            },
+            "description": "yaml test transform on airline-data",
+            "version": "7.3.0"
+          }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
@@ -78,7 +78,7 @@ setup:
           }
 
 ---
-"Test put valid config with create_time in the body":
+"Test put config with create_time in the body":
 
   - do:
       catch: /unknown field \[create_time\], parser not found/
@@ -97,7 +97,7 @@ setup:
           }
 
 ---
-"Test put valid config with version in the body":
+"Test put config with version in the body":
 
   - do:
       catch: /unknown field \[version\], parser not found/

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
@@ -55,6 +55,8 @@ setup:
   - match: { dest.index: "index-dest" }
   - match: { analysis: {"outlier_detection":{}} }
   - match: { analyzed_fields: {"includes" : ["obj1.*", "obj2.*" ], "excludes": [] } }
+  - is_true: create_time
+  - is_true: version
 
 ---
 "Test put config with security headers in the body":
@@ -73,6 +75,44 @@ setup:
             },
             "analysis": {"outlier_detection":{}},
             "headers":{ "a_security_header" : "secret" }
+          }
+
+---
+"Test put valid config with create_time in the body":
+
+  - do:
+      catch: /unknown field \[create_time\], parser not found/
+      ml.put_data_frame_analytics:
+        id: "data_frame_with_create_time"
+        body: >
+          {
+            "source": {
+              "index": "index-source"
+            },
+            "dest": {
+              "index": "index-dest"
+            },
+            "analysis": {"outlier_detection":{}},
+            "create_time": 123456789
+          }
+
+---
+"Test put valid config with version in the body":
+
+  - do:
+      catch: /unknown field \[version\], parser not found/
+      ml.put_data_frame_analytics:
+        id: "data_frame_with_version"
+        body: >
+          {
+            "source": {
+              "index": "index-source"
+            },
+            "dest": {
+              "index": "index-dest"
+            },
+            "analysis": {"outlier_detection":{}},
+            "version": "7.3.0"
           }
 
 ---
@@ -96,6 +136,8 @@ setup:
   - match: { source.query: {"match_all" : {} } }
   - match: { dest.index: "index-dest" }
   - match: { analysis: {"outlier_detection":{}} }
+  - is_true: create_time
+  - is_true: version
 
 ---
 "Test put valid config with custom outlier detection":
@@ -126,6 +168,8 @@ setup:
   - match: { analysis.outlier_detection.n_neighbors: 5 }
   - match: { analysis.outlier_detection.method: "lof" }
   - match: { analysis.outlier_detection.minimum_score_to_write_feature_influence: 0.0 }
+  - is_true: create_time
+  - is_true: version
 
 ---
 "Test put config with inconsistent body/param ids":

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
@@ -58,6 +58,19 @@ setup:
   - is_true: create_time
   - is_true: version
 
+  - do:
+      ml.get_data_frame_analytics:
+        id: "simple-outlier-detection-with-query"
+  - match: { count: 1 }
+  - match: { data_frame_analytics.0.id: "simple-outlier-detection-with-query" }
+  - match: { data_frame_analytics.0.source.index: "index-source" }
+  - match: { data_frame_analytics.0.source.query: {"term" : { "user" : "Kimchy"} } }
+  - match: { data_frame_analytics.0.dest.index: "index-dest" }
+  - match: { data_frame_analytics.0.analysis: {"outlier_detection":{}} }
+  - match: { data_frame_analytics.0.analyzed_fields: {"includes" : ["obj1.*", "obj2.*" ], "excludes": [] } }
+  - is_true: data_frame_analytics.0.create_time
+  - is_true: data_frame_analytics.0.version
+
 ---
 "Test put config with security headers in the body":
   - do:


### PR DESCRIPTION
Add two new fields to data frame analytics config: create_time and version.
These fields are autogenerated on PUT
They cannot be set explicitly by the user.