### PR TITLE
SQL: Handle the edge case of an empty array of values to return from source

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/FieldHitExtractor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/FieldHitExtractor.java
@@ -177,7 +177,7 @@ public class FieldHitExtractor implements HitExtractor {
                 
                 if (node instanceof List) {
                     List listOfValues = (List) node;
-                    if (listOfValues.size() == 1 || arrayLeniency) {
+                    if ((i < path.length - 1) && (listOfValues.size() == 1 || arrayLeniency)) {
                         // this is a List with a size of 1 e.g.: {"a" : [{"b" : "value"}]} meaning the JSON is a list with one element
                         // or a list of values with one element e.g.: {"a": {"b" : ["value"]}}
                         // in case of being lenient about arrays, just extract the first value in the array

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/FieldHitExtractorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/FieldHitExtractorTests.java
@@ -289,6 +289,12 @@ public class FieldHitExtractorTests extends AbstractWireSerializingTestCase<Fiel
         assertEquals(value, fe.extractFromSource(map));
     }
 
+    public void testEmptyArrayOfValues() {
+        FieldHitExtractor fe = new FieldHitExtractor("test_field", null, UTC, false, randomBoolean());
+        Map<String, Object> map = singletonMap("test_field", Collections.emptyList());
+        assertNull(fe.extractFromSource(map));
+    }
+
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public void testNestedFieldsWithDotsAndRandomHiearachy() {
         String[] path = new String[100];


### PR DESCRIPTION
This PR covers an edge case scenario where a field has an empty array of values in the `_source`. Something like `"my_field":[]`.

Fixes https://github.com/elastic/elasticsearch/issues/43863.