### PR TITLE
Correct a formatting mistake in the _field_caps docs.

### DIFF
--- a/docs/reference/search/field-caps.asciidoc
+++ b/docs/reference/search/field-caps.asciidoc
@@ -70,8 +70,8 @@ GET _field_caps?fields=rating,title
 [source,js]
 --------------------------------------------------
 {
+    "indices": ["index1", "index2", "index3", "index4", "index5"],
     "fields": {
-        "indices": ["index1", "index2", "index3", "index4", "index5"],
         "rating": { <1>
             "long": {
                 "searchable": true,
@@ -122,8 +122,8 @@ some indices but not all:
 [source,js]
 --------------------------------------------------
 {
+    "indices": ["index1", "index2", "index3"],
     "fields": {
-        "indices": ["index1", "index2", "index3"],
         "rating": {
             "long": {
                 "searchable": true,


### PR DESCRIPTION
The 'indices' block that was recently added should appear in the top-level of
the response, as opposed to being nested under 'fields'.