### PR TITLE
[DOCS] Adds sync to data frame transform API

### DIFF
--- a/docs/reference/data-frames/apis/put-transform.asciidoc
+++ b/docs/reference/data-frames/apis/put-transform.asciidoc
@@ -67,6 +67,15 @@ IMPORTANT:  You must use {kib} or this API to create a {dataframe-transform}.
 `source`::
   (object) Required. The source configuration, which consists of `index` and 
   optionally a `query`. See <<data-frame-transform-source>>.
+  
+`sync`::
+  (Optional, object) Defines the properties required to run continuously.
+  `field`:::
+    (Required, string) The date field that is used to identify new documents in
+    the source.
+  `delay`:::
+    (Optional, time units) The time delay between the current time and the
+    latest input data time.
 
 [[put-data-frame-transform-example]]
 ==== {api-examples-title}
@@ -85,11 +94,6 @@ PUT _data_frame/transforms/ecommerce_transform
       }
     }
   },
-  "dest": {
-    "index": "kibana_sample_data_ecommerce_transform",
-    "pipeline": "add_timestamp_pipeline"
-  },
-  "frequency": "5m",
   "pivot": {
     "group_by": {
       "customer_id": {
@@ -106,7 +110,18 @@ PUT _data_frame/transforms/ecommerce_transform
       }
     }
   },
-  "description": "Maximum priced ecommerce data by customer_id in Asia"
+  "description": "Maximum priced ecommerce data by customer_id in Asia",
+  "dest": {
+    "index": "kibana_sample_data_ecommerce_transform",
+    "pipeline": "add_timestamp_pipeline"
+  },
+  "frequency": "5m",
+  "sync": {
+    "time": {
+      "field": "order_date",
+      "delay": "60s"
+    }
+  }
 }
 --------------------------------------------------
 // CONSOLE

--- a/docs/reference/data-frames/apis/put-transform.asciidoc
+++ b/docs/reference/data-frames/apis/put-transform.asciidoc
@@ -70,12 +70,15 @@ IMPORTANT:  You must use {kib} or this API to create a {dataframe-transform}.
   
 `sync`::
   (Optional, object) Defines the properties required to run continuously.
-  `field`:::
-    (Required, string) The date field that is used to identify new documents in
-    the source.
-  `delay`:::
-    (Optional, time units) The time delay between the current time and the
-    latest input data time.
+  `time`:::
+    (Required, object) Specifies that the {dataframe-transform} uses a time
+    field to synchronize the source and destination indices.
+    `field`::::
+      (Required, string) The date field that is used to identify new documents
+      in the source.
+    `delay`::::
+      (Optional, time units) The time delay between the current time and the
+      latest input data time.
 
 [[put-data-frame-transform-example]]
 ==== {api-examples-title}

--- a/docs/reference/data-frames/apis/put-transform.asciidoc
+++ b/docs/reference/data-frames/apis/put-transform.asciidoc
@@ -76,9 +76,17 @@ IMPORTANT:  You must use {kib} or this API to create a {dataframe-transform}.
     `field`::::
       (Required, string) The date field that is used to identify new documents
       in the source.
++
+--
+TIP: In general, it’s a good idea to use a field that contains the
+<<accessing-ingest-metadata,ingest timestamp>>. If you use a different field,
+you might need to set the `delay` such that it accounts for data transmission
+delays.
+
+--
     `delay`::::
       (Optional, time units) The time delay between the current time and the
-      latest input data time.
+      latest input data time. The default value is `60s`.
 
 [[put-data-frame-transform-example]]
 ==== {api-examples-title}


### PR DESCRIPTION
This PR adds the sync property to the create data frame transform API reference (https://www.elastic.co/guide/en/elasticsearch/reference/master/put-data-frame-transform.html)