### PR TITLE
Enable BwC Tests after #43148 Backport

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,8 +160,8 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
-final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/44261" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = true
+final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
@@ -172,7 +172,7 @@ public class SnapshotStatus implements ToXContentObject, Streamable {
         includeGlobalState = in.readOptionalBoolean();
         final long startTime;
         final long time;
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_4_0)) {
             startTime = in.readLong();
             time = in.readLong();
         } else {
@@ -191,7 +191,7 @@ public class SnapshotStatus implements ToXContentObject, Streamable {
             shard.writeTo(out);
         }
         out.writeOptionalBoolean(includeGlobalState);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_4_0)) {
             out.writeLong(stats.getStartTime());
             out.writeLong(stats.getTime());
         }


### PR DESCRIPTION
* #43148 has been backported to `7.4` -> we can re-enable these tests
after adjusting the version in the serialization logic
