### PR TITLE
[DOCS] Make Query DSL titles consistent

### DIFF
--- a/docs/reference/query-dsl.asciidoc
+++ b/docs/reference/query-dsl.asciidoc
@@ -29,21 +29,21 @@ Query clauses behave differently depending on whether they are used in
 
 include::query-dsl/query_filter_context.asciidoc[]
 
-include::query-dsl/match-all-query.asciidoc[]
+include::query-dsl/compound-queries.asciidoc[]
 
 include::query-dsl/full-text-queries.asciidoc[]
 
-include::query-dsl/term-level-queries.asciidoc[]
-
-include::query-dsl/compound-queries.asciidoc[]
+include::query-dsl/geo-queries.asciidoc[]
 
 include::query-dsl/joining-queries.asciidoc[]
 
-include::query-dsl/geo-queries.asciidoc[]
+include::query-dsl/match-all-query.asciidoc[]
+
+include::query-dsl/span-queries.asciidoc[]
 
 include::query-dsl/special-queries.asciidoc[]
 
-include::query-dsl/span-queries.asciidoc[]
+include::query-dsl/term-level-queries.asciidoc[]
 
 include::query-dsl/minimum-should-match.asciidoc[]
 

--- a/docs/reference/query-dsl/bool-query.asciidoc
+++ b/docs/reference/query-dsl/bool-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-bool-query]]
-=== Bool Query
+=== Boolean query
+++++
+<titleabbrev>Boolean</titleabbrev>
+++++
 
 A query that matches documents matching boolean combinations of other
 queries. The bool query maps to Lucene `BooleanQuery`. It is built using

--- a/docs/reference/query-dsl/boosting-query.asciidoc
+++ b/docs/reference/query-dsl/boosting-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-boosting-query]]
-=== Boosting Query
+=== Boosting query
+++++
+<titleabbrev>Boosting</titleabbrev>
+++++
 
 Returns documents matching a `positive` query while reducing the
 <<query-filter-context, relevance score>> of documents that also match a

--- a/docs/reference/query-dsl/compound-queries.asciidoc
+++ b/docs/reference/query-dsl/compound-queries.asciidoc
@@ -7,39 +7,34 @@ filter context.
 
 The queries in this group are:
 
-<<query-dsl-constant-score-query,`constant_score` query>>::
-
-A query which wraps another query, but executes it in filter context.  All
-matching documents are given the same ``constant'' `_score`.
-
 <<query-dsl-bool-query,`bool` query>>::
-
 The default query for combining multiple leaf or compound query clauses, as
 `must`, `should`, `must_not`, or `filter` clauses.  The `must` and `should`
 clauses have their scores combined -- the more matching clauses, the better --
 while the `must_not` and `filter` clauses are executed in filter context.
 
-<<query-dsl-dis-max-query,`dis_max` query>>::
+<<query-dsl-boosting-query,`boosting` query>>::
+Return documents which match a `positive` query, but reduce the score of
+documents which also match a `negative` query.
 
+<<query-dsl-constant-score-query,`constant_score` query>>::
+A query which wraps another query, but executes it in filter context.  All
+matching documents are given the same ``constant'' `_score`.
+
+<<query-dsl-dis-max-query,`dis_max` query>>::
 A query which accepts multiple queries, and returns any documents which match
 any of the query clauses.  While the `bool` query combines the scores from all
 matching queries, the `dis_max` query uses the score of the single best-
 matching query clause.
 
 <<query-dsl-function-score-query,`function_score` query>>::
-
 Modify the scores returned by the main query with functions to take into
 account factors like popularity, recency, distance, or custom algorithms
 implemented with scripting.
 
-<<query-dsl-boosting-query,`boosting` query>>::
 
-Return documents which match a `positive` query, but reduce the score of
-documents which also match a `negative` query.
-
-
-include::constant-score-query.asciidoc[]
 include::bool-query.asciidoc[]
+include::boosting-query.asciidoc[]
+include::constant-score-query.asciidoc[]
 include::dis-max-query.asciidoc[]
 include::function-score-query.asciidoc[]
-include::boosting-query.asciidoc[]

--- a/docs/reference/query-dsl/constant-score-query.asciidoc
+++ b/docs/reference/query-dsl/constant-score-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-constant-score-query]]
-=== Constant Score Query
+=== Constant score query
+++++
+<titleabbrev>Constant score</titleabbrev>
+++++
 
 Wraps a <<query-dsl-bool-query, filter query>> and returns every matching
 document with a <<query-filter-context, relevance score>> equal to the `boost`

--- a/docs/reference/query-dsl/dis-max-query.asciidoc
+++ b/docs/reference/query-dsl/dis-max-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-dis-max-query]]
-=== Disjunction Max Query
+=== Disjunction max query
+++++
+<titleabbrev>Disjunction max</titleabbrev>
+++++
 
 Returns documents matching one or more wrapped queries, called query clauses or
 clauses.

