### PR TITLE
[DOCS] Bump docs version from 7.2.0 to 7.2.1

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -1,8 +1,8 @@
-:version:               7.2.0
+:version:               7.2.1
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:          7.2.0
+:bare_version:          7.2.1
 :major-version:         7.x
 :prev-major-version:    6.x
 :lucene_version:        8.0.0


### PR DESCRIPTION
Increments the Elasticsearch documentation for the 7.2.1 release.

Will merge on release day.