### PR TITLE
SQL: ODBC: document newest connection string parameters

### DIFF
--- a/docs/reference/sql/endpoints/odbc/configuration.asciidoc
+++ b/docs/reference/sql/endpoints/odbc/configuration.asciidoc
@@ -364,6 +364,8 @@ will escape these special characters if not already done by the application.
 
 
 `IndexIncludeFrozen` (default: `false`)::
-If this parameter is `true`, the server will allow quering of frozen indices.
+If this parameter is `true`, the server will include the frozen indices in the
+query execution.
 This corresponds to {es-sql}'s request parameter `index_include_frozen`
 (see <<sql-rest-fields>>).
+

--- a/docs/reference/sql/endpoints/odbc/configuration.asciidoc
+++ b/docs/reference/sql/endpoints/odbc/configuration.asciidoc
@@ -273,12 +273,12 @@ logging.
 
 The following is a list of additional parameters that can be configured for a
 particular connection, in case the default behavior of the driver is not
-suitable. This can be done within the client application, in a manner
-particular to that application, generally in a free text input box (sometimes
-named "Connection string", "String extras", or similar).  The format of the
-string is `Attribute1=Value1`. Multiple attributes can be specified, separated
-by a semicolon `Attribute1=Value1;Attribute2=Value2;`. The attribute names are
-given below.
+suitable. For earlier versions of the driver, this needs to be done within the
+client application, in a manner particular to that application, generally in a
+free text input box (sometimes named "Connection string", "String extras", or
+similar).  The format of the string is `Attribute1=Value1`. Multiple attributes
+can be specified, separated by a semicolon
+`Attribute1=Value1;Attribute2=Value2;`. The attribute names are given below.
 
 `Timeout` (default: `0`)::
 The maximum time (in seconds) a request to the server can take. This can be
@@ -354,3 +354,16 @@ it as the value for the column. If not set, the server will return an error.
 This corresponds to {es-sql}'s request parameter `field_multi_value_leniency`
 (see <<sql-rest-fields>>).
 
+
+`AutoEscapePVA` (default: `true`)::
+The pattern-value arguments make use of `_` and `%` as special characters to
+build patern matching values. Some applications however use these chars as
+regular ones, which can lead to {es-sql} returning more data than the app
+intended. With the auto escaping, the driver will inspect the arguments and
+will escape these special characters if not already done by the application.
+
+
+`IndexIncludeFrozen` (default: `false`)::
+If this parameter is `true`, the server will allow quering of frozen indices.
+This corresponds to {es-sql}'s request parameter `index_include_frozen`
+(see <<sql-rest-fields>>).

--- a/docs/reference/sql/endpoints/odbc/installation.asciidoc
+++ b/docs/reference/sql/endpoints/odbc/installation.asciidoc
@@ -8,14 +8,15 @@ The {odbc} can be installed on Microsoft Windows using an MSI package. The insta
 [[prerequisites]]
 ==== Installation Prerequisites
 
+The recommended installation platform is Windows 10 64 bit _or_ Windows Server 2016 64 bit.
+
 Before you install the {odbc} you need to meet the following prerequisites;
 
-* Windows 10 64 bit _or_ Windows Server 2016 64 bit operating system
 * .NET Framework 4.0 full - https://www.microsoft.com/en-au/download/details.aspx?id=17718
 * Microsoft Visual C++ Redistributable for Visual Studio 2017 - https://support.microsoft.com/en-au/help/2977003/the-latest-supported-visual-c-downloads
-- The 64 bit driver requires the x64 redistributable (this also installs the components needed for the 32 bit driver)
-- The 32 bit driver requires the x86 redistributable
-* Elevated privileges (administrator) for the User performing the installation
+- The 64 bit driver requires the x64 redistributable
+- The 32 bit driver requires the x86 or the x64 redistributable (the latter also installs the components needed for the 32 bit driver)
+* Elevated privileges (administrator) for the User performing the installation.
 
 If you fail to meet any of the prerequisites the installer will show an error message and abort the installation.
 


### PR DESCRIPTION
This PR adds the documentation for two newly added connection string
parameters: `AutoEscapePVA` and `IndexIncludeFrozen`.

It also removes the recommended OSes from the prerequisites list and
places the recommendation distinctively: the unmet prerequisites will
fail the installation (as documented), while the driver would install on 
other OSes than those recommended.
Fixes https://github.com/elastic/elasticsearch-sql-odbc/issues/146