### PR TITLE
Convert BaseNode(s) Request/Response classes to Writeable

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodeHotThreads.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodeHotThreads.java
@@ -30,7 +30,9 @@ public class NodeHotThreads extends BaseNodeResponse {
 
     private String hotThreads;
 
-    NodeHotThreads() {
+    NodeHotThreads(StreamInput in) throws IOException {
+        super(in);
+        hotThreads = in.readString();
     }
 
     public NodeHotThreads(DiscoveryNode node, String hotThreads) {
@@ -40,18 +42,6 @@ public class NodeHotThreads extends BaseNodeResponse {
 
     public String getHotThreads() {
         return this.hotThreads;
-    }
-
-    public static NodeHotThreads readNodeHotThreads(StreamInput in) throws IOException {
-        NodeHotThreads node = new NodeHotThreads();
-        node.readFrom(in);
-        return node;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        hotThreads = in.readString();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsAction.java
@@ -19,19 +19,14 @@
 
 package org.elasticsearch.action.admin.cluster.node.hotthreads;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class NodesHotThreadsAction extends StreamableResponseActionType<NodesHotThreadsResponse> {
+public class NodesHotThreadsAction extends ActionType<NodesHotThreadsResponse> {
 
     public static final NodesHotThreadsAction INSTANCE = new NodesHotThreadsAction();
     public static final String NAME = "cluster:monitor/nodes/hot_threads";
 
     private NodesHotThreadsAction() {
-        super(NAME);
-    }
-
-    @Override
-    public NodesHotThreadsResponse newResponse() {
-        return new NodesHotThreadsResponse();
+        super(NAME, NodesHotThreadsResponse::new);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
@@ -36,8 +36,13 @@ public class NodesHotThreadsRequest extends BaseNodesRequest<NodesHotThreadsRequ
     boolean ignoreIdleThreads = true;
 
     // for serialization
-    public NodesHotThreadsRequest() {
-
+    public NodesHotThreadsRequest(StreamInput in) throws IOException {
+        super(in);
+        threads = in.readInt();
+        ignoreIdleThreads = in.readBoolean();
+        type = in.readString();
+        interval = in.readTimeValue();
+        snapshots = in.readInt();
     }
 
     /**
@@ -91,16 +96,6 @@ public class NodesHotThreadsRequest extends BaseNodesRequest<NodesHotThreadsRequ
     public NodesHotThreadsRequest snapshots(int snapshots) {
         this.snapshots = snapshots;
         return this;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        threads = in.readInt();
-        ignoreIdleThreads = in.readBoolean();
-        type = in.readString();
-        interval = in.readTimeValue();
-        snapshots = in.readInt();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsResponse.java
@@ -30,7 +30,8 @@ import java.util.List;
 
 public class NodesHotThreadsResponse extends BaseNodesResponse<NodeHotThreads> {
 
-    NodesHotThreadsResponse() {
+    public NodesHotThreadsResponse(StreamInput in) throws IOException {
+        super(in);
     }
 
     public NodesHotThreadsResponse(ClusterName clusterName, List<NodeHotThreads> nodes, List<FailedNodeException> failures) {
@@ -39,7 +40,7 @@ public class NodesHotThreadsResponse extends BaseNodesResponse<NodeHotThreads> {
 
     @Override
     protected List<NodeHotThreads> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(NodeHotThreads::readNodeHotThreads);
+        return in.readList(NodeHotThreads::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
@@ -60,8 +60,8 @@ public class TransportNodesHotThreadsAction extends TransportNodesAction<NodesHo
     }
 
     @Override
-    protected NodeHotThreads newNodeResponse() {
-        return new NodeHotThreads();
+    protected NodeHotThreads newNodeResponse(StreamInput in) throws IOException {
+        return new NodeHotThreads(in);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
@@ -83,18 +83,13 @@ public class TransportNodesHotThreadsAction extends TransportNodesAction<NodesHo
 
         NodesHotThreadsRequest request;
 
-        public NodeRequest() {
+        public NodeRequest(StreamInput in) throws IOException {
+            super(in);
+            request = new NodesHotThreadsRequest(in);
         }
 
         NodeRequest(NodesHotThreadsRequest request) {
             this.request = request;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            request = new NodesHotThreadsRequest();
-            request.readFrom(in);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfo.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfo.java
@@ -76,7 +76,26 @@ public class NodeInfo extends BaseNodeResponse {
     @Nullable
     private ByteSizeValue totalIndexingBuffer;
 
-    public NodeInfo() {
+    public NodeInfo(StreamInput in) throws IOException {
+        super(in);
+        version = Version.readVersion(in);
+        build = Build.readBuild(in);
+        if (in.readBoolean()) {
+            totalIndexingBuffer = new ByteSizeValue(in.readLong());
+        } else {
+            totalIndexingBuffer = null;
+        }
+        if (in.readBoolean()) {
+            settings = Settings.readSettingsFromStream(in);
+        }
+        os = in.readOptionalWriteable(OsInfo::new);
+        process = in.readOptionalWriteable(ProcessInfo::new);
+        jvm = in.readOptionalWriteable(JvmInfo::new);
+        threadPool = in.readOptionalWriteable(ThreadPoolInfo::new);
+        transport = in.readOptionalWriteable(TransportInfo::new);
+        http = in.readOptionalWriteable(HttpInfo::new);
+        plugins = in.readOptionalWriteable(PluginsAndModules::new);
+        ingest = in.readOptionalWriteable(IngestInfo::new);
     }
 
     public NodeInfo(Version version, Build build, DiscoveryNode node, @Nullable Settings settings,
@@ -180,35 +199,6 @@ public class NodeInfo extends BaseNodeResponse {
     @Nullable
     public ByteSizeValue getTotalIndexingBuffer() {
         return totalIndexingBuffer;
-    }
-
-    public static NodeInfo readNodeInfo(StreamInput in) throws IOException {
-        NodeInfo nodeInfo = new NodeInfo();
-        nodeInfo.readFrom(in);
-        return nodeInfo;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        version = Version.readVersion(in);
-        build = Build.readBuild(in);
-        if (in.readBoolean()) {
-            totalIndexingBuffer = new ByteSizeValue(in.readLong());
-        } else {
-            totalIndexingBuffer = null;
-        }
-        if (in.readBoolean()) {
-            settings = Settings.readSettingsFromStream(in);
-        }
-        os = in.readOptionalWriteable(OsInfo::new);
-        process = in.readOptionalWriteable(ProcessInfo::new);
-        jvm = in.readOptionalWriteable(JvmInfo::new);
-        threadPool = in.readOptionalWriteable(ThreadPoolInfo::new);
-        transport = in.readOptionalWriteable(TransportInfo::new);
-        http = in.readOptionalWriteable(HttpInfo::new);
-        plugins = in.readOptionalWriteable(PluginsAndModules::new);
-        ingest = in.readOptionalWriteable(IngestInfo::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoAction.java
@@ -19,19 +19,14 @@
 
 package org.elasticsearch.action.admin.cluster.node.info;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class NodesInfoAction extends StreamableResponseActionType<NodesInfoResponse> {
+public class NodesInfoAction extends ActionType<NodesInfoResponse> {
 
     public static final NodesInfoAction INSTANCE = new NodesInfoAction();
     public static final String NAME = "cluster:monitor/nodes/info";
 
     private NodesInfoAction() {
-        super(NAME);
-    }
-
-    @Override
-    public NodesInfoResponse newResponse() {
-        return new NodesInfoResponse();
+        super(NAME, NodesInfoResponse::new);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
@@ -41,7 +41,18 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
     private boolean ingest = true;
     private boolean indices = true;
 
-    public NodesInfoRequest() {
+    public NodesInfoRequest(StreamInput in) throws IOException {
+        super(in);
+        settings = in.readBoolean();
+        os = in.readBoolean();
+        process = in.readBoolean();
+        jvm = in.readBoolean();
+        threadPool = in.readBoolean();
+        transport = in.readBoolean();
+        http = in.readBoolean();
+        plugins = in.readBoolean();
+        ingest = in.readBoolean();
+        indices = in.readBoolean();
     }
 
     /**
@@ -238,21 +249,6 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      */
     public boolean indices() {
         return indices;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        settings = in.readBoolean();
-        os = in.readBoolean();
-        process = in.readBoolean();
-        jvm = in.readBoolean();
-        threadPool = in.readBoolean();
-        transport = in.readBoolean();
-        http = in.readBoolean();
-        plugins = in.readBoolean();
-        ingest = in.readBoolean();
-        indices = in.readBoolean();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
@@ -37,7 +37,8 @@ import java.util.Map;
 
 public class NodesInfoResponse extends BaseNodesResponse<NodeInfo> implements ToXContentFragment {
 
-    public NodesInfoResponse() {
+    public NodesInfoResponse(StreamInput in) throws IOException {
+        super(in);
     }
 
     public NodesInfoResponse(ClusterName clusterName, List<NodeInfo> nodes, List<FailedNodeException> failures) {
@@ -46,7 +47,7 @@ public class NodesInfoResponse extends BaseNodesResponse<NodeInfo> implements To
 
     @Override
     protected List<NodeInfo> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(NodeInfo::readNodeInfo);
+        return in.readList(NodeInfo::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
@@ -62,8 +62,8 @@ public class TransportNodesInfoAction extends TransportNodesAction<NodesInfoRequ
     }
 
     @Override
-    protected NodeInfo newNodeResponse() {
-        return new NodeInfo();
+    protected NodeInfo newNodeResponse(StreamInput in) throws IOException {
+        return new NodeInfo(in);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
@@ -77,18 +77,13 @@ public class TransportNodesInfoAction extends TransportNodesAction<NodesInfoRequ
 
         NodesInfoRequest request;
 
-        public NodeInfoRequest() {
+        public NodeInfoRequest(StreamInput in) throws IOException {
+            super(in);
+            request = new NodesInfoRequest(in);
         }
 
         public NodeInfoRequest(NodesInfoRequest request) {
             this.request = request;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            request = new NodesInfoRequest();
-            request.readFrom(in);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsAction.java
@@ -19,21 +19,14 @@
 
 package org.elasticsearch.action.admin.cluster.node.reload;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class NodesReloadSecureSettingsAction
-        extends StreamableResponseActionType<NodesReloadSecureSettingsResponse> {
+public class NodesReloadSecureSettingsAction extends ActionType<NodesReloadSecureSettingsResponse> {
 
     public static final NodesReloadSecureSettingsAction INSTANCE = new NodesReloadSecureSettingsAction();
     public static final String NAME = "cluster:admin/nodes/reload_secure_settings";
 
     private NodesReloadSecureSettingsAction() {
-        super(NAME);
+        super(NAME, NodesReloadSecureSettingsResponse::new);
     }
-
-    @Override
-    public NodesReloadSecureSettingsResponse newResponse() {
-        return new NodesReloadSecureSettingsResponse();
-    }
-
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsRequest.java
@@ -20,6 +20,9 @@
 package org.elasticsearch.action.admin.cluster.node.reload;
 
 import org.elasticsearch.action.support.nodes.BaseNodesRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
 
 /**
  * Request for a reload secure settings action.
@@ -27,6 +30,11 @@ import org.elasticsearch.action.support.nodes.BaseNodesRequest;
 public class NodesReloadSecureSettingsRequest extends BaseNodesRequest<NodesReloadSecureSettingsRequest> {
 
     public NodesReloadSecureSettingsRequest() {
+        super((String[]) null);
+    }
+
+    public NodesReloadSecureSettingsRequest(StreamInput in) throws IOException {
+        super(in);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsResponse.java
@@ -40,7 +40,8 @@ import java.util.List;
 public class NodesReloadSecureSettingsResponse extends BaseNodesResponse<NodesReloadSecureSettingsResponse.NodeResponse>
         implements ToXContentFragment {
 
-    public NodesReloadSecureSettingsResponse() {
+    public NodesReloadSecureSettingsResponse(StreamInput in) throws IOException {
+        super(in);
     }
 
     public NodesReloadSecureSettingsResponse(ClusterName clusterName, List<NodeResponse> nodes, List<FailedNodeException> failures) {
@@ -49,7 +50,7 @@ public class NodesReloadSecureSettingsResponse extends BaseNodesResponse<NodesRe
 
     @Override
     protected List<NodesReloadSecureSettingsResponse.NodeResponse> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(NodeResponse::readNodeResponse);
+        return in.readList(NodeResponse::new);
     }
 
     @Override
@@ -92,7 +93,11 @@ public class NodesReloadSecureSettingsResponse extends BaseNodesResponse<NodesRe
 
         private Exception reloadException = null;
 
-        public NodeResponse() {
+        public NodeResponse(StreamInput in) throws IOException {
+            super(in);
+            if (in.readBoolean()) {
+                reloadException = in.readException();
+            }
         }
 
         public NodeResponse(DiscoveryNode node, Exception reloadException) {
@@ -102,14 +107,6 @@ public class NodesReloadSecureSettingsResponse extends BaseNodesResponse<NodesRe
 
         public Exception reloadException() {
             return this.reloadException;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            if (in.readBoolean()) {
-                reloadException = in.readException();
-            }
         }
 
         @Override
@@ -138,12 +135,6 @@ public class NodesReloadSecureSettingsResponse extends BaseNodesResponse<NodesRe
         @Override
         public int hashCode() {
             return reloadException != null ? reloadException.hashCode() : 0;
-        }
-
-        public static NodeResponse readNodeResponse(StreamInput in) throws IOException {
-            final NodeResponse node = new NodeResponse();
-            node.readFrom(in);
-            return node;
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/TransportNodesReloadSecureSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/TransportNodesReloadSecureSettingsAction.java
@@ -74,8 +74,8 @@ public class TransportNodesReloadSecureSettingsAction extends TransportNodesActi
     }
 
     @Override
-    protected NodesReloadSecureSettingsResponse.NodeResponse newNodeResponse() {
-        return new NodesReloadSecureSettingsResponse.NodeResponse();
+    protected NodesReloadSecureSettingsResponse.NodeResponse newNodeResponse(StreamInput in) throws IOException {
+        return new NodesReloadSecureSettingsResponse.NodeResponse(in);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/TransportNodesReloadSecureSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/TransportNodesReloadSecureSettingsAction.java
@@ -114,18 +114,13 @@ public class TransportNodesReloadSecureSettingsAction extends TransportNodesActi
 
         NodesReloadSecureSettingsRequest request;
 
-        public NodeRequest() {
+        public NodeRequest(StreamInput in) throws IOException {
+            super(in);
+            request = new NodesReloadSecureSettingsRequest(in);
         }
 
         NodeRequest(NodesReloadSecureSettingsRequest request) {
             this.request = request;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            request = new NodesReloadSecureSettingsRequest();
-            request.readFrom(in);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -90,7 +90,24 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
     @Nullable
     private AdaptiveSelectionStats adaptiveSelectionStats;
 
-    NodeStats() {
+    public NodeStats(StreamInput in) throws IOException {
+        super(in);
+        timestamp = in.readVLong();
+        if (in.readBoolean()) {
+            indices = NodeIndicesStats.readIndicesStats(in);
+        }
+        os = in.readOptionalWriteable(OsStats::new);
+        process = in.readOptionalWriteable(ProcessStats::new);
+        jvm = in.readOptionalWriteable(JvmStats::new);
+        threadPool = in.readOptionalWriteable(ThreadPoolStats::new);
+        fs = in.readOptionalWriteable(FsInfo::new);
+        transport = in.readOptionalWriteable(TransportStats::new);
+        http = in.readOptionalWriteable(HttpStats::new);
+        breaker = in.readOptionalWriteable(AllCircuitBreakerStats::new);
+        scriptStats = in.readOptionalWriteable(ScriptStats::new);
+        discoveryStats = in.readOptionalWriteable(DiscoveryStats::new);
+        ingestStats = in.readOptionalWriteable(IngestStats::new);
+        adaptiveSelectionStats = in.readOptionalWriteable(AdaptiveSelectionStats::new);
     }
 
     public NodeStats(DiscoveryNode node, long timestamp, @Nullable NodeIndicesStats indices,
@@ -208,33 +225,6 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
     @Nullable
     public AdaptiveSelectionStats getAdaptiveSelectionStats() {
         return adaptiveSelectionStats;
-    }
-
-    public static NodeStats readNodeStats(StreamInput in) throws IOException {
-        NodeStats nodeInfo = new NodeStats();
-        nodeInfo.readFrom(in);
-        return nodeInfo;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        timestamp = in.readVLong();
-        if (in.readBoolean()) {
-            indices = NodeIndicesStats.readIndicesStats(in);
-        }
-        os = in.readOptionalWriteable(OsStats::new);
-        process = in.readOptionalWriteable(ProcessStats::new);
-        jvm = in.readOptionalWriteable(JvmStats::new);
-        threadPool = in.readOptionalWriteable(ThreadPoolStats::new);
-        fs = in.readOptionalWriteable(FsInfo::new);
-        transport = in.readOptionalWriteable(TransportStats::new);
-        http = in.readOptionalWriteable(HttpStats::new);
-        breaker = in.readOptionalWriteable(AllCircuitBreakerStats::new);
-        scriptStats = in.readOptionalWriteable(ScriptStats::new);
-        discoveryStats = in.readOptionalWriteable(DiscoveryStats::new);
-        ingestStats = in.readOptionalWriteable(IngestStats::new);
-        adaptiveSelectionStats = in.readOptionalWriteable(AdaptiveSelectionStats::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsAction.java
@@ -19,19 +19,14 @@
 
 package org.elasticsearch.action.admin.cluster.node.stats;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class NodesStatsAction extends StreamableResponseActionType<NodesStatsResponse> {
+public class NodesStatsAction extends ActionType<NodesStatsResponse> {
 
     public static final NodesStatsAction INSTANCE = new NodesStatsAction();
     public static final String NAME = "cluster:monitor/nodes/stats";
 
     private NodesStatsAction() {
-        super(NAME);
-    }
-
-    @Override
-    public NodesStatsResponse newResponse() {
-        return new NodesStatsResponse();
+        super(NAME, NodesStatsResponse::new);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequest.java
@@ -46,6 +46,24 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
     private boolean adaptiveSelection;
 
     public NodesStatsRequest() {
+        super((String[]) null);
+    }
+
+    public NodesStatsRequest(StreamInput in) throws IOException {
+        super(in);
+        indices = new CommonStatsFlags(in);
+        os = in.readBoolean();
+        process = in.readBoolean();
+        jvm = in.readBoolean();
+        threadPool = in.readBoolean();
+        fs = in.readBoolean();
+        transport = in.readBoolean();
+        http = in.readBoolean();
+        breaker = in.readBoolean();
+        script = in.readBoolean();
+        discovery = in.readBoolean();
+        ingest = in.readBoolean();
+        adaptiveSelection = in.readBoolean();
     }
 
     /**
@@ -278,24 +296,6 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
     public NodesStatsRequest adaptiveSelection(boolean adaptiveSelection) {
         this.adaptiveSelection = adaptiveSelection;
         return this;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        indices = new CommonStatsFlags(in);
-        os = in.readBoolean();
-        process = in.readBoolean();
-        jvm = in.readBoolean();
-        threadPool = in.readBoolean();
-        fs = in.readBoolean();
-        transport = in.readBoolean();
-        http = in.readBoolean();
-        breaker = in.readBoolean();
-        script = in.readBoolean();
-        discovery = in.readBoolean();
-        ingest = in.readBoolean();
-        adaptiveSelection = in.readBoolean();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsResponse.java
@@ -34,7 +34,8 @@ import java.util.List;
 
 public class NodesStatsResponse extends BaseNodesResponse<NodeStats> implements ToXContentFragment {
 
-    NodesStatsResponse() {
+    public NodesStatsResponse(StreamInput in) throws IOException {
+        super(in);
     }
 
     public NodesStatsResponse(ClusterName clusterName, List<NodeStats> nodes, List<FailedNodeException> failures) {
@@ -43,7 +44,7 @@ public class NodesStatsResponse extends BaseNodesResponse<NodeStats> implements 
 
     @Override
     protected List<NodeStats> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(NodeStats::readNodeStats);
+        return in.readList(NodeStats::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
@@ -61,8 +61,8 @@ public class TransportNodesStatsAction extends TransportNodesAction<NodesStatsRe
     }
 
     @Override
-    protected NodeStats newNodeResponse() {
-        return new NodeStats();
+    protected NodeStats newNodeResponse(StreamInput in) throws IOException {
+        return new NodeStats(in);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
@@ -77,18 +77,13 @@ public class TransportNodesStatsAction extends TransportNodesAction<NodesStatsRe
 
         NodesStatsRequest request;
 
-        public NodeStatsRequest() {
+        public NodeStatsRequest(StreamInput in) throws IOException {
+            super(in);
+            request = new NodesStatsRequest(in);
         }
 
         NodeStatsRequest(NodesStatsRequest request) {
             this.request = request;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            request = new NodesStatsRequest();
-            request.readFrom(in);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodeUsage.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodeUsage.java
@@ -23,7 +23,6 @@ import org.elasticsearch.action.support.nodes.BaseNodeResponse;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -36,13 +35,11 @@ public class NodeUsage extends BaseNodeResponse implements ToXContentFragment {
     private long sinceTime;
     private Map<String, Long> restUsage;
 
-    NodeUsage() {
-    }
-
-    public static NodeUsage readNodeStats(StreamInput in) throws IOException {
-        NodeUsage nodeInfo = new NodeUsage();
-        nodeInfo.readFrom(in);
-        return nodeInfo;
+    public NodeUsage(StreamInput in) throws IOException {
+        super(in);
+        timestamp = in.readLong();
+        sinceTime = in.readLong();
+        restUsage = (Map<String, Long>) in.readGenericValue();
     }
 
     /**
@@ -94,15 +91,6 @@ public class NodeUsage extends BaseNodeResponse implements ToXContentFragment {
             builder.map(restUsage);
         }
         return builder;
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        timestamp = in.readLong();
-        sinceTime = in.readLong();
-        restUsage = (Map<String, Long>) in.readGenericValue();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodesUsageAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodesUsageAction.java
@@ -19,20 +19,14 @@
 
 package org.elasticsearch.action.admin.cluster.node.usage;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class NodesUsageAction extends StreamableResponseActionType<NodesUsageResponse> {
+public class NodesUsageAction extends ActionType<NodesUsageResponse> {
 
     public static final NodesUsageAction INSTANCE = new NodesUsageAction();
     public static final String NAME = "cluster:monitor/nodes/usage";
 
     protected NodesUsageAction() {
-        super(NAME);
+        super(NAME, NodesUsageResponse::new);
     }
-
-    @Override
-    public NodesUsageResponse newResponse() {
-        return new NodesUsageResponse();
-    }
-
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodesUsageRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodesUsageRequest.java
@@ -29,8 +29,9 @@ public class NodesUsageRequest extends BaseNodesRequest<NodesUsageRequest> {
 
     private boolean restActions;
 
-    public NodesUsageRequest() {
-        super();
+    public NodesUsageRequest(StreamInput in) throws IOException {
+        super(in);
+        this.restActions = in.readBoolean();
     }
 
     /**
@@ -70,12 +71,6 @@ public class NodesUsageRequest extends BaseNodesRequest<NodesUsageRequest> {
     public NodesUsageRequest restActions(boolean restActions) {
         this.restActions = restActions;
         return this;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        this.restActions = in.readBoolean();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodesUsageResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodesUsageResponse.java
@@ -38,7 +38,8 @@ import java.util.List;
  */
 public class NodesUsageResponse extends BaseNodesResponse<NodeUsage> implements ToXContentFragment {
 
-    NodesUsageResponse() {
+    public NodesUsageResponse(StreamInput in) throws IOException {
+        super(in);
     }
 
     public NodesUsageResponse(ClusterName clusterName, List<NodeUsage> nodes, List<FailedNodeException> failures) {
@@ -47,7 +48,7 @@ public class NodesUsageResponse extends BaseNodesResponse<NodeUsage> implements 
 
     @Override
     protected List<NodeUsage> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(NodeUsage::readNodeStats);
+        return in.readList(NodeUsage::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/TransportNodesUsageAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/TransportNodesUsageAction.java
@@ -59,8 +59,8 @@ public class TransportNodesUsageAction
     }
 
     @Override
-    protected NodeUsage newNodeResponse() {
-        return new NodeUsage();
+    protected NodeUsage newNodeResponse(StreamInput in) throws IOException {
+        return new NodeUsage(in);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/TransportNodesUsageAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/TransportNodesUsageAction.java
@@ -73,18 +73,13 @@ public class TransportNodesUsageAction
 
         NodesUsageRequest request;
 
-        public NodeUsageRequest() {
+        public NodeUsageRequest(StreamInput in) throws IOException {
+            super(in);
+            request = new NodesUsageRequest(in);
         }
 
         NodeUsageRequest(NodesUsageRequest request) {
             this.request = request;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            request = new NodesUsageRequest();
-            request.readFrom(in);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
@@ -123,7 +123,10 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<Transpor
 
         private Snapshot[] snapshots;
 
-        public Request() {
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            // This operation is never executed remotely
+            throw new UnsupportedOperationException("shouldn't be here");
         }
 
         public Request(String[] nodesIds) {
@@ -133,12 +136,6 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<Transpor
         public Request snapshots(Snapshot[] snapshots) {
             this.snapshots = snapshots;
             return this;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            // This operation is never executed remotely
-            throw new UnsupportedOperationException("shouldn't be here");
         }
 
         @Override
@@ -174,17 +171,13 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<Transpor
 
         private List<Snapshot> snapshots;
 
-        public NodeRequest() {
+        public NodeRequest(StreamInput in) throws IOException {
+            super(in);
+            snapshots = in.readList(Snapshot::new);
         }
 
         NodeRequest(TransportNodesSnapshotsStatus.Request request) {
             snapshots = Arrays.asList(request.snapshots);
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            snapshots = in.readList(Snapshot::new);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsAction.java
@@ -19,19 +19,14 @@
 
 package org.elasticsearch.action.admin.cluster.stats;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class ClusterStatsAction extends StreamableResponseActionType<ClusterStatsResponse> {
+public class ClusterStatsAction extends ActionType<ClusterStatsResponse> {
 
     public static final ClusterStatsAction INSTANCE = new ClusterStatsAction();
     public static final String NAME = "cluster:monitor/stats";
 
     private ClusterStatsAction() {
-        super(NAME);
-    }
-
-    @Override
-    public ClusterStatsResponse newResponse() {
-        return new ClusterStatsResponse();
+        super(NAME, ClusterStatsResponse::new);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodeResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodeResponse.java
@@ -38,7 +38,19 @@ public class ClusterStatsNodeResponse extends BaseNodeResponse {
     private ShardStats[] shardsStats;
     private ClusterHealthStatus clusterStatus;
 
-    ClusterStatsNodeResponse() {
+    public ClusterStatsNodeResponse(StreamInput in) throws IOException {
+        super(in);
+        clusterStatus = null;
+        if (in.readBoolean()) {
+            clusterStatus = ClusterHealthStatus.fromValue(in.readByte());
+        }
+        this.nodeInfo = new NodeInfo(in);
+        this.nodeStats = new NodeStats(in);
+        int size = in.readVInt();
+        shardsStats = new ShardStats[size];
+        for (int i = 0; i < size; i++) {
+            shardsStats[i] = ShardStats.readShardStats(in);
+        }
     }
 
     public ClusterStatsNodeResponse(DiscoveryNode node, @Nullable ClusterHealthStatus clusterStatus,
@@ -71,25 +83,7 @@ public class ClusterStatsNodeResponse extends BaseNodeResponse {
     }
 
     public static ClusterStatsNodeResponse readNodeResponse(StreamInput in) throws IOException {
-        ClusterStatsNodeResponse nodeResponse = new ClusterStatsNodeResponse();
-        nodeResponse.readFrom(in);
-        return nodeResponse;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        clusterStatus = null;
-        if (in.readBoolean()) {
-            clusterStatus = ClusterHealthStatus.fromValue(in.readByte());
-        }
-        this.nodeInfo = NodeInfo.readNodeInfo(in);
-        this.nodeStats = NodeStats.readNodeStats(in);
-        int size = in.readVInt();
-        shardsStats = new ShardStats[size];
-        for (int i = 0; i < size; i++) {
-            shardsStats[i] = ShardStats.readShardStats(in);
-        }
+        return new ClusterStatsNodeResponse(in);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsRequest.java
@@ -30,7 +30,8 @@ import java.io.IOException;
  */
 public class ClusterStatsRequest extends BaseNodesRequest<ClusterStatsRequest> {
 
-    public ClusterStatsRequest() {
+    public ClusterStatsRequest(StreamInput in) throws IOException {
+        super(in);
     }
 
     /**
@@ -39,11 +40,6 @@ public class ClusterStatsRequest extends BaseNodesRequest<ClusterStatsRequest> {
      */
     public ClusterStatsRequest(String... nodesIds) {
         super(nodesIds);
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsResponse.java
@@ -42,7 +42,11 @@ public class ClusterStatsResponse extends BaseNodesResponse<ClusterStatsNodeResp
     long timestamp;
     String clusterUUID;
 
-    ClusterStatsResponse() {
+    public ClusterStatsResponse(StreamInput in) throws IOException {
+        super(in);
+        timestamp = in.readVLong();
+        // it may be that the master switched on us while doing the operation. In this case the status may be null.
+        status = in.readOptionalWriteable(ClusterHealthStatus::readFrom);
     }
 
     public ClusterStatsResponse(long timestamp,
@@ -82,14 +86,6 @@ public class ClusterStatsResponse extends BaseNodesResponse<ClusterStatsNodeResp
 
     public ClusterStatsIndices getIndicesStats() {
         return indicesStats;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        timestamp = in.readVLong();
-        // it may be that the master switched on us while doing the operation. In this case the status may be null.
-        status = in.readOptionalWriteable(ClusterHealthStatus::readFrom);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -140,18 +140,14 @@ public class TransportClusterStatsAction extends TransportNodesAction<ClusterSta
 
         ClusterStatsRequest request;
 
-        public ClusterStatsNodeRequest() {
+        public ClusterStatsNodeRequest(StreamInput in) throws IOException {
+            super(in);
+            request = new ClusterStatsRequest();
+            request.readFrom(in);
         }
 
         ClusterStatsNodeRequest(ClusterStatsRequest request) {
             this.request = request;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            request = new ClusterStatsRequest();
-            request.readFrom(in);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -87,8 +87,8 @@ public class TransportClusterStatsAction extends TransportNodesAction<ClusterSta
     }
 
     @Override
-    protected ClusterStatsNodeResponse newNodeResponse() {
-        return new ClusterStatsNodeResponse();
+    protected ClusterStatsNodeResponse newNodeResponse(StreamInput in) throws IOException {
+        return new ClusterStatsNodeResponse(in);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -142,8 +142,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<ClusterSta
 
         public ClusterStatsNodeRequest(StreamInput in) throws IOException {
             super(in);
-            request = new ClusterStatsRequest();
-            request.readFrom(in);
+            request = new ClusterStatsRequest(in);
         }
 
         ClusterStatsNodeRequest(ClusterStatsRequest request) {

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodeRequest.java
@@ -31,12 +31,15 @@ public abstract class BaseNodeRequest extends TransportRequest {
 
     public BaseNodeRequest() {}
 
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
+    public BaseNodeRequest(StreamInput in) throws IOException {
         if (in.getVersion().before(Version.V_7_3_0)) {
             in.readString(); // previously nodeId
         }
+    }
+
+    @Override
+    public final void readFrom(StreamInput in) throws IOException {
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodeRequest.java
@@ -32,6 +32,7 @@ public abstract class BaseNodeRequest extends TransportRequest {
     public BaseNodeRequest() {}
 
     public BaseNodeRequest(StreamInput in) throws IOException {
+        super(in);
         if (in.getVersion().before(Version.V_7_3_0)) {
             in.readString(); // previously nodeId
         }

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodeResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodeResponse.java
@@ -33,7 +33,8 @@ public abstract class BaseNodeResponse extends TransportResponse {
 
     private DiscoveryNode node;
 
-    protected BaseNodeResponse() {
+    protected BaseNodeResponse(StreamInput in) throws IOException {
+        node = new DiscoveryNode(in);
     }
 
     protected BaseNodeResponse(DiscoveryNode node) {
@@ -49,9 +50,8 @@ public abstract class BaseNodeResponse extends TransportResponse {
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        node = new DiscoveryNode(in);
+    public final void readFrom(StreamInput in) throws IOException {
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodeResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodeResponse.java
@@ -34,6 +34,7 @@ public abstract class BaseNodeResponse extends TransportResponse {
     private DiscoveryNode node;
 
     protected BaseNodeResponse(StreamInput in) throws IOException {
+        super(in);
         node = new DiscoveryNode(in);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesRequest.java
@@ -50,8 +50,10 @@ public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>
 
     private TimeValue timeout;
 
-    protected BaseNodesRequest() {
-
+    protected BaseNodesRequest(StreamInput in) throws IOException {
+        nodesIds = in.readStringArray();
+        concreteNodes = in.readOptionalArray(DiscoveryNode::new, DiscoveryNode[]::new);
+        timeout = in.readOptionalTimeValue();
     }
 
     protected BaseNodesRequest(String... nodesIds) {
@@ -102,11 +104,8 @@ public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        nodesIds = in.readStringArray();
-        concreteNodes = in.readOptionalArray(DiscoveryNode::new, DiscoveryNode[]::new);
-        timeout = in.readOptionalTimeValue();
+    public final void readFrom(StreamInput in) throws IOException {
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesRequest.java
@@ -51,6 +51,7 @@ public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>
     private TimeValue timeout;
 
     protected BaseNodesRequest(StreamInput in) throws IOException {
+        super(in);
         nodesIds = in.readStringArray();
         concreteNodes = in.readOptionalArray(DiscoveryNode::new, DiscoveryNode[]::new);
         timeout = in.readOptionalTimeValue();

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesResponse.java
@@ -39,6 +39,7 @@ public abstract class BaseNodesResponse<TNodeResponse extends BaseNodeResponse> 
     private Map<String, TNodeResponse> nodesMap;
 
     protected BaseNodesResponse(StreamInput in) throws IOException {
+        super(in);
         clusterName = new ClusterName(in);
         nodes = readNodesFrom(in);
         failures = in.readList(FailedNodeException::new);

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesResponse.java
@@ -38,7 +38,10 @@ public abstract class BaseNodesResponse<TNodeResponse extends BaseNodeResponse> 
     private List<TNodeResponse> nodes;
     private Map<String, TNodeResponse> nodesMap;
 
-    protected BaseNodesResponse() {
+    protected BaseNodesResponse(StreamInput in) throws IOException {
+        clusterName = new ClusterName(in);
+        nodes = readNodesFrom(in);
+        failures = in.readList(FailedNodeException::new);
     }
 
     protected BaseNodesResponse(ClusterName clusterName, List<TNodeResponse> nodes, List<FailedNodeException> failures) {
@@ -101,11 +104,8 @@ public abstract class BaseNodesResponse<TNodeResponse extends BaseNodeResponse> 
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        clusterName = new ClusterName(in);
-        nodes = readNodesFrom(in);
-        failures = in.readList(FailedNodeException::new);
+    public final void readFrom(StreamInput in) throws IOException {
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.NodeShouldNotConnectException;
@@ -46,7 +47,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReferenceArray;
-import java.util.function.Supplier;
 
 public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest<NodesRequest>,
                                            NodesResponse extends BaseNodesResponse,
@@ -63,9 +63,9 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
 
     protected TransportNodesAction(String actionName, ThreadPool threadPool,
                                    ClusterService clusterService, TransportService transportService, ActionFilters actionFilters,
-                                   Supplier<NodesRequest> request, Supplier<NodeRequest> nodeRequest, String nodeExecutor,
+                                   Writeable.Reader<NodesRequest> request, Writeable.Reader<NodeRequest> nodeRequest, String nodeExecutor,
                                    Class<NodeResponse> nodeResponseClass) {
-        super(actionName, transportService, request, actionFilters);
+        super(actionName, transportService, actionFilters, request);
         this.threadPool = threadPool;
         this.clusterService = Objects.requireNonNull(clusterService);
         this.transportService = Objects.requireNonNull(transportService);
@@ -74,7 +74,7 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
         this.transportNodeAction = actionName + "[n]";
 
         transportService.registerRequestHandler(
-            transportNodeAction, nodeRequest, nodeExecutor, new NodeTransportHandler());
+            transportNodeAction, nodeExecutor, nodeRequest, new NodeTransportHandler());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -121,7 +121,7 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
 
     protected abstract NodeRequest newNodeRequest(NodesRequest request);
 
-    protected abstract NodeResponse newNodeResponse();
+    protected abstract NodeResponse newNodeResponse(StreamInput in) throws IOException;
 
     protected abstract NodeResponse nodeOperation(NodeRequest request, Task task);
 
@@ -179,9 +179,7 @@ public abstract class TransportNodesAction<NodesRequest extends BaseNodesRequest
                             new TransportResponseHandler<NodeResponse>() {
                                 @Override
                                 public NodeResponse read(StreamInput in) throws IOException {
-                                    NodeResponse nodeResponse = newNodeResponse();
-                                    nodeResponse.readFrom(in);
-                                    return nodeResponse;
+                                    return newNodeResponse(in);
                                 }
 
                                 @Override

--- a/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayMetaState.java
@@ -21,7 +21,6 @@ package org.elasticsearch.gateway;
 
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.FailedNodeException;
-import org.elasticsearch.action.StreamableResponseActionType;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.BaseNodeRequest;
 import org.elasticsearch.action.support.nodes.BaseNodeResponse;
@@ -48,12 +47,7 @@ public class TransportNodesListGatewayMetaState extends TransportNodesAction<Tra
                                                                              TransportNodesListGatewayMetaState.NodeGatewayMetaState> {
 
     public static final String ACTION_NAME = "internal:gateway/local/meta_state";
-    public static final ActionType<NodesGatewayMetaState> TYPE = new StreamableResponseActionType<>(ACTION_NAME) {
-        @Override
-        public NodesGatewayMetaState newResponse() {
-            return new NodesGatewayMetaState();
-        }
-    };
+    public static final ActionType<NodesGatewayMetaState> TYPE = new ActionType<>(ACTION_NAME, NodesGatewayMetaState::new);
 
     private final GatewayMetaState metaState;
 
@@ -71,8 +65,8 @@ public class TransportNodesListGatewayMetaState extends TransportNodesAction<Tra
     }
 
     @Override
-    protected NodeGatewayMetaState newNodeResponse() {
-        return new NodeGatewayMetaState();
+    protected NodeGatewayMetaState newNodeResponse(StreamInput in) throws IOException {
+        return new NodeGatewayMetaState(in);
     }
 
     @Override
@@ -97,7 +91,9 @@ public class TransportNodesListGatewayMetaState extends TransportNodesAction<Tra
 
     public static class NodesGatewayMetaState extends BaseNodesResponse<NodeGatewayMetaState> {
 
-        public NodesGatewayMetaState() {}
+        public NodesGatewayMetaState(StreamInput in) throws IOException {
+            super(in);
+        }
 
         public NodesGatewayMetaState(ClusterName clusterName, List<NodeGatewayMetaState> nodes, List<FailedNodeException> failures) {
             super(clusterName, nodes, failures);
@@ -105,7 +101,7 @@ public class TransportNodesListGatewayMetaState extends TransportNodesAction<Tra
 
         @Override
         protected List<NodeGatewayMetaState> readNodesFrom(StreamInput in) throws IOException {
-            return in.readStreamableList(NodeGatewayMetaState::new);
+            return in.readList(NodeGatewayMetaState::new);
         }
 
         @Override
@@ -121,7 +117,11 @@ public class TransportNodesListGatewayMetaState extends TransportNodesAction<Tra
 
         private MetaData metaData;
 
-        NodeGatewayMetaState() {
+        public NodeGatewayMetaState(StreamInput in) throws IOException {
+            super(in);
+            if (in.readBoolean()) {
+                metaData = MetaData.readFrom(in);
+            }
         }
 
         public NodeGatewayMetaState(DiscoveryNode node, MetaData metaData) {
@@ -131,14 +131,6 @@ public class TransportNodesListGatewayMetaState extends TransportNodesAction<Tra
 
         public MetaData metaData() {
             return metaData;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            if (in.readBoolean()) {
-                metaData = MetaData.readFrom(in);
-            }
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayMetaState.java
@@ -81,7 +81,8 @@ public class TransportNodesListGatewayMetaState extends TransportNodesAction<Tra
 
     public static class Request extends BaseNodesRequest<Request> {
 
-        public Request() {
+        public Request(StreamInput in) throws IOException {
+            super(in);
         }
 
         public Request(String... nodesIds) {
@@ -111,6 +112,10 @@ public class TransportNodesListGatewayMetaState extends TransportNodesAction<Tra
     }
 
     public static class NodeRequest extends BaseNodeRequest {
+        NodeRequest() {}
+        NodeRequest(StreamInput in) throws IOException {
+            super(in);
+        }
     }
 
     public static class NodeGatewayMetaState extends BaseNodeResponse {

--- a/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
+++ b/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
@@ -164,7 +164,9 @@ public class TransportNodesListGatewayStartedShards extends
 
         private ShardId shardId;
 
-        public Request() {
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            shardId = new ShardId(in);
         }
 
         public Request(ShardId shardId, DiscoveryNode[] nodes) {
@@ -175,12 +177,6 @@ public class TransportNodesListGatewayStartedShards extends
 
         public ShardId shardId() {
             return this.shardId;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            shardId = new ShardId(in);
         }
 
         @Override
@@ -217,17 +213,13 @@ public class TransportNodesListGatewayStartedShards extends
 
         private ShardId shardId;
 
-        public NodeRequest() {
+        public NodeRequest(StreamInput in) throws IOException {
+            super(in);
+            shardId = new ShardId(in);
         }
 
         public NodeRequest(Request request) {
             this.shardId = request.shardId();
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            shardId = new ShardId(in);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
@@ -23,7 +23,6 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.FailedNodeException;
-import org.elasticsearch.action.StreamableResponseActionType;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.BaseNodeRequest;
 import org.elasticsearch.action.support.nodes.BaseNodeResponse;
@@ -65,12 +64,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
     TransportNodesListShardStoreMetaData.NodeStoreFilesMetaData> {
 
     public static final String ACTION_NAME = "internal:cluster/nodes/indices/shard/store";
-    public static final ActionType<NodesStoreFilesMetaData> TYPE = new StreamableResponseActionType<>(ACTION_NAME) {
-        @Override
-        public NodesStoreFilesMetaData newResponse() {
-            return new NodesStoreFilesMetaData();
-        }
-    };
+    public static final ActionType<NodesStoreFilesMetaData> TYPE = new ActionType<>(ACTION_NAME, NodesStoreFilesMetaData::new);
 
     private final Settings settings;
     private final IndicesService indicesService;
@@ -96,8 +90,8 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
     }
 
     @Override
-    protected NodeStoreFilesMetaData newNodeResponse() {
-        return new NodeStoreFilesMetaData();
+    protected NodeStoreFilesMetaData newNodeResponse(StreamInput in) throws IOException {
+        return new NodeStoreFilesMetaData(in);
     }
 
     @Override
@@ -267,7 +261,9 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
 
     public static class NodesStoreFilesMetaData extends BaseNodesResponse<NodeStoreFilesMetaData> {
 
-        public NodesStoreFilesMetaData() {}
+        public NodesStoreFilesMetaData(StreamInput in) throws IOException {
+            super(in);
+        }
 
         public NodesStoreFilesMetaData(ClusterName clusterName, List<NodeStoreFilesMetaData> nodes, List<FailedNodeException> failures) {
             super(clusterName, nodes, failures);
@@ -313,7 +309,9 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
 
         private StoreFilesMetaData storeFilesMetaData;
 
-        NodeStoreFilesMetaData() {
+        public NodeStoreFilesMetaData(StreamInput in) throws IOException {
+            super(in);
+            storeFilesMetaData = StoreFilesMetaData.readStoreFilesMetaData(in);
         }
 
         public NodeStoreFilesMetaData(DiscoveryNode node, StoreFilesMetaData storeFilesMetaData) {
@@ -326,15 +324,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
         }
 
         public static NodeStoreFilesMetaData readListShardStoreNodeOperationResponse(StreamInput in) throws IOException {
-            NodeStoreFilesMetaData resp = new NodeStoreFilesMetaData();
-            resp.readFrom(in);
-            return resp;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            storeFilesMetaData = StoreFilesMetaData.readStoreFilesMetaData(in);
+            return new NodeStoreFilesMetaData(in);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
@@ -238,18 +238,14 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
 
         private ShardId shardId;
 
-        public Request() {
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            shardId = new ShardId(in);
         }
 
         public Request(ShardId shardId, DiscoveryNode[] nodes) {
             super(nodes);
             this.shardId = shardId;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            shardId = new ShardId(in);
         }
 
         @Override
@@ -285,17 +281,13 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
 
         private ShardId shardId;
 
-        public NodeRequest() {
+        public NodeRequest(StreamInput in) throws IOException {
+            super(in);
+            shardId = new ShardId(in);
         }
 
         NodeRequest(TransportNodesListShardStoreMetaData.Request request) {
             this.shardId = request.shardId;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            shardId = new ShardId(in);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -58,7 +58,7 @@ public class NodeStatsTests extends ESTestCase {
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             nodeStats.writeTo(out);
             try (StreamInput in = out.bytes().streamInput()) {
-                NodeStats deserializedNodeStats = NodeStats.readNodeStats(in);
+                NodeStats deserializedNodeStats = new NodeStats(in);
                 assertEquals(nodeStats.getNode(), deserializedNodeStats.getNode());
                 assertEquals(nodeStats.getTimestamp(), deserializedNodeStats.getTimestamp());
                 if (nodeStats.getOs() == null) {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksTests.java
@@ -65,14 +65,13 @@ public class CancellableTasksTests extends TaskManagerTestCase {
             super();
         }
 
-        public CancellableNodeRequest(CancellableNodesRequest request) {
-            requestName = request.requestName;
+        public CancellableNodeRequest(StreamInput in) throws IOException {
+            super(in);
+            requestName = in.readString();
         }
 
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            requestName = in.readString();
+        public CancellableNodeRequest(CancellableNodesRequest request) {
+            requestName = request.requestName;
         }
 
         @Override
@@ -100,19 +99,14 @@ public class CancellableTasksTests extends TaskManagerTestCase {
     public static class CancellableNodesRequest extends BaseNodesRequest<CancellableNodesRequest> {
         private String requestName;
 
-        private CancellableNodesRequest() {
-            super();
+        private CancellableNodesRequest(StreamInput in) throws IOException {
+            super(in);
+            requestName = in.readString();
         }
 
         public CancellableNodesRequest(String requestName, String... nodesIds) {
             super(nodesIds);
             this.requestName = requestName;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            requestName = in.readString();
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
@@ -37,6 +37,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
@@ -61,7 +62,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
@@ -139,8 +139,8 @@ public abstract class TaskManagerTestCase extends ESTestCase {
             extends TransportNodesAction<NodesRequest, NodesResponse, NodeRequest, NodeResponse> {
 
         AbstractTestNodesAction(String actionName, ThreadPool threadPool,
-                                ClusterService clusterService, TransportService transportService, Supplier<NodesRequest> request,
-                                Supplier<NodeRequest> nodeRequest) {
+                                ClusterService clusterService, TransportService transportService, Writeable.Reader<NodesRequest> request,
+                                Writeable.Reader<NodeRequest> nodeRequest) {
             super(actionName, threadPool, clusterService, transportService,
                     new ActionFilters(new HashSet<>()),
                 request, nodeRequest, ThreadPool.Names.GENERIC, NodeResponse.class);

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
@@ -102,8 +102,8 @@ public abstract class TaskManagerTestCase extends ESTestCase {
 
     static class NodeResponse extends BaseNodeResponse {
 
-        protected NodeResponse() {
-            super();
+        protected NodeResponse(StreamInput in) throws IOException {
+            super(in);
         }
 
         protected NodeResponse(DiscoveryNode node) {
@@ -119,7 +119,7 @@ public abstract class TaskManagerTestCase extends ESTestCase {
 
         @Override
         protected List<NodeResponse> readNodesFrom(StreamInput in) throws IOException {
-            return in.readStreamableList(NodeResponse::new);
+            return in.readList(NodeResponse::new);
         }
 
         @Override
@@ -152,8 +152,8 @@ public abstract class TaskManagerTestCase extends ESTestCase {
         }
 
         @Override
-        protected NodeResponse newNodeResponse() {
-            return new NodeResponse();
+        protected NodeResponse newNodeResponse(StreamInput in) throws IOException {
+            return new NodeResponse(in);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TestTaskPlugin.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TestTaskPlugin.java
@@ -18,14 +18,13 @@
  */
 package org.elasticsearch.action.admin.cluster.node.tasks;
 
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.IndicesRequest;
-import org.elasticsearch.action.StreamableResponseActionType;
 import org.elasticsearch.action.TaskOperationFailure;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.BaseNodeRequest;
@@ -128,8 +127,8 @@ public class TestTaskPlugin extends Plugin implements ActionPlugin, NetworkPlugi
 
     public static class NodeResponse extends BaseNodeResponse {
 
-        protected NodeResponse() {
-            super();
+        public NodeResponse(StreamInput in) throws IOException {
+            super(in);
         }
 
         public NodeResponse(DiscoveryNode node) {
@@ -139,8 +138,8 @@ public class TestTaskPlugin extends Plugin implements ActionPlugin, NetworkPlugi
 
     public static class NodesResponse extends BaseNodesResponse<NodeResponse> implements ToXContentFragment {
 
-        NodesResponse() {
-
+        public NodesResponse(StreamInput in) throws IOException {
+            super(in);
         }
 
         public NodesResponse(ClusterName clusterName, List<NodeResponse> nodes, List<FailedNodeException> failures) {
@@ -149,7 +148,7 @@ public class TestTaskPlugin extends Plugin implements ActionPlugin, NetworkPlugi
 
         @Override
         protected List<NodeResponse> readNodesFrom(StreamInput in) throws IOException {
-            return in.readStreamableList(NodeResponse::new);
+            return in.readList(NodeResponse::new);
         }
 
         @Override
@@ -302,8 +301,8 @@ public class TestTaskPlugin extends Plugin implements ActionPlugin, NetworkPlugi
         }
 
         @Override
-        protected NodeResponse newNodeResponse() {
-            return new NodeResponse();
+        protected NodeResponse newNodeResponse(StreamInput in) throws IOException {
+            return new NodeResponse(in);
         }
 
         @Override
@@ -331,18 +330,13 @@ public class TestTaskPlugin extends Plugin implements ActionPlugin, NetworkPlugi
         }
     }
 
-    public static class TestTaskAction extends StreamableResponseActionType<NodesResponse> {
+    public static class TestTaskAction extends ActionType<NodesResponse> {
 
         public static final TestTaskAction INSTANCE = new TestTaskAction();
         public static final String NAME = "cluster:admin/tasks/test";
 
         private TestTaskAction() {
-            super(NAME);
-        }
-
-        @Override
-        public NodesResponse newResponse() {
-            return new NodesResponse();
+            super(NAME, NodesResponse::new);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TestTaskPlugin.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TestTaskPlugin.java
@@ -171,20 +171,15 @@ public class TestTaskPlugin extends Plugin implements ActionPlugin, NetworkPlugi
         protected String requestName;
         protected boolean shouldBlock;
 
-        public NodeRequest() {
-            super();
+        public NodeRequest(StreamInput in) throws IOException {
+            super(in);
+            requestName = in.readString();
+            shouldBlock = in.readBoolean();
         }
 
         public NodeRequest(NodesRequest request, boolean shouldBlock) {
             requestName = request.requestName;
             this.shouldBlock = shouldBlock;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            requestName = in.readString();
-            shouldBlock = in.readBoolean();
         }
 
         @Override
@@ -211,8 +206,12 @@ public class TestTaskPlugin extends Plugin implements ActionPlugin, NetworkPlugi
         private boolean shouldBlock = true;
         private boolean shouldFail = false;
 
-        NodesRequest() {
-            super();
+        NodesRequest(StreamInput in) throws IOException {
+            super(in);
+            requestName = in.readString();
+            shouldStoreResult = in.readBoolean();
+            shouldBlock = in.readBoolean();
+            shouldFail = in.readBoolean();
         }
 
         public NodesRequest(String requestName, String... nodesIds) {
@@ -243,15 +242,6 @@ public class TestTaskPlugin extends Plugin implements ActionPlugin, NetworkPlugi
 
         public boolean getShouldFail() {
             return shouldFail;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            requestName = in.readString();
-            shouldStoreResult = in.readBoolean();
-            shouldBlock = in.readBoolean();
-            shouldFail = in.readBoolean();
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
@@ -161,8 +161,8 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
         }
 
         @Override
-        protected NodeResponse newNodeResponse() {
-            return new NodeResponse();
+        protected NodeResponse newNodeResponse(StreamInput in) throws IOException {
+            return new NodeResponse(in);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
@@ -80,18 +80,13 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
     public static class NodeRequest extends BaseNodeRequest {
         protected String requestName;
 
-        public NodeRequest() {
-            super();
+        public NodeRequest(StreamInput in) throws IOException {
+            super(in);
+            requestName = in.readString();
         }
 
         public NodeRequest(NodesRequest request) {
             requestName = request.requestName;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            requestName = in.readString();
         }
 
         @Override
@@ -114,19 +109,14 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
     public static class NodesRequest extends BaseNodesRequest<NodesRequest> {
         private String requestName;
 
-        NodesRequest() {
-            super();
+        NodesRequest(StreamInput in) throws IOException {
+            super(in);
+            requestName = in.readString();
         }
 
         public NodesRequest(String requestName, String... nodesIds) {
             super(nodesIds);
             this.requestName = requestName;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            requestName = in.readString();
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/action/support/nodes/TransportNodesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/nodes/TransportNodesActionTests.java
@@ -57,6 +57,7 @@ import java.util.function.Supplier;
 
 import static org.elasticsearch.test.ClusterServiceUtils.createClusterService;
 import static org.elasticsearch.test.ClusterServiceUtils.setState;
+import static org.mockito.Mockito.mock;
 
 public class TransportNodesActionTests extends ESTestCase {
 
@@ -263,8 +264,8 @@ public class TransportNodesActionTests extends ESTestCase {
         }
 
         @Override
-        protected TestNodeResponse newNodeResponse() {
-            return new TestNodeResponse();
+        protected TestNodeResponse newNodeResponse(StreamInput in) throws IOException {
+            return new TestNodeResponse(in);
         }
 
         @Override
@@ -307,7 +308,7 @@ public class TransportNodesActionTests extends ESTestCase {
 
         @Override
         protected List<TestNodeResponse> readNodesFrom(StreamInput in) throws IOException {
-            return in.readStreamableList(TestNodeResponse::new);
+            return in.readList(TestNodeResponse::new);
         }
 
         @Override
@@ -318,8 +319,23 @@ public class TransportNodesActionTests extends ESTestCase {
 
     private static class TestNodeRequest extends BaseNodeRequest { }
 
-    private static class TestNodeResponse extends BaseNodeResponse { }
+    private static class TestNodeResponse extends BaseNodeResponse {
+        TestNodeResponse() {
+            super(mock(DiscoveryNode.class));
+        }
+        protected TestNodeResponse(StreamInput in) throws IOException {
+            super(in);
+        }
+    }
 
-    private static class OtherNodeResponse extends BaseNodeResponse { }
+    private static class OtherNodeResponse extends BaseNodeResponse {
+        OtherNodeResponse() {
+            super(mock(DiscoveryNode.class));
+        }
+
+        protected OtherNodeResponse(StreamInput in) throws IOException {
+            super(in);
+        }
+    }
 
 }

--- a/server/src/test/java/org/elasticsearch/action/support/nodes/TransportNodesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/nodes/TransportNodesActionTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.transport.CapturingTransport;
@@ -246,8 +247,8 @@ public class TransportNodesActionTests extends ESTestCase {
         extends TransportNodesAction<TestNodesRequest, TestNodesResponse, TestNodeRequest, TestNodeResponse> {
 
         TestTransportNodesAction(ThreadPool threadPool, ClusterService clusterService, TransportService
-                transportService, ActionFilters actionFilters, Supplier<TestNodesRequest> request,
-                                 Supplier<TestNodeRequest> nodeRequest, String nodeExecutor) {
+                transportService, ActionFilters actionFilters, Writeable.Reader<TestNodesRequest> request,
+                                 Writeable.Reader<TestNodeRequest> nodeRequest, String nodeExecutor) {
             super("indices:admin/test", threadPool, clusterService, transportService, actionFilters,
                 request, nodeRequest, nodeExecutor, TestNodeResponse.class);
         }
@@ -279,8 +280,8 @@ public class TransportNodesActionTests extends ESTestCase {
         extends TestTransportNodesAction {
 
         DataNodesOnlyTransportNodesAction(ThreadPool threadPool, ClusterService clusterService, TransportService
-            transportService, ActionFilters actionFilters, Supplier<TestNodesRequest> request,
-                                          Supplier<TestNodeRequest> nodeRequest, String nodeExecutor) {
+            transportService, ActionFilters actionFilters, Writeable.Reader<TestNodesRequest> request,
+                                          Writeable.Reader<TestNodeRequest> nodeRequest, String nodeExecutor) {
             super(threadPool, clusterService, transportService, actionFilters, request, nodeRequest, nodeExecutor);
         }
 
@@ -291,6 +292,9 @@ public class TransportNodesActionTests extends ESTestCase {
     }
 
     private static class TestNodesRequest extends BaseNodesRequest<TestNodesRequest> {
+        TestNodesRequest(StreamInput in) throws IOException {
+            super(in);
+        }
         TestNodesRequest(String... nodesIds) {
             super(nodesIds);
         }
@@ -317,7 +321,12 @@ public class TransportNodesActionTests extends ESTestCase {
         }
     }
 
-    private static class TestNodeRequest extends BaseNodeRequest { }
+    private static class TestNodeRequest extends BaseNodeRequest {
+        TestNodeRequest() {}
+        TestNodeRequest(StreamInput in) throws IOException {
+            super(in);
+        }
+    }
 
     private static class TestNodeResponse extends BaseNodeResponse {
         TestNodeResponse() {

--- a/server/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
+++ b/server/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
@@ -64,7 +64,7 @@ public class NodeInfoStreamingTests extends ESTestCase {
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             nodeInfo.writeTo(out);
             try (StreamInput in = out.bytes().streamInput()) {
-                NodeInfo readNodeInfo = NodeInfo.readNodeInfo(in);
+                NodeInfo readNodeInfo = new NodeInfo(in);
                 assertExpectedUnchanged(nodeInfo, readNodeInfo);
             }
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/NodesDeprecationCheckAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/NodesDeprecationCheckAction.java
@@ -35,16 +35,13 @@ public class NodesDeprecationCheckAction extends ActionType<NodesDeprecationChec
 
         NodesDeprecationCheckRequest request;
 
-        public NodeRequest() {}
-        public NodeRequest(NodesDeprecationCheckRequest request) {
-            this.request = request;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
+        public NodeRequest(StreamInput in) throws IOException {
+            super(in);
             request = new NodesDeprecationCheckRequest();
             request.readFrom(in);
+        }
+        public NodeRequest(NodesDeprecationCheckRequest request) {
+            this.request = request;
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/NodesDeprecationCheckAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/NodesDeprecationCheckAction.java
@@ -37,8 +37,7 @@ public class NodesDeprecationCheckAction extends ActionType<NodesDeprecationChec
 
         public NodeRequest(StreamInput in) throws IOException {
             super(in);
-            request = new NodesDeprecationCheckRequest();
-            request.readFrom(in);
+            request = new NodesDeprecationCheckRequest(in);
         }
         public NodeRequest(NodesDeprecationCheckRequest request) {
             this.request = request;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/NodesDeprecationCheckAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/NodesDeprecationCheckAction.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.core.deprecation;
 
 import org.elasticsearch.action.ActionType;
-import org.elasticsearch.action.StreamableResponseActionType;
 import org.elasticsearch.action.support.nodes.BaseNodeRequest;
 import org.elasticsearch.action.support.nodes.BaseNodeResponse;
 import org.elasticsearch.action.support.nodes.NodesOperationRequestBuilder;
@@ -24,17 +23,12 @@ import java.util.Objects;
  * Runs deprecation checks on each node. Deprecation checks are performed locally so that filtered settings
  * can be accessed in the deprecation checks.
  */
-public class NodesDeprecationCheckAction extends StreamableResponseActionType<NodesDeprecationCheckResponse> {
+public class NodesDeprecationCheckAction extends ActionType<NodesDeprecationCheckResponse> {
     public static final NodesDeprecationCheckAction INSTANCE = new NodesDeprecationCheckAction();
     public static final String NAME = "cluster:admin/xpack/deprecation/nodes/info";
 
     private NodesDeprecationCheckAction() {
-        super(NAME);
-    }
-
-    @Override
-    public NodesDeprecationCheckResponse newResponse() {
-        return new NodesDeprecationCheckResponse();
+        super(NAME, NodesDeprecationCheckResponse::new);
     }
 
     public static class NodeRequest extends BaseNodeRequest {
@@ -63,8 +57,9 @@ public class NodesDeprecationCheckAction extends StreamableResponseActionType<No
     public static class NodeResponse extends BaseNodeResponse {
         private List<DeprecationIssue> deprecationIssues;
 
-        public NodeResponse() {
-            super();
+        public NodeResponse(StreamInput in) throws IOException {
+            super(in);
+            deprecationIssues = in.readList(DeprecationIssue::new);
         }
 
         public NodeResponse(DiscoveryNode node, List<DeprecationIssue> deprecationIssues) {
@@ -73,21 +68,9 @@ public class NodesDeprecationCheckAction extends StreamableResponseActionType<No
         }
 
         @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            deprecationIssues = in.readList(DeprecationIssue::new);
-        }
-
-        @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeList(this.deprecationIssues);
-        }
-
-        public static NodeResponse readNodeResponse(StreamInput in) throws IOException {
-            NodeResponse nodeResponse = new NodeResponse();
-            nodeResponse.readFrom(in);
-            return nodeResponse;
         }
 
         public List<DeprecationIssue> getDeprecationIssues() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/NodesDeprecationCheckRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/NodesDeprecationCheckRequest.java
@@ -15,15 +15,12 @@ import java.util.Arrays;
 import java.util.Objects;
 
 public class NodesDeprecationCheckRequest extends BaseNodesRequest<NodesDeprecationCheckRequest> {
-    public NodesDeprecationCheckRequest() {}
+    public NodesDeprecationCheckRequest(StreamInput in) throws IOException {
+        super(in);
+    }
 
     public NodesDeprecationCheckRequest(String... nodesIds) {
         super(nodesIds);
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/NodesDeprecationCheckResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/NodesDeprecationCheckResponse.java
@@ -18,7 +18,9 @@ import java.util.Objects;
 
 public class NodesDeprecationCheckResponse extends BaseNodesResponse<NodesDeprecationCheckAction.NodeResponse> {
 
-    public NodesDeprecationCheckResponse() {}
+    public NodesDeprecationCheckResponse(StreamInput in) throws IOException {
+        super(in);
+    }
 
     public NodesDeprecationCheckResponse(ClusterName clusterName,
                                          List<NodesDeprecationCheckAction.NodeResponse> nodes,
@@ -28,7 +30,7 @@ public class NodesDeprecationCheckResponse extends BaseNodesResponse<NodesDeprec
 
     @Override
     protected List<NodesDeprecationCheckAction.NodeResponse> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(NodesDeprecationCheckAction.NodeResponse::readNodeResponse);
+        return in.readList(NodesDeprecationCheckAction.NodeResponse::new);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/realm/ClearRealmCacheAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/realm/ClearRealmCacheAction.java
@@ -5,19 +5,14 @@
  */
 package org.elasticsearch.xpack.core.security.action.realm;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class ClearRealmCacheAction extends StreamableResponseActionType<ClearRealmCacheResponse> {
+public class ClearRealmCacheAction extends ActionType<ClearRealmCacheResponse> {
 
     public static final ClearRealmCacheAction INSTANCE = new ClearRealmCacheAction();
     public static final String NAME = "cluster:admin/xpack/security/realm/cache/clear";
 
     protected ClearRealmCacheAction() {
-        super(NAME);
-    }
-
-    @Override
-    public ClearRealmCacheResponse newResponse() {
-        return new ClearRealmCacheResponse();
+        super(NAME, ClearRealmCacheResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/realm/ClearRealmCacheRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/realm/ClearRealmCacheRequest.java
@@ -17,6 +17,17 @@ public class ClearRealmCacheRequest extends BaseNodesRequest<ClearRealmCacheRequ
     String[] realms;
     String[] usernames;
 
+
+    public ClearRealmCacheRequest() {
+        super((String[]) null);
+    }
+
+    public ClearRealmCacheRequest(StreamInput in) throws IOException {
+        super(in);
+        realms = in.readStringArray();
+        usernames = in.readStringArray();
+    }
+
     /**
      * @return  {@code true} if this request targets realms, {@code false} otherwise.
      */
@@ -68,13 +79,6 @@ public class ClearRealmCacheRequest extends BaseNodesRequest<ClearRealmCacheRequ
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        realms = in.readStringArray();
-        usernames = in.readStringArray();
-    }
-
-    @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeStringArrayNullable(realms);
@@ -86,7 +90,10 @@ public class ClearRealmCacheRequest extends BaseNodesRequest<ClearRealmCacheRequ
         private String[] realms;
         private String[] usernames;
 
-        public Node() {
+        public Node(StreamInput in) throws IOException {
+            super(in);
+            realms = in.readStringArray();
+            usernames = in.readStringArray();
         }
 
         public Node(ClearRealmCacheRequest request) {
@@ -95,13 +102,6 @@ public class ClearRealmCacheRequest extends BaseNodesRequest<ClearRealmCacheRequ
         }
         public String[] getRealms() { return realms; }
         public String[] getUsernames() { return usernames; }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            realms = in.readStringArray();
-            usernames = in.readStringArray();
-        }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/realm/ClearRealmCacheResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/realm/ClearRealmCacheResponse.java
@@ -22,7 +22,8 @@ import java.util.List;
 
 public class ClearRealmCacheResponse extends BaseNodesResponse<ClearRealmCacheResponse.Node> implements ToXContentFragment {
 
-    public ClearRealmCacheResponse() {
+    public ClearRealmCacheResponse(StreamInput in) throws IOException {
+        super(in);
     }
 
     public ClearRealmCacheResponse(ClusterName clusterName, List<Node> nodes, List<FailedNodeException> failures) {
@@ -31,7 +32,7 @@ public class ClearRealmCacheResponse extends BaseNodesResponse<ClearRealmCacheRe
 
     @Override
     protected List<ClearRealmCacheResponse.Node> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(Node::readNodeResponse);
+        return in.readList(Node::new);
     }
 
     @Override
@@ -67,17 +68,12 @@ public class ClearRealmCacheResponse extends BaseNodesResponse<ClearRealmCacheRe
 
     public static class Node extends BaseNodeResponse {
 
-        public Node() {
+        public Node(StreamInput in) throws IOException {
+            super(in);
         }
 
         public Node(DiscoveryNode node) {
             super(node);
-        }
-
-        public static Node readNodeResponse(StreamInput in) throws IOException {
-            Node node = new Node();
-            node.readFrom(in);
-            return node;
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/ClearRolesCacheAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/ClearRolesCacheAction.java
@@ -5,22 +5,17 @@
  */
 package org.elasticsearch.xpack.core.security.action.role;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * The action for clearing the cache used by native roles that are stored in an index.
  */
-public class ClearRolesCacheAction extends StreamableResponseActionType<ClearRolesCacheResponse> {
+public class ClearRolesCacheAction extends ActionType<ClearRolesCacheResponse> {
 
     public static final ClearRolesCacheAction INSTANCE = new ClearRolesCacheAction();
     public static final String NAME = "cluster:admin/xpack/security/roles/cache/clear";
 
     protected ClearRolesCacheAction() {
-        super(NAME);
-    }
-
-    @Override
-    public ClearRolesCacheResponse newResponse() {
-        return new ClearRolesCacheResponse();
+        super(NAME, ClearRolesCacheResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/ClearRolesCacheRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/ClearRolesCacheRequest.java
@@ -19,6 +19,14 @@ public class ClearRolesCacheRequest extends BaseNodesRequest<ClearRolesCacheRequ
 
     String[] names;
 
+    public ClearRolesCacheRequest() {
+        super((String[]) null);
+    }
+
+    public ClearRolesCacheRequest(StreamInput in) throws IOException {
+        super(in);
+        names = in.readOptionalStringArray();
+    }
     /**
      * Sets the roles for which caches will be evicted. When not set all the roles will be evicted from the cache.
      *
@@ -37,12 +45,6 @@ public class ClearRolesCacheRequest extends BaseNodesRequest<ClearRolesCacheRequ
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        names = in.readOptionalStringArray();
-    }
-
-    @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeOptionalStringArray(names);
@@ -51,7 +53,9 @@ public class ClearRolesCacheRequest extends BaseNodesRequest<ClearRolesCacheRequ
     public static class Node extends BaseNodeRequest {
         private String[] names;
 
-        public Node() {
+        public Node(StreamInput in) throws IOException {
+            super(in);
+            names = in.readOptionalStringArray();
         }
 
         public Node(ClearRolesCacheRequest request) {
@@ -59,12 +63,6 @@ public class ClearRolesCacheRequest extends BaseNodesRequest<ClearRolesCacheRequ
         }
 
         public String[] getNames() { return names; }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            names = in.readOptionalStringArray();
-        }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/ClearRolesCacheResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/ClearRolesCacheResponse.java
@@ -25,7 +25,8 @@ import java.util.List;
  */
 public class ClearRolesCacheResponse extends BaseNodesResponse<ClearRolesCacheResponse.Node> implements ToXContentFragment {
 
-    public ClearRolesCacheResponse() {
+    public ClearRolesCacheResponse(StreamInput in) throws IOException {
+        super(in);
     }
 
     public ClearRolesCacheResponse(ClusterName clusterName, List<Node> nodes, List<FailedNodeException> failures) {
@@ -34,7 +35,7 @@ public class ClearRolesCacheResponse extends BaseNodesResponse<ClearRolesCacheRe
 
     @Override
     protected List<ClearRolesCacheResponse.Node> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(Node::readNodeResponse);
+        return in.readList(Node::new);
     }
 
     @Override
@@ -70,17 +71,12 @@ public class ClearRolesCacheResponse extends BaseNodesResponse<ClearRolesCacheRe
 
     public static class Node extends BaseNodeResponse {
 
-        public Node() {
+        public Node(StreamInput in) throws IOException {
+            super(in);
         }
 
         public Node(DiscoveryNode node) {
             super(node);
-        }
-
-        public static Node readNodeResponse(StreamInput in) throws IOException {
-            Node node = new Node();
-            node.readFrom(in);
-            return node;
         }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/stats/WatcherStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/stats/WatcherStatsAction.java
@@ -5,22 +5,17 @@
  */
 package org.elasticsearch.xpack.core.watcher.transport.actions.stats;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * This ActionType gets the stats for the watcher plugin
  */
-public class WatcherStatsAction extends StreamableResponseActionType<WatcherStatsResponse> {
+public class WatcherStatsAction extends ActionType<WatcherStatsResponse> {
 
     public static final WatcherStatsAction INSTANCE = new WatcherStatsAction();
     public static final String NAME = "cluster:monitor/xpack/watcher/stats/dist";
 
     private WatcherStatsAction() {
-        super(NAME);
-    }
-
-    @Override
-    public WatcherStatsResponse newResponse() {
-        return new WatcherStatsResponse();
+        super(NAME, WatcherStatsResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/stats/WatcherStatsRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/stats/WatcherStatsRequest.java
@@ -23,6 +23,14 @@ public class WatcherStatsRequest extends BaseNodesRequest<WatcherStatsRequest> {
     private boolean includeStats;
 
     public WatcherStatsRequest() {
+        super((String[]) null);
+    }
+
+    public WatcherStatsRequest(StreamInput in) throws IOException {
+        super(in);
+        includeCurrentWatches = in.readBoolean();
+        includeQueuedWatches = in.readBoolean();
+        includeStats = in.readBoolean();
     }
 
     public boolean includeCurrentWatches() {
@@ -55,14 +63,6 @@ public class WatcherStatsRequest extends BaseNodesRequest<WatcherStatsRequest> {
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        includeCurrentWatches = in.readBoolean();
-        includeQueuedWatches = in.readBoolean();
-        includeStats = in.readBoolean();
-    }
-
-    @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeBoolean(includeCurrentWatches);
@@ -81,7 +81,12 @@ public class WatcherStatsRequest extends BaseNodesRequest<WatcherStatsRequest> {
         private boolean includeQueuedWatches;
         private boolean includeStats;
 
-        public Node() {}
+        public Node(StreamInput in) throws IOException {
+            super(in);
+            includeCurrentWatches = in.readBoolean();
+            includeQueuedWatches = in.readBoolean();
+            includeStats = in.readBoolean();
+        }
 
         public Node(WatcherStatsRequest request) {
             includeCurrentWatches = request.includeCurrentWatches();
@@ -99,14 +104,6 @@ public class WatcherStatsRequest extends BaseNodesRequest<WatcherStatsRequest> {
 
         public boolean includeStats() {
             return includeStats;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            includeCurrentWatches = in.readBoolean();
-            includeQueuedWatches = in.readBoolean();
-            includeStats = in.readBoolean();
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/stats/WatcherStatsResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/stats/WatcherStatsResponse.java
@@ -30,7 +30,9 @@ public class WatcherStatsResponse extends BaseNodesResponse<WatcherStatsResponse
 
     private WatcherMetaData watcherMetaData;
 
-    public WatcherStatsResponse() {
+    public WatcherStatsResponse(StreamInput in) throws IOException {
+        super(in);
+        watcherMetaData = new WatcherMetaData(in.readBoolean());
     }
 
     public WatcherStatsResponse(ClusterName clusterName, WatcherMetaData watcherMetaData,
@@ -46,14 +48,8 @@ public class WatcherStatsResponse extends BaseNodesResponse<WatcherStatsResponse
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        watcherMetaData = new WatcherMetaData(in.readBoolean());
-    }
-
-    @Override
     protected List<Node> readNodesFrom(StreamInput in) throws IOException {
-        return in.readList(Node::readNodeResponse);
+        return in.readList(Node::new);
     }
 
     @Override
@@ -96,7 +92,22 @@ public class WatcherStatsResponse extends BaseNodesResponse<WatcherStatsResponse
         private List<QueuedWatch> queuedWatches;
         private Counters stats;
 
-        public Node() {
+        public Node(StreamInput in) throws IOException {
+            super(in);
+            watchesCount = in.readLong();
+            threadPoolQueueSize = in.readLong();
+            threadPoolMaxSize = in.readLong();
+            watcherState = WatcherState.fromId(in.readByte());
+
+            if (in.readBoolean()) {
+                snapshots = in.readStreamableList(WatchExecutionSnapshot::new);
+            }
+            if (in.readBoolean()) {
+                queuedWatches = in.readStreamableList(QueuedWatch::new);
+            }
+            if (in.readBoolean()) {
+                stats = Counters.read(in);
+            }
         }
 
         public Node(DiscoveryNode node) {
@@ -174,25 +185,6 @@ public class WatcherStatsResponse extends BaseNodesResponse<WatcherStatsResponse
         }
 
         @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            watchesCount = in.readLong();
-            threadPoolQueueSize = in.readLong();
-            threadPoolMaxSize = in.readLong();
-            watcherState = WatcherState.fromId(in.readByte());
-
-            if (in.readBoolean()) {
-                snapshots = in.readStreamableList(WatchExecutionSnapshot::new);
-            }
-            if (in.readBoolean()) {
-                queuedWatches = in.readStreamableList(QueuedWatch::new);
-            }
-            if (in.readBoolean()) {
-                stats = Counters.read(in);
-            }
-        }
-
-        @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeLong(watchesCount);
@@ -246,13 +238,6 @@ public class WatcherStatsResponse extends BaseNodesResponse<WatcherStatsResponse
             }
             builder.endObject();
             return builder;
-        }
-
-        static WatcherStatsResponse.Node readNodeResponse(StreamInput in)
-                throws IOException {
-            WatcherStatsResponse.Node node = new WatcherStatsResponse.Node();
-            node.readFrom(in);
-            return node;
         }
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/deprecation/NodesDeprecationCheckRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/deprecation/NodesDeprecationCheckRequestTests.java
@@ -6,16 +6,17 @@
 
 package org.elasticsearch.xpack.core.deprecation;
 
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.io.IOException;
 
 public class NodesDeprecationCheckRequestTests
-    extends AbstractStreamableTestCase<NodesDeprecationCheckRequest> {
+    extends AbstractWireSerializingTestCase<NodesDeprecationCheckRequest> {
 
     @Override
-    protected NodesDeprecationCheckRequest createBlankInstance() {
-        return new NodesDeprecationCheckRequest();
+    protected Writeable.Reader<NodesDeprecationCheckRequest> instanceReader() {
+        return NodesDeprecationCheckRequest::new;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/deprecation/NodesDeprecationCheckResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/deprecation/NodesDeprecationCheckResponseTests.java
@@ -10,8 +10,9 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -21,11 +22,11 @@ import java.util.Collections;
 import java.util.List;
 
 public class NodesDeprecationCheckResponseTests
-    extends AbstractStreamableTestCase<NodesDeprecationCheckResponse> {
+    extends AbstractWireSerializingTestCase<NodesDeprecationCheckResponse> {
 
     @Override
-    protected NodesDeprecationCheckResponse createBlankInstance() {
-        return new NodesDeprecationCheckResponse();
+    protected Writeable.Reader<NodesDeprecationCheckResponse> instanceReader() {
+        return NodesDeprecationCheckResponse::new;
     }
 
     @Override

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckAction.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.tasks.Task;
@@ -22,6 +23,7 @@ import org.elasticsearch.xpack.core.deprecation.NodesDeprecationCheckAction;
 import org.elasticsearch.xpack.core.deprecation.NodesDeprecationCheckRequest;
 import org.elasticsearch.xpack.core.deprecation.NodesDeprecationCheckResponse;
 
+import java.io.IOException;
 import java.util.List;
 
 public class TransportNodeDeprecationCheckAction extends TransportNodesAction<NodesDeprecationCheckRequest,
@@ -58,8 +60,8 @@ public class TransportNodeDeprecationCheckAction extends TransportNodesAction<No
     }
 
     @Override
-    protected NodesDeprecationCheckAction.NodeResponse newNodeResponse() {
-        return new NodesDeprecationCheckAction.NodeResponse();
+    protected NodesDeprecationCheckAction.NodeResponse newNodeResponse(StreamInput in) throws IOException {
+        return new NodesDeprecationCheckAction.NodeResponse(in);
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/realm/TransportClearRealmCacheAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/realm/TransportClearRealmCacheAction.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -22,6 +23,7 @@ import org.elasticsearch.xpack.security.authc.AuthenticationService;
 import org.elasticsearch.xpack.security.authc.Realms;
 import org.elasticsearch.xpack.security.authc.support.CachingRealm;
 
+import java.io.IOException;
 import java.util.List;
 
 public class TransportClearRealmCacheAction extends TransportNodesAction<ClearRealmCacheRequest, ClearRealmCacheResponse,
@@ -52,8 +54,8 @@ public class TransportClearRealmCacheAction extends TransportNodesAction<ClearRe
     }
 
     @Override
-    protected ClearRealmCacheResponse.Node newNodeResponse() {
-        return new ClearRealmCacheResponse.Node();
+    protected ClearRealmCacheResponse.Node newNodeResponse(StreamInput in) throws IOException {
+        return new ClearRealmCacheResponse.Node(in);
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportClearRolesCacheAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportClearRolesCacheAction.java
@@ -10,6 +10,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -18,6 +19,7 @@ import org.elasticsearch.xpack.core.security.action.role.ClearRolesCacheRequest;
 import org.elasticsearch.xpack.core.security.action.role.ClearRolesCacheResponse;
 import org.elasticsearch.xpack.security.authz.store.CompositeRolesStore;
 
+import java.io.IOException;
 import java.util.List;
 
 public class TransportClearRolesCacheAction extends TransportNodesAction<ClearRolesCacheRequest, ClearRolesCacheResponse,
@@ -45,8 +47,8 @@ public class TransportClearRolesCacheAction extends TransportNodesAction<ClearRo
     }
 
     @Override
-    protected ClearRolesCacheResponse.Node newNodeResponse() {
-        return new ClearRolesCacheResponse.Node();
+    protected ClearRolesCacheResponse.Node newNodeResponse(StreamInput in) throws IOException {
+        return new ClearRolesCacheResponse.Node(in);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/SqlStatsAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/SqlStatsAction.java
@@ -6,20 +6,14 @@
 
 package org.elasticsearch.xpack.sql.plugin;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class SqlStatsAction extends StreamableResponseActionType<SqlStatsResponse> {
+public class SqlStatsAction extends ActionType<SqlStatsResponse> {
 
     public static final SqlStatsAction INSTANCE = new SqlStatsAction();
     public static final String NAME = "cluster:monitor/xpack/sql/stats/dist";
 
     private SqlStatsAction() {
-        super(NAME);
+        super(NAME, SqlStatsResponse::new);
     }
-
-    @Override
-    public SqlStatsResponse newResponse() {
-        return new SqlStatsResponse();
-    }
-
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/SqlStatsRequest.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/SqlStatsRequest.java
@@ -19,8 +19,14 @@ import java.io.IOException;
 public class SqlStatsRequest extends BaseNodesRequest<SqlStatsRequest> {
     
     private boolean includeStats;
-    
+
     public SqlStatsRequest() {
+        super((String[]) null);
+    }
+    
+    public SqlStatsRequest(StreamInput in) throws IOException {
+        super(in);
+        includeStats = in.readBoolean();
     }
     
     public boolean includeStats() {
@@ -29,12 +35,6 @@ public class SqlStatsRequest extends BaseNodesRequest<SqlStatsRequest> {
 
     public void includeStats(boolean includeStats) {
         this.includeStats = includeStats;
-    }
-    
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        includeStats = in.readBoolean();
     }
 
     @Override
@@ -51,7 +51,10 @@ public class SqlStatsRequest extends BaseNodesRequest<SqlStatsRequest> {
     static class NodeStatsRequest extends BaseNodeRequest {
         boolean includeStats;
         
-        NodeStatsRequest() {}
+        NodeStatsRequest(StreamInput in) throws IOException {
+            super(in);
+            includeStats = in.readBoolean();
+        }
 
         NodeStatsRequest(SqlStatsRequest request) {
             includeStats = request.includeStats();
@@ -59,12 +62,6 @@ public class SqlStatsRequest extends BaseNodesRequest<SqlStatsRequest> {
         
         public boolean includeStats() {
             return includeStats;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            includeStats = in.readBoolean();
         }
 
         @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/SqlStatsResponse.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/SqlStatsResponse.java
@@ -22,7 +22,8 @@ import java.util.List;
 
 public class SqlStatsResponse extends BaseNodesResponse<SqlStatsResponse.NodeStatsResponse> implements ToXContentObject {
     
-    public SqlStatsResponse() {
+    public SqlStatsResponse(StreamInput in) throws IOException {
+        super(in);
     }
     
     public SqlStatsResponse(ClusterName clusterName, List<NodeStatsResponse> nodes, List<FailedNodeException> failures) {
@@ -54,7 +55,11 @@ public class SqlStatsResponse extends BaseNodesResponse<SqlStatsResponse.NodeSta
         
         private Counters stats;
         
-        public NodeStatsResponse() {
+        public NodeStatsResponse(StreamInput in) throws IOException {
+            super(in);
+            if (in.readBoolean()) {
+                stats = Counters.read(in);
+            }
         }
 
         public NodeStatsResponse(DiscoveryNode node) {
@@ -67,14 +72,6 @@ public class SqlStatsResponse extends BaseNodesResponse<SqlStatsResponse.NodeSta
 
         public void setStats(Counters stats) {
             this.stats = stats;
-        }
-        
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            if (in.readBoolean()) {
-                stats = Counters.read(in);
-            }
         }
 
         @Override
@@ -97,9 +94,7 @@ public class SqlStatsResponse extends BaseNodesResponse<SqlStatsResponse.NodeSta
         }
         
         static SqlStatsResponse.NodeStatsResponse readNodeResponse(StreamInput in) throws IOException {
-            SqlStatsResponse.NodeStatsResponse node = new SqlStatsResponse.NodeStatsResponse();
-            node.readFrom(in);
-            return node;
+            return new SqlStatsResponse.NodeStatsResponse(in);
         }
 
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlStatsAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlStatsAction.java
@@ -10,11 +10,13 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.sql.execution.PlanExecutor;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -47,8 +49,8 @@ public class TransportSqlStatsAction extends TransportNodesAction<SqlStatsReques
     }
 
     @Override
-    protected SqlStatsResponse.NodeStatsResponse newNodeResponse() {
-        return new SqlStatsResponse.NodeStatsResponse();
+    protected SqlStatsResponse.NodeStatsResponse newNodeResponse(StreamInput in) throws IOException {
+        return new SqlStatsResponse.NodeStatsResponse(in);
     }
 
     @Override

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/stats/TransportWatcherStatsAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/stats/TransportWatcherStatsAction.java
@@ -10,6 +10,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -22,6 +23,7 @@ import org.elasticsearch.xpack.watcher.WatcherLifeCycleService;
 import org.elasticsearch.xpack.watcher.execution.ExecutionService;
 import org.elasticsearch.xpack.watcher.trigger.TriggerService;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -58,8 +60,8 @@ public class TransportWatcherStatsAction extends TransportNodesAction<WatcherSta
     }
 
     @Override
-    protected WatcherStatsResponse.Node newNodeResponse() {
-        return new WatcherStatsResponse.Node();
+    protected WatcherStatsResponse.Node newNodeResponse(StreamInput in) throws IOException {
+        return new WatcherStatsResponse.Node(in);
     }
 
     @Override


### PR DESCRIPTION
This commit converts all Request/Response classes associated with TransportNodesAction
classes to implement Writeable.Reader instead of Streamable.

relates #34389