### PR TITLE
[ML][DataFrame] Consider data frame templates internal in REST tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -944,6 +944,9 @@ public abstract class ESRestTestCase extends ESTestCase {
         if (name.startsWith(".watch") || name.startsWith(".triggered_watches")) {
             return true;
         }
+        if (name.startsWith(".data-frame-")) {
+            return true;
+        }
         if (name.startsWith(".ml-")) {
             return true;
         }


### PR DESCRIPTION
The data frame index template pattern was not in the list
considered as internal and therefore not needing cleanup
after every test.