### PR TITLE
Link rare_terms docs from buckets index page

### DIFF
--- a/docs/reference/aggregations/bucket.asciidoc
+++ b/docs/reference/aggregations/bucket.asciidoc
@@ -55,6 +55,8 @@ include::bucket/parent-aggregation.asciidoc[]
 
 include::bucket/range-aggregation.asciidoc[]
 
+include::bucket/rare-terms-aggregation.asciidoc[]
+
 include::bucket/reverse-nested-aggregation.asciidoc[]
 
 include::bucket/sampler-aggregation.asciidoc[]


### PR DESCRIPTION
Docs for `rare_terms` were added in #35718, but neglected to link it from the bucket index page :man_facepalming: 

Putting this up for a quick CI just to make sure tests work, etc. No need for review