### PR TITLE
SQL: change the size of the list of concrete indices when resolving multiple indices

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolver.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolver.java
@@ -497,7 +497,7 @@ public class IndexResolver {
                     if (unmappedIndices.isEmpty() == true) {
                         concreteIndices = asList(capIndices);
                     } else {
-                        concreteIndices = new ArrayList<>(capIndices.length - unmappedIndices.size() + 1);
+                        concreteIndices = new ArrayList<>(capIndices.length);
                         for (String capIndex : capIndices) {
                             // add only indices that have a mapping
                             if (unmappedIndices.contains(capIndex) == false) {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
@@ -10,6 +10,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.type.DataType;
 import org.elasticsearch.xpack.sql.type.EsField;
 import org.elasticsearch.xpack.sql.type.InvalidMappedField;
+import org.elasticsearch.xpack.sql.type.KeywordEsField;
 import org.elasticsearch.xpack.sql.type.TypesTests;
 
 import java.util.ArrayList;
@@ -164,8 +165,6 @@ public class IndexResolverTests extends ESTestCase {
                 ((InvalidMappedField) esField).errorMessage());
     }
 
-
-
     public void testSeparateSameMappingDifferentIndices() throws Exception {
         Map<String, EsField> oneMapping = TypesTests.loadMapping("mapping-basic.json", true);
         Map<String, EsField> sameMapping = TypesTests.loadMapping("mapping-basic.json", true);
@@ -190,6 +189,26 @@ public class IndexResolverTests extends ESTestCase {
         assertEquals(2, indices.size());
         assertEqualsMaps(basicMapping, indices.get(0).mapping());
         assertEqualsMaps(incompatible, indices.get(1).mapping());
+    }
+
+    // covers the scenario described in https://github.com/elastic/elasticsearch/issues/43876
+    public void testMultipleCompatibleIndicesWithDifferentFields() {
+        int indicesCount = randomIntBetween(3, 15);
+        EsIndex[] expectedIndices = new EsIndex[indicesCount];
+        
+        // each index will have one field with different name than all others
+        for (int i = 0; i < indicesCount; i++) {
+            Map<String, EsField> mapping = new HashMap<>(1);
+            String fieldName = "field" + (i + 1);
+            mapping.put(fieldName, new KeywordEsField(fieldName));
+            expectedIndices[i] = new EsIndex("index" + (i + 1), mapping);
+        }
+        
+        List<EsIndex> actualIndices = separate(expectedIndices);
+        assertEquals(indicesCount, actualIndices.size());
+        for (int i = 0; i < indicesCount; i++) {
+            assertEqualsMaps(expectedIndices[i].mapping(), actualIndices.get(i).mapping());
+        }
     }
 
     public static IndexResolution merge(EsIndex... indices) {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
@@ -193,7 +193,7 @@ public class IndexResolverTests extends ESTestCase {
 
     // covers the scenario described in https://github.com/elastic/elasticsearch/issues/43876
     public void testMultipleCompatibleIndicesWithDifferentFields() {
-        int indicesCount = randomIntBetween(3, 15);
+        int indicesCount = randomIntBetween(2, 15);
         EsIndex[] expectedIndices = new EsIndex[indicesCount];
         
         // each index will have one field with different name than all others


### PR DESCRIPTION
The size of the ArrayList we were creating was wrong for more than four indices. This PR adds a test covering this scenario, as well.

Fixes https://github.com/elastic/elasticsearch/issues/43876.