### PR TITLE
Remove non-SMILE Serialization from ChecksumBlobStoreFormat (#44278)

### DIFF
--- a/server/src/test/java/org/elasticsearch/snapshots/BlobStoreFormatIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/BlobStoreFormatIT.java
@@ -35,7 +35,6 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.translog.BufferedChecksumStreamOutput;
 import org.elasticsearch.repositories.blobstore.ChecksumBlobStoreFormat;
 import org.elasticsearch.snapshots.mockstore.BlobContainerWrapper;
@@ -110,24 +109,17 @@ public class BlobStoreFormatIT extends AbstractSnapshotIntegTestCase {
     public void testBlobStoreOperations() throws IOException {
         BlobStore blobStore = createTestBlobStore();
         BlobContainer blobContainer = blobStore.blobContainer(BlobPath.cleanPath());
-        ChecksumBlobStoreFormat<BlobObj> checksumJSON = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj::fromXContent,
-            xContentRegistry(), false, XContentType.JSON);
         ChecksumBlobStoreFormat<BlobObj> checksumSMILE = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj::fromXContent,
-            xContentRegistry(), false, XContentType.SMILE);
+            xContentRegistry(), false);
         ChecksumBlobStoreFormat<BlobObj> checksumSMILECompressed = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj::fromXContent,
-            xContentRegistry(), true, XContentType.SMILE);
+            xContentRegistry(), true);
 
         // Write blobs in different formats
-        checksumJSON.write(new BlobObj("checksum json"), blobContainer, "check-json");
         checksumSMILE.write(new BlobObj("checksum smile"), blobContainer, "check-smile");
         checksumSMILECompressed.write(new BlobObj("checksum smile compressed"), blobContainer, "check-smile-comp");
 
         // Assert that all checksum blobs can be read by all formats
-        assertEquals(checksumJSON.read(blobContainer, "check-json").getText(), "checksum json");
-        assertEquals(checksumSMILE.read(blobContainer, "check-json").getText(), "checksum json");
-        assertEquals(checksumJSON.read(blobContainer, "check-smile").getText(), "checksum smile");
         assertEquals(checksumSMILE.read(blobContainer, "check-smile").getText(), "checksum smile");
-        assertEquals(checksumJSON.read(blobContainer, "check-smile-comp").getText(), "checksum smile compressed");
         assertEquals(checksumSMILE.read(blobContainer, "check-smile-comp").getText(), "checksum smile compressed");
     }
 
@@ -139,9 +131,9 @@ public class BlobStoreFormatIT extends AbstractSnapshotIntegTestCase {
             veryRedundantText.append("Blah ");
         }
         ChecksumBlobStoreFormat<BlobObj> checksumFormat = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj::fromXContent,
-            xContentRegistry(), false, randomBoolean() ? XContentType.SMILE : XContentType.JSON);
+            xContentRegistry(), false);
         ChecksumBlobStoreFormat<BlobObj> checksumFormatComp = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj::fromXContent,
-            xContentRegistry(), true, randomBoolean() ? XContentType.SMILE : XContentType.JSON);
+            xContentRegistry(), true);
         BlobObj blobObj = new BlobObj(veryRedundantText.toString());
         checksumFormatComp.write(blobObj, blobContainer, "blob-comp");
         checksumFormat.write(blobObj, blobContainer, "blob-not-comp");
@@ -156,7 +148,7 @@ public class BlobStoreFormatIT extends AbstractSnapshotIntegTestCase {
         String testString = randomAlphaOfLength(randomInt(10000));
         BlobObj blobObj = new BlobObj(testString);
         ChecksumBlobStoreFormat<BlobObj> checksumFormat = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj::fromXContent,
-            xContentRegistry(), randomBoolean(), randomBoolean() ? XContentType.SMILE : XContentType.JSON);
+            xContentRegistry(), randomBoolean());
         checksumFormat.write(blobObj, blobContainer, "test-path");
         assertEquals(checksumFormat.read(blobContainer, "test-path").getText(), testString);
         randomCorruption(blobContainer, "test-path");
@@ -191,7 +183,7 @@ public class BlobStoreFormatIT extends AbstractSnapshotIntegTestCase {
             }
         };
         final ChecksumBlobStoreFormat<BlobObj> checksumFormat = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj::fromXContent,
-            xContentRegistry(), randomBoolean(), randomBoolean() ? XContentType.SMILE : XContentType.JSON);
+            xContentRegistry(), randomBoolean());
         ExecutorService threadPool = Executors.newFixedThreadPool(1);
         try {
             Future<Void> future = threadPool.submit(new Callable<Void>() {
@@ -215,7 +207,7 @@ public class BlobStoreFormatIT extends AbstractSnapshotIntegTestCase {
         final String name = randomAlphaOfLength(10);
         final BlobObj blobObj = new BlobObj("test");
         final ChecksumBlobStoreFormat<BlobObj> checksumFormat = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj::fromXContent,
-            xContentRegistry(), randomBoolean(), randomBoolean() ? XContentType.SMILE : XContentType.JSON);
+            xContentRegistry(), randomBoolean());
 
         final BlobStore blobStore = createTestBlobStore();
         final BlobContainer blobContainer = blobStore.blobContainer(BlobPath.cleanPath());


### PR DESCRIPTION
* At least all the way back to 6.x we never use anything but `SMILE` in
production code with this class so I removed the more general
constructor and removed the format leniency from the deserialization

backport of #44278 