### PR TITLE
Create missing PRRLs after primary activation

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -418,7 +418,7 @@ public class RecoveryIT extends AbstractRollingTestCase {
             case OLD:
                 Settings.Builder settings = Settings.builder()
                     .put(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), between(1, 5))
-                    .put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 1)
+                    .put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), between(0, 1))
                     .put(INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), "100ms")
                     .put(SETTING_ALLOCATION_MAX_RETRY.getKey(), "0") // fail faster
                     .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true);

--- a/server/src/test/java/org/elasticsearch/index/seqno/PeerRecoveryRetentionLeaseCreationIT.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/PeerRecoveryRetentionLeaseCreationIT.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.seqno;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.env.NodeMetaData;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.test.VersionUtils;
+
+import java.nio.file.Path;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.equalTo;
+
+@ESIntegTestCase.ClusterScope(numDataNodes = 0)
+public class PeerRecoveryRetentionLeaseCreationIT extends ESIntegTestCase {
+
+    @Override
+    protected boolean forbidPrivateIndexSettings() {
+        return false;
+    }
+
+    public void testCanRecoverFromStoreWithoutPeerRecoveryRetentionLease() throws Exception {
+        /*
+         * In a full cluster restart from a version without peer-recovery retention leases, the leases on disk will not include a lease for
+         * the local node. The same sort of thing can happen in weird situations This test ensures that a primary that is recovering from
+         * store creates a lease for itself.
+         */
+
+        internalCluster().startMasterOnlyNode();
+        final String dataNode = internalCluster().startDataOnlyNode();
+        final Path[] nodeDataPaths = internalCluster().getInstance(NodeEnvironment.class, dataNode).nodeDataPaths();
+
+        assertAcked(prepareCreate("index").setSettings(Settings.builder()
+            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
+            .put(IndexMetaData.SETTING_VERSION_CREATED,
+                VersionUtils.randomVersionBetween(random(), Version.CURRENT.minimumIndexCompatibilityVersion(), Version.CURRENT))));
+        ensureGreen("index");
+
+        // Change the node ID so that the persisted retention lease no longer applies.
+        final String oldNodeId = client().admin().cluster().prepareNodesInfo(dataNode).clear().get().getNodes().get(0).getNode().getId();
+        final String newNodeId = randomValueOtherThan(oldNodeId, () -> UUIDs.randomBase64UUID(random()));
+
+        internalCluster().restartNode(dataNode, new InternalTestCluster.RestartCallback() {
+            @Override
+            public Settings onNodeStopped(String nodeName) throws Exception {
+                final NodeMetaData nodeMetaData = new NodeMetaData(newNodeId, Version.CURRENT);
+                NodeMetaData.FORMAT.writeAndCleanup(nodeMetaData, nodeDataPaths);
+                return Settings.EMPTY;
+            }
+        });
+
+        ensureGreen("index");
+        assertThat(client().admin().cluster().prepareNodesInfo(dataNode).clear().get().getNodes().get(0).getNode().getId(),
+            equalTo(newNodeId));
+        final RetentionLeases retentionLeases = client().admin().indices().prepareStats("index").get().getShards()[0]
+            .getRetentionLeaseStats().retentionLeases();
+        assertTrue("expected lease for [" + newNodeId + "] in " + retentionLeases,
+            retentionLeases.contains(ReplicationTracker.getPeerRecoveryRetentionLeaseId(newNodeId)));
+    }
+
+}

--- a/test/framework/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseUtils.java
@@ -18,10 +18,26 @@
  */
 package org.elasticsearch.index.seqno;
 
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.cluster.routing.RecoverySource;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.UnassignedInfo;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.test.rest.yaml.ObjectPath;
+import org.junit.Assert;
+
+import java.io.IOException;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.hasItems;
 
 public class RetentionLeaseUtils {
 
@@ -44,5 +60,40 @@ public class RetentionLeaseUtils {
                     throw new AssertionError("unexpectedly merging " + o1 + " and " + o2);
                 },
                 LinkedHashMap::new));
+    }
+
+    /**
+     * Asserts that every copy of every shard of the given index has a peer recovery retention lease according to the stats exposed by the
+     * REST API
+     */
+    public static void assertAllCopiesHavePeerRecoveryRetentionLeases(RestClient restClient, String index) throws IOException {
+        final Request statsRequest = new Request("GET", "/" + index + "/_stats");
+        statsRequest.addParameter("level", "shards");
+        final Map<?, ?> shardsStats = ObjectPath.createFromResponse(restClient.performRequest(statsRequest))
+            .evaluate("indices." + index + ".shards");
+        for (Map.Entry<?, ?> shardCopiesEntry : shardsStats.entrySet()) {
+            final List<?> shardCopiesList = (List<?>) shardCopiesEntry.getValue();
+
+            final Set<String> expectedLeaseIds = new HashSet<>();
+            for (Object shardCopyStats : shardCopiesList) {
+                final String nodeId
+                    = Objects.requireNonNull((String) ((Map<?, ?>) (((Map<?, ?>) shardCopyStats).get("routing"))).get("node"));
+                expectedLeaseIds.add(ReplicationTracker.getPeerRecoveryRetentionLeaseId(
+                    ShardRouting.newUnassigned(new ShardId("_na_", "test", 0), false, RecoverySource.PeerRecoverySource.INSTANCE,
+                        new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test")).initialize(nodeId, null, 0L)));
+            }
+
+            final Set<String> actualLeaseIds = new HashSet<>();
+            for (Object shardCopyStats : shardCopiesList) {
+                final List<?> leases
+                    = (List<?>) ((Map<?, ?>) (((Map<?, ?>) shardCopyStats).get("retention_leases"))).get("leases");
+                for (Object lease : leases) {
+                    actualLeaseIds.add(Objects.requireNonNull((String) (((Map<?, ?>) lease).get("id"))));
+                }
+            }
+            Assert.assertThat("[" + index + "][" + shardCopiesEntry.getKey() + "] has leases " + actualLeaseIds
+                    + " but expected " + expectedLeaseIds,
+                actualLeaseIds, hasItems(expectedLeaseIds.toArray(new String[0])));
+        }
     }
 }


### PR DESCRIPTION
Today peer recovery retention leases (PRRLs) are created when starting a
replication group from scratch and during peer recovery. However, if the
replication group was migrated from nodes running a version which does not
create PRRLs (e.g. 7.3 and earlier) then it's possible that the primary was
relocated or promoted without first establishing all the expected leases.

It's not possible to establish these leases before or during primary
activation, so we must create them as soon as possible afterwards. This gives
weaker guarantees about history retention, since there's a possibility that
history will be discarded before it can be used. In practice such situations
are expected to occur only rarely.

This commit adds the machinery to create missing leases after primary
activation, and strengthens the assertions about the existence of such leases
in order to ensure that once all the leases do exist we never again enter a
state where there's a missing lease.

Relates #41536