### PR TITLE
Wait for pending ml tasks in docs tests

### DIFF
--- a/docs/reference/data-frames/apis/put-transform.asciidoc
+++ b/docs/reference/data-frames/apis/put-transform.asciidoc
@@ -110,7 +110,7 @@ PUT _data_frame/transforms/ecommerce_transform
 }
 --------------------------------------------------
 // CONSOLE
-// TEST[skip: https://github.com/elastic/elasticsearch/issues/43271]
+// TEST[setup:kibana_sample_data_ecommerce]
 
 When the transform is created, you receive the following results:
 [source,js]

--- a/docs/reference/ml/apis/put-job.asciidoc
+++ b/docs/reference/ml/apis/put-job.asciidoc
@@ -116,7 +116,6 @@ PUT _ml/anomaly_detectors/total-requests
 }
 --------------------------------------------------
 // CONSOLE
-// TEST[skip: https://github.com/elastic/elasticsearch/issues/43271]
 
 When the job is created, you receive the following results:
 [source,js]

--- a/docs/src/test/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
+++ b/docs/src/test/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentLocation;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
+import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.yaml.ClientYamlDocsTestClient;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestClient;
@@ -41,6 +42,7 @@ import org.elasticsearch.test.rest.yaml.ClientYamlTestResponse;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 import org.elasticsearch.test.rest.yaml.restspec.ClientYamlSuiteRestSpec;
 import org.elasticsearch.test.rest.yaml.section.ExecutableSection;
+import org.junit.After;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -95,6 +97,24 @@ public class DocsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
             final Version esVersion,
             final Version masterVersion) {
         return new ClientYamlDocsTestClient(restSpec, restClient, hosts, esVersion, masterVersion, this::getClientBuilderWithSniffedHosts);
+    }
+
+    @After
+    public void cleanup() throws Exception {
+        if (isMachineLearningTest() || isDataFrameTest()) {
+            logger.info("{}: waiting for pending tasks");
+            ESRestTestCase.waitForPendingTasks(adminClient());
+        }
+    }
+
+    protected boolean isMachineLearningTest() {
+        String testName = getTestName();
+        return testName != null && (testName.contains("=ml/") || testName.contains("=ml\\"));
+    }
+
+    protected boolean isDataFrameTest() {
+        String testName = getTestName();
+        return testName != null && (testName.contains("=data_frames/") || testName.contains("=data_frames\\"));
     }
 
     /**

--- a/docs/src/test/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
+++ b/docs/src/test/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
@@ -102,19 +102,18 @@ public class DocsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
     @After
     public void cleanup() throws Exception {
         if (isMachineLearningTest() || isDataFrameTest()) {
-            logger.info("{}: waiting for pending tasks");
             ESRestTestCase.waitForPendingTasks(adminClient());
         }
     }
 
     protected boolean isMachineLearningTest() {
         String testName = getTestName();
-        return testName != null && (testName.contains("=ml/") || testName.contains("=ml\\"));
+        return testName != null && (testName.contains("/ml/") || testName.contains("\\ml\\"));
     }
 
     protected boolean isDataFrameTest() {
         String testName = getTestName();
-        return testName != null && (testName.contains("=data_frames/") || testName.contains("=data_frames\\"));
+        return testName != null && (testName.contains("/data-frames/") || testName.contains("\\data-frames\\"));
     }
 
     /**


### PR DESCRIPTION
#43271 describes the problem where PUTing a ml job or data frame causes a notification document (saying something like Job X created) to be written to the `ml-notifications` index. This is done async and can occur after the test has finished and the teardown deleting indices has completed causing the index to be recreated and leaking into the next test. 

This is a known issue [XPackRestIT](https://github.com/elastic/elasticsearch/blob/ccb5d934363c37506b76119ac050a254fa80b5e7/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/XPackRestIT.java#L252) handles this by waiting for pending tasks to complete. This change adds the same step to `DocsClientYamlTestSuiteIT`

Unmutes the muted ml and data frame tests and closes #43271

`XPackRestIT` also has logic to stop datafeeds and close jobs post test that isn't necessary here as none of the tests start a job or data frame but may be required in the future