### PR TITLE
Document xpack.security.dls.bitset.cache settings

### DIFF
--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -128,6 +128,18 @@ level security].
 Set to `false` to prevent document and field level security
 from being configured. Defaults to `true`.
 
+`xpack.security.dls.bitset.cache.ttl`::
+The time-to-live for cached `BitSet` entries for document level security.
+Document level security queries may depend on Lucene BitSet objects, and these are
+automatically cached to improve performance. Defaults to expire entries that are
+unused for `168h` (7 days).
+
+`xpack.security.dls.bitset.cache.size`::
+The maximum memory usage of cached `BitSet` entries for document level security.
+Document level security queries may depend on Lucene BitSet objects, and these are
+automatically cached to improve performance. Defaults to `50mb`, after which 
+least-recently-used entries will be evicted.
+
 [float]
 [[token-service-settings]]
 ==== Token service settings


### PR DESCRIPTION
Two new settings were introduced in #43669 (bb130f5) to control the
behaviour of the Document Level Security BitSet cache.

This change adds documentation for these 2 settings.
