### PR TITLE
[DOCS] Reformat freeze unfreeze APis to use new API format

### DIFF
--- a/docs/reference/indices/apis/freeze.asciidoc
+++ b/docs/reference/indices/apis/freeze.asciidoc
@@ -1,37 +1,41 @@
 [role="xpack"]
 [testenv="basic"]
 [[freeze-index-api]]
-== Freeze index API
+=== Freeze index API
 ++++
 <titleabbrev>Freeze index</titleabbrev>
 ++++
 
 Freezes an index. 
 
-[float]
-=== Request
+[[freeze-index-api-request]]
+==== {api-request-title}
 
 `POST /<index>/_freeze`
 
-[float]
-=== Description
+//[[freeze-index-api-prereqs]]
+//==== {api-prereq-title}
+
+[[freeze-index-api-desc]]
+==== {api-description-title}
 
 A frozen index has almost no overhead on the cluster (except
 for maintaining its metadata in memory), and is blocked for write operations.
 See <<frozen-indices>> and <<unfreeze-index-api>>.
 
-[float]
-=== Path Parameters
+IMPORTANT: Freezing an index will close the index and reopen it within the same
+API call. This causes primaries to not be allocated for a short amount of time
+and causes the cluster to go red until the primaries are allocated again. This
+limitation might be removed in the future.
 
-`index` (required)::
-(string) Identifier for the index
+[[freeze-index-api-path-parms]]
+==== {api-path-parms-title}
 
-//=== Query Parameters
+`<index>` (Required)::
+(string) Identifier for the index.
 
-//=== Authorization
-
-[float]
-=== Examples
+[[freeze-index-api-examples]]
+==== {api-examples-title}
 
 The following example freezes and unfreezes an index:
 
@@ -43,8 +47,3 @@ POST /my_index/_unfreeze
 // CONSOLE
 // TEST[s/^/PUT my_index\n/]
 
-[IMPORTANT]
-================================
- Freezing an index will close the index and reopen it within the same API call. This causes primaries to not be allocated for a short
- amount of time and causes the cluster to go red until the primaries are allocated again. This limitation might be removed in the future.
-================================

--- a/docs/reference/indices/apis/index.asciidoc
+++ b/docs/reference/indices/apis/index.asciidoc
@@ -1,0 +1,11 @@
+[[index-apis]]
+== Index APIs
+
+The index APIs are used to manage individual indices.
+
+* <<freeze-index-api>>, <<unfreeze-index-api>>
+
+See also <<indices>>.
+
+include::freeze.asciidoc[]
+include::unfreeze.asciidoc[]

--- a/docs/reference/indices/apis/unfreeze.asciidoc
+++ b/docs/reference/indices/apis/unfreeze.asciidoc
@@ -1,37 +1,40 @@
 [role="xpack"]
 [testenv="basic"]
 [[unfreeze-index-api]]
-== Unfreeze index API
+=== Unfreeze index API
 ++++
 <titleabbrev>Unfreeze index</titleabbrev>
 ++++
 
 Unfreezes an index.
 
-[float]
-=== Request
+[[unfreeze-index-api-request]]
+==== {api-request-title}
 
 `POST /<index>/_unfreeze`
 
-[float]
-=== Description
+//[[unfreeze-index-api-prereqs]]
+//==== {api-prereq-title}
+
+[[unfreeze-index-api-desc]]
+==== {api-description-title}
 
 When a frozen index is unfrozen, the index goes through the normal recovery 
 process and becomes writeable again. See <<frozen-indices>> and <<freeze-index-api>>.
 
-[float]
-=== Path Parameters
+IMPORTANT: Freezing an index will close the index and reopen it within the same
+API call. This causes primaries to not be allocated for a short amount of time
+and causes the cluster to go red until the primaries are allocated again. This
+limitation might be removed in the future.
 
-`index` (required)::
-(string) Identifier for the index
+[[unfreeze-index-api-path-parms]]
+==== {api-path-parms-title}
 
+`<index>` (Required)::
+(string) Identifier for the index.
 
-//=== Query Parameters
-
-//=== Authorization
-
-[float]
-=== Examples
+[[unfreeze-index-api-examples]]
+==== {api-examples-title}
 
 The following example freezes and unfreezes an index:
 
@@ -42,9 +45,3 @@ POST /my_index/_unfreeze
 --------------------------------------------------
 // CONSOLE
 // TEST[s/^/PUT my_index\n/]
-
-[IMPORTANT]
-================================
- Freezing an index will close the index and reopen it within the same API call. This causes primaries to not be allocated for a short
- amount of time and causes the cluster to go red until the primaries are allocated again. This limitation might be removed in the future.
-================================

--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -14,7 +14,7 @@ not be included yet.
 * <<ccr-apis,{ccr-cap} APIs>>
 * <<data-frame-apis,{dataframe-cap} APIs>>
 * <<graph-explore-api,Graph Explore API>>
-* <<freeze-index-api>>, <<unfreeze-index-api>>
+* <<index-apis>>
 * <<indices-reload-analyzers,Reload Search Analyzers API>>
 * <<index-lifecycle-management-api,Index lifecycle management APIs>>
 * <<licensing-apis,Licensing APIs>>
@@ -30,14 +30,13 @@ include::info.asciidoc[]
 include::{es-repo-dir}/ccr/apis/ccr-apis.asciidoc[]
 include::{es-repo-dir}/data-frames/apis/index.asciidoc[]
 include::{es-repo-dir}/graph/explore.asciidoc[]
-include::{es-repo-dir}/indices/apis/freeze.asciidoc[]
 include::{es-repo-dir}/ilm/apis/ilm-api.asciidoc[]
+include::{es-repo-dir}/indices/apis/index.asciidoc[]
 include::{es-repo-dir}/licensing/index.asciidoc[]
 include::{es-repo-dir}/migration/migration.asciidoc[]
 include::{es-repo-dir}/ml/apis/ml-api.asciidoc[]
 include::{es-repo-dir}/rollup/rollup-api.asciidoc[]
 include::{xes-repo-dir}/rest-api/security.asciidoc[]
-include::{es-repo-dir}/indices/apis/unfreeze.asciidoc[]
 include::{xes-repo-dir}/rest-api/watcher.asciidoc[]
 include::{es-repo-dir}/indices/apis/reload-analyzers.asciidoc[]
 include::defs.asciidoc[]


### PR DESCRIPTION
With elastic/docs#938, we created a standard template
for Elastic API Reference documentation.

This PR edits the freeze and unfreeze index APIs to use that template. It also creates a "index APIs" section under "REST APIs" to contain those pages.

Relates to elastic/docs#937 and https://github.com/elastic/elasticsearch/pull/43546.