### PR TITLE
Inference Processor

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -41,12 +41,14 @@ import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.TokenizerFactory;
 import org.elasticsearch.indices.analysis.AnalysisModule.AnalysisProvider;
+import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.monitor.os.OsProbe;
 import org.elasticsearch.monitor.os.OsStats;
 import org.elasticsearch.persistent.PersistentTasksExecutor;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.AnalysisPlugin;
+import org.elasticsearch.plugins.IngestPlugin;
 import org.elasticsearch.plugins.PersistentTaskPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestController;
@@ -191,6 +193,7 @@ import org.elasticsearch.xpack.ml.dataframe.persistence.DataFrameAnalyticsConfig
 import org.elasticsearch.xpack.ml.dataframe.process.AnalyticsProcessFactory;
 import org.elasticsearch.xpack.ml.dataframe.process.AnalyticsProcessManager;
 import org.elasticsearch.xpack.ml.dataframe.process.NativeAnalyticsProcessFactory;
+import org.elasticsearch.xpack.ml.inference.InferenceProcessor;
 import org.elasticsearch.xpack.ml.job.JobManager;
 import org.elasticsearch.xpack.ml.job.JobManagerHolder;
 import org.elasticsearch.xpack.ml.job.UpdateJobProcessNotifier;
@@ -286,7 +289,7 @@ import java.util.function.UnaryOperator;
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
 
