### PR TITLE
[DOCS] Clarify array is not a field datatype

### DIFF
--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -17,8 +17,6 @@ string::         <<text,`text`>> and <<keyword,`keyword`>>
 
 [float]
 === Complex datatypes
-
-<<array>>::     Array support does not require a dedicated `type`
 <<object>>::    `object` for single JSON objects
 <<nested>>::    `nested` for arrays of JSON objects
 
@@ -56,6 +54,10 @@ string::         <<text,`text`>> and <<keyword,`keyword`>>
 
 <<flattened>>:: Allows an entire JSON object to be indexed as a single field.
 
+[float]
+[[types-array-handling]]
+=== Array handling
+In {es}, arrays do not require a dedicated field datatype. See <<array>>.
 
 [float]
 === Multi-fields
@@ -72,8 +74,6 @@ This is the purpose of _multi-fields_.  Most datatypes support multi-fields
 via the <<multi-fields>> parameter.
 
 include::types/alias.asciidoc[]
-
-include::types/array.asciidoc[]
 
 include::types/binary.asciidoc[]
 
@@ -118,3 +118,5 @@ include::types/dense-vector.asciidoc[]
 include::types/sparse-vector.asciidoc[]
 
 include::types/search-as-you-type.asciidoc[]
+
+include::types/array.asciidoc[]

--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -56,7 +56,7 @@ string::         <<text,`text`>> and <<keyword,`keyword`>>
 
 [float]
 [[types-array-handling]]
-=== Array handling
+=== Arrays
 In {es}, arrays do not require a dedicated field datatype. Any field can contain
 zero or more values by default, however, all values in the array must be of the
 same datatype. See <<array>>.
@@ -76,6 +76,8 @@ This is the purpose of _multi-fields_.  Most datatypes support multi-fields
 via the <<multi-fields>> parameter.
 
 include::types/alias.asciidoc[]
+
+include::types/array.asciidoc[]
 
 include::types/binary.asciidoc[]
 
@@ -120,5 +122,3 @@ include::types/dense-vector.asciidoc[]
 include::types/sparse-vector.asciidoc[]
 
 include::types/search-as-you-type.asciidoc[]
-
-include::types/array.asciidoc[]

--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -57,7 +57,9 @@ string::         <<text,`text`>> and <<keyword,`keyword`>>
 [float]
 [[types-array-handling]]
 === Array handling
-In {es}, arrays do not require a dedicated field datatype. See <<array>>.
+In {es}, arrays do not require a dedicated field datatype. Any field can contain
+zero or more values by default, however, all values in the array must be of the
+same datatype. See <<array>>.
 
 [float]
 === Multi-fields

--- a/docs/reference/mapping/types/array.asciidoc
+++ b/docs/reference/mapping/types/array.asciidoc
@@ -1,5 +1,5 @@
 [[array]]
-=== Array handling
+=== Arrays
 
 In Elasticsearch, there is no dedicated `array` datatype.  Any field can contain
 zero or more values by default, however, all values in the array must be of the

--- a/docs/reference/mapping/types/array.asciidoc
+++ b/docs/reference/mapping/types/array.asciidoc
@@ -1,9 +1,9 @@
 [[array]]
-=== Array datatype
+=== Array handling
 
-In Elasticsearch, there is no dedicated `array` type.  Any field can contain
-zero or more values by default, however, all values in the array must be of
-the same datatype. For instance:
+In Elasticsearch, there is no dedicated `array` datatype.  Any field can contain
+zero or more values by default, however, all values in the array must be of the
+same datatype. For instance:
 
 * an array of strings: [ `"one"`, `"two"` ]
 * an array of integers: [ `1`, `2` ]
@@ -81,6 +81,7 @@ GET my_index/_search
 <3> The second document contains no arrays, but can be indexed into the same fields.
 <4> The query looks for `elasticsearch` in the `tags` field, and matches both documents.
 
+[[multi-value-fields-inverted-index]]
 .Multi-value fields and the inverted index
 ****************************************************
 

--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -78,6 +78,11 @@ to help make a decision.
 |`half_float`|+2^-24^+ |+65504+ |+11+ / +3.31+
 |=======================================================================
 
+[[number-array]]
+==== Array handling for numeric fields
+You can use a numeric field to store an array of numbers. However, all values in
+the array must be of the same datatype.  See <<array>>.
+
 [[number-params]]
 ==== Parameters for numeric fields
 

--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -78,11 +78,6 @@ to help make a decision.
 |`half_float`|+2^-24^+ |+65504+ |+11+ / +3.31+
 |=======================================================================
 
-[[number-array]]
-==== Array handling for numeric fields
-You can use a numeric field to store an array of numbers. However, all values in
-the array must be of the same datatype.  See <<array>>.
-
 [[number-params]]
 ==== Parameters for numeric fields
 

--- a/docs/reference/mapping/types/text.asciidoc
+++ b/docs/reference/mapping/types/text.asciidoc
@@ -30,6 +30,12 @@ PUT my_index
 --------------------------------
 // CONSOLE
 
+[[text-array]]
+==== Array handling for text fields
+You can use a `text` field to store an array of strings. See <<array>>.
+
+[[text-multi-fields]]
+==== Use a field as both text and keyword
 Sometimes it is useful to have both a full text (`text`) and a keyword
 (`keyword`) version of the same field: one for full text search and the
 other for aggregations and sorting. This can be achieved with

--- a/docs/reference/mapping/types/text.asciidoc
+++ b/docs/reference/mapping/types/text.asciidoc
@@ -30,10 +30,6 @@ PUT my_index
 --------------------------------
 // CONSOLE
 
-[[text-array]]
-==== Array handling for text fields
-You can use a `text` field to store an array of strings. See <<array>>.
-
 [[text-multi-fields]]
 ==== Use a field as both text and keyword
 Sometimes it is useful to have both a full text (`text`) and a keyword


### PR DESCRIPTION
Based on its page title, it's possible that users can assume arrays are a dedicated field datatype. These changes make it clearer that Elasticsearch supports array handling, but that arrays are not a datatype.

Resolves #43892.

### Changes

- Retitles [Array datatype](https://www.elastic.co/guide/en/elasticsearch/reference/master/array.html) page to **Array handling**
- Moves the **Array handling** page to the bottom of the **Field datatypes** nav
- Adds a new **Array handling** section to the [Field datatypes](https://www.elastic.co/guide/en/elasticsearch/reference/master/mapping-types.html) page.
- Add an anchor to **Multi-value fields and the inverted index** aside of  the **Array handling** page

### Screenshots

<details>
 <summary>Array handling title</summary>
<img width="774" alt="Array handling title" src="https://user-images.githubusercontent.com/40268737/60602241-6efe1c80-9d81-11e9-9acc-fbae69ff66c2.png">
</details>

<details>
 <summary>Array handling section</summary>
<img width="780" alt="Array handling section" src="https://user-images.githubusercontent.com/40268737/60602705-517d8280-9d82-11e9-8a00-9bd506e3f3a0.png">
</details>


<details>
 <summary>Field datatypes nav</summary>
<img width="403" alt="Field datatypes nav" src="https://user-images.githubusercontent.com/40268737/60601973-f8611f00-9d80-11e9-87f5-81fe279b7deb.png">
</details>