### PR TITLE
Backporting Eclipse IDE fixes

### DIFF
--- a/server/src/test/java/org/elasticsearch/BuildTests.java
+++ b/server/src/test/java/org/elasticsearch/BuildTests.java
@@ -119,8 +119,9 @@ public class BuildTests extends ESTestCase {
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(new WriteableBuild(new Build(
                 randomFrom(Build.Flavor.values()), randomFrom(Build.Type.values()),
                 randomAlphaOfLength(6), randomAlphaOfLength(6), randomBoolean())),
-            b -> copyWriteable(b, writableRegistry(), WriteableBuild::new, Version.CURRENT),
-            b -> {
+        // Note: the cast of the Copy- and MutateFunction is needed for some IDE (specifically Eclipse 4.10.0) to infer the right type
+        (WriteableBuild b) -> copyWriteable(b, writableRegistry(), WriteableBuild::new, Version.CURRENT),
+        (WriteableBuild b) -> {
                 switch (randomIntBetween(1, 5)) {
                     case 1:
                         return new WriteableBuild(new Build(

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/QuerierTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/QuerierTests.java
@@ -75,7 +75,8 @@ public class QuerierTests extends ESTestCase {
         for (int j = 0; j < noColumns; j++) {
             boolean order = randomBoolean();
             ordering[j] = order;
-            tuples.add(new Tuple<>(j, order ? Comparator.naturalOrder() : Comparator.reverseOrder()));
+            Comparator comp = order ? Comparator.naturalOrder() : Comparator.reverseOrder();
+            tuples.add(new Tuple<>(j, comp));
         }
 
         // Insert random no of documents (rows) with random 0/1 values for each field


### PR DESCRIPTION
Backports two code changes needed for Eclipse IDEs compile for correct type
inference. These changes are already on the 7.x branches but haven't been
backported to 6.8 so far.