### PR TITLE
Improve Repository Consistency Check in Tests

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -143,13 +143,13 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
     private static final String METADATA_PREFIX = "meta-";
 
-    private static final String METADATA_NAME_FORMAT = METADATA_PREFIX + "%s.dat";
+    public static final String METADATA_NAME_FORMAT = METADATA_PREFIX + "%s.dat";
 
     private static final String METADATA_CODEC = "metadata";
 
     private static final String INDEX_METADATA_CODEC = "index-metadata";
 
-    private static final String SNAPSHOT_NAME_FORMAT = SNAPSHOT_PREFIX + "%s.dat";
+    public static final String SNAPSHOT_NAME_FORMAT = SNAPSHOT_PREFIX + "%s.dat";
 
     private static final String SNAPSHOT_INDEX_PREFIX = "index-";
 

--- a/server/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -504,6 +504,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
     }
 
     public void testRestoreIndexWithMissingShards() throws Exception {
+        disableRepoConsistencyCheck("This test leaves behind a purposely broken repository");
         logger.info("--> start 2 nodes");
         internalCluster().startNode();
         internalCluster().startNode();

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
@@ -127,7 +127,14 @@ public final class BlobStoreTestUtil {
                     .collect(Collectors.toSet());
                 assertThat(foundSnapshotUUIDs, containsInAnyOrder(expectedSnapshotUUIDs.toArray(Strings.EMPTY_ARRAY)));
         }
-        final Map<String, BlobContainer> indices= repository.getBlobContainer().children().get("indices").children();
+
+        final BlobContainer indicesContainer = repository.getBlobContainer().children().get("indices");
+        final Map<String, BlobContainer> indices;
+        if (indicesContainer == null) {
+            indices = Collections.emptyMap();
+        } else {
+            indices = indicesContainer.children();
+        }
         // Assert that for each snapshot, the relevant metadata was written to index and shard folders
         for (SnapshotId snapshotId: snapshotIds) {
             final SnapshotInfo snapshotInfo = repository.getSnapshotInfo(snapshotId);

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
@@ -41,6 +41,7 @@ import java.io.InputStream;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
@@ -134,11 +135,13 @@ public final class BlobStoreTestUtil {
                 final IndexId indexId = repositoryData.resolveIndexId(index);
                 assertThat(indices, hasKey(indexId.getId()));
                 final BlobContainer indexContainer = indices.get(indexId.getId());
-                assertThat(indexContainer.listBlobs(), hasKey("meta-" + snapshotId.getUUID() + ".dat"));
+                assertThat(indexContainer.listBlobs(),
+                    hasKey(String.format(Locale.ROOT, BlobStoreRepository.METADATA_NAME_FORMAT, snapshotId.getUUID())));
                 for (Map.Entry<String, BlobContainer> entry : indexContainer.children().entrySet()) {
                     if (snapshotInfo.shardFailures().stream().noneMatch(shardFailure ->
                         shardFailure.index().equals(index) != false && shardFailure.shardId() == Integer.parseInt(entry.getKey()))) {
-                        assertThat(entry.getValue().listBlobs(), hasKey("snap-" + snapshotId.getUUID() + ".dat"));
+                        assertThat(entry.getValue().listBlobs(),
+                            hasKey(String.format(Locale.ROOT, BlobStoreRepository.SNAPSHOT_NAME_FORMAT, snapshotId.getUUID())));
                     }
                 }
             }

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
@@ -31,6 +31,7 @@ import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.RepositoryData;
 import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -40,10 +41,12 @@ import java.io.InputStream;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasKey;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -84,7 +87,7 @@ public final class BlobStoreTestUtil {
                     repositoryData = RepositoryData.snapshotsFromXContent(parser, latestGen);
                 }
                 assertIndexUUIDs(blobContainer, repositoryData);
-                assertSnapshotUUIDs(blobContainer, repositoryData);
+                assertSnapshotUUIDs(repository, repositoryData);
                 listener.onResponse(null);
             }
         });
@@ -113,14 +116,32 @@ public final class BlobStoreTestUtil {
         assertThat(foundIndexUUIDs, containsInAnyOrder(expectedIndexUUIDs.toArray(Strings.EMPTY_ARRAY)));
     }
 
-    private static void assertSnapshotUUIDs(BlobContainer repoRoot, RepositoryData repositoryData) throws IOException {
-        final List<String> expectedSnapshotUUIDs =
-            repositoryData.getSnapshotIds().stream().map(SnapshotId::getUUID).collect(Collectors.toList());
+    private static void assertSnapshotUUIDs(BlobStoreRepository repository, RepositoryData repositoryData) throws IOException {
+        final BlobContainer repoRoot = repository.blobContainer();
+        final Collection<SnapshotId> snapshotIds = repositoryData.getSnapshotIds();
+        final List<String> expectedSnapshotUUIDs = snapshotIds.stream().map(SnapshotId::getUUID).collect(Collectors.toList());
         for (String prefix : new String[]{"snap-", "meta-"}) {
                 final Collection<String> foundSnapshotUUIDs = repoRoot.listBlobs().keySet().stream().filter(p -> p.startsWith(prefix))
                     .map(p -> p.replace(prefix, "").replace(".dat", ""))
                     .collect(Collectors.toSet());
                 assertThat(foundSnapshotUUIDs, containsInAnyOrder(expectedSnapshotUUIDs.toArray(Strings.EMPTY_ARRAY)));
+        }
+        final Map<String, BlobContainer> indices= repository.getBlobContainer().children().get("indices").children();
+        // Assert that for each snapshot, the relevant metadata was written to index and shard folders
+        for (SnapshotId snapshotId: snapshotIds) {
+            final SnapshotInfo snapshotInfo = repository.getSnapshotInfo(snapshotId);
+            for (String index : snapshotInfo.indices()) {
+                final IndexId indexId = repositoryData.resolveIndexId(index);
+                assertThat(indices, hasKey(indexId.getId()));
+                final BlobContainer indexContainer = indices.get(indexId.getId());
+                assertThat(indexContainer.listBlobs(), hasKey("meta-" + snapshotId.getUUID() + ".dat"));
+                for (Map.Entry<String, BlobContainer> entry : indexContainer.children().entrySet()) {
+                    if (snapshotInfo.shardFailures().stream().noneMatch(shardFailure ->
+                        shardFailure.index().equals(index) != false && shardFailure.shardId() == Integer.parseInt(entry.getKey()))) {
+                        assertThat(entry.getValue().listBlobs(), hasKey("snap-" + snapshotId.getUUID() + ".dat"));
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
* Check that index metadata as well as snapshot metadata always exists
when referenced by other metadata
   * This is kind of nice to have with all the indices cleanup we're doing since it makes sure we never deleted an index accidentally