### PR TITLE
[DOCS] Updates 7.3 version in data frame analytics API

### DIFF
--- a/docs/reference/ml/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/apis/put-dfanalytics.asciidoc
@@ -98,7 +98,7 @@ PUT _ml/data_frame/analytics/loganalytics
 }
 --------------------------------------------------
 // CONSOLE
-// TEST[skip:setup:setup_logdata]
+// TEST[setup:setup_logdata]
 
 The API returns the following result:
 

--- a/docs/reference/ml/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/apis/put-dfanalytics.asciidoc
@@ -105,24 +105,26 @@ The API returns the following result:
 [source,js]
 ----
 {
-    "id": "loganalytics",
-    "source": {
-        "index": ["logdata"],
-        "query": {
-            "match_all": {}
-        }
-    },
-    "dest": {
-        "index": "logdata_out",
-        "results_field": "ml"
-    },
-    "analysis": {
-        "outlier_detection": {}
-    },
-    "model_memory_limit": "1gb",
-    "create_time" : 1562265491319,
-    "version" : "8.0.0"
+  "id" : "loganalytics",
+  "source" : {
+    "index" : [
+      "logdata"
+    ],
+    "query" : {
+      "match_all" : { }
+    }
+  },
+  "dest" : {
+    "index" : "logdata_out",
+    "results_field" : "ml"
+  },
+  "analysis" : {
+    "outlier_detection" : { }
+  },
+  "model_memory_limit" : "1gb",
+  "create_time" : 1562351429434,
+  "version" : "7.3.0"
 }
 ----
-// TESTRESPONSE[s/1562265491319/$body.$_path/]
-// TESTRESPONSE[s/"version": "8.0.0"/"version": $body.version/]
+// TESTRESPONSE[s/1562351429434/$body.$_path/]
+// TESTRESPONSE[s/"version" : "7.3.0"/"version" : $body.version/]


### PR DESCRIPTION
Related to #43875

This PR addresses the following CI failures:

> 10:34:54 org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT > test {yaml=reference/ml/apis/put-dfanalytics/line_85} FAILED
10:34:54     java.lang.AssertionError: Failure at [reference/ml/apis/put-dfanalytics:51]: $body didn't match expected value:
10:34:54                              $body: 
10:34:54                             analysis: 
10:34:54                      outlier_detection: same [empty map]
10:34:54                          create_time: same [1562348094310]
10:34:54                                 dest: 
10:34:54                                  index: same [logdata_out]
10:34:54                          results_field: same [ml]
10:34:54                                   id: same [loganalytics]
10:34:54                   model_memory_limit: same [1gb]
10:34:54                               source: 
10:34:54                                  index: 
10:34:54                                        0: same [logdata]
10:34:54                                  query: 
10:34:54                                match_all: same [empty map]
10:34:54                              version: expected [8.0.0] but was [7.3.0]
10:34:54 