### PR TITLE
Fix an issue where a TransportClient with master = false and transpor…

### DIFF
--- a/server/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
+++ b/server/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
@@ -494,19 +494,10 @@ final class TransportClientNodesService implements Closeable {
 
                         @Override
                         protected void doRun() throws Exception {
-                            Transport.Connection pingConnection = null;
-                            if (nodes.contains(nodeToPing)) {
-                                try {
-                                    pingConnection = transportService.getConnection(nodeToPing);
-                                } catch (NodeNotConnectedException e) {
-                                    // will use a temp connection
-                                }
-                            }
-                            if (pingConnection == null) {
-                                logger.trace("connecting to cluster node [{}]", nodeToPing);
-                                connectionToClose = transportService.openConnection(nodeToPing, LISTED_NODES_PROFILE);
-                                pingConnection = connectionToClose;
-                            }
+                            logger.trace("connecting to cluster node [{}]", nodeToPing);
+                            connectionToClose = transportService.openConnection(nodeToPing, LISTED_NODES_PROFILE);
+                            Transport.Connection pingConnection = connectionToClose;
+
                             transportService.sendRequest(pingConnection, ClusterStateAction.NAME,
                                 Requests.clusterStateRequest().clear().nodes(true).local(true),
                                 TransportRequestOptions.builder().withType(TransportRequestOptions.Type.STATE)

--- a/server/src/test/java/org/elasticsearch/client/transport/FailAndRetryMockTransport.java
+++ b/server/src/test/java/org/elasticsearch/client/transport/FailAndRetryMockTransport.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.client.transport;
 
+import com.google.common.base.Preconditions;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.node.liveness.LivenessResponse;
@@ -92,6 +93,9 @@ abstract class FailAndRetryMockTransport<Response extends TransportResponse> imp
             @Override
             public void sendRequest(long requestId, String action, TransportRequest request, TransportRequestOptions options)
                 throws TransportException {
+                // Captures the logic in ConnectionProfile.ConnectionTypeHandle.getChannel
+                Preconditions.checkArgument(profile.getNumConnectionsPerType(options.type()) != 0,
+                    "can't select channel size is 0 for types: %s", options.type().toString());
                 //we make sure that nodes get added to the connected ones when calling addTransportAddress, by returning proper nodes info
                 if (connectMode) {
                     if (TransportLivenessAction.NAME.equals(action)) {


### PR DESCRIPTION
…t sniff set true would throw during node sampling due to lack of a STATE channel

The issue manifested as the following exception being thrown every 5 seconds:

```
org.elasticsearch.client.transport.TransportClientNodesService: failed to get local cluster state for ..., disconnecting... (0: {...}{192.168.0.5:9300}, throwable0_message: [192.168.0.5:9300][cluster:monitor/state], throwable1_message: can't select channel size is 0 for types: [STATE])
org.elasticsearch.transport.SendRequestTransportException: [...][192.168.0.5:9300][cluster:monitor/state]
        at org.elasticsearch.transport.TransportService.sendRequestInternal(TransportService.java:617)
        at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:524)
        at org.elasticsearch.client.transport.TransportClientNodesService$SniffNodesSampler$1.doRun(TransportClientNodesService.java:507)
        at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:723)
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.IllegalStateException: can't select channel size is 0 for types: [STATE]
        at org.elasticsearch.transport.ConnectionProfile$ConnectionTypeHandle.getChannel(ConnectionProfile.java:213)
        at org.elasticsearch.transport.TcpTransport$NodeChannels.channel(TcpTransport.java:462)
        at org.elasticsearch.transport.TcpTransport$NodeChannels.sendRequest(TcpTransport.java:510)
        at org.elasticsearch.transport.TransportService.sendRequestInternal(TransportService.java:605)
        at org.elasticsearch.transport.TransportService.sendRequest(TransportService.java:524)
        at org.elasticsearch.client.transport.TransportClientNodesService$SniffNodesSampler$1.doRun(TransportClientNodesService.java:507)
        at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:723)
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```

`TcpTransport`'s default `ConnectionProfile` is created like such:

```
static ConnectionProfile buildDefaultConnectionProfile(Settings settings) {
   int connectionsPerNodeState = CONNECTIONS_PER_NODE_STATE.get(settings);
   ...
   builder.addConnections(DiscoveryNode.isMasterNode(settings) ? connectionsPerNodeState : 0, TransportRequestOptions.Type.STATE);
   return builder.build();
```

which is then used when creating all connections to the nodes. If master is set to false, then the default connection profile will have an empty `STATE` channel .

When enabling `client.transport.sniff`, `TransportClientNodeServices` will schedule the `SniffNodeSampler` to run every 5 seconds (instead of the standard `SimpleNodeSampler` which is not affected by this bug since it creates a new connection and uses the correct connection profile `LISTED_NODES_PROFILE` in `TransportClientNodeServices` which does contain a non-zero size channel `STATE`).


`SniffNodeSampler` will then attempt to use the already existing connection:

```
    if (nodes.contains(nodeToPing)) {
        try {
            pingConnection = transportService.getConnection(nodeToPing);
        } catch (NodeNotConnectedException e) {
            // will use a temp connection
        }
    }
```

and there is such a connection (a `NodeChannels`) after we've established connection to the node (in `establishNodeConnections`), however, it doesn't have any channel for `STATE`, and thus will throw in `ConnectionTypeHandle.getChannel`.

This PR uses the same mechanism (opening a new connection with the correct connection profile) as the `SimpleNodeSampler`, and avoids the issue. 