### PR TITLE
[DOCS] Rewrite put field mapping API docs to use new format

### DIFF
--- a/docs/reference/indices/get-field-mapping.asciidoc
+++ b/docs/reference/indices/get-field-mapping.asciidoc
@@ -1,53 +1,116 @@
 [[indices-get-field-mapping]]
-== Get Field Mapping
+== Get field mapping API
+++++
+<titleabbrev>Get field mapping</titleabbrev>
+++++
 
-The get field mapping API allows you to retrieve mapping definitions for one or more fields.
-This is useful when you do not need the complete type mapping returned by
-the <<indices-get-mapping>> API.
+Returns mapping definitions for one or more fields in an index.
 
-For example, consider the following mapping:
+[float]
+[[indices-get-field-mapping-request]]
+=== {api-request-title}
+
+`GET /<index>/_mapping/field/<field>`
+
+[float]
+[[indices-get-field-mapping-desc]]
+=== {api-description-title}
+
+You can use the get field mapping API to retrieve mapping definitions for one or
+more fields.
+
+This API can be useful when you only need mapping definitions for a
+few fields rather than the entire mapping returned by the
+<<indices-get-mapping,get mapping>> API.
+
+[float]
+[[indices-get-field-mapping-path-params]]
+=== {api-path-parms-title}
+
+`<index>` (Optional)::
++
+--
+(string) Comma-separated list or wildcard expression of index names from which to
+retrieve field mapping information.
+
+You can use a value of `_all` or `*` to retrieve mapping information from all
+indices matching the `<field>` parameter.
+
+If no value is provided, the API retrieves mapping information from all
+indices matching the `<field>` parameter.
+--
+
+`<field>` (Required)::
+(string) Comma-separated list or wildcard expression of fields for which to
+retrieve mapping information. You can retrieve mapping information for nested
+fields using dot notation, such as `id.abstract`.
+
+[float]
+[[indices-get-field-mapping-query-params]]
+=== {api-query-parms-title}
+
+`allow_no_indices` (Optional)::
+(boolean) Indicates whether the operation is skipped if a wildcard expression
+matches no indices. Defaults to `false`.
+
+`expand_wildcards` (Optional)::
++
+--
+(string) Indicates whether wildcard expressions should expand to
+<<indices-open-close, open or closed indices>>. Possible values are:
+
+* `open` (Default)
+* `closed`
+* `none`
+* `all`
+--
+
+`ignore_unavailable` (Optional)::
+(boolean) Indicates whether unavailable indices are skipped. Defaults to
+`false`.
+
+`include_defaults` (Optional)::
+(boolean) Indicates whether default settings are included in the response.
+Defaults to `false`.
+
+`include_type_name` (Optional)::
++
+--
+(boolean) Indicates whether the type name is included in the response. Defaults
+to `false`.
+
+NOTE: Before 7.0.0, the 'mappings' definition used to include a type name.
+Although mappings in responses no longer contain a type name by default, you can
+still request the old format through the parameter include_type_name. For more
+details, please see <<removal-of-types>>.
+--
+
+`local` (Optional)::
+(boolean) Indicates whether only local node information is included in the
+response. Defaults to `false`. If `true`, state information is not retrieved
+from the master node.
+
+[float]
+[[sample-api-example]]
+=== {api-examples-title}
 
 [source,js]
---------------------------------------------------
-PUT publications
-{
-    "mappings": {
-        "properties": {
-            "id": { "type": "text" },
-            "title":  { "type": "text"},
-            "abstract": { "type": "text"},
-            "author": {
-                "properties": {
-                    "id": { "type": "text" },
-                    "name": { "type": "text" }
-                }
-            }
-        }
-    }
-}
---------------------------------------------------
-// TESTSETUP
+----
+GET /twitter/_mapping/field/message
+----
 // CONSOLE
 
-The following returns the mapping of the field `title` only:
+The API returns the following response:
 
 [source,js]
