### PR TITLE
Remove Outdated Comments from BlobStoreRepository

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -951,14 +951,11 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 lastSnapshotStatus.getIndexVersion(),
                 indexCommitPointFiles,
                 lastSnapshotStatus.getStartTime(),
-                // snapshotStatus.startTime() is assigned on the same machine,
-                // so it's safe to use the relative time in millis
                 threadPool.absoluteTimeInMillis() - lastSnapshotStatus.getStartTime(),
                 lastSnapshotStatus.getIncrementalFileCount(),
                 lastSnapshotStatus.getIncrementalSize()
             );
 
-            //TODO: The time stored in snapshot doesn't include cleanup time.
             logger.trace("[{}] [{}] writing shard snapshot file", shardId, snapshotId);
             try {
                 indexShardSnapshotFormat.write(snapshot, shardContainer, snapshotId.getUUID());


### PR DESCRIPTION
As a result of #43148 neitehr of these apply:
* First comment about relative time doesn't apply anymore since we use absolute time here again
* The overall time in all snapshot APIs is now consistent and contains cleanup the time since it's not just calculated as the maximum of all shard upload times
