### PR TITLE
Fix wrong logic in `match_phrase` query with multi-word synonyms

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -468,8 +468,8 @@ public class MatchQuery {
             }
             SpanQuery[] spanQueries = new SpanQuery[terms.length];
             for (int i = 0; i < terms.length; i++) {
-                spanQueries[i] = isPrefix ? new SpanTermQuery(terms[i]) :
-                    fieldType.spanPrefixQuery(terms[i].text(), spanRewriteMethod, context);
+                spanQueries[i] = isPrefix ? fieldType.spanPrefixQuery(terms[i].text(), spanRewriteMethod, context) :
+                    new SpanTermQuery(terms[i]);
             }
             return new SpanOrQuery(spanQueries);
         }

--- a/server/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
@@ -32,6 +32,10 @@ import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.spans.SpanNearQuery;
+import org.apache.lucene.search.spans.SpanOrQuery;
+import org.apache.lucene.search.spans.SpanQuery;
+import org.apache.lucene.search.spans.SpanTermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.common.ParsingException;
@@ -448,6 +452,29 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
                     BooleanClause.Occur.SHOULD).build();
             assertThat(query, equalTo(expectedQuery));
         }
+    }
+
+    public void testMultiWordSynonymsPhrase() throws Exception {
+        final MatchQuery matchQuery = new MatchQuery(createShardContext());
+        matchQuery.setAnalyzer(new MockSynonymAnalyzer());
+        final Query actual = matchQuery.parse(Type.PHRASE, STRING_FIELD_NAME, "guinea pig dogs");
+        Query expected = SpanNearQuery.newOrderedNearQuery(STRING_FIELD_NAME)
+            .addClause(
+                new SpanOrQuery(new SpanQuery[]{
+                    SpanNearQuery.newOrderedNearQuery(STRING_FIELD_NAME)
+                        .addClause(new SpanTermQuery(new Term(STRING_FIELD_NAME, "guinea")))
+                        .addClause(new SpanTermQuery(new Term(STRING_FIELD_NAME, "pig")))
+                        .setSlop(0)
+                        .build(),
+                    new SpanTermQuery(new Term(STRING_FIELD_NAME, "cavy"))
+                })
+            )
+            .addClause(new SpanOrQuery(new SpanQuery[]{
+                new SpanTermQuery(new Term(STRING_FIELD_NAME, "dogs")),
+                new SpanTermQuery(new Term(STRING_FIELD_NAME, "dog"))
+            }))
+            .build();
+        assertEquals(expected, actual);
     }
 
     public void testMaxBooleanClause() {


### PR DESCRIPTION
Disjunction over two individual terms in a phrase query with multi-word synonyms
wrongly applies a prefix query to each of these terms. This change fixes this bug
by inversing the logic to use prefixes on `match_phrase_prefix` queries only.

Closes #43308