### PR TITLE
Fix Incorrect Version in Migration Docs

### DIFF
--- a/docs/reference/migration/migrate_8_0/http.asciidoc
+++ b/docs/reference/migration/migrate_8_0/http.asciidoc
@@ -17,7 +17,7 @@ The `http.tcp_no_delay` setting was deprecated in 7.x and has been removed in 8.
 [float]
 ==== Changes to Encoding Plus Signs in URLs
 
-Starting in version 7.3, a `+` in a URL will be encoded as `%2B` by all REST API functionality. Prior versions handled a `+` as a single space.
+Starting in version 7.4, a `+` in a URL will be encoded as `%2B` by all REST API functionality. Prior versions handled a `+` as a single space.
 If your application requires handling `+` as a single space you can return to the old behaviour by setting the system property
 `es.rest.url_plus_as_space` to `true`. Note that this behaviour is deprecated and setting this system property to `true` will cease
 to be supported in version 8.


### PR DESCRIPTION
* This was accidentally left at `7.3` in #33164 but that PR was merged too late and it should now be `7.4`
