### PR TITLE
[7.x][ML] Report correct count for df-analytics get-stats API (#43969)

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
@@ -776,6 +776,7 @@ setup:
       ml.get_data_frame_analytics_stats:
         id: "*"
   - match: { count: 3 }
+  - length: { data_frame_analytics : 3 }
   - match: { data_frame_analytics.0.id: "bar" }
   - match: { data_frame_analytics.0.state: "stopped" }
   - match: { data_frame_analytics.1.id: "foo-1" }
@@ -787,6 +788,7 @@ setup:
       ml.get_data_frame_analytics_stats:
         id: "foo-*"
   - match: { count: 2 }
+  - length: { data_frame_analytics : 2 }
   - match: { data_frame_analytics.0.id: "foo-1" }
   - match: { data_frame_analytics.0.state: "stopped" }
   - match: { data_frame_analytics.1.id: "foo-2" }
@@ -796,20 +798,23 @@ setup:
       ml.get_data_frame_analytics_stats:
         id: "bar"
   - match: { count: 1 }
+  - length: { data_frame_analytics : 1 }
   - match: { data_frame_analytics.0.id: "bar" }
   - match: { data_frame_analytics.0.state: "stopped" }
 
   - do:
       ml.get_data_frame_analytics_stats:
         from: 2
-  - match: { count: 1 }
+  - match: { count: 3 }
+  - length: { data_frame_analytics : 1 }
   - match: { data_frame_analytics.0.id: "foo-2" }
   - match: { data_frame_analytics.0.state: "stopped" }
 
   - do:
       ml.get_data_frame_analytics_stats:
         size: 2
-  - match: { count: 2 }
+  - match: { count: 3 }
+  - length: { data_frame_analytics : 2 }
   - match: { data_frame_analytics.0.id: "bar" }
   - match: { data_frame_analytics.0.state: "stopped" }
   - match: { data_frame_analytics.1.id: "foo-1" }
@@ -819,7 +824,8 @@ setup:
       ml.get_data_frame_analytics_stats:
         from: 1
         size: 1
-  - match: { count: 1 }
+  - match: { count: 3 }
+  - length: { data_frame_analytics : 1 }
   - match: { data_frame_analytics.0.id: "foo-1" }
   - match: { data_frame_analytics.0.state: "stopped" }
 


### PR DESCRIPTION
The count should match the number of all df-analytics that
matched the id in the request. However, we set the count
to the number of df-analytics returned which was bound to the
`size` parameter. This commit fixes this by setting the count
to the count of the `get` response.

