### PR TITLE
[DOCS] Adds description to GET info and GET stats data frame transforms APIs

### DIFF
--- a/docs/reference/data-frames/apis/get-transform-stats.asciidoc
+++ b/docs/reference/data-frames/apis/get-transform-stats.asciidoc
@@ -37,9 +37,15 @@ If the {es} {security-features} are enabled, you must have
 see {stack-ov}/security-privileges.html[Security privileges] and
 {stack-ov}/built-in-roles.html[Built-in roles].
 
-//[discrete]
-//[[get-data-frame-transform-stats-desc]]
-//===== {api-description-title}
+[discrete]
+[[get-data-frame-transform-stats-desc]]
+==== {api-description-title}
+
+You can get statistics for multiple {dataframe-transforms} in a single API
+request by using a comma-separated list of identifiers or a wildcard expression.
+You can get statistics for all {dataframe-transforms} by using `_all`, by
+specifying `*` as the `<data_frame_transform_id>`, or by omitting the
+`<data_frame_transform_id>`.
 
 [discrete]
 [[get-data-frame-transform-stats-path-parms]]

--- a/docs/reference/data-frames/apis/get-transform.asciidoc
+++ b/docs/reference/data-frames/apis/get-transform.asciidoc
@@ -37,6 +37,16 @@ see {stack-ov}/security-privileges.html[Security privileges] and
 {stack-ov}/built-in-roles.html[Built-in roles].
 
 [discrete]
+[[get-data-frame-transform-desc]]
+==== {api-description-title}
+
+You can get information for multiple {dataframe-transforms} in a single API
+request by using a comma-separated list of identifiers or a wildcard expression.
+You can get information for all {dataframe-transforms} by using `_all`, by
+specifying `*` as the `<data_frame_transform_id>`, or by omitting the
+`<data_frame_transform_id>`.
+
+[discrete]
 [[get-data-frame-transform-path-parms]]
 ==== {api-path-parms-title}
 


### PR DESCRIPTION
The description of the GET info and GET stats df transforms APIs is missing in 7.2. This PR fixes this issue.