### PR TITLE
Fix eclipse type inference issue

### DIFF
--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/QuerierTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/QuerierTests.java
@@ -75,7 +75,8 @@ public class QuerierTests extends ESTestCase {
         for (int j = 0; j < noColumns; j++) {
             boolean order = randomBoolean();
             ordering[j] = order;
-            tuples.add(new Tuple<>(j, order ? Comparator.naturalOrder() : Comparator.reverseOrder()));
+            Comparator comp = order ? Comparator.naturalOrder() : Comparator.reverseOrder();
+            tuples.add(new Tuple<>(j, comp));
         }
 
         // Insert random no of documents (rows) with random 0/1 values for each field


### PR DESCRIPTION
The internal Eclipse java compiler occasionally has problems infering generic types. 
In this case it cannot correctly find the Comparator type of the second Tuple argument.
This change fixes that.