--- a/docs/reference/query-dsl/distance-feature-query.asciidoc
+++ b/docs/reference/query-dsl/distance-feature-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-distance-feature-query]]
-=== Distance Feature Query
+=== Distance feature query
+++++
+<titleabbrev>Distance feature</titleabbrev>
+++++
 
 The `distance_feature` query is a specialized query that only works
 on <<date, `date`>>, <<date_nanos, `date_nanos`>> or <<geo-point,`geo_point`>>

--- a/docs/reference/query-dsl/exists-query.asciidoc
+++ b/docs/reference/query-dsl/exists-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-exists-query]]
-=== Exists Query
+=== Exists query
+++++
+<titleabbrev>Exists</titleabbrev>
+++++
 
 Returns documents that contain an indexed value for a field.
 

--- a/docs/reference/query-dsl/full-text-queries.asciidoc
+++ b/docs/reference/query-dsl/full-text-queries.asciidoc
@@ -7,56 +7,49 @@ the field during indexing.
 
 The queries in this group are:
 
+<<query-dsl-intervals-query,`intervals` query>>::
+A full text query that allows fine-grained control of the ordering and
+proximity of matching terms.
+
 <<query-dsl-match-query,`match` query>>::
-
-    The standard query for performing full text queries, including fuzzy matching
-    and phrase or proximity queries.
-
-<<query-dsl-match-query-phrase,`match_phrase` query>>::
-
-    Like the `match` query but used for matching exact phrases or word proximity matches.
-    
-<<query-dsl-match-query-phrase-prefix,`match_phrase_prefix` query>>::
-
-    Like the `match_phrase` query, but does a wildcard search on the final word.
+The standard query for performing full text queries, including fuzzy matching
+and phrase or proximity queries.
 
 <<query-dsl-match-bool-prefix-query,`match_bool_prefix` query>>::
+Creates a `bool` query that matches each term as a `term` query, except for
+the last term, which is matched as a `prefix` query
 
-    Creates a `bool` query that matches each term as a `term` query, except for
-    the last term, which is matched as a `prefix` query
+<<query-dsl-match-query-phrase,`match_phrase` query>>::
+Like the `match` query but used for matching exact phrases or word proximity matches.
     
+<<query-dsl-match-query-phrase-prefix,`match_phrase_prefix` query>>::
+Like the `match_phrase` query, but does a wildcard search on the final word.
+  
 <<query-dsl-multi-match-query,`multi_match` query>>::
-
-    The multi-field version of the `match` query.
+The multi-field version of the `match` query.
 
 <<query-dsl-query-string-query,`query_string` query>>::
-
-    Supports the compact Lucene <<query-string-syntax,query string syntax>>,
-    allowing you to specify AND|OR|NOT conditions and multi-field search
-    within a single query string. For expert users only.
+Supports the compact Lucene <<query-string-syntax,query string syntax>>,
+allowing you to specify AND|OR|NOT conditions and multi-field search
+within a single query string. For expert users only.
 
 <<query-dsl-simple-query-string-query,`simple_query_string` query>>::
+A simpler, more robust version of the `query_string` syntax suitable
+for exposing directly to users.
 
-    A simpler, more robust version of the `query_string` syntax suitable
-    for exposing directly to users.
 
-<<query-dsl-intervals-query,`intervals` query>>::
-
-    A full text query that allows fine-grained control of the ordering and
-    proximity of matching terms
+include::intervals-query.asciidoc[]
 
 include::match-query.asciidoc[]
+
+include::match-bool-prefix-query.asciidoc[]
 
 include::match-phrase-query.asciidoc[]
 
 include::match-phrase-prefix-query.asciidoc[]
-
-include::match-bool-prefix-query.asciidoc[]
 
 include::multi-match-query.asciidoc[]
 
 include::query-string-query.asciidoc[]
 
 include::simple-query-string-query.asciidoc[]
-
-include::intervals-query.asciidoc[]

--- a/docs/reference/query-dsl/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/function-score-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-function-score-query]]
-=== Function Score Query
+=== Function score query
+++++
+<titleabbrev>Function score</titleabbrev>
+++++
 
 The `function_score` allows you to modify the score of documents that are
 retrieved by a query. This can be useful if, for example, a score

--- a/docs/reference/query-dsl/fuzzy-query.asciidoc
+++ b/docs/reference/query-dsl/fuzzy-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-fuzzy-query]]
-=== Fuzzy Query
+=== Fuzzy query
+++++
+<titleabbrev>Fuzzy</titleabbrev>
+++++
 
 The fuzzy query uses similarity based on Levenshtein edit distance.
 

--- a/docs/reference/query-dsl/geo-bounding-box-query.asciidoc
+++ b/docs/reference/query-dsl/geo-bounding-box-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-geo-bounding-box-query]]
-=== Geo Bounding Box Query
+=== Geo-bounding box query
+++++
+<titleabbrev>Geo-bounding box</titleabbrev>
+++++
 
 A query allowing to filter hits based on a point location using a
 bounding box. Assuming the following indexed document:

--- a/docs/reference/query-dsl/geo-distance-query.asciidoc
+++ b/docs/reference/query-dsl/geo-distance-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-geo-distance-query]]
-=== Geo Distance Query
+=== Geo-distance query
+++++
+<titleabbrev>Geo-distance</titleabbrev>
+++++
 
 Filters documents that include only hits that exists within a specific
 distance from a geo point. Assuming the following mapping and indexed

--- a/docs/reference/query-dsl/geo-polygon-query.asciidoc
+++ b/docs/reference/query-dsl/geo-polygon-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-geo-polygon-query]]
-=== Geo Polygon Query
+=== Geo-polygon query
+++++
+<titleabbrev>Geo-polygon</titleabbrev>
+++++
 
 A query returning hits that only fall within a polygon of
 points. Here is an example:

--- a/docs/reference/query-dsl/geo-queries.asciidoc
+++ b/docs/reference/query-dsl/geo-queries.asciidoc
@@ -8,29 +8,24 @@ lines, circles, polygons, multi-polygons, etc.
 
 The queries in this group are:
 
-<<query-dsl-geo-shape-query,`geo_shape`>> query::
-
-    Finds documents with geo-shapes which either intersect, are contained by, or
-    do not intersect with the specified geo-shape.
-
 <<query-dsl-geo-bounding-box-query,`geo_bounding_box`>> query::
-
-    Finds documents with geo-points that fall into the specified rectangle.
+Finds documents with geo-points that fall into the specified rectangle.
 
 <<query-dsl-geo-distance-query,`geo_distance`>> query::
-
-    Finds documents with geo-points within the specified distance of a central
-    point.
+Finds documents with geo-points within the specified distance of a central point.
 
 <<query-dsl-geo-polygon-query,`geo_polygon`>> query::
+Find documents with geo-points within the specified polygon.
 
-    Find documents with geo-points within the specified polygon.
+<<query-dsl-geo-shape-query,`geo_shape`>> query::
+Finds documents with geo-shapes which either intersect, are contained by, or do not intersect with the specified
+geo-shape.
 
-
-include::geo-shape-query.asciidoc[]
 
 include::geo-bounding-box-query.asciidoc[]
 
 include::geo-distance-query.asciidoc[]
 
 include::geo-polygon-query.asciidoc[]
+
+include::geo-shape-query.asciidoc[]

--- a/docs/reference/query-dsl/geo-shape-query.asciidoc
+++ b/docs/reference/query-dsl/geo-shape-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-geo-shape-query]]
-=== GeoShape Query
+=== Geo-shape query
+++++
+<titleabbrev>Geo-shape</titleabbrev>
+++++
 
 Filter documents indexed using the `geo_shape` type.
 

--- a/docs/reference/query-dsl/has-child-query.asciidoc
+++ b/docs/reference/query-dsl/has-child-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-has-child-query]]
-=== Has Child Query
+=== Has child query
+++++
+<titleabbrev>Has child</titleabbrev>
+++++
 
 The `has_child` filter accepts a query and the child type to run against, and
 results in parent documents that have child docs matching the query. Here is

--- a/docs/reference/query-dsl/has-parent-query.asciidoc
+++ b/docs/reference/query-dsl/has-parent-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-has-parent-query]]
-=== Has Parent Query
+=== Has parent query
+++++
+<titleabbrev>Has parent</titleabbrev>
+++++
 
 The `has_parent` query accepts a query and a parent type. The query is
 executed in the parent document space, which is specified by the parent

--- a/docs/reference/query-dsl/ids-query.asciidoc
+++ b/docs/reference/query-dsl/ids-query.asciidoc
@@ -1,5 +1,9 @@
 [[query-dsl-ids-query]]
-=== Ids Query
+=== IDs
+++++
+<titleabbrev>IDs</titleabbrev>
+++++
+
 Returns documents based on their IDs. This query uses document IDs stored in
 the <<mapping-id-field,`_id`>> field.
 

--- a/docs/reference/query-dsl/intervals-query.asciidoc
+++ b/docs/reference/query-dsl/intervals-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-intervals-query]]
 === Intervals query
+++++
+<titleabbrev>Intervals</titleabbrev>
+++++
 
 An `intervals` query allows fine-grained control over the order and proximity of
 matching terms.  Matching rules are constructed from a small set of definitions,

--- a/docs/reference/query-dsl/joining-queries.asciidoc
+++ b/docs/reference/query-dsl/joining-queries.asciidoc
@@ -6,13 +6,11 @@ prohibitively expensive.  Instead, Elasticsearch offers two forms of join
 which are designed to scale horizontally.
 
 <<query-dsl-nested-query,`nested` query>>::
