### PR TITLE
[DOCS] Rewrite shrink index API docs

### DIFF
--- a/docs/reference/administering.asciidoc
+++ b/docs/reference/administering.asciidoc
@@ -9,17 +9,8 @@ cluster.
 
 --
 
-[[backup-cluster]]
-== Back up a cluster
+include::{docdir}/administering/shrink-index.asciidoc[]
 
-As with any software that stores data, it is important to routinely back up your
-data. {es} replicas provide high availability during runtime; they enable you to
-tolerate sporadic node loss without an interruption of service.
-
-Replicas do not provide protection from catastrophic failure, however. For that,
-you need a real backup of your cluster—a complete copy in case something goes
-wrong.
-
-To back up your cluster, you can use the <<modules-snapshots,snapshot API>>.
+include::{docdir}/administering/back-up-cluster.asciidoc[]
 
 include::{es-repo-dir}/modules/snapshots.asciidoc[tag=snapshot-intro]

--- a/docs/reference/administering/back-up-cluster.asciidoc
+++ b/docs/reference/administering/back-up-cluster.asciidoc
@@ -1,0 +1,12 @@
+[[backup-cluster]]
+== Back up a cluster
+
+As with any software that stores data, it is important to routinely back up your
+data. {es} replicas provide high availability during runtime; they enable you to
+tolerate sporadic node loss without an interruption of service.
+
+Replicas do not provide protection from catastrophic failure, however. For that,
+you need a real backup of your cluster—a complete copy in case something goes
+wrong.
+
+To back up your cluster, you can use the <<modules-snapshots,snapshot API>>.

