### PR TITLE
Enable Kotlin compiler to recognise @org.elasticsearch.common.Nullable annotation for null checks.

### DIFF
--- a/libs/core/build.gradle
+++ b/libs/core/build.gradle
@@ -22,6 +22,9 @@ apply plugin: 'nebula.maven-base-publish'
 apply plugin: 'nebula.maven-scm'
 
 dependencies {
+    // This dependency is used only by :libs:core for null-checking interop with other tools
+    compileOnly "com.google.code.findbugs:jsr305:3.0.2"
+
     testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
     testCompile "junit:junit:${versions.junit}"
     testCompile "org.hamcrest:hamcrest:${versions.hamcrest}"

--- a/libs/core/src/main/java/org/elasticsearch/common/Nullable.java
+++ b/libs/core/src/main/java/org/elasticsearch/common/Nullable.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.common;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.meta.TypeQualifierNickname;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -33,6 +35,8 @@ import java.lang.annotation.Target;
  *
  */
 @Documented
+@TypeQualifierNickname
+@CheckForNull
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.PARAMETER, ElementType.FIELD, ElementType.METHOD})
 public @interface Nullable {


### PR DESCRIPTION
This change allows Elasticsearch plugins written in Kotlin to read the nullability
information present in the ES API declarations and warn of unsafe API usage during compile time. 
Details here: https://kotlinlang.org/docs/reference/java-interop.html#jsr-305-support.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
