### PR TITLE
Fix InternalTestCluster StopRandomNode Assertion

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
@@ -71,7 +71,6 @@ public class IndicesShardStoreRequestIT extends ESIntegTestCase {
         assertThat(rsp.getStoreStatuses().size(), equalTo(0));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/44245")
     public void testBasic() throws Exception {
         String index = "test";
         internalCluster().ensureAtLeastNumDataNodes(2);

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1485,7 +1485,9 @@ public final class InternalTestCluster extends TestCluster {
         ensureOpen();
         NodeAndClient nodeAndClient = getRandomNodeAndClient(nc -> filter.test(nc.node.settings()));
         if (nodeAndClient != null) {
-            if (nodeAndClient.nodeAndClientId() < sharedNodesSeeds.length && nodeAndClient.isMasterEligible() && autoManageMasterNodes
+            if (nodePrefix.equals(ESIntegTestCase.SUITE_CLUSTER_NODE_PREFIX) && nodeAndClient.nodeAndClientId() < sharedNodesSeeds.length
+                && nodeAndClient.isMasterEligible()
+                && autoManageMasterNodes
                 && nodes.values().stream()
                         .filter(NodeAndClient::isMasterEligible)
                         .filter(n -> n.nodeAndClientId() < sharedNodesSeeds.length)


### PR DESCRIPTION
* The assertion added in #44214 is tripped by tests running dedicated
test clusters (`TEST` scope) needlessly.This breaks existing tests like the one in #44245.
  * This is a relatively quick fix and I'd suggest getting it in before we run into if deemed ok as more failures like #44214 might pop up soon. I think we could do a follow-up cleanup here and simply make all the shared nodes logic in `InternalTestCluster` specific to suit-scoped clusters and pass in the cluster scope type instead of guessing it from the node prefix.  
* Closes #44245
