### PR TITLE
Do not copy initial recovery filter during split

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/ShrinkIndexIT.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/ShrinkIndexIT.java
@@ -564,10 +564,6 @@ public class ShrinkIndexIT extends ESIntegTestCase {
         prepareCreate("original").setSettings(Settings.builder().put(indexSettings())
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
             .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, shardCount)).get();
-        for (int i = 0; i < 30; i++) {
-            client().prepareIndex("original", "_doc")
-                .setSource("{\"foo\" : \"bar\", \"i\" : " + i + "}", XContentType.JSON).get();
-        }
         client().admin().indices().prepareFlush("original").get();
         ensureGreen();
         final String shrinkNode

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/ShrinkIndexIT.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/ShrinkIndexIT.java
@@ -32,6 +32,7 @@ import org.elasticsearch.action.admin.indices.segments.IndexShardSegments;
 import org.elasticsearch.action.admin.indices.segments.IndicesSegmentResponse;
 import org.elasticsearch.action.admin.indices.segments.ShardSegments;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
+import org.elasticsearch.action.admin.indices.shrink.ResizeType;
 import org.elasticsearch.action.admin.indices.stats.CommonStats;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
@@ -61,6 +62,7 @@ import org.elasticsearch.index.seqno.SeqNoStats;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.VersionUtils;
 
 import java.util.Arrays;
@@ -553,5 +555,47 @@ public class ShrinkIndexIT extends ESIntegTestCase {
         client().admin().cluster().prepareUpdateSettings().setTransientSettings(Settings.builder().put(
             EnableAllocationDecider.CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING.getKey(), (String)null
         )).get();
+    }
+
+    public void testShrinkThenSplitWithFailedNode() throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(3);
+
+        final int shardCount = between(2, 5);
+        prepareCreate("original").setSettings(Settings.builder().put(indexSettings())
+            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, shardCount)).get();
+        for (int i = 0; i < 30; i++) {
+            client().prepareIndex("original", "_doc")
+                .setSource("{\"foo\" : \"bar\", \"i\" : " + i + "}", XContentType.JSON).get();
+        }
+        client().admin().indices().prepareFlush("original").get();
+        ensureGreen();
+        final String shrinkNode
+            = client().admin().cluster().prepareNodesInfo("data:true").clear().get().getNodes().get(0).getNode().getName();
+        client().admin().indices().prepareUpdateSettings("original")
+            .setSettings(Settings.builder()
+                .put(IndexMetaData.INDEX_ROUTING_REQUIRE_GROUP_SETTING.getConcreteSettingForNamespace("_name").getKey(), shrinkNode)
+                .put(IndexMetaData.SETTING_BLOCKS_WRITE, true)).get();
+        ensureGreen();
+
+        assertAcked(client().admin().indices().prepareResizeIndex("original", "shrunk").setSettings(Settings.builder()
+            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1)
+            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+            .putNull(IndexMetaData.INDEX_ROUTING_REQUIRE_GROUP_SETTING.getConcreteSettingForNamespace("_name").getKey())
+            .build()).setResizeType(ResizeType.SHRINK).get());
+        ensureGreen();
+
+        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(shrinkNode));
+
+        // demonstrate that the index.routing.allocation.initial_recovery setting from the shrink doesn't carry over into the split index,
+        // because this would cause the shrink to fail as the initial_recovery node is no longer present.
+
+        logger.info("--> executing split");
+        assertAcked(client().admin().indices().prepareResizeIndex("shrunk", "splitagain").setSettings(Settings.builder()
+                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, shardCount)
+                .putNull(IndexMetaData.INDEX_ROUTING_REQUIRE_GROUP_SETTING.getConcreteSettingForNamespace("_name").getKey())
+                .build()).setResizeType(ResizeType.SPLIT));
+        ensureGreen("splitagain");
     }
 }


### PR DESCRIPTION
If an index is the result of a shrink then it will have a value set for
`index.routing.allocation.initial_recovery._id`. If this index is subsequently
split then this value will be copied over, forcing the initial allocation of
the split shards to occur on the node on which the shrink took place. Moreover
if this node no longer exists then the split will fail.  This commit suppresses
the copying of this setting when splitting an index.

Fixes #43955