### PR TITLE
Fix SnapshotResiliencyTests on ExtraFS

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
@@ -111,6 +111,7 @@ public final class BlobStoreTestUtil {
         if (indicesContainer == null) {
             foundIndexUUIDs = Collections.emptyList();
         } else {
+            // Skip Lucene MockFS extraN directory
             foundIndexUUIDs = indicesContainer.children().keySet().stream().filter(
                 s -> s.startsWith("extra") == false).collect(Collectors.toList());
         }
@@ -145,6 +146,10 @@ public final class BlobStoreTestUtil {
                 assertThat(indexContainer.listBlobs(),
                     hasKey(String.format(Locale.ROOT, BlobStoreRepository.METADATA_NAME_FORMAT, snapshotId.getUUID())));
                 for (Map.Entry<String, BlobContainer> entry : indexContainer.children().entrySet()) {
+                    // Skip Lucene MockFS extraN directory
+                    if (entry.getKey().startsWith("extra")) {
+                        continue;
+                    }
                     if (snapshotInfo.shardFailures().stream().noneMatch(shardFailure ->
                         shardFailure.index().equals(index) != false && shardFailure.shardId() == Integer.parseInt(entry.getKey()))) {
                         assertThat(entry.getValue().listBlobs(),


### PR DESCRIPTION
* As a result of #44099 we're now checking more directories and have to
ignore the `extraN` folders for those like we do for indices already
* Closes #44112
