### PR TITLE
[ML][Data Frame] responding with 409 status code when failing _stop

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameMessages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameMessages.java
@@ -32,6 +32,9 @@ public class DataFrameMessages {
     public static final String DATA_FRAME_FAILED_TO_PERSIST_STATS = "Failed to persist data frame statistics for transform [{0}]";
     public static final String DATA_FRAME_UNKNOWN_TRANSFORM_STATS = "Statistics for transform [{0}] could not be found";
 
+    public static final String DATA_FRAME_CANNOT_STOP_FAILED_TRANSFORM =
+        "Unable to stop data frame transform [{0}] as it is in a failed state with reason [{1}]." +
+            " Use force stop to stop the data frame transform.";
     public static final String FAILED_TO_CREATE_DESTINATION_INDEX = "Could not create destination index [{0}] for transform [{1}]";
     public static final String FAILED_TO_LOAD_TRANSFORM_CONFIGURATION =
             "Failed to load data frame transform configuration for transform [{0}]";

--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameRestTestCase.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameRestTestCase.java
@@ -161,7 +161,8 @@ public abstract class DataFrameRestTestCase extends ESRestTestCase {
 
         String config = "{ \"dest\": {\"index\":\"" + dataFrameIndex + "\"},"
             + " \"source\": {\"index\":\"" + REVIEWS_INDEX_NAME + "\"},"
-            + " \"sync\": {\"time\":{\"field\": \"timestamp\", \"delay\": \"15m\"}},"
+            //Set frequency high for testing
+            + " \"sync\": {\"time\":{\"field\": \"timestamp\", \"delay\": \"15m\", \"frequency\": \"1s\"}},"
             + " \"pivot\": {"
             + "   \"group_by\": {"
             + "     \"reviewer\": {"

--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameTaskFailedStateIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameTaskFailedStateIT.java
@@ -11,8 +11,9 @@ import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformTaskState;
 
+import java.io.IOException;
+import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -29,34 +30,29 @@ public class DataFrameTaskFailedStateIT extends DataFrameRestTestCase {
         createReviewsIndex();
         String transformId = "failure_pivot_1";
         String dataFrameIndex = "failure_pivot_reviews";
-        createContinuousPivotReviewsTransform(transformId, dataFrameIndex, null);
-        startDataframeTransform(transformId, false);
-        // wait for our initial indexing to complete
-        waitForDataFrameCheckpoint(transformId);
-
-        // Deleting the only concrete index should make the checkpoint gathering fail
+        createPivotReviewsTransform(transformId, dataFrameIndex, null);
         deleteIndex(REVIEWS_INDEX_NAME); // trigger start failure due to index missing
-
+        startDataframeTransform(transformId, false);
         awaitState(transformId, DataFrameTransformTaskState.FAILED);
         Map<?, ?> fullState = getDataFrameState(transformId);
 
         // Verify we have failed for the expected reason
         assertThat(XContentMapValues.extractValue("state.reason", fullState),
             equalTo("task encountered irrecoverable failure: no such index [reviews]"));
+        assertThat(XContentMapValues.extractValue("state.indexer_state", fullState), equalTo("started"));
 
         // Verify that we cannot stop or start the transform when the task is in a failed state
         ResponseException ex = expectThrows(ResponseException.class, () -> stopDataFrameTransform(transformId, false));
         assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(RestStatus.CONFLICT.getStatus()));
         assertThat(XContentMapValues.extractValue("error.reason", entityAsMap(ex.getResponse())),
-            equalTo("Unable to stop data frame transform [failure_pivot_1] as it is in a failed state with reason [" +
-                "task encountered irrecoverable failure: no such index [reviews]. " +
-                "Use force stop to stop the data frame transform."));
+            equalTo("Unable to stop data frame transform [failure_pivot_1] as it is in a failed state with reason: [" +
+                "task encountered irrecoverable failure: no such index [reviews]]. Use force stop to stop the data frame transform."));
 
         ex = expectThrows(ResponseException.class, () -> startDataframeTransform(transformId, false));
         assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(RestStatus.CONFLICT.getStatus()));
         assertThat(XContentMapValues.extractValue("error.reason", entityAsMap(ex.getResponse())),
             equalTo("Unable to start data frame transform [failure_pivot_1] as it is in a failed state with failure: [" +
-                "task encountered irrecoverable failure: no such index [reviews]. " +
+                "task encountered irrecoverable failure: no such index [reviews]]. " +
                 "Use force start to restart data frame transform once error is resolved."));
 
         // Correct the failure by creating the reviews index again
