### PR TITLE
[ML] Fix datafeed checks when a concrete remote index is present

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/DataExtractorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/DataExtractorFactoryTests.java
@@ -223,6 +223,60 @@ public class DataExtractorFactoryTests extends ESTestCase {
         DataExtractorFactory.create(client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), listener);
     }
 
+    public void testCreateDataExtractorFactoryGivenRollupAndRemoteIndex() {
+        givenAggregatableRollup("myField", "max", 5, "termField");
+        DataDescription.Builder dataDescription = new DataDescription.Builder();
+        dataDescription.setTimeField("time");
+        Job.Builder jobBuilder = DatafeedManagerTests.createDatafeedJob();
+        jobBuilder.setDataDescription(dataDescription);
+        DatafeedConfig.Builder datafeedConfig = DatafeedManagerTests.createDatafeedConfig("datafeed1", "foo");
+        datafeedConfig.setIndices(Collections.singletonList("cluster_two:my_index"));
+        datafeedConfig.setChunkingConfig(ChunkingConfig.newOff());
+        MaxAggregationBuilder maxTime = AggregationBuilders.max("time").field("time");
+        MaxAggregationBuilder myField = AggregationBuilders.max("myField").field("myField");
+        TermsAggregationBuilder myTerm = AggregationBuilders.terms("termAgg").field("termField").subAggregation(myField);
+        datafeedConfig.setParsedAggregations(AggregatorFactories.builder().addAggregator(
+            AggregationBuilders.dateHistogram("time").interval(600_000).subAggregation(maxTime).subAggregation(myTerm).field("time")));
+
+        // Test with remote index, aggregation, and no chunking
+        ActionListener<DataExtractorFactory> listener = ActionListener.wrap(
+            dataExtractorFactory -> {
+                assertThat(dataExtractorFactory, instanceOf(AggregationDataExtractorFactory.class));
+                assertWarnings("[interval] on [date_histogram] is deprecated, use [fixed_interval] or [calendar_interval] in the future.");
+            },
+            e -> fail()
+        );
+        DataExtractorFactory.create(client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), listener);
+
+        // Test with remote index, aggregation, and chunking
+        datafeedConfig.setChunkingConfig(ChunkingConfig.newAuto());
+        listener = ActionListener.wrap(
+            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(ChunkedDataExtractorFactory.class)),
+            e -> fail()
+        );
+        DataExtractorFactory.create(client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), listener);
+
+        // Test with remote index, no aggregation, and no chunking
+        datafeedConfig = DatafeedManagerTests.createDatafeedConfig("datafeed1", "foo");
+        datafeedConfig.setIndices(Collections.singletonList("cluster_two:my_index"));
+        datafeedConfig.setChunkingConfig(ChunkingConfig.newOff());
+
+        listener = ActionListener.wrap(
+            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(ScrollDataExtractorFactory.class)),
+            e -> fail()
+        );
+
+        DataExtractorFactory.create(client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), listener);
+
+        // Test with remote index, no aggregation, and chunking
+        datafeedConfig.setChunkingConfig(ChunkingConfig.newAuto());
+        listener = ActionListener.wrap(
+            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(ChunkedDataExtractorFactory.class)),
+            e -> fail()
+        );
+        DataExtractorFactory.create(client, datafeedConfig.build(), jobBuilder.build(new Date()), xContentRegistry(), listener);
+    }
+
     public void testCreateDataExtractorFactoryGivenRollupAndValidAggregationAndAutoChunk() {
         givenAggregatableRollup("myField", "max", 5, "termField");
         DataDescription.Builder dataDescription = new DataDescription.Builder();


### PR DESCRIPTION
A bug was introduced in 6.6.0 when we added support for rollup indices. Rollup caps does NOT support looking at remote indices, consequently, since we always look up rollup caps, the datafeed fails with an error if its config includes a concrete remote index.  (When all remote indices in a datafeed config are wildcards the problem did not occur.)

The rollups feature does not support remote indices, so if there is any remote index in a datafeed config (wildcarded or not), we can skip the rollup cap checks.  This PR implements that change.

Fixes #42113