### PR TITLE
Simplify port usage in transport tests

### DIFF
--- a/plugins/transport-nio/src/test/java/org/elasticsearch/transport/nio/SimpleNioTransportTests.java
+++ b/plugins/transport-nio/src/test/java/org/elasticsearch/transport/nio/SimpleNioTransportTests.java
@@ -29,16 +29,11 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
-import org.elasticsearch.node.Node;
-import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.AbstractSimpleTransportTestCase;
-import org.elasticsearch.transport.BindTransportException;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.ConnectionProfile;
 import org.elasticsearch.transport.TcpChannel;
 import org.elasticsearch.transport.Transport;
-import org.elasticsearch.transport.TransportSettings;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -52,11 +47,11 @@ import static org.hamcrest.Matchers.instanceOf;
 
 public class SimpleNioTransportTests extends AbstractSimpleTransportTestCase {
 
-    public MockTransportService nioFromThreadPool(Settings settings, ThreadPool threadPool, final Version version,
-                                                         ClusterSettings clusterSettings, boolean doHandshake) {
+    @Override
+    protected Transport build(Settings settings, final Version version, ClusterSettings clusterSettings, boolean doHandshake) {
         NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(Collections.emptyList());
         NetworkService networkService = new NetworkService(Collections.emptyList());
-        Transport transport = new NioTransport(settings, version, threadPool, networkService, new MockPageCacheRecycler(settings),
+        return new NioTransport(settings, version, threadPool, networkService, new MockPageCacheRecycler(settings),
             namedWriteableRegistry, new NoneCircuitBreakerService(), new NioGroupFactory(settings, logger)) {
 
             @Override
@@ -69,20 +64,6 @@ public class SimpleNioTransportTests extends AbstractSimpleTransportTestCase {
                 }
             }
         };
-        MockTransportService mockTransportService =
-            MockTransportService.createNewService(settings, transport, version, threadPool, clusterSettings, Collections.emptySet());
-        mockTransportService.start();
-        return mockTransportService;
-    }
-
-    @Override
-    protected MockTransportService build(Settings settings, Version version, ClusterSettings clusterSettings, boolean doHandshake) {
-        settings = Settings.builder().put(settings)
-            .put(TransportSettings.PORT.getKey(), "0")
-            .build();
-        MockTransportService transportService = nioFromThreadPool(settings, threadPool, version, clusterSettings, doHandshake);
-        transportService.start();
-        return transportService;
     }
 
     public void testConnectException() throws UnknownHostException {
@@ -96,27 +77,5 @@ public class SimpleNioTransportTests extends AbstractSimpleTransportTestCase {
             Throwable cause = e.getCause();
             assertThat(cause, instanceOf(IOException.class));
         }
-    }
-
-    public void testBindUnavailableAddress() {
-        // this is on a lower level since it needs access to the TransportService before it's started
-        int port = serviceA.boundAddress().publishAddress().getPort();
-        Settings settings = Settings.builder()
-            .put(Node.NODE_NAME_SETTING.getKey(), "foobar")
-            .put(TransportSettings.TRACE_LOG_INCLUDE_SETTING.getKey(), "")
-            .put(TransportSettings.TRACE_LOG_EXCLUDE_SETTING.getKey(), "NOTHING")
-            .put(TransportSettings.PORT.getKey(), port)
-            .build();
-        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        BindTransportException bindTransportException = expectThrows(BindTransportException.class, () -> {
-            MockTransportService transportService = nioFromThreadPool(settings, threadPool, Version.CURRENT, clusterSettings, true);
-            try {
-                transportService.start();
-            } finally {
-                transportService.stop();
-                transportService.close();
-            }
-        });
-        assertEquals("Failed to bind to ["+ port + "]", bindTransportException.getMessage());
     }
 }

--- a/server/src/test/java/org/elasticsearch/discovery/single/SingleNodeDiscoveryIT.java
+++ b/server/src/test/java/org/elasticsearch/discovery/single/SingleNodeDiscoveryIT.java
@@ -66,6 +66,8 @@ public class SingleNodeDiscoveryIT extends ESIntegTestCase {
     public void testSingleNodesDoNotDiscoverEachOther() throws IOException, InterruptedException {
         final TransportService service = internalCluster().getInstance(TransportService.class);
         final int port = service.boundAddress().publishAddress().getPort();
+        final int upperPortRangeBound = port + 5 - 1;
+        assumeTrue("port must be in range", upperPortRangeBound <= 65535);
         final NodeConfigurationSource configurationSource = new NodeConfigurationSource() {
             @Override
             public Settings nodeSettings(int nodeOrdinal) {
@@ -77,7 +79,7 @@ public class SingleNodeDiscoveryIT extends ESIntegTestCase {
                          * We align the port ranges of the two as then with zen discovery these two
                          * nodes would find each other.
                          */
-                        .put("transport.port", port + "-" + (port + 5 - 1))
+                        .put("transport.port", port + "-" + upperPortRangeBound)
                         .build();
             }
 

--- a/server/src/test/java/org/elasticsearch/discovery/single/SingleNodeDiscoveryIT.java
+++ b/server/src/test/java/org/elasticsearch/discovery/single/SingleNodeDiscoveryIT.java
@@ -34,6 +34,7 @@ import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.MockHttpTransport;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.NodeConfigurationSource;
+import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.transport.TransportService;
 
@@ -59,15 +60,13 @@ public class SingleNodeDiscoveryIT extends ESIntegTestCase {
                 .builder()
                 .put(super.nodeSettings(nodeOrdinal))
                 .put("discovery.type", "single-node")
-                .put("transport.port", "0")
+                .put("transport.port", MockTransportService.getPortRange())
                 .build();
     }
 
     public void testSingleNodesDoNotDiscoverEachOther() throws IOException, InterruptedException {
         final TransportService service = internalCluster().getInstance(TransportService.class);
         final int port = service.boundAddress().publishAddress().getPort();
-        final int upperPortRangeBound = port + 5 - 1;
-        assumeTrue("port must be in range", upperPortRangeBound <= 65535);
         final NodeConfigurationSource configurationSource = new NodeConfigurationSource() {
             @Override
             public Settings nodeSettings(int nodeOrdinal) {
@@ -79,7 +78,7 @@ public class SingleNodeDiscoveryIT extends ESIntegTestCase {
                          * We align the port ranges of the two as then with zen discovery these two
                          * nodes would find each other.
                          */
-                        .put("transport.port", port + "-" + upperPortRangeBound)
+                        .put("transport.port", port + "-" + (port + 5 - 1))
                         .build();
             }
 

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -184,8 +184,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             clusterSettings = new ClusterSettings(updatedSettings, getSupportedSettings());
         }
         Transport transport = build(updatedSettings, version, clusterSettings, doHandshake);
-        MockTransportService service = MockTransportService.createNewService(settings, transport, version, threadPool, clusterSettings,
-            Collections.emptySet());
+        MockTransportService service = MockTransportService.createNewService(updatedSettings, transport, version, threadPool,
+            clusterSettings, Collections.emptySet());
         service.start();
         if (acceptRequests) {
             service.acceptIncomingRequests();

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -92,6 +92,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
+import static org.elasticsearch.test.transport.MockTransportService.getPortRange;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -116,7 +117,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
     protected volatile DiscoveryNode nodeB;
     protected volatile MockTransportService serviceB;
 
-    protected abstract MockTransportService build(Settings settings, Version version, ClusterSettings clusterSettings, boolean doHandshake);
+    protected abstract Transport build(Settings settings, Version version, ClusterSettings clusterSettings, boolean doHandshake);
 
     protected int channelsPerNodeConnection() {
         // This is a customized profile for this test case.
@@ -175,13 +176,17 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
     private MockTransportService buildService(final String name, final Version version, @Nullable ClusterSettings clusterSettings,
                                               Settings settings, boolean acceptRequests, boolean doHandshake) {
         Settings updatedSettings = Settings.builder()
+            .put(TransportSettings.PORT.getKey(), getPortRange())
             .put(settings)
             .put(Node.NODE_NAME_SETTING.getKey(), name)
             .build();
         if (clusterSettings == null) {
             clusterSettings = new ClusterSettings(updatedSettings, getSupportedSettings());
         }
-        MockTransportService service = build(updatedSettings, version, clusterSettings, doHandshake);
+        Transport transport = build(updatedSettings, version, clusterSettings, doHandshake);
+        MockTransportService service = MockTransportService.createNewService(settings, transport, version, threadPool, clusterSettings,
+            Collections.emptySet());
+        service.start();
         if (acceptRequests) {
             service.acceptIncomingRequests();
         }
@@ -1992,7 +1997,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
     public void testTcpHandshake() {
         assumeTrue("only tcp transport has a handshake method", serviceA.getOriginalTransport() instanceof TcpTransport);
-        try (MockTransportService service = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool, null)) {
+        try (MockTransportService service = buildService("TS_BAD", Version.CURRENT, Settings.EMPTY)) {
             service.addMessageListener(new TransportMessageListener() {
                 @Override
                 public void onRequestReceived(long requestId, String action) {
@@ -2652,6 +2657,17 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         assertEquals(2, profileSettings.size());
         assertEquals(new HashSet<>(Arrays.asList("default", "test")), profileSettings.stream().map(s -> s.profileName).collect(Collectors
             .toSet()));
+    }
+
+    public void testBindUnavailableAddress() {
+        int port = serviceA.boundAddress().publishAddress().getPort();
+        Settings settings = Settings.builder()
+            .put(Node.NODE_NAME_SETTING.getKey(), "foobar")
+            .put(TransportSettings.PORT.getKey(), port)
+            .build();
+        BindTransportException bindTransportException = expectThrows(BindTransportException.class,
+            () -> buildService("test", Version.CURRENT, settings));
+        assertEquals("Failed to bind to ["+ port + "]", bindTransportException.getMessage());
     }
 
     public void testChannelCloseWhileConnecting() {

--- a/test/framework/src/test/java/org/elasticsearch/transport/nio/SimpleMockNioTransportTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/transport/nio/SimpleMockNioTransportTests.java
@@ -29,16 +29,12 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.AbstractSimpleTransportTestCase;
-import org.elasticsearch.transport.BindTransportException;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.ConnectionProfile;
 import org.elasticsearch.transport.TcpChannel;
 import org.elasticsearch.transport.Transport;
-import org.elasticsearch.transport.TransportSettings;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -52,11 +48,11 @@ import static org.hamcrest.Matchers.instanceOf;
 
 public class SimpleMockNioTransportTests extends AbstractSimpleTransportTestCase {
 
-    public static MockTransportService nioFromThreadPool(Settings settings, ThreadPool threadPool, final Version version,
-                                                         ClusterSettings clusterSettings, boolean doHandshake) {
+    @Override
+    protected Transport build(Settings settings, final Version version, ClusterSettings clusterSettings, boolean doHandshake) {
         NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(Collections.emptyList());
         NetworkService networkService = new NetworkService(Collections.emptyList());
-        Transport transport = new MockNioTransport(settings, version, threadPool, networkService, new MockPageCacheRecycler(settings),
+        return new MockNioTransport(settings, version, threadPool, networkService, new MockPageCacheRecycler(settings),
             namedWriteableRegistry, new NoneCircuitBreakerService()) {
 
             @Override
@@ -69,20 +65,6 @@ public class SimpleMockNioTransportTests extends AbstractSimpleTransportTestCase
                 }
             }
         };
-        MockTransportService mockTransportService =
-            MockTransportService.createNewService(settings, transport, version, threadPool, clusterSettings, Collections.emptySet());
-        mockTransportService.start();
-        return mockTransportService;
-    }
-
-    @Override
-    protected MockTransportService build(Settings settings, Version version, ClusterSettings clusterSettings, boolean doHandshake) {
-        settings = Settings.builder().put(settings)
-            .put(TransportSettings.PORT.getKey(), "0")
-            .build();
-        MockTransportService transportService = nioFromThreadPool(settings, threadPool, version, clusterSettings, doHandshake);
-        transportService.start();
-        return transportService;
     }
 
     @Override
@@ -101,25 +83,5 @@ public class SimpleMockNioTransportTests extends AbstractSimpleTransportTestCase
             Throwable cause = e.getCause();
             assertThat(cause, instanceOf(IOException.class));
         }
-    }
-
-    public void testBindUnavailableAddress() {
-        // this is on a lower level since it needs access to the TransportService before it's started
-        int port = serviceA.boundAddress().publishAddress().getPort();
-        Settings settings = Settings.builder()
-            .put(Node.NODE_NAME_SETTING.getKey(), "foobar")
-            .put(TransportSettings.PORT.getKey(), port)
-            .build();
-        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        BindTransportException bindTransportException = expectThrows(BindTransportException.class, () -> {
-            MockTransportService transportService = nioFromThreadPool(settings, threadPool, Version.CURRENT, clusterSettings, true);
-            try {
-                transportService.start();
-            } finally {
-                transportService.stop();
-                transportService.close();
-            }
-        });
-        assertEquals("Failed to bind to ["+ port + "]", bindTransportException.getMessage());
     }
 }

--- a/test/framework/src/test/java/org/elasticsearch/transport/nio/SimpleMockNioTransportTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/transport/nio/SimpleMockNioTransportTests.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
-import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.transport.AbstractSimpleTransportTestCase;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.ConnectionProfile;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/AbstractSimpleSecurityTransportTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/AbstractSimpleSecurityTransportTestCase.java
@@ -20,7 +20,6 @@ import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.test.transport.StubbableTransport;
 import org.elasticsearch.transport.AbstractSimpleTransportTestCase;
-import org.elasticsearch.transport.BindTransportException;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.ConnectionProfile;
 import org.elasticsearch.transport.TcpChannel;
@@ -28,7 +27,6 @@ import org.elasticsearch.transport.TcpTransport;
 import org.elasticsearch.transport.TestProfiles;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.transport.TransportSettings;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.common.socket.SocketAccess;
 import org.elasticsearch.xpack.core.ssl.SSLClientAuth;
@@ -46,7 +44,6 @@ import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLServerSocketFactory;
 import javax.net.ssl.SSLSocket;
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.InetAddress;
@@ -117,6 +114,7 @@ public abstract class AbstractSimpleSecurityTransportTestCase extends AbstractSi
             Throwable cause = e.getCause();
             assertThat(cause, instanceOf(IOException.class));
         }
+
     }
 
     @Override

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/AbstractSimpleSecurityTransportTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/AbstractSimpleSecurityTransportTestCase.java
@@ -119,24 +119,6 @@ public abstract class AbstractSimpleSecurityTransportTestCase extends AbstractSi
         }
     }
 
-    public void testBindUnavailableAddress() {
-        // this is on a lower level since it needs access to the TransportService before it's started
-        int port = serviceA.boundAddress().publishAddress().getPort();
-        Settings settings = Settings.builder()
-            .put(TransportSettings.PORT.getKey(), port)
-            .build();
-        BindTransportException bindTransportException = expectThrows(BindTransportException.class, () -> {
-            MockTransportService transportService = buildService("TS_C", Version.CURRENT, settings);
-            try {
-                transportService.start();
-            } finally {
-                transportService.stop();
-                transportService.close();
-            }
-        });
-        assertEquals("Failed to bind to [" + port + "]", bindTransportException.getMessage());
-    }
-
     @Override
     public void testTcpHandshake() {
         assumeTrue("only tcp transport has a handshake method", serviceA.getOriginalTransport() instanceof TcpTransport);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/nio/SimpleSecurityNioTransportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/nio/SimpleSecurityNioTransportTests.java
@@ -14,12 +14,9 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
-import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ConnectionProfile;
 import org.elasticsearch.transport.TcpChannel;
 import org.elasticsearch.transport.Transport;
-import org.elasticsearch.transport.TransportSettings;
 import org.elasticsearch.transport.nio.NioGroupFactory;
 import org.elasticsearch.xpack.security.transport.AbstractSimpleSecurityTransportTestCase;
 
@@ -27,14 +24,14 @@ import java.util.Collections;
 
 public class SimpleSecurityNioTransportTests extends AbstractSimpleSecurityTransportTestCase {
 
-    public MockTransportService nioFromThreadPool(Settings settings, ThreadPool threadPool, final Version version,
-                                                  ClusterSettings clusterSettings, boolean doHandshake) {
+    @Override
+    protected Transport build(Settings settings, final Version version, ClusterSettings clusterSettings, boolean doHandshake) {
         NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(Collections.emptyList());
         NetworkService networkService = new NetworkService(Collections.emptyList());
         Settings settings1 = Settings.builder()
                 .put(settings)
                 .put("xpack.security.transport.ssl.enabled", true).build();
-        Transport transport = new SecurityNioTransport(settings1, version, threadPool, networkService, new MockPageCacheRecycler(settings),
+        return new SecurityNioTransport(settings1, version, threadPool, networkService, new MockPageCacheRecycler(settings),
             namedWriteableRegistry, new NoneCircuitBreakerService(), null, createSSLService(settings1),
             new NioGroupFactory(settings, logger)) {
 
@@ -48,22 +45,5 @@ public class SimpleSecurityNioTransportTests extends AbstractSimpleSecurityTrans
                 }
             }
         };
-        MockTransportService mockTransportService =
-                MockTransportService.createNewService(settings, transport, version, threadPool, clusterSettings,
-                        Collections.emptySet());
-        mockTransportService.start();
-        return mockTransportService;
-    }
-
-    @Override
-    protected MockTransportService build(Settings settings, Version version, ClusterSettings clusterSettings, boolean doHandshake) {
-        if (TransportSettings.PORT.exists(settings) == false) {
-            settings = Settings.builder().put(settings)
-                .put(TransportSettings.PORT.getKey(), "0")
-                .build();
-        }
-        MockTransportService transportService = nioFromThreadPool(settings, threadPool, version, clusterSettings, doHandshake);
-        transportService.start();
-        return transportService;
     }
 }


### PR DESCRIPTION
Simplifies `AbstractSimpleTransportTestCase` to use JVM-local ports and fixes issue reported here: https://github.com/elastic/elasticsearch/issues/44134#issuecomment-509946379

Also adds an assertion so that cases like https://github.com/elastic/elasticsearch/issues/44134#issue-465940419 can be more easily debugged. The likely reason for that one is that a test, which was repeated again and again while always spawning a fresh Gradle worker (due to Gradle daemon) kept increasing Gradle worker IDs, causing an overflow at some point.