### PR TITLE
[ML] Rename outlier score setting to feature_influence_threshold

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/dataframe/OutlierDetection.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/dataframe/OutlierDetection.java
@@ -47,8 +47,7 @@ public class OutlierDetection implements DataFrameAnalysis {
     public static final ParseField NAME = new ParseField("outlier_detection");
     static final ParseField N_NEIGHBORS = new ParseField("n_neighbors");
     static final ParseField METHOD = new ParseField("method");
-    public static final ParseField MINIMUM_SCORE_TO_WRITE_FEATURE_INFLUENCE =
-        new ParseField("minimum_score_to_write_feature_influence");
+    public static final ParseField FEATURE_INFLUENCE_THRESHOLD = new ParseField("feature_influence_threshold");
 
     private static ObjectParser<Builder, Void> PARSER = new ObjectParser<>(NAME.getPreferredName(), true, Builder::new);
 
@@ -60,23 +59,23 @@ public class OutlierDetection implements DataFrameAnalysis {
             }
             throw new IllegalArgumentException("Unsupported token [" + p.currentToken() + "]");
         }, METHOD, ObjectParser.ValueType.STRING);
-        PARSER.declareDouble(Builder::setMinScoreToWriteFeatureInfluence, MINIMUM_SCORE_TO_WRITE_FEATURE_INFLUENCE);
+        PARSER.declareDouble(Builder::setFeatureInfluenceThreshold, FEATURE_INFLUENCE_THRESHOLD);
     }
 
     private final Integer nNeighbors;
     private final Method method;
-    private final Double minScoreToWriteFeatureInfluence;
+    private final Double featureInfluenceThreshold;
 
     /**
      * Constructs the outlier detection configuration
      * @param nNeighbors The number of neighbors. Leave unspecified for dynamic detection.
      * @param method The method. Leave unspecified for a dynamic mixture of methods.
-     * @param minScoreToWriteFeatureInfluence The min outlier score required to calculate feature influence. Defaults to 0.1.
+     * @param featureInfluenceThreshold The min outlier score required to calculate feature influence. Defaults to 0.1.
      */