@@ -64,12 +60,23 @@ public class DataFrameTaskFailedStateIT extends DataFrameRestTestCase {
         // Force start the data frame to indicate failure correction
         startDataframeTransform(transformId, true);
         // Wait for data to be indexed appropriately and refresh for search
-        awaitState(transformId, DataFrameTransformTaskState.STARTED);
+        waitForDataFrameCheckpoint(transformId);
+        refreshIndex(dataFrameIndex);
 
         // Verify that we have started and that our reason is cleared
         fullState = getDataFrameState(transformId);
         assertThat(XContentMapValues.extractValue("state.reason", fullState), is(nullValue()));
         assertThat(XContentMapValues.extractValue("state.task_state", fullState), equalTo("started"));
+        assertThat(XContentMapValues.extractValue("state.indexer_state", fullState), equalTo("started"));
+        assertThat(XContentMapValues.extractValue("stats.search_failures", fullState), equalTo(1));
+
+        // get and check some users to verify we restarted
+        assertOnePivotValue(dataFrameIndex + "/_search?q=reviewer:user_0", 3.776978417);
+        assertOnePivotValue(dataFrameIndex + "/_search?q=reviewer:user_5", 3.72);
+        assertOnePivotValue(dataFrameIndex + "/_search?q=reviewer:user_11", 3.846153846);
+        assertOnePivotValue(dataFrameIndex + "/_search?q=reviewer:user_20", 3.769230769);
+        assertOnePivotValue(dataFrameIndex + "/_search?q=reviewer:user_26", 3.918918918);
+
 
         stopDataFrameTransform(transformId, true);
         deleteDataFrameTransform(transformId);
@@ -79,6 +86,14 @@ public class DataFrameTaskFailedStateIT extends DataFrameRestTestCase {
         assertBusy(() -> {
             String currentState = getDataFrameTaskState(transformId);
             assertThat(state.value(), equalTo(currentState));
-        }, 60, TimeUnit.SECONDS);
+        });
+    }
+
+    private void assertOnePivotValue(String query, double expected) throws IOException {
+        Map<String, Object> searchResult = getAsMap(query);
+
+        assertEquals(1, XContentMapValues.extractValue("hits.total.value", searchResult));
+        double actual = (Double) ((List<?>) XContentMapValues.extractValue("hits.hits._source.avg_rating", searchResult)).get(0);
+        assertEquals(expected, actual, 0.000001);
     }
 }

--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameTaskFailedStateIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameTaskFailedStateIT.java
@@ -11,9 +11,8 @@ import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformTaskState;
 
-import java.io.IOException;
-import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -30,29 +29,34 @@ public class DataFrameTaskFailedStateIT extends DataFrameRestTestCase {
         createReviewsIndex();
         String transformId = "failure_pivot_1";
         String dataFrameIndex = "failure_pivot_reviews";
-        createPivotReviewsTransform(transformId, dataFrameIndex, null);
-        deleteIndex(REVIEWS_INDEX_NAME); // trigger start failure due to index missing
+        createContinuousPivotReviewsTransform(transformId, dataFrameIndex, null);
         startDataframeTransform(transformId, false);
+        // wait for our initial indexing to complete
+        waitForDataFrameCheckpoint(transformId);
+
+        // Deleting the only concrete index should make the checkpoint gathering fail
+        deleteIndex(REVIEWS_INDEX_NAME); // trigger start failure due to index missing
+
         awaitState(transformId, DataFrameTransformTaskState.FAILED);
         Map<?, ?> fullState = getDataFrameState(transformId);
 
         // Verify we have failed for the expected reason
         assertThat(XContentMapValues.extractValue("state.reason", fullState),
             equalTo("task encountered irrecoverable failure: no such index [reviews]"));
-        assertThat(XContentMapValues.extractValue("state.indexer_state", fullState), equalTo("started"));
 
         // Verify that we cannot stop or start the transform when the task is in a failed state
         ResponseException ex = expectThrows(ResponseException.class, () -> stopDataFrameTransform(transformId, false));
         assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(RestStatus.CONFLICT.getStatus()));
         assertThat(XContentMapValues.extractValue("error.reason", entityAsMap(ex.getResponse())),
-            equalTo("Unable to stop data frame transform [failure_pivot_1] as it is in a failed state with reason: [" +
-                "task encountered irrecoverable failure: no such index [reviews]]. Use force stop to stop the data frame transform."));
+            equalTo("Unable to stop data frame transform [failure_pivot_1] as it is in a failed state with reason [" +
+                "task encountered irrecoverable failure: no such index [reviews]. " +
+                "Use force stop to stop the data frame transform."));
 
         ex = expectThrows(ResponseException.class, () -> startDataframeTransform(transformId, false));
         assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(RestStatus.CONFLICT.getStatus()));
         assertThat(XContentMapValues.extractValue("error.reason", entityAsMap(ex.getResponse())),
             equalTo("Unable to start data frame transform [failure_pivot_1] as it is in a failed state with failure: [" +
-                "task encountered irrecoverable failure: no such index [reviews]]. " +
+                "task encountered irrecoverable failure: no such index [reviews]. " +
                 "Use force start to restart data frame transform once error is resolved."));
 
         // Correct the failure by creating the reviews index again
