### PR TITLE
Fix SnapshotResiliencyTest

### DIFF
--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -654,7 +654,9 @@ public class SnapshotResiliencyTests extends ESTestCase {
     }
 
     private static ClusterState stateForNode(ClusterState state, DiscoveryNode node) {
-        return ClusterState.builder(state).nodes(DiscoveryNodes.builder(state.nodes()).localNodeId(node.getId())).build();
+        // Remove and add back local node to update ephemeral id on restarts
+        return ClusterState.builder(state).nodes(DiscoveryNodes.builder(
+            state.nodes()).remove(node.getId()).add(node).localNodeId(node.getId())).build();
     }
 
     private final class TestClusterNodes {


### PR DESCRIPTION
* I could not find a seed for which the issue described in #43989 happens, but the problem is that the fact persisted state supplier we use in these tests doesn't do any of the recovery steps that are taken by `org.elasticsearch.gateway.GatewayMetaState#getPersistedState` so a quick fix to not need any of the state recovery behavior would be to simply force the correct ephemeral id for the node in the quasi-persisted state to not trip this assertion
   * Admittedly, this looks a little dirty but as far as I can tell `org.elasticsearch.cluster.coordination.AbstractCoordinatorTestCase.Cluster.MockPersistedState` has its own workaround here so we're not testing production behavior anyway and this might be good enough for the snapshot tests?
* Closes #43989 