### PR TITLE
Pass tests.jvms system property to test tasks for maxParallelForks

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -825,7 +825,7 @@ class BuildPlugin implements Plugin<Project> {
 
                 test.executable = "${ext.get('runtimeJavaHome')}/bin/java"
                 test.workingDir = project.file("${project.buildDir}/testrun/${test.name}")
-                test.maxParallelForks = project.rootProject.extensions.getByType(ExtraPropertiesExtension).get('defaultParallel') as Integer
+                test.maxParallelForks = System.getProperty('tests.jvms', project.rootProject.extensions.extraProperties.get('defaultParallel').toString()) as Integer
 
                 test.exclude '**/*$*.class'
 


### PR DESCRIPTION
This PR addresses #43998. If `-Dtests.jvms=n` is passed to the build we will use this value for `maxParallelForks` such that users can specifically tell the build how many parallel tests to run. This capability existed with the previous Ant-based test execution implementation so we are restoring it.