### PR TITLE
Add usage stats for frozen indices

### DIFF
--- a/docs/reference/rest-api/info.asciidoc
+++ b/docs/reference/rest-api/info.asciidoc
@@ -75,6 +75,10 @@ Example response:
          "available" : true,
          "enabled" : true
       },
+      "frozen_indices" : {
+         "available" : true,
+         "enabled" : true
+      },
       "graph" : {
          "available" : true,
          "enabled" : true

--- a/docs/reference/rest-api/info.asciidoc
+++ b/docs/reference/rest-api/info.asciidoc
@@ -75,10 +75,6 @@ Example response:
          "available" : true,
          "enabled" : true
       },
-      "frozen_indices" : {
-         "available" : true,
-         "enabled" : true
-      },
       "graph" : {
          "available" : true,
          "enabled" : true

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
@@ -52,6 +52,7 @@ import org.elasticsearch.xpack.core.dataframe.transforms.SyncConfig;
 import org.elasticsearch.xpack.core.dataframe.transforms.TimeSyncConfig;
 import org.elasticsearch.xpack.core.deprecation.DeprecationInfoAction;
 import org.elasticsearch.xpack.core.flattened.FlattenedFeatureSetUsage;
+import org.elasticsearch.xpack.core.frozen.FrozenIndicesFeatureSetUsage;
 import org.elasticsearch.xpack.core.graph.GraphFeatureSetUsage;
 import org.elasticsearch.xpack.core.graph.action.GraphExploreAction;
 import org.elasticsearch.xpack.core.indexlifecycle.AllocateAction;
@@ -491,7 +492,9 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
                 // Vectors
                 new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.VECTORS, VectorsFeatureSetUsage::new),
                 // Voting Only Node