-
 Documents may contain fields of type <<nested,`nested`>>. These
 fields are used to index arrays of objects, where each object can be queried
 (with the `nested` query) as an independent document.
 
 <<query-dsl-has-child-query,`has_child`>> and <<query-dsl-has-parent-query,`has_parent`>> queries::
-
 A <<parent-join,`join` field relationship>> can exist between
 documents within a single index. The `has_child` query returns parent
 documents whose child documents match the specified query, while the

--- a/docs/reference/query-dsl/match-all-query.asciidoc
+++ b/docs/reference/query-dsl/match-all-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-match-all-query]]
-== Match All Query
+== Match all query
+++++
+<titleabbrev>Match all</titleabbrev>
+++++
 
 The most simple query, which matches all documents, giving them all a `_score`
 of `1.0`.

--- a/docs/reference/query-dsl/match-bool-prefix-query.asciidoc
+++ b/docs/reference/query-dsl/match-bool-prefix-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-match-bool-prefix-query]]
-=== Match Bool Prefix Query
+=== Match boolean prefix query
+++++
+<titleabbrev>Match boolean prefix</titleabbrev>
+++++
 
 A `match_bool_prefix` query analyzes its input and constructs a
 <<query-dsl-bool-query,`bool` query>> from the terms. Each term except the last

--- a/docs/reference/query-dsl/match-phrase-prefix-query.asciidoc
+++ b/docs/reference/query-dsl/match-phrase-prefix-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-match-query-phrase-prefix]]
-=== Match Phrase Prefix Query
+=== Match phrase prefix query
+++++
+<titleabbrev>Match phrase prefix</titleabbrev>
+++++
 
 The `match_phrase_prefix` is the same as `match_phrase`, except that it
 allows for prefix matches on the last term in the text. For example:

--- a/docs/reference/query-dsl/match-phrase-query.asciidoc
+++ b/docs/reference/query-dsl/match-phrase-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-match-query-phrase]]
-=== Match Phrase Query
+=== Match phrase query
+++++
+<titleabbrev>Match phrase</titleabbrev>
+++++
 
 The `match_phrase` query analyzes the text and creates a `phrase` query
 out of the analyzed text. For example:

--- a/docs/reference/query-dsl/match-query.asciidoc
+++ b/docs/reference/query-dsl/match-query.asciidoc
@@ -1,5 +1,5 @@
 [[query-dsl-match-query]]
-=== Match Query
+=== Match query
 ++++
 <titleabbrev>Match</titleabbrev>
 ++++

--- a/docs/reference/query-dsl/match-query.asciidoc
+++ b/docs/reference/query-dsl/match-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-match-query]]
 === Match Query
+++++
+<titleabbrev>Match</titleabbrev>
+++++
 
 
 `match` queries accept text/numerics/dates, analyzes

--- a/docs/reference/query-dsl/minimum-should-match.asciidoc
+++ b/docs/reference/query-dsl/minimum-should-match.asciidoc
@@ -1,5 +1,5 @@
 [[query-dsl-minimum-should-match]]
-== Minimum Should Match
+== `minimum_should_match` parameter
 
 The `minimum_should_match` parameter possible values:
 

--- a/docs/reference/query-dsl/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/mlt-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-mlt-query]]
-=== More Like This Query
+=== More like this query
+++++
+<titleabbrev>More like this</titleabbrev>
+++++
 
 The More Like This Query finds documents that are "like" a given
 set of documents. In order to do so, MLT selects a set of representative terms

--- a/docs/reference/query-dsl/multi-match-query.asciidoc
+++ b/docs/reference/query-dsl/multi-match-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-multi-match-query]]
-=== Multi Match Query
+=== Multi-match query
+++++
+<titleabbrev>Multi-match</titleabbrev>
+++++
 
 The `multi_match` query builds on the <<query-dsl-match-query,`match` query>>
 to allow multi-field queries:

--- a/docs/reference/query-dsl/multi-term-rewrite.asciidoc
+++ b/docs/reference/query-dsl/multi-term-rewrite.asciidoc
@@ -1,5 +1,5 @@
 [[query-dsl-multi-term-rewrite]]
-== `rewrite` Parameter
+== `rewrite` parameter
 
 WARNING: This parameter is for expert users only. Changing the value of
 this parameter can impact search performance and relevance.

--- a/docs/reference/query-dsl/nested-query.asciidoc
+++ b/docs/reference/query-dsl/nested-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-nested-query]]
-=== Nested Query
+=== Nested query
+++++
+<titleabbrev>Nested</titleabbrev>
+++++
 
 Nested query allows to query nested objects / docs (see
 <<nested,nested mapping>>). The

--- a/docs/reference/query-dsl/parent-id-query.asciidoc
+++ b/docs/reference/query-dsl/parent-id-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-parent-id-query]]
-=== Parent Id Query
+=== Parent ID query
+++++
+<titleabbrev>Parent ID</titleabbrev>
+++++
 
 The `parent_id` query can be used to find child documents which belong to a particular parent.
 Given the following mapping definition:

--- a/docs/reference/query-dsl/percolate-query.asciidoc
+++ b/docs/reference/query-dsl/percolate-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-percolate-query]]
-=== Percolate Query
+=== Percolate query
+++++
+<titleabbrev>Percolate</titleabbrev>
+++++
 
 The `percolate` query can be used to match queries
 stored in an index. The `percolate` query itself

--- a/docs/reference/query-dsl/prefix-query.asciidoc
+++ b/docs/reference/query-dsl/prefix-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-prefix-query]]
-=== Prefix Query
+=== Prefix query
+++++
+<titleabbrev>Prefix</titleabbrev>
+++++
 
 Matches documents that have fields containing terms with a specified
 prefix (*not analyzed*). The prefix query maps to Lucene `PrefixQuery`.

--- a/docs/reference/query-dsl/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/query-string-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-query-string-query]]
-=== Query String Query
+=== Query string query
+++++
+<titleabbrev>Query string</titleabbrev>
+++++
 
 A query that uses a query parser in order to parse its content. Here is
 an example:

--- a/docs/reference/query-dsl/range-query.asciidoc
+++ b/docs/reference/query-dsl/range-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-range-query]]
-=== Range Query
+=== Range query
+++++
+<titleabbrev>Range</titleabbrev>
+++++
 
 Returns documents that contain terms within a provided range.
 

--- a/docs/reference/query-dsl/rank-feature-query.asciidoc
+++ b/docs/reference/query-dsl/rank-feature-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-rank-feature-query]]
-=== Rank Feature Query
+=== Rank feature query
+++++
+<titleabbrev>Rank feature</titleabbrev>
+++++
 
 The `rank_feature` query is a specialized query that only works on
 <<rank-feature,`rank_feature`>> fields and <<rank-features,`rank_features`>> fields.

--- a/docs/reference/query-dsl/regexp-query.asciidoc
+++ b/docs/reference/query-dsl/regexp-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-regexp-query]]
-=== Regexp Query
+=== Regexp query
+++++
+<titleabbrev>Regexp</titleabbrev>
+++++
 
 The `regexp` query allows you to use regular expression term queries.
 See <<regexp-syntax>> for details of the supported regular expression language.

--- a/docs/reference/query-dsl/script-query.asciidoc
+++ b/docs/reference/query-dsl/script-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-script-query]]
-=== Script Query
+=== Script query
+++++
+<titleabbrev>Script</titleabbrev>
+++++
 
 A query allowing to define
 <<modules-scripting,scripts>> as queries. They are typically used in a filter

--- a/docs/reference/query-dsl/script-score-query.asciidoc
+++ b/docs/reference/query-dsl/script-score-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-script-score-query]]
-=== Script Score Query
+=== Script score query
+++++
+<titleabbrev>Script score</titleabbrev>
+++++
 
 The `script_score` allows you to modify the score of documents that are
 retrieved by a query. This can be useful if, for example, a score

--- a/docs/reference/query-dsl/simple-query-string-query.asciidoc
+++ b/docs/reference/query-dsl/simple-query-string-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-simple-query-string-query]]
-=== Simple Query String Query
+=== Simple query string query
+++++
+<titleabbrev>Simple query string</titleabbrev>
+++++
 
 A query that uses the SimpleQueryParser to parse its context. Unlike the
 regular `query_string` query, the `simple_query_string` query will never

--- a/docs/reference/query-dsl/span-containing-query.asciidoc
+++ b/docs/reference/query-dsl/span-containing-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-span-containing-query]]
-=== Span Containing Query
+=== Span containing query
+++++
+<titleabbrev>Span containing</titleabbrev>
+++++
 
 Returns matches which enclose another span query. The span containing
 query maps to Lucene `SpanContainingQuery`. Here is an example:

--- a/docs/reference/query-dsl/span-field-masking-query.asciidoc
+++ b/docs/reference/query-dsl/span-field-masking-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-span-field-masking-query]]
-=== Span Field Masking Query
+=== Span field masking query
+++++
+<titleabbrev>Span field masking</titleabbrev>
+++++
 
 Wrapper to allow span queries to participate in composite single-field span queries by 'lying' about their search field. The span field masking query maps to Lucene's `SpanFieldMaskingQuery`
 

--- a/docs/reference/query-dsl/span-first-query.asciidoc
+++ b/docs/reference/query-dsl/span-first-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-span-first-query]]
-=== Span First Query
+=== Span first query
+++++
+<titleabbrev>Span first</titleabbrev>
+++++
 
 Matches spans near the beginning of a field. The span first query maps
 to Lucene `SpanFirstQuery`. Here is an example:

--- a/docs/reference/query-dsl/span-multi-term-query.asciidoc
+++ b/docs/reference/query-dsl/span-multi-term-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-span-multi-term-query]]
-=== Span Multi Term Query
+=== Span multi-term query
+++++
+<titleabbrev>Span multi-term</titleabbrev>
+++++
 
 The `span_multi` query allows you to wrap a `multi term query` (one of wildcard,
 fuzzy, prefix, range or regexp query) as a `span query`, so