--- a/docs/reference/administering/shrink-index.asciidoc
+++ b/docs/reference/administering/shrink-index.asciidoc
@@ -1,0 +1,154 @@
+[[shrink-index]]
+== Shrink an index
+
+The shrink index API allows you to shrink an existing index into a new index
+with fewer primary shards. The requested number of primary shards in the target index
+must be a factor of the number of shards in the source index. For example an index with
+`8` primary shards can be shrunk into `4`, `2` or `1` primary shards or an index
+with `15` primary shards can be shrunk into `5`, `3` or `1`. If the number
+of shards in the index is a prime number it can only be shrunk into a single
+primary shard. Before shrinking, a (primary or replica) copy of every shard
+in the index must be present on the same node.
+
+Shrinking works as follows:
+
+* First, it creates a new target index with the same definition as the source
+  index, but with a smaller number of primary shards.
+
+* Then it hard-links segments from the source index into the target index. (If
+  the file system doesn't support hard-linking, then all segments are copied
+  into the new index, which is a much more time consuming process. Also if using 
+  multiple data paths, shards on different data paths require a full copy of 
+  segment files if they are not on the same disk since hardlinks don’t work across
+  disks)
+
+* Finally, it recovers the target index as though it were a closed index which
+  had just been re-opened.
+
+[float]
+[[prepare-index-for-shrinking]]
+=== Prepare an index for shrinking
+
+In order to shrink an index, the index must be marked as read-only, and a
+(primary or replica) copy of every shard in the index must be relocated to the
+same node and have <<cluster-health,health>> `green`.
+
+These two conditions can be achieved with the following request:
+
+[source,js]
+--------------------------------------------------
+PUT /my_source_index/_settings
+{
+  "settings": {
+    "index.routing.allocation.require._name": "shrink_node_name", <1>
+    "index.blocks.write": true <2>
+  }
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[s/^/PUT my_source_index\n{"settings":{"index.number_of_shards":2}}\n/]
+<1> Forces the relocation of a copy of each shard to the node with name
+    `shrink_node_name`.  See <<shard-allocation-filtering>> for more options.
+
+<2> Prevents write operations to this index while still allowing metadata
+    changes like deleting the index.
+
+It can take a while to relocate the source index.  Progress can be tracked
+with the <<cat-recovery,`_cat recovery` API>>, or the <<cluster-health,
+`cluster health` API>> can be used to wait until all shards have relocated
+with the `wait_for_no_relocating_shards` parameter.
+
+[float]
+=== Shrink an index
+
+To shrink `my_source_index` into a new index called `my_target_index`, issue
+the following request:
+
+[source,js]
+--------------------------------------------------
+POST my_source_index/_shrink/my_target_index
+{
+  "settings": {
+    "index.routing.allocation.require._name": null, <1>
+    "index.blocks.write": null <2>
+  }
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[continued]
+
+<1> Clear the allocation requirement copied from the source index.
+<2> Clear the index write block copied from the source index.
+
+The above request returns immediately once the target index has been added to
+the cluster state -- it doesn't wait for the shrink operation to start.
+
+[IMPORTANT]
+=====================================
+
+Indices can only be shrunk if they satisfy the following requirements:
+
+* the target index must not exist
+
+* The index must have more primary shards than the target index.
+
+* The number of primary shards in the target index must be a factor of the
+  number of primary shards in the source index. The source index must have
+  more primary shards than the target index.
+
+* The index must not contain more than `2,147,483,519` documents in total
+  across all shards that will be shrunk into a single shard on the target index
+  as this is the maximum number of docs that can fit into a single shard.
+
+* The node handling the shrink process must have sufficient free disk space to
+  accommodate a second copy of the existing index.
+
+=====================================
+
+The `_shrink` API is similar to the <<indices-create-index, `create index` API>>
+and accepts `settings` and `aliases` parameters for the target index:
+
+[source,js]
+--------------------------------------------------
+POST my_source_index/_shrink/my_target_index
+{
+  "settings": {
+    "index.number_of_replicas": 1,
+    "index.number_of_shards": 1, <1>
+    "index.codec": "best_compression" <2>
+  },
+  "aliases": {
+    "my_search_indices": {}
+  }
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[s/^/PUT my_source_index\n{"settings": {"index.number_of_shards":5,"index.blocks.write": true}}\n/]
+
+<1> The number of shards in the target index. This must be a factor of the
+    number of shards in the source index.
+<2> Best compression will only take affect when new writes are made to the
+    index, such as when <<indices-forcemerge,force-merging>> the shard to a single
+    segment.
+
+
+NOTE: Mappings may not be specified in the `_shrink` request.
+
+[float]
+=== Monitor the shrink process
+
+The shrink process can be monitored with the <<cat-recovery,`_cat recovery`
+API>>, or the <<cluster-health, `cluster health` API>> can be used to wait
+until all primary shards have been allocated by setting the  `wait_for_status`
+parameter to `yellow`.
+
+The `_shrink` API returns as soon as the target index has been added to the
+cluster state, before any shards have been allocated. At this point, all
+shards are in the state `unassigned`. If, for any reason, the target index
+can't be allocated on the shrink node, its primary shard will remain
+`unassigned` until it can be allocated on that node.
+
+Once the primary shard is allocated, it moves to state `initializing`, and the
+shrink process begins. When the shrink operation completes, the shard will
+become `active`. At that  point, Elasticsearch will try to allocate any
+replicas and may decide to relocate the primary shard to another node.

--- a/docs/reference/indices/shrink-index.asciidoc
+++ b/docs/reference/indices/shrink-index.asciidoc
@@ -16,7 +16,7 @@ Shrinks an existing index into a new index with fewer primary shards.
 [[indices-shrink-index-prereqs]]
 === {api-prereq-title}
 
-To be shrunk, the source index must meet the following criteria:
+To be shrunk, an index must meet the following criteria:
 
 * The index cannot contain more than `2,147,483,519` documents that will be
 shrunk into a single shard. This is the maximum number of documents a shard can

--- a/docs/reference/indices/shrink-index.asciidoc
+++ b/docs/reference/indices/shrink-index.asciidoc
@@ -63,7 +63,7 @@ This cannot be an existing index. If this index exists prior to the request,
 
 `wait_for_active_shards` (Optional)::
 (integer) Number of active shard copies required to start before returning a
-response. See <<index-wait-for-active-shards, Wait For active shards>>.
+response. See <<index-wait-for-active-shards>>.
 
 include::{docdir}/rest-api/timeoutparms.asciidoc[]
 

--- a/docs/reference/indices/shrink-index.asciidoc
+++ b/docs/reference/indices/shrink-index.asciidoc
@@ -1,160 +1,120 @@
 [[indices-shrink-index]]
-== Shrink Index
+== Shrink Index API
+++++
+<titleabbrev>Shrink Index</titleabbrev>
+++++
 
-The shrink index API allows you to shrink an existing index into a new index
-with fewer primary shards. The requested number of primary shards in the target index
-must be a factor of the number of shards in the source index. For example an index with
-`8` primary shards can be shrunk into `4`, `2` or `1` primary shards or an index
-with `15` primary shards can be shrunk into `5`, `3` or `1`. If the number
-of shards in the index is a prime number it can only be shrunk into a single
-primary shard. Before shrinking, a (primary or replica) copy of every shard
-in the index must be present on the same node.
-
-Shrinking works as follows:
-
-* First, it creates a new target index with the same definition as the source
-  index, but with a smaller number of primary shards.
-
-* Then it hard-links segments from the source index into the target index. (If
-  the file system doesn't support hard-linking, then all segments are copied
-  into the new index, which is a much more time consuming process. Also if using 
-  multiple data paths, shards on different data paths require a full copy of 
-  segment files if they are not on the same disk since hardlinks don’t work across
-  disks)
-
-* Finally, it recovers the target index as though it were a closed index which
-  had just been re-opened.
+Shrinks an existing index into a new index with fewer primary shards.
 
 [float]
-=== Preparing an index for shrinking
+[[indices-shrink-index-request]]
+=== {api-request-title}
 
-In order to shrink an index, the index must be marked as read-only, and a
-(primary or replica) copy of every shard in the index must be relocated to the
-same node and have <<cluster-health,health>> `green`.
-
-These two conditions can be achieved with the following request:
-
-[source,js]
---------------------------------------------------
-PUT /my_source_index/_settings
-{
-  "settings": {
-    "index.routing.allocation.require._name": "shrink_node_name", <1>
-    "index.blocks.write": true <2>
-  }
-}
---------------------------------------------------
-// CONSOLE
-// TEST[s/^/PUT my_source_index\n{"settings":{"index.number_of_shards":2}}\n/]
-<1> Forces the relocation of a copy of each shard to the node with name
-    `shrink_node_name`.  See <<shard-allocation-filtering>> for more options.
-
-<2> Prevents write operations to this index while still allowing metadata
-    changes like deleting the index.
-
-It can take a while to relocate the source index.  Progress can be tracked
-with the <<cat-recovery,`_cat recovery` API>>, or the <<cluster-health,
-`cluster health` API>> can be used to wait until all shards have relocated
-with the `wait_for_no_relocating_shards` parameter.
+`POST <source-index>/_shrink/<target-index>`
 
 [float]
-=== Shrinking an index
+[[indices-shrink-index-prereqs]]
+=== {api-prereq-title}
 
-To shrink `my_source_index` into a new index called `my_target_index`, issue
-the following request:
+To be shrunk, the source index must meet the following criteria:
 
-[source,js]
---------------------------------------------------
-POST my_source_index/_shrink/my_target_index
-{
-  "settings": {
-    "index.routing.allocation.require._name": null, <1>
-    "index.blocks.write": null <2>
-  }
-}
---------------------------------------------------
-// CONSOLE
-// TEST[continued]
+* The index cannot contain more than `2,147,483,519` documents that will be
+shrunk into a single shard. This is the maximum number of documents a shard can
+contain.
 
-<1> Clear the allocation requirement copied from the source index.
-<2> Clear the index write block copied from the source index.
+* The index must be read-only.
 
-The above request returns immediately once the target index has been added to
-the cluster state -- it doesn't wait for the shrink operation to start.
+* All primary and replica shards in the index must be on the same node.
+
+* The cluster must have a `green` health status. You can check the health
+status of a cluster using the <<cluster-health, cluster health API>>.
+
+* The node handling the shrink process must have enough free disk space for a
+second copy of the source index.
+
+See <<prepare-index-for-shrinking>>.
+
+[float]
+[[indices-shrink-index-desc]]
+=== {api-description-title}
+
+You can use shrink index API to shrink an existing source index into a new
+target index with fewer primary shards.
+
+[float]
+[[indices-shrink-index-path-params]]
+=== {api-path-parms-title}
+
+`<source-index>` (Required)::
+(string) Name of the existing index to shrink.
+
+`<target-index>` (Required)::
++
+--
+(string) Name of the new index to create.
+
+This cannot be an existing index. If this index exists prior to the request,
+{es} returns an error.
+--
+
+[float]
+[[indices-shrink-index-query-params]]
+=== {api-query-parms-title}
+
+`wait_for_active_shards` (Optional)::
+(integer) Number of active shard copies required to start before returning a
+response. See <<index-wait-for-active-shards, Wait For active shards>>.
+
+include::{docdir}/rest-api/timeoutparms.asciidoc[]
+
+[float]
+[[indices-shrink-index-request-body]]
+=== {api-request-body-title}
+
+`aliases` (Optional)::
+(object) Index aliases which include the new `<target-index>`. See
+<<indices-aliases, Index aliases>>.
+
+`settings` (Optional)::
++
+--
+(object) Configuration options for the new `<target-index>`. See
+<<index-modules-settings, Index settings>>.
 
 [IMPORTANT]
-=====================================
+====
+You can set the number of primary shards for the new `<target-index>` using the
+`index.number_of_shards` setting.
 
-Indices can only be shrunk if they satisfy the following requirements:
+The new number of primary shards in the target index **must be**:
 
-* the target index must not exist
+* Less than the current number of shards in the source index.
 
-* The index must have more primary shards than the target index.
+* A factor of the number of shards in the source index.
 
-* The number of primary shards in the target index must be a factor of the
-  number of primary shards in the source index. The source index must have
-  more primary shards than the target index.
+For example, you can shrink a `<source-index>` with `8` primary shards into a
+`<target-index>` with `4`, `2` or `1` primary shards.
 
-* The index must not contain more than `2,147,483,519` documents in total
-  across all shards that will be shrunk into a single shard on the target index
-  as this is the maximum number of docs that can fit into a single shard.
+See <<shrink-index>>.
+====
+--
 
-* The node handling the shrink process must have sufficient free disk space to
-  accommodate a second copy of the existing index.
-
-=====================================
-
-The `_shrink` API is similar to the <<indices-create-index, `create index` API>>
-and accepts `settings` and `aliases` parameters for the target index:
+[float]
+[[indices-shrink-index-example]]
+=== {api-example-title}
 
 [source,js]
---------------------------------------------------
+----
 POST my_source_index/_shrink/my_target_index
 {
   "settings": {
     "index.number_of_replicas": 1,
-    "index.number_of_shards": 1, <1>
-    "index.codec": "best_compression" <2>
+    "index.number_of_shards": 1
   },
   "aliases": {
     "my_search_indices": {}
   }
 }
---------------------------------------------------
+----
 // CONSOLE
 // TEST[s/^/PUT my_source_index\n{"settings": {"index.number_of_shards":5,"index.blocks.write": true}}\n/]
-
-<1> The number of shards in the target index. This must be a factor of the
-    number of shards in the source index.
-<2> Best compression will only take affect when new writes are made to the
-    index, such as when <<indices-forcemerge,force-merging>> the shard to a single
-    segment.
-
-
-NOTE: Mappings may not be specified in the `_shrink` request.
-
-[float]
-=== Monitoring the shrink process
-
-The shrink process can be monitored with the <<cat-recovery,`_cat recovery`
-API>>, or the <<cluster-health, `cluster health` API>> can be used to wait
-until all primary shards have been allocated by setting the  `wait_for_status`
-parameter to `yellow`.
-
-The `_shrink` API returns as soon as the target index has been added to the
-cluster state, before any shards have been allocated. At this point, all
-shards are in the state `unassigned`. If, for any reason, the target index
-can't be allocated on the shrink node, its primary shard will remain
-`unassigned` until it can be allocated on that node.
-
-Once the primary shard is allocated, it moves to state `initializing`, and the
-shrink process begins. When the shrink operation completes, the shard will
-become `active`. At that  point, Elasticsearch will try to allocate any
-replicas and may decide to relocate the primary shard to another node.
-
-[float]
-=== Wait For Active Shards
-
-Because the shrink operation creates a new index to shrink the shards to,
-the <<create-index-wait-for-active-shards,wait for active shards>> setting
-on index creation applies to the shrink index action as well.


### PR DESCRIPTION
Rewrites the shrink index API docs to use the[ Elastic API reference template](https://github.com/elastic/docs/blame/master/shared/api-ref-ex.asciidoc).

Other supporting changes:
- Retitles existing shrink index tutorial content and moves it to [Administering Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/master/administer-elasticsearch.html)
- Moves [**Back up a cluster**](https://www.elastic.co/guide/en/elasticsearch/reference/master/backup-cluster.html) to its own file.

## Before
<details>
 <summary>Shrink Index API - Before</summary>
<img width="775" alt="Screen Shot 2019-06-27 at 9 45 59 AM" src="https://user-images.githubusercontent.com/40268737/60357932-f115cc00-99a2-11e9-9d79-836d7476411a.png">
</details>


## After
<details>
 <summary>Administering Elasticsearch Nav - After</summary>
<img width="768" alt="Nav" src="https://user-images.githubusercontent.com/40268737/60358002-1efb1080-99a3-11e9-83a3-773f09eeec66.png">
</details>

<details>
 <summary>Shrink Index Tutorial - After</summary>
<img width="768" alt="Shrink-index-tutorial" src="https://user-images.githubusercontent.com/40268737/60358014-25898800-99a3-11e9-8249-e7ae912f2a33.png">
</details>

<details>
 <summary>Shrink Index API - After</summary>
<img width="768" alt="Shrink-index-API" src="https://user-images.githubusercontent.com/40268737/60358039-36d29480-99a3-11e9-9828-78381076dc3f.png">
</details>