### PR TITLE
[Backport 7.x] Document API-Key APIs require manage_api_key priv

### DIFF
--- a/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
+++ b/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
@@ -48,6 +48,10 @@ same as the request for create role API. For more details, see
 `expiration`::
 (string) Optional expiration time for the API key. By default, API keys never expire.
 
+==== Authorization
+
+To use this API, you must have at least the `manage_api_key` cluster privilege.
+
 ==== Examples
 
 The following example creates an API key:

--- a/x-pack/docs/en/rest-api/security/get-api-keys.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-api-keys.asciidoc
@@ -39,6 +39,10 @@ or `name`.
 
 NOTE: While all parameters are optional, at least one of them is required.
 
+==== Authorization
+
+To use this API, you must have at least the `manage_api_key` cluster privilege.
+
 ==== Examples
 
 If you create an API key as follows:

--- a/x-pack/docs/en/rest-api/security/invalidate-api-keys.asciidoc
+++ b/x-pack/docs/en/rest-api/security/invalidate-api-keys.asciidoc
@@ -39,6 +39,10 @@ either `id` or `name`.
 
 NOTE: While all parameters are optional, at least one of them is required.
 
+==== Authorization
+
+To use this API, you must have at least the `manage_api_key` cluster privilege.
+
 ==== Examples
 
 If you create an API key as follows:


### PR DESCRIPTION
Add the "Authorization" section to the API key API docs.
These APIs require The new manage_api_key cluster privilege.

Relates: #43865
Backport of: #43811