@@ -60,23 +64,12 @@ public class DataFrameTaskFailedStateIT extends DataFrameRestTestCase {
         // Force start the data frame to indicate failure correction
         startDataframeTransform(transformId, true);
         // Wait for data to be indexed appropriately and refresh for search
-        waitForDataFrameCheckpoint(transformId);
-        refreshIndex(dataFrameIndex);
+        awaitState(transformId, DataFrameTransformTaskState.STARTED);
 
         // Verify that we have started and that our reason is cleared
         fullState = getDataFrameState(transformId);
         assertThat(XContentMapValues.extractValue("state.reason", fullState), is(nullValue()));
         assertThat(XContentMapValues.extractValue("state.task_state", fullState), equalTo("started"));
-        assertThat(XContentMapValues.extractValue("state.indexer_state", fullState), equalTo("started"));
-        assertThat(XContentMapValues.extractValue("stats.search_failures", fullState), equalTo(1));
-
-        // get and check some users to verify we restarted
-        assertOnePivotValue(dataFrameIndex + "/_search?q=reviewer:user_0", 3.776978417);
-        assertOnePivotValue(dataFrameIndex + "/_search?q=reviewer:user_5", 3.72);
-        assertOnePivotValue(dataFrameIndex + "/_search?q=reviewer:user_11", 3.846153846);
-        assertOnePivotValue(dataFrameIndex + "/_search?q=reviewer:user_20", 3.769230769);
-        assertOnePivotValue(dataFrameIndex + "/_search?q=reviewer:user_26", 3.918918918);
-
 
         stopDataFrameTransform(transformId, true);
         deleteDataFrameTransform(transformId);
@@ -86,14 +79,6 @@ public class DataFrameTaskFailedStateIT extends DataFrameRestTestCase {
         assertBusy(() -> {
             String currentState = getDataFrameTaskState(transformId);
             assertThat(state.value(), equalTo(currentState));
-        });
-    }
-
-    private void assertOnePivotValue(String query, double expected) throws IOException {
-        Map<String, Object> searchResult = getAsMap(query);
-
-        assertEquals(1, XContentMapValues.extractValue("hits.total.value", searchResult));
-        double actual = (Double) ((List<?>) XContentMapValues.extractValue("hits.hits._source.avg_rating", searchResult)).get(0);
-        assertEquals(expected, actual, 0.000001);
+        }, 60, TimeUnit.SECONDS);
     }
 }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportStopDataFrameTransformAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportStopDataFrameTransformAction.java
