### PR TITLE
Add name() method to TokenizerFactory

### DIFF
--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CharGroupTokenizerFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CharGroupTokenizerFactory.java
@@ -39,7 +39,7 @@ public class CharGroupTokenizerFactory extends AbstractTokenizerFactory{
     private boolean tokenizeOnSymbol = false;
 
     public CharGroupTokenizerFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, settings);
+        super(indexSettings, settings, name);
 
         for (final String c : settings.getAsList("tokenize_on_chars")) {
             if (c == null || c.length() == 0) {

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ClassicTokenizerFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ClassicTokenizerFactory.java
@@ -35,7 +35,7 @@ public class ClassicTokenizerFactory extends AbstractTokenizerFactory {
     private final int maxTokenLength;
 
     ClassicTokenizerFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, settings);
+        super(indexSettings, settings, name);
         maxTokenLength = settings.getAsInt("max_token_length", StandardAnalyzer.DEFAULT_MAX_TOKEN_LENGTH);
     }
 

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/EdgeNGramTokenizerFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/EdgeNGramTokenizerFactory.java
@@ -36,7 +36,7 @@ public class EdgeNGramTokenizerFactory extends AbstractTokenizerFactory {
     private final CharMatcher matcher;
 
     EdgeNGramTokenizerFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, settings);
+        super(indexSettings, settings, name);
         this.minGram = settings.getAsInt("min_gram", NGramTokenizer.DEFAULT_MIN_NGRAM_SIZE);
         this.maxGram = settings.getAsInt("max_gram", NGramTokenizer.DEFAULT_MAX_NGRAM_SIZE);
         this.matcher = parseTokenChars(settings.getAsList("token_chars"));

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/KeywordTokenizerFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/KeywordTokenizerFactory.java
@@ -31,7 +31,7 @@ public class KeywordTokenizerFactory extends AbstractTokenizerFactory {
     private final int bufferSize;
 
     KeywordTokenizerFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, settings);
+        super(indexSettings, settings, name);
         bufferSize = settings.getAsInt("buffer_size", 256);
     }
 

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/LetterTokenizerFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/LetterTokenizerFactory.java
@@ -29,7 +29,7 @@ import org.elasticsearch.index.analysis.AbstractTokenizerFactory;
 public class LetterTokenizerFactory extends AbstractTokenizerFactory {
 
     LetterTokenizerFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, settings);
+        super(indexSettings, settings, name);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/NGramTokenizerFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/NGramTokenizerFactory.java
@@ -84,7 +84,7 @@ public class NGramTokenizerFactory extends AbstractTokenizerFactory {
     }
 
     NGramTokenizerFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, settings);
+        super(indexSettings, settings, name);
         int maxAllowedNgramDiff = indexSettings.getMaxNgramDiff();
         this.minGram = settings.getAsInt("min_gram", NGramTokenizer.DEFAULT_MIN_NGRAM_SIZE);
         this.maxGram = settings.getAsInt("max_gram", NGramTokenizer.DEFAULT_MAX_NGRAM_SIZE);

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/PathHierarchyTokenizerFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/PathHierarchyTokenizerFactory.java
@@ -37,7 +37,7 @@ public class PathHierarchyTokenizerFactory extends AbstractTokenizerFactory {
     private final boolean reverse;
 
     PathHierarchyTokenizerFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, settings);
+        super(indexSettings, settings, name);
         bufferSize = settings.getAsInt("buffer_size", 1024);
         String delimiter = settings.get("delimiter");
         if (delimiter == null) {

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/PatternTokenizerFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/PatternTokenizerFactory.java
@@ -35,7 +35,7 @@ public class PatternTokenizerFactory extends AbstractTokenizerFactory {
     private final int group;
 
     PatternTokenizerFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, settings);
+        super(indexSettings, settings, name);
 
         String sPattern = settings.get("pattern", "\\W+" /*PatternAnalyzer.NON_WORD_PATTERN*/);
         if (sPattern == null) {

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SimplePatternSplitTokenizerFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SimplePatternSplitTokenizerFactory.java
@@ -31,7 +31,7 @@ public class SimplePatternSplitTokenizerFactory extends AbstractTokenizerFactory
     private final String pattern;
 
     public SimplePatternSplitTokenizerFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, settings);
+        super(indexSettings, settings, name);
 
         pattern = settings.get("pattern", "");
     }

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SimplePatternTokenizerFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SimplePatternTokenizerFactory.java
@@ -31,7 +31,7 @@ public class SimplePatternTokenizerFactory extends AbstractTokenizerFactory {
     private final String pattern;
 
     public SimplePatternTokenizerFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, settings);
