### PR TITLE
[DOCS] Updates 7.x version in data frame analytics API

### DIFF
--- a/docs/reference/ml/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/apis/put-dfanalytics.asciidoc
@@ -120,9 +120,9 @@ The API returns the following result:
         "outlier_detection": {}
     },
     "model_memory_limit": "1gb",
-    "create_time" : 1562265491319,
-    "version" : "8.0.0"
+    "create_time": 1562265491319,
+    "version": "7.4.0"
 }
 ----
 // TESTRESPONSE[s/1562265491319/$body.$_path/]
-// TESTRESPONSE[s/"version": "8.0.0"/"version": $body.version/]
+// TESTRESPONSE[s/"version": "7.4.0"/"version": $body.version/]

--- a/docs/reference/ml/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/apis/put-dfanalytics.asciidoc
@@ -98,31 +98,33 @@ PUT _ml/data_frame/analytics/loganalytics
 }
 --------------------------------------------------
 // CONSOLE
-// TEST[skip:setup:setup_logdata]
+// TEST[setup:setup_logdata]
 
 The API returns the following result:
 
 [source,js]
 ----
 {
-    "id": "loganalytics",
-    "source": {
-        "index": ["logdata"],
-        "query": {
-            "match_all": {}
-        }
-    },
-    "dest": {
-        "index": "logdata_out",
-        "results_field": "ml"
-    },
-    "analysis": {
-        "outlier_detection": {}
-    },
-    "model_memory_limit": "1gb",
-    "create_time": 1562265491319,
-    "version": "7.4.0"
+  "id" : "loganalytics",
+  "source" : {
+    "index" : [
+      "logdata"
+    ],
+    "query" : {
+      "match_all" : { }
+    }
+  },
+  "dest" : {
+    "index" : "logdata_out",
+    "results_field" : "ml"
+  },
+  "analysis" : {
+    "outlier_detection" : { }
+  },
+  "model_memory_limit" : "1gb",
+  "create_time" : 1562351429434,
+  "version" : "7.3.0"
 }
 ----
-// TESTRESPONSE[s/1562265491319/$body.$_path/]
-// TESTRESPONSE[s/"version": "7.4.0"/"version": $body.version/]
+// TESTRESPONSE[s/1562351429434/$body.$_path/]
+// TESTRESPONSE[s/"version" : "7.3.0"/"version" : $body.version/]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/43875

This PR addresses the following CI failures:

> 10:32:44     java.lang.AssertionError: Failure at [reference/ml/apis/put-dfanalytics:51]: $body didn't match expected value:
10:32:44                              $body: 
10:32:44                             analysis: 
10:32:44                      outlier_detection: same [empty map]
10:32:44                          create_time: same [1562347964279]
10:32:44                                 dest: 
10:32:44                                  index: same [logdata_out]
10:32:44                          results_field: same [ml]
10:32:44                                   id: same [loganalytics]
10:32:44                   model_memory_limit: same [1gb]
10:32:44                               source: 
10:32:44                                  index: 
10:32:44                                        0: same [logdata]
10:32:44                                  query: 
10:32:44                                match_all: same [empty map]
10:32:44                              version: expected [8.0.0] but was [7.4.0]