### PR TITLE
[Backport 7.x] Restrict testCreateEmptyDirNoPermissions to Unix (#44282)

### DIFF
--- a/buildSrc/src/test/java/org/elasticsearch/gradle/EmptyDirTaskTests.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/EmptyDirTaskTests.java
@@ -21,6 +21,8 @@ package org.elasticsearch.gradle;
 import java.io.File;
 import java.io.IOException;
 
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+import org.apache.tools.ant.taskdefs.condition.Os;
 import org.elasticsearch.gradle.test.GradleUnitTestCase;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
@@ -49,6 +51,8 @@ public class EmptyDirTaskTests extends GradleUnitTestCase {
     }
 
     public void testCreateEmptyDirNoPermissions() throws Exception {
+        RandomizedTest.assumeFalse("Functionality is Unix specific", Os.isFamily(Os.FAMILY_WINDOWS));
+
         Project project = ProjectBuilder.builder().build();
         EmptyDirTask emptyDirTask = project.getTasks().create("emptyDirTask", EmptyDirTask.class);
         emptyDirTask.setDirMode(0000);


### PR DESCRIPTION
The test EmptyDirTaskTests#testCreateEmptyDirNoPermissions may fail on
Windows. However, the test is only meaningful for Unix permissions
structures, so we should assume a Unix-family OS and skip the test on
Windows.

Backport of #44282
Fixes #44064