### PR TITLE
Remove most direct test calls to TransportAction.execute

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexActionTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.admin.indices.get;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.replication.ClusterStateCreationUtils;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -82,7 +83,7 @@ public class GetIndexActionTests extends ESSingleNodeTestCase {
 
     public void testIncludeDefaults() {
         GetIndexRequest defaultsRequest = new GetIndexRequest().indices(indexName).includeDefaults(true);
-        getIndexAction.execute(null, defaultsRequest, ActionListener.wrap(
+        ActionTestUtils.execute(getIndexAction, null, defaultsRequest, ActionListener.wrap(
             defaultsResponse -> assertNotNull(
                 "index.refresh_interval should be set as we are including defaults",
                 defaultsResponse.getSetting(indexName, "index.refresh_interval")
@@ -94,7 +95,7 @@ public class GetIndexActionTests extends ESSingleNodeTestCase {
 
     public void testDoNotIncludeDefaults() {
         GetIndexRequest noDefaultsRequest = new GetIndexRequest().indices(indexName);
-        getIndexAction.execute(null, noDefaultsRequest, ActionListener.wrap(
+        ActionTestUtils.execute(getIndexAction, null, noDefaultsRequest, ActionListener.wrap(
             noDefaultsResponse -> assertNull(
                 "index.refresh_interval should be null as it was never set",
                 noDefaultsResponse.getSetting(indexName, "index.refresh_interval")

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsActionTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.admin.indices.settings.get;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.replication.ClusterStateCreationUtils;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -97,7 +98,7 @@ public class GetSettingsActionTests extends ESTestCase {
 
     public void testIncludeDefaults() {
         GetSettingsRequest noDefaultsRequest = new GetSettingsRequest().indices(indexName);
-        getSettingsAction.execute(null, noDefaultsRequest, ActionListener.wrap(noDefaultsResponse -> {
+        ActionTestUtils.execute(getSettingsAction, null, noDefaultsRequest, ActionListener.wrap(noDefaultsResponse -> {
             assertNull("index.refresh_interval should be null as it was never set", noDefaultsResponse.getSetting(indexName,
                 "index.refresh_interval"));
         }, exception -> {
@@ -106,7 +107,7 @@ public class GetSettingsActionTests extends ESTestCase {
 
         GetSettingsRequest defaultsRequest = new GetSettingsRequest().indices(indexName).includeDefaults(true);
 
-        getSettingsAction.execute(null, defaultsRequest, ActionListener.wrap(defaultsResponse -> {
+        ActionTestUtils.execute(getSettingsAction, null, defaultsRequest, ActionListener.wrap(defaultsResponse -> {
             assertNotNull("index.refresh_interval should be set as we are including defaults", defaultsResponse.getSetting(indexName,
                 "index.refresh_interval"));
         }, exception -> {
@@ -118,7 +119,7 @@ public class GetSettingsActionTests extends ESTestCase {
     public void testIncludeDefaultsWithFiltering() {
         GetSettingsRequest defaultsRequest = new GetSettingsRequest().indices(indexName).includeDefaults(true)
             .names("index.refresh_interval");
-        getSettingsAction.execute(null, defaultsRequest, ActionListener.wrap(defaultsResponse -> {
+        ActionTestUtils.execute(getSettingsAction, null, defaultsRequest, ActionListener.wrap(defaultsResponse -> {
             assertNotNull("index.refresh_interval should be set as we are including defaults", defaultsResponse.getSetting(indexName,
                 "index.refresh_interval"));
             assertNull("index.number_of_shards should be null as this query is filtered",

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIngestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIngestTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.index.IndexAction;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.AutoCreateIndex;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.cluster.ClusterChangedEvent;
@@ -219,7 +220,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
         IndexRequest indexRequest = new IndexRequest("index", "type", "id");
         indexRequest.source(Collections.emptyMap());
         bulkRequest.add(indexRequest);
-        action.execute(null, bulkRequest, ActionListener.wrap(response -> {}, exception -> {
+        ActionTestUtils.execute(action, null, bulkRequest, ActionListener.wrap(response -> {}, exception -> {
             throw new AssertionError(exception);
         }));
         assertTrue(action.isExecuted);
@@ -229,7 +230,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
     public void testSingleItemBulkActionIngestSkipped() throws Exception {
         IndexRequest indexRequest = new IndexRequest("index", "type", "id");
         indexRequest.source(Collections.emptyMap());
-        singleItemBulkWriteAction.execute(null, indexRequest, ActionListener.wrap(response -> {}, exception -> {
+        ActionTestUtils.execute(singleItemBulkWriteAction, null, indexRequest, ActionListener.wrap(response -> {}, exception -> {
             throw new AssertionError(exception);
         }));
         assertTrue(action.isExecuted);
@@ -250,7 +251,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
 
         AtomicBoolean responseCalled = new AtomicBoolean(false);
         AtomicBoolean failureCalled = new AtomicBoolean(false);
-        action.execute(null, bulkRequest, ActionListener.wrap(
+        ActionTestUtils.execute(action, null, bulkRequest, ActionListener.wrap(
             response -> {
                 BulkItemResponse itemResponse = response.iterator().next();
                 assertThat(itemResponse.getFailure().getMessage(), containsString("fake exception"));
@@ -286,7 +287,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
         indexRequest.setPipeline("testpipeline");
         AtomicBoolean responseCalled = new AtomicBoolean(false);
         AtomicBoolean failureCalled = new AtomicBoolean(false);
-        singleItemBulkWriteAction.execute(null, indexRequest, ActionListener.wrap(
+        ActionTestUtils.execute(singleItemBulkWriteAction, null, indexRequest, ActionListener.wrap(
                 response -> {
                     responseCalled.set(true);
                 },
@@ -328,7 +329,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
             e -> {
                 throw new AssertionError(e);
             });
-        action.execute(null, bulkRequest, listener);
+        ActionTestUtils.execute(action, null, bulkRequest, listener);
 
         // should not have executed ingest locally
         verify(ingestService, never()).executeBulkRequest(any(), any(), any(), any());
@@ -348,7 +349,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
 
         // now make sure ingest nodes are rotated through with a subsequent request
         reset(transportService);
-        action.execute(null, bulkRequest, listener);
+        ActionTestUtils.execute(action, null, bulkRequest, listener);
         verify(transportService).sendRequest(node.capture(), eq(BulkAction.NAME), any(), remoteResponseHandler.capture());
         if (usedNode1) {
             assertSame(remoteNode2, node.getValue());
@@ -372,7 +373,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
                 e -> {
                     throw new AssertionError(e);
                 });
-        singleItemBulkWriteAction.execute(null, indexRequest, listener);
+        ActionTestUtils.execute(singleItemBulkWriteAction, null, indexRequest, listener);
 
         // should not have executed ingest locally
         verify(ingestService, never()).executeBulkRequest(any(), any(), any(), any());
@@ -395,7 +396,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
 
         // now make sure ingest nodes are rotated through with a subsequent request
         reset(transportService);
-        singleItemBulkWriteAction.execute(null, indexRequest, listener);
+        ActionTestUtils.execute(singleItemBulkWriteAction, null, indexRequest, listener);
         verify(transportService).sendRequest(node.capture(), eq(BulkAction.NAME), any(), remoteResponseHandler.capture());
         if (usedNode1) {
             assertSame(remoteNode2, node.getValue());
@@ -444,7 +445,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
         assertNull(indexRequest1.getPipeline());
         assertNull(indexRequest2.getPipeline());
         assertNull(indexRequest3.getPipeline());
-        action.execute(null, bulkRequest, ActionListener.wrap(
+        ActionTestUtils.execute(action, null, bulkRequest, ActionListener.wrap(
             response -> {
                 BulkItemResponse itemResponse = response.iterator().next();
                 assertThat(itemResponse.getFailure().getMessage(), containsString("fake exception"));
@@ -485,7 +486,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
         AtomicBoolean failureCalled = new AtomicBoolean(false);
         action.needToCheck = true;
         action.indexCreated = false;
-        singleItemBulkWriteAction.execute(null, indexRequest, ActionListener.wrap(
+        ActionTestUtils.execute(singleItemBulkWriteAction, null, indexRequest, ActionListener.wrap(
             response -> responseCalled.set(true),
             e -> {
                 assertThat(e, sameInstance(exception));
@@ -517,7 +518,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
         indexRequest.source(Collections.emptyMap());
         AtomicBoolean responseCalled = new AtomicBoolean(false);
         AtomicBoolean failureCalled = new AtomicBoolean(false);
-        singleItemBulkWriteAction.execute(null, indexRequest, ActionListener.wrap(
+        ActionTestUtils.execute(singleItemBulkWriteAction, null, indexRequest, ActionListener.wrap(
             response -> responseCalled.set(true),
             e -> {
                 assertThat(e, sameInstance(exception));
@@ -553,7 +554,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
         indexRequest.source(Collections.emptyMap());
         AtomicBoolean responseCalled = new AtomicBoolean(false);
         AtomicBoolean failureCalled = new AtomicBoolean(false);
-        singleItemBulkWriteAction.execute(null, indexRequest, ActionListener.wrap(
+        ActionTestUtils.execute(singleItemBulkWriteAction, null, indexRequest, ActionListener.wrap(
             response -> responseCalled.set(true),
             e -> {
                 assertThat(e, sameInstance(exception));
@@ -570,7 +571,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
         AtomicBoolean responseCalled = new AtomicBoolean(false);
         AtomicBoolean failureCalled = new AtomicBoolean(false);
         assertNull(indexRequest.getPipeline());
-        singleItemBulkWriteAction.execute(null, indexRequest, ActionListener.wrap(
+        ActionTestUtils.execute(singleItemBulkWriteAction, null, indexRequest, ActionListener.wrap(
             response -> {
                 responseCalled.set(true);
             },

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.bulk.TransportBulkActionTookTests.Resolver;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.AutoCreateIndex;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -101,7 +102,7 @@ public class TransportBulkActionTests extends ESTestCase {
     public void testDeleteNonExistingDocDoesNotCreateIndex() throws Exception {
         BulkRequest bulkRequest = new BulkRequest().add(new DeleteRequest("index", "type", "id"));
 
-        bulkAction.execute(null, bulkRequest, ActionListener.wrap(response -> {
+        ActionTestUtils.execute(bulkAction, null, bulkRequest, ActionListener.wrap(response -> {
             assertFalse(bulkAction.indexCreated);
             BulkItemResponse[] bulkResponses = ((BulkResponse) response).getItems();
             assertEquals(bulkResponses.length, 1);
@@ -117,7 +118,7 @@ public class TransportBulkActionTests extends ESTestCase {
         BulkRequest bulkRequest = new BulkRequest()
                 .add(new DeleteRequest("index", "type", "id").versionType(VersionType.EXTERNAL).version(0));
 
-        bulkAction.execute(null, bulkRequest, ActionListener.wrap(response -> {
+        ActionTestUtils.execute(bulkAction, null, bulkRequest, ActionListener.wrap(response -> {
             assertTrue(bulkAction.indexCreated);
         }, exception -> {
             throw new AssertionError(exception);
@@ -128,7 +129,7 @@ public class TransportBulkActionTests extends ESTestCase {
         BulkRequest bulkRequest = new BulkRequest()
                 .add(new DeleteRequest("index2", "type", "id").versionType(VersionType.EXTERNAL_GTE).version(0));
 
-        bulkAction.execute(null, bulkRequest, ActionListener.wrap(response -> {
+        ActionTestUtils.execute(bulkAction, null, bulkRequest, ActionListener.wrap(response -> {
             assertTrue(bulkAction.indexCreated);
         }, exception -> {
             throw new AssertionError(exception);

--- a/server/src/test/java/org/elasticsearch/action/get/TransportMultiGetActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/get/TransportMultiGetActionTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.RoutingMissingException;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -183,7 +184,7 @@ public class TransportMultiGetActionTests extends ESTestCase {
             }
         };
 
-        transportAction.execute(task, request.request(), new ActionListenerAdapter());
+        ActionTestUtils.execute(transportAction, task, request.request(), new ActionListenerAdapter());
         assertTrue(shardActionInvoked.get());
     }
 
@@ -210,7 +211,7 @@ public class TransportMultiGetActionTests extends ESTestCase {
             }
         };
 
-        transportAction.execute(task, request.request(), new ActionListenerAdapter());
+        ActionTestUtils.execute(transportAction, task, request.request(), new ActionListenerAdapter());
         assertTrue(shardActionInvoked.get());
 
     }

--- a/server/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainTests.java
@@ -109,7 +109,7 @@ public class TransportActionFilterChainTests extends ESTestCase {
 
         PlainActionFuture<TestResponse> future = PlainActionFuture.newFuture();
 
-        transportAction.execute(new TestRequest(), future);
+        ActionTestUtils.execute(transportAction, null, new TestRequest(), future);
         try {
             assertThat(future.get(), notNullValue());
             assertThat("shouldn't get here if an error is expected", errorExpected, equalTo(false));
@@ -172,7 +172,7 @@ public class TransportActionFilterChainTests extends ESTestCase {
         final AtomicInteger responses = new AtomicInteger();
         final List<Throwable> failures = new CopyOnWriteArrayList<>();
 
-        transportAction.execute(new TestRequest(), new LatchedActionListener<>(new ActionListener<TestResponse>() {
+        ActionTestUtils.execute(transportAction, null, new TestRequest(), new LatchedActionListener<>(new ActionListener<>() {
             @Override
             public void onResponse(TestResponse testResponse) {
                 responses.incrementAndGet();

--- a/server/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.ThreadedActionListener;
 import org.elasticsearch.action.support.replication.ClusterStateCreationUtils;
@@ -205,7 +206,7 @@ public class TransportMasterNodeActionTests extends ESTestCase {
 
         setState(clusterService, ClusterStateCreationUtils.state(localNode, localNode, allNodes));
 
-        new Action("internal:testAction", transportService, clusterService, threadPool) {
+        ActionTestUtils.execute(new Action("internal:testAction", transportService, clusterService, threadPool) {
             @Override
             protected void masterOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener) {
                 if (masterOperationFailure) {
@@ -214,7 +215,7 @@ public class TransportMasterNodeActionTests extends ESTestCase {
                     listener.onResponse(response);
                 }
             }
-        }.execute(request, listener);
+        }, null, request, listener);
         assertTrue(listener.isDone());
 
         if (masterOperationFailure) {
@@ -242,13 +243,13 @@ public class TransportMasterNodeActionTests extends ESTestCase {
                 .blocks(ClusterBlocks.builder().addGlobalBlock(block)).build();
         setState(clusterService, stateWithBlock);
 
-        new Action("internal:testAction", transportService, clusterService, threadPool) {
+        ActionTestUtils.execute(new Action("internal:testAction", transportService, clusterService, threadPool) {
             @Override
             protected ClusterBlockException checkBlock(Request request, ClusterState state) {
                 Set<ClusterBlock> blocks = state.blocks().global();
                 return blocks.isEmpty() ? null : new ClusterBlockException(blocks);
             }
-        }.execute(request, listener);
+        }, null, request, listener);
 
         if (retryableBlock && unblockBeforeTimeout) {
             assertFalse(listener.isDone());
@@ -284,7 +285,7 @@ public class TransportMasterNodeActionTests extends ESTestCase {
             .blocks(ClusterBlocks.builder().addGlobalBlock(block)).build();
         setState(clusterService, stateWithBlock);
 
-        new Action("internal:testAction", transportService, clusterService, threadPool) {
+        ActionTestUtils.execute(new Action("internal:testAction", transportService, clusterService, threadPool) {
             @Override
             protected ClusterBlockException checkBlock(Request request, ClusterState state) {
                 Set<ClusterBlock> blocks = state.blocks().global();
@@ -294,7 +295,7 @@ public class TransportMasterNodeActionTests extends ESTestCase {
                 return new ClusterBlockException(blocks);
 
             }
-        }.execute(request, listener);
+        }, null, request, listener);
 
         if (throwExceptionOnRetry == false) {
             assertListenerThrows("checkBlock has thrown exception", listener, RuntimeException.class);
@@ -312,12 +313,12 @@ public class TransportMasterNodeActionTests extends ESTestCase {
 
         setState(clusterService, ClusterStateCreationUtils.state(localNode, randomFrom(localNode, remoteNode, null), allNodes));
 
-        new Action("internal:testAction", transportService, clusterService, threadPool) {
+        ActionTestUtils.execute(new Action("internal:testAction", transportService, clusterService, threadPool) {
             @Override
             protected boolean localExecute(Request request) {
                 return true;
             }
-        }.execute(request, listener);
+        }, null, request, listener);
 
         assertTrue(listener.isDone());
         listener.get();
@@ -327,7 +328,7 @@ public class TransportMasterNodeActionTests extends ESTestCase {
         Request request = new Request().masterNodeTimeout(TimeValue.timeValueSeconds(0));
         setState(clusterService, ClusterStateCreationUtils.state(localNode, null, allNodes));
         PlainActionFuture<Response> listener = new PlainActionFuture<>();
-        new Action("internal:testAction", transportService, clusterService, threadPool).execute(request, listener);
+        ActionTestUtils.execute(new Action("internal:testAction", transportService, clusterService, threadPool), null, request, listener);
         assertTrue(listener.isDone());
         assertListenerThrows("MasterNotDiscoveredException should be thrown", listener, MasterNotDiscoveredException.class);
     }
@@ -336,7 +337,7 @@ public class TransportMasterNodeActionTests extends ESTestCase {
         Request request = new Request();
         setState(clusterService, ClusterStateCreationUtils.state(localNode, null, allNodes));
         PlainActionFuture<Response> listener = new PlainActionFuture<>();
-        new Action("internal:testAction", transportService, clusterService, threadPool).execute(request, listener);
+        ActionTestUtils.execute(new Action("internal:testAction", transportService, clusterService, threadPool), null, request, listener);
         assertFalse(listener.isDone());
         setState(clusterService, ClusterStateCreationUtils.state(localNode, localNode, allNodes));
         assertTrue(listener.isDone());
@@ -348,7 +349,7 @@ public class TransportMasterNodeActionTests extends ESTestCase {
         setState(clusterService, ClusterStateCreationUtils.state(localNode, remoteNode, allNodes));
 
         PlainActionFuture<Response> listener = new PlainActionFuture<>();
-        new Action("internal:testAction", transportService, clusterService, threadPool).execute(request, listener);
+        ActionTestUtils.execute(new Action("internal:testAction", transportService, clusterService, threadPool), null, request, listener);
 
         assertThat(transport.capturedRequests().length, equalTo(1));
         CapturingTransport.CapturedRequest capturedRequest = transport.capturedRequests()[0];
@@ -371,7 +372,7 @@ public class TransportMasterNodeActionTests extends ESTestCase {
             .version(randomIntBetween(0, 10))); // use a random base version so it can go down when simulating a restart.
 
         PlainActionFuture<Response> listener = new PlainActionFuture<>();
-        new Action("internal:testAction", transportService, clusterService, threadPool).execute(request, listener);
+        ActionTestUtils.execute(new Action("internal:testAction", transportService, clusterService, threadPool), null, request, listener);
 
         CapturingTransport.CapturedRequest[] capturedRequests = transport.getCapturedRequestsAndClear();
         assertThat(capturedRequests.length, equalTo(1));
@@ -444,7 +445,7 @@ public class TransportMasterNodeActionTests extends ESTestCase {
 
         setState(clusterService, ClusterStateCreationUtils.state(localNode, localNode, allNodes));
 
-        new Action( "internal:testAction", transportService, clusterService, threadPool) {
+        ActionTestUtils.execute(new Action( "internal:testAction", transportService, clusterService, threadPool) {
             @Override
             protected void masterOperation(Task task, Request request, ClusterState state,
                                            ActionListener<Response> listener) throws Exception {
@@ -455,7 +456,7 @@ public class TransportMasterNodeActionTests extends ESTestCase {
                         : new NotMasterException("Fake error");
                 listener.onFailure(failure);
             }
-        }.execute(request, listener);
+        }, null, request, listener);
 
         assertThat(transport.capturedRequests().length, equalTo(1));
         CapturingTransport.CapturedRequest capturedRequest = transport.capturedRequests()[0];

--- a/server/src/test/java/org/elasticsearch/action/support/replication/BroadcastReplicationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/BroadcastReplicationTests.java
@@ -125,7 +125,7 @@ public class BroadcastReplicationTests extends ESTestCase {
                 randomBoolean() ? ShardRoutingState.INITIALIZING : ShardRoutingState.UNASSIGNED, ShardRoutingState.UNASSIGNED));
         logger.debug("--> using initial state:\n{}", clusterService.state());
         PlainActionFuture<BroadcastResponse> response = PlainActionFuture.newFuture();
-        broadcastReplicationAction.execute(new DummyBroadcastRequest(index), response);
+        ActionTestUtils.execute(broadcastReplicationAction, null, new DummyBroadcastRequest(index), response);
         for (Tuple<ShardId, ActionListener<ReplicationResponse>> shardRequests : broadcastReplicationAction.capturedShardRequests) {
             if (randomBoolean()) {
                 shardRequests.v2().onFailure(new NoShardAvailableActionException(shardRequests.v1()));
@@ -145,7 +145,7 @@ public class BroadcastReplicationTests extends ESTestCase {
                 ShardRoutingState.STARTED));
         logger.debug("--> using initial state:\n{}", clusterService.state());
         PlainActionFuture<BroadcastResponse> response = PlainActionFuture.newFuture();
-        broadcastReplicationAction.execute(new DummyBroadcastRequest(index), response);
+        ActionTestUtils.execute(broadcastReplicationAction, null, new DummyBroadcastRequest(index), response);
         for (Tuple<ShardId, ActionListener<ReplicationResponse>> shardRequests : broadcastReplicationAction.capturedShardRequests) {
             ReplicationResponse replicationResponse = new ReplicationResponse();
             replicationResponse.setShardInfo(new ReplicationResponse.ShardInfo(1, 1));
@@ -161,7 +161,7 @@ public class BroadcastReplicationTests extends ESTestCase {
         setState(clusterService, stateWithAssignedPrimariesAndOneReplica(index, numShards));
         logger.debug("--> using initial state:\n{}", clusterService.state());
         PlainActionFuture<BroadcastResponse> response = PlainActionFuture.newFuture();
-        broadcastReplicationAction.execute(new DummyBroadcastRequest().indices(index), response);
+        ActionTestUtils.execute(broadcastReplicationAction, null, new DummyBroadcastRequest().indices(index), response);
         int succeeded = 0;
         int failed = 0;
         for (Tuple<ShardId, ActionListener<ReplicationResponse>> shardRequests : broadcastReplicationAction.capturedShardRequests) {
@@ -255,7 +255,7 @@ public class BroadcastReplicationTests extends ESTestCase {
             TransportBroadcastReplicationAction<DummyBroadcastRequest, BroadcastResponse, ?, ?> broadcastAction,
             DummyBroadcastRequest request) {
         PlainActionFuture<BroadcastResponse> response = PlainActionFuture.newFuture();
-        broadcastAction.execute(request, response);
+        ActionTestUtils.execute(broadcastAction, null, request, response);
         return response.actionGet("5s");
     }
 

--- a/server/src/test/java/org/elasticsearch/action/termvectors/TransportMultiTermVectorsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/termvectors/TransportMultiTermVectorsActionTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.RoutingMissingException;
 import org.elasticsearch.action.get.TransportMultiGetActionTests;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -185,7 +186,7 @@ public class TransportMultiTermVectorsActionTests extends ESTestCase {
             }
         };
 
-        transportAction.execute(task, request.request(), new ActionListenerAdapter());
+        ActionTestUtils.execute(transportAction, task, request.request(), new ActionListenerAdapter());
         assertTrue(shardActionInvoked.get());
     }
 
@@ -212,7 +213,7 @@ public class TransportMultiTermVectorsActionTests extends ESTestCase {
             }
         };
 
-        transportAction.execute(task, request.request(), new ActionListenerAdapter());
+        ActionTestUtils.execute(transportAction, task, request.request(), new ActionListenerAdapter());
         assertTrue(shardActionInvoked.get());
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.health.TransportClusterHealthAction;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.ClusterName;
@@ -143,7 +144,7 @@ public class ClusterStateHealthTests extends ESTestCase {
         TransportClusterHealthAction action = new TransportClusterHealthAction(transportService,
             clusterService, threadPool, new ActionFilters(new HashSet<>()), indexNameExpressionResolver, new TestGatewayAllocator());
         PlainActionFuture<ClusterHealthResponse> listener = new PlainActionFuture<>();
-        action.execute(new ClusterHealthRequest().waitForGreenStatus(), listener);
+        ActionTestUtils.execute(action, null, new ClusterHealthRequest().waitForGreenStatus(), listener);
 
         assertFalse(listener.isDone());
 

--- a/test/framework/src/main/java/org/elasticsearch/action/support/ActionTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/action/support/ActionTestUtils.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.CheckedConsumer;
+import org.elasticsearch.tasks.Task;
 
 import static org.elasticsearch.action.support.PlainActionFuture.newFuture;
 
@@ -35,6 +36,16 @@ public class ActionTestUtils {
         PlainActionFuture<Response> future = newFuture();
         action.execute(request, future);
         return future.actionGet();
+    }
+
+    /**
+     * Executes the given action.
+     *
+     * This is a shim method to make execution publicly available in tests.
+     */
+    public static <Request extends ActionRequest, Response extends ActionResponse>
+    void execute(TransportAction<Request, Response> action, Task task, Request request, ActionListener<Response> listener) {
+        action.execute(task, request, listener);
     }
 
     public static <T> ActionListener<T> assertNoFailureListener(CheckedConsumer<T, Exception> consumer) {

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardChangesActionTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardChangesActionTests.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.ccr.action;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
@@ -183,7 +184,7 @@ public class ShardChangesActionTests extends ESSingleNodeTestCase {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Exception> reference = new AtomicReference<>();
         final ShardChangesAction.TransportAction transportAction = node().injector().getInstance(ShardChangesAction.TransportAction.class);
-        transportAction.execute(
+        ActionTestUtils.execute(transportAction, null,
                 new ShardChangesAction.Request(new ShardId(new Index("non-existent", "uuid"), 0), "uuid"),
                 new ActionListener<ShardChangesAction.Response>() {
                     @Override
@@ -208,7 +209,7 @@ public class ShardChangesActionTests extends ESSingleNodeTestCase {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Exception> reference = new AtomicReference<>();
         final ShardChangesAction.TransportAction transportAction = node().injector().getInstance(ShardChangesAction.TransportAction.class);
-        transportAction.execute(
+        ActionTestUtils.execute(transportAction, null,
                 new ShardChangesAction.Request(new ShardId(indexService.getMetaData().getIndex(), numberOfShards), "uuid"),
                 new ActionListener<ShardChangesAction.Response>() {
                     @Override


### PR DESCRIPTION
There are currently 3 variants of TransportAction.execute. The
implementations of these require additional ctor arguments to all
TransportAction implementations. While the non test uses can be
converted to using NodeClient to execute other actions, using that for
test cases would be cumbersome and defeat the purpose of unit tests
testing an action's implementation directly. This commit adds a public
test-only utility method for test to use to call execute. This method
will continue to be available when the execute implementations are
collapsed and made package private.

relates #43881