+        super(indexSettings, settings, name);
 
         pattern = settings.get("pattern", "");
     }

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
@@ -116,7 +116,7 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
 
     Analyzer buildSynonymAnalyzer(TokenizerFactory tokenizer, List<CharFilterFactory> charFilters,
                                   List<TokenFilterFactory> tokenFilters, Function<String, TokenFilterFactory> allFilters) {
-        return new CustomAnalyzer("synonyms", tokenizer, charFilters.toArray(new CharFilterFactory[0]),
+        return new CustomAnalyzer(tokenizer, charFilters.toArray(new CharFilterFactory[0]),
             tokenFilters.stream()
                 .map(TokenFilterFactory::getSynonymFilter)
                 .toArray(TokenFilterFactory[]::new));

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ThaiTokenizerFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ThaiTokenizerFactory.java
@@ -32,7 +32,7 @@ import org.elasticsearch.index.analysis.AbstractTokenizerFactory;
 public class ThaiTokenizerFactory extends AbstractTokenizerFactory {
 
     ThaiTokenizerFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, settings);
+        super(indexSettings, settings, name);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/UAX29URLEmailTokenizerFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/UAX29URLEmailTokenizerFactory.java
@@ -32,7 +32,7 @@ public class UAX29URLEmailTokenizerFactory extends AbstractTokenizerFactory {
     private final int maxTokenLength;
 
     UAX29URLEmailTokenizerFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, settings);
+        super(indexSettings, settings, name);
         maxTokenLength = settings.getAsInt("max_token_length", StandardAnalyzer.DEFAULT_MAX_TOKEN_LENGTH);
     }
 

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/WhitespaceTokenizerFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/WhitespaceTokenizerFactory.java
@@ -34,7 +34,7 @@ public class WhitespaceTokenizerFactory extends AbstractTokenizerFactory {
     private Integer maxTokenLength;
 
     WhitespaceTokenizerFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, settings);
+        super(indexSettings, settings, name);
         maxTokenLength = settings.getAsInt(MAX_TOKEN_LENGTH, StandardAnalyzer.DEFAULT_MAX_TOKEN_LENGTH);
     }
 

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/XLowerCaseTokenizerFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/XLowerCaseTokenizerFactory.java
@@ -30,7 +30,7 @@ import org.elasticsearch.index.analysis.AbstractTokenizerFactory;
 public class XLowerCaseTokenizerFactory extends AbstractTokenizerFactory {
 
     public XLowerCaseTokenizerFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, settings);
+        super(indexSettings, settings, name);
     }
 
     @Override

--- a/modules/analysis-common/src/test/resources/rest-api-spec/test/analysis-common/30_tokenizers.yml
+++ b/modules/analysis-common/src/test/resources/rest-api-spec/test/analysis-common/30_tokenizers.yml
@@ -19,7 +19,7 @@
             tokenizer:
               type: keyword
     - length: { detail.tokenizer.tokens: 1 }
-    - match:  { detail.tokenizer.name: _anonymous_tokenizer }
+    - match:  { detail.tokenizer.name: __anonymous__keyword }
     - match:  { detail.tokenizer.tokens.0.token: Foo Bar! }
 
 ---
@@ -33,7 +33,7 @@
               type: simple_pattern
               pattern: "[abcdef0123456789]{4}"
     - length: { detail.tokenizer.tokens: 2 }
-    - match:  { detail.tokenizer.name: _anonymous_tokenizer }
+    - match:  { detail.tokenizer.name: __anonymous__simple_pattern }
     - match:  { detail.tokenizer.tokens.0.token: a6bf }
     - match:  { detail.tokenizer.tokens.1.token: ff61 }
 
@@ -48,7 +48,7 @@
               type: simple_pattern_split
               pattern: ==
     - length: { detail.tokenizer.tokens: 2 }
-    - match:  { detail.tokenizer.name: _anonymous_tokenizer }
+    - match:  { detail.tokenizer.name: __anonymous__simple_pattern_split }
     - match:  { detail.tokenizer.tokens.0.token: foo }
     - match:  { detail.tokenizer.tokens.1.token: bar }
 
@@ -62,7 +62,7 @@
             tokenizer:
               type: thai
     - length: { detail.tokenizer.tokens: 2 }
-    - match:  { detail.tokenizer.name: _anonymous_tokenizer }
+    - match:  { detail.tokenizer.name: __anonymous__thai }
     - match:  { detail.tokenizer.tokens.0.token: ภาษา }
     - match:  { detail.tokenizer.tokens.1.token: ไทย }
 
@@ -89,7 +89,7 @@
               min_gram: 3
               max_gram: 3
     - length: { detail.tokenizer.tokens: 4 }
-    - match:  { detail.tokenizer.name: _anonymous_tokenizer }
+    - match:  { detail.tokenizer.name: __anonymous__ngram }
     - match:  { detail.tokenizer.tokens.0.token: foo }
     - match:  { detail.tokenizer.tokens.1.token: oob }
     - match:  { detail.tokenizer.tokens.2.token: oba }
@@ -105,7 +105,7 @@
               min_gram: 3
               max_gram: 3
     - length: { detail.tokenizer.tokens: 4 }
-    - match:  { detail.tokenizer.name: _anonymous_tokenizer }
+    - match:  { detail.tokenizer.name: __anonymous__ngram }
     - match:  { detail.tokenizer.tokens.0.token: foo }
     - match:  { detail.tokenizer.tokens.1.token: oob }
     - match:  { detail.tokenizer.tokens.2.token: oba }
