### PR TITLE
[DOCS] Enables testing for create job ML API

### DIFF
--- a/docs/reference/ml/apis/ml-api.asciidoc
+++ b/docs/reference/ml/apis/ml-api.asciidoc
@@ -7,7 +7,21 @@ You can use the following APIs to perform {ml} activities.
 See <<ml-api-definitions, Definitions>> for the resource definitions used by the
 machine learning APIs and in advanced job configuration options in Kibana.
 
-[float]
+[discrete]
+[[ml-api-anomaly-job-endpoint]]
+=== {anomaly-jobs-cap}
+//* <<ml-valid-detector,Validate detectors>>, <<ml-valid-job,Validate job>>
+* <<ml-put-job,Create>> or <<ml-delete-job,delete {anomaly-jobs}>>
+* <<ml-put-calendar-job,Add>> or <<ml-delete-calendar-job,delete a {anomaly-job} from a calendar>>
+* <<ml-open-job,Open>> or <<ml-close-job,close {anomaly-jobs}>>
+* <<ml-get-job,Get {anomaly-jobs} info>> or <<ml-get-job-stats,statistics>>
+* <<ml-flush-job,Flush {anomaly-jobs}>>
+* <<ml-post-data,Post data to {anomaly-jobs}>>
+* <<ml-update-job,Update {anomaly-jobs}>>
+* <<ml-forecast,Create>> or <<ml-delete-forecast,delete forecasts>>
+
+
+[discrete]
 [[ml-api-calendar-endpoint]]
 === Calendars
 
@@ -16,7 +30,7 @@ machine learning APIs and in advanced job configuration options in Kibana.
 * <<ml-post-calendar-event,Add scheduled events to calendar>>, <<ml-delete-calendar-event,Delete scheduled events from calendar>>
 * <<ml-get-calendar,Get calendars>>, <<ml-get-calendar-event,Get scheduled events>>
 
-[float]
+[discrete]
 [[ml-api-filter-endpoint]]
 === Filters
 
@@ -24,7 +38,7 @@ machine learning APIs and in advanced job configuration options in Kibana.
 * <<ml-update-filter,Update filters>>
 * <<ml-get-filter,Get filters>>
 
-[float]
+[discrete]
 [[ml-api-datafeed-endpoint]]
 === {dfeeds-cap}
 
@@ -34,7 +48,7 @@ machine learning APIs and in advanced job configuration options in Kibana.
 * <<ml-preview-datafeed,Preview {dfeed}>>
 * <<ml-update-datafeed,Update {dfeed}>>
 
-[float]
+[discrete]
 [[ml-api-dfanalytics-endpoint]]
 === {dfanalytics-cap} APIs
 
@@ -45,21 +59,14 @@ machine learning APIs and in advanced job configuration options in Kibana.
 * <<start-dfanalytics,Start>> or <<stop-dfanalytics,stop {dfanalytics-jobs}>>
 * <<evaluate-dfanalytics,Evaluate {dfanalytics}>>
 
-[float]
+
+[discrete]
 [[ml-api-job-endpoint]]
 === Jobs
 
-//* <<ml-valid-detector,Validate detectors>>, <<ml-valid-job,Validate job>>
-* <<ml-put-job,Create job>>, <<ml-delete-job,Delete job>>
-* <<ml-put-calendar-job,Add job to calendar>>, <<ml-delete-calendar-job,Delete job from calendar>>
-* <<ml-open-job,Open job>>, <<ml-close-job,Close job>>
-* <<ml-get-job,Get job info>>, <<ml-get-job-stats,Get job statistics>>
-* <<ml-flush-job,Flush job>>
-* <<ml-post-data,Post data to job>>
-* <<ml-update-job,Update job>>
-* <<ml-forecast,Forecast job behavior>>, <<ml-delete-forecast,Delete forecasts>>
+See <<ml-api-anomaly-job-endpoint>> and <<ml-api-dfanalytics-endpoint>>.
 
-[float]
+[discrete]
 [[ml-api-snapshot-endpoint]]
 === Model Snapshots
 
@@ -69,7 +76,7 @@ machine learning APIs and in advanced job configuration options in Kibana.
 * <<ml-update-snapshot,Update model snapshot>>
 
 
-[float]
+[discrete]
 [[ml-api-result-endpoint]]
 === Results
 
@@ -79,25 +86,25 @@ machine learning APIs and in advanced job configuration options in Kibana.
 * <<ml-get-influencer,Get influencers>>
 * <<ml-get-record,Get records>>
 
-[float]
+[discrete]
 [[ml-api-file-structure-endpoint]]
 === File structure
 
 * <<ml-find-file-structure,Find file structure>>
 
-[float]
+[discrete]
 [[ml-api-ml-info-endpoint]]
 === Info
 
 * <<get-ml-info,Machine learning info>>
 
-[float]
+[discrete]
 [[ml-api-delete-expired-data-endpoint]]
 === Delete expired data
 
 * <<ml-delete-expired-data,Delete expired data>>
 
-[float]
+[discrete]
 [[ml-set-upgrade-mode-endpoint]]
 === Set upgrade mode
 
@@ -109,10 +116,10 @@ include::put-calendar-job.asciidoc[]
 //CLOSE
 include::close-job.asciidoc[]
 //CREATE
+include::put-job.asciidoc[]
 include::put-calendar.asciidoc[]
 include::put-datafeed.asciidoc[]
 include::put-filter.asciidoc[]
