### PR TITLE
 Ensure test cluster classpath inputs have predictable ordering

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -57,6 +57,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -880,6 +881,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
             // https://docs.gradle.org/nightly/release-notes.html#improved-handling-of-zip-archives-on-classpaths
             .map(zipFile -> project.zipTree(zipFile).matching(filter))
             .flatMap(tree -> tree.getFiles().stream())
+            .sorted(Comparator.comparing(File::getName))
             .collect(Collectors.toList());
     }
 
@@ -901,8 +903,11 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     }
 
     @Classpath
-    private Set<File> getDistributionClasspath() {
-        return project.fileTree(getExtractedDistributionDir()).matching(filter -> filter.include("**/*.jar")).getFiles();
+    private List<File> getDistributionClasspath() {
+        ArrayList<File> files = new ArrayList<>(project.fileTree(getExtractedDistributionDir()).matching(filter -> filter.include("**/*.jar")).getFiles());
+        files.sort(Comparator.comparing(File::getName));
+
+        return files;
     }
 
     @InputFiles

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -904,7 +904,9 @@ public class ElasticsearchNode implements TestClusterConfiguration {
 
     @Classpath
     private List<File> getDistributionClasspath() {
-        ArrayList<File> files = new ArrayList<>(project.fileTree(getExtractedDistributionDir()).matching(filter -> filter.include("**/*.jar")).getFiles());
+        ArrayList<File> files = new ArrayList<>(project.fileTree(getExtractedDistributionDir())
+            .matching(filter -> filter.include("**/*.jar"))
+            .getFiles());
         files.sort(Comparator.comparing(File::getName));
 
         return files;


### PR DESCRIPTION
Because we build test cluster distribution classpaths using a unordered set implementation, file order for otherwise identical sets can differ across build invocations. The result of this is different build cache keys and cache misses. To combat this we sort these collections so that we can ensure stable and predictable ordering given the same set of files. As an example, here's a [build scan](https://gradle-enterprise.elastic.dev/c/fh7xhnddktipq/tkpqj4pz5pdne/task-inputs?expanded=WzM3NjksImxzZnUyeHN2NnBrcGstY2x1c3RlcnMuaW50ZWdUZXN0JDAubm9kZXMuJDAuZGlzdHJpYnV0aW9uQ2xhc3NwYXRoLTAtZmlsZS1vcmRlciJd&task-text=:plugins:ingest-attachment#change-lsfu2xsv6pkpk-clusters.integTest$0.nodes.$0.distributionClasspath-0-file-order) where the classpath is otherwise identical except for order.