### PR TITLE
[DOCS] Add `boost` parameter page

### DIFF
--- a/docs/reference/query-dsl.asciidoc
+++ b/docs/reference/query-dsl.asciidoc
@@ -45,6 +45,8 @@ include::query-dsl/special-queries.asciidoc[]
 
 include::query-dsl/span-queries.asciidoc[]
 
+include::query-dsl/boost.asciidoc[]
+
 include::query-dsl/minimum-should-match.asciidoc[]
 
 include::query-dsl/multi-term-rewrite.asciidoc[]

--- a/docs/reference/query-dsl/boost.asciidoc
+++ b/docs/reference/query-dsl/boost.asciidoc
@@ -8,9 +8,9 @@ The `boost` value is a floating point number used to decrease or increase the
 relevance scores of documents returned by a query. The default value is `1.0`.
 
 A value greater than `1.0` increases the relevance score, meaning those
-documents higher in the search results. A boost value between `0` and `1.0`
-decreases the relevance score of matching documents, meaning they appear lower
-in the search results.
+documents appear higher in the search results. A boost value between `0` and
+`1.0` decreases the relevance score of matching documents, meaning they appear
+lower in the search results.
 
 [WARNING]
 ====
@@ -25,7 +25,7 @@ in the search results.
 ==== Increase relevance scores
 
 The following search returns documents matching "full text search." Documents
-that also match "Elasticsearch" receive higher relevance scores, which means
+that also match "Elasticsearch" receive higher relevance scores, meaning
 they appear higher in the search results.
 
 