@@ -91,13 +91,14 @@ public class TransportStopDataFrameTransformAction extends
                 new PageParams(0, 10_000),
                 request.isAllowNoMatch(),
                 ActionListener.wrap(hitsAndIds -> {
-                    if (request.isForce() == false) {
-                        PersistentTasksCustomMetaData tasks = state.metaData().custom(PersistentTasksCustomMetaData.TYPE);
+                    PersistentTasksCustomMetaData tasks = state.metaData().custom(PersistentTasksCustomMetaData.TYPE);
+                    if (request.isForce() == false && tasks != null) {
                         List<String> failedTasks = new ArrayList<>();
                         List<String> failedReasons = new ArrayList<>();
                         for (String transformId : hitsAndIds.v2()) {
                             PersistentTasksCustomMetaData.PersistentTask<?> dfTask = tasks.getTask(transformId);
-                            if (dfTask.getState() instanceof DataFrameTransformState
+                            if (dfTask != null
+                                && dfTask.getState() instanceof DataFrameTransformState
                                 && ((DataFrameTransformState) dfTask.getState()).getTaskState() == DataFrameTransformTaskState.FAILED) {
                                 failedTasks.add(transformId);
                                 failedReasons.add(((DataFrameTransformState) dfTask.getState()).getReason());

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/action/TransportStopDataFrameTransformActionTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/action/TransportStopDataFrameTransformActionTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.dataframe.action;
+
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.dataframe.DataFrameMessages;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransform;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformState;
+import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformTaskState;
+import org.elasticsearch.xpack.core.indexing.IndexerState;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.elasticsearch.rest.RestStatus.CONFLICT;
+import static org.hamcrest.Matchers.equalTo;
+
+public class TransportStopDataFrameTransformActionTests extends ESTestCase {
+
+    private MetaData.Builder buildMetadata(PersistentTasksCustomMetaData ptasks) {
+        return MetaData.builder().putCustom(PersistentTasksCustomMetaData.TYPE, ptasks);
+    }
+
+    public void testTaskStateValidationWithNoTasks() {
+        MetaData.Builder metaData = MetaData.builder();
+        ClusterState.Builder csBuilder = ClusterState.builder(new ClusterName("_name")).metaData(metaData);
+        TransportStopDataFrameTransformAction.validateTaskState(csBuilder.build(), Collections.singletonList("non-failed-task"), false);
+
+        PersistentTasksCustomMetaData.Builder pTasksBuilder = PersistentTasksCustomMetaData.builder();
+        csBuilder = ClusterState.builder(new ClusterName("_name")).metaData(buildMetadata(pTasksBuilder.build()));
+        TransportStopDataFrameTransformAction.validateTaskState(csBuilder.build(), Collections.singletonList("non-failed-task"), false);
+    }
+
+    public void testTaskStateValidationWithDataFrameTasks() {
+        // Test with the task state being null
+        PersistentTasksCustomMetaData.Builder pTasksBuilder = PersistentTasksCustomMetaData.builder()
+            .addTask("non-failed-task",
+                DataFrameTransform.NAME,
+                new DataFrameTransform("data-frame-task-1", Version.CURRENT, null),
+                new PersistentTasksCustomMetaData.Assignment("current-data-node-with-1-tasks", ""));
+        ClusterState.Builder csBuilder = ClusterState.builder(new ClusterName("_name")).metaData(buildMetadata(pTasksBuilder.build()));
+
+        TransportStopDataFrameTransformAction.validateTaskState(csBuilder.build(), Collections.singletonList("non-failed-task"), false);
+
+        // test again with a non failed task but this time it has internal state
+        pTasksBuilder.updateTaskState("non-failed-task", new DataFrameTransformState(DataFrameTransformTaskState.STOPPED,
+            IndexerState.STOPPED,
+            null,
+            0L,
+            null,
+            null));
+        csBuilder = ClusterState.builder(new ClusterName("_name")).metaData(buildMetadata(pTasksBuilder.build()));
+
+        TransportStopDataFrameTransformAction.validateTaskState(csBuilder.build(), Collections.singletonList("non-failed-task"), false);
+
+        pTasksBuilder.addTask("failed-task",
+            DataFrameTransform.NAME,
+            new DataFrameTransform("data-frame-task-1", Version.CURRENT, null),
+            new PersistentTasksCustomMetaData.Assignment("current-data-node-with-1-tasks", ""))
+            .updateTaskState("failed-task", new DataFrameTransformState(DataFrameTransformTaskState.FAILED,
+                IndexerState.STOPPED,
+                null,
+                0L,
+                "task has failed",
+                null));
+        csBuilder = ClusterState.builder(new ClusterName("_name")).metaData(buildMetadata(pTasksBuilder.build()));
+
+        TransportStopDataFrameTransformAction.validateTaskState(csBuilder.build(), Arrays.asList("non-failed-task", "failed-task"), true);
+
+        TransportStopDataFrameTransformAction.validateTaskState(csBuilder.build(), Collections.singletonList("non-failed-task"), false);
+
+        ClusterState.Builder csBuilderFinal = ClusterState.builder(new ClusterName("_name")).metaData(buildMetadata(pTasksBuilder.build()));
+        ElasticsearchStatusException ex = expectThrows(ElasticsearchStatusException.class,
+            () -> TransportStopDataFrameTransformAction.validateTaskState(csBuilderFinal.build(),
+                Collections.singletonList("failed-task"),
+                false));
+
+        assertThat(ex.status(), equalTo(CONFLICT));
+        assertThat(ex.getMessage(),
+            equalTo(DataFrameMessages.getMessage(DataFrameMessages.DATA_FRAME_CANNOT_STOP_FAILED_TRANSFORM,
+                "failed-task",
+                "task has failed")));
+    }
+
+}


### PR DESCRIPTION
When attempting a `_stop` call against any number of tasks with `force=false` and any of the tasks are failed, we should not stop any of the tasks. The response code should indicate an error with details in the body.

closes #44103