### PR TITLE
Add enrich coordinator proxy action

### DIFF
--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPlugin.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPlugin.java
@@ -67,6 +67,16 @@ public class EnrichPlugin extends Plugin implements ActionPlugin, IngestPlugin {
     public static final Setting<Integer> COORDINATOR_PROXY_MAX_LOOKUPS_PER_REQUEST =
         Setting.intSetting("enrich.coordinator_proxy.max_lookups_per_request", 128, 1, 10000, Setting.Property.NodeScope);
 
+    private static final String QUEUE_CAPACITY_SETTING_NAME = "enrich.coordinator_proxy.queue_capacity";
+    public static final Setting<Integer> COORDINATOR_PROXY_QUEUE_CAPACITY = new Setting<>(QUEUE_CAPACITY_SETTING_NAME,
+            settings -> {
+                int maxConcurrentRequests = COORDINATOR_PROXY_MAX_CONCURRENT_REQUESTS.get(settings);
+                int maxLookupsPerRequest = COORDINATOR_PROXY_MAX_LOOKUPS_PER_REQUEST.get(settings);
+                return String.valueOf(maxConcurrentRequests * maxLookupsPerRequest);
+            },
+            val -> Setting.parseInt(val, 1, Integer.MAX_VALUE, QUEUE_CAPACITY_SETTING_NAME),
+            Setting.Property.NodeScope);
+
     private final Settings settings;
     private final Boolean enabled;
 
@@ -141,6 +151,11 @@ public class EnrichPlugin extends Plugin implements ActionPlugin, IngestPlugin {
 
     @Override
     public List<Setting<?>> getSettings() {
-        return List.of(ENRICH_FETCH_SIZE_SETTING, COORDINATOR_PROXY_MAX_CONCURRENT_REQUESTS, COORDINATOR_PROXY_MAX_LOOKUPS_PER_REQUEST);
+        return List.of(
+            ENRICH_FETCH_SIZE_SETTING,
+            COORDINATOR_PROXY_MAX_CONCURRENT_REQUESTS,
+            COORDINATOR_PROXY_MAX_LOOKUPS_PER_REQUEST,
+            COORDINATOR_PROXY_QUEUE_CAPACITY
+        );
     }
 }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/ExactMatchProcessor.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/ExactMatchProcessor.java
@@ -18,10 +18,10 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 import org.elasticsearch.xpack.enrich.EnrichProcessorFactory.EnrichSpecification;
+import org.elasticsearch.xpack.enrich.action.CoordinatorProxyAction;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Semaphore;
 import java.util.function.BiConsumer;
 
 final class ExactMatchProcessor extends AbstractProcessor {
@@ -146,28 +146,13 @@ final class ExactMatchProcessor extends AbstractProcessor {
         return specifications;
     }
 
-    // TODO: This is temporary and will be removed once internal transport action that does an efficient lookup instead of a search.
-    // This semaphore purpose is to throttle the number of concurrent search requests, if this is not done then search thread pool
-    // on nodes may get full and search request fail because they get rejected.
-    // Because this code is going to change, a semaphore seemed like an easy quick fix to address this problem.
-    private static final Semaphore SEMAPHORE = new Semaphore(100);
-
     private static BiConsumer<SearchRequest, BiConsumer<SearchResponse, Exception>> createSearchRunner(Client client) {
         return (req, handler) -> {
-            try {
-                SEMAPHORE.acquire();
-            } catch (InterruptedException e) {
-                Thread.interrupted();
-                handler.accept(null, e);
-                return;
-            }
-            client.search(req, ActionListener.wrap(
+            client.execute(CoordinatorProxyAction.INSTANCE, req, ActionListener.wrap(
                 resp -> {
-                    SEMAPHORE.release();
                     handler.accept(resp, null);
                 },
                 e -> {
-                    SEMAPHORE.release();
                     handler.accept(null, e);
                 }));
         };

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/CoordinatorProxyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/CoordinatorProxyAction.java
@@ -112,7 +112,7 @@ public class CoordinatorProxyAction extends ActionType<SearchResponse> {
 
                 numberOfOutstandingRequests.incrementAndGet();
                 lookupFunction.accept(multiSearchRequest, (response, e) -> {
-                    handleResponse(slots, response, null);
+                    handleResponse(slots, response, e);
                 });
             }
         }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/CoordinatorProxyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/CoordinatorProxyAction.java
@@ -97,7 +97,7 @@ public class CoordinatorProxyAction extends ActionType<SearchResponse> {
 
         synchronized void coordinateLookups() {
             while (queue.isEmpty() == false &&
-                numberOfOutstandingRequests.get() <= maxNumberOfConcurrentRequests) {
+                numberOfOutstandingRequests.get() < maxNumberOfConcurrentRequests) {
 
                 final List<Item> items = new ArrayList<>();
                 queue.drainTo(items, maxLookupsPerRequest);

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/CoordinatorProxyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/CoordinatorProxyAction.java
@@ -24,8 +24,8 @@ import org.elasticsearch.xpack.enrich.EnrichPlugin;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -78,7 +78,7 @@ public class CoordinatorProxyAction extends ActionType<SearchResponse> {
             this.client = client;
             this.maxLookupsPerRequest = maxLookupsPerRequest;
             this.maxNumberOfConcurrentRequests = maxNumberOfConcurrentRequests;
-            this.queue = new LinkedBlockingQueue<>(queueCapacity);
+            this.queue = new ArrayBlockingQueue<>(queueCapacity);
         }
 
         void schedule(SearchRequest searchRequest, ActionListener<SearchResponse> listener) {

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/CoordinatorProxyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/CoordinatorProxyAction.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.enrich.action;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.search.MultiSearchRequest;
+import org.elasticsearch.action.search.MultiSearchResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.enrich.EnrichPlugin;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+/**
+ * An internal action to locally manage the load of the search requests the originate from the enrich processor.
+ * This is because the enrich processor executes in non blocking manner and a bulk request could easily overload
+ * the search tp.
+ */
+public class CoordinatorProxyAction extends ActionType<SearchResponse> {
+
+    public static final CoordinatorProxyAction INSTANCE = new CoordinatorProxyAction();
+    public static final String NAME = "indices:data/read/xpack/enrich/coordinate_lookups";
+
+    private CoordinatorProxyAction() {
+        super(NAME, SearchResponse::new);
+    }
+
+    public static class TransportAction extends HandledTransportAction<SearchRequest, SearchResponse> {
+
+        private final Coordinator coordinator;
+
+        @Inject
+        public TransportAction(TransportService transportService, ActionFilters actionFilters, Coordinator coordinator) {
+            super(NAME, transportService, actionFilters, (Writeable.Reader<SearchRequest>) SearchRequest::new);
+            this.coordinator = coordinator;
+        }
+
+        @Override
+        protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> listener) {
+            coordinator.schedule(request, listener);
+        }
+    }
+
+    public static class Coordinator {
+
+        final Client client;
+        final int maxLookupsPerRequest;
+        final int maxNumberOfConcurrentRequests;
+        final BlockingQueue<Item> queue = new LinkedBlockingQueue<>();
+
+        int numberOfOutstandingRequests = 0;
+
+        public Coordinator(Client client, Settings settings) {
+            this(client,
+                EnrichPlugin.COORDINATOR_PROXY_MAX_LOOKUPS_PER_REQUEST.get(settings),
+                EnrichPlugin.COORDINATOR_PROXY_MAX_CONCURRENT_REQUESTS.get(settings));
+        }
+
+        Coordinator(Client client, int maxLookupsPerRequest, int maxNumberOfConcurrentRequests) {
+            this.client = client;
+            this.maxLookupsPerRequest = maxLookupsPerRequest;
+            this.maxNumberOfConcurrentRequests = maxNumberOfConcurrentRequests;
+        }
+
+        void schedule(SearchRequest searchRequest, ActionListener<SearchResponse> listener) {
+            queue.add(new Item(searchRequest, listener));
+            coordinateLookups();
+        }
+
+        synchronized void coordinateLookups() {
+            while (queue.isEmpty() == false &&
+                numberOfOutstandingRequests <= maxNumberOfConcurrentRequests) {
+
+                final List<Item> items = new LinkedList<>();
+                queue.drainTo(items, maxLookupsPerRequest);
+                final MultiSearchRequest multiSearchRequest = new MultiSearchRequest();
+                items.forEach(item -> multiSearchRequest.add(item.searchRequest));
+
+                numberOfOutstandingRequests++;
+                client.multiSearch(multiSearchRequest, ActionListener.wrap(response -> {
+                    handleResponse(items, response, null);
+                }, e -> {
+                    handleResponse(items, null, e);
+                }));
+            }
+        }
+
+        synchronized void handleResponse(List<Item> items, MultiSearchResponse response, Exception e) {
+            numberOfOutstandingRequests--;
+
+            if (response != null) {
+                assert items.size() == response.getResponses().length;
+                for (int i = 0; i < response.getResponses().length; i++) {
+                    MultiSearchResponse.Item responseItem = response.getResponses()[i];
+                    Item item = items.get(i);
+
+                    if (responseItem.isFailure()) {
+                        item.actionListener.onFailure(responseItem.getFailure());
+                    } else {
+                        item.actionListener.onResponse(responseItem.getResponse());
+                    }
+                }
+            } else if (e != null) {
+                items.forEach(item -> item.actionListener.onFailure(e));
+            } else {
+                assert false;
+            }
+
+            coordinateLookups();
+        }
+
+        static class Item {
+
+            final SearchRequest searchRequest;
+            final ActionListener<SearchResponse> actionListener;
+
+            Item(SearchRequest searchRequest, ActionListener<SearchResponse> actionListener) {
+                this.searchRequest = searchRequest;
+                this.actionListener = actionListener;
+            }
+        }
+
+    }
+
+}

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/CoordinatorProxyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/CoordinatorProxyAction.java
@@ -22,7 +22,6 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.enrich.EnrichPlugin;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/CoordinatorProxyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/CoordinatorProxyAction.java
@@ -64,19 +64,21 @@ public class CoordinatorProxyAction extends ActionType<SearchResponse> {
         final Client client;
         final int maxLookupsPerRequest;
         final int maxNumberOfConcurrentRequests;
-        final BlockingQueue<Item> queue = new LinkedBlockingQueue<>();
+        final BlockingQueue<Item> queue;
         final AtomicInteger numberOfOutstandingRequests = new AtomicInteger(0);
 
         public Coordinator(Client client, Settings settings) {
             this(client,
                 EnrichPlugin.COORDINATOR_PROXY_MAX_LOOKUPS_PER_REQUEST.get(settings),
-                EnrichPlugin.COORDINATOR_PROXY_MAX_CONCURRENT_REQUESTS.get(settings));
+                EnrichPlugin.COORDINATOR_PROXY_MAX_CONCURRENT_REQUESTS.get(settings),
+                EnrichPlugin.COORDINATOR_PROXY_QUEUE_CAPACITY.get(settings));
         }
 
-        Coordinator(Client client, int maxLookupsPerRequest, int maxNumberOfConcurrentRequests) {
+        Coordinator(Client client, int maxLookupsPerRequest, int maxNumberOfConcurrentRequests, int queueCapacity) {
             this.client = client;
             this.maxLookupsPerRequest = maxLookupsPerRequest;
             this.maxNumberOfConcurrentRequests = maxNumberOfConcurrentRequests;
+            this.queue = new LinkedBlockingQueue<>(queueCapacity);
         }
 
         void schedule(SearchRequest searchRequest, ActionListener<SearchResponse> listener) {

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/CoordinatorTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/CoordinatorTests.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.enrich.action;
+
+import org.apache.logging.log4j.util.BiConsumer;
+import org.apache.lucene.search.TotalHits;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.MultiSearchRequest;
+import org.elasticsearch.action.search.MultiSearchResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.index.query.MatchQueryBuilder;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.internal.InternalSearchResponse;
+import org.elasticsearch.test.ESTestCase;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.elasticsearch.xpack.enrich.action.CoordinatorProxyAction.Coordinator;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class CoordinatorTests extends ESTestCase {
+
+    public void testCoordinateLookups() {
+        MockLookupFunction lookupFunction = new MockLookupFunction();
+        Coordinator coordinator = new Coordinator(lookupFunction, 5, 1, 100);
+
+        List<ActionListener<SearchResponse>> searchActionListeners = new ArrayList<>();
+        for (int i = 0; i < 9; i++) {
+            SearchRequest searchRequest = new SearchRequest("my-index");
+            searchRequest.source().query(new MatchQueryBuilder("my_field", String.valueOf(i)));
+            @SuppressWarnings("unchecked")
+            ActionListener<SearchResponse> actionListener = Mockito.mock(ActionListener.class);
+            searchActionListeners.add(actionListener);
+            coordinator.queue.add(new Coordinator.Slot(searchRequest, actionListener));
+        }
+
+        SearchRequest searchRequest = new SearchRequest("my-index");
+        searchRequest.source().query(new MatchQueryBuilder("my_field", String.valueOf(10)));
+        @SuppressWarnings("unchecked")
+        ActionListener<SearchResponse> actionListener = Mockito.mock(ActionListener.class);
+        searchActionListeners.add(actionListener);
+        coordinator.schedule(searchRequest, actionListener);
+
+        // First batch of search requests have been sent off:
+        // (However still 5 should remain in the queue)
+        assertThat(coordinator.queue.size(), equalTo(5));
+        assertThat(coordinator.numberOfOutstandingRequests.get(), equalTo(1));
+        assertThat(lookupFunction.capturedRequests.size(), equalTo(1));
+        assertThat(lookupFunction.capturedRequests.get(0).requests().size(), equalTo(5));
+
+        // Nothing should happen now, because there is an outstanding request and max number of requests has been set to 1:
+        coordinator.coordinateLookups();
+        assertThat(coordinator.queue.size(), equalTo(5));
+        assertThat(coordinator.numberOfOutstandingRequests.get(), equalTo(1));
+        assertThat(lookupFunction.capturedRequests.size(), equalTo(1));
+
+        SearchResponse emptyResponse = emptySearchResponse();
+        // Replying a response and that should trigger another coordination round
+        MultiSearchResponse.Item[] responseItems = new MultiSearchResponse.Item[5];
+        for (int i = 0; i < 5; i++) {
+            responseItems[i] = new MultiSearchResponse.Item(emptyResponse, null);
+        }
+        lookupFunction.capturedConsumers.get(0).accept(new MultiSearchResponse(responseItems, 1L), null);
+        assertThat(coordinator.queue.size(), equalTo(0));
+        assertThat(coordinator.numberOfOutstandingRequests.get(), equalTo(1));
+        assertThat(lookupFunction.capturedRequests.size(), equalTo(2));
+
+        // Replying last response, resulting in an empty queue and no outstanding requests.
+        responseItems = new MultiSearchResponse.Item[5];
+        for (int i = 0; i < 5; i++) {
+            responseItems[i] = new MultiSearchResponse.Item(emptyResponse, null);
+        }
+        lookupFunction.capturedConsumers.get(1).accept(new MultiSearchResponse(responseItems, 1L), null);
+        assertThat(coordinator.queue.size(), equalTo(0));
+        assertThat(coordinator.numberOfOutstandingRequests.get(), equalTo(0));
+        assertThat(lookupFunction.capturedRequests.size(), equalTo(2));
+
+        // All individual action listeners for the search requests should have been invoked:
+        for (ActionListener<SearchResponse> searchActionListener : searchActionListeners) {
+            Mockito.verify(searchActionListener).onResponse(Mockito.eq(emptyResponse));
+        }
+    }
+
+    public void testQueueing() throws Exception {
+        MockLookupFunction lookupFunction = new MockLookupFunction();
+        Coordinator coordinator = new Coordinator(lookupFunction, 1, 1, 1);
+        coordinator.queue.add(new Coordinator.Slot(new SearchRequest(), ActionListener.wrap(() -> {})));
+
+        AtomicBoolean completed = new AtomicBoolean(false);
+        SearchRequest searchRequest = new SearchRequest();
+        Thread t = new Thread(() -> {
+            coordinator.schedule(searchRequest, ActionListener.wrap(() -> {}));
+            completed.set(true);
+        });
+        t.start();
+        assertBusy(() -> {
+            assertThat(t.getState(), equalTo(Thread.State.WAITING));
+            assertThat(completed.get(), is(false));
+        });
+
+        coordinator.coordinateLookups();
+        lookupFunction.capturedConsumers.get(0).accept(
+            new MultiSearchResponse(new MultiSearchResponse.Item[]{new MultiSearchResponse.Item(emptySearchResponse(), null)}, 1L), null);
+        assertThat(completed.get(), is(true));
+        assertThat(coordinator.queue.size(), equalTo(0));
+        assertThat(lookupFunction.capturedRequests.size(), equalTo(2));
+        assertThat(lookupFunction.capturedRequests.get(1).requests().get(0), sameInstance(searchRequest));
+    }
+
+    private static SearchResponse emptySearchResponse() {
+        InternalSearchResponse response = new InternalSearchResponse(new SearchHits(new SearchHit[0],
+            new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN), InternalAggregations.EMPTY, null, null, false, null, 1);
+        return new SearchResponse(response, null, 1, 1, 0, 100, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY);
+    }
+
+    private class MockLookupFunction implements BiConsumer<MultiSearchRequest, BiConsumer<MultiSearchResponse, Exception>> {
+
+        private final List<MultiSearchRequest> capturedRequests = new ArrayList<>();
+        private final List<BiConsumer<MultiSearchResponse, Exception>> capturedConsumers = new ArrayList<>();
+
+        @Override
+        public void accept(MultiSearchRequest multiSearchRequest, BiConsumer<MultiSearchResponse, Exception> consumer) {
+            capturedRequests.add(multiSearchRequest);
+            capturedConsumers.add(consumer);
+        }
+    }
+
+}

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/CoordinatorTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/CoordinatorTests.java
@@ -196,9 +196,12 @@ public class CoordinatorTests extends ESTestCase {
         });
 
         coordinator.coordinateLookups();
+        assertBusy(() -> {
+            assertThat(completed.get(), is(true));
+        });
+
         lookupFunction.capturedConsumers.get(0).accept(
             new MultiSearchResponse(new MultiSearchResponse.Item[]{new MultiSearchResponse.Item(emptySearchResponse(), null)}, 1L), null);
-        assertThat(completed.get(), is(true));
         assertThat(coordinator.queue.size(), equalTo(0));
         assertThat(lookupFunction.capturedRequests.size(), equalTo(2));
         assertThat(lookupFunction.capturedRequests.get(1).requests().get(0), sameInstance(searchRequest));


### PR DESCRIPTION
Introduced proxy api the handle the search request load that originates from enrich processor.

The enrich processor executes search requests asynchronous and because of this it can easily overload the search thread pool of a node. 

The proxy action coordinates the search requests that originates from the enrich processor by controlling the maximum number of concurrent requests and combining the search requests into a multi search request to optimize the number of remote calls to be made.

~~This is a WIP pr, tests are missing.~~