### PR TITLE
add disable_chunked_encoding configuration

### DIFF
--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -153,6 +153,13 @@ settings belong in the `elasticsearch.yml` file.
    https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#setPathStyleAccessEnabled-java.lang.Boolean-[AWS
    documentation] for details). Defaults to `false`.
 
+`disable_chunked_encoding`::
+    Whether chunked encoding should be disabled or not. If `true`, the
+    chunked encoding will be disabled. If `false`, the chunked encoding will
+    be automatically determined by the AWS Java SDK (See
+    https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#withChunkedEncodingDisabled-java.lang.Boolean-[AWS
+    documentation] for details). Defaults to `false`.
+
 [[repository-s3-path-style-deprecation]]
 NOTE: In versions `7.0`, `7.1`, `7.2` and `7.3` all bucket operations used the
 https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/[now-deprecated]

--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -160,11 +160,15 @@ path style access pattern. If your deployment requires the path style access
 pattern then you should set this setting to `true` when upgrading.
 
 `disable_chunked_encoding`::
-    Whether chunked encoding should be disabled or not. If `true`, the
-    chunked encoding will be disabled. If `false`, the chunked encoding will
-    be automatically determined by the AWS Java SDK (See
-    https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#withChunkedEncodingDisabled-java.lang.Boolean-[AWS
-    documentation] for details). Defaults to `false`.
+
+    Whether chunked encoding should be disabled or not. If `false`, chunked
+    encoding is enabled and will be used where appropriate. If `true`, chunked
+    encoding is disabled and will not be used, which may mean that snapshot
+    operations consume more resources and take longer to complete. It should
+    only be set to `true` if you are using a storage service that does not
+    support chunked encoding. See the
+    https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#disableChunkedEncoding--[AWS
+    Java SDK documentation] for details. Defaults to `false`.
 
 [float]
 [[repository-s3-compatible-services]]

--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -153,18 +153,18 @@ settings belong in the `elasticsearch.yml` file.
    https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#setPathStyleAccessEnabled-java.lang.Boolean-[AWS
    documentation] for details). Defaults to `false`.
 
+[[repository-s3-path-style-deprecation]]
+NOTE: In versions `7.0`, `7.1`, `7.2` and `7.3` all bucket operations used the
+https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/[now-deprecated]
+path style access pattern. If your deployment requires the path style access
+pattern then you should set this setting to `true` when upgrading.
+
 `disable_chunked_encoding`::
     Whether chunked encoding should be disabled or not. If `true`, the
     chunked encoding will be disabled. If `false`, the chunked encoding will
     be automatically determined by the AWS Java SDK (See
     https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#withChunkedEncodingDisabled-java.lang.Boolean-[AWS
     documentation] for details). Defaults to `false`.
-
-[[repository-s3-path-style-deprecation]]
-NOTE: In versions `7.0`, `7.1`, `7.2` and `7.3` all bucket operations used the
-https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/[now-deprecated]
-path style access pattern. If your deployment requires the path style access
-pattern then you should set this setting to `true` when upgrading.
 
 [float]
 [[repository-s3-compatible-services]]

--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -101,6 +101,8 @@ String s3EC2BasePath = System.getenv("amazon_s3_base_path_ec2")
 String s3ECSBucket = System.getenv("amazon_s3_bucket_ecs")
 String s3ECSBasePath = System.getenv("amazon_s3_base_path_ecs")
 
+boolean s3DisableChunkedEncoding = (new Random()).nextBoolean()
+
 // If all these variables are missing then we are testing against the internal fixture instead, which has the following
 // credentials hard-coded in.
 
@@ -257,7 +259,8 @@ processTestResources {
           'ec2_bucket': s3EC2Bucket,
           'ec2_base_path': s3EC2BasePath,
           'ecs_bucket': s3ECSBucket,
-          'ecs_base_path': s3ECSBasePath
+          'ecs_base_path': s3ECSBasePath,
+          'disable_chunked_encoding': s3DisableChunkedEncoding,
   ]
   inputs.properties(expansions)
   MavenFilteringHack.filter(it, expansions)

--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -101,7 +101,7 @@ String s3EC2BasePath = System.getenv("amazon_s3_base_path_ec2")
 String s3ECSBucket = System.getenv("amazon_s3_bucket_ecs")
 String s3ECSBasePath = System.getenv("amazon_s3_base_path_ecs")
 
-boolean s3DisableChunkedEncoding = (new Random()).nextBoolean()
+boolean s3DisableChunkedEncoding = (new Random(Long.parseUnsignedLong(project.rootProject.testSeed.tokenize(':').get(0), 16))).nextBoolean()
 
 // If all these variables are missing then we are testing against the internal fixture instead, which has the following
 // credentials hard-coded in.
@@ -235,9 +235,7 @@ task s3FixtureProperties {
       "s3Fixture.disableChunkedEncoding" : s3DisableChunkedEncoding
   ]
 
-  doLast {
-    file(s3FixtureFile).text = s3FixtureOptions.collect { k, v -> "$k = $v" }.join("\n")
-  }
+  file(s3FixtureFile).text = s3FixtureOptions.collect { k, v -> "$k = $v" }.join("\n")
 }
 
 /** A task to start the AmazonS3Fixture which emulates an S3 service **/

--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -235,7 +235,10 @@ task s3FixtureProperties {
       "s3Fixture.disableChunkedEncoding" : s3DisableChunkedEncoding
   ]
 
-  file(s3FixtureFile).text = s3FixtureOptions.collect { k, v -> "$k = $v" }.join("\n")
+  outputs.upToDateWhen { false }
+  doLast {
+    file(s3FixtureFile).text = s3FixtureOptions.collect { k, v -> "$k = $v" }.join("\n")
+  }
 }
 
 /** A task to start the AmazonS3Fixture which emulates an S3 service **/

--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -235,7 +235,6 @@ task s3FixtureProperties {
       "s3Fixture.disableChunkedEncoding" : s3DisableChunkedEncoding
   ]
 
-  outputs.upToDateWhen { false }
   doLast {
     file(s3FixtureFile).text = s3FixtureOptions.collect { k, v -> "$k = $v" }.join("\n")
   }

--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -231,7 +231,8 @@ task s3FixtureProperties {
       "s3Fixture.temporary_key"          : s3TemporaryAccessKey,
       "s3Fixture.temporary_session_token": s3TemporarySessionToken,
       "s3Fixture.ec2_bucket_name"        : s3EC2Bucket,
-      "s3Fixture.ecs_bucket_name"        : s3ECSBucket
+      "s3Fixture.ecs_bucket_name"        : s3ECSBucket,
+      "s3Fixture.disableChunkedEncoding" : s3DisableChunkedEncoding
   ]
 
   doLast {

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
@@ -157,6 +157,10 @@ class S3Service implements Closeable {
         if (clientSettings.pathStyleAccess) {
             builder.enablePathStyleAccess();
         }
+
+        if (clientSettings.disableChunkedEncoding) {
+            builder.withChunkedEncodingDisabled(true);
+        }
         return builder.build();
     }
 

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
@@ -157,9 +157,8 @@ class S3Service implements Closeable {
         if (clientSettings.pathStyleAccess) {
             builder.enablePathStyleAccess();
         }
-
         if (clientSettings.disableChunkedEncoding) {
-            builder.withChunkedEncodingDisabled(true);
+            builder.disableChunkedEncoding();
         }
         return builder.build();
     }

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AmazonS3Fixture.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AmazonS3Fixture.java
@@ -254,7 +254,7 @@ public class AmazonS3Fixture extends AbstractHttpFixture {
                         return new Response(RestStatus.OK.getStatus(), TEXT_PLAIN_CONTENT_TYPE, EMPTY_BYTE);
                     }
                 } else {
-                    if (!disableChunkedEncoding) {
+                    if (disableChunkedEncoding == false) {
                         return newInternalError(request.getId(), "Something is wrong with this PUT request");
                     }
                     // Read from body directly

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AmazonS3Fixture.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AmazonS3Fixture.java
@@ -76,6 +76,7 @@ public class AmazonS3Fixture extends AbstractHttpFixture {
     /** Request handlers for the requests made by the S3 client **/
     private final PathTrie<RequestHandler> handlers;
 
+    private final boolean disableChunkedEncoding;
     /**
      * Creates a {@link AmazonS3Fixture}
      */
@@ -93,6 +94,8 @@ public class AmazonS3Fixture extends AbstractHttpFixture {
             randomAsciiAlphanumOfLength(random, 10), randomAsciiAlphanumOfLength(random, 10));
 
         this.handlers = defaultHandlers(buckets, ec2Bucket, ecsBucket);
+
+        this.disableChunkedEncoding = Boolean.parseBoolean(prop(properties, "s3Fixture.disableChunkedEncoding"));
     }
 
     private static String nonAuthPath(Request request) {
@@ -219,6 +222,9 @@ public class AmazonS3Fixture extends AbstractHttpFixture {
 
                 String headerDecodedContentLength = request.getHeader("X-amz-decoded-content-length");
                 if (headerDecodedContentLength != null) {
+                    if (disableChunkedEncoding) {
+                        return newInternalError(request.getId(), "Something is wrong with this PUT request");
+                    }
                     // This is a chunked upload request. We should have the header "Content-Encoding : aws-chunked,gzip"
                     // to detect it but it seems that the AWS SDK does not follow the S3 guidelines here.
                     //
@@ -248,6 +254,9 @@ public class AmazonS3Fixture extends AbstractHttpFixture {
                         return new Response(RestStatus.OK.getStatus(), TEXT_PLAIN_CONTENT_TYPE, EMPTY_BYTE);
                     }
                 } else {
+                    if (!disableChunkedEncoding) {
+                        return newInternalError(request.getId(), "Something is wrong with this PUT request");
+                    }
                     // Read from body directly
                     try (BufferedInputStream inputStream = new BufferedInputStream(new ByteArrayInputStream(request.getBody()))) {
                         byte[] bytes = IOUtils.toByteArray(inputStream);

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3ClientSettingsTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3ClientSettingsTests.java
@@ -151,4 +151,11 @@ public class S3ClientSettingsTests extends ESTestCase {
         assertThat(settings.get("default").pathStyleAccess, is(false));
         assertThat(settings.get("other").pathStyleAccess, is(true));
     }
+
+    public void testUseChunkedEncodingCanBeSet() {
+        final Map<String, S3ClientSettings> settings = S3ClientSettings.load(
+            Settings.builder().put("s3.client.other.disable_chunked_encoding", true).build());
+        assertThat(settings.get("default").disableChunkedEncoding, is(false));
+        assertThat(settings.get("other").disableChunkedEncoding, is(true));
+    }
 }

--- a/plugins/repository-s3/src/test/resources/rest-api-spec/test/repository_s3/20_repository_permanent_credentials.yml
+++ b/plugins/repository-s3/src/test/resources/rest-api-spec/test/repository_s3/20_repository_permanent_credentials.yml
@@ -15,6 +15,7 @@ setup:
             base_path: "${permanent_base_path}"
             canned_acl: private
             storage_class: standard
+            disable_chunked_encoding: ${disable_chunked_encoding}
 
   # Remove the snapshots, if a previous test failed to delete them. This is
   # useful for third party tests that runs the test against a real external service.

--- a/plugins/repository-s3/src/test/resources/rest-api-spec/test/repository_s3/30_repository_temporary_credentials.yml
+++ b/plugins/repository-s3/src/test/resources/rest-api-spec/test/repository_s3/30_repository_temporary_credentials.yml
@@ -15,6 +15,7 @@ setup:
             base_path: "${temporary_base_path}"
             canned_acl: private
             storage_class: standard
+            disable_chunked_encoding: ${disable_chunked_encoding}
 
 ---
 "Snapshot and Restore with repository-s3 using temporary credentials":

--- a/plugins/repository-s3/src/test/resources/rest-api-spec/test/repository_s3/40_repository_ec2_credentials.yml
+++ b/plugins/repository-s3/src/test/resources/rest-api-spec/test/repository_s3/40_repository_ec2_credentials.yml
@@ -15,6 +15,7 @@ setup:
             base_path: "${ec2_base_path}"
             canned_acl: private
             storage_class: standard
+            disable_chunked_encoding: ${disable_chunked_encoding}
 
 ---
 "Snapshot and Restore with repository-s3 using ec2 credentials":

--- a/plugins/repository-s3/src/test/resources/rest-api-spec/test/repository_s3/50_repository_ecs_credentials.yml
+++ b/plugins/repository-s3/src/test/resources/rest-api-spec/test/repository_s3/50_repository_ecs_credentials.yml
@@ -15,6 +15,7 @@ setup:
             base_path: "${ecs_base_path}"
             canned_acl: private
             storage_class: standard
+            disable_chunked_encoding: ${disable_chunked_encoding}
 
 ---
 "Snapshot and Restore with repository-s3 using ecs credentials":


### PR DESCRIPTION
Hi, es team. We are using **repository-s3** to access s3-compatible service(Alibaba Cloud Object Storage Service). However, it does not support chunked encoding.
```bash
[root@master ~]# curl -XPUT 'http://localhost:9200/_snapshot/backup' -H 'Content-Type: application/json' -d '{ "type": "s3", "settings": { "bucket": "hadoop-oss-test", "endpoint": "oss-cn-zhangjiakou.aliyuncs.com", "protocol": "http"} }'
```
```json
{
	"error": {
		"root_cause": [{
			"type": "repository_verification_exception",
			"reason": "[backup] path  is not accessible on master node"
		}],
		"type": "repository_verification_exception",
		"reason": "[backup] path  is not accessible on master node",
		"caused_by": {
			"type": "i_o_exception",
			"reason": "Unable to upload object [tests-jI3CAPLSTeWReGDUP_Pf_w/master.dat] using a single upload",
			"caused_by": {
				"type": "amazon_s3_exception",
				"reason": "Aws MultiChunkedEncoding is not supported. (Service: Amazon S3; Status Code: 400; Error Code: NotImplemented; Request ID: 5D22E6C1F73A3FB709ECAB2F; S3 Extended Request ID: hadoop-oss-test.oss-cn-zhangjiakou.aliyuncs.com)"
			}
		}
	},
	"status": 500
}
```

After we add chunked encoding as a configuration(**disable_chunked_encoding**), it works!
```bash
curl -XPUT 'http://localhost:9200/_snapshot/backup' -H 'Content-Type: application/json' -d '{ "type": "s3", "settings": { "bucket": "hadoop-oss-test", "endpoint": "oss-cn-zhangjiakou.aliyuncs.com", "protocol": "http", "disable_chunked_encoding": true} }'
```
```json
{"acknowledged":true}
```

I created this PR for this change. :)