### PR TITLE
Document that pipeline aggs are not compatible with composite agg

### DIFF
--- a/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
@@ -590,3 +590,13 @@ GET /_search
 }
 --------------------------------------------------
 // TESTRESPONSE[s/\.\.\.//]
+
+==== Pipeline aggregations
+
+The composite agg is not currently compatible with pipeline aggregations, nor does it make sense in most cases.
+E.g. due to the paging nature of composite aggs, a single logical partition (one day for example) might be spread
+over multiple pages.  Since pipeline aggregations are purely post-processing on the final list of buckets,
+running something like a derivative on a composite page could lead to inaccurate results as it is only taking into
+account a "partial" result on that page.
+
+Pipeline aggs that are self contained to a single bucket (such as `bucket_selector`) might be supported in the future.


### PR DESCRIPTION
Until https://github.com/elastic/elasticsearch/issues/32692 is resolved one way or another, we should at least document that pipelines do not work with composite agg.