### PR TITLE
Remove the xpack label from configuring tls docker

### DIFF
--- a/docs/reference/security/securing-communications/configuring-tls-docker.asciidoc
+++ b/docs/reference/security/securing-communications/configuring-tls-docker.asciidoc
@@ -1,4 +1,3 @@
-[role="xpack"]
 [[configuring-tls-docker]]
 === Encrypting communications in an {es} Docker Container
 


### PR DESCRIPTION
Removed the xpack label from the documentation for configuring tls in docker