### PR TITLE
[DOCS] Rewrite force merge API to use new format

### DIFF
--- a/docs/reference/indices/forcemerge.asciidoc
+++ b/docs/reference/indices/forcemerge.asciidoc
@@ -1,71 +1,107 @@
 [[indices-forcemerge]]
-== Force Merge
+== Force merge API
+++++
+<titleabbrev>Force merge</titleabbrev>
+++++
 
-The force merge API allows to force merging of one or more indices through an
-API. The merge relates to the number of segments a Lucene index holds within
-each shard. The force merge operation allows to reduce the number of segments by
-merging them.
+Merges the segments one or more read-only indices.
+
+[float]
+[[indices-forcemerge-request]]
+=== {api-request-title}
+
+`POST <index>/_forcemerge`
+
+[float]
+[[indices-forcemerge-desc]]
+=== {api-description-title}
+
+You can use the force merge API to merge the segments of one or more indices
+through an API. The merge relates to the number of segments a Lucene index holds
+within each shard. The force merge operation allows to reduce the number of
+segments by merging them.
 
 This call will block until the merge is complete. If the http connection is
 lost, the request will continue in the background, and any new requests will
 block until the previous force merge is complete.
 
-WARNING: Force merge should only be called against *read-only indices*. Running 
-force merge against a read-write index can cause very large segments to be produced 
-(>5Gb per segment), and the merge policy will never consider it for merging again until 
-it mostly consists of deleted docs. This can cause very large segments to remain in the shards.
+WARNING: Force merge should only be called against *read-only indices*. Running
+force merge against a read-write index can cause very large segments to be
+produced (>5Gb per segment), and the merge policy will never consider it for
+merging again until it mostly consists of deleted docs. This can cause very
+large segments to remain in the shards.
+
+[float]
+[[indices-forcemerge-path-params]]
+=== {api-path-parms-title}
+
+`<index>` (Required)::
++
+--
+(string) Comma-separated list or wildcard expression of indices to merge.
+
+You can use a value of `_all` or `*` to merge all indices.
+
+If no value is provided, the API merges all indices.
+--
+
+[float]
+[[indices-forcemerge-query-params]]
+=== {api-query-parms-title}
+
+`allow_no_indices` (Optional)::
+(boolean) Indicates whether the operation is skipped if a wildcard expression
+matches no indices. Defaults to `false`.
+
+`expand_wildcards` (Optional)::
++
+--
+(string) Indicates whether wildcard expressions should expand to
+<<indices-open-close, open or closed indices>>. Possible values are:
+
+ * `open` (Default)
+* `closed`
+* `none`
+* `all`
+--
+
+`flush` (Optional)::
+(boolean) Indicates whether the index is flushed after the operation. Defaults
+to `true`.
+
+`ignore_unavailable` (Optional)::
+(boolean) Indicates whether unavailable indices are skipped. Defaults to
+`false`.
+
+`max_num_segments` (Optional)::
++
+--
+(integer) Number of segments for the new merged index.
+
+To fully merge indices, use a value of `1`. Defaults to checking if a
+merge is needed, and if so, executes it.
+--
+
+`only_expunge_deletes` (Optional)::
++
+--
+(boolean) Indicates whether the merge operation only removes segments containing
+delete documents. Defaults to `false`.
+
+In Lucene, a document is not deleted from a segment, just marked as deleted.
+During a merge process of segments, a new segment is created that does not have
+those deletes. This flag allows to only merge segments that have deletes. Note
+that this won't override the `index.merge.policy.expunge_deletes_allowed`
+setting threshold.
+--
+
+[float]
+[[indices-forcemerge-example]]
+=== {api-examples-title}
 
 [source,js]
---------------------------------------------------
+----
 POST /twitter/_forcemerge
---------------------------------------------------
+----
 // CONSOLE
 // TEST[setup:twitter]
-
-[float]
-[[forcemerge-parameters]]
-=== Request Parameters
-
-The force merge API accepts the following request parameters:
-
-[horizontal]
-`max_num_segments`:: The number of segments to merge to. To fully
-merge the index, set it to `1`. Defaults to simply checking if a
-merge needs to execute, and if so, executes it.
-
-`only_expunge_deletes`:: Should the merge process only expunge segments with
-deletes in it. In Lucene, a document is not deleted from a segment, just marked
-as deleted. During a merge process of segments, a new segment is created that
-does not have those deletes. This flag allows to only merge segments that have
-deletes. Defaults to `false`.  Note that this won't override the
-`index.merge.policy.expunge_deletes_allowed` threshold.
-
-`flush`::  Should a flush be performed after the forced merge. Defaults to
-`true`.
-
-[source,js]
---------------------------------------------------
-POST /kimchy/_forcemerge?only_expunge_deletes=false&max_num_segments=100&flush=true
---------------------------------------------------
-// CONSOLE
-// TEST[s/^/PUT kimchy\n/]
-
-[float]
-[[forcemerge-multi-index]]
-=== Multi Index
-
-The force merge API can be applied to more than one index with a single call, or
-even on `_all` the indices. Multi index operations are executed one shard at a
-time per node. Force merge makes the storage for the shard being merged
-temporarily increase, up to double its size in case `max_num_segments` is set
-to `1`, as all segments need to be rewritten into a new one.
-
-
-[source,js]
---------------------------------------------------
-POST /kimchy,elasticsearch/_forcemerge
-
-POST /_forcemerge
---------------------------------------------------
-// CONSOLE
-// TEST[s/^/PUT kimchy\nPUT elasticsearch\n/]


### PR DESCRIPTION
With https://github.com/elastic/docs/pull/938, we created a standard template for Elastic API Reference documentation.

This PR rewrites the force merge API to use that template.

Relates to elastic/docs#937

## Before
<details>
 <summary>Force merge API - Before</summary>
<img width="776" alt="Force merge API - Before" src="https://user-images.githubusercontent.com/40268737/60894251-55048400-a230-11e9-9e4e-4c30fae108c5.png">
</details>


## After
<details>
 <summary>Force merge API - After</summary>
<img width="776" alt="Force merge API - Afte" src="https://user-images.githubusercontent.com/40268737/60894662-23d88380-a231-11e9-8b3a-efa01b542dd7.png">
</details>