### PR TITLE
Use specific version constant for wire bwc check

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/FindFileStructureAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/FindFileStructureAction.java
@@ -338,7 +338,7 @@ public class FindFileStructureAction extends StreamableResponseActionType<FindFi
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
             linesToSample = in.readOptionalVInt();
-            if (in.getVersion().onOrAfter(Version.CURRENT)) {
+            if (in.getVersion().onOrAfter(Version.V_7_3_0)) {
                 lineMergeSizeLimit = in.readOptionalVInt();
             }
             timeout = in.readOptionalTimeValue();
@@ -359,7 +359,7 @@ public class FindFileStructureAction extends StreamableResponseActionType<FindFi
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeOptionalVInt(linesToSample);
-            if (out.getVersion().onOrAfter(Version.CURRENT)) {
+            if (out.getVersion().onOrAfter(Version.V_7_3_0)) {
                 out.writeOptionalVInt(lineMergeSizeLimit);
             }
             out.writeOptionalTimeValue(timeout);


### PR DESCRIPTION
This commit modifies bwc behavior in FindFileStructureAction to check
against a concrete version instead of Version.CURRENT. Checking against
Version.CURRENT does not work since it is changing, in addition to it
having different meanings on each branch.

relates #42501