### PR TITLE
Remove ActionResponse uses from HLRC

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/GetAliasesResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/GetAliasesResponse.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.client;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.common.xcontent.StatusToXContentObject;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -47,7 +46,7 @@ import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpect
  * We would usually throw such exception, but we configure the client to not throw for 404 to support the case above, hence we also not
  * throw in case an index is not found, although it is a hard error that doesn't come back with aliases.
  */
-public class GetAliasesResponse extends ActionResponse implements StatusToXContentObject {
+public class GetAliasesResponse implements StatusToXContentObject {
 
     private final RestStatus status;
     private final String error;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/SyncedFlushResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/SyncedFlushResponse.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.client;
 
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
@@ -40,7 +39,7 @@ import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constru
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
-public class SyncedFlushResponse extends ActionResponse implements ToXContentObject {
+public class SyncedFlushResponse implements ToXContentObject {
 
     public static final String SHARDS_FIELD = "_shards";
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/core/CountResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/core/CountResponse.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.client.core;
 
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -35,7 +34,7 @@ import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpect
 /**
  * A response to _count API request.
  */
-public final class CountResponse extends ActionResponse {
+public final class CountResponse {
 
     static final ParseField COUNT = new ParseField("count");
     static final ParseField TERMINATED_EARLY = new ParseField("terminated_early");

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/graph/GraphExploreRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/graph/GraphExploreRequest.java
@@ -23,8 +23,6 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Validatable;
 import org.elasticsearch.client.ValidationException;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -313,17 +311,6 @@ public class GraphExploreRequest implements IndicesRequest.Replaceable, ToXConte
         public float getBoost() {
             return boost;
         }
-
-        void readFrom(StreamInput in) throws IOException {
-            this.term = in.readString();
-            this.boost = in.readFloat();
-        }
-
-        void writeTo(StreamOutput out) throws IOException {
-            out.writeString(term);
-            out.writeFloat(boost);
-        }
-
     }
 
     @Override

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/AbstractResultResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/AbstractResultResponse.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.client.ml;
 
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -32,7 +31,7 @@ import java.util.Objects;
 /**
  * Abstract class that provides a list of results and their count.
  */
-public abstract class AbstractResultResponse<T extends ToXContent> extends ActionResponse implements ToXContentObject {
+public abstract class AbstractResultResponse<T extends ToXContent> implements ToXContentObject {
 
     public static final ParseField COUNT = new ParseField("count");
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/CloseJobResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/CloseJobResponse.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.client.ml;
 
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -31,7 +30,7 @@ import java.util.Objects;
 /**
  * Response indicating if the Job(s) closed or not
  */
-public class CloseJobResponse extends ActionResponse implements ToXContentObject {
+public class CloseJobResponse implements ToXContentObject {
 
     private static final ParseField CLOSED = new ParseField("closed");
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/DeleteExpiredDataResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/DeleteExpiredDataResponse.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.client.ml;
 
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -33,7 +32,7 @@ import java.util.Objects;
 /**
  * A response acknowledging the deletion of expired data
  */
-public class DeleteExpiredDataResponse extends ActionResponse implements ToXContentObject {
+public class DeleteExpiredDataResponse implements ToXContentObject {
 
     private static final ParseField DELETED = new ParseField("deleted");
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/DeleteJobResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/DeleteJobResponse.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.client.ml;
 
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
@@ -35,7 +34,7 @@ import java.util.Objects;
  * Response object that contains the acknowledgement or the task id
  * depending on whether the delete job action was requested to wait for completion.
  */
-public class DeleteJobResponse extends ActionResponse implements ToXContentObject {
+public class DeleteJobResponse implements ToXContentObject {
 
     private static final ParseField ACKNOWLEDGED = new ParseField("acknowledged");
     private static final ParseField TASK = new ParseField("task");

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/FlushJobResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/FlushJobResponse.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.client.ml;
 
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
@@ -33,7 +32,7 @@ import java.util.Objects;
 /**
  * Response object containing flush acknowledgement and additional data
  */
-public class FlushJobResponse extends ActionResponse implements ToXContentObject {
+public class FlushJobResponse implements ToXContentObject {
 
     public static final ParseField FLUSHED = new ParseField("flushed");
     public static final ParseField LAST_FINALIZED_BUCKET_END = new ParseField("last_finalized_bucket_end");

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/ForecastJobResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/ForecastJobResponse.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.client.ml;
 
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -31,7 +30,7 @@ import java.util.Objects;
 /**
  * Forecast response object
  */
-public class ForecastJobResponse extends ActionResponse implements ToXContentObject {
+public class ForecastJobResponse implements ToXContentObject {
 
     public static final ParseField ACKNOWLEDGED = new ParseField("acknowledged");
     public static final ParseField FORECAST_ID = new ParseField("forecast_id");

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/OpenJobResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/OpenJobResponse.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.client.ml;
 
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -31,7 +30,7 @@ import java.util.Objects;
 /**
  * Response indicating if the Machine Learning Job is now opened or not
  */
-public class OpenJobResponse extends ActionResponse implements ToXContentObject {
+public class OpenJobResponse implements ToXContentObject {
 
     private static final ParseField OPENED = new ParseField("opened");
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/PostCalendarEventResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/PostCalendarEventResponse.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.client.ml;
 
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.client.ml.calendars.ScheduledEvent;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
@@ -33,7 +32,7 @@ import java.util.Objects;
 /**
  * Response to adding ScheduledEvent(s) to a Machine Learning calendar
  */
-public class PostCalendarEventResponse extends ActionResponse implements ToXContentObject {
+public class PostCalendarEventResponse implements ToXContentObject {
 
     private final List<ScheduledEvent> scheduledEvents;
     public static final ParseField EVENTS = new ParseField("events");

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/PostDataResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/PostDataResponse.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.client.ml;
 
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.client.ml.job.process.DataCounts;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -31,7 +30,7 @@ import java.util.Objects;
 /**
  * Response object when posting data to a Machine Learning Job
  */
-public class PostDataResponse extends ActionResponse implements ToXContentObject {
+public class PostDataResponse implements ToXContentObject {
 
     private DataCounts dataCounts;
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/PreviewDatafeedResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/PreviewDatafeedResponse.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.client.ml;
 
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -41,7 +40,7 @@ import java.util.stream.Collectors;
 /**
  * Response containing a datafeed preview in JSON format
  */
-public class PreviewDatafeedResponse extends ActionResponse implements ToXContentObject {
+public class PreviewDatafeedResponse implements ToXContentObject {
 
     private BytesReference preview;
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/RevertModelSnapshotResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/RevertModelSnapshotResponse.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.client.ml;
 
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.client.ml.job.process.ModelSnapshot;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
@@ -27,13 +26,12 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
-
 import java.util.Objects;
 
 /**
  * A response containing the reverted model snapshot
  */
-public class RevertModelSnapshotResponse extends ActionResponse implements ToXContentObject {
+public class RevertModelSnapshotResponse implements ToXContentObject {
 
     private static final ParseField MODEL = new ParseField("model");
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/StartDatafeedResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/StartDatafeedResponse.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.client.ml;
 
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -31,7 +30,7 @@ import java.util.Objects;
 /**
  * Response indicating if the Machine Learning Datafeed is now started or not
  */
-public class StartDatafeedResponse extends ActionResponse implements ToXContentObject {
+public class StartDatafeedResponse implements ToXContentObject {
 
     private static final ParseField STARTED = new ParseField("started");
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/StopDatafeedResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/StopDatafeedResponse.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.client.ml;
 
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -31,7 +30,7 @@ import java.util.Objects;
 /**
  * Response indicating if the Machine Learning Datafeed is now stopped or not
  */
-public class StopDatafeedResponse extends ActionResponse implements ToXContentObject {
+public class StopDatafeedResponse implements ToXContentObject {
 
     private static final ParseField STOPPED = new ParseField("stopped");
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/UpdateModelSnapshotResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/UpdateModelSnapshotResponse.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.client.ml;
 
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.client.ml.job.process.ModelSnapshot;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
@@ -33,7 +32,7 @@ import java.util.Objects;
 /**
  * A response acknowledging the update of information for an existing model snapshot for a given job
  */
-public class UpdateModelSnapshotResponse extends ActionResponse implements ToXContentObject {
+public class UpdateModelSnapshotResponse implements ToXContentObject {
 
     private static final ParseField ACKNOWLEDGED = new ParseField("acknowledged");
     private static final ParseField MODEL = new ParseField("model");

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/tasks/TaskSubmissionResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/tasks/TaskSubmissionResponse.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.client.tasks;
 
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -27,7 +26,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 import java.util.Objects;
 
-public class TaskSubmissionResponse extends ActionResponse {
+public class TaskSubmissionResponse {
 
     private static final ParseField TASK = new ParseField("task");
 


### PR DESCRIPTION
The rest client does not communicate over the transport protocol.
However, in the move to make all apis supported in the HLRC, some
response classes were copied with extending ActionResponse, which is
meant strictly for the transport protocol. This commit removes uses of
that base class from HLRC.