---------------------------------------------------
-GET publications/_mapping/field/title
---------------------------------------------------
-// CONSOLE
-
-For which the response is:
-
-[source,js]
---------------------------------------------------
+----
 {
-   "publications": {
+   "twitter": {
       "mappings": {
-          "title": {
-             "full_name": "title",
+          "message": {
+             "full_name": "message",
              "mapping": {
-                "title": {
+                "message": {
                    "type": "text"
                 }
              }
@@ -55,123 +118,5 @@ For which the response is:
        }
    }
 }
---------------------------------------------------
+----
 // TESTRESPONSE
-
-[float]
-=== Multiple Indices and Fields
-
-The get field mapping API can be used to get the mapping of multiple fields from more than one index
-with a single call. General usage of the API follows the
-following syntax: `host:port/{index}/_mapping/field/{field}` where
-`{index}` and `{field}` can stand for comma-separated list of names or wild cards. To
-get mappings for all indices you can use `_all` for `{index}`. The
-following are some examples:
-
-[source,js]
---------------------------------------------------
-GET /twitter,kimchy/_mapping/field/message
-
-GET /_all/_mapping/field/message,user.id
-
-GET /_all/_mapping/field/*.id
---------------------------------------------------
-// CONSOLE
-// TEST[setup:twitter]
-// TEST[s/^/PUT kimchy\nPUT book\n/]
-
-[float]
-=== Specifying fields
-
-The get mapping api allows you to specify a comma-separated list of fields.
-
-For instance to select the `id` of the `author` field, you must use its full name `author.id`.
-
-[source,js]
---------------------------------------------------
-GET publications/_mapping/field/author.id,abstract,name
---------------------------------------------------
-// CONSOLE
-
-returns:
-
-[source,js]
---------------------------------------------------
-{
-   "publications": {
-      "mappings": {
-        "author.id": {
-           "full_name": "author.id",
-           "mapping": {
-              "id": {
-                 "type": "text"
-              }
-           }
-        },
-        "abstract": {
-           "full_name": "abstract",
-           "mapping": {
-              "abstract": {
-                 "type": "text"
-              }
-           }
-        }
-     }
-   }
-}
---------------------------------------------------
-// TESTRESPONSE
-
-The get field mapping API also supports wildcard notation.
-
-[source,js]
---------------------------------------------------
-GET publications/_mapping/field/a*
---------------------------------------------------
-// CONSOLE
-
-returns:
-
-[source,js]
---------------------------------------------------
-{
-   "publications": {
-      "mappings": {
-         "author.name": {
-            "full_name": "author.name",
-            "mapping": {
-               "name": {
-                 "type": "text"
-               }
-            }
-         },
-         "abstract": {
-            "full_name": "abstract",
-            "mapping": {
-               "abstract": {
-                  "type": "text"
-               }
-            }
-         },
-         "author.id": {
-            "full_name": "author.id",
-            "mapping": {
-               "id": {
-                  "type": "text"
-               }
-            }
-         }
-      }
-   }
-}
---------------------------------------------------
-// TESTRESPONSE
-
-[float]
-=== Other options
-
-[horizontal]
-`include_defaults`::
-
-    adding `include_defaults=true` to the query string will cause the response
-    to include default values, which are normally suppressed.

--- a/docs/reference/indices/get-field-mapping.asciidoc
+++ b/docs/reference/indices/get-field-mapping.asciidoc
@@ -99,6 +99,7 @@ from the master node.
 GET /twitter/_mapping/field/message
 ----
 // CONSOLE
+// TEST[setup:twitter]
 
 The API returns the following response:
 
@@ -111,7 +112,13 @@ The API returns the following response:
              "full_name": "message",
              "mapping": {
                 "message": {
-                   "type": "text"
+                   "type": "text",
+                   "fields" : {
+                     "keyword" : {
+                        "type" : "keyword",
+                        "ignore_above" : 256
+                     }
+                   }
                 }
              }
           }


### PR DESCRIPTION
With https://github.com/elastic/docs/pull/938, we created a standard template for Elastic API Reference documentation.

This PR rewrites the get field mapping API to use that template.

Relates to elastic/docs#937

## Before
<details>
 <summary>Get field mapping - Before</summary>
<img width="776" alt="get-mapping-before" src="https://user-images.githubusercontent.com/40268737/60837206-9f84f280-a195-11e9-9c08-bebc0a0a6204.png">
</details>


## After
<details>
 <summary>Get field mapping - After</summary>
<img width="776" alt="get-mapping-before" src="https://user-images.githubusercontent.com/40268737/60837212-a3187980-a195-11e9-8a82-d214ef69ca68.png">
</details>