### PR TITLE
Test fixtures improovements

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
@@ -48,9 +48,7 @@ class PrecommitTasks {
         }
 
         Configuration jarHellConfig = project.configurations.create("jarHell")
-        if (project.findProject(":libs:elasticsearch-core") != null &&
-                project.path.equals(":libs:elasticsearch-core") == false
-        ) {
+        if (ClasspathUtils.isElasticsearchProject() && project.path.equals(":libs:elasticsearch-core") == false) {
             // External plugins will depend on this already via transitive dependencies.
             // Internal projects are not all plugins, so make sure the check is available
             // we are not doing this for this project itself to avoid jar hell with itself

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
@@ -23,9 +23,7 @@ import com.avast.gradle.dockercompose.DockerComposePlugin;
 import com.avast.gradle.dockercompose.tasks.ComposeUp;
 import org.elasticsearch.gradle.OS;
 import org.elasticsearch.gradle.SystemPropertyCommandLineArgumentProvider;
-import org.elasticsearch.gradle.precommit.JarHellTask;
 import org.elasticsearch.gradle.precommit.TestingConventionsTasks;
-import org.elasticsearch.gradle.precommit.ThirdPartyAuditTask;
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Plugin;
@@ -53,12 +51,6 @@ public class TestFixturesPlugin implements Plugin<Project> {
         );
 
         if (project.file(DOCKER_COMPOSE_YML).exists()) {
-            // convenience boilerplate with build plugin
-            // Can't reference tasks that are implemented in Groovy, use reflection  instead
-            disableTaskByType(tasks, getTaskClass("org.elasticsearch.gradle.precommit.LicenseHeadersTask"));
-            disableTaskByType(tasks, ThirdPartyAuditTask.class);
-            disableTaskByType(tasks, JarHellTask.class);
-
             // the project that defined a test fixture can also use it
             extension.fixtures.add(project);
 
@@ -100,6 +92,14 @@ public class TestFixturesPlugin implements Plugin<Project> {
                         .getByType(ExtraPropertiesExtension.class).set(name, port)
                 );
             }
+        } else {
+            project.afterEvaluate(spec -> {
+                if (extension.fixtures.isEmpty()) {
+                    // if only one fixture is used, that's this one, but without a compose file that's not a valid configuration
+                    throw new IllegalStateException("No " + DOCKER_COMPOSE_YML + " found for " + project.getPath() +
+                        " nor does it use other fixtures.");
+                }
+            });
         }
 
         extension.fixtures

--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -331,7 +331,16 @@ thirdPartyAudit.ignoreMissingClasses (
   'software.amazon.ion.system.IonBinaryWriterBuilder',
   'software.amazon.ion.system.IonSystemBuilder',
   'software.amazon.ion.system.IonTextWriterBuilder',
-  'software.amazon.ion.system.IonWriterBuilder'
+  'software.amazon.ion.system.IonWriterBuilder',
+  // We don't use the kms dependency 
+  'com.amazonaws.services.kms.AWSKMS',
+  'com.amazonaws.services.kms.AWSKMSClient',
+  'com.amazonaws.services.kms.model.DecryptRequest',
+  'com.amazonaws.services.kms.model.DecryptResult',
+  'com.amazonaws.services.kms.model.EncryptRequest',
+  'com.amazonaws.services.kms.model.EncryptResult',
+  'com.amazonaws.services.kms.model.GenerateDataKeyRequest',
+  'com.amazonaws.services.kms.model.GenerateDataKeyResult'
 )
 
 thirdPartyAudit.ignoreMissingClasses 'javax.activation.DataHandler'


### PR DESCRIPTION
Don't disable some of the precommit tasks on fixtures.
This no longer makes sense now that a project can both produce and use a
fixture.

In order for this to be possible, had to add an additional configuration
to make JarHell class accessible to the task even if it's not a
dependency of the project and fix some of the third party audit fallout
from  #43671 which wasn't detected at the time due to the issue being
fixed here.

Closes #43918