@@ -164,7 +164,7 @@
               min_gram: 1
               max_gram: 3
     - length: { detail.tokenizer.tokens: 3 }
-    - match:  { detail.tokenizer.name: _anonymous_tokenizer }
+    - match:  { detail.tokenizer.name: __anonymous__edge_ngram }
     - match:  { detail.tokenizer.tokens.0.token: f }
     - match:  { detail.tokenizer.tokens.1.token: fo }
     - match:  { detail.tokenizer.tokens.2.token: foo }
@@ -179,7 +179,7 @@
               min_gram: 1
               max_gram: 3
     - length: { detail.tokenizer.tokens: 3 }
-    - match:  { detail.tokenizer.name: _anonymous_tokenizer }
+    - match:  { detail.tokenizer.name: __anonymous__edge_ngram }
     - match:  { detail.tokenizer.tokens.0.token: f }
     - match:  { detail.tokenizer.tokens.1.token: fo }
     - match:  { detail.tokenizer.tokens.2.token: foo }
@@ -216,7 +216,7 @@
             tokenizer:
               type: classic
     - length: { detail.tokenizer.tokens: 4 }
-    - match:  { detail.tokenizer.name: _anonymous_tokenizer }
+    - match:  { detail.tokenizer.name: __anonymous__classic }
     - match:  { detail.tokenizer.tokens.0.token: Brown }
     - match:  { detail.tokenizer.tokens.1.token: Foxes }
     - match:  { detail.tokenizer.tokens.2.token: don't }
@@ -245,7 +245,7 @@
             tokenizer:
               type: letter
     - length: { detail.tokenizer.tokens: 5 }
-    - match:  { detail.tokenizer.name: _anonymous_tokenizer }
+    - match:  { detail.tokenizer.name: __anonymous__letter }
     - match:  { detail.tokenizer.tokens.0.token: Brown }
     - match:  { detail.tokenizer.tokens.1.token: Foxes }
     - match:  { detail.tokenizer.tokens.2.token: don }
@@ -276,7 +276,7 @@
             tokenizer:
               type: lowercase
     - length: { detail.tokenizer.tokens: 5 }
-    - match:  { detail.tokenizer.name: _anonymous_tokenizer }
+    - match:  { detail.tokenizer.name: __anonymous__lowercase }
     - match:  { detail.tokenizer.tokens.0.token: brown }
     - match:  { detail.tokenizer.tokens.1.token: foxes }
     - match:  { detail.tokenizer.tokens.2.token: don }
@@ -307,7 +307,7 @@
             tokenizer:
               type: path_hierarchy
     - length: { detail.tokenizer.tokens: 3 }
-    - match:  { detail.tokenizer.name: _anonymous_tokenizer }
+    - match:  { detail.tokenizer.name: __anonymous__path_hierarchy }
     - match:  { detail.tokenizer.tokens.0.token: a }
     - match:  { detail.tokenizer.tokens.1.token: a/b }
     - match:  { detail.tokenizer.tokens.2.token: a/b/c }
@@ -320,7 +320,7 @@
             tokenizer:
               type: PathHierarchy
     - length: { detail.tokenizer.tokens: 3 }
-    - match:  { detail.tokenizer.name: _anonymous_tokenizer }
+    - match:  { detail.tokenizer.name: __anonymous__PathHierarchy }
     - match:  { detail.tokenizer.tokens.0.token: a }
     - match:  { detail.tokenizer.tokens.1.token: a/b }
     - match:  { detail.tokenizer.tokens.2.token: a/b/c }
@@ -359,7 +359,7 @@
             tokenizer:
               type: pattern
     - length: { detail.tokenizer.tokens: 5 }
-    - match:  { detail.tokenizer.name: _anonymous_tokenizer }
+    - match:  { detail.tokenizer.name: __anonymous__pattern }
     - match:  { detail.tokenizer.tokens.0.token: split }
     - match:  { detail.tokenizer.tokens.1.token: by }
     - match:  { detail.tokenizer.tokens.2.token: whitespace }
@@ -390,7 +390,7 @@
             tokenizer:
               type: uax_url_email
     - length: { detail.tokenizer.tokens: 4 }
-    - match:  { detail.tokenizer.name: _anonymous_tokenizer }
+    - match:  { detail.tokenizer.name: __anonymous__uax_url_email }
     - match:  { detail.tokenizer.tokens.0.token: Email }
     - match:  { detail.tokenizer.tokens.1.token: me }
     - match:  { detail.tokenizer.tokens.2.token: at }
@@ -419,7 +419,7 @@
             tokenizer:
               type: whitespace
     - length: { detail.tokenizer.tokens: 3 }
-    - match:  { detail.tokenizer.name: _anonymous_tokenizer }
+    - match:  { detail.tokenizer.name: __anonymous__whitespace }
     - match:  { detail.tokenizer.tokens.0.token: split }
     - match:  { detail.tokenizer.tokens.1.token: by }
     - match:  { detail.tokenizer.tokens.2.token: whitespace }

--- a/modules/analysis-common/src/test/resources/rest-api-spec/test/indices.analyze/10_analyze.yml
+++ b/modules/analysis-common/src/test/resources/rest-api-spec/test/indices.analyze/10_analyze.yml
@@ -55,7 +55,7 @@
 
     - length: { detail.tokenizer.tokens: 1 }
     - length: { detail.tokenfilters.0.tokens: 1 }
-    - match:  { detail.tokenizer.name: keyword_for_normalizer }
+    - match:  { detail.tokenizer.name: keyword }
     - match:  { detail.tokenizer.tokens.0.token: ABc }
     - match:  { detail.tokenfilters.0.name: lowercase }
     - match:  { detail.tokenfilters.0.tokens.0.token: abc }

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/analysis/IcuTokenizerFactory.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/analysis/IcuTokenizerFactory.java
@@ -47,7 +47,7 @@ public class IcuTokenizerFactory extends AbstractTokenizerFactory {
     private static final String RULE_FILES = "rule_files";
 
     public IcuTokenizerFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, settings);
+        super(indexSettings, settings, name);
         config = getIcuConfig(environment, settings);
     }
 

