### PR TITLE
Add include_type_name in indices.exitst REST API spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists.json
@@ -13,6 +13,10 @@
         }
       },
       "params": {
+        "include_type_name": {
+          "type" : "boolean",
+          "description" : "Whether to add the type name to the response (default: false)"
+        },
         "local": {
           "type": "boolean",
           "description": "Return local information, do not retrieve the state from master node (default: false)"


### PR DESCRIPTION
The parameter exists in the indices.get API already, they both map to the same
REST action. Although the response body for the HEAD request used for checking
existence is empty, the parameter can be used to avoid deprecation warnings and
should be added so clients that generate their API from the rest spec pick it
up.

Closes #43905