### PR TITLE
Actually close IndexAnalyzers contents

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/analysis/IndexAnalyzers.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/IndexAnalyzers.java
@@ -24,6 +24,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.unmodifiableMap;
@@ -106,8 +107,9 @@ public final class IndexAnalyzers implements Closeable {
 
     @Override
     public void close() throws IOException {
-       IOUtils.close(() -> Stream.concat(analyzers.values().stream(), normalizers.values().stream())
-           .filter(a -> a.scope() == AnalyzerScope.INDEX)
-           .iterator());
+        IOUtils.close(Stream.of(analyzers.values().stream(), normalizers.values().stream(), whitespaceNormalizers.values().stream())
+            .flatMap(s -> s)
+            .filter(a -> a.scope() == AnalyzerScope.INDEX)
+            .collect(Collectors.toList()));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/analysis/IndexAnalyzersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/IndexAnalyzersTests.java
@@ -22,14 +22,12 @@ package org.elasticsearch.index.analysis;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.elasticsearch.common.inject.Key;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class IndexAnalyzersTests extends ESTestCase {

--- a/server/src/test/java/org/elasticsearch/index/analysis/IndexAnalyzersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/IndexAnalyzersTests.java
@@ -19,13 +19,18 @@
 
 package org.elasticsearch.index.analysis;
 
+import org.apache.lucene.analysis.core.KeywordAnalyzer;
+import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.elasticsearch.common.inject.Key;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class IndexAnalyzersTests extends ESTestCase {
 
@@ -75,6 +80,39 @@ public class IndexAnalyzersTests extends ESTestCase {
             assertEquals("my_search_analyzer", indexAnalyzers.getDefaultSearchAnalyzer().name());
             assertEquals("my_search_quote_analyzer", indexAnalyzers.getDefaultSearchQuoteAnalyzer().name());
         }
+    }
+
+    public void testClose() throws IOException {
+
+        AtomicInteger closes = new AtomicInteger(0);
+        NamedAnalyzer a = new NamedAnalyzer("default", AnalyzerScope.INDEX, new WhitespaceAnalyzer()){
+            @Override
+            public void close() {
+                super.close();
+                closes.incrementAndGet();
+            }
+        };
+
+        NamedAnalyzer n = new NamedAnalyzer("keyword_normalizer", AnalyzerScope.INDEX, new KeywordAnalyzer()){
+            @Override
+            public void close() {
+                super.close();
+                closes.incrementAndGet();
+            }
+        };
+
+        NamedAnalyzer w = new NamedAnalyzer("whitespace_normalizer", AnalyzerScope.INDEX, new WhitespaceAnalyzer()){
+            @Override
+            public void close() {
+                super.close();
+                closes.incrementAndGet();
+            }
+        };
+
+        IndexAnalyzers ia = new IndexAnalyzers(Map.of("default", a), Map.of("n", n), Map.of("w", w));
+        ia.close();
+        assertEquals(3, closes.get());
+
     }
 
 }


### PR DESCRIPTION
IndexAnalyzers has a `close()` method that should iterate through all its wrapped
analyzers and close each one in turn.  However, instead of delegating to the 
analyzers' `close()` methods, it instead wraps them in a `Closeable` interface,
which just returns a list of the analyzers.  In addition, whitespace normalizers are
ignored entirely.