### PR TITLE
Fix IndexShardIT.testIndexCanChangeCustomDataPath()

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardIT.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardIT.java
@@ -30,6 +30,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.cluster.ClusterState;
@@ -296,7 +297,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
         assertHitCount(client().prepareSearch(index).setSize(0).get(), 1L);
 
         logger.info("--> closing the index [{}]", index);
-        assertAcked(client().admin().indices().prepareClose(index));
+        assertAcked(client().admin().indices().prepareClose(index).setWaitForActiveShards(ActiveShardCount.DEFAULT));
         logger.info("--> index closed, re-opening...");
         assertAcked(client().admin().indices().prepareOpen(index));
         logger.info("--> index re-opened");
@@ -306,7 +307,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
 
         // Now, try closing and changing the settings
         logger.info("--> closing the index [{}] before updating data_path", index);
-        assertAcked(client().admin().indices().prepareClose(index));
+        assertAcked(client().admin().indices().prepareClose(index).setWaitForActiveShards(ActiveShardCount.DEFAULT));
 
         final Path newIndexDataPath = sharedDataPath.resolve("end-" + randomAlphaOfLength(10));
         IOUtils.rm(newIndexDataPath);


### PR DESCRIPTION
The test` IndexShardIT.testIndexCanChangeCustomDataPath()` fails on `7.x` and `7.3` because the translog cannot be recovered. 

While I can't reproduce the issue, I think it has been introduced in #43752 which changed `ReadOnlyEngine` so that it opens the translog in its constructor in order to load the translog stats. This opening writes a new checkpoint file, but because 7.x/7.3 does not wait for shards to be started after being closed, the test immediately starts to copy shard files to a new directory and possibly does not copy all the
required translog files.

By waiting for the shards to be started after being closed, we ensure that the shards (and engines) have been correctly initialized and that the translog checkpoint file is not currently being written.

closes #43964 