-public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlugin, PersistentTaskPlugin {
+public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlugin, IngestPlugin, PersistentTaskPlugin {
     public static final String NAME = "ml";
     public static final String BASE_PATH = "/_ml/";
     public static final String PRE_V7_BASE_PATH = "/_xpack/ml/";
@@ -574,6 +577,10 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                 new TransportStartDataFrameAnalyticsAction.TaskExecutor(settings, client, clusterService, dataFrameAnalyticsManager.get(),
                     memoryTracker.get())
         );
+    }
+
+    public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {
+        return Collections.singletonMap(InferenceProcessor.TYPE, new InferenceProcessor.Factory());
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/InferenceProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/InferenceProcessor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.inference;
+
+import org.elasticsearch.ingest.AbstractProcessor;
+import org.elasticsearch.ingest.ConfigurationUtils;
+import org.elasticsearch.ingest.IngestDocument;
+import org.elasticsearch.ingest.Processor;
+
+import java.util.Map;
+
+public class InferenceProcessor extends AbstractProcessor {
+
+    public static final String TYPE = "inference";
+
+    private final String targetField;
+
+
+    public InferenceProcessor(String tag, String targetField) {
+        super(tag);
+        this.targetField = targetField;
+    }
+    @Override
+    public IngestDocument execute(IngestDocument document) {
+        document.setFieldValue(targetField, Boolean.TRUE);
+        return document;
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    public static final class Factory implements Processor.Factory {
+
+        @Override
+        public Processor create(Map<String, Processor.Factory> processorFactories, String tag, Map<String, Object> config) {
+
+            String targetField = ConfigurationUtils.readOptionalStringProperty(TYPE, tag, config, "target_field");
+            return new InferenceProcessor(tag, targetField);
+        }
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/InferenceProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/InferenceProcessor.java
@@ -6,6 +6,8 @@
 
 package org.elasticsearch.xpack.ml.inference;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ingest.AbstractProcessor;
 import org.elasticsearch.ingest.ConfigurationUtils;
 import org.elasticsearch.ingest.IngestDocument;
@@ -15,14 +17,19 @@ import java.util.Map;
 
 public class InferenceProcessor extends AbstractProcessor {
 
+    private static final Logger LOGGER = LogManager.getLogger(InferenceProcessor.class);
     public static final String TYPE = "inference";
+    private static final String MODEL_NAME = "model";
+    private static final String TARGET_FIELD = "target_field";
 
     private final String targetField;
+    private final String modelId;
 
 
-    public InferenceProcessor(String tag, String targetField) {
+    public InferenceProcessor(String tag, String modelId, String targetField) {
         super(tag);
         this.targetField = targetField;
+        this.modelId = modelId;
     }
     @Override
     public IngestDocument execute(IngestDocument document) {
@@ -35,13 +42,23 @@ public class InferenceProcessor extends AbstractProcessor {
         return TYPE;
     }
 
+    public String getModelId() {
+        return modelId;
+    }
+
+    public String getTargetField() {
+        return targetField;
+    }
+
     public static final class Factory implements Processor.Factory {
 
         @Override
-        public Processor create(Map<String, Processor.Factory> processorFactories, String tag, Map<String, Object> config) {
+        public InferenceProcessor create(Map<String, Processor.Factory> processorFactories, String tag, Map<String, Object> config) {
 
-            String targetField = ConfigurationUtils.readOptionalStringProperty(TYPE, tag, config, "target_field");
-            return new InferenceProcessor(tag, targetField);
+            LOGGER.info("Inference processor tag [{}]", tag);
+            String model = ConfigurationUtils.readStringProperty(TYPE, tag, config, MODEL_NAME);
+            String targetField = ConfigurationUtils.readStringProperty(TYPE, tag, config, TARGET_FIELD);
+            return new InferenceProcessor(tag, model, targetField);
         }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ModelMeta.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ModelMeta.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.inference;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class ModelMeta implements ToXContentObject, Writeable {
+
+    private static String MODEL_META = "model_meta";
+    private static ParseField MODEL = new ParseField("model");
+    private static ParseField TYPE = new ParseField("type");
+
+    public static final ConstructingObjectParser<ModelMeta, Void> STRICT_PARSER = createParser(false);
+    public static final ConstructingObjectParser<ModelMeta, Void> LENIENT_PARSER = createParser(true);
+
+    private static ConstructingObjectParser<ModelMeta, Void> createParser(boolean lenient) {
+        ConstructingObjectParser<ModelMeta, Void> parser = new ConstructingObjectParser<>("model_meta", lenient,
+                a -> new ModelMeta((String) a[0], (String) a[1]));
+
+        parser.declareString(ConstructingObjectParser.constructorArg(),  MODEL);
+        parser.declareString(ConstructingObjectParser.optionalConstructorArg(), TYPE);
+        return parser;
+    }
+
+    public static ModelMeta fromXContent(XContentParser parser) throws IOException {
+        return STRICT_PARSER.parse(parser, null);
+    }
+
+    public static String documentId(String modelId) {
+        return modelId;
+    }
+
+    private final String modelId;
+    private final String type;
+
+    public ModelMeta(String modelId, String type) {
+        this.modelId = modelId;
+        this.type = type;
+    }
+
+    public ModelMeta(StreamInput in) throws IOException {
+        modelId = in.readString();
+        type = in.readString();
+    }
+
+    public String getModelId() {
+        return modelId;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(getModelId());
+        out.writeString(getType());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        ModelMeta other = (ModelMeta) obj;
+
+        return Objects.equals(modelId, other.modelId) && Objects.equals(type, other.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(modelId, type);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        if (params.paramAsBoolean(ToXContentParams.INCLUDE_TYPE, false) == true) {
+            builder.field(DatafeedConfig.CONFIG_TYPE.getPreferredName(), MODEL_META);
+        }
+        builder.field(TYPE.getPreferredName(), getType());
+        builder.field(MODEL.getPreferredName(), getModelId());
+        return builder.endObject();
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ModelMetadataManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ModelMetadataManager.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.inference;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.ResourceAlreadyExistsException;
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.delete.DeleteAction;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.get.GetAction;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.index.IndexAction;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.engine.VersionConflictEngineException;
+import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
+import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+
+public class ModelMetadataManager {
+
+    private static final Map<String, String> TO_XCONTENT_PARAMS = Map.of(ToXContentParams.INCLUDE_TYPE, "true");
+
+    private final Client client;
+    private final NamedXContentRegistry xContentRegistry;
+
+    public ModelMetadataManager(Client client, NamedXContentRegistry xContentRegistry) {
+        this.client = client;
+        this.xContentRegistry = xContentRegistry;
+    }
+
+    /**
+     * Persist model meta to the ml config index.
+     * It is an error if a document with the same Id already exists -
+     * the config will not be overwritten.
+     *
+     * @param modelMeta The meta data
+     * @param listener Index response listener
+     */
+    public void putModelMeta(ModelMeta modelMeta, ActionListener<IndexResponse> listener) {
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            XContentBuilder source = modelMeta.toXContent(builder, new ToXContent.MapParams(TO_XCONTENT_PARAMS));
+            String documentId = ModelMeta.documentId(modelMeta.getModelId());
+            IndexRequest indexRequest =  new IndexRequest(AnomalyDetectorsIndex.configIndexName())
+                    .id(documentId)
+                    .source(source)
+                    .opType(DocWriteRequest.OpType.CREATE)
+                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+            executeAsyncWithOrigin(client, ML_ORIGIN, IndexAction.INSTANCE, indexRequest, ActionListener.wrap(
+                    listener::onResponse,
+                    e -> {
+                        if (e instanceof VersionConflictEngineException) {
+                            listener.onFailure(new ResourceAlreadyExistsException(
+                                    "The model cannot be created with the Id [{}]. The Id is already used.", documentId));
+                        } else {
+                            listener.onFailure(e);
+                        }
+                    }));
+
+        } catch (IOException e) {
+            listener.onFailure(
+                    new ElasticsearchParseException("Failed to serialise model meta with id [" + modelMeta.getModelId() + "]", e));
+        }
+    }
+
+    /**
+     * Get the model meta specified by {@code modelId}.
+     * If the document is missing a {@code ResourceNotFoundException}
+     * is returned via the listener.
+     *
+     * If the .ml-config index does not exist it is treated as a
+     * resource not found error.
+     *
+     * @param modelId The model ID
+     * @param listener The model meta listener
+     */
+    public void getModelMeta(String modelId, ActionListener<ModelMeta> listener) {
+        GetRequest getRequest = new GetRequest(AnomalyDetectorsIndex.configIndexName(), ModelMeta.documentId(modelId));
+        executeAsyncWithOrigin(client, ML_ORIGIN, GetAction.INSTANCE, getRequest, new ActionListener<>() {
+            @Override
+            public void onResponse(GetResponse getResponse) {
+                if (getResponse.isExists() == false) {
+                    listener.onFailure(missingDocumentExecption(modelId));
+                    return;
+                }
+                BytesReference source = getResponse.getSourceAsBytesRef();
+                parseLenientlyFromSource(source, listener);
+            }
+            @Override
+            public void onFailure(Exception e) {
+                if (e.getClass() == IndexNotFoundException.class) {
+                    listener.onFailure(missingDocumentExecption(modelId));
+                } else {
+                    listener.onFailure(e);
+                }
+            }
+        });
+    }
+
+    /**
+     * Delete the model meta document
+     *
+     * @param modelId The model id
+     * @param actionListener Deleted listener
+     */
+    public void deleteModelMeta(String modelId,  ActionListener<DeleteResponse> actionListener) {
+        DeleteRequest request = new DeleteRequest(AnomalyDetectorsIndex.configIndexName(), ModelMeta.documentId(modelId));
+        request.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        executeAsyncWithOrigin(client, ML_ORIGIN, DeleteAction.INSTANCE, request, new ActionListener<>() {
+            @Override
+            public void onResponse(DeleteResponse deleteResponse) {
+                if (deleteResponse.getResult() == DocWriteResponse.Result.NOT_FOUND) {
+                    actionListener.onFailure(missingDocumentExecption(modelId));
+                    return;
+                }
+                assert deleteResponse.getResult() == DocWriteResponse.Result.DELETED;
+                actionListener.onResponse(deleteResponse);
+            }
+            @Override
+            public void onFailure(Exception e) {
+                actionListener.onFailure(e);
+            }
+        });
+    }
+
+    private ResourceNotFoundException missingDocumentExecption(String modelId) {
+        return new ResourceNotFoundException("No model with id [{}] found", modelId);
+    }
+
+    private void parseLenientlyFromSource(BytesReference source, ActionListener<ModelMeta> listener)  {
+        try (InputStream stream = source.streamInput();
+             XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+                     .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, stream)) {
+            listener.onResponse(ModelMeta.LENIENT_PARSER.apply(parser, null));
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/InferenceProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/InferenceProcessorTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.inference;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class InferenceProcessorTests extends ESTestCase {
+
+    public void testFactory() {
+        InferenceProcessor.Factory factory = new InferenceProcessor.Factory();
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("model", "k2");
+        config.put("target_field", "lion");
+        String processorTag = randomAlphaOfLength(10);
+
+        InferenceProcessor processor = factory.create(Collections.emptyMap(), processorTag, config);
+        assertThat(processor.getTag(), equalTo(processorTag));
+        assertThat(processor.getType(), equalTo("inference"));
+        assertThat(processor.getModelId(), equalTo("k2"));
+        assertThat(processor.getTargetField(), equalTo("lion"));
+    }
+
+    public void testFactory_givenMissingModel() {
+        InferenceProcessor.Factory factory = new InferenceProcessor.Factory();
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("target_field", "lion");
+        String processorTag = randomAlphaOfLength(10);
+
+        ElasticsearchParseException parseException = expectThrows(ElasticsearchParseException.class,
+                () -> factory.create(Collections.emptyMap(), processorTag, config));
+        assertThat(parseException.getMessage(), equalTo("[model] required property is missing"));
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ModelMetaTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ModelMetaTests.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.inference;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+
+import java.io.IOException;
+
+public class ModelMetaTests extends AbstractSerializingTestCase<ModelMeta> {
+    @Override
+    protected ModelMeta doParseInstance(XContentParser parser) throws IOException {
+        return ModelMeta.fromXContent(parser);
+    }
+
+    @Override
+    protected ModelMeta createTestInstance() {
+        return new ModelMeta(randomAlphaOfLength(6), randomAlphaOfLength(6));
+    }
+
+    @Override
+    protected Writeable.Reader<ModelMeta> instanceReader() {
+        return ModelMeta::new;
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/ModelMetadataManagerIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/ModelMetadataManagerIT.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.integration;
+
+import org.elasticsearch.ResourceAlreadyExistsException;
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
+import org.elasticsearch.xpack.ml.inference.ModelMeta;
+import org.elasticsearch.xpack.ml.inference.ModelMetadataManager;
+import org.junit.Before;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+
+public class ModelMetadataManagerIT extends MlSingleNodeTestCase {
+
+    private ModelMetadataManager modelMetadataManager;
+
+    @Before
+    public void createComponents() throws Exception {
+        modelMetadataManager = new ModelMetadataManager(client(), xContentRegistry());
+        waitForMlTemplates();
+    }
+
+    public void testCreateReadDelete() throws InterruptedException {
+
+        ModelMeta modelMeta = new ModelMeta(randomAlphaOfLength(6), randomAlphaOfLength(6));
+
+        AtomicReference<IndexResponse> indexResponseHolder = new AtomicReference<>();
+        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+        blockingCall(listener -> modelMetadataManager.putModelMeta(modelMeta, listener), indexResponseHolder, exceptionHolder);
+        assertNull(exceptionHolder.get());
+        assertEquals(RestStatus.CREATED, indexResponseHolder.get().status());
+
+        AtomicReference<ModelMeta> modelMetaHolder = new AtomicReference<>();
+        blockingCall(listener -> modelMetadataManager.getModelMeta(modelMeta.getModelId(), listener), modelMetaHolder, exceptionHolder);
+        assertNull(exceptionHolder.get());
+        assertEquals(modelMeta, modelMetaHolder.get());
+
+        AtomicReference<DeleteResponse> deleteResponseHolder = new AtomicReference<>();
+        blockingCall(listener -> modelMetadataManager.deleteModelMeta(modelMeta.getModelId(), listener),
+                deleteResponseHolder, exceptionHolder);
+        assertNull(exceptionHolder.get());
+        assertEquals(DocWriteResponse.Result.DELETED, deleteResponseHolder.get().getResult());
+    }
+
+    public void testCannotCreateTwice() throws InterruptedException {
+        ModelMeta modelMeta = new ModelMeta("same-id", randomAlphaOfLength(6));
+
+        AtomicReference<IndexResponse> indexResponseHolder = new AtomicReference<>();
+        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+        blockingCall(listener -> modelMetadataManager.putModelMeta(modelMeta, listener), indexResponseHolder, exceptionHolder);
+        assertNull(exceptionHolder.get());
+        assertEquals(RestStatus.CREATED, indexResponseHolder.get().status());
+
+        indexResponseHolder.set(null);
+        blockingCall(listener -> modelMetadataManager.putModelMeta(modelMeta, listener), indexResponseHolder, exceptionHolder);
+        assertNotNull(exceptionHolder.get());
+        assertNull(indexResponseHolder.get());
+        assertThat(exceptionHolder.get(), instanceOf(ResourceAlreadyExistsException.class));
+        assertEquals("The model cannot be created with the Id [same-id]. The Id is already used.", exceptionHolder.get().getMessage());
+    }
+
+    public void testMissingDocument() throws InterruptedException {
+
+        // first put anything to create the index otherwise the
+        // GETs will cause a IndexNotFoundException
+        AtomicReference<IndexResponse> indexResponseHolder = new AtomicReference<>();
+        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+        blockingCall(listener -> modelMetadataManager.putModelMeta(new ModelMeta("unrelated", "config"), listener),
+                indexResponseHolder, exceptionHolder);
+        assertEquals(RestStatus.CREATED, indexResponseHolder.get().status());
+
+        AtomicReference<ModelMeta> modelMetaHolder = new AtomicReference<>();
+        blockingCall(listener -> modelMetadataManager.getModelMeta("missing", listener), modelMetaHolder, exceptionHolder);
+        assertNull(modelMetaHolder.get());
+        assertThat(exceptionHolder.get(), instanceOf(ResourceNotFoundException.class));
+        assertEquals("No model with id [missing] found", exceptionHolder.get().getMessage());
+
+        exceptionHolder.set(null);
+        AtomicReference<DeleteResponse> deleteResponseHolder = new AtomicReference<>();
+        blockingCall(listener -> modelMetadataManager.deleteModelMeta("missing", listener), deleteResponseHolder, exceptionHolder);
+        assertNull(deleteResponseHolder.get());
+        assertThat(exceptionHolder.get(), instanceOf(ResourceNotFoundException.class));
+        assertEquals("No model with id [missing] found", exceptionHolder.get().getMessage());
+    }
+
+    public void testGetMissingDocumentIndexNotCreated() throws InterruptedException {
+        // the .ml-config does not exist this checks that the
+        // subsequent IndexNotFoundException is converted to ResourceNotFoundException
+        AtomicReference<ModelMeta> modelMetaHolder = new AtomicReference<>();
+        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+        blockingCall(listener -> modelMetadataManager.getModelMeta("missing", listener), modelMetaHolder, exceptionHolder);
+        assertThat(exceptionHolder.get(), instanceOf(ResourceNotFoundException.class));
+    }
+}


### PR DESCRIPTION
This is a working prototype for discussion it will not be merged.

1. Makes the MachineLearning plugin an ingest plugin and adds a trivial inference processor
2. Defines a `ModelMeta` class for holding information about about a model.
3. A CRUD manager for `ModelMeta`