--- a/docs/reference/query-dsl/span-near-query.asciidoc
+++ b/docs/reference/query-dsl/span-near-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-span-near-query]]
-=== Span Near Query
+=== Span near query
+++++
+<titleabbrev>Span near</titleabbrev>
+++++
 
 Matches spans which are near one another. One can specify _slop_, the
 maximum number of intervening unmatched positions, as well as whether

--- a/docs/reference/query-dsl/span-not-query.asciidoc
+++ b/docs/reference/query-dsl/span-not-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-span-not-query]]
-=== Span Not Query
+=== Span not query
+++++
+<titleabbrev>Span not</titleabbrev>
+++++
 
 Removes matches which overlap with another span query or which are
 within x tokens before (controlled by the parameter `pre`) or y tokens

--- a/docs/reference/query-dsl/span-or-query.asciidoc
+++ b/docs/reference/query-dsl/span-or-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-span-or-query]]
-=== Span Or Query
+=== Span or query
+++++
+<titleabbrev>Span or</titleabbrev>
+++++
 
 Matches the union of its span clauses. The span or query maps to Lucene
 `SpanOrQuery`. Here is an example:

--- a/docs/reference/query-dsl/span-queries.asciidoc
+++ b/docs/reference/query-dsl/span-queries.asciidoc
@@ -15,62 +15,55 @@ Span queries cannot be mixed with non-span queries (with the exception of the `s
 
 The queries in this group are:
 
+<<query-dsl-span-containing-query,`span_containing` query>>::
+Accepts a list of span queries, but only returns those spans which also match a second span query.
+
+<<query-dsl-span-field-masking-query,`field_masking_span` query>>::
+Allows queries like `span-near` or `span-or` across different fields.
+
+<<query-dsl-span-first-query,`span_first` query>>::
+Accepts another span query whose matches must appear within the first N
+positions of the field.
+
+<<query-dsl-span-multi-term-query,`span_multi` query>>::
+Wraps a <<query-dsl-term-query,`term`>>, <<query-dsl-range-query,`range`>>,
+<<query-dsl-prefix-query,`prefix`>>, <<query-dsl-wildcard-query,`wildcard`>>,
+<<query-dsl-regexp-query,`regexp`>>, or <<query-dsl-fuzzy-query,`fuzzy`>> query.
+
+<<query-dsl-span-near-query,`span_near` query>>::
+Accepts multiple span queries whose matches must be within the specified distance of each other, and possibly in the same order.
+
+<<query-dsl-span-not-query,`span_not` query>>::
+Wraps another span query, and excludes any documents which match that query.
+
+<<query-dsl-span-or-query,`span_or` query>>::
+Combines multiple span queries -- returns documents which match any of the
+specified queries.
+
 <<query-dsl-span-term-query,`span_term` query>>::
 
 The equivalent of the <<query-dsl-term-query,`term` query>> but for use with
 other span queries.
 
-<<query-dsl-span-multi-term-query,`span_multi` query>>::
-
-Wraps a <<query-dsl-term-query,`term`>>, <<query-dsl-range-query,`range`>>,
-<<query-dsl-prefix-query,`prefix`>>, <<query-dsl-wildcard-query,`wildcard`>>,
-<<query-dsl-regexp-query,`regexp`>>, or <<query-dsl-fuzzy-query,`fuzzy`>> query.
-
-<<query-dsl-span-first-query,`span_first` query>>::
-
-Accepts another span query whose matches must appear within the first N
-positions of the field.
-
-<<query-dsl-span-near-query,`span_near` query>>::
-
-Accepts multiple span queries whose matches must be within the specified distance of each other, and possibly in the same order.
-
-<<query-dsl-span-or-query,`span_or` query>>::
-
-Combines multiple span queries -- returns documents which match any of the
-specified queries.
-
-<<query-dsl-span-not-query,`span_not` query>>::
-
-Wraps another span query, and excludes any documents which match that query.
-
-<<query-dsl-span-containing-query,`span_containing` query>>::
-
-Accepts a list of span queries, but only returns those spans which also match a second span query.
-
 <<query-dsl-span-within-query,`span_within` query>>::
-
 The result from a single span query is returned as long is its span falls
 within the spans returned by a list of other span queries.
 
-<<query-dsl-span-field-masking-query,`field_masking_span` query>>::
-
-Allows queries like `span-near` or `span-or` across different fields.
-
-include::span-term-query.asciidoc[]
-
-include::span-multi-term-query.asciidoc[]
-
-include::span-first-query.asciidoc[]
-
-include::span-near-query.asciidoc[]
-
-include::span-or-query.asciidoc[]
-
-include::span-not-query.asciidoc[]
 
 include::span-containing-query.asciidoc[]
 
-include::span-within-query.asciidoc[]
-
 include::span-field-masking-query.asciidoc[]
+
+include::span-first-query.asciidoc[]
+
+include::span-multi-term-query.asciidoc[]
+
+include::span-near-query.asciidoc[]
+
+include::span-not-query.asciidoc[]
+
+include::span-or-query.asciidoc[]
+
+include::span-term-query.asciidoc[]
+
+include::span-within-query.asciidoc[]

--- a/docs/reference/query-dsl/span-term-query.asciidoc
+++ b/docs/reference/query-dsl/span-term-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-span-term-query]]
-=== Span Term Query
+=== Span term query
+++++
+<titleabbrev>Span term</titleabbrev>
+++++
 
 Matches spans containing a term. The span term query maps to Lucene
 `SpanTermQuery`. Here is an example:

--- a/docs/reference/query-dsl/span-within-query.asciidoc
+++ b/docs/reference/query-dsl/span-within-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-span-within-query]]
-=== Span Within Query
+=== Span within query
+++++
+<titleabbrev>Span within</titleabbrev>
+++++
 
 Returns matches which are enclosed inside another span query. The span within
 query maps to Lucene `SpanWithinQuery`. Here is an example:

--- a/docs/reference/query-dsl/special-queries.asciidoc
+++ b/docs/reference/query-dsl/special-queries.asciidoc
@@ -4,50 +4,44 @@
 
 This group contains queries which do not fit into the other groups:
 
-<<query-dsl-mlt-query,`more_like_this` query>>::
-
-This query finds documents which are similar to the specified text, document,
-or collection of documents.
-
-<<query-dsl-script-query,`script` query>>::
-
-This query allows a script to act as a filter.  Also see the
-<<query-dsl-function-score-query,`function_score` query>>.
-
-<<query-dsl-script-score-query,`script_score` query>>::
-
-A query that allows to modify the score of a sub-query with a script.
-
-<<query-dsl-percolate-query,`percolate` query>>::
-
-This query finds queries that are stored as documents that match with
-the specified document.
-
-<<query-dsl-rank-feature-query,`rank_feature` query>>::
-
-A query that computes scores based on the values of numeric features and is
-able to efficiently skip non-competitive hits.
-
 <<query-dsl-distance-feature-query,`distance_feature` query>>::
-
 A query that computes scores based on the dynamically computed distances
 between the origin and documents' date, date_nanos and geo_point fields.
 It is able to efficiently skip non-competitive hits.
 
-<<query-dsl-wrapper-query,`wrapper` query>>::
+<<query-dsl-mlt-query,`more_like_this` query>>::
+This query finds documents which are similar to the specified text, document,
+or collection of documents.
 
+<<query-dsl-percolate-query,`percolate` query>>::
+This query finds queries that are stored as documents that match with
+the specified document.
+
+<<query-dsl-rank-feature-query,`rank_feature` query>>::
+A query that computes scores based on the values of numeric features and is
+able to efficiently skip non-competitive hits.
+
+<<query-dsl-script-query,`script` query>>::
+This query allows a script to act as a filter.  Also see the
+<<query-dsl-function-score-query,`function_score` query>>.
+
+<<query-dsl-script-score-query,`script_score` query>>::
+A query that allows to modify the score of a sub-query with a script.
+
+<<query-dsl-wrapper-query,`wrapper` query>>::
 A query that accepts other queries as json or yaml string.
 
+
+include::distance-feature-query.asciidoc[]
+
 include::mlt-query.asciidoc[]
-
-include::script-query.asciidoc[]
-
-include::script-score-query.asciidoc[]
 
 include::percolate-query.asciidoc[]
 
 include::rank-feature-query.asciidoc[]
 
-include::distance-feature-query.asciidoc[]
+include::script-query.asciidoc[]
+
+include::script-score-query.asciidoc[]
 
 include::wrapper-query.asciidoc[]

--- a/docs/reference/query-dsl/term-level-queries.asciidoc
+++ b/docs/reference/query-dsl/term-level-queries.asciidoc
@@ -20,6 +20,27 @@ Term-level queries still normalize search terms for `keyword` fields with the
 [[term-level-query-types]]
 === Types of term-level queries
 
+<<query-dsl-exists-query,`exists` query>>::
+Returns documents that contain any indexed value for a field.
+
+<<query-dsl-fuzzy-query,`fuzzy` query>>::
+Returns documents that contain terms similar to the search term. {es} measures
+similarity, or fuzziness, using a
+http://en.wikipedia.org/wiki/Levenshtein_distance[Levenshtein edit distance].
+
+<<query-dsl-ids-query,`ids` query>>::
+Returns documents based on their <<mapping-id-field, document IDs>>. 
+
+<<query-dsl-prefix-query,`prefix` query>>::
+Returns documents that contain a specific prefix in a provided field.
+
+<<query-dsl-range-query,`range` query>>::
+Returns documents that contain terms within a provided range.
+
+<<query-dsl-regexp-query,`regexp` query>>::
+Returns documents that contain terms matching a
+https://en.wikipedia.org/wiki/Regular_expression[regular expression].
+
 <<query-dsl-term-query,`term` query>>::
 Returns documents that contain an exact term in a provided field.
 
@@ -31,30 +52,21 @@ Returns documents that contain a minimum number of exact terms in a provided
 field. You can define the minimum number of matching terms using a field or
 script.
 
-<<query-dsl-range-query,`range` query>>::
-Returns documents that contain terms within a provided range.
-
-<<query-dsl-exists-query,`exists` query>>::
-Returns documents that contain any indexed value for a field.
-
-<<query-dsl-prefix-query,`prefix` query>>::
-Returns documents that contain a specific prefix in a provided field.
-
 <<query-dsl-wildcard-query,`wildcard` query>>::
 Returns documents that contain terms matching a wildcard pattern.
 
-<<query-dsl-regexp-query,`regexp` query>>::
-Returns documents that contain terms matching a
-https://en.wikipedia.org/wiki/Regular_expression[regular expression].
 
-<<query-dsl-fuzzy-query,`fuzzy` query>>::
-Returns documents that contain terms similar to the search term. {es} measures
-similarity, or fuzziness, using a
-http://en.wikipedia.org/wiki/Levenshtein_distance[Levenshtein edit distance].
+include::exists-query.asciidoc[]
 
-<<query-dsl-ids-query,`ids` query>>::
-Returns documents based on their <<mapping-id-field, document IDs>>. 
+include::fuzzy-query.asciidoc[]
 
+include::ids-query.asciidoc[]
+
+include::prefix-query.asciidoc[]
+
+include::range-query.asciidoc[]
+
+include::regexp-query.asciidoc[]
 
 include::term-query.asciidoc[]
 
@@ -62,16 +74,4 @@ include::terms-query.asciidoc[]
 
 include::terms-set-query.asciidoc[]
 
-include::range-query.asciidoc[]
-
-include::exists-query.asciidoc[]
-
-include::prefix-query.asciidoc[]
-
 include::wildcard-query.asciidoc[]
-
-include::regexp-query.asciidoc[]
-
-include::fuzzy-query.asciidoc[]
-
-include::ids-query.asciidoc[]

--- a/docs/reference/query-dsl/term-query.asciidoc
+++ b/docs/reference/query-dsl/term-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-term-query]]
-=== Term Query
+=== Term query
+++++
+<titleabbrev>Term</titleabbrev>
+++++
 
 Returns documents that contain an *exact* term in a provided field.
 

--- a/docs/reference/query-dsl/terms-query.asciidoc
+++ b/docs/reference/query-dsl/terms-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-terms-query]]
-=== Terms Query
+=== Terms query
+++++
+<titleabbrev>Terms</titleabbrev>
+++++
 
 Returns documents that contain one or more *exact* terms in a provided field.
 

--- a/docs/reference/query-dsl/terms-set-query.asciidoc
+++ b/docs/reference/query-dsl/terms-set-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-terms-set-query]]
-=== Terms Set Query
+=== Terms set query
+++++
+<titleabbrev>Terms set</titleabbrev>
+++++
 
 Returns documents that contain a minimum number of *exact* terms in a provided
 field.

--- a/docs/reference/query-dsl/wildcard-query.asciidoc
+++ b/docs/reference/query-dsl/wildcard-query.asciidoc
@@ -1,5 +1,9 @@
 [[query-dsl-wildcard-query]]
-=== Wildcard Query
+=== Wildcard query
+++++
+<titleabbrev>Wildcard</titleabbrev>
+++++
+
 Returns documents that contain terms matching a wildcard pattern.
 
 A wildcard operator is a placeholder that matches one or more characters. For

--- a/docs/reference/query-dsl/wrapper-query.asciidoc
+++ b/docs/reference/query-dsl/wrapper-query.asciidoc
@@ -1,5 +1,8 @@
 [[query-dsl-wrapper-query]]
-=== Wrapper Query
+=== Wrapper query
+++++
+<titleabbrev>Wrapper</titleabbrev>
+++++
 
 A query that accepts any other query as base64 encoded string.
 


### PR DESCRIPTION
### Changes

- Adds title abbreviations for query type. This removes the " query" endings from most nav items but retains them for the on-page title.
- Change titles to sentence case
- Hyphenates some titles as needed.

### Screenshots

<details>
 <summary>Query DSL nav</summary>
<img width="293" alt="Query DSL nav" src="https://user-images.githubusercontent.com/40268737/60610652-4af70700-9d92-11e9-898a-6203137ac16d.png">
</details>

<details>
 <summary>Example query title</summary>
<img width="772" alt="Example query title" src="https://user-images.githubusercontent.com/40268737/60610660-4fbbbb00-9d92-11e9-91ae-13e2c78e4781.png">
</details>