### PR TITLE
Improve build scan metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,16 +29,13 @@ import org.gradle.util.DistributionLocator
 import org.gradle.plugins.ide.eclipse.model.SourceFolder
 
 plugins {
-    id 'com.gradle.build-scan' version '2.2.1'
+    id 'com.gradle.build-scan' version '2.3'
     id 'base'
     id 'elasticsearch.global-build-info'
 }
-if (Boolean.valueOf(project.findProperty('org.elasticsearch.acceptScanTOS') ?: "false")) {
-    buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
-    }
-}
+
+apply plugin: 'nebula.info-scm'
+apply from: 'gradle/build-scan.gradle'
 
 // common maven publishing configuration
 allprojects {
@@ -49,7 +46,6 @@ allprojects {
 
 BuildPlugin.configureRepositories(project)
 
-apply plugin: 'nebula.info-scm'
 String licenseCommit
 if (VersionProperties.elasticsearch.toString().endsWith('-SNAPSHOT')) {
   licenseCommit = scminfo.change ?: "master" // leniency for non git builds

--- a/gradle/build-scan.gradle
+++ b/gradle/build-scan.gradle
@@ -1,0 +1,35 @@
+import nebula.plugin.info.scm.ScmInfoExtension
+
+buildScan {
+    // Accept Gradle ToS when project property org.elasticsearch.acceptScanTOS=true
+    if (Boolean.valueOf(project.findProperty('org.elasticsearch.acceptScanTOS') ?: "false")) {
+        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+        termsOfServiceAgree = 'yes'
+    }
+
+    // Jenkins-specific build scan metadata
+    if (System.getenv('JENKINS_URL')) {
+        tag 'CI'
+        tag System.getenv('JOB_NAME')
+        link 'Jenkins Build', System.getenv('JOB_URL')
+
+        // Capture changes included in this CI build
+        if (System.getenv('GIT_COMMIT')) {
+            background {
+                def changes = "git diff --name-only ${System.getenv('GIT_PREVIOUS_COMMIT')}..${System.getenv('GIT_COMMIT')}".execute().text.trim()
+                value 'Git Changes', changes
+            }
+        }
+    } else {
+        tag 'LOCAL'
+    }
+
+    // Add SCM information
+    def scmInfo = project.extensions.findByType(ScmInfoExtension)
+    if (scmInfo && scmInfo.change && scmInfo.branch) {
+        value 'Git Commit ID', scmInfo.change
+        value 'Git Branch', scmInfo.branch
+        tag scmInfo.branch
+        link 'Source', "https://github.com/elastic/elasticsearch/commit/${scmInfo.change}"
+    }
+}

--- a/gradle/build-scan.gradle
+++ b/gradle/build-scan.gradle
@@ -29,7 +29,7 @@ buildScan {
     if (scmInfo && scmInfo.change && scmInfo.branch) {
         value 'Git Commit ID', scmInfo.change
         // Don't tag the branch if we are in a detached head state
-        if (scmInfo.branch.startsWith(scmInfo.change) == false) {
+        if (scmInfo.branch ==~ /[0-9a-f]{5,40}/ == false) {
             value 'Git Branch', scmInfo.branch
             tag scmInfo.branch
         }

--- a/gradle/build-scan.gradle
+++ b/gradle/build-scan.gradle
@@ -14,6 +14,9 @@ buildScan {
         tag 'CI'
         tag System.getenv('JOB_NAME')
         link 'Jenkins Build', System.getenv('BUILD_URL')
+        System.getenv('NODE_LABELS').split(' ').each {
+            value 'Jenkins Worker Label', it
+        }
 
         // Capture changes included in this CI build except for pull request builds
         if (System.getenv('GIT_COMMIT') && System.getenv('ROOT_BUILD_CAUSE_GHPRBCAUSE') == null) {

--- a/gradle/build-scan.gradle
+++ b/gradle/build-scan.gradle
@@ -1,14 +1,16 @@
 import nebula.plugin.info.scm.ScmInfoExtension
 
 buildScan {
-    // Accept Gradle ToS when project property org.elasticsearch.acceptScanTOS=true
-    if (Boolean.valueOf(project.findProperty('org.elasticsearch.acceptScanTOS') ?: "false")) {
+    def jenkinsUrl = System.getenv('JENKINS_URL') ? new URL(System.getenv('JENKINS_URL')) : null
+
+    // Accept Gradle ToS when project property org.elasticsearch.acceptScanTOS=true or this is an Elastic CI build
+    if (jenkinsUrl?.host?.endsWith('elastic.co') || Boolean.valueOf(project.findProperty('org.elasticsearch.acceptScanTOS') ?: "false")) {
         termsOfServiceUrl = 'https://gradle.com/terms-of-service'
         termsOfServiceAgree = 'yes'
     }
 
     // Jenkins-specific build scan metadata
-    if (System.getenv('JENKINS_URL')) {
+    if (jenkinsUrl) {
         tag 'CI'
         tag System.getenv('JOB_NAME')
         link 'Jenkins Build', System.getenv('BUILD_URL')

--- a/gradle/build-scan.gradle
+++ b/gradle/build-scan.gradle
@@ -30,7 +30,7 @@ buildScan {
         value 'Git Commit ID', scmInfo.change
         // Don't tag the branch if we are in a detached head state
         if (scmInfo.branch.startsWith(scmInfo.change) == false) {
-            value 'Git Branch', ? '' : scmInfo.branch
+            value 'Git Branch', scmInfo.branch
             tag scmInfo.branch
         }
         link 'Source', "https://github.com/elastic/elasticsearch/commit/${scmInfo.change}"

--- a/gradle/build-scan.gradle
+++ b/gradle/build-scan.gradle
@@ -13,8 +13,8 @@ buildScan {
         tag System.getenv('JOB_NAME')
         link 'Jenkins Build', System.getenv('BUILD_URL')
 
-        // Capture changes included in this CI build
-        if (System.getenv('GIT_COMMIT')) {
+        // Capture changes included in this CI build except for pull request builds
+        if (System.getenv('GIT_COMMIT') && System.getenv('ROOT_BUILD_CAUSE_GHPRBCAUSE') == null) {
             background {
                 def changes = "git diff --name-only ${System.getenv('GIT_PREVIOUS_COMMIT')}..${System.getenv('GIT_COMMIT')}".execute().text.trim()
                 value 'Git Changes', changes
@@ -28,8 +28,11 @@ buildScan {
     def scmInfo = project.extensions.findByType(ScmInfoExtension)
     if (scmInfo && scmInfo.change && scmInfo.branch) {
         value 'Git Commit ID', scmInfo.change
-        value 'Git Branch', scmInfo.branch
-        tag scmInfo.branch
+        // Don't tag the branch if we are in a detached head state
+        if (scmInfo.branch.startsWith(scmInfo.change) == false) {
+            value 'Git Branch', ? '' : scmInfo.branch
+            tag scmInfo.branch
+        }
         link 'Source', "https://github.com/elastic/elasticsearch/commit/${scmInfo.change}"
     }
 }

--- a/gradle/build-scan.gradle
+++ b/gradle/build-scan.gradle
@@ -11,7 +11,7 @@ buildScan {
     if (System.getenv('JENKINS_URL')) {
         tag 'CI'
         tag System.getenv('JOB_NAME')
-        link 'Jenkins Build', System.getenv('JOB_URL')
+        link 'Jenkins Build', System.getenv('BUILD_URL')
 
         // Capture changes included in this CI build
         if (System.getenv('GIT_COMMIT')) {


### PR DESCRIPTION
This PR does a couple of things:

First, we move the logic for some of our custom build scan into the build itself vs having this live in our Jenkins configuration. Having the conditional tagging logic in our Jenkins config is awkward for a few reasons.

1. Any actual conditional logic has to be done in bash, rather than in Groovy.
2. There's a good deal of duplication as this gets copied to all our builder macros.
3. For any complex custom values we have to workaround Jenkins odd handling of string escaping which doesn't often align with normal shell escaping rules.
4. We can't easily add custom data computed from actual build configuration.

Second, we've added some addition bits of information, mainly to fill in context gaps with the goal of making it less necessary to have to go back to the original Jenkins job page to get that information.

1. The actual git commit, as well as link to the commit info on GitHub.
2. The git branch.
3. For CI builds, include the list of changes included in the job run.