### PR TITLE
AnalyzeAction.Response doesn't need to call super.readFrom()

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeAction.java
@@ -301,7 +301,6 @@ public class AnalyzeAction extends ActionType<AnalyzeAction.Response> {
         }
 
         public Response(StreamInput in) throws IOException {
-            super.readFrom(in);
             if (in.getVersion().onOrAfter(Version.V_7_3_0)) {
                 AnalyzeToken[] tokenArray = in.readOptionalArray(AnalyzeToken::new, AnalyzeToken[]::new);
                 tokens = tokenArray != null ? Arrays.asList(tokenArray) : null;


### PR DESCRIPTION
The call to AnalyzeAction.Responses super.writeTo() method was removed in #44092, so the corresponding
contructor that reads from a stream shouldn't call super itself. This currently only works because its
implementation is empty.