--- a/plugins/analysis-kuromoji/src/main/java/org/elasticsearch/index/analysis/KuromojiTokenizerFactory.java
+++ b/plugins/analysis-kuromoji/src/main/java/org/elasticsearch/index/analysis/KuromojiTokenizerFactory.java
@@ -45,7 +45,7 @@ public class KuromojiTokenizerFactory extends AbstractTokenizerFactory {
     private boolean discartPunctuation;
 
     public KuromojiTokenizerFactory(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, settings);
+        super(indexSettings, settings, name);
         mode = getMode(settings);
         userDictionary = getUserDictionary(env, settings);
         discartPunctuation = settings.getAsBoolean("discard_punctuation", true);

--- a/plugins/analysis-nori/src/main/java/org/elasticsearch/index/analysis/NoriTokenizerFactory.java
+++ b/plugins/analysis-nori/src/main/java/org/elasticsearch/index/analysis/NoriTokenizerFactory.java
@@ -41,7 +41,7 @@ public class NoriTokenizerFactory extends AbstractTokenizerFactory {
     private final KoreanTokenizer.DecompoundMode decompoundMode;
 
     public NoriTokenizerFactory(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, settings);
+        super(indexSettings, settings, name);
         decompoundMode = getMode(settings);
         userDictionary = getUserDictionary(env, settings);
     }

--- a/plugins/analysis-smartcn/src/main/java/org/elasticsearch/index/analysis/SmartChineseTokenizerTokenizerFactory.java
+++ b/plugins/analysis-smartcn/src/main/java/org/elasticsearch/index/analysis/SmartChineseTokenizerTokenizerFactory.java
@@ -28,7 +28,7 @@ import org.elasticsearch.index.IndexSettings;
 public class SmartChineseTokenizerTokenizerFactory extends AbstractTokenizerFactory {
 
     public SmartChineseTokenizerTokenizerFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, settings);
+        super(indexSettings, settings, name);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
@@ -278,7 +278,6 @@ public class TransportAnalyzeAction extends TransportSingleShardAction<AnalyzeAc
             CharFilterFactory[] charFilterFactories = components.getCharFilters();
             TokenizerFactory tokenizerFactory = components.getTokenizerFactory();
             TokenFilterFactory[] tokenFilterFactories = components.getTokenFilters();
-            String tokenizerName = components.getTokenizerName();
 
             String[][] charFiltersTexts = new String[charFilterFactories != null ? charFilterFactories.length : 0][request.text().length];
             TokenListCreator[] tokenFiltersTokenListCreator = new TokenListCreator[tokenFilterFactories != null ?
@@ -338,7 +337,8 @@ public class TransportAnalyzeAction extends TransportSingleShardAction<AnalyzeAc
                 }
             }
             detailResponse = new AnalyzeAction.DetailAnalyzeResponse(charFilteredLists,
-                    new AnalyzeAction.AnalyzeTokenList(tokenizerName, tokenizerTokenListCreator.getArrayTokens()), tokenFilterLists);
+                new AnalyzeAction.AnalyzeTokenList(tokenizerFactory.name(), tokenizerTokenListCreator.getArrayTokens()),
+                tokenFilterLists);
         } else {
             String name;
             if (analyzer instanceof NamedAnalyzer) {

--- a/server/src/main/java/org/elasticsearch/index/analysis/AbstractTokenizerFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/AbstractTokenizerFactory.java
@@ -26,13 +26,20 @@ import org.elasticsearch.index.IndexSettings;
 
 public abstract class AbstractTokenizerFactory extends AbstractIndexComponent implements TokenizerFactory {
     protected final Version version;
+    private final String name;
 
-    public AbstractTokenizerFactory(IndexSettings indexSettings, Settings settings) {
+    public AbstractTokenizerFactory(IndexSettings indexSettings, Settings settings, String name) {
         super(indexSettings);
         this.version = Analysis.parseAnalysisVersion(this.indexSettings.getSettings(), settings, logger);
+        this.name = name;
     }
 
     public final Version version() {
         return version;
+    }
+
+    @Override
+    public String name() {
+        return name;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.index.analysis;
 
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.core.KeywordTokenizer;
 import org.apache.lucene.analysis.core.WhitespaceTokenizer;
 import org.elasticsearch.ElasticsearchException;

--- a/server/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
@@ -19,6 +19,8 @@
 package org.elasticsearch.index.analysis;
 
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.core.KeywordTokenizer;
 import org.apache.lucene.analysis.core.WhitespaceTokenizer;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
@@ -245,11 +247,7 @@ public final class AnalysisRegistry implements Closeable {
             tokenFilterFactories.add(tff);
         }
 
-        String tokenizerName = tokenizer.name == null ? "_anonymous_tokenizer" : tokenizer.name;
-        if (normalizer) {
-            tokenizerName = "keyword_for_normalizer";
-        }
-        Analyzer analyzer = new CustomAnalyzer(tokenizerName, tokenizerFactory,
+        Analyzer analyzer = new CustomAnalyzer(tokenizerFactory,
             charFilterFactories.toArray(new CharFilterFactory[]{}),
             tokenFilterFactories.toArray(new TokenFilterFactory[]{}));
         return produceAnalyzer("__custom__", new AnalyzerProvider<>() {
@@ -531,10 +529,12 @@ public final class AnalysisRegistry implements Closeable {
                     });
         }
         for (Map.Entry<String, AnalyzerProvider<?>> entry : normalizerProviders.entrySet()) {
-            processNormalizerFactory(entry.getKey(), entry.getValue(), normalizers, "keyword",
-                tokenizerFactoryFactories.get("keyword"), tokenFilterFactoryFactories, charFilterFactoryFactories);
+            processNormalizerFactory(entry.getKey(), entry.getValue(), normalizers,
+                TokenizerFactory.newFactory("keyword", KeywordTokenizer::new),
+                tokenFilterFactoryFactories, charFilterFactoryFactories);
             processNormalizerFactory(entry.getKey(), entry.getValue(), whitespaceNormalizers,
-                    "whitespace", () -> new WhitespaceTokenizer(), tokenFilterFactoryFactories, charFilterFactoryFactories);
+                TokenizerFactory.newFactory("whitespace", WhitespaceTokenizer::new),
+                tokenFilterFactoryFactories, charFilterFactoryFactories);
         }
 
         if (!analyzers.containsKey(DEFAULT_ANALYZER_NAME)) {
@@ -607,7 +607,6 @@ public final class AnalysisRegistry implements Closeable {
             String name,
             AnalyzerProvider<?> normalizerFactory,
             Map<String, NamedAnalyzer> normalizers,
-            String tokenizerName,
             TokenizerFactory tokenizerFactory,
             Map<String, TokenFilterFactory> tokenFilters,
             Map<String, CharFilterFactory> charFilters) {
@@ -616,7 +615,7 @@ public final class AnalysisRegistry implements Closeable {
         }
 
         if (normalizerFactory instanceof CustomNormalizerProvider) {
-            ((CustomNormalizerProvider) normalizerFactory).build(tokenizerName, tokenizerFactory, charFilters, tokenFilters);
+            ((CustomNormalizerProvider) normalizerFactory).build(tokenizerFactory, charFilters, tokenFilters);
         }
         if (normalizers.containsKey(name)) {
             throw new IllegalStateException("already registered analyzer with name: " + name);

--- a/server/src/main/java/org/elasticsearch/index/analysis/AnalyzerComponents.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/AnalyzerComponents.java
@@ -30,15 +30,15 @@ import java.util.Map;
  * See {@link ReloadableCustomAnalyzer} for an example usage.
  */
 public final class AnalyzerComponents {
-    private final String tokenizerName;
+
     private final TokenizerFactory tokenizerFactory;
     private final CharFilterFactory[] charFilters;
     private final TokenFilterFactory[] tokenFilters;
     private final AnalysisMode analysisMode;
 
-    AnalyzerComponents(String tokenizerName, TokenizerFactory tokenizerFactory, CharFilterFactory[] charFilters,
+    AnalyzerComponents(TokenizerFactory tokenizerFactory, CharFilterFactory[] charFilters,
                        TokenFilterFactory[] tokenFilters) {
-        this.tokenizerName = tokenizerName;
+
         this.tokenizerFactory = tokenizerFactory;
         this.charFilters = charFilters;
         this.tokenFilters = tokenFilters;
@@ -85,12 +85,8 @@ public final class AnalyzerComponents {
             tokenFilterList.add(tokenFilter);
         }
 
-        return new AnalyzerComponents(tokenizerName, tokenizer, charFiltersList.toArray(new CharFilterFactory[charFiltersList.size()]),
+        return new AnalyzerComponents(tokenizer, charFiltersList.toArray(new CharFilterFactory[charFiltersList.size()]),
                 tokenFilterList.toArray(new TokenFilterFactory[tokenFilterList.size()]));
-    }
-
-    public String getTokenizerName() {
-        return tokenizerName;
     }
 
     public TokenizerFactory getTokenizerFactory() {

--- a/server/src/main/java/org/elasticsearch/index/analysis/CustomAnalyzer.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/CustomAnalyzer.java
@@ -32,14 +32,14 @@ public final class CustomAnalyzer extends Analyzer implements AnalyzerComponents
     private final int offsetGap;
     private final AnalysisMode analysisMode;
 
-    public CustomAnalyzer(String tokenizerName, TokenizerFactory tokenizerFactory, CharFilterFactory[] charFilters,
+    public CustomAnalyzer(TokenizerFactory tokenizerFactory, CharFilterFactory[] charFilters,
             TokenFilterFactory[] tokenFilters) {
-        this(tokenizerName, tokenizerFactory, charFilters, tokenFilters, 0, -1);
+        this(tokenizerFactory, charFilters, tokenFilters, 0, -1);
     }
 
-    public CustomAnalyzer(String tokenizerName, TokenizerFactory tokenizerFactory, CharFilterFactory[] charFilters,
+    public CustomAnalyzer(TokenizerFactory tokenizerFactory, CharFilterFactory[] charFilters,
             TokenFilterFactory[] tokenFilters, int positionIncrementGap, int offsetGap) {
-        this.components = new AnalyzerComponents(tokenizerName, tokenizerFactory, charFilters, tokenFilters);
+        this.components = new AnalyzerComponents(tokenizerFactory, charFilters, tokenFilters);
         this.positionIncrementGap = positionIncrementGap;
         this.offsetGap = offsetGap;
         // merge and transfer token filter analysis modes with analyzer
@@ -48,13 +48,6 @@ public final class CustomAnalyzer extends Analyzer implements AnalyzerComponents
             mode = mode.merge(f.getAnalysisMode());
         }
         this.analysisMode = mode;
-    }
-
-    /**
-     * The name of the tokenizer as configured by the user.
-     */
-    public String getTokenizerName() {
-        return this.components.getTokenizerName();
     }
 
     public TokenizerFactory tokenizerFactory() {

--- a/server/src/main/java/org/elasticsearch/index/analysis/CustomAnalyzerProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/CustomAnalyzerProvider.java
@@ -64,7 +64,7 @@ public class CustomAnalyzerProvider extends AbstractIndexAnalyzerProvider<Analyz
         if (components.analysisMode().equals(AnalysisMode.SEARCH_TIME)) {
             return new ReloadableCustomAnalyzer(components, positionIncrementGap, offsetGap);
         } else {
-            return new CustomAnalyzer(components.getTokenizerName(), components.getTokenizerFactory(), components.getCharFilters(),
+            return new CustomAnalyzer(components.getTokenizerFactory(), components.getCharFilters(),
                     components.getTokenFilters(), positionIncrementGap, offsetGap);
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/analysis/CustomNormalizerProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/CustomNormalizerProvider.java
@@ -43,7 +43,7 @@ public final class CustomNormalizerProvider extends AbstractIndexAnalyzerProvide
         this.analyzerSettings = settings;
     }
 
-    public void build(final String tokenizerName, final TokenizerFactory tokenizerFactory, final Map<String, CharFilterFactory> charFilters,
+    public void build(final TokenizerFactory tokenizerFactory, final Map<String, CharFilterFactory> charFilters,
             final Map<String, TokenFilterFactory> tokenFilters) {
         if (analyzerSettings.get("tokenizer") != null) {
             throw new IllegalArgumentException("Custom normalizer [" + name() + "] cannot configure a tokenizer");
@@ -79,7 +79,6 @@ public final class CustomNormalizerProvider extends AbstractIndexAnalyzerProvide
         }
 
         this.customAnalyzer = new CustomAnalyzer(
-                tokenizerName,
                 tokenizerFactory,
                 charFiltersList.toArray(new CharFilterFactory[charFiltersList.size()]),
                 tokenFilterList.toArray(new TokenFilterFactory[tokenFilterList.size()])

--- a/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredAnalysisComponent.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredAnalysisComponent.java
@@ -32,7 +32,7 @@ import java.io.IOException;
  * Shared implementation for pre-configured analysis components.
  */
 public abstract class PreConfiguredAnalysisComponent<T> implements AnalysisModule.AnalysisProvider<T> {
-    private final String name;
+    protected final String name;
     protected final PreBuiltCacheFactory.PreBuiltCache<T> cache;
 
     protected PreConfiguredAnalysisComponent(String name, PreBuiltCacheFactory.CachingStrategy cache) {

--- a/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredTokenizer.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredTokenizer.java
@@ -70,6 +70,6 @@ public final class PreConfiguredTokenizer extends PreConfiguredAnalysisComponent
 
     @Override
     protected TokenizerFactory create(Version version) {
-        return () -> create.apply(version);
+        return TokenizerFactory.newFactory(name, () -> create.apply(version));
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/analysis/StandardTokenizerFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/StandardTokenizerFactory.java
@@ -31,7 +31,7 @@ public class StandardTokenizerFactory extends AbstractTokenizerFactory {
     private final int maxTokenLength;
 
     public StandardTokenizerFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, settings);
+        super(indexSettings, settings, name);
         maxTokenLength = settings.getAsInt("max_token_length", StandardAnalyzer.DEFAULT_MAX_TOKEN_LENGTH);
     }
 

--- a/server/src/main/java/org/elasticsearch/index/analysis/TokenizerFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/TokenizerFactory.java
@@ -21,6 +21,25 @@ package org.elasticsearch.index.analysis;
 
 import org.apache.lucene.analysis.Tokenizer;
 
+import java.util.function.Supplier;
+
 public interface TokenizerFactory {
+
+    String name();
+
     Tokenizer create();
+
+    static TokenizerFactory newFactory(String name, Supplier<Tokenizer> supplier) {
+        return new TokenizerFactory() {
+            @Override
+            public String name() {
+                return name;
+            }
+
+            @Override
+            public Tokenizer create() {
+                return supplier.get();
+            }
+        };
+    }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/TransportAnalyzeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/TransportAnalyzeActionTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.action.admin.indices;
 import org.apache.lucene.analysis.MockTokenFilter;
 import org.apache.lucene.analysis.MockTokenizer;
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.elasticsearch.Version;

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/TransportAnalyzeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/TransportAnalyzeActionTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.indices;
 import org.apache.lucene.analysis.MockTokenFilter;
 import org.apache.lucene.analysis.MockTokenizer;
 import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.elasticsearch.Version;
@@ -131,7 +132,7 @@ public class TransportAnalyzeActionTests extends ESTestCase {
             @Override
             public Map<String, AnalysisProvider<TokenizerFactory>> getTokenizers() {
                 return singletonMap("keyword", (indexSettings, environment, name, settings) ->
-                    () -> new MockTokenizer(MockTokenizer.KEYWORD, false));
+                    TokenizerFactory.newFactory(name, () -> new MockTokenizer(MockTokenizer.KEYWORD, false)));
             }
 
             @Override

--- a/server/src/test/java/org/elasticsearch/index/analysis/AnalysisRegistryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/AnalysisRegistryTests.java
@@ -120,7 +120,7 @@ public class AnalysisRegistryTests extends ESTestCase {
                 return null;
             }
         };
-        Analyzer analyzer = new CustomAnalyzer("tokenizerName", null, new CharFilterFactory[0], new TokenFilterFactory[] { tokenFilter });
+        Analyzer analyzer = new CustomAnalyzer(null, new CharFilterFactory[0], new TokenFilterFactory[] { tokenFilter });
         MapperException ex = expectThrows(MapperException.class,
                 () -> emptyRegistry.build(IndexSettingsModule.newIndexSettings("index", settings),
                         singletonMap("default", new PreBuiltAnalyzerProvider("default", AnalyzerScope.INDEX, analyzer)), emptyMap(),

--- a/server/src/test/java/org/elasticsearch/index/analysis/CustomNormalizerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/CustomNormalizerTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.analysis;
 
 import org.apache.lucene.analysis.MockLowerCaseFilter;
 import org.apache.lucene.analysis.MockTokenizer;
-import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;

--- a/server/src/test/java/org/elasticsearch/index/analysis/CustomNormalizerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/CustomNormalizerTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.analysis;
 
 import org.apache.lucene.analysis.MockLowerCaseFilter;
 import org.apache.lucene.analysis.MockTokenizer;
+import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
@@ -170,7 +171,7 @@ public class CustomNormalizerTests extends ESTokenStreamTestCase {
         @Override
         public Map<String, AnalysisProvider<TokenizerFactory>> getTokenizers() {
             return singletonMap("keyword", (indexSettings, environment, name, settings) ->
-                () -> new MockTokenizer(MockTokenizer.KEYWORD, false));
+                TokenizerFactory.newFactory(name, () -> new MockTokenizer(MockTokenizer.KEYWORD, false)));
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/analysis/NamedAnalyzerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/NamedAnalyzerTests.java
@@ -73,7 +73,7 @@ public class NamedAnalyzerTests extends ESTestCase {
                 return mode;
             }
         };
-        return new CustomAnalyzer("tokenizerName", null, new CharFilterFactory[0],
+        return new CustomAnalyzer(null, new CharFilterFactory[0],
                 new TokenFilterFactory[] { tokenFilter  });
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/analysis/ReloadableCustomAnalyzerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/ReloadableCustomAnalyzerTests.java
@@ -94,7 +94,7 @@ public class ReloadableCustomAnalyzerTests extends ESTestCase {
         try (ReloadableCustomAnalyzer analyzer = new ReloadableCustomAnalyzer(components, positionIncrementGap, offsetGap)) {
             assertEquals(positionIncrementGap, analyzer.getPositionIncrementGap(randomAlphaOfLength(5)));
             assertEquals(offsetGap >= 0 ? offsetGap : 1, analyzer.getOffsetGap(randomAlphaOfLength(5)));
-            assertEquals("standard", analyzer.getComponents().getTokenizerName());
+            assertEquals("standard", analyzer.getComponents().getTokenizerFactory().name());
             assertEquals(0, analyzer.getComponents().getCharFilters().length);
             assertSame(testAnalysis.tokenizer.get("standard"), analyzer.getComponents().getTokenizerFactory());
             assertEquals(1, analyzer.getComponents().getTokenFilters().length);

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -69,16 +69,8 @@ public class KeywordFieldMapperTests extends ESSingleNodeTestCase {
 
         @Override
         public Map<String, AnalysisModule.AnalysisProvider<TokenizerFactory>> getTokenizers() {
-            return singletonMap("keyword", (indexSettings, environment, name, settings) -> {
-                class Factory implements TokenizerFactory {
-
-                    @Override
-                    public Tokenizer create() {
-                        return new MockTokenizer(MockTokenizer.KEYWORD, false);
-                    }
-                }
-                return new Factory();
-            });
+            return singletonMap("keyword", (indexSettings, environment, name, settings) ->
+                TokenizerFactory.newFactory(name, () -> new MockTokenizer(MockTokenizer.KEYWORD, false)));
         }
 
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.analysis.MockLowerCaseFilter;
 import org.apache.lucene.analysis.MockTokenizer;
-import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;

--- a/server/src/test/java/org/elasticsearch/index/mapper/TypeParsersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TypeParsersTests.java
@@ -224,7 +224,7 @@ public class TypeParsersTests extends ESTestCase {
                 return null;
             }
         };
-        return new CustomAnalyzer("tokenizerName", null, new CharFilterFactory[0],
+        return new CustomAnalyzer(null, new CharFilterFactory[0],
                 new TokenFilterFactory[] { tokenFilter  });
     }
 }

--- a/server/src/test/java/org/elasticsearch/indices/analysis/AnalysisModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/analysis/AnalysisModuleTests.java
@@ -264,8 +264,8 @@ public class AnalysisModuleTests extends ESTestCase {
             @Override
             public Map<String, AnalysisProvider<TokenizerFactory>> getTokenizers() {
                 // Need mock keyword tokenizer here, because alpha / beta versions are broken up by the dash.
-                return singletonMap("keyword", (indexSettings, environment, name, settings) ->
-                    () -> new MockTokenizer(MockTokenizer.KEYWORD, false));
+                return singletonMap("keyword", (indexSettings, environment, name, settings)
+                    -> TokenizerFactory.newFactory(name, () -> new MockTokenizer(MockTokenizer.KEYWORD, false)));
             }
         })).getAnalysisRegistry();
 

--- a/test/framework/src/main/java/org/elasticsearch/test/MockKeywordPlugin.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/MockKeywordPlugin.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.test;
 
 import org.apache.lucene.analysis.MockTokenizer;
-import org.apache.lucene.analysis.Tokenizer;
 import org.elasticsearch.index.analysis.TokenizerFactory;
 import org.elasticsearch.indices.analysis.AnalysisModule;
 import org.elasticsearch.plugins.AnalysisPlugin;

--- a/test/framework/src/main/java/org/elasticsearch/test/MockKeywordPlugin.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/MockKeywordPlugin.java
@@ -40,15 +40,7 @@ public class MockKeywordPlugin extends Plugin implements AnalysisPlugin {
 
     @Override
     public Map<String, AnalysisModule.AnalysisProvider<TokenizerFactory>> getTokenizers() {
-        return singletonMap("keyword", (indexSettings, environment, name, settings) -> {
-            class Factory implements TokenizerFactory {
-
-                @Override
-                public Tokenizer create() {
-                    return new MockTokenizer(MockTokenizer.KEYWORD, false);
-                }
-            }
-            return new Factory();
-        });
+        return singletonMap("keyword", (indexSettings, environment, name, settings) ->
+            TokenizerFactory.newFactory(name, () -> new MockTokenizer(MockTokenizer.KEYWORD, false)));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/categorization/MlClassicTokenizerFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/categorization/MlClassicTokenizerFactory.java
@@ -20,7 +20,7 @@ import org.elasticsearch.index.analysis.AbstractTokenizerFactory;
 public class MlClassicTokenizerFactory extends AbstractTokenizerFactory {
 
     public MlClassicTokenizerFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, settings);
+        super(indexSettings, settings, name);
     }
 
     @Override


### PR DESCRIPTION
This brings TokenizerFactory into line with CharFilterFactory and TokenFilterFactory,
and removes the need to pass around tokenizer names when building custom analyzers.

As this means that TokenizerFactory is no longer a functional interface, the commit also
adds a factory method to TokenizerFactory to make construction simpler.