### PR TITLE
[ML][Data Frame] account for delay in writing stats docs

### DIFF
--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameUsageIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameUsageIT.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.xpack.core.dataframe.DataFrameField.INDEX_DOC_TYPE;
 import static org.elasticsearch.xpack.dataframe.DataFrameInfoTransportAction.PROVIDED_STATS;
@@ -75,22 +76,29 @@ public class DataFrameUsageIT extends DataFrameRestTestCase {
             expectedStats.put(statName, statistic);
         }
 
-        usageResponse = client().performRequest(new Request("GET", "_xpack/usage"));
-
-        usageAsMap = entityAsMap(usageResponse);
-        // we should see some stats
-        assertEquals(3, XContentMapValues.extractValue("data_frame.transforms._all", usageAsMap));
-        assertEquals(2, XContentMapValues.extractValue("data_frame.transforms.stopped", usageAsMap));
-        assertEquals(1, XContentMapValues.extractValue("data_frame.transforms.started", usageAsMap));
-        for(String statName : PROVIDED_STATS) {
-            if (statName.equals(DataFrameIndexerTransformStats.INDEX_TIME_IN_MS.getPreferredName())
-                ||statName.equals(DataFrameIndexerTransformStats.SEARCH_TIME_IN_MS.getPreferredName())) {
-                continue;
-            }
-            assertEquals("Incorrect stat " +  statName,
+        // Simply because we wait for continuous to reach checkpoint 1, does not mean that the statistics are written yet.
+        // Since we search against the indices for the statistics, we need to ensure they are written, so we will wait for that
+        // to be the case.
+        assertBusy(() -> {
+            Response response = client().performRequest(new Request("GET", "_xpack/usage"));
+            Map<String, Object> statsMap = entityAsMap(response);
+            // we should see some stats
+            assertEquals(3, XContentMapValues.extractValue("data_frame.transforms._all", statsMap));
+            assertEquals(2, XContentMapValues.extractValue("data_frame.transforms.stopped", statsMap));
+            assertEquals(1, XContentMapValues.extractValue("data_frame.transforms.started", statsMap));
+            for(String statName : PROVIDED_STATS) {
+                if (statName.equals(DataFrameIndexerTransformStats.INDEX_TIME_IN_MS.getPreferredName())
+                    ||statName.equals(DataFrameIndexerTransformStats.SEARCH_TIME_IN_MS.getPreferredName())) {
+                    continue;
+                }
+                assertEquals("Incorrect stat " +  statName,
                     expectedStats.get(statName) * 2,
-                XContentMapValues.extractValue("data_frame.stats." + statName, usageAsMap));
-        }
+                    XContentMapValues.extractValue("data_frame.stats." + statName, statsMap));
+            }
+            // Refresh the index so that statistics are searchable
+            refreshIndex(DataFrameInternalIndex.INDEX_TEMPLATE_NAME);
+        }, 60, TimeUnit.SECONDS);
+
 
         stopDataFrameTransform("test_usage_continuous", false);
 


### PR DESCRIPTION
There is a delay between reaching `checkpoint == 1` and the statistics documents actually being written. Since the usage endpoint searches the documents directly, it may not see the stats right away. Adding an `assertBusy` to account for this.

I validated that I was able to repeat the test failure immediately with
```
./gradlew :x-pack:plugin:data-frame:qa:single-node-tests:integTestRunner --tests "org.elasticsearch.xpack.dataframe.integration.DataFrameUsageIT.testUsage" -Dtests.iters=10 
```

After my change, I ran numerous times (with `-Dtest.iters=50`) and could not get it to fail again.