### PR TITLE
Update the gcs chunk_size documentation. (#38749)

### DIFF
--- a/docs/plugins/repository-gcs.asciidoc
+++ b/docs/plugins/repository-gcs.asciidoc
@@ -233,7 +233,7 @@ The following settings are supported:
 
     Big files can be broken down into chunks during snapshotting if needed.
     The chunk size can be specified in bytes or by using size value notation,
-    i.e. `1g`, `10m`, `5k`. Defaults to `100m`.
+    e.g. , `10m` or `5k`. Defaults to `100m`, which is the maximum permitted.
 
 `compress`::
 


### PR DESCRIPTION
Remove `1g` from the examples, as the GCS repository chunk_size can be at most 100m.

backport of #38749 