### PR TITLE
[Distributed/Snapshot/Restore] Add configurations: use_path_style && use_chunked_encoding

### DIFF
--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -145,6 +145,20 @@ settings belong in the `elasticsearch.yml` file.
     Whether retries should be throttled (i.e. should back off). Must be `true`
     or `false`. Defaults to `true`.
 
+`use_path_style`::
+    Whether path style should be used to access a bucket. Must be `true` or
+    `false`. Defaults to `true`.
+    See
+    https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro[AWS
+    documentation] for more details about path style or virtual hosted style.
+
+`use_chunked_encoding`::
+    Whether chunked encoding should be used or not. Must be `true` or
+    `false`. Defaults to `true`.
+    See
+    https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html[AWS
+    documentation] for more details about this.
+
 [float]
 [[repository-s3-compatible-services]]
 ===== S3-compatible services

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
@@ -100,7 +100,7 @@ final class S3ClientSettings {
         key -> Setting.boolSetting(key, true, Property.NodeScope));
 
     /** Whether chunked encoding should be used or not (Default is true). */
-    static final Setting.AffixSetting<Boolean> USE_CHUNKED_ENCODING = Setting.affixKeySetting(PREFIX, "use_chunked_encoding",
+    static final Setting.AffixSetting<Boolean> USE_CHUNKED_ENCODING_SETTING = Setting.affixKeySetting(PREFIX, "use_chunked_encoding",
         key -> Setting.boolSetting(key, true, Property.NodeScope));
 
     /** Credentials to authenticate with s3. */
@@ -186,7 +186,7 @@ final class S3ClientSettings {
             newCredentials = credentials;
         }
         final boolean newUsePathStyle = getRepoSettingOrDefault(USE_PATH_STYLE_SETTING, normalizedSettings, usePathStyle);
-        final boolean newUseChunkedEncoding = getRepoSettingOrDefault(USE_CHUNKED_ENCODING, normalizedSettings, useChunkedEncoding);
+        final boolean newUseChunkedEncoding = getRepoSettingOrDefault(USE_CHUNKED_ENCODING_SETTING, normalizedSettings, useChunkedEncoding);
         if (Objects.equals(endpoint, newEndpoint) && protocol == newProtocol && Objects.equals(proxyHost, newProxyHost)
             && proxyPort == newProxyPort && newReadTimeoutMillis == readTimeoutMillis && maxRetries == newMaxRetries
             && newThrottleRetries == throttleRetries && Objects.equals(credentials, newCredentials)
@@ -294,7 +294,7 @@ final class S3ClientSettings {
                 getConfigValue(settings, clientName, MAX_RETRIES_SETTING),
                 getConfigValue(settings, clientName, USE_THROTTLE_RETRIES_SETTING),
                 getConfigValue(settings, clientName, USE_PATH_STYLE_SETTING),
-                getConfigValue(settings, clientName, USE_CHUNKED_ENCODING)
+                getConfigValue(settings, clientName, USE_CHUNKED_ENCODING_SETTING)
             );
         }
     }

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
@@ -154,7 +154,8 @@ class S3Service implements Closeable {
         // We do this because directly constructing the client is deprecated (was already deprecated in 1.1.223 too)
         // so this change removes that usage of a deprecated API.
         builder.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, null))
-            .enablePathStyleAccess();
+            .withPathStyleAccessEnabled(clientSettings.usePathStyle)
+            .withChunkedEncodingDisabled(!clientSettings.useChunkedEncoding);
 
         return builder.build();
     }

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3ClientSettingsTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3ClientSettingsTests.java
@@ -49,27 +49,39 @@ public class S3ClientSettingsTests extends ESTestCase {
         assertThat(defaultSettings.readTimeoutMillis, is(ClientConfiguration.DEFAULT_SOCKET_TIMEOUT));
         assertThat(defaultSettings.maxRetries, is(ClientConfiguration.DEFAULT_RETRY_POLICY.getMaxErrorRetry()));
         assertThat(defaultSettings.throttleRetries, is(ClientConfiguration.DEFAULT_THROTTLE_RETRIES));
+        assertThat(defaultSettings.usePathStyle, is(true));
+        assertThat(defaultSettings.useChunkedEncoding, is(true));
     }
 
     public void testDefaultClientSettingsCanBeSet() {
         final Map<String, S3ClientSettings> settings = S3ClientSettings.load(Settings.builder()
-            .put("s3.client.default.max_retries", 10).build());
+            .put("s3.client.default.max_retries", 10)
+            .put("s3.client.default.use_path_style", false)
+            .put("s3.client.default.use_chunked_encoding", false).build());
         assertThat(settings.keySet(), contains("default"));
 
         final S3ClientSettings defaultSettings = settings.get("default");
         assertThat(defaultSettings.maxRetries, is(10));
+        assertThat(defaultSettings.usePathStyle, is(false));
+        assertThat(defaultSettings.useChunkedEncoding, is(false));
     }
 
     public void testNondefaultClientCreatedBySettingItsSettings() {
         final Map<String, S3ClientSettings> settings = S3ClientSettings.load(Settings.builder()
-            .put("s3.client.another_client.max_retries", 10).build());
+            .put("s3.client.another_client.max_retries", 10)
+            .put("s3.client.another_client.use_path_style", false)
+            .put("s3.client.another_client.use_chunked_encoding", false).build());
         assertThat(settings.keySet(), contains("default", "another_client"));
 
         final S3ClientSettings defaultSettings = settings.get("default");
         assertThat(defaultSettings.maxRetries, is(ClientConfiguration.DEFAULT_RETRY_POLICY.getMaxErrorRetry()));
+        assertThat(defaultSettings.usePathStyle, is(true));
+        assertThat(defaultSettings.useChunkedEncoding, is(true));
 
         final S3ClientSettings anotherClientSettings = settings.get("another_client");
         assertThat(anotherClientSettings.maxRetries, is(10));
+        assertThat(anotherClientSettings.usePathStyle, is(false));
+        assertThat(anotherClientSettings.useChunkedEncoding, is(false));
     }
 
     public void testRejectionOfLoneAccessKey() {


### PR DESCRIPTION
This PR adds two configurations: use_path_style and use_chunked_encoding.
Reasons:
**use_path_style**: Amazon S3 path will be deprecated. Here is its plan https://aws.amazon.com/cn/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/.
And some S3-compatible services do not support path style to access a bucket.

**use_chunked_encoding**: Some S3-compatible services do not support chunked encoding.

So, we should add these two configurations and users can use repository-s3 to access S3-compatible services.
