### PR TITLE
Update painless-watcher-context-variables.asciidoc

### DIFF
--- a/docs/painless/painless-contexts/painless-watcher-context-variables.asciidoc
+++ b/docs/painless/painless-contexts/painless-watcher-context-variables.asciidoc
@@ -27,7 +27,7 @@ The following variables are available in all watcher contexts.
         The actual trigger time for the watch. This is the time the
         watch was triggered for execution.
 
-`ctx['payload']` (`Map`, read-only)::
+`ctx['payload']` (`Map`)::
         The accessible watch data based upon the
         {xpack-ref}/input.html[watch input].
 


### PR DESCRIPTION
The `ctx['payload']` is not `read-only`