-    private OutlierDetection(@Nullable Integer nNeighbors, @Nullable Method method, @Nullable Double minScoreToWriteFeatureInfluence) {
+    private OutlierDetection(@Nullable Integer nNeighbors, @Nullable Method method, @Nullable Double featureInfluenceThreshold) {
         this.nNeighbors = nNeighbors;
         this.method = method;
-        this.minScoreToWriteFeatureInfluence = minScoreToWriteFeatureInfluence;
+        this.featureInfluenceThreshold = featureInfluenceThreshold;
     }
 
     @Override
@@ -92,8 +91,8 @@ public class OutlierDetection implements DataFrameAnalysis {
         return method;
     }
 
-    public Double getMinScoreToWriteFeatureInfluence() {
-        return minScoreToWriteFeatureInfluence;
+    public Double getFeatureInfluenceThreshold() {
+        return featureInfluenceThreshold;
     }
 
     @Override
@@ -105,8 +104,8 @@ public class OutlierDetection implements DataFrameAnalysis {
         if (method != null) {
             builder.field(METHOD.getPreferredName(), method);
         }
-        if (minScoreToWriteFeatureInfluence != null) {
-            builder.field(MINIMUM_SCORE_TO_WRITE_FEATURE_INFLUENCE.getPreferredName(), minScoreToWriteFeatureInfluence);
+        if (featureInfluenceThreshold != null) {
+            builder.field(FEATURE_INFLUENCE_THRESHOLD.getPreferredName(), featureInfluenceThreshold);
         }
         builder.endObject();
         return builder;
@@ -120,12 +119,12 @@ public class OutlierDetection implements DataFrameAnalysis {
         OutlierDetection other = (OutlierDetection) o;
         return Objects.equals(nNeighbors, other.nNeighbors)
             && Objects.equals(method, other.method)
-            && Objects.equals(minScoreToWriteFeatureInfluence, other.minScoreToWriteFeatureInfluence);
+            && Objects.equals(featureInfluenceThreshold, other.featureInfluenceThreshold);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(nNeighbors, method, minScoreToWriteFeatureInfluence);
+        return Objects.hash(nNeighbors, method, featureInfluenceThreshold);
     }
 
     @Override
@@ -150,7 +149,7 @@ public class OutlierDetection implements DataFrameAnalysis {
 
         private Integer nNeighbors;
         private Method method;
-        private Double minScoreToWriteFeatureInfluence;
+        private Double featureInfluenceThreshold;
 
         private Builder() {}
 
@@ -164,13 +163,13 @@ public class OutlierDetection implements DataFrameAnalysis {
             return this;
         }
 
-        public Builder setMinScoreToWriteFeatureInfluence(Double minScoreToWriteFeatureInfluence) {
-            this.minScoreToWriteFeatureInfluence = minScoreToWriteFeatureInfluence;
+        public Builder setFeatureInfluenceThreshold(Double featureInfluenceThreshold) {
+            this.featureInfluenceThreshold = featureInfluenceThreshold;
             return this;
         }
 
         public OutlierDetection build() {
-            return new OutlierDetection(nNeighbors, method, minScoreToWriteFeatureInfluence);
+            return new OutlierDetection(nNeighbors, method, featureInfluenceThreshold);
         }
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/dataframe/OutlierDetectionTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/dataframe/OutlierDetectionTests.java
@@ -33,7 +33,7 @@ public class OutlierDetectionTests extends AbstractXContentTestCase<OutlierDetec
         return OutlierDetection.builder()
             .setNNeighbors(randomBoolean() ? null : randomIntBetween(1, 20))
             .setMethod(randomBoolean() ? null : randomFrom(OutlierDetection.Method.values()))
-            .setMinScoreToWriteFeatureInfluence(randomBoolean() ? null : randomDoubleBetween(0.0, 1.0, true))
+            .setFeatureInfluenceThreshold(randomBoolean() ? null : randomDoubleBetween(0.0, 1.0, true))
             .build();
     }
 
@@ -56,7 +56,7 @@ public class OutlierDetectionTests extends AbstractXContentTestCase<OutlierDetec
         OutlierDetection outlierDetection = OutlierDetection.createDefault();
         assertNull(outlierDetection.getNNeighbors());
         assertNull(outlierDetection.getMethod());
-        assertNull(outlierDetection.getMinScoreToWriteFeatureInfluence());
+        assertNull(outlierDetection.getFeatureInfluenceThreshold());
     }
 
     public void testGetParams_GivenExplicitValues() {
@@ -64,10 +64,10 @@ public class OutlierDetectionTests extends AbstractXContentTestCase<OutlierDetec
             OutlierDetection.builder()
                 .setNNeighbors(42)
                 .setMethod(OutlierDetection.Method.LDOF)
-                .setMinScoreToWriteFeatureInfluence(0.5)
+                .setFeatureInfluenceThreshold(0.5)
                 .build();
         assertThat(outlierDetection.getNNeighbors(), equalTo(42));
         assertThat(outlierDetection.getMethod(), equalTo(OutlierDetection.Method.LDOF));
-        assertThat(outlierDetection.getMinScoreToWriteFeatureInfluence(), closeTo(0.5, 1E-9));
+        assertThat(outlierDetection.getFeatureInfluenceThreshold(), closeTo(0.5, 1E-9));
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
@@ -27,8 +27,7 @@ public class OutlierDetection implements DataFrameAnalysis {
 
     public static final ParseField N_NEIGHBORS = new ParseField("n_neighbors");
     public static final ParseField METHOD = new ParseField("method");
-    public static final ParseField MINIMUM_SCORE_TO_WRITE_FEATURE_INFLUENCE =
-        new ParseField("minimum_score_to_write_feature_influence");
+    public static final ParseField FEATURE_INFLUENCE_THRESHOLD = new ParseField("feature_influence_threshold");
 
     private static final ConstructingObjectParser<OutlierDetection, Void> LENIENT_PARSER = createParser(true);
     private static final ConstructingObjectParser<OutlierDetection, Void> STRICT_PARSER = createParser(false);
@@ -43,7 +42,7 @@ public class OutlierDetection implements DataFrameAnalysis {
             }
             throw new IllegalArgumentException("Unsupported token [" + p.currentToken() + "]");
         }, METHOD, ObjectParser.ValueType.STRING);
-        parser.declareDouble(ConstructingObjectParser.optionalConstructorArg(), MINIMUM_SCORE_TO_WRITE_FEATURE_INFLUENCE);
+        parser.declareDouble(ConstructingObjectParser.optionalConstructorArg(), FEATURE_INFLUENCE_THRESHOLD);
         return parser;
     }
 
@@ -53,27 +52,26 @@ public class OutlierDetection implements DataFrameAnalysis {
 
     private final Integer nNeighbors;
     private final Method method;
-    private final Double minScoreToWriteFeatureInfluence;
+    private final Double featureInfluenceThreshold;
 
     /**
      * Constructs the outlier detection configuration
      * @param nNeighbors The number of neighbors. Leave unspecified for dynamic detection.
      * @param method The method. Leave unspecified for a dynamic mixture of methods.
-     * @param minScoreToWriteFeatureInfluence The min outlier score required to calculate feature influence. Defaults to 0.1.
+     * @param featureInfluenceThreshold The min outlier score required to calculate feature influence. Defaults to 0.1.
      */
-    public OutlierDetection(@Nullable Integer nNeighbors, @Nullable Method method, @Nullable Double minScoreToWriteFeatureInfluence) {
+    public OutlierDetection(@Nullable Integer nNeighbors, @Nullable Method method, @Nullable Double featureInfluenceThreshold) {
         if (nNeighbors != null && nNeighbors <= 0) {
             throw ExceptionsHelper.badRequestException("[{}] must be a positive integer", N_NEIGHBORS.getPreferredName());
         }
 
-        if (minScoreToWriteFeatureInfluence != null && (minScoreToWriteFeatureInfluence < 0.0 || minScoreToWriteFeatureInfluence > 1.0)) {
-            throw ExceptionsHelper.badRequestException("[{}] must be in [0, 1]",
-                MINIMUM_SCORE_TO_WRITE_FEATURE_INFLUENCE.getPreferredName());
+        if (featureInfluenceThreshold != null && (featureInfluenceThreshold < 0.0 || featureInfluenceThreshold > 1.0)) {
+            throw ExceptionsHelper.badRequestException("[{}] must be in [0, 1]", FEATURE_INFLUENCE_THRESHOLD.getPreferredName());
         }
 
         this.nNeighbors = nNeighbors;
         this.method = method;
-        this.minScoreToWriteFeatureInfluence = minScoreToWriteFeatureInfluence;
+        this.featureInfluenceThreshold = featureInfluenceThreshold;
     }
 
     /**
@@ -86,7 +84,7 @@ public class OutlierDetection implements DataFrameAnalysis {
     public OutlierDetection(StreamInput in) throws IOException {
         nNeighbors = in.readOptionalVInt();
         method = in.readBoolean() ? in.readEnum(Method.class) : null;
-        minScoreToWriteFeatureInfluence = in.readOptionalDouble();
+        featureInfluenceThreshold = in.readOptionalDouble();
     }
 
     @Override
@@ -105,7 +103,7 @@ public class OutlierDetection implements DataFrameAnalysis {
             out.writeBoolean(false);
         }
 
-        out.writeOptionalDouble(minScoreToWriteFeatureInfluence);
+        out.writeOptionalDouble(featureInfluenceThreshold);
     }
 
     @Override
@@ -117,8 +115,8 @@ public class OutlierDetection implements DataFrameAnalysis {
         if (method != null) {
             builder.field(METHOD.getPreferredName(), method);
         }
-        if (minScoreToWriteFeatureInfluence != null) {
-            builder.field(MINIMUM_SCORE_TO_WRITE_FEATURE_INFLUENCE.getPreferredName(), minScoreToWriteFeatureInfluence);
+        if (featureInfluenceThreshold != null) {
+            builder.field(FEATURE_INFLUENCE_THRESHOLD.getPreferredName(), featureInfluenceThreshold);
         }
         builder.endObject();
         return builder;
@@ -131,12 +129,12 @@ public class OutlierDetection implements DataFrameAnalysis {
         OutlierDetection that = (OutlierDetection) o;
         return Objects.equals(nNeighbors, that.nNeighbors)
             && Objects.equals(method, that.method)
-            && Objects.equals(minScoreToWriteFeatureInfluence, that.minScoreToWriteFeatureInfluence);
+            && Objects.equals(featureInfluenceThreshold, that.featureInfluenceThreshold);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(nNeighbors, method, minScoreToWriteFeatureInfluence);
+        return Objects.hash(nNeighbors, method, featureInfluenceThreshold);
     }
 
     @Override
@@ -148,8 +146,8 @@ public class OutlierDetection implements DataFrameAnalysis {
         if (method != null) {
             params.put(METHOD.getPreferredName(), method);
         }
-        if (minScoreToWriteFeatureInfluence != null) {
-            params.put(MINIMUM_SCORE_TO_WRITE_FEATURE_INFLUENCE.getPreferredName(), minScoreToWriteFeatureInfluence);
+        if (featureInfluenceThreshold != null) {
+            params.put(FEATURE_INFLUENCE_THRESHOLD.getPreferredName(), featureInfluenceThreshold);
         }
         return params;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
@@ -432,7 +432,7 @@ public class ElasticsearchMappings {
                         .startObject(OutlierDetection.METHOD.getPreferredName())
                             .field(TYPE, KEYWORD)
                         .endObject()
-                        .startObject(OutlierDetection.MINIMUM_SCORE_TO_WRITE_FEATURE_INFLUENCE.getPreferredName())
+                        .startObject(OutlierDetection.FEATURE_INFLUENCE_THRESHOLD.getPreferredName())
                             .field(TYPE, DOUBLE)
                         .endObject()
                     .endObject()

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ReservedFieldNames.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ReservedFieldNames.java
@@ -286,7 +286,7 @@ public final class ReservedFieldNames {
             OutlierDetection.NAME.getPreferredName(),
             OutlierDetection.N_NEIGHBORS.getPreferredName(),
             OutlierDetection.METHOD.getPreferredName(),
-            OutlierDetection.MINIMUM_SCORE_TO_WRITE_FEATURE_INFLUENCE.getPreferredName(),
+            OutlierDetection.FEATURE_INFLUENCE_THRESHOLD.getPreferredName(),
 
             ElasticsearchMappings.CONFIG_TYPE,
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetectionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetectionTests.java
@@ -53,7 +53,7 @@ public class OutlierDetectionTests extends AbstractSerializingTestCase<OutlierDe
         assertThat(params.size(), equalTo(3));
         assertThat(params.get(OutlierDetection.N_NEIGHBORS.getPreferredName()), equalTo(42));
         assertThat(params.get(OutlierDetection.METHOD.getPreferredName()), equalTo(OutlierDetection.Method.LDOF));
-        assertThat((Double) params.get(OutlierDetection.MINIMUM_SCORE_TO_WRITE_FEATURE_INFLUENCE.getPreferredName()),
+        assertThat((Double) params.get(OutlierDetection.FEATURE_INFLUENCE_THRESHOLD.getPreferredName()),
             is(closeTo(0.42, 1E-9)));
     }
 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
@@ -170,7 +170,7 @@ setup:
               "outlier_detection":{
                 "n_neighbors": 5,
                 "method": "lof",
-                "minimum_score_to_write_feature_influence": 0.0
+                "feature_influence_threshold": 0.0
               }
             }
           }
@@ -180,7 +180,7 @@ setup:
   - match: { dest.index: "index-dest" }
   - match: { analysis.outlier_detection.n_neighbors: 5 }
   - match: { analysis.outlier_detection.method: "lof" }
-  - match: { analysis.outlier_detection.minimum_score_to_write_feature_influence: 0.0 }
+  - match: { analysis.outlier_detection.feature_influence_threshold: 0.0 }
   - is_true: create_time
   - is_true: version
 


### PR DESCRIPTION
Renames outlier score setting `minimum_score_to_write_feature_influence`
to `feature_influence_threshold`.