@@ -37,7 +37,7 @@ GET /_search
         "bool": {
             "must": {
                 "match": {
-                    "content": {
+                    "message": {
                         "query":    "full text search",
                         "operator": "and"
                     }
@@ -45,7 +45,7 @@ GET /_search
             },
             "should": [
                 { "match": {
-                    "content": {
+                    "message": {
                         "query": "Elasticsearch",
                         "boost": 3
                     }
@@ -55,12 +55,13 @@ GET /_search
     }
 }
 ----
+// CONSOLE
 
 [float]
 ==== Decrease relevance scores
 
 The following search returns documents matching "apple." Documents that also
-match "pie" receive lower relevance scores, which means they appear lower in
+match "pie" receive lower relevance scores, meaning they appear lower in
 the search results.
 
 
@@ -72,7 +73,7 @@ GET /_search
         "bool": {
             "must": {
                 "match": {
-                    "content": {
+                    "message": {
                         "query":    "apple",
                         "operator": "and"
                     }
@@ -80,7 +81,7 @@ GET /_search
             },
             "should": [
                 { "match": {
-                    "content": {
+                    "message": {
                         "query": "pie",
                         "boost": 0.5
                     }
@@ -90,3 +91,4 @@ GET /_search
     }
 }
 ----
+// CONSOLE

--- a/docs/reference/query-dsl/boost.asciidoc
+++ b/docs/reference/query-dsl/boost.asciidoc
@@ -1,0 +1,92 @@
+[[query-dsl-boost]]
+== `boost` parameter
+
+You can use the `boost` parameter to adjust <<query-filter-context,relevance
+scores>> for searches containing two or more queries.
+
+The `boost` value is a floating point number used to decrease or increase the
+relevance scores of documents returned by a query. The default value is `1.0`.
+
+A value greater than `1.0` increases the relevance score, meaning those
+documents higher in the search results. A boost value between `0` and `1.0`
+decreases the relevance score of matching documents, meaning they appear lower
+in the search results.
+
+[WARNING]
+====
+{es} does **not** support negative `boost` values.
+====
+
+[float]
+[[query-dsl-boost-examples]]
+=== Examples
+
+[float]
+==== Increase relevance scores
+
+The following search returns documents matching "full text search." Documents
+that also match "Elasticsearch" receive higher relevance scores, which means
+they appear higher in the search results.
+
+
+[source,js]
+----
+GET /_search
+{
+    "query": {
+        "bool": {
+            "must": {
+                "match": {
+                    "content": {
+                        "query":    "full text search",
+                        "operator": "and"
+                    }
+                }
+            },
+            "should": [
+                { "match": {
+                    "content": {
+                        "query": "Elasticsearch",
+                        "boost": 3
+                    }
+                }}
+            ]
+        }
+    }
+}
+----
+
+[float]
+==== Decrease relevance scores
+
+The following search returns documents matching "apple." Documents that also
+match "pie" receive lower relevance scores, which means they appear lower in
+the search results.
+
+
+[source,js]
+----
+GET /_search
+{
+    "query": {
+        "bool": {
+            "must": {
+                "match": {
+                    "content": {
+                        "query":    "apple",
+                        "operator": "and"
+                    }
+                }
+            },
+            "should": [
+                { "match": {
+                    "content": {
+                        "query": "pie",
+                        "boost": 0.5
+                    }
+                }}
+            ]
+        }
+    }
+}
+----

--- a/docs/reference/query-dsl/boost.asciidoc
+++ b/docs/reference/query-dsl/boost.asciidoc
@@ -8,9 +8,9 @@ The `boost` value is a floating point number used to decrease or increase the
 relevance scores of documents returned by a query. The default value is `1.0`.
 
 A value greater than `1.0` increases the relevance score, meaning those
-documents appear higher in the search results. A boost value between `0` and
-`1.0` decreases the relevance score of matching documents, meaning they appear
-lower in the search results.
+documents appear higher in the search results by default. A boost value between
+`0` and `1.0` decreases the relevance score of matching documents, meaning they
+appear lower in the search results.
 
 [WARNING]
 ====
@@ -25,8 +25,7 @@ lower in the search results.
 ==== Increase relevance scores
 
 The following search returns documents matching "full text search." Documents
-that also match "Elasticsearch" receive higher relevance scores, meaning
-they appear higher in the search results.
+that also match "Elasticsearch" receive higher relevance scores.
 
 
 [source,js]
@@ -61,8 +60,7 @@ GET /_search
 ==== Decrease relevance scores
 
 The following search returns documents matching "apple." Documents that also
-match "pie" receive lower relevance scores, meaning they appear lower in
-the search results.
+match "pie" receive lower relevance scores.
 
 
 [source,js]

--- a/docs/reference/query-dsl/boost.asciidoc
+++ b/docs/reference/query-dsl/boost.asciidoc
@@ -1,7 +1,7 @@
 [[query-dsl-boost]]
 == `boost` parameter
 
-You can use the `boost` parameter to adjust <<query-filter-context,relevance
+You can use the `boost` parameter to adjust <<relevance-scores,relevance
 scores>> for searches containing two or more queries.
 
 The `boost` value is a floating point number used to decrease or increase the

--- a/docs/reference/query-dsl/minimum-should-match.asciidoc
+++ b/docs/reference/query-dsl/minimum-should-match.asciidoc
@@ -1,5 +1,5 @@
 [[query-dsl-minimum-should-match]]
-== Minimum Should Match
+== `minimum_should_match` parameter
 
 The `minimum_should_match` parameter possible values:
 

--- a/docs/reference/query-dsl/multi-term-rewrite.asciidoc
+++ b/docs/reference/query-dsl/multi-term-rewrite.asciidoc
@@ -1,5 +1,5 @@
 [[query-dsl-multi-term-rewrite]]
-== `rewrite` Parameter
+== `rewrite` parameter
 
 WARNING: This parameter is for expert users only. Changing the value of
 this parameter can impact search performance and relevance.


### PR DESCRIPTION
### Changes
Adds a separate page for the `boost` query parameter. Also retitles the `minimum_should_match` and `rewrite` parameter pages for consistency.

This is part of #40977, an effort to standardize documentation for query types.

Any and all feedback welcome!

## Screenshots
<details>
 <summary>Nav changes</summary>
<img width="398" alt="Nav Changes" src="https://user-images.githubusercontent.com/40268737/60450748-865dce00-9bf8-11e9-8f60-9a16a03b919b.png">
</summary>
</details>

<details>
 <summary>`boost` parameter page</summary>
<img width="398" alt="Boost Page" src="https://user-images.githubusercontent.com/40268737/60450766-91186300-9bf8-11e9-943b-51f0069e3879.png">
</details>

