### PR TITLE
Add a note mentioning the privileges needed for SLM

### DIFF
--- a/docs/reference/ilm/getting-started-slm.asciidoc
+++ b/docs/reference/ilm/getting-started-slm.asciidoc
@@ -9,6 +9,51 @@ indices using the <<modules-snapshots,snapshots>> every day at a particular
 time.
 
 [float]
+[[slm-and-security]]
+=== Security and SLM
+Before starting, it's important to understand the privileges that are needed
+when configuring SLM if you are using the security plugin. There are two
+built-in cluster privileges that can be used to assist: `manage_slm` and
+`read_slm`.
+
+An example of configuring an administrator role for SLM follows:
+
+[source,js]
+-----------------------------------
+POST /_security/role/slm-admin
+{
+  "cluster": ["manage_slm", "create_snapshot"],
+  "indices": [
+    {
+      "names": [".slm-history-*"],
+      "privileges": ["all"]
+    }
+  ]
+}
+-----------------------------------
+// CONSOLE
+// TEST[skip:security is not enabled here]
+
+Or, for a read-only role that can retrieve policies (but not update, execute, or
+delete them), as well as only view the history index:
+
+[source,js]
+-----------------------------------
+POST /_security/role/slm-read-only
+{
+  "cluster": ["read_slm"],
+  "indices": [
+    {
+      "names": [".slm-history-*"],
+      "privileges": ["read"]
+    }
+  ]
+}
+-----------------------------------
+// CONSOLE
+// TEST[skip:security is not enabled here]
+
+[float]
 [[slm-gs-create-policy]]
 === Setting up a repository
 

--- a/docs/reference/ilm/getting-started-slm.asciidoc
+++ b/docs/reference/ilm/getting-started-slm.asciidoc
@@ -14,7 +14,8 @@ time.
 Before starting, it's important to understand the privileges that are needed
 when configuring SLM if you are using the security plugin. There are two
 built-in cluster privileges that can be used to assist: `manage_slm` and
-`read_slm`.
+`read_slm`. It's also good to note that the `create_snapshot` permission
+allows taking snapshots even for indices the role may not have access to.
 
 An example of configuring an administrator role for SLM follows:
 


### PR DESCRIPTION
This adds a note to the top of the "getting started with SLM"
documentation mentioning that there are two built-in privileges to
assist with creating roles for SLM users and administrators.

Relates to #38461
