### PR TITLE
Mute WatcherRestIT

### DIFF
--- a/x-pack/qa/smoke-test-watcher/src/test/resources/rest-api-spec/test/painless/10_basic.yml
+++ b/x-pack/qa/smoke-test-watcher/src/test/resources/rest-api-spec/test/painless/10_basic.yml
@@ -123,6 +123,10 @@
 
 ---
 "Test execute watch api with rest_total_hits_as_int":
+  - skip:
+      version: "all"
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/43889"
+
   - do:
       cluster.health:
         wait_for_status: green


### PR DESCRIPTION
With this commit we mute the test `execute watch api with
rest_total_hits_as_int failure` from `WatcherRestIT`.

Relates #43889