### PR TITLE
Avoid Needless Set Instantiation in InboundMessage

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/InboundMessage.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundMessage.java
@@ -104,7 +104,7 @@ public abstract class InboundMessage extends NetworkMessage implements Closeable
                     if (featuresFound.length == 0) {
                         features = Collections.emptySet();
                     } else {
-                        features = Collections.unmodifiableSet(new TreeSet<>(Arrays.asList(streamInput.readStringArray())));
+                        features = Collections.unmodifiableSet(new TreeSet<>(Arrays.asList(featuresFound)));
                     }
                     final String action = streamInput.readString();
                     message = new Request(threadContext, remoteVersion, status, requestId, action, features, streamInput);

--- a/server/src/main/java/org/elasticsearch/transport/InboundMessage.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundMessage.java
@@ -99,7 +99,13 @@ public abstract class InboundMessage extends NetworkMessage implements Closeable
 
                 InboundMessage message;
                 if (TransportStatus.isRequest(status)) {
-                    final Set<String> features = Collections.unmodifiableSet(new TreeSet<>(Arrays.asList(streamInput.readStringArray())));
+                    final String[] featuresFound = streamInput.readStringArray();
+                    final Set<String> features;
+                    if (featuresFound.length == 0) {
+                        features = Collections.emptySet();
+                    } else {
+                        features = Collections.unmodifiableSet(new TreeSet<>(Arrays.asList(streamInput.readStringArray())));
+                    }
                     final String action = streamInput.readString();
                     message = new Request(threadContext, remoteVersion, status, requestId, action, features, streamInput);
                 } else {


### PR DESCRIPTION
* When `features` is empty (when there's no xpack) we constantly and needless instantiated a few objects here for the empty set on every message
