### PR TITLE
Fix gradle "eclipse" goal for `mapper-flattened` and `voting-only-node`

### DIFF
--- a/x-pack/plugin/mapper-flattened/build.gradle
+++ b/x-pack/plugin/mapper-flattened/build.gradle
@@ -19,9 +19,6 @@ archivesBaseName = 'x-pack-flattened'
 dependencies {
     compileOnly project(path: xpackModule('core'), configuration: 'default')
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-    if (isEclipse) {
-        testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
-    }
 }
 
 integTest.enabled = false

--- a/x-pack/plugin/voting-only-node/build.gradle
+++ b/x-pack/plugin/voting-only-node/build.gradle
@@ -11,9 +11,6 @@ esplugin {
 dependencies {
     compileOnly project(path: xpackModule('core'), configuration: 'default')
     testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-    if (isEclipse) {
-        testCompile project(path: xpackModule('core-tests'), configuration: 'testArtifacts')
-    }
 }
 
 // xpack modules are installed in real clusters as the meta plugin, so


### PR DESCRIPTION
I got errors building the 7.x eclipse project files using `./gradlew eclipse` lately. I got failures like 

```
FAILURE: Build failed with an exception.

* Where:
Build file '/Users/christoph/workspace/es_7/elasticsearch/x-pack/build.gradle' line: 9

* What went wrong:
A problem occurred evaluating project ':x-pack:plugin:mapper-flattened'.
> Project with path 'plugin:core-tests' could not be found in project ':x-pack'.
```

That led me to remove the conditional dependencies in this PR (the one in `voting-only-node` as well because after removing the former, there was a similar error in the other project). I'm not too familiar with the build setup here but it looks these blocks are necessary on master but not on 7.x).
After removal I at least can build run the eclipse goal successfully.