### PR TITLE
Prevent types deprecation warning for indices.exists requests

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -192,8 +192,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
             = new org.elasticsearch.action.admin.indices.get.GetIndexRequest();
         request.indices(indexName);
 
-        boolean response = execute(request, highLevelClient().indices()::exists, highLevelClient().indices()::existsAsync,
-                expectWarnings(RestGetIndicesAction.TYPES_DEPRECATION_MESSAGE));
+        boolean response = execute(request, highLevelClient().indices()::exists, highLevelClient().indices()::existsAsync);
         assertTrue(response);
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesAction.java
@@ -70,8 +70,8 @@ public class RestGetIndicesAction extends BaseRestHandler {
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
-        // starting with 7.0 we don't include types by default in the response
-        if (request.hasParam(INCLUDE_TYPE_NAME_PARAMETER)) {
+        // starting with 7.0 we don't include types by default in the response to GET requests
+        if (request.hasParam(INCLUDE_TYPE_NAME_PARAMETER) && request.method().equals(GET)) {
             deprecationLogger.deprecatedAndMaybeLog("get_indices_with_types", TYPES_DEPRECATION_MESSAGE);
         }
         final GetIndexRequest getIndexRequest = new GetIndexRequest();

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesActionTests.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.mock;
 public class RestGetIndicesActionTests extends RestActionTestCase {
 
     /**
-     * Test that setting the "include_type_name" parameter raises a warning
+     * Test that setting the "include_type_name" parameter raises a warning for the GET request
      */
     public void testIncludeTypeNamesWarning() throws IOException {
         Map<String, String> params = new HashMap<>();
@@ -56,6 +56,22 @@ public class RestGetIndicesActionTests extends RestActionTestCase {
                 .withMethod(RestRequest.Method.GET)
                 .withPath("/some_index")
                 .build();
+        handler.prepareRequest(request, mock(NodeClient.class));
+    }
+
+    /**
+     * Test that setting the "include_type_name" parameter doesn't raises a warning if the HEAD method is used (indices.exists)
+     */
+    public void testIncludeTypeNamesWarningExists() throws IOException {
+        Map<String, String> params = new HashMap<>();
+        params.put(INCLUDE_TYPE_NAME_PARAMETER, randomFrom("true", "false"));
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(RestRequest.Method.HEAD)
+            .withPath("/some_index")
+            .withParams(params)
+            .build();
+
+        RestGetIndicesAction handler = new RestGetIndicesAction(Settings.EMPTY, mock(RestController.class));
         handler.prepareRequest(request, mock(NodeClient.class));
     }
 }


### PR DESCRIPTION
Currently we log a deprecation warning to the types removal in
RestGetIndicesAction even if the REST method is HEAD, which is used by the
indices.exists API. Since the body is empty in this case we should not show
the deprecation warning.

Closes #43905