### PR TITLE
[ML-DataFrame] Rewrite continuous logic to prevent terms count limit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,8 +160,8 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
-final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = false
+final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/44219" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/DataFrameIndexerPosition.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/DataFrameIndexerPosition.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.dataframe.transforms;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ObjectParser.ValueType;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+public class DataFrameIndexerPosition {
+    public static final ParseField INDEXER_POSITION = new ParseField("indexer_position");
+    public static final ParseField CHANGES_POSITION = new ParseField("changes_position");
+
+    private final Map<String, Object> indexerPosition;
+    private final Map<String, Object> changesPosition;
+
+    @SuppressWarnings("unchecked")
+    public static final ConstructingObjectParser<DataFrameIndexerPosition, Void> PARSER = new ConstructingObjectParser<>(
+            "data_frame_indexer_position",
+            true,
+            args -> new DataFrameIndexerPosition((Map<String, Object>) args[0],(Map<String, Object>) args[1]));
+
+    static {
+        PARSER.declareField(optionalConstructorArg(), XContentParser::mapOrdered, INDEXER_POSITION, ValueType.OBJECT);
+        PARSER.declareField(optionalConstructorArg(), XContentParser::mapOrdered, CHANGES_POSITION, ValueType.OBJECT);
+    }
+
+    public DataFrameIndexerPosition(Map<String, Object> indexerPosition, Map<String, Object> changesPosition) {
+        this.indexerPosition = indexerPosition;
+        this.changesPosition = changesPosition;
+    }
+
+    public Map<String, Object> getIndexerPosition() {
+        return indexerPosition;
+    }
+
+    public Map<String, Object> getChangesPosition() {
+        return changesPosition;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        DataFrameIndexerPosition that = (DataFrameIndexerPosition) other;
+
+        return Objects.equals(this.indexerPosition, that.indexerPosition) &&
+            Objects.equals(this.changesPosition, that.changesPosition);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(indexerPosition, changesPosition);
+    }
+
+    public static DataFrameIndexerPosition fromXContent(XContentParser parser) {
+        try {
+            return PARSER.parse(parser, null);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/DataFrameIndexerPosition.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/DataFrameIndexerPosition.java
@@ -56,8 +56,8 @@ public class DataFrameIndexerPosition {
     }
 
     public DataFrameIndexerPosition(Map<String, Object> indexerPosition, Map<String, Object> bucketsPosition) {
-        this.indexerPosition = Collections.unmodifiableMap(indexerPosition);
-        this.bucketsPosition = Collections.unmodifiableMap(bucketsPosition);
+        this.indexerPosition = indexerPosition == null ? null : Collections.unmodifiableMap(indexerPosition);
+        this.bucketsPosition = bucketsPosition == null ? null : Collections.unmodifiableMap(bucketsPosition);
     }
 
     public Map<String, Object> getIndexerPosition() {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/DataFrameIndexerPosition.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/DataFrameIndexerPosition.java
@@ -35,14 +35,14 @@ import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optiona
  * Holds state of the cursors:
  *
  *  indexer_position: the position of the indexer querying the source
- *  buckets_position: the position used for identifying changes
+ *  bucket_position: the position used for identifying changes
  */
 public class DataFrameIndexerPosition {
     public static final ParseField INDEXER_POSITION = new ParseField("indexer_position");
-    public static final ParseField BUCKETS_POSITION = new ParseField("buckets_position");
+    public static final ParseField BUCKET_POSITION = new ParseField("bucket_position");
 
     private final Map<String, Object> indexerPosition;
-    private final Map<String, Object> bucketsPosition;
+    private final Map<String, Object> bucketPosition;
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<DataFrameIndexerPosition, Void> PARSER = new ConstructingObjectParser<>(
@@ -52,12 +52,12 @@ public class DataFrameIndexerPosition {
 
     static {
         PARSER.declareField(optionalConstructorArg(), XContentParser::mapOrdered, INDEXER_POSITION, ValueType.OBJECT);
-        PARSER.declareField(optionalConstructorArg(), XContentParser::mapOrdered, BUCKETS_POSITION, ValueType.OBJECT);
+        PARSER.declareField(optionalConstructorArg(), XContentParser::mapOrdered, BUCKET_POSITION, ValueType.OBJECT);
     }
 
-    public DataFrameIndexerPosition(Map<String, Object> indexerPosition, Map<String, Object> bucketsPosition) {
+    public DataFrameIndexerPosition(Map<String, Object> indexerPosition, Map<String, Object> bucketPosition) {
         this.indexerPosition = indexerPosition == null ? null : Collections.unmodifiableMap(indexerPosition);
-        this.bucketsPosition = bucketsPosition == null ? null : Collections.unmodifiableMap(bucketsPosition);
+        this.bucketPosition = bucketPosition == null ? null : Collections.unmodifiableMap(bucketPosition);
     }
 
     public Map<String, Object> getIndexerPosition() {
@@ -65,7 +65,7 @@ public class DataFrameIndexerPosition {
     }
 
     public Map<String, Object> getBucketsPosition() {
-        return bucketsPosition;
+        return bucketPosition;
     }
 
     @Override
@@ -81,12 +81,12 @@ public class DataFrameIndexerPosition {
         DataFrameIndexerPosition that = (DataFrameIndexerPosition) other;
 
         return Objects.equals(this.indexerPosition, that.indexerPosition) &&
-            Objects.equals(this.bucketsPosition, that.bucketsPosition);
+            Objects.equals(this.bucketPosition, that.bucketPosition);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(indexerPosition, bucketsPosition);
+        return Objects.hash(indexerPosition, bucketPosition);
     }
 
     public static DataFrameIndexerPosition fromXContent(XContentParser parser) {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/DataFrameIndexerPosition.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/DataFrameIndexerPosition.java
@@ -25,17 +25,24 @@ import org.elasticsearch.common.xcontent.ObjectParser.ValueType;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
+/**
+ * Holds state of the cursors:
+ *
+ *  indexer_position: the position of the indexer querying the source
+ *  buckets_position: the position used for identifying changes
+ */
 public class DataFrameIndexerPosition {
     public static final ParseField INDEXER_POSITION = new ParseField("indexer_position");
-    public static final ParseField CHANGES_POSITION = new ParseField("changes_position");
+    public static final ParseField BUCKETS_POSITION = new ParseField("buckets_position");
 
     private final Map<String, Object> indexerPosition;
-    private final Map<String, Object> changesPosition;
+    private final Map<String, Object> bucketsPosition;
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<DataFrameIndexerPosition, Void> PARSER = new ConstructingObjectParser<>(
@@ -45,20 +52,20 @@ public class DataFrameIndexerPosition {
 
     static {
         PARSER.declareField(optionalConstructorArg(), XContentParser::mapOrdered, INDEXER_POSITION, ValueType.OBJECT);
-        PARSER.declareField(optionalConstructorArg(), XContentParser::mapOrdered, CHANGES_POSITION, ValueType.OBJECT);
+        PARSER.declareField(optionalConstructorArg(), XContentParser::mapOrdered, BUCKETS_POSITION, ValueType.OBJECT);
     }
 
-    public DataFrameIndexerPosition(Map<String, Object> indexerPosition, Map<String, Object> changesPosition) {
-        this.indexerPosition = indexerPosition;
-        this.changesPosition = changesPosition;
+    public DataFrameIndexerPosition(Map<String, Object> indexerPosition, Map<String, Object> bucketsPosition) {
+        this.indexerPosition = Collections.unmodifiableMap(indexerPosition);
+        this.bucketsPosition = Collections.unmodifiableMap(bucketsPosition);
     }
 
     public Map<String, Object> getIndexerPosition() {
         return indexerPosition;
     }
 
-    public Map<String, Object> getChangesPosition() {
-        return changesPosition;
+    public Map<String, Object> getBucketsPosition() {
+        return bucketsPosition;
     }
 
     @Override
@@ -74,12 +81,12 @@ public class DataFrameIndexerPosition {
         DataFrameIndexerPosition that = (DataFrameIndexerPosition) other;
 
         return Objects.equals(this.indexerPosition, that.indexerPosition) &&
-            Objects.equals(this.changesPosition, that.changesPosition);
+            Objects.equals(this.bucketsPosition, that.bucketsPosition);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(indexerPosition, changesPosition);
+        return Objects.hash(indexerPosition, bucketsPosition);
     }
 
     public static DataFrameIndexerPosition fromXContent(XContentParser parser) {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformState.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformState.java
@@ -65,7 +65,8 @@ public class DataFrameTransformState {
                         DataFrameTransformProgress progress = (DataFrameTransformProgress) args[6];
                         NodeAttributes node = (NodeAttributes) args[7];
 
-                        return new DataFrameTransformState(taskState, indexerState, dataFrameIndexerPosition, checkpoint, reason, progress, node);
+                        return new DataFrameTransformState(taskState, indexerState, dataFrameIndexerPosition, checkpoint, reason, progress,
+                                node);
                     });
 
     static {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformState.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformState.java
@@ -38,9 +38,9 @@ public class DataFrameTransformState {
     private static final ParseField INDEXER_STATE = new ParseField("indexer_state");
     private static final ParseField TASK_STATE = new ParseField("task_state");
 
-    // 7.3 BWC: current_position only exists in 7.2.  In 7.3+ it is replaced by next_position.
+    // 7.3 BWC: current_position only exists in 7.2.  In 7.3+ it is replaced by position.
     private static final ParseField CURRENT_POSITION = new ParseField("current_position");
-    private static final ParseField NEXT_POSITION = new ParseField("next_position");
+    private static final ParseField POSITION = new ParseField("position");
     private static final ParseField CHECKPOINT = new ParseField("checkpoint");
     private static final ParseField REASON = new ParseField("reason");
     private static final ParseField PROGRESS = new ParseField("progress");
@@ -55,7 +55,7 @@ public class DataFrameTransformState {
                         Map<String, Object> bwcCurrentPosition = (Map<String, Object>) args[2];
                         DataFrameIndexerPosition dataFrameIndexerPosition = (DataFrameIndexerPosition) args[3];
 
-                        // BWC handling, translate current_position to next_position iff next_position isn't set
+                        // BWC handling, translate current_position to position iff position isn't set
                         if (bwcCurrentPosition != null && dataFrameIndexerPosition == null) {
                             dataFrameIndexerPosition = new DataFrameIndexerPosition(bwcCurrentPosition, null);
                         }
@@ -72,7 +72,7 @@ public class DataFrameTransformState {
         PARSER.declareField(constructorArg(), p -> DataFrameTransformTaskState.fromString(p.text()), TASK_STATE, ValueType.STRING);
         PARSER.declareField(constructorArg(), p -> IndexerState.fromString(p.text()), INDEXER_STATE, ValueType.STRING);
         PARSER.declareField(optionalConstructorArg(), (p, c) -> p.mapOrdered(), CURRENT_POSITION, ValueType.OBJECT);
-        PARSER.declareField(optionalConstructorArg(), DataFrameIndexerPosition::fromXContent, NEXT_POSITION, ValueType.OBJECT);
+        PARSER.declareField(optionalConstructorArg(), DataFrameIndexerPosition::fromXContent, POSITION, ValueType.OBJECT);
         PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), CHECKPOINT);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), REASON);
         PARSER.declareField(optionalConstructorArg(), DataFrameTransformProgress::fromXContent, PROGRESS, ValueType.OBJECT);
@@ -86,7 +86,7 @@ public class DataFrameTransformState {
     private final DataFrameTransformTaskState taskState;
     private final IndexerState indexerState;
     private final long checkpoint;
-    private final DataFrameIndexerPosition nextPosition;
+    private final DataFrameIndexerPosition position;
     private final String reason;
     private final DataFrameTransformProgress progress;
     private final NodeAttributes node;
@@ -100,7 +100,7 @@ public class DataFrameTransformState {
                                    @Nullable NodeAttributes node) {
         this.taskState = taskState;
         this.indexerState = indexerState;
-        this.nextPosition = position;
+        this.position = position;
         this.checkpoint = checkpoint;
         this.reason = reason;
         this.progress = progress;
@@ -117,7 +117,7 @@ public class DataFrameTransformState {
 
     @Nullable
     public DataFrameIndexerPosition getPosition() {
-        return nextPosition;
+        return position;
     }
 
     public long getCheckpoint() {
@@ -153,7 +153,7 @@ public class DataFrameTransformState {
 
         return Objects.equals(this.taskState, that.taskState) &&
             Objects.equals(this.indexerState, that.indexerState) &&
-            Objects.equals(this.nextPosition, that.nextPosition) &&
+            Objects.equals(this.position, that.position) &&
             Objects.equals(this.progress, that.progress) &&
             this.checkpoint == that.checkpoint &&
             Objects.equals(this.node, that.node) &&
@@ -162,7 +162,7 @@ public class DataFrameTransformState {
 
     @Override
     public int hashCode() {
-        return Objects.hash(taskState, indexerState, nextPosition, checkpoint, reason, progress, node);
+        return Objects.hash(taskState, indexerState, position, checkpoint, reason, progress, node);
     }
 
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/DataFrameIndexerPositionTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/DataFrameIndexerPositionTests.java
@@ -37,7 +37,7 @@ public class DataFrameIndexerPositionTests extends ESTestCase {
                 DataFrameIndexerPosition::fromXContent)
                 .supportsUnknownFields(true)
                 .randomFieldsExcludeFilter(field -> field.equals("indexer_position") ||
-                    field.equals("changes_position"))
+                    field.equals("buckets_position"))
                 .test();
     }
 
@@ -50,8 +50,8 @@ public class DataFrameIndexerPositionTests extends ESTestCase {
         if (position.getIndexerPosition() != null) {
             builder.field("indexer_position", position.getIndexerPosition());
         }
-        if (position.getChangesPosition() != null) {
-            builder.field("changes_position", position.getChangesPosition());
+        if (position.getBucketsPosition() != null) {
+            builder.field("buckets_position", position.getBucketsPosition());
         }
         builder.endObject();
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/DataFrameIndexerPositionTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/DataFrameIndexerPositionTests.java
@@ -37,7 +37,7 @@ public class DataFrameIndexerPositionTests extends ESTestCase {
                 DataFrameIndexerPosition::fromXContent)
                 .supportsUnknownFields(true)
                 .randomFieldsExcludeFilter(field -> field.equals("indexer_position") ||
-                    field.equals("buckets_position"))
+                    field.equals("bucket_position"))
                 .test();
     }
 
@@ -51,7 +51,7 @@ public class DataFrameIndexerPositionTests extends ESTestCase {
             builder.field("indexer_position", position.getIndexerPosition());
         }
         if (position.getBucketsPosition() != null) {
-            builder.field("buckets_position", position.getBucketsPosition());
+            builder.field("bucket_position", position.getBucketsPosition());
         }
         builder.endObject();
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/DataFrameIndexerPositionTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/DataFrameIndexerPositionTests.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.dataframe.transforms;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.elasticsearch.test.AbstractXContentTestCase.xContentTester;
+
+public class DataFrameIndexerPositionTests extends ESTestCase {
+
+    public void testFromXContent() throws IOException {
+        xContentTester(this::createParser,
+                DataFrameIndexerPositionTests::randomDataFrameIndexerPosition,
+                DataFrameIndexerPositionTests::toXContent,
+                DataFrameIndexerPosition::fromXContent)
+                .supportsUnknownFields(true)
+                .randomFieldsExcludeFilter(field -> field.equals("indexer_position") ||
+                    field.equals("changes_position"))
+                .test();
+    }
+
+    public static DataFrameIndexerPosition randomDataFrameIndexerPosition() {
+        return new DataFrameIndexerPosition(randomPositionMap(), randomPositionMap());
+    }
+
+    public static void toXContent(DataFrameIndexerPosition position, XContentBuilder builder) throws IOException {
+        builder.startObject();
+        if (position.getIndexerPosition() != null) {
+            builder.field("indexer_position", position.getIndexerPosition());
+        }
+        if (position.getChangesPosition() != null) {
+            builder.field("changes_position", position.getChangesPosition());
+        }
+        builder.endObject();
+    }
+
+    private static Map<String, Object> randomPositionMap() {
+        if (randomBoolean()) {
+            return null;
+        }
+        int numFields = randomIntBetween(1, 5);
+        Map<String, Object> position = new LinkedHashMap<>();
+        for (int i = 0; i < numFields; i++) {
+            Object value;
+            if (randomBoolean()) {
+                value = randomLong();
+            } else {
+                value = randomAlphaOfLengthBetween(1, 10);
+            }
+            position.put(randomAlphaOfLengthBetween(3, 10), value);
+        }
+        return position;
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformStateTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformStateTests.java
@@ -37,7 +37,7 @@ public class DataFrameTransformStateTests extends ESTestCase {
                 DataFrameTransformState::fromXContent)
                 .supportsUnknownFields(true)
                 .randomFieldsExcludeFilter(field -> field.equals("next_position.indexer_position") ||
-                        field.equals("next_position.changes_position") ||
+                        field.equals("next_position.buckets_position") ||
                         field.equals("node.attributes"))
                 .test();
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformStateTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformStateTests.java
@@ -36,8 +36,8 @@ public class DataFrameTransformStateTests extends ESTestCase {
                 DataFrameTransformStateTests::toXContent,
                 DataFrameTransformState::fromXContent)
                 .supportsUnknownFields(true)
-                .randomFieldsExcludeFilter(field -> field.equals("next_position.indexer_position") ||
-                        field.equals("next_position.buckets_position") ||
+                .randomFieldsExcludeFilter(field -> field.equals("position.indexer_position") ||
+                        field.equals("position.buckets_position") ||
                         field.equals("node.attributes"))
                 .test();
     }
@@ -57,7 +57,7 @@ public class DataFrameTransformStateTests extends ESTestCase {
         builder.field("task_state", state.getTaskState().value());
         builder.field("indexer_state", state.getIndexerState().value());
         if (state.getPosition() != null) {
-            builder.field("next_position");
+            builder.field("position");
             DataFrameIndexerPositionTests.toXContent(state.getPosition(), builder);
         }
         builder.field("checkpoint", state.getCheckpoint());

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformStateTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/DataFrameTransformStateTests.java
@@ -37,7 +37,7 @@ public class DataFrameTransformStateTests extends ESTestCase {
                 DataFrameTransformState::fromXContent)
                 .supportsUnknownFields(true)
                 .randomFieldsExcludeFilter(field -> field.equals("position.indexer_position") ||
-                        field.equals("position.buckets_position") ||
+                        field.equals("position.bucket_position") ||
                         field.equals("node.attributes"))
                 .test();
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameIndexerPositionTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameIndexerPositionTests.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.dataframe.transforms.hlrc;
+
+import org.elasticsearch.client.AbstractResponseTestCase;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerPosition;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class DataFrameIndexerPositionTests extends AbstractResponseTestCase<
+        DataFrameIndexerPosition,
+        org.elasticsearch.client.dataframe.transforms.DataFrameIndexerPosition> {
+
+    public static DataFrameIndexerPosition fromHlrc(
+            org.elasticsearch.client.dataframe.transforms.DataFrameIndexerPosition instance) {
+        if (instance == null) {
+            return null;
+        }
+        return new DataFrameIndexerPosition(instance.getIndexerPosition(), instance.getChangesPosition());
+    }
+
+    @Override
+    protected DataFrameIndexerPosition createServerTestInstance() {
+        return new DataFrameIndexerPosition(randomPositionMap(), randomPositionMap());
+    }
+
+    @Override
+    protected org.elasticsearch.client.dataframe.transforms.DataFrameIndexerPosition doParseToClientInstance(XContentParser parser) {
+        return org.elasticsearch.client.dataframe.transforms.DataFrameIndexerPosition.fromXContent(parser);
+    }
+
+    @Override
+    protected void assertInstances(DataFrameIndexerPosition serverTestInstance,
+                                   org.elasticsearch.client.dataframe.transforms.DataFrameIndexerPosition clientInstance) {
+        assertThat(serverTestInstance.getIndexerPosition(), equalTo(clientInstance.getIndexerPosition()));
+        assertThat(serverTestInstance.getChangesPosition(), equalTo(clientInstance.getChangesPosition()));
+    }
+
+    private static Map<String, Object> randomPositionMap() {
+        if (randomBoolean()) {
+            return null;
+        }
+        int numFields = randomIntBetween(1, 5);
+        Map<String, Object> position = new LinkedHashMap<>();
+        for (int i = 0; i < numFields; i++) {
+            Object value;
+            if (randomBoolean()) {
+                value = randomLong();
+            } else {
+                value = randomAlphaOfLengthBetween(1, 10);
+            }
+            position.put(randomAlphaOfLengthBetween(3, 10), value);
+        }
+        return position;
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameIndexerPositionTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameIndexerPositionTests.java
@@ -37,7 +37,7 @@ public class DataFrameIndexerPositionTests extends AbstractResponseTestCase<
         if (instance == null) {
             return null;
         }
-        return new DataFrameIndexerPosition(instance.getIndexerPosition(), instance.getChangesPosition());
+        return new DataFrameIndexerPosition(instance.getIndexerPosition(), instance.getBucketsPosition());
     }
 
     @Override
@@ -54,7 +54,7 @@ public class DataFrameIndexerPositionTests extends AbstractResponseTestCase<
     protected void assertInstances(DataFrameIndexerPosition serverTestInstance,
                                    org.elasticsearch.client.dataframe.transforms.DataFrameIndexerPosition clientInstance) {
         assertThat(serverTestInstance.getIndexerPosition(), equalTo(clientInstance.getIndexerPosition()));
-        assertThat(serverTestInstance.getChangesPosition(), equalTo(clientInstance.getChangesPosition()));
+        assertThat(serverTestInstance.getBucketsPosition(), equalTo(clientInstance.getBucketsPosition()));
     }
 
     private static Map<String, Object> randomPositionMap() {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformStateAndStatsTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformStateAndStatsTests.java
@@ -19,8 +19,8 @@
 
 package org.elasticsearch.client.dataframe.transforms.hlrc;
 
-import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.client.AbstractHlrcXContentTestCase;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerTransformStats;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformStateAndStats;
 
@@ -64,7 +64,10 @@ public class DataFrameTransformStateAndStatsTests extends AbstractHlrcXContentTe
 
     @Override
     protected Predicate<String> getRandomFieldsExcludeFilter() {
-        return field -> field.equals("state.current_position") || field.equals("state.node") || field.equals("state.node.attributes");
+        return field -> field.equals("state.next_position.indexer_position") ||
+                field.equals("state.next_position.changes_position") ||
+                field.equals("state.node") ||
+                field.equals("state.node.attributes");
     }
 }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformStateAndStatsTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformStateAndStatsTests.java
@@ -65,7 +65,7 @@ public class DataFrameTransformStateAndStatsTests extends AbstractHlrcXContentTe
     @Override
     protected Predicate<String> getRandomFieldsExcludeFilter() {
         return field -> field.equals("state.next_position.indexer_position") ||
-                field.equals("state.next_position.changes_position") ||
+                field.equals("state.next_position.buckets_position") ||
                 field.equals("state.node") ||
                 field.equals("state.node.attributes");
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformStateAndStatsTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformStateAndStatsTests.java
@@ -64,8 +64,8 @@ public class DataFrameTransformStateAndStatsTests extends AbstractHlrcXContentTe
 
     @Override
     protected Predicate<String> getRandomFieldsExcludeFilter() {
-        return field -> field.equals("state.next_position.indexer_position") ||
-                field.equals("state.next_position.buckets_position") ||
+        return field -> field.equals("state.position.indexer_position") ||
+                field.equals("state.position.buckets_position") ||
                 field.equals("state.node") ||
                 field.equals("state.node.attributes");
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformStateAndStatsTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformStateAndStatsTests.java
@@ -65,7 +65,7 @@ public class DataFrameTransformStateAndStatsTests extends AbstractHlrcXContentTe
     @Override
     protected Predicate<String> getRandomFieldsExcludeFilter() {
         return field -> field.equals("state.position.indexer_position") ||
-                field.equals("state.position.buckets_position") ||
+                field.equals("state.position.bucket_position") ||
                 field.equals("state.node") ||
                 field.equals("state.node.attributes");
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformStateTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformStateTests.java
@@ -87,7 +87,7 @@ public class DataFrameTransformStateTests extends AbstractHlrcXContentTestCase<D
     @Override
     protected Predicate<String> getRandomFieldsExcludeFilter() {
         return field -> field.equals("position.indexer_position") ||
-                field.equals("position.buckets_position") ||
+                field.equals("position.bucket_position") ||
                 field.equals("node.attributes");
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformStateTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformStateTests.java
@@ -87,7 +87,7 @@ public class DataFrameTransformStateTests extends AbstractHlrcXContentTestCase<D
     @Override
     protected Predicate<String> getRandomFieldsExcludeFilter() {
         return field -> field.equals("next_position.indexer_position") ||
-                field.equals("next_position.changes_position") ||
+                field.equals("next_position.buckets_position") ||
                 field.equals("node.attributes");
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformStateTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformStateTests.java
@@ -86,8 +86,8 @@ public class DataFrameTransformStateTests extends AbstractHlrcXContentTestCase<D
 
     @Override
     protected Predicate<String> getRandomFieldsExcludeFilter() {
-        return field -> field.equals("next_position.indexer_position") ||
-                field.equals("next_position.buckets_position") ||
+        return field -> field.equals("position.indexer_position") ||
+                field.equals("position.buckets_position") ||
                 field.equals("node.attributes");
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformStateTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformStateTests.java
@@ -19,8 +19,9 @@
 
 package org.elasticsearch.client.dataframe.transforms.hlrc;
 
-import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.client.AbstractHlrcXContentTestCase;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerPosition;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerTransformStats;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformCheckpointStats;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformCheckpointingInfo;
@@ -42,7 +43,7 @@ public class DataFrameTransformStateTests extends AbstractHlrcXContentTestCase<D
     public static DataFrameTransformState fromHlrc(org.elasticsearch.client.dataframe.transforms.DataFrameTransformState instance) {
         return new DataFrameTransformState(DataFrameTransformTaskState.fromString(instance.getTaskState().value()),
             IndexerState.fromString(instance.getIndexerState().value()),
-            instance.getPosition(),
+            DataFrameIndexerPositionTests.fromHlrc(instance.getPosition()),
             instance.getCheckpoint(),
             instance.getReason(),
             DataFrameTransformProgressTests.fromHlrc(instance.getProgress()),
@@ -85,7 +86,9 @@ public class DataFrameTransformStateTests extends AbstractHlrcXContentTestCase<D
 
     @Override
     protected Predicate<String> getRandomFieldsExcludeFilter() {
-        return field -> field.equals("current_position") || field.equals("node.attributes");
+        return field -> field.equals("next_position.indexer_position") ||
+                field.equals("next_position.changes_position") ||
+                field.equals("node.attributes");
     }
 
     public static DataFrameTransformStateAndStats randomDataFrameTransformStateAndStats(String id) {
@@ -93,6 +96,10 @@ public class DataFrameTransformStateTests extends AbstractHlrcXContentTestCase<D
             randomDataFrameTransformState(),
             randomStats(id),
             randomDataFrameTransformCheckpointingInfo());
+    }
+
+    public static DataFrameIndexerPosition randomDataFrameIndexerPosition() {
+        return new DataFrameIndexerPosition(randomPosition(), randomPosition());
     }
 
     public static DataFrameTransformCheckpointingInfo randomDataFrameTransformCheckpointingInfo() {
@@ -134,7 +141,7 @@ public class DataFrameTransformStateTests extends AbstractHlrcXContentTestCase<D
     public static DataFrameTransformState randomDataFrameTransformState() {
         return new DataFrameTransformState(randomFrom(DataFrameTransformTaskState.values()),
             randomFrom(IndexerState.values()),
-            randomPosition(),
+            randomDataFrameIndexerPosition(),
             randomLongBetween(0,10),
             randomBoolean() ? null : randomAlphaOfLength(10),
             randomBoolean() ? null : randomDataFrameTransformProgress(),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameMessages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameMessages.java
@@ -40,7 +40,9 @@ public class DataFrameMessages {
     public static final String FAILED_TO_PARSE_TRANSFORM_STATISTICS_CONFIGURATION =
             "Failed to parse transform statistics for data frame transform [{0}]";
     public static final String FAILED_TO_LOAD_TRANSFORM_CHECKPOINT =
-            "Failed to load data frame transform configuration for transform [{0}]";
+            "Failed to load data frame transform checkpoint for transform [{0}]";
+    public static final String FAILED_TO_LOAD_TRANSFORM_STATE =
+            "Failed to load data frame transform state for transform [{0}]";
     public static final String DATA_FRAME_TRANSFORM_CONFIGURATION_NO_TRANSFORM =
             "Data frame transform configuration must specify exactly 1 function";
     public static final String DATA_FRAME_TRANSFORM_CONFIGURATION_PIVOT_NO_GROUP_BY =

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameIndexerPosition.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameIndexerPosition.java
@@ -30,8 +30,8 @@ public class DataFrameIndexerPosition implements Writeable, ToXContentObject {
     public static final ParseField INDEXER_POSITION = new ParseField("indexer_position");
     public static final ParseField CHANGES_POSITION = new ParseField("changes_position");
 
-    private Map<String, Object> indexerPosition;
-    private Map<String, Object> changesPosition;
+    private final Map<String, Object> indexerPosition;
+    private final Map<String, Object> changesPosition;
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<DataFrameIndexerPosition, Void> PARSER = new ConstructingObjectParser<>(NAME,
@@ -59,16 +59,8 @@ public class DataFrameIndexerPosition implements Writeable, ToXContentObject {
         return indexerPosition;
     }
 
-    public void setIndexerPosition(Map<String, Object> indexerPosition) {
-        this.indexerPosition = indexerPosition;
-    }
-
     public Map<String, Object> getChangesPosition() {
         return changesPosition;
-    }
-
-    public void setChangesPosition(Map<String, Object> changesPosition) {
-        this.changesPosition = changesPosition;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameIndexerPosition.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameIndexerPosition.java
@@ -43,9 +43,9 @@ public class DataFrameIndexerPosition implements Writeable, ToXContentObject {
         PARSER.declareField(optionalConstructorArg(), XContentParser::mapOrdered, BUCKET_POSITION, ValueType.OBJECT);
     }
 
-    public DataFrameIndexerPosition(Map<String, Object> indexerPosition, Map<String, Object> bucketsPosition) {
+    public DataFrameIndexerPosition(Map<String, Object> indexerPosition, Map<String, Object> bucketPosition) {
         this.indexerPosition = indexerPosition == null ? null : Collections.unmodifiableMap(indexerPosition);
-        this.bucketPosition = bucketsPosition == null ? null : Collections.unmodifiableMap(bucketsPosition);
+        this.bucketPosition = bucketPosition == null ? null : Collections.unmodifiableMap(bucketPosition);
     }
 
     public DataFrameIndexerPosition(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameIndexerPosition.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameIndexerPosition.java
@@ -28,10 +28,10 @@ public class DataFrameIndexerPosition implements Writeable, ToXContentObject {
     public static final String NAME = "data_frame/indexer_position";
 
     public static final ParseField INDEXER_POSITION = new ParseField("indexer_position");
-    public static final ParseField BUCKETS_POSITION = new ParseField("buckets_position");
+    public static final ParseField BUCKET_POSITION = new ParseField("bucket_position");
 
     private final Map<String, Object> indexerPosition;
-    private final Map<String, Object> bucketsPosition;
+    private final Map<String, Object> bucketPosition;
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<DataFrameIndexerPosition, Void> PARSER = new ConstructingObjectParser<>(NAME,
@@ -40,19 +40,19 @@ public class DataFrameIndexerPosition implements Writeable, ToXContentObject {
 
     static {
         PARSER.declareField(optionalConstructorArg(), XContentParser::mapOrdered, INDEXER_POSITION, ValueType.OBJECT);
-        PARSER.declareField(optionalConstructorArg(), XContentParser::mapOrdered, BUCKETS_POSITION, ValueType.OBJECT);
+        PARSER.declareField(optionalConstructorArg(), XContentParser::mapOrdered, BUCKET_POSITION, ValueType.OBJECT);
     }
 
     public DataFrameIndexerPosition(Map<String, Object> indexerPosition, Map<String, Object> bucketsPosition) {
         this.indexerPosition = indexerPosition == null ? null : Collections.unmodifiableMap(indexerPosition);
-        this.bucketsPosition = bucketsPosition == null ? null : Collections.unmodifiableMap(bucketsPosition);
+        this.bucketPosition = bucketsPosition == null ? null : Collections.unmodifiableMap(bucketsPosition);
     }
 
     public DataFrameIndexerPosition(StreamInput in) throws IOException {
         Map<String, Object> position = in.readMap();
         indexerPosition = position == null ? null : Collections.unmodifiableMap(position);
         position = in.readMap();
-        bucketsPosition = position == null ? null : Collections.unmodifiableMap(position);
+        bucketPosition = position == null ? null : Collections.unmodifiableMap(position);
     }
 
     public Map<String, Object> getIndexerPosition() {
@@ -60,13 +60,13 @@ public class DataFrameIndexerPosition implements Writeable, ToXContentObject {
     }
 
     public Map<String, Object> getBucketsPosition() {
-        return bucketsPosition;
+        return bucketPosition;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeMap(indexerPosition);
-        out.writeMap(bucketsPosition);
+        out.writeMap(bucketPosition);
     }
 
     @Override
@@ -75,8 +75,8 @@ public class DataFrameIndexerPosition implements Writeable, ToXContentObject {
         if (indexerPosition != null) {
             builder.field(INDEXER_POSITION.getPreferredName(), indexerPosition);
         }
-        if (bucketsPosition != null) {
-            builder.field(BUCKETS_POSITION.getPreferredName(), bucketsPosition);
+        if (bucketPosition != null) {
+            builder.field(BUCKET_POSITION.getPreferredName(), bucketPosition);
         }
         builder.endObject();
         return builder;
@@ -95,12 +95,12 @@ public class DataFrameIndexerPosition implements Writeable, ToXContentObject {
         DataFrameIndexerPosition that = (DataFrameIndexerPosition) other;
 
         return Objects.equals(this.indexerPosition, that.indexerPosition) &&
-            Objects.equals(this.bucketsPosition, that.bucketsPosition);
+            Objects.equals(this.bucketPosition, that.bucketPosition);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(indexerPosition, bucketsPosition);
+        return Objects.hash(indexerPosition, bucketPosition);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameIndexerPosition.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameIndexerPosition.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.dataframe.transforms;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ObjectParser.ValueType;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+public class DataFrameIndexerPosition implements Writeable, ToXContentObject {
+    public static final String NAME = "data_frame/indexer_position";
+
+    public static final ParseField INDEXER_POSITION = new ParseField("indexer_position");
+    public static final ParseField CHANGES_POSITION = new ParseField("changes_position");
+
+    private Map<String, Object> indexerPosition;
+    private Map<String, Object> changesPosition;
+
+    @SuppressWarnings("unchecked")
+    public static final ConstructingObjectParser<DataFrameIndexerPosition, Void> PARSER = new ConstructingObjectParser<>(NAME,
+            true,
+            args -> new DataFrameIndexerPosition((Map<String, Object>) args[0],(Map<String, Object>) args[1]));
+
+    static {
+        PARSER.declareField(optionalConstructorArg(), XContentParser::mapOrdered, INDEXER_POSITION, ValueType.OBJECT);
+        PARSER.declareField(optionalConstructorArg(), XContentParser::mapOrdered, CHANGES_POSITION, ValueType.OBJECT);
+    }
+
+    public DataFrameIndexerPosition(Map<String, Object> indexerPosition, Map<String, Object> changesPosition) {
+        this.indexerPosition = indexerPosition;
+        this.changesPosition = changesPosition;
+    }
+
+    public DataFrameIndexerPosition(StreamInput in) throws IOException {
+        Map<String, Object> position = in.readMap();
+        indexerPosition = position == null ? null : Collections.unmodifiableMap(position);
+        position = in.readMap();
+        changesPosition = position == null ? null : Collections.unmodifiableMap(position);
+    }
+
+    public Map<String, Object> getIndexerPosition() {
+        return indexerPosition;
+    }
+
+    public void setIndexerPosition(Map<String, Object> indexerPosition) {
+        this.indexerPosition = indexerPosition;
+    }
+
+    public Map<String, Object> getChangesPosition() {
+        return changesPosition;
+    }
+
+    public void setChangesPosition(Map<String, Object> changesPosition) {
+        this.changesPosition = changesPosition;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeMap(indexerPosition);
+        out.writeMap(changesPosition);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        if (indexerPosition != null) {
+            builder.field(INDEXER_POSITION.getPreferredName(), indexerPosition);
+        }
+        if (changesPosition != null) {
+            builder.field(CHANGES_POSITION.getPreferredName(), changesPosition);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        DataFrameIndexerPosition that = (DataFrameIndexerPosition) other;
+
+        return Objects.equals(this.indexerPosition, that.indexerPosition) &&
+            Objects.equals(this.changesPosition, that.changesPosition);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(indexerPosition, changesPosition);
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
+    }
+
+    public static DataFrameIndexerPosition fromXContent(XContentParser parser) {
+        try {
+            return PARSER.parse(parser, null);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameIndexerPosition.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameIndexerPosition.java
@@ -44,8 +44,8 @@ public class DataFrameIndexerPosition implements Writeable, ToXContentObject {
     }
 
     public DataFrameIndexerPosition(Map<String, Object> indexerPosition, Map<String, Object> bucketsPosition) {
-        this.indexerPosition = Collections.unmodifiableMap(indexerPosition);
-        this.bucketsPosition = Collections.unmodifiableMap(bucketsPosition);
+        this.indexerPosition = indexerPosition == null ? null : Collections.unmodifiableMap(indexerPosition);
+        this.bucketsPosition = bucketsPosition == null ? null : Collections.unmodifiableMap(bucketsPosition);
     }
 
     public DataFrameIndexerPosition(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameIndexerPosition.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameIndexerPosition.java
@@ -28,10 +28,10 @@ public class DataFrameIndexerPosition implements Writeable, ToXContentObject {
     public static final String NAME = "data_frame/indexer_position";
 
     public static final ParseField INDEXER_POSITION = new ParseField("indexer_position");
-    public static final ParseField CHANGES_POSITION = new ParseField("changes_position");
+    public static final ParseField BUCKETS_POSITION = new ParseField("buckets_position");
 
     private final Map<String, Object> indexerPosition;
-    private final Map<String, Object> changesPosition;
+    private final Map<String, Object> bucketsPosition;
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<DataFrameIndexerPosition, Void> PARSER = new ConstructingObjectParser<>(NAME,
@@ -40,33 +40,33 @@ public class DataFrameIndexerPosition implements Writeable, ToXContentObject {
 
     static {
         PARSER.declareField(optionalConstructorArg(), XContentParser::mapOrdered, INDEXER_POSITION, ValueType.OBJECT);
-        PARSER.declareField(optionalConstructorArg(), XContentParser::mapOrdered, CHANGES_POSITION, ValueType.OBJECT);
+        PARSER.declareField(optionalConstructorArg(), XContentParser::mapOrdered, BUCKETS_POSITION, ValueType.OBJECT);
     }
 
-    public DataFrameIndexerPosition(Map<String, Object> indexerPosition, Map<String, Object> changesPosition) {
-        this.indexerPosition = indexerPosition;
-        this.changesPosition = changesPosition;
+    public DataFrameIndexerPosition(Map<String, Object> indexerPosition, Map<String, Object> bucketsPosition) {
+        this.indexerPosition = Collections.unmodifiableMap(indexerPosition);
+        this.bucketsPosition = Collections.unmodifiableMap(bucketsPosition);
     }
 
     public DataFrameIndexerPosition(StreamInput in) throws IOException {
         Map<String, Object> position = in.readMap();
         indexerPosition = position == null ? null : Collections.unmodifiableMap(position);
         position = in.readMap();
-        changesPosition = position == null ? null : Collections.unmodifiableMap(position);
+        bucketsPosition = position == null ? null : Collections.unmodifiableMap(position);
     }
 
     public Map<String, Object> getIndexerPosition() {
         return indexerPosition;
     }
 
-    public Map<String, Object> getChangesPosition() {
-        return changesPosition;
+    public Map<String, Object> getBucketsPosition() {
+        return bucketsPosition;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeMap(indexerPosition);
-        out.writeMap(changesPosition);
+        out.writeMap(bucketsPosition);
     }
 
     @Override
@@ -75,8 +75,8 @@ public class DataFrameIndexerPosition implements Writeable, ToXContentObject {
         if (indexerPosition != null) {
             builder.field(INDEXER_POSITION.getPreferredName(), indexerPosition);
         }
-        if (changesPosition != null) {
-            builder.field(CHANGES_POSITION.getPreferredName(), changesPosition);
+        if (bucketsPosition != null) {
+            builder.field(BUCKETS_POSITION.getPreferredName(), bucketsPosition);
         }
         builder.endObject();
         return builder;
@@ -95,12 +95,12 @@ public class DataFrameIndexerPosition implements Writeable, ToXContentObject {
         DataFrameIndexerPosition that = (DataFrameIndexerPosition) other;
 
         return Objects.equals(this.indexerPosition, that.indexerPosition) &&
-            Objects.equals(this.changesPosition, that.changesPosition);
+            Objects.equals(this.bucketsPosition, that.bucketsPosition);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(indexerPosition, changesPosition);
+        return Objects.hash(indexerPosition, bucketsPosition);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformState.java
@@ -115,7 +115,7 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
     public DataFrameTransformState(StreamInput in) throws IOException {
         taskState = DataFrameTransformTaskState.fromStream(in);
         indexerState = IndexerState.fromStream(in);
-        if (in.getVersion().onOrAfter(Version.CURRENT)) {
+        if (in.getVersion().onOrAfter(Version.V_7_3_0)) {
             position = in.readOptionalWriteable(DataFrameIndexerPosition::new);
         } else {
             Map<String, Object> pos = in.readMap();
@@ -212,7 +212,7 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
     public void writeTo(StreamOutput out) throws IOException {
         taskState.writeTo(out);
         indexerState.writeTo(out);
-        if (out.getVersion().onOrAfter(Version.CURRENT)) {
+        if (out.getVersion().onOrAfter(Version.V_7_3_0)) {
             out.writeOptionalWriteable(position);
         } else {
             out.writeMap(position != null ? position.getIndexerPosition() : null);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformState.java
@@ -22,8 +22,6 @@ import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -39,7 +37,7 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
     private final long checkpoint;
 
     @Nullable
-    private final Map<String, Object> currentPosition;
+    private final DataFrameIndexerPosition currentPosition;
     @Nullable
     private final String reason;
     @Nullable
@@ -47,7 +45,10 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
 
     public static final ParseField TASK_STATE = new ParseField("task_state");
     public static final ParseField INDEXER_STATE = new ParseField("indexer_state");
+
+    // 7.3 BWC, replaced by next_position
     public static final ParseField CURRENT_POSITION = new ParseField("current_position");
+    public static final ParseField NEXT_POSITION = new ParseField("next_position");
     public static final ParseField CHECKPOINT = new ParseField("checkpoint");
     public static final ParseField REASON = new ParseField("reason");
     public static final ParseField PROGRESS = new ParseField("progress");
@@ -56,18 +57,26 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<DataFrameTransformState, Void> PARSER = new ConstructingObjectParser<>(NAME,
             true,
-            args -> new DataFrameTransformState((DataFrameTransformTaskState) args[0],
-                (IndexerState) args[1],
-                (Map<String, Object>) args[2],
-                (long) args[3],
-                (String) args[4],
-                (DataFrameTransformProgress) args[5],
-                (NodeAttributes) args[6]));
+            args -> {
+                DataFrameTransformTaskState taskState = (DataFrameTransformTaskState) args[0];
+                IndexerState indexerState = (IndexerState) args[1];
+                Map<String, Object> bwcCurrentPosition = (Map<String, Object>) args[2];
+                // TODO: handle BWC
+
+                DataFrameIndexerPosition dataFrameIndexerPosition= (DataFrameIndexerPosition) args[3];
+                long checkpoint = (long) args[4];
+                String reason = (String) args[5];
+                DataFrameTransformProgress progress = (DataFrameTransformProgress) args[6];
+                NodeAttributes node = (NodeAttributes) args[7];
+
+                return new DataFrameTransformState(taskState, indexerState, dataFrameIndexerPosition, checkpoint, reason, progress, node);
+            });
 
     static {
         PARSER.declareField(constructorArg(), p -> DataFrameTransformTaskState.fromString(p.text()), TASK_STATE, ValueType.STRING);
         PARSER.declareField(constructorArg(), p -> IndexerState.fromString(p.text()), INDEXER_STATE, ValueType.STRING);
         PARSER.declareField(optionalConstructorArg(), XContentParser::mapOrdered, CURRENT_POSITION, ValueType.OBJECT);
+        PARSER.declareField(optionalConstructorArg(), DataFrameIndexerPosition::fromXContent, NEXT_POSITION, ValueType.OBJECT);
         PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), CHECKPOINT);
         PARSER.declareString(optionalConstructorArg(), REASON);
         PARSER.declareField(optionalConstructorArg(), DataFrameTransformProgress.PARSER::apply, PROGRESS, ValueType.OBJECT);
@@ -76,14 +85,14 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
 
     public DataFrameTransformState(DataFrameTransformTaskState taskState,
                                    IndexerState indexerState,
-                                   @Nullable Map<String, Object> position,
+                                   @Nullable DataFrameIndexerPosition position,
                                    long checkpoint,
                                    @Nullable String reason,
                                    @Nullable DataFrameTransformProgress progress,
                                    @Nullable NodeAttributes node) {
         this.taskState = taskState;
         this.indexerState = indexerState;
-        this.currentPosition = position == null ? null : Collections.unmodifiableMap(new LinkedHashMap<>(position));
+        this.currentPosition = position;
         this.checkpoint = checkpoint;
         this.reason = reason;
         this.progress = progress;
@@ -92,7 +101,7 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
 
     public DataFrameTransformState(DataFrameTransformTaskState taskState,
                                    IndexerState indexerState,
-                                   @Nullable Map<String, Object> position,
+                                   @Nullable DataFrameIndexerPosition position,
                                    long checkpoint,
                                    @Nullable String reason,
                                    @Nullable DataFrameTransformProgress progress) {
@@ -102,8 +111,12 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
     public DataFrameTransformState(StreamInput in) throws IOException {
         taskState = DataFrameTransformTaskState.fromStream(in);
         indexerState = IndexerState.fromStream(in);
-        Map<String, Object> position = in.readMap();
-        currentPosition = position == null ? null : Collections.unmodifiableMap(position);
+        if (in.getVersion().onOrAfter(Version.CURRENT)) {
+            currentPosition = new DataFrameIndexerPosition(in);
+        } else {
+            Map<String, Object> position = in.readMap();
+            currentPosition = new DataFrameIndexerPosition(position, null);
+        }
         checkpoint = in.readLong();
         reason = in.readOptionalString();
         progress = in.readOptionalWriteable(DataFrameTransformProgress::new);
@@ -122,7 +135,7 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
         return indexerState;
     }
 
-    public Map<String, Object> getPosition() {
+    public DataFrameIndexerPosition getPosition() {
         return currentPosition;
     }
 
@@ -170,7 +183,7 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
         builder.field(TASK_STATE.getPreferredName(), taskState.value());
         builder.field(INDEXER_STATE.getPreferredName(), indexerState.value());
         if (currentPosition != null) {
-            builder.field(CURRENT_POSITION.getPreferredName(), currentPosition);
+            builder.field(NEXT_POSITION.getPreferredName(), currentPosition);
         }
         builder.field(CHECKPOINT.getPreferredName(), checkpoint);
         if (reason != null) {
@@ -195,7 +208,11 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
     public void writeTo(StreamOutput out) throws IOException {
         taskState.writeTo(out);
         indexerState.writeTo(out);
-        out.writeMap(currentPosition);
+        if (out.getVersion().onOrAfter(Version.V_7_3_0)) {
+            currentPosition.writeTo(out);
+        } else {
+            out.writeMap(currentPosition.getIndexerPosition());
+        }
         out.writeLong(checkpoint);
         out.writeOptionalString(reason);
         out.writeOptionalWriteable(progress);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformState.java
@@ -112,7 +112,7 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
         taskState = DataFrameTransformTaskState.fromStream(in);
         indexerState = IndexerState.fromStream(in);
         if (in.getVersion().onOrAfter(Version.CURRENT)) {
-            currentPosition = new DataFrameIndexerPosition(in);
+            currentPosition = in.readOptionalWriteable(DataFrameIndexerPosition::new);
         } else {
             Map<String, Object> position = in.readMap();
             currentPosition = new DataFrameIndexerPosition(position, null);
@@ -209,9 +209,9 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
         taskState.writeTo(out);
         indexerState.writeTo(out);
         if (out.getVersion().onOrAfter(Version.V_7_3_0)) {
-            currentPosition.writeTo(out);
+            out.writeOptionalWriteable(currentPosition);
         } else {
-            out.writeMap(currentPosition.getIndexerPosition());
+            out.writeMap(currentPosition != null ? currentPosition.getIndexerPosition() : null);
         }
         out.writeLong(checkpoint);
         out.writeOptionalString(reason);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameIndexerPositionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameIndexerPositionTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.dataframe.transforms;
+
+import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Predicate;
+
+public class DataFrameIndexerPositionTests extends AbstractSerializingTestCase<DataFrameIndexerPosition> {
+
+    public static DataFrameIndexerPosition randomDataFrameIndexerPosition() {
+        return new DataFrameIndexerPosition(randomPosition(), randomPosition());
+    }
+
+    @Override
+    protected DataFrameIndexerPosition createTestInstance() {
+        return randomDataFrameIndexerPosition();
+    }
+
+    @Override
+    protected Reader<DataFrameIndexerPosition> instanceReader() {
+        return DataFrameIndexerPosition::new;
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return true;
+    }
+
+    @Override
+    protected Predicate<String> getRandomFieldsExcludeFilter() {
+        return field -> !field.isEmpty();
+    }
+
+    @Override
+    protected DataFrameIndexerPosition doParseInstance(XContentParser parser) throws IOException {
+        return DataFrameIndexerPosition.fromXContent(parser);
+    }
+
+    private static Map<String, Object> randomPosition() {
+        if (randomBoolean()) {
+            return null;
+        }
+        int numFields = randomIntBetween(1, 5);
+        Map<String, Object> position = new HashMap<>();
+        for (int i = 0; i < numFields; i++) {
+            Object value;
+            if (randomBoolean()) {
+                value = randomLong();
+            } else {
+                value = randomAlphaOfLengthBetween(1, 10);
+            }
+            position.put(randomAlphaOfLengthBetween(3, 10), value);
+        }
+
+        return position;
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformStateTests.java
@@ -12,8 +12,6 @@ import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.function.Predicate;
 
 import static org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformProgressTests.randomDataFrameTransformProgress;
@@ -24,7 +22,7 @@ public class DataFrameTransformStateTests extends AbstractSerializingTestCase<Da
     public static DataFrameTransformState randomDataFrameTransformState() {
         return new DataFrameTransformState(randomFrom(DataFrameTransformTaskState.values()),
             randomFrom(IndexerState.values()),
-            randomPosition(),
+            DataFrameIndexerPositionTests.randomDataFrameIndexerPosition(),
             randomLongBetween(0,10),
             randomBoolean() ? null : randomAlphaOfLength(10),
             randomBoolean() ? null : randomDataFrameTransformProgress(),
@@ -44,24 +42,6 @@ public class DataFrameTransformStateTests extends AbstractSerializingTestCase<Da
     @Override
     protected Reader<DataFrameTransformState> instanceReader() {
         return DataFrameTransformState::new;
-    }
-
-    private static Map<String, Object> randomPosition() {
-        if (randomBoolean()) {
-            return null;
-        }
-        int numFields = randomIntBetween(1, 5);
-        Map<String, Object> position = new HashMap<>();
-        for (int i = 0; i < numFields; i++) {
-            Object value;
-            if (randomBoolean()) {
-                value = randomLong();
-            } else {
-                value = randomAlphaOfLengthBetween(1, 10);
-            }
-            position.put(randomAlphaOfLengthBetween(3, 10), value);
-        }
-        return position;
     }
 
     @Override

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
@@ -225,8 +225,6 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<DataFrameInd
     private IterationResult<DataFrameIndexerPosition> processChangedBuckets(final CompositeAggregation agg) {
         // initialize the map of changed buckets, the map might be empty if source do not require/implement
         // changed bucket detection
-
-        // TODO: what about histogram only data frame transforms????
         changedBuckets = pivot.initialIncrementalBucketUpdateMap();
 
         // reached the end?
@@ -406,7 +404,6 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<DataFrameInd
                 .filter(config.getSyncConfig()
                         .getRangeQuery(nextCheckpoint));
 
-        // TODO: can changedBuckets be empty for histograms?
         if (changedBuckets != null && changedBuckets.isEmpty() == false) {
             QueryBuilder pivotFilter = pivot.filterBuckets(changedBuckets);
             if (pivotFilter != null) {
@@ -464,7 +461,10 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<DataFrameInd
             return RunState.FULL_RUN;
         }
 
-        // TODO: if incremental update is not supported (histogram only), do a full run
+        // if incremental update is not supported, do a full run
+        if (pivot.supportsIncrementalBucketUpdate() == false) {
+            return RunState.FULL_RUN;
+        }
 
         // continuous mode: we need to get the changed buckets first
         return RunState.PARTIAL_RUN_IDENTIFY_CHANGES;

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
@@ -191,14 +191,17 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<DataFrameInd
 
         DataFrameIndexerPosition oldPosition = getPosition();
         DataFrameIndexerPosition newPosition = new DataFrameIndexerPosition(agg.afterKey(),
-                oldPosition != null ? getPosition().getChangesPosition() : null);
+                oldPosition != null ? getPosition().getBucketsPosition() : null);
 
-        IterationResult<DataFrameIndexerPosition> result = new IterationResult<>(processBucketsToIndexRequests(agg).collect(Collectors.toList()),
-            newPosition,
-            agg.getBuckets().isEmpty());
+        IterationResult<DataFrameIndexerPosition> result = new IterationResult<>(
+                processBucketsToIndexRequests(agg).collect(Collectors.toList()),
+                newPosition,
+                agg.getBuckets().isEmpty());
+
         if (progress != null) {
             progress.docsProcessed(getStats().getNumDocuments() - docsBeforeProcess);
         }
+
         return result;
     }
 
@@ -372,7 +375,7 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<DataFrameInd
         DataFrameIndexerPosition position = getPosition();
 
         CompositeAggregationBuilder changesAgg = pivot.buildIncrementalBucketUpdateAggregation(pageSize);
-        changesAgg.aggregateAfter(position != null ? position.getChangesPosition() : null);
+        changesAgg.aggregateAfter(position != null ? position.getBucketsPosition() : null);
         sourceBuilder.aggregation(changesAgg);
 
         QueryBuilder pivotQueryBuilder = getConfig().getSource().getQueryConfig().getQuery();

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
@@ -104,6 +104,8 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<DataFrameInd
         this.progress = transformProgress;
         this.lastCheckpoint = lastCheckpoint;
         this.nextCheckpoint = nextCheckpoint;
+        // give runState a default
+        this.runState = RunState.FULL_RUN;
     }
 
     protected abstract void failIndexer(String message);

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
@@ -362,7 +362,7 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<DataFrameInd
             sourceBuilder.query(pivotQueryBuilder);
         }
 
-        logger.trace("running full run query: {}", sourceBuilder.query());
+        logger.trace("running full run query: {}", sourceBuilder);
 
         return sourceBuilder;
     }
@@ -385,7 +385,7 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<DataFrameInd
 
         sourceBuilder.query(filteredQuery);
 
-        logger.trace("running changes query {}", sourceBuilder.query());
+        logger.trace("running changes query {}", sourceBuilder);
         return sourceBuilder;
     }
 
@@ -413,7 +413,7 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<DataFrameInd
         }
 
         sourceBuilder.query(filteredQuery);
-        logger.trace("running partial update query: {}", sourceBuilder.query());
+        logger.trace("running partial update query: {}", sourceBuilder);
 
         return sourceBuilder;
     }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexer.java
@@ -217,7 +217,6 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<DataFrameInd
 
 
     private IterationResult<DataFrameIndexerPosition> processChangedBuckets(final CompositeAggregation agg) {
-
         // initialize the map of changed buckets, the map might be empty if source do not require/implement
         // changed bucket detection
 
@@ -292,13 +291,12 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<DataFrameInd
     }
 
     protected QueryBuilder buildFilterQuery() {
+        assert nextCheckpoint != null;
+
         QueryBuilder pivotQueryBuilder = getConfig().getSource().getQueryConfig().getQuery();
 
         DataFrameTransformConfig config = getConfig();
-        if (config.getSyncConfig() != null) {
-            if (nextCheckpoint == null) {
-                throw new RuntimeException("in progress checkpoint not found");
-            }
+        if (this.isContinuous()) {
 
             BoolQueryBuilder filteredQuery = new BoolQueryBuilder()
                 .filter(pivotQueryBuilder);
@@ -308,12 +306,10 @@ public abstract class DataFrameIndexer extends AsyncTwoPhaseIndexer<DataFrameInd
             } else {
                 filteredQuery.filter(config.getSyncConfig().getRangeQuery(nextCheckpoint));
             }
-
-            logger.trace("running filtered query: {}", filteredQuery);
             return filteredQuery;
-        } else {
-            return pivotQueryBuilder;
         }
+
+        return pivotQueryBuilder;
     }
 
     @Override

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.dataframe.transforms;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.LatchedActionListener;
@@ -110,7 +111,6 @@ public class DataFrameTransformPersistentTasksExecutor extends PersistentTasksEx
     protected void nodeOperation(AllocatedPersistentTask task, @Nullable DataFrameTransform params, PersistentTaskState state) {
         final String transformId = params.getId();
         final DataFrameTransformTask buildTask = (DataFrameTransformTask) task;
-        final DataFrameTransformState transformPTaskState = (DataFrameTransformState) state;
 
         final DataFrameTransformTask.ClientDataFrameIndexerBuilder indexerBuilder =
             new DataFrameTransformTask.ClientDataFrameIndexerBuilder(transformId)
@@ -119,14 +119,53 @@ public class DataFrameTransformPersistentTasksExecutor extends PersistentTasksEx
                 .setTransformsCheckpointService(dataFrameTransformsCheckpointService)
                 .setTransformsConfigManager(transformsConfigManager);
 
+        final SetOnce<DataFrameTransformState> stateHolder = new SetOnce<>();
+
         ActionListener<StartDataFrameTransformTaskAction.Response> startTaskListener = ActionListener.wrap(
             response -> logger.info("Successfully completed and scheduled task in node operation"),
             failure -> logger.error("Failed to start task ["+ transformId +"] in node operation", failure)
         );
 
-        Long previousCheckpoint = transformPTaskState != null ? transformPTaskState.getCheckpoint() : null;
+        // <5> load next checkpoint
+        ActionListener<DataFrameTransformCheckpoint> getTransformNextCheckpointListener = ActionListener.wrap(
+                nextCheckpoint -> {
+                    indexerBuilder.setNextCheckpoint(nextCheckpoint);
 
-        // <4> Set the previous stats (if they exist), initialize the indexer, start the task (If it is STOPPED)
+                    final long lastCheckpoint = stateHolder.get().getCheckpoint();
+
+                    logger.trace("[{}] No next checkpoint found, starting the task", transformId);
+                    startTask(buildTask, indexerBuilder, lastCheckpoint, startTaskListener);
+                },
+                error -> {
+                    // TODO: do not use the same error message as for loading the last checkpoint
+                    String msg = DataFrameMessages.getMessage(DataFrameMessages.FAILED_TO_LOAD_TRANSFORM_CHECKPOINT, transformId);
+                    logger.error(msg, error);
+                    markAsFailed(buildTask, msg);
+                }
+        );
+
+        // <4> load last checkpoint
+        ActionListener<DataFrameTransformCheckpoint> getTransformLastCheckpointListener = ActionListener.wrap(
+                lastCheckpoint -> {
+                    indexerBuilder.setLastCheckpoint(lastCheckpoint);
+
+                    final long nextCheckpoint = stateHolder.get().getInProgressCheckpoint();
+
+                    if (nextCheckpoint > 0) {
+                        transformsConfigManager.getTransformCheckpoint(transformId, nextCheckpoint, getTransformNextCheckpointListener);
+                    } else {
+                        logger.trace("[{}] No next checkpoint found, starting the task", transformId);
+                        startTask(buildTask, indexerBuilder, lastCheckpoint.getCheckpoint(), startTaskListener);
+                    }
+                },
+                error -> {
+                    String msg = DataFrameMessages.getMessage(DataFrameMessages.FAILED_TO_LOAD_TRANSFORM_CHECKPOINT, transformId);
+                    logger.error(msg, error);
+                    markAsFailed(buildTask, msg);
+                }
+        );
+
+        // <3> Set the previous stats (if they exist), initialize the indexer, start the task (If it is STOPPED)
         // Since we don't create the task until `_start` is called, if we see that the task state is stopped, attempt to start
         // Schedule execution regardless
         ActionListener<DataFrameTransformStateAndStats> transformStatsActionListener = ActionListener.wrap(
@@ -141,27 +180,26 @@ public class DataFrameTransformPersistentTasksExecutor extends PersistentTasksEx
                     stateAndStats.getTransformState(),
                     stateAndStats.getTransformState().getPosition());
 
-                final Long checkpoint = stateAndStats.getTransformState().getCheckpoint();
-                startTask(buildTask, indexerBuilder, checkpoint, startTaskListener);
+                stateHolder.set(stateAndStats.getTransformState());
+                final long lastCheckpoint = stateHolder.get().getCheckpoint();
+
+                if (lastCheckpoint == 0) {
+                    logger.trace("[{}] No checkpoint found, starting the task", transformId);
+                    startTask(buildTask, indexerBuilder, lastCheckpoint, startTaskListener);
+                } else {
+                    logger.trace ("[{}] Restore last checkpoint: [{}]", transformId, lastCheckpoint);
+                    transformsConfigManager.getTransformCheckpoint(transformId, lastCheckpoint, getTransformLastCheckpointListener);
+                }
             },
             error -> {
                 if (error instanceof ResourceNotFoundException == false) {
-                    logger.warn("Unable to load previously persisted statistics for transform [" + params.getId() + "]", error);
+                    String msg = DataFrameMessages.getMessage(DataFrameMessages.FAILED_TO_LOAD_TRANSFORM_STATE, transformId);
+                    logger.error(msg, error);
+                    markAsFailed(buildTask, msg);
                 }
-                startTask(buildTask, indexerBuilder, previousCheckpoint, startTaskListener);
-            }
-        );
 
-        // <3> set the in progress checkpoint for the indexer, get the in progress checkpoint
-        ActionListener<DataFrameTransformCheckpoint> getTransformCheckpointListener = ActionListener.wrap(
-            cp -> {
-                indexerBuilder.setInProgressOrLastCheckpoint(cp);
-                transformsConfigManager.getTransformStats(transformId, transformStatsActionListener);
-            },
-            error -> {
-                String msg = DataFrameMessages.getMessage(DataFrameMessages.FAILED_TO_LOAD_TRANSFORM_CHECKPOINT, transformId);
-                logger.error(msg, error);
-                markAsFailed(buildTask, msg);
+                logger.trace("[{}] No stats found(new transform), starting the task", transformId);
+                startTask(buildTask, indexerBuilder, null, startTaskListener);
             }
         );
 
@@ -169,17 +207,7 @@ public class DataFrameTransformPersistentTasksExecutor extends PersistentTasksEx
         ActionListener<Map<String, String>> getFieldMappingsListener = ActionListener.wrap(
             fieldMappings -> {
                 indexerBuilder.setFieldMappings(fieldMappings);
-
-                long inProgressCheckpoint = transformPTaskState == null ? 0L :
-                    Math.max(transformPTaskState.getCheckpoint(), transformPTaskState.getInProgressCheckpoint());
-
-                logger.debug("Restore in progress or last checkpoint: {}", inProgressCheckpoint);
-
-                if (inProgressCheckpoint == 0) {
-                    getTransformCheckpointListener.onResponse(DataFrameTransformCheckpoint.EMPTY);
-                } else {
-                    transformsConfigManager.getTransformCheckpoint(transformId, inProgressCheckpoint, getTransformCheckpointListener);
-                }
+                transformsConfigManager.getTransformStats(transformId, transformStatsActionListener);
             },
             error -> {
                 String msg = DataFrameMessages.getMessage(DataFrameMessages.DATA_FRAME_UNABLE_TO_GATHER_FIELD_MAPPINGS,

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
@@ -30,6 +30,7 @@ import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.dataframe.DataFrameField;
 import org.elasticsearch.xpack.core.dataframe.action.StartDataFrameTransformTaskAction;
 import org.elasticsearch.xpack.core.dataframe.action.StartDataFrameTransformTaskAction.Response;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerPosition;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerTransformStats;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransform;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformCheckpoint;
@@ -72,7 +73,7 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
     private final SchedulerEngine schedulerEngine;
     private final ThreadPool threadPool;
     private final DataFrameAuditor auditor;
-    private final Map<String, Object> initialPosition;
+    private final DataFrameIndexerPosition initialPosition;
     private final IndexerState initialIndexerState;
 
     private final SetOnce<ClientDataFrameIndexer> indexer = new SetOnce<>();
@@ -95,7 +96,7 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
         DataFrameTransformTaskState initialTaskState = DataFrameTransformTaskState.STOPPED;
         String initialReason = null;
         long initialGeneration = 0;
-        Map<String, Object> initialPosition = null;
+        DataFrameIndexerPosition initialPosition = null;
         if (state != null) {
             initialTaskState = state.getTaskState();
             initialReason = state.getReason();
@@ -383,7 +384,7 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
         private DataFrameTransformConfig transformConfig;
         private DataFrameIndexerTransformStats initialStats;
         private IndexerState indexerState = IndexerState.STOPPED;
-        private Map<String, Object> initialPosition;
+        private DataFrameIndexerPosition initialPosition;
         private DataFrameTransformProgress progress;
         private DataFrameTransformCheckpoint inProgressOrLastCheckpoint;
 
@@ -457,7 +458,7 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
             return this;
         }
 
-        ClientDataFrameIndexerBuilder setInitialPosition(Map<String, Object> initialPosition) {
+        ClientDataFrameIndexerBuilder setInitialPosition(DataFrameIndexerPosition initialPosition) {
             this.initialPosition = initialPosition;
             return this;
         }
@@ -491,7 +492,7 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
                                DataFrameTransformsConfigManager transformsConfigManager,
                                DataFrameTransformsCheckpointService transformsCheckpointService,
                                AtomicReference<IndexerState> initialState,
-                               Map<String, Object> initialPosition,
+                               DataFrameIndexerPosition initialPosition,
                                Client client,
                                DataFrameAuditor auditor,
                                DataFrameIndexerTransformStats initialStats,
@@ -615,7 +616,7 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
         }
 
         @Override
-        protected void doSaveState(IndexerState indexerState, Map<String, Object> position, Runnable next) {
+        protected void doSaveState(IndexerState indexerState, DataFrameIndexerPosition position, Runnable next) {
             if (indexerState.equals(IndexerState.ABORTING)) {
                 // If we're aborting, just invoke `next` (which is likely an onFailure handler)
                 next.run();

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
@@ -51,7 +51,6 @@ import org.elasticsearch.xpack.dataframe.transforms.pivot.AggregationResultUtils
 
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -536,11 +535,11 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
             // Since multiple checkpoints can be executed in the task while it is running on the same node, we need to gather
             // the progress here, and not in the executor.
             if (initialRun()) {
-                ActionListener<Map<String, Set<String>>> changedBucketsListener = ActionListener.wrap(
-                    r -> {
-                        TransformProgressGatherer.getInitialProgress(this.client, buildFilterQuery(), getConfig(), ActionListener.wrap(
+                createCheckpoint(ActionListener.wrap(cp -> {
+                    nextCheckpoint = cp;
+                    TransformProgressGatherer.getInitialProgress(this.client, buildFilterQuery(), getConfig(), ActionListener.wrap(
                             newProgress -> {
-                                logger.info("[{}] reset the progress from [{}] to [{}]", transformId, progress, newProgress);
+                                logger.trace("[{}] reset the progress from [{}] to [{}]", transformId, progress, newProgress);
                                 progress = newProgress;
                                 super.onStart(now, listener);
                             },
@@ -550,13 +549,6 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
                                 super.onStart(now, listener);
                             }
                         ));
-                    },
-                    listener::onFailure
-                );
-
-                createCheckpoint(ActionListener.wrap(cp -> {
-                    nextCheckpoint = cp;
-                    changedBucketsListener.onResponse(null);
                 }, listener::onFailure));
             } else {
                 logger.info("on start");

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
@@ -551,7 +551,6 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
                         ));
                 }, listener::onFailure));
             } else {
-                logger.info("on start");
                 super.onStart(now, listener);
             }
         }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/pivot/Pivot.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/pivot/Pivot.java
@@ -51,6 +51,7 @@ public class Pivot {
     private static final Logger logger = LogManager.getLogger(Pivot.class);
 
     private final PivotConfig config;
+    private final boolean supportsIncrementalBucketUpdate;
 
     // objects for re-using
     private final CompositeAggregationBuilder cachedCompositeAggregation;
@@ -58,6 +59,13 @@ public class Pivot {
     public Pivot(PivotConfig config) {
         this.config = config;
         this.cachedCompositeAggregation = createCompositeAggregation(config);
+
+        boolean supportsIncrementalBucketUpdate = false;
+        for(Entry<String, SingleGroupSource> entry: config.getGroupConfig().getGroups().entrySet()) {
+            supportsIncrementalBucketUpdate |= entry.getValue().supportsIncrementalBucketUpdate();
+        }
+
+        this.supportsIncrementalBucketUpdate = supportsIncrementalBucketUpdate;
     }
 
     public void validate(Client client, SourceConfig sourceConfig, final ActionListener<Boolean> listener) {
@@ -133,6 +141,10 @@ public class Pivot {
         }
 
         return changedBuckets;
+    }
+
+    public boolean supportsIncrementalBucketUpdate() {
+        return supportsIncrementalBucketUpdate;
     }
 
     public Stream<Map<String, Object>> extractResults(CompositeAggregation agg,

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexerTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameIndexerTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerPosition;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerTransformStats;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformCheckpoint;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
@@ -68,7 +69,7 @@ public class DataFrameIndexerTests extends ESTestCase {
                 Map<String, String> fieldMappings,
                 DataFrameAuditor auditor,
                 AtomicReference<IndexerState> initialState,
-                Map<String, Object> initialPosition,
+                DataFrameIndexerPosition initialPosition,
                 DataFrameIndexerTransformStats jobStats,
                 Function<SearchRequest, SearchResponse> searchFunction,
                 Function<BulkRequest, BulkResponse> bulkFunction,
@@ -129,7 +130,7 @@ public class DataFrameIndexerTests extends ESTestCase {
         }
 
         @Override
-        protected void doSaveState(IndexerState state, Map<String, Object> position, Runnable next) {
+        protected void doSaveState(IndexerState state, DataFrameIndexerPosition position, Runnable next) {
             assert state == IndexerState.STARTED || state == IndexerState.INDEXING || state == IndexerState.STOPPED;
             next.run();
         }
@@ -198,7 +199,7 @@ public class DataFrameIndexerTests extends ESTestCase {
 
         Function<BulkRequest, BulkResponse> bulkFunction = bulkRequest -> new BulkResponse(new BulkItemResponse[0], 100);
 
-        Consumer<Exception> failureConsumer = e -> fail("expected circuit breaker exception to be handled");
+        Consumer<Exception> failureConsumer = e -> fail("expected circuit breaker exception to be handled, got:" + e);
 
         final ExecutorService executor = Executors.newFixedThreadPool(1);
         try {


### PR DESCRIPTION
Rewrites how continuous data frame transforms calculates and handles buckets that require an update. Instead of storing the whole set in memory it pages through the updates using a 2nd cursor. This lowers not only memory consumption but prevents problems with limits at query time (max_terms_count). Apart from that the list of updates can be re-retrieved in a failure case (#43662)

Todo:

- [x] disable/enable BWC, adapt versions
- [x] cleanup, re-visit naming
- [x] test correctness
- [x] check behavior for histogram only pivots