### PR TITLE
Relax Failure Type Assertion in TransportWriteAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
@@ -35,7 +35,6 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.engine.Engine;
-import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.translog.Translog;
@@ -74,9 +73,7 @@ public abstract class TransportWriteAction<
         final Location location;
         if (operationResult.getFailure() != null) {
             // check if any transient write operation failures should be bubbled up
-            Exception failure = operationResult.getFailure();
-            assert failure instanceof MapperParsingException : "expected mapper parsing failures. got " + failure;
-            throw failure;
+            throw operationResult.getFailure();
         } else {
             location = locationToSync(currentLocation, operationResult.getTranslogLocation());
         }


### PR DESCRIPTION
* Other IOException during the replica write are simulated in the test
(`SearchWithRandomExceptionsIT`) and seem possible but will trip the assertion here -> removed it
* Closes #40435


@ywelsch can you take a look here? It is not clear to me why we need that type assertion since we could theoretically run into all kinds of `IOException`s during the replica action?