### PR TITLE
[DOCS] Removes links to machine learning tutorial

### DIFF
--- a/docs/reference/ml/configuring.asciidoc
+++ b/docs/reference/ml/configuring.asciidoc
@@ -21,8 +21,8 @@ send your data to that job.
 The results of {ml} analysis are stored in {es} and you can use {kib} to help
 you visualize and explore the results.
 
-For a tutorial that walks you through these configuration steps,
-see <<ml-getting-started>>.
+//For a tutorial that walks you through these configuration steps,
+//see <<ml-getting-started>>.
 
 Though it is quite simple to analyze your data and provide quick {ml} results,
 gaining deep insights might require some additional planning and configuration.

--- a/docs/reference/ml/functions.asciidoc
+++ b/docs/reference/ml/functions.asciidoc
@@ -11,7 +11,8 @@ you specify the functions in
 {ref}/ml-job-resource.html#ml-detectorconfig[Detector Configuration Objects].
 If you are creating your job in {kib}, you specify the functions differently
 depending on whether you are creating single metric, multi-metric, or advanced
-jobs. For a demonstration of creating jobs in {kib}, see <<ml-getting-started>>.
+jobs.
+//For a demonstration of creating jobs in {kib}, see <<ml-getting-started>>.
 
 Most functions detect anomalies in both low and high values. In statistical
 terminology, they apply a two-sided test. Some functions offer low and high

--- a/docs/reference/ml/stopping-ml.asciidoc
+++ b/docs/reference/ml/stopping-ml.asciidoc
@@ -35,7 +35,7 @@ For more information, see <<security-privileges>>.
 
 A {dfeed} can be started and stopped multiple times throughout its lifecycle.
 
-For examples of stopping {dfeeds} in {kib}, see <<ml-gs-job1-manage>>.
+//For examples of stopping {dfeeds} in {kib}, see <<ml-gs-job1-manage>>.
 
 [float]
 [[stopping-all-ml-datafeeds]]

--- a/docs/reference/ml/transforms.asciidoc
+++ b/docs/reference/ml/transforms.asciidoc
@@ -176,8 +176,10 @@ the `error_count` and `aborted_count` values:
 ----------------------------------
 
 NOTE: This example demonstrates how to use script fields, but it contains
-insufficient data to generate meaningful results. For a full demonstration of
-how to create jobs with sample data, see <<ml-getting-started>>.
+insufficient data to generate meaningful results.
+
+//For a full demonstration of
+//how to create jobs with sample data, see <<ml-getting-started>>.
 
 You can alternatively use {kib} to create an advanced job that uses script
 fields. To add the `script_fields` property to your {dfeed}, you must use the


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/pull/225

This PR removes links to the existing machine learning tutorial. 