-include::put-job.asciidoc[]
 include::put-dfanalytics.asciidoc[]
 //DELETE
 include::delete-calendar.asciidoc[]

--- a/docs/reference/ml/apis/put-job.asciidoc
+++ b/docs/reference/ml/apis/put-job.asciidoc
@@ -121,34 +121,34 @@ When the job is created, you receive the following results:
 [source,js]
 ----
 {
-  "job_id": "total-requests",
-  "job_type": "anomaly_detector",
-  "job_version": "8.0.0",
-  "description": "Total sum of requests",
-  "create_time": 1562346643557,
-  "analysis_config": {
-    "bucket_span": "10m",
-    "detectors": [
+  "job_id" : "total-requests",
+  "job_type" : "anomaly_detector",
+  "job_version" : "8.0.0",
+  "description" : "Total sum of requests",
+  "create_time" : 1562352500629,
+  "analysis_config" : {
+    "bucket_span" : "10m",
+    "detectors" : [
       {
-        "detector_description": "Sum of total",
-        "function": "sum",
-        "field_name": "total",
-        "detector_index": 0
+        "detector_description" : "Sum of total",
+        "function" : "sum",
+        "field_name" : "total",
+        "detector_index" : 0
       }
     ],
-    "influencers": []
+    "influencers" : [ ]
   },
-  "analysis_limits": {
-    "model_memory_limit": "1024mb",
-    "categorization_examples_limit": 4
+  "analysis_limits" : {
+    "model_memory_limit" : "1024mb",
+    "categorization_examples_limit" : 4
   },
-  "data_description": {
-    "time_field": "timestamp",
-    "time_format": "epoch_ms"
+  "data_description" : {
+    "time_field" : "timestamp",
+    "time_format" : "epoch_ms"
   },
-  "model_snapshot_retention_days": 1,
-  "results_index_name": "shared"
+  "model_snapshot_retention_days" : 1,
+  "results_index_name" : "shared"
 }
 ----
-// TESTRESPONSE[s/"job_version": "8.0.0"/"job_version": $body.job_version/]
-// TESTRESPONSE[s/1562346643557/$body.$_path/]
+// TESTRESPONSE[s/"job_version" : "8.0.0"/"job_version" : $body.job_version/]
+// TESTRESPONSE[s/1562352500629/$body.$_path/]

--- a/docs/reference/ml/apis/put-job.asciidoc
+++ b/docs/reference/ml/apis/put-job.asciidoc
@@ -114,7 +114,6 @@ PUT _ml/anomaly_detectors/total-requests
 }
 --------------------------------------------------
 // CONSOLE
-// TEST[skip:need-licence]
 
 When the job is created, you receive the following results:
 [source,js]

--- a/docs/reference/ml/apis/put-job.asciidoc
+++ b/docs/reference/ml/apis/put-job.asciidoc
@@ -2,6 +2,8 @@
 [testenv="platinum"]
 [[ml-put-job]]
 === Create {anomaly-jobs} API
+
+[subs="attributes"]
 ++++
 <titleabbrev>Create {anomaly-jobs}</titleabbrev>
 ++++

--- a/docs/reference/ml/apis/put-job.asciidoc
+++ b/docs/reference/ml/apis/put-job.asciidoc
@@ -1,12 +1,12 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-put-job]]
-=== Create jobs API
+=== Create {anomaly-jobs} API
 ++++
-<titleabbrev>Create jobs</titleabbrev>
+<titleabbrev>Create {anomaly-jobs}</titleabbrev>
 ++++
 
-Instantiates a job.
+Instantiates an {anomaly-job}.
 
 [[ml-put-job-request]]
 ==== {api-request-title}
@@ -23,10 +23,10 @@ Instantiates a job.
 [[ml-put-job-desc]]
 ==== {api-description-title}
 
-IMPORTANT: You must use {kib} or this API to create a {ml} job. Do not put a job
-            directly to the `.ml-config` index using the Elasticsearch index API.
-            If {es} {security-features} are enabled, do not give users `write`
-            privileges on the `.ml-config` index.
+IMPORTANT: You must use {kib} or this API to create an {anomaly-job}. Do not put
+a job directly to the `.ml-config` index using the {es} index API. If {es}
+{security-features} are enabled, do not give users `write` privileges on the
+`.ml-config` index.
 
 [[ml-put-job-path-parms]]
 ==== {api-path-parms-title}
@@ -121,9 +121,9 @@ When the job is created, you receive the following results:
 {
   "job_id": "total-requests",
   "job_type": "anomaly_detector",
-  "job_version": "7.0.0-alpha1",
+  "job_version": "8.0.0",
   "description": "Total sum of requests",
-  "create_time": 1517011406091,
+  "create_time": 1562346643557,
   "analysis_config": {
     "bucket_span": "10m",
     "detectors": [
@@ -148,5 +148,5 @@ When the job is created, you receive the following results:
   "results_index_name": "shared"
 }
 ----
-// TESTRESPONSE[s/"job_version": "7.0.0-alpha1"/"job_version": $body.job_version/]
-// TESTRESPONSE[s/"create_time": 1517011406091/"create_time": $body.create_time/]
+// TESTRESPONSE[s/"job_version": "8.0.0"/"job_version": $body.job_version/]
+// TESTRESPONSE[s/1562346643557/$body.$_path/]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/33539

This PR re-enables code snippet testing for the create job API examples.

It also updates the terminology so that it's clear this PR pertains to anomaly detection jobs.

