### PR TITLE
BACKPORT UserRoleMapper non-null groups and metadata

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealm.java
@@ -216,10 +216,12 @@ public final class KerberosRealm extends Realm implements CachingRealm {
             if (user != null) {
                 listener.onResponse(AuthenticationResult.success(user));
             } else {
-                final String realmName = (userAndRealmName.length > 1) ? userAndRealmName[1] : null;
                 final Map<String, Object> metadata = new HashMap<>();
-                metadata.put(KRB_METADATA_REALM_NAME_KEY, realmName);
                 metadata.put(KRB_METADATA_UPN_KEY, userPrincipalName);
+                if (userAndRealmName.length > 1) {
+                    final String realmName = userAndRealmName[1];
+                    metadata.put(KRB_METADATA_REALM_NAME_KEY, realmName);
+                }
                 buildUser(username, metadata, listener);
             }
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealm.java
@@ -427,6 +427,10 @@ public class OpenIdConnectRealm extends Realm implements Releasable {
                                     + claimValueObject.getClass().getName());
                             }
                             return values.stream().map(s -> {
+                                if (s == null) {
+                                    logger.debug("OpenID Connect Claim [{}] is null", claimName);
+                                    return null;
+                                }
                                 final Matcher matcher = regex.matcher(s);
                                 if (matcher.find() == false) {
                                     logger.debug("OpenID Connect Claim [{}] is [{}], which does not match [{}]",
@@ -456,7 +460,9 @@ public class OpenIdConnectRealm extends Realm implements Releasable {
                                     + " expects a claim with String or a String Array value but found a "
                                     + claimValueObject.getClass().getName());
                             }
-                            return (List<String>) claimValueObject;
+                            return ((List<String>) claimValueObject).stream()
+                                        .filter(Objects::nonNull)
+                                        .collect(Collectors.toList());
                         });
                 }
             } else if (required) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlAttributes.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlAttributes.java
@@ -46,9 +46,6 @@ public class SamlAttributes {
         if (name != null && NameIDType.PERSISTENT.equals(name.format) && attributeId.equals(PERSISTENT_NAMEID_SYNTHENTIC_ATTRIBUTE)) {
             return Collections.singletonList(name.value);
         }
-        if (Strings.isNullOrEmpty(attributeId)) {
-            return Collections.emptyList();
-        }
         return attributes.stream()
                 .filter(attr -> attributeId.equals(attr.name) || attributeId.equals(attr.friendlyName))
                 .flatMap(attr -> attr.values.stream())
@@ -79,7 +76,10 @@ public class SamlAttributes {
 
         SamlAttribute(Attribute attribute) {
             this(attribute.getName(), attribute.getFriendlyName(),
-                    attribute.getAttributeValues().stream().map(x -> x.getDOM().getTextContent()).collect(Collectors.toList()));
+                    attribute.getAttributeValues().stream()
+                        .map(x -> x.getDOM().getTextContent())
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList()));
         }
 
         SamlAttribute(String name, @Nullable String friendlyName, List<String> values) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRealm.java
@@ -450,7 +450,9 @@ public final class SamlRealm extends Realm implements Releasable {
         }
         if (attributes.name() != null) {
             userMeta.put(USER_METADATA_NAMEID_VALUE, attributes.name().value);
-            userMeta.put(USER_METADATA_NAMEID_FORMAT, attributes.name().format);
+            if (attributes.name().format != null) {
+                userMeta.put(USER_METADATA_NAMEID_FORMAT, attributes.name().format);
+            }
         }
 
 


### PR DESCRIPTION
This is an odd backport of https://github.com/elastic/elasticsearch/pull/41774
_It is odd because filtering out null values in collections without actually enforcing it, is a best effort type of thing. One enforces non-null elements in collections if using the new java 9 collection APIs, to copy collections, which are not available in the 7.x releases. Anyway, null elements in UserRoleMapper don't make any sense and this PR sanitizes them._

UserRoleMapper.UserData is constructed by each realm and it is used to
"match" role mapping expressions that eventually supply the role names
of the principal.

null values as group names or metadata values were not properly
supported. Most of the time they were filtered out, but under some
circumstances they might cause NPEs (depending of how the OIDC and
SAML's underlying libraries parse purposefully crafted assertions -
these libraries don't have internal null checks the same way that the
unboundid library does).

This PR filters out null collection values (lists and maps) earliest in
the process.
