### PR TITLE
Mute SearchWithRandomExceptionsIT (#44147)

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/basic/SearchWithRandomExceptionsIT.java
+++ b/server/src/test/java/org/elasticsearch/search/basic/SearchWithRandomExceptionsIT.java
@@ -67,6 +67,7 @@ public class SearchWithRandomExceptionsIT extends ESIntegTestCase {
         return false;
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/40435")
     public void testRandomExceptions() throws IOException, InterruptedException, ExecutionException {
         String mapping = Strings.toString(XContentFactory.jsonBuilder().
                 startObject().


### PR DESCRIPTION
* This is failing quiete often and we can reproduce it now so we don't
need additional test logging on CI
* Relates #40435
