### PR TITLE
[DOCS] Fixes attribute in data frame transform API

### DIFF
--- a/docs/java-rest/high-level/dataframe/put_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/put_data_frame.asciidoc
@@ -19,7 +19,7 @@ A +{request}+ requires the following argument:
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
-<1> The configuration of the {dataframe-job} to create
+<1> The configuration of the {dataframe-transform} to create
 
 [id="{upid}-{api}-config"]
 ==== Data Frame Transform Configuration


### PR DESCRIPTION
This page contains an unresolved attribute: https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/java-rest-high-dataframe-put-data-frame-transform.html#java-rest-high-dataframe-put-data-frame-transform-request
> The configuration of the {dataframe-job} to create