### PR TITLE
Fix AnalyzeAction response serialization

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/AnalyzeResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/AnalyzeResponseTests.java
@@ -19,17 +19,16 @@
 
 package org.elasticsearch.client.indices;
 
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+
 import org.elasticsearch.action.admin.indices.analyze.AnalyzeAction;
 import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
+@Repeat(iterations = 100)
 public class AnalyzeResponseTests extends AbstractResponseTestCase<AnalyzeAction.Response, AnalyzeResponse> {
 
     @Override
@@ -37,7 +36,7 @@ public class AnalyzeResponseTests extends AbstractResponseTestCase<AnalyzeAction
         int tokenCount = randomIntBetween(1, 30);
         AnalyzeAction.AnalyzeToken[] tokens = new AnalyzeAction.AnalyzeToken[tokenCount];
         for (int i = 0; i < tokenCount; i++) {
-            tokens[i] = randomToken();
+            tokens[i] = org.elasticsearch.action.admin.indices.analyze.AnalyzeResponseTests.randomToken();
         }
         if (randomBoolean()) {
             AnalyzeAction.CharFilteredText[] charfilters = null;
@@ -60,45 +59,6 @@ public class AnalyzeResponseTests extends AbstractResponseTestCase<AnalyzeAction
             return new AnalyzeAction.Response(null, dar);
         }
         return new AnalyzeAction.Response(Arrays.asList(tokens), null);
-    }
-
-    private AnalyzeAction.AnalyzeToken randomToken() {
-        String token = randomAlphaOfLengthBetween(1, 20);
-        int position = randomIntBetween(0, 1000);
-        int startOffset = randomIntBetween(0, 1000);
-        int endOffset = randomIntBetween(0, 1000);
-        int posLength = randomIntBetween(1, 5);
-        String type = randomAlphaOfLengthBetween(1, 20);
-        Map<String, Object> extras = new HashMap<>();
-        if (randomBoolean()) {
-            int entryCount = randomInt(6);
-            for (int i = 0; i < entryCount; i++) {
-                switch (randomInt(6)) {
-                    case 0:
-                    case 1:
-                    case 2:
-                    case 3:
-                        String key = randomAlphaOfLength(5);
-                        String value = randomAlphaOfLength(10);
-                        extras.put(key, value);
-                        break;
-                    case 4:
-                        String objkey = randomAlphaOfLength(5);
-                        Map<String, String> obj = new HashMap<>();
-                        obj.put(randomAlphaOfLength(5), randomAlphaOfLength(10));
-                        extras.put(objkey, obj);
-                        break;
-                    case 5:
-                        String listkey = randomAlphaOfLength(5);
-                        List<String> list = new ArrayList<>();
-                        list.add(randomAlphaOfLength(4));
-                        list.add(randomAlphaOfLength(6));
-                        extras.put(listkey, list);
-                        break;
-                }
-            }
-        }
-        return new AnalyzeAction.AnalyzeToken(token, position, startOffset, endOffset, posLength, type, extras);
     }
 
     @Override

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/AnalyzeResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/AnalyzeResponseTests.java
@@ -19,16 +19,14 @@
 
 package org.elasticsearch.client.indices;
 
-import com.carrotsearch.randomizedtesting.annotations.Repeat;
-
 import org.elasticsearch.action.admin.indices.analyze.AnalyzeAction;
 import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.RandomObjects;
 
 import java.io.IOException;
 import java.util.Arrays;
 
-@Repeat(iterations = 100)
 public class AnalyzeResponseTests extends AbstractResponseTestCase<AnalyzeAction.Response, AnalyzeResponse> {
 
     @Override
@@ -36,7 +34,7 @@ public class AnalyzeResponseTests extends AbstractResponseTestCase<AnalyzeAction
         int tokenCount = randomIntBetween(1, 30);
         AnalyzeAction.AnalyzeToken[] tokens = new AnalyzeAction.AnalyzeToken[tokenCount];
         for (int i = 0; i < tokenCount; i++) {
-            tokens[i] = org.elasticsearch.action.admin.indices.analyze.AnalyzeResponseTests.randomToken();
+            tokens[i] = RandomObjects.randomToken(random());
         }
         if (randomBoolean()) {
             AnalyzeAction.CharFilteredText[] charfilters = null;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeAction.java
@@ -19,9 +19,10 @@
 
 package org.elasticsearch.action.admin.indices.analyze;
 
-import org.elasticsearch.action.ActionType;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.single.shard.SingleShardRequest;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
@@ -292,21 +293,28 @@ public class AnalyzeAction extends ActionType<AnalyzeAction.Response> {
         private final List<AnalyzeToken> tokens;
 
         public Response(List<AnalyzeToken> tokens, DetailAnalyzeResponse detail) {
+            if (tokens == null && detail == null) {
+                throw new IllegalArgumentException("Neither token nor detail set on AnalysisAction.Response");
+            }
             this.tokens = tokens;
             this.detail = detail;
         }
 
         public Response(StreamInput in) throws IOException {
             super.readFrom(in);
-            int size = in.readVInt();
-            if (size > 0) {
-                tokens = new ArrayList<>(size);
-                for (int i = 0; i < size; i++) {
-                    tokens.add(new AnalyzeToken(in));
+            if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+                AnalyzeToken[] tokenArray = in.readOptionalArray(AnalyzeToken::new, AnalyzeToken[]::new);
+                tokens = tokenArray != null ? Arrays.asList(tokenArray) : null;
+            } else {
+                int size = in.readVInt();
+                if (size > 0) {
+                    tokens = new ArrayList<>(size);
+                    for (int i = 0; i < size; i++) {
+                        tokens.add(new AnalyzeToken(in));
+                    }
+                } else {
+                    tokens = null;
                 }
-            }
-            else {
-                tokens = null;
             }
             detail = in.readOptionalWriteable(DetailAnalyzeResponse::new);
         }
@@ -346,21 +354,33 @@ public class AnalyzeAction extends ActionType<AnalyzeAction.Response> {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            if (tokens != null) {
-                out.writeVInt(tokens.size());
-                for (AnalyzeToken token : tokens) {
-                    token.writeTo(out);
+            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+                AnalyzeToken[] tokenArray = null;
+                if (tokens != null) {
+                    tokenArray = tokens.toArray(new AnalyzeToken[0]);
                 }
+                out.writeOptionalArray(tokenArray);
             } else {
-                out.writeVInt(0);
+                if (tokens != null) {
+                    out.writeVInt(tokens.size());
+                    for (AnalyzeToken token : tokens) {
+                        token.writeTo(out);
+                    }
+                } else {
+                    out.writeVInt(0);
+                }
             }
             out.writeOptionalWriteable(detail);
         }
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
             Response that = (Response) o;
             return Objects.equals(detail, that.detail) &&
                 Objects.equals(tokens, that.tokens);
@@ -401,8 +421,12 @@ public class AnalyzeAction extends ActionType<AnalyzeAction.Response> {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
             AnalyzeToken that = (AnalyzeToken) o;
             return startOffset == that.startOffset &&
                 endOffset == that.endOffset &&
@@ -582,8 +606,12 @@ public class AnalyzeAction extends ActionType<AnalyzeAction.Response> {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
             DetailAnalyzeResponse that = (DetailAnalyzeResponse) o;
             return customAnalyzer == that.customAnalyzer &&
                 Objects.equals(analyzer, that.analyzer) &&
@@ -669,8 +697,12 @@ public class AnalyzeAction extends ActionType<AnalyzeAction.Response> {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
             AnalyzeTokenList that = (AnalyzeTokenList) o;
             return Objects.equals(name, that.name) &&
                 Arrays.equals(tokens, that.tokens);
@@ -690,15 +722,18 @@ public class AnalyzeAction extends ActionType<AnalyzeAction.Response> {
 
         AnalyzeTokenList(StreamInput in) throws IOException {
             name = in.readString();
-            int size = in.readVInt();
-            if (size > 0) {
-                tokens = new AnalyzeToken[size];
-                for (int i = 0; i < size; i++) {
-                    tokens[i] = new AnalyzeToken(in);
+            if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+                tokens = in.readOptionalArray(AnalyzeToken::new, AnalyzeToken[]::new);
+            } else {
+                int size = in.readVInt();
+                if (size > 0) {
+                    tokens = new AnalyzeToken[size];
+                    for (int i = 0; i < size; i++) {
+                        tokens[i] = new AnalyzeToken(in);
+                    }
+                } else {
+                    tokens = null;
                 }
-            }
-            else {
-                tokens = null;
             }
         }
 
@@ -732,13 +767,17 @@ public class AnalyzeAction extends ActionType<AnalyzeAction.Response> {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeString(name);
-            if (tokens != null) {
-                out.writeVInt(tokens.length);
-                for (AnalyzeToken token : tokens) {
-                    token.writeTo(out);
-                }
+            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+                out.writeOptionalArray(tokens);
             } else {
-                out.writeVInt(0);
+                if (tokens != null) {
+                    out.writeVInt(tokens.length);
+                    for (AnalyzeToken token : tokens) {
+                        token.writeTo(out);
+                    }
+                } else {
+                    out.writeVInt(0);
+                }
             }
         }
     }
@@ -789,8 +828,12 @@ public class AnalyzeAction extends ActionType<AnalyzeAction.Response> {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
             CharFilteredText that = (CharFilteredText) o;
             return Objects.equals(name, that.name) &&
                 Arrays.equals(texts, that.texts);

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeResponseTests.java
@@ -27,11 +27,11 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.test.RandomObjects;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -76,7 +76,7 @@ public class AnalyzeResponseTests extends AbstractWireSerializingTestCase<Analyz
         int tokenCount = randomIntBetween(0, 30);
         AnalyzeAction.AnalyzeToken[] tokens = new AnalyzeAction.AnalyzeToken[tokenCount];
         for (int i = 0; i < tokenCount; i++) {
-            tokens[i] = randomToken();
+            tokens[i] = RandomObjects.randomToken(random());
         }
         if (randomBoolean()) {
             AnalyzeAction.CharFilteredText[] charfilters = null;
@@ -108,7 +108,7 @@ public class AnalyzeResponseTests extends AbstractWireSerializingTestCase<Analyz
     protected AnalyzeAction.Response mutateInstance(AnalyzeAction.Response instance) throws IOException {
         if (instance.getTokens() != null) {
             List<AnalyzeToken> extendedList = new ArrayList<>(instance.getTokens());
-            extendedList.add(randomToken());
+            extendedList.add(RandomObjects.randomToken(random()));
             return new AnalyzeAction.Response(extendedList, null);
         } else {
             AnalyzeToken[] tokens = instance.detail().tokenizer().getTokens();
@@ -122,45 +122,6 @@ public class AnalyzeResponseTests extends AbstractWireSerializingTestCase<Analyz
     @Override
     protected Reader<AnalyzeAction.Response> instanceReader() {
         return AnalyzeAction.Response::new;
-    }
-
-    public static AnalyzeToken randomToken() {
-        String token = randomAlphaOfLengthBetween(1, 20);
-        int position = randomIntBetween(0, 1000);
-        int startOffset = randomIntBetween(0, 1000);
-        int endOffset = randomIntBetween(0, 1000);
-        int posLength = randomIntBetween(1, 5);
-        String type = randomAlphaOfLengthBetween(1, 20);
-        Map<String, Object> extras = new HashMap<>();
-        if (randomBoolean()) {
-            int entryCount = randomInt(6);
-            for (int i = 0; i < entryCount; i++) {
-                switch (randomInt(6)) {
-                    case 0:
-                    case 1:
-                    case 2:
-                    case 3:
-                        String key = randomAlphaOfLength(5);
-                        String value = randomAlphaOfLength(10);
-                        extras.put(key, value);
-                        break;
-                    case 4:
-                        String objkey = randomAlphaOfLength(5);
-                        Map<String, String> obj = new HashMap<>();
-                        obj.put(randomAlphaOfLength(5), randomAlphaOfLength(10));
-                        extras.put(objkey, obj);
-                        break;
-                    case 5:
-                        String listkey = randomAlphaOfLength(5);
-                        List<String> list = new ArrayList<>();
-                        list.add(randomAlphaOfLength(4));
-                        list.add(randomAlphaOfLength(6));
-                        extras.put(listkey, list);
-                        break;
-                }
-            }
-        }
-        return new AnalyzeAction.AnalyzeToken(token, position, startOffset, endOffset, posLength, type, extras);
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeResponseTests.java
@@ -19,20 +19,25 @@
 
 package org.elasticsearch.action.admin.indices.analyze;
 
+import org.elasticsearch.action.admin.indices.analyze.AnalyzeAction.AnalyzeToken;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class AnalyzeResponseTests extends ESTestCase {
+public class AnalyzeResponseTests extends AbstractWireSerializingTestCase<AnalyzeAction.Response> {
 
     @SuppressWarnings("unchecked")
     public void testNullResponseToXContent() throws IOException {
@@ -59,6 +64,103 @@ public class AnalyzeResponseTests extends ESTestCase {
             assertThat(nullTokens.size(), equalTo(0));
             assertThat(name, equalTo(nameValue));
         }
-
     }
+
+    public void testConstructorArgs() {
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> new AnalyzeAction.Response(null, null));
+        assertEquals("Neither token nor detail set on AnalysisAction.Response", ex.getMessage());
+    }
+
+    @Override
+    protected AnalyzeAction.Response createTestInstance() {
+        int tokenCount = randomIntBetween(0, 30);
+        AnalyzeAction.AnalyzeToken[] tokens = new AnalyzeAction.AnalyzeToken[tokenCount];
+        for (int i = 0; i < tokenCount; i++) {
+            tokens[i] = randomToken();
+        }
+        if (randomBoolean()) {
+            AnalyzeAction.CharFilteredText[] charfilters = null;
+            AnalyzeAction.AnalyzeTokenList[] tokenfilters = null;
+            if (randomBoolean()) {
+                charfilters = new AnalyzeAction.CharFilteredText[]{
+                    new AnalyzeAction.CharFilteredText("my_charfilter", new String[]{"one two"})
+                };
+            }
+            if (randomBoolean()) {
+                tokenfilters = new AnalyzeAction.AnalyzeTokenList[]{
+                    new AnalyzeAction.AnalyzeTokenList("my_tokenfilter_1", tokens),
+                    new AnalyzeAction.AnalyzeTokenList("my_tokenfilter_2", tokens)
+                };
+            }
+            AnalyzeAction.DetailAnalyzeResponse dar = new AnalyzeAction.DetailAnalyzeResponse(
+                charfilters,
+                new AnalyzeAction.AnalyzeTokenList("my_tokenizer", tokens),
+                tokenfilters);
+            return new AnalyzeAction.Response(null, dar);
+        }
+        return new AnalyzeAction.Response(Arrays.asList(tokens), null);
+    }
+
+    /**
+     * Either add a token to the token list or change the details token list name
+     */
+    @Override
+    protected AnalyzeAction.Response mutateInstance(AnalyzeAction.Response instance) throws IOException {
+        if (instance.getTokens() != null) {
+            List<AnalyzeToken> extendedList = new ArrayList<>(instance.getTokens());
+            extendedList.add(randomToken());
+            return new AnalyzeAction.Response(extendedList, null);
+        } else {
+            AnalyzeToken[] tokens = instance.detail().tokenizer().getTokens();
+            return new AnalyzeAction.Response(null, new AnalyzeAction.DetailAnalyzeResponse(
+                    instance.detail().charfilters(),
+                    new AnalyzeAction.AnalyzeTokenList("my_other_tokenizer", tokens),
+                    instance.detail().tokenfilters()));
+        }
+    }
+
+    @Override
+    protected Reader<AnalyzeAction.Response> instanceReader() {
+        return AnalyzeAction.Response::new;
+    }
+
+    public static AnalyzeToken randomToken() {
+        String token = randomAlphaOfLengthBetween(1, 20);
+        int position = randomIntBetween(0, 1000);
+        int startOffset = randomIntBetween(0, 1000);
+        int endOffset = randomIntBetween(0, 1000);
+        int posLength = randomIntBetween(1, 5);
+        String type = randomAlphaOfLengthBetween(1, 20);
+        Map<String, Object> extras = new HashMap<>();
+        if (randomBoolean()) {
+            int entryCount = randomInt(6);
+            for (int i = 0; i < entryCount; i++) {
+                switch (randomInt(6)) {
+                    case 0:
+                    case 1:
+                    case 2:
+                    case 3:
+                        String key = randomAlphaOfLength(5);
+                        String value = randomAlphaOfLength(10);
+                        extras.put(key, value);
+                        break;
+                    case 4:
+                        String objkey = randomAlphaOfLength(5);
+                        Map<String, String> obj = new HashMap<>();
+                        obj.put(randomAlphaOfLength(5), randomAlphaOfLength(10));
+                        extras.put(objkey, obj);
+                        break;
+                    case 5:
+                        String listkey = randomAlphaOfLength(5);
+                        List<String> list = new ArrayList<>();
+                        list.add(randomAlphaOfLength(4));
+                        list.add(randomAlphaOfLength(6));
+                        extras.put(listkey, list);
+                        break;
+                }
+            }
+        }
+        return new AnalyzeAction.AnalyzeToken(token, position, startOffset, endOffset, posLength, type, extras);
+    }
+
 }

--- a/server/src/test/java/org/elasticsearch/indices/analyze/AnalyzeActionIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/analyze/AnalyzeActionIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.admin.indices.analyze.AnalyzeRequestBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.MockKeywordPlugin;
 import org.hamcrest.core.IsNull;
 
@@ -41,6 +42,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 
+@ClusterScope(minNumDataNodes = 2)
 public class AnalyzeActionIT extends ESIntegTestCase {
 
     @Override
@@ -387,5 +389,17 @@ public class AnalyzeActionIT extends ESIntegTestCase {
         assertThat(token.getPositionLength(), equalTo(1));
     }
 
+    /**
+     * Input text that doesn't produce tokens should return an empty token list
+     */
+    public void testZeroTokenAnalysis() throws IOException {
+        assertAcked(prepareCreate("test"));
+        ensureGreen("test");
+
+        AnalyzeAction.Response analyzeResponse = client().admin().indices().prepareAnalyze("test", ".").get();
+        System.out.println(analyzeResponse);
+        assertNotNull(analyzeResponse.getTokens());
+        assertThat(analyzeResponse.getTokens().size(), equalTo(0));
+    }
 
 }

--- a/server/src/test/java/org/elasticsearch/indices/analyze/AnalyzeActionIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/analyze/AnalyzeActionIT.java
@@ -397,7 +397,6 @@ public class AnalyzeActionIT extends ESIntegTestCase {
         ensureGreen("test");
 
         AnalyzeAction.Response analyzeResponse = client().admin().indices().prepareAnalyze("test", ".").get();
-        System.out.println(analyzeResponse);
         assertNotNull(analyzeResponse.getTokens());
         assertThat(analyzeResponse.getTokens().size(), equalTo(0));
     }


### PR DESCRIPTION
Currently we loose information about whether a token list in an AnalyzeAction
response is null or an empty list, because we write a 0 value to the stream in
both cases and deserialize to a null value on the receiving side. This change
fixes this so we write an additional flag indicating whether the value is null
or not, followed by the size of the list and its content.

Closes #44078