### PR TITLE
Avoid IP addresses for bootstrapping in setup docs

### DIFF
--- a/docs/reference/setup/important-settings/discovery-settings.asciidoc
+++ b/docs/reference/setup/important-settings/discovery-settings.asciidoc
@@ -39,9 +39,9 @@ first election. In <<dev-vs-prod-mode,development mode>>, with no discovery
 settings configured, this step is automatically performed by the nodes
 themselves. As this auto-bootstrapping is <<modules-discovery-quorums,inherently
 unsafe>>, when you start a brand new cluster in <<dev-vs-prod-mode,production
-mode>>, you must explicitly list the names or IP addresses of the
-master-eligible nodes whose votes should be counted in the very first election.
-This list is set using the `cluster.initial_master_nodes` setting.
+mode>>, you must explicitly list the master-eligible nodes whose votes should be
+counted in the very first election.  This list is set using the
+`cluster.initial_master_nodes` setting.
 
 [source,yaml]
 --------------------------------------------------


### PR DESCRIPTION
Removes the suggestion to use IP addresses for `cluster.initial_master_nodes`
in the "important settings" discovery docs, leaving only the suggestion to use
node names.

Relates #41179, #41569