### PR TITLE
[TEST] Fix testCollectNodes

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
@@ -176,7 +176,6 @@ final class RemoteClusterConnection implements TransportConnectionListener, Clos
     @Override
     public void onNodeDisconnected(DiscoveryNode node) {
         boolean remove = connectedNodes.remove(node);
-        logger.trace("node disconnected: {}, removed: {}", node, remove);
         if (remove && connectedNodes.size() < maxNumRemoteConnections) {
             // try to reconnect and fill up the slot of the disconnected node
             connectHandler.forceConnect();

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.Strings;
@@ -553,14 +554,19 @@ public class RemoteClusterServiceTests extends ESTestCase {
         final List<DiscoveryNode> knownNodes_c1 = new CopyOnWriteArrayList<>();
         final List<DiscoveryNode> knownNodes_c2 = new CopyOnWriteArrayList<>();
 
+        final Settings settingsCluster1 = Settings.builder().put(settings).put(ClusterName.CLUSTER_NAME_SETTING.getKey(),
+            randomAlphaOfLength(10)).build();
+        final Settings settingsCluster2 = Settings.builder().put(settings).put(ClusterName.CLUSTER_NAME_SETTING.getKey(),
+            randomAlphaOfLength(10)).build();
+
         try (MockTransportService c1N1 =
-                 startTransport("cluster_1_node_1", knownNodes_c1, Version.CURRENT, settings);
+                 startTransport("cluster_1_node_1", knownNodes_c1, Version.CURRENT, settingsCluster1);
              MockTransportService c1N2 =
-                 startTransport("cluster_1_node_2", knownNodes_c1, Version.CURRENT, settings);
+                 startTransport("cluster_1_node_2", knownNodes_c1, Version.CURRENT, settingsCluster1);
              MockTransportService c2N1 =
-                 startTransport("cluster_2_node_1", knownNodes_c2, Version.CURRENT, settings);
+                 startTransport("cluster_2_node_1", knownNodes_c2, Version.CURRENT, settingsCluster2);
              MockTransportService c2N2 =
-                 startTransport("cluster_2_node_2", knownNodes_c2, Version.CURRENT, settings)) {
+                 startTransport("cluster_2_node_2", knownNodes_c2, Version.CURRENT, settingsCluster2)) {
             final DiscoveryNode c1N1Node = c1N1.getLocalDiscoNode();
             final DiscoveryNode c1N2Node = c1N2.getLocalDiscoNode();
             final DiscoveryNode c2N1Node = c2N1.getLocalDiscoNode();

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
@@ -35,7 +35,6 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -548,8 +547,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
         return ActionListener.wrap(x -> latch.countDown(), x -> fail());
     }
 
-    @TestLogging("org.elasticsearch.transport:TRACE") // added for https://github.com/elastic/elasticsearch/issues/41067
-    public void testCollectNodes() throws Exception {
+    public void testCollectNodes() throws InterruptedException, IOException {
         final Settings settings = Settings.EMPTY;
         final List<DiscoveryNode> knownNodes_c1 = new CopyOnWriteArrayList<>();
         final List<DiscoveryNode> knownNodes_c2 = new CopyOnWriteArrayList<>();
@@ -673,7 +671,6 @@ public class RemoteClusterServiceTests extends ESTestCase {
                             new ActionListener<BiFunction<String, String, DiscoveryNode>>() {
                                 @Override
                                 public void onResponse(BiFunction<String, String, DiscoveryNode> stringStringDiscoveryNodeBiFunction) {
-                                    logger.warn("unexpected call", new Exception("just for the stack trace"));
                                     try {
                                         fail("should not be called");
                                     } finally {


### PR DESCRIPTION
The test fails as it can interact with other tests (see explanation at https://github.com/elastic/elasticsearch/issues/41067#issuecomment-508419634).

It is fixed by giving unique cluster names to each remote cluster. As `RemoteClusterConnection` is sticky to the remote cluster name (see `RemoteClusterConnection.remoteClusterName`), this should prevent the test from connecting to nodes of other tests with different cluster name.

Also reverts a commit (8a1a000) that was added to increase log levels.

Closes #41067