### PR TITLE
Avoid Needless Set Instantiation in InboundMessage (#44318)

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/InboundMessage.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundMessage.java
@@ -101,7 +101,12 @@ public abstract class InboundMessage extends NetworkMessage implements Closeable
                 if (TransportStatus.isRequest(status)) {
                     final Set<String> features;
                     if (remoteVersion.onOrAfter(Version.V_6_3_0)) {
-                        features = Collections.unmodifiableSet(new TreeSet<>(Arrays.asList(streamInput.readStringArray())));
+                        final String[] featuresFound = streamInput.readStringArray();
+                        if (featuresFound.length == 0) {
+                            features = Collections.emptySet();
+                        } else {
+                            features = Collections.unmodifiableSet(new TreeSet<>(Arrays.asList(featuresFound)));
+                        }
                     } else {
                         features = Collections.emptySet();
                     }


### PR DESCRIPTION
* Avoid Needless Set Instantiation in InboundMessage

* When `features` is empty (when there's no xpack) we constantly and needless instantiated a few objects here for the empty set on every message

backport of #44318 