### PR TITLE
Patch to calculate the no. of physical cores on s390x

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
@@ -152,15 +152,15 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         if (_defaultParallel == null) {
             File cpuInfoFile = new File("/proc/cpuinfo");
             if ("s390x".equals(System.getProperty("os.arch"))) {             
-		// Ask s390x to count physical CPUs for us 
-		ByteArrayOutputStream stdout = new ByteArrayOutputStream();
-		project.exec(spec -> { 
-			spec.setExecutable("nproc"); 
-			spec.args("--all"); 
-			spec.setStandardOutput(stdout); 
-		}); 
-
-		_defaultParallel = Integer.parseInt(stdout.toString().trim()); 		
+		         // Ask s390x to count physical CPUs for us 
+		         ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+		         project.exec(spec -> { 
+			             spec.setExecutable("nproc"); 
+			             spec.args("--all"); 
+			             spec.setStandardOutput(stdout); 
+		    }); 
+ 
+     		_defaultParallel = Integer.parseInt(stdout.toString().trim()); 		
             } else if (cpuInfoFile.exists()) {
                 // Count physical cores on any Linux distro ( don't count hyper-threading )
                 Map<String, Integer> socketToCore = new HashMap<>();

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
@@ -151,7 +151,17 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         // It's safe to store this in a static variable since it's just a primitive so leaking memory isn't an issue
         if (_defaultParallel == null) {
             File cpuInfoFile = new File("/proc/cpuinfo");
-            if (cpuInfoFile.exists()) {
+            if ("s390x".equals(System.getProperty("os.arch"))) {             
+		// Ask s390x to count physical CPUs for us 
+		ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+		project.exec(spec -> { 
+			spec.setExecutable("nproc"); 
+			spec.args("--all"); 
+			spec.setStandardOutput(stdout); 
+		}); 
+
+		_defaultParallel = Integer.parseInt(stdout.toString().trim()); 		
+            } else if (cpuInfoFile.exists()) {
                 // Count physical cores on any Linux distro ( don't count hyper-threading )
                 Map<String, Integer> socketToCore = new HashMap<>();
                 String currentID = "";


### PR DESCRIPTION
The method used to calculate physical cores on a system in existing code doesn't support s390x. 
 Added a patch to calculate the no. of physical cores on s390x by using the "nproc --all" command to get the number of installed processors on a system (core count)