-                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.VOTING_ONLY, VotingOnlyNodeFeatureSetUsage::new)
+                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.VOTING_ONLY, VotingOnlyNodeFeatureSetUsage::new),
+                // Frozen indices
+                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.FROZEN_INDICES, FrozenIndicesFeatureSetUsage::new)
         );
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackField.java
@@ -43,6 +43,8 @@ public final class XPackField {
     public static final String VECTORS = "vectors";
     /** Name constant for the voting-only-node feature. */
     public static final String VOTING_ONLY = "voting_only";
+    /** Name constant for the frozen index feature. */
+    public static final String FROZEN_INDICES = "frozen_indices";
 
     private XPackField() {}
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
@@ -63,7 +63,9 @@ import org.elasticsearch.xpack.core.action.TransportXPackInfoAction;
 import org.elasticsearch.xpack.core.action.TransportXPackUsageAction;
 import org.elasticsearch.xpack.core.action.XPackInfoAction;
 import org.elasticsearch.xpack.core.action.XPackUsageAction;
+import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
 import org.elasticsearch.xpack.core.action.XPackUsageResponse;
+import org.elasticsearch.xpack.core.frozen.FrozenIndicesUsageTransportAction;
 import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.rest.action.RestFreezeIndexAction;
 import org.elasticsearch.xpack.core.rest.action.RestReloadAnalyzersAction;
@@ -251,6 +253,7 @@ public class XPackPlugin extends XPackClientPlugin implements ExtensiblePlugin, 
         actions.add(new ActionHandler<>(XPackUsageAction.INSTANCE, getUsageAction()));
         actions.add(new ActionHandler<>(TransportFreezeIndexAction.FreezeIndexAction.INSTANCE,
             TransportFreezeIndexAction.class));
+        actions.add(new ActionHandler<>(XPackUsageFeatureAction.FROZEN_INDICES, FrozenIndicesUsageTransportAction.class));
         actions.addAll(licensing.getActions());
         actions.add(new ActionHandler<>(ReloadAnalyzerAction.INSTANCE, TransportReloadAnalyzersAction.class));
         return actions;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageFeatureAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageFeatureAction.java
@@ -36,10 +36,11 @@ public class XPackUsageFeatureAction extends StreamableResponseActionType<XPackU
     public static final XPackUsageFeatureAction FLATTENED = new XPackUsageFeatureAction(XPackField.FLATTENED);
     public static final XPackUsageFeatureAction VECTORS = new XPackUsageFeatureAction(XPackField.VECTORS);
     public static final XPackUsageFeatureAction VOTING_ONLY = new XPackUsageFeatureAction(XPackField.VOTING_ONLY);
+    public static final XPackUsageFeatureAction FROZEN_INDICES = new XPackUsageFeatureAction(XPackField.FROZEN_INDICES);
 
     public static final List<XPackUsageFeatureAction> ALL = Arrays.asList(
         SECURITY, MONITORING, WATCHER, GRAPH, MACHINE_LEARNING, LOGSTASH, SQL, ROLLUP, INDEX_LIFECYCLE, CCR, DATA_FRAME, FLATTENED,
-        VECTORS, VOTING_ONLY
+        VECTORS, VOTING_ONLY, FROZEN_INDICES
     );
 
     private XPackUsageFeatureAction(String name) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/frozen/FrozenIndicesFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/frozen/FrozenIndicesFeatureSetUsage.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.frozen;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.XPackFeatureSet;
+import org.elasticsearch.xpack.core.XPackField;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class FrozenIndicesFeatureSetUsage extends XPackFeatureSet.Usage {
+
+    private final int numberOfFrozenIndices;
+
+    public FrozenIndicesFeatureSetUsage(StreamInput input) throws IOException {
+        super(input);
+        numberOfFrozenIndices = input.readVInt();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeVInt(numberOfFrozenIndices);
+    }
+
+    public FrozenIndicesFeatureSetUsage(boolean available, boolean enabled, int numberOfFrozenIndices) {
+        super(XPackField.FROZEN_INDICES, available, enabled);
+        this.numberOfFrozenIndices = numberOfFrozenIndices;
+    }
+
+    @Override
+    protected void innerXContent(XContentBuilder builder, Params params) throws IOException {
+        super.innerXContent(builder, params);
+        builder.field("indices_count", numberOfFrozenIndices);
+    }
+
+    public int getNumberOfFrozenIndices() {
+        return numberOfFrozenIndices;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(available, enabled, numberOfFrozenIndices);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        FrozenIndicesFeatureSetUsage other = (FrozenIndicesFeatureSetUsage) obj;
+        return Objects.equals(available, other.available) &&
+            Objects.equals(enabled, other.enabled) &&
+            Objects.equals(numberOfFrozenIndices, other.numberOfFrozenIndices);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/frozen/FrozenIndicesUsageTransportAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/frozen/FrozenIndicesUsageTransportAction.java
@@ -35,7 +35,7 @@ public class FrozenIndicesUsageTransportAction extends XPackUsageFeatureTranspor
                                    ActionListener<XPackUsageFeatureResponse> listener) {
         int numFrozenIndices = 0;
         for (IndexMetaData indexMetaData : state.metaData()) {
-            if (FrozenEngine.INDEX_FROZEN.exists(indexMetaData.getSettings())) {
+            if (FrozenEngine.INDEX_FROZEN.get(indexMetaData.getSettings())) {
                 numFrozenIndices++;
             }
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/frozen/FrozenIndicesUsageTransportAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/frozen/FrozenIndicesUsageTransportAction.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.frozen;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.index.engine.FrozenEngine;
+import org.elasticsearch.protocol.xpack.XPackUsageRequest;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
+import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
+import org.elasticsearch.xpack.core.action.XPackUsageFeatureTransportAction;
+
+public class FrozenIndicesUsageTransportAction extends XPackUsageFeatureTransportAction {
+
+    @Inject
+    public FrozenIndicesUsageTransportAction(TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
+                                             ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(XPackUsageFeatureAction.FROZEN_INDICES.name(), transportService, clusterService, threadPool, actionFilters,
+            indexNameExpressionResolver);
+    }
+
+    @Override
+    protected void masterOperation(Task task, XPackUsageRequest request, ClusterState state,
+                                   ActionListener<XPackUsageFeatureResponse> listener) {
+        int numFrozenIndices = 0;
+        for (IndexMetaData indexMetaData : state.metaData()) {
+            if (FrozenEngine.INDEX_FROZEN.exists(indexMetaData.getSettings())) {
+                numFrozenIndices++;
+            }
+        }
+        listener.onResponse(new XPackUsageFeatureResponse(new FrozenIndicesFeatureSetUsage(true, true, numFrozenIndices)));
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/frozen/FrozenIndicesFeatureSetUsageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/frozen/FrozenIndicesFeatureSetUsageTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.frozen;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+
+import java.io.IOException;
+
+public class FrozenIndicesFeatureSetUsageTests extends AbstractWireSerializingTestCase<FrozenIndicesFeatureSetUsage> {
+
+    @Override
+    protected FrozenIndicesFeatureSetUsage createTestInstance() {
+        boolean available = randomBoolean();
+        boolean enabled = randomBoolean();
+        return new FrozenIndicesFeatureSetUsage(available, enabled, randomIntBetween(0, 100000));
+    }
+
+    @Override
+    protected FrozenIndicesFeatureSetUsage mutateInstance(FrozenIndicesFeatureSetUsage instance) throws IOException {
+        boolean available = instance.available();
+        boolean enabled = instance.enabled();
+        int numFrozenIndices = instance.getNumberOfFrozenIndices();
+        switch (between(0, 2)) {
+            case 0:
+                available = available == false;
+                break;
+            case 1:
+                enabled = enabled == false;
+                break;
+            case 2:
+                numFrozenIndices = randomValueOtherThan(numFrozenIndices, () -> randomIntBetween(0, 100000));
+                break;
+            default:
+                throw new AssertionError("Illegal randomisation branch");
+        }
+        return new FrozenIndicesFeatureSetUsage(available, enabled, numFrozenIndices);
+    }
+
+    @Override
+    protected Writeable.Reader<FrozenIndicesFeatureSetUsage> instanceReader() {
+        return FrozenIndicesFeatureSetUsage::new;
+    }
+
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/indices.freeze/20_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/indices.freeze/20_stats.yml
@@ -51,7 +51,7 @@ setup:
 
   # unfreeze index
   - do:
-      indices.freeze:
+      indices.unfreeze:
         index: test
   - is_true: acknowledged
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/indices.freeze/30_usage.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/indices.freeze/30_usage.yml
@@ -1,0 +1,60 @@
+---
+setup:
+  - do:
+      indices.create:
+        index: test
+  - do:
+      cluster.health:
+        wait_for_no_initializing_shards: true
+
+---
+"Usage stats on frozen indices":
+  - skip:
+      version: " - 7.9.99"
+      reason:  "frozen indices have usage stats starting in version 8.0.0"
+
+  - do:
+      index:
+        index: test
+        id:    1
+        body:  { "foo": "bar" }
+
+  - do:
+      index:
+        index: test
+        id:    2
+        body:  { "foo": "bar" }
+
+  - do:
+      index:
+        index: test
+        id:    3
+        body:  { "foo": "bar" }
+
+  - do: {xpack.usage: {}}
+  - match: { frozen_indices.available: true }
+  - match: { frozen_indices.enabled: true }
+  - match: { frozen_indices.indices_count: 0 }
+
+  # freeze index
+  - do:
+      indices.freeze:
+        index: test
+  - is_true: acknowledged
+
+
+  - do: {xpack.usage: {}}
+  - match: { frozen_indices.available: true }
+  - match: { frozen_indices.enabled: true }
+  - match: { frozen_indices.indices_count: 1 }
+
+  # unfreeze index
+  - do:
+      indices.unfreeze:
+        index: test
+  - is_true: acknowledged
+
+  - do: {xpack.usage: {}}
+  - match: { frozen_indices.available: true }
+  - match: { frozen_indices.enabled: true }
+  - match: { frozen_indices.indices_count: 0 }


### PR DESCRIPTION
Adds usage stats for frozen indices:

```
  "frozen_indices" : {
    "available" : true,
    "enabled" : true,
    "indices_count" : 0
  }
```