### PR TITLE
[DOCS] Adds command reference for elasticsearch-croneval

### DIFF
--- a/docs/reference/commands/croneval.asciidoc
+++ b/docs/reference/commands/croneval.asciidoc
@@ -1,0 +1,52 @@
+[role="xpack"]
+[testenv="gold+"]
+[[elasticsearch-croneval]]
+== elasticsearch-croneval
+
+Validates and evaluates a cron expression. 
+
+[discrete]
+=== Synopsis
+
+[source,shell]
+--------------------------------------------------
+bin/elasticsearch-croneval <expression>
+[-c, --count <integer>] [-h, --help]
+([-s, --silent] | [-v, --verbose])
+--------------------------------------------------
+
+[discrete]
+=== Description
+
+This command enables you to verify that your
+https://en.wikipedia.org/wiki/Cron[cron] expressions are valid for use with the
+{es} {alert-features} and produce the expected results.
+
+This command is provided in the `$ES_HOME/bin` directory.
+
+[discrete]
+=== Parameters
+
+`-c, --count` <Integer>::
+  The number of future times this expression will be triggered. The default
+  value is `10`.
+  
+`-h, --help`::
+  Returns all of the command parameters.
+
+`-s, --silent`::
+  Shows minimal output.
+                                 
+`-v, --verbose`::
+  Shows verbose output.
+
+[discrete]
+=== Examples
+
+If the cron expression is valid, the following command displays the next
+20 times that the schedule will be triggered:
+
+[source,bash]
+--------------------------------------------------
+bin/elasticsearch-croneval "0 0/1 * * * ?" -c 20
+--------------------------------------------------

--- a/docs/reference/commands/index.asciidoc
+++ b/docs/reference/commands/index.asciidoc
@@ -9,6 +9,7 @@ tasks from the command line:
 
 * <<certgen>>
 * <<certutil>>
+* <<elasticsearch-croneval>>
 * <<node-tool>>
 * <<saml-metadata>>
 * <<setup-passwords>>
@@ -20,6 +21,7 @@ tasks from the command line:
 
 include::certgen.asciidoc[]
 include::certutil.asciidoc[]
+include::croneval.asciidoc[]
 include::node-tool.asciidoc[]
 include::saml-metadata.asciidoc[]
 include::setup-passwords.asciidoc[]

--- a/x-pack/docs/en/watcher/trigger/schedule/cron.asciidoc
+++ b/x-pack/docs/en/watcher/trigger/schedule/cron.asciidoc
@@ -211,27 +211,21 @@ minute during the weekend:
 // NOTCONSOLE
 
 [[croneval]]
-===== Verifying Cron Expressions
+===== Verifying cron expressions
 
-The {es} {alert-features} provide a `elasticsearch-croneval` command line tool
-that you can use to verify that
-your cron expressions are valid and produce the expected results. This tool is
-provided in the `$ES_HOME/bin` directory.
+The {es} {alert-features} provide a
+{ref}/elasticsearch-croneval.html[`elasticsearch-croneval`] command line tool
+that you can use to verify that your cron expressions are valid and produce the
+expected results. This tool is provided in the `$ES_HOME/bin` directory.
 
-To verify a cron expression, simply pass it in as a parameter to `elasticsearch-croneval`:
+To verify a cron expression, simply pass it in as a parameter to
+`elasticsearch-croneval`:
 
 [source,bash]
 --------------------------------------------------
 bin/elasticsearch-croneval "0 0/1 * * * ?"
 --------------------------------------------------
 
-If the cron expression is valid, `elasticsearch-croneval` displays the next 10 times that the
-schedule will be triggered.
-
-You can specify the `-c` option to control how many future trigger times are
-displayed. For example, the following command displays the next 20 trigger times:
-
-[source,bash]
---------------------------------------------------
-bin/elasticsearch-croneval "0 0/1 * * * ?" -c 20
---------------------------------------------------
+If the cron expression is valid, `elasticsearch-croneval` displays the next 10
+times that the schedule will be triggered. You can specify the `-c` option to
+control how many future trigger times are displayed.


### PR DESCRIPTION
This PR adds a page in the Elasticsearch Reference > Command line tools section (https://www.elastic.co/guide/en/elasticsearch/reference/master/commands.html) for the elasticsearch-croneval tool. It also adds a link to that page from the Stack Overview (https://www.elastic.co/guide/en/elastic-stack-overview/master/trigger-schedule.html#croneval).

Related to https://github.com/elastic/kibana/pull/40106