### PR TITLE
[DOCS] Adds frequency option to data frame transform resource

### DIFF
--- a/docs/reference/data-frames/apis/get-transform.asciidoc
+++ b/docs/reference/data-frames/apis/get-transform.asciidoc
@@ -143,6 +143,7 @@ The API returns the following results:
       "dest" : {
         "index" : "kibana_sample_data_ecommerce_transform"
       },
+      "frequency": "1m",
       "pivot" : {
         "group_by" : {
           "customer_id" : {

--- a/docs/reference/data-frames/apis/transformresource.asciidoc
+++ b/docs/reference/data-frames/apis/transformresource.asciidoc
@@ -18,6 +18,11 @@ For more information, see
 `dest`::
   (object) The destination for the {dataframe-transform}. See
   <<data-frame-transform-dest>>.
+  
+`frequency`::
+  (time units) The interval between checks for changes in the source indices
+  when the {dataframe-transform} is running continuously. The minimum value is
+  `1s` and the maximum is `1h`. The default value is `1m`.
 
 `id`::
   (string) A unique identifier for the {dataframe-transform}.


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/44120

This PR adds the `frequency` property to the "Data frame transform resources" (https://www.elastic.co/guide/en/elasticsearch/reference/master/data-frame-transform-resource.html) and "get data frame transforms API" (https://www.elastic.co/guide/en/elasticsearch/reference/master/get-data-frame-transform.html)