### PR TITLE
BACKPORT Fix X509AuthenticationToken principal (#43932)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/pki/PkiRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/pki/PkiRealm.java
@@ -110,7 +110,30 @@ public class PkiRealm extends Realm implements CachingRealm {
 
     @Override
     public X509AuthenticationToken token(ThreadContext context) {
-        return token(context.getTransient(PKI_CERT_HEADER_NAME), principalPattern, logger);
+        Object pkiHeaderValue = context.getTransient(PKI_CERT_HEADER_NAME);
+        if (pkiHeaderValue == null) {
+            return null;
+        }
+        assert pkiHeaderValue instanceof X509Certificate[];
+        X509Certificate[] certificates = (X509Certificate[]) pkiHeaderValue;
+        if (certificates.length == 0) {
+            return null;
+        }
+        X509AuthenticationToken token = new X509AuthenticationToken(certificates);
+        // the following block of code maintains BWC:
+        // When constructing the token object we only return it if the Subject DN of the certificate can be parsed by at least one PKI
+        // realm. We then consider the parsed Subject DN as the "principal" even though it is potentially incorrect because when several
+        // realms are installed the one that first parses the principal might not be the one that finally authenticates (does trusted chain
+        // validation). In this case the principal should be set by the realm that completes the authentication. But in the common case,
+        // where a single PKI realm is configured, there is no risk of eagerly parsing the principal before authentication and it also
+        // maintains BWC.
+        String parsedPrincipal = getPrincipalFromSubjectDN(principalPattern, token, logger);
+        if (parsedPrincipal == null) {
+            return null;
+        }
+        token.setPrincipal(parsedPrincipal);
+        // end BWC code block
+        return token;
     }
 
     @Override
@@ -122,25 +145,41 @@ public class PkiRealm extends Realm implements CachingRealm {
             User user = cache.get(fingerprint);
             if (user != null) {
                 if (delegatedRealms.hasDelegation()) {
-                    delegatedRealms.resolve(token.principal(), listener);
+                    delegatedRealms.resolve(user.principal(), listener);
                 } else {
                     listener.onResponse(AuthenticationResult.success(user));
                 }
             } else if (isCertificateChainTrusted(trustManager, token, logger) == false) {
                 listener.onResponse(AuthenticationResult.unsuccessful("Certificate for " + token.dn() + " is not trusted", null));
             } else {
-                final ActionListener<AuthenticationResult> cachingListener = ActionListener.wrap(result -> {
-                    if (result.isAuthenticated()) {
-                        try (ReleasableLock ignored = readLock.acquire()) {
-                            cache.put(fingerprint, result.getUser());
-                        }
-                    }
-                    listener.onResponse(result);
-                }, listener::onFailure);
-                if (delegatedRealms.hasDelegation()) {
-                    delegatedRealms.resolve(token.principal(), cachingListener);
+                // parse the principal again after validating the cert chain, and do not rely on the token.principal one, because that could
+                // be set by a different realm that failed trusted chain validation. We SHOULD NOT parse the principal BEFORE this step, but
+                // we do it for BWC purposes. Changing this is a breaking change.
+                final String principal = getPrincipalFromSubjectDN(principalPattern, token, logger);
+                if (principal == null) {
+                    logger.debug((Supplier<?>) () -> new ParameterizedMessage(
+                            "the extracted principal after cert chain validation, from DN [{}], using pattern [{}] is null", token.dn(),
+                            principalPattern.toString()));
+                    listener.onResponse(AuthenticationResult.unsuccessful("Could not parse principal from Subject DN " + token.dn(), null));
                 } else {
-                    this.buildUser(token, cachingListener);
+                    final ActionListener<AuthenticationResult> cachingListener = ActionListener.wrap(result -> {
+                        if (result.isAuthenticated()) {
+                            try (ReleasableLock ignored = readLock.acquire()) {
+                                cache.put(fingerprint, result.getUser());
+                            }
+                        }
+                        listener.onResponse(result);
+                    }, listener::onFailure);
+                    if (false == principal.equals(token.principal())) {
+                        logger.debug((Supplier<?>) () -> new ParameterizedMessage(
+                                "the extracted principal before [{}] and after [{}] cert chain validation, for DN [{}], are different",
+                                token.principal(), principal, token.dn()));
+                    }
+                    if (delegatedRealms.hasDelegation()) {
+                        delegatedRealms.resolve(principal, cachingListener);
+                    } else {
+                        buildUser(token, principal, cachingListener);
+                    }
                 }
             }
         } catch (CertificateEncodingException e) {
@@ -148,13 +187,12 @@ public class PkiRealm extends Realm implements CachingRealm {
         }
     }
 
-    private void buildUser(X509AuthenticationToken token, ActionListener<AuthenticationResult> listener) {
+    private void buildUser(X509AuthenticationToken token, String principal, ActionListener<AuthenticationResult> listener) {
         final Map<String, Object> metadata = Collections.singletonMap("pki_dn", token.dn());
-        final UserRoleMapper.UserData userData = new UserRoleMapper.UserData(token.principal(),
-                token.dn(), Collections.emptySet(), metadata, this.config);
+        final UserRoleMapper.UserData userData = new UserRoleMapper.UserData(principal, token.dn(), Collections.emptySet(), metadata,
+                this.config);
         roleMapper.resolveRoles(userData, ActionListener.wrap(roles -> {
-            final User computedUser =
-                    new User(token.principal(), roles.toArray(new String[roles.size()]), null, null, metadata, true);
+            final User computedUser = new User(principal, roles.toArray(new String[roles.size()]), null, null, metadata, true);
             listener.onResponse(AuthenticationResult.success(computedUser));
         }, listener::onFailure));
     }
@@ -164,47 +202,33 @@ public class PkiRealm extends Realm implements CachingRealm {
         listener.onResponse(null);
     }
 
-    static X509AuthenticationToken token(Object pkiHeaderValue, Pattern principalPattern, Logger logger) {
-        if (pkiHeaderValue == null) {
-            return null;
-        }
-
-        assert pkiHeaderValue instanceof X509Certificate[];
-        X509Certificate[] certificates = (X509Certificate[]) pkiHeaderValue;
-        if (certificates.length == 0) {
-            return null;
-        }
-
-        String dn = certificates[0].getSubjectX500Principal().toString();
+    static String getPrincipalFromSubjectDN(Pattern principalPattern, X509AuthenticationToken token, Logger logger) {
+        String dn = token.credentials()[0].getSubjectX500Principal().toString();
         Matcher matcher = principalPattern.matcher(dn);
-        if (!matcher.find()) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("certificate authentication succeeded for [{}] but could not extract principal from DN", dn);
-            }
+        if (false == matcher.find()) {
+            logger.debug((Supplier<?>) () -> new ParameterizedMessage("could not extract principal from DN [{}] using pattern [{}]", dn,
+                    principalPattern.toString()));
             return null;
         }
-
         String principal = matcher.group(1);
         if (Strings.isNullOrEmpty(principal)) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("certificate authentication succeeded for [{}] but extracted principal was empty", dn);
-            }
+            logger.debug((Supplier<?>) () -> new ParameterizedMessage("the extracted principal from DN [{}] using pattern [{}] is empty",
+                    dn, principalPattern.toString()));
             return null;
         }
-        return new X509AuthenticationToken(certificates, principal, dn);
+        return principal;
     }
 
-    static boolean isCertificateChainTrusted(X509TrustManager trustManager, X509AuthenticationToken token, Logger logger) {
+    private static boolean isCertificateChainTrusted(X509TrustManager trustManager, X509AuthenticationToken token, Logger logger) {
         if (trustManager != null) {
             try {
                 trustManager.checkClientTrusted(token.credentials(), AUTH_TYPE);
                 return true;
             } catch (CertificateException e) {
                 if (logger.isTraceEnabled()) {
-                    logger.trace((Supplier<?>)
-                            () -> new ParameterizedMessage("failed certificate validation for principal [{}]", token.principal()), e);
+                    logger.trace("failed certificate validation for Subject DN [" + token.dn() + "]", e);
                 } else if (logger.isDebugEnabled()) {
-                    logger.debug("failed certificate validation for principal [{}]", token.principal());
+                    logger.debug("failed certificate validation for Subject DN [{}]", token.dn());
                 }
             }
             return false;
@@ -214,7 +238,7 @@ public class PkiRealm extends Realm implements CachingRealm {
         return true;
     }
 
-    X509TrustManager trustManagers(RealmConfig realmConfig) {
+    private X509TrustManager trustManagers(RealmConfig realmConfig) {
         final List<String> certificateAuthorities = realmConfig.hasSetting(PkiRealmSettings.CAPATH_SETTING) ?
                 realmConfig.getSetting(PkiRealmSettings.CAPATH_SETTING) : null;
         String truststorePath = realmConfig.getSetting(PkiRealmSettings.TRUST_STORE_PATH).orElse(null);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/pki/X509AuthenticationToken.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/pki/X509AuthenticationToken.java
@@ -8,22 +8,27 @@ package org.elasticsearch.xpack.security.authc.pki;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
 
 import java.security.cert.X509Certificate;
+import java.util.Objects;
 
 public class X509AuthenticationToken implements AuthenticationToken {
 
-    private final String principal;
     private final String dn;
-    private X509Certificate[] credentials;
+    private final X509Certificate[] credentials;
+    private String principal;
 
-    public X509AuthenticationToken(X509Certificate[] certificates, String principal, String dn) {
-        this.principal = principal;
-        this.credentials = certificates;
-        this.dn = dn;
+    public X509AuthenticationToken(X509Certificate[] certificates) {
+        this.credentials = Objects.requireNonNull(certificates);
+        this.dn = certificates.length == 0 ? "" : certificates[0].getSubjectX500Principal().toString();
+        this.principal = this.dn;
     }
 
     @Override
     public String principal() {
         return principal;
+    }
+
+    public void setPrincipal(String principal) {
+        this.principal = principal;
     }
 
     @Override
@@ -37,6 +42,6 @@ public class X509AuthenticationToken implements AuthenticationToken {
 
     @Override
     public void clearCredentials() {
-        credentials = null;
+        // noop
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/pki/PkiAuthenticationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/pki/PkiAuthenticationTests.java
@@ -67,9 +67,16 @@ public class PkiAuthenticationTests extends SecuritySingleNodeTestCase {
             .put("xpack.security.authc.realms.file.file.order", "0")
             .put("xpack.security.authc.realms.pki.pki1.order", "1")
             .putList("xpack.security.authc.realms.pki.pki1.certificate_authorities",
+                getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testclient.crt").toString())
+            .put("xpack.security.authc.realms.pki.pki1.files.role_mapping", getDataPath("role_mapping.yml"))
+            .put("xpack.security.authc.realms.pki.pki1.files.role_mapping", getDataPath("role_mapping.yml"))
+            // pki1 never authenticates because of the principal pattern
+            .put("xpack.security.authc.realms.pki.pki1.username_pattern", "CN=(MISMATCH.*?)(?:,|$)")
+            .put("xpack.security.authc.realms.pki.pki2.order", "2")
+            .putList("xpack.security.authc.realms.pki.pki2.certificate_authorities",
                 getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt").toString(),
                 getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode_ec.crt").toString())
-            .put("xpack.security.authc.realms.pki.pki1.files.role_mapping", getDataPath("role_mapping.yml"));
+            .put("xpack.security.authc.realms.pki.pki2.files.role_mapping", getDataPath("role_mapping.yml"));
         return builder.build();
     }
 


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/43932

Fixes a bug in the PKI authentication. This manifests when there
are multiple PKI realms configured in the chain, with different
principal parse patterns. There are a few configuration scenarios
where one PKI realm might parse the principal from the Subject
DN (according to the `username_pattern` realm setting) but
another one might do the truststore validation (according to
the truststore.* realm settings).

This is caused by the two passes through the realm chain, first to
build the authentication token and secondly to authenticate it, and
that the X509AuthenticationToken sets the principal during
construction.