### PR TITLE
Fix varying responses for <index>/_analyze request

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
@@ -70,9 +70,9 @@ import org.elasticsearch.client.indices.GetFieldMappingsResponse;
 import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.client.indices.GetIndexResponse;
 import org.elasticsearch.client.indices.GetIndexTemplatesRequest;
+import org.elasticsearch.client.indices.GetIndexTemplatesResponse;
 import org.elasticsearch.client.indices.GetMappingsRequest;
 import org.elasticsearch.client.indices.GetMappingsResponse;
-import org.elasticsearch.client.indices.GetIndexTemplatesResponse;
 import org.elasticsearch.client.indices.IndexTemplateMetaData;
 import org.elasticsearch.client.indices.IndexTemplatesExistRequest;
 import org.elasticsearch.client.indices.PutIndexTemplateRequest;
@@ -2083,7 +2083,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                     "      \"type\": \"text\"\n" +
                     "    }\n" +
                     "  }\n" +
-                    "}", 
+                    "}",
                 XContentType.JSON);
             // end::put-template-request-mappings-json
             assertTrue(client.indices().putTemplate(request, RequestOptions.DEFAULT).isAcknowledged());
@@ -2098,7 +2098,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
                     message.put("type", "text");
                     properties.put("message", message);
                 }
-                jsonMap.put("properties", properties);                
+                jsonMap.put("properties", properties);
             }
             request.mapping(jsonMap); // <1>
             //end::put-template-request-mappings-map
@@ -2455,7 +2455,7 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
             DetailAnalyzeResponse detail = response.detail();                   // <1>
             // end::analyze-response-detail
 
-            assertNull(tokens);
+            assertEquals(0, tokens.size());
             assertNotNull(detail.tokenizer());
         }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeResponse.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -233,7 +234,7 @@ public class AnalyzeResponse extends ActionResponse implements Iterable<AnalyzeR
     }
 
     public List<AnalyzeToken> getTokens() {
-        return this.tokens;
+        return this.tokens != null ? this.tokens : Collections.emptyList();
     }
 
     public DetailAnalyzeResponse detail() {
@@ -253,6 +254,10 @@ public class AnalyzeResponse extends ActionResponse implements Iterable<AnalyzeR
             for (AnalyzeToken token : tokens) {
                 token.toXContent(builder, params);
             }
+            builder.endArray();
+        } else if (detail == null) {
+            // at least write an empty list
+            builder.startArray(Fields.TOKENS);
             builder.endArray();
         }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/DetailAnalyzeResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/DetailAnalyzeResponse.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.admin.indices.analyze;
 
 
+import org.elasticsearch.action.admin.indices.analyze.AnalyzeResponse.AnalyzeToken;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -284,7 +285,7 @@ public class DetailAnalyzeResponse implements Streamable, ToXContentFragment {
         }
 
         public AnalyzeResponse.AnalyzeToken[] getTokens() {
-            return tokens;
+            return tokens != null ? tokens : new AnalyzeToken[0];
         }
 
         public static AnalyzeTokenList readAnalyzeTokenList(StreamInput in) throws IOException {
@@ -296,8 +297,10 @@ public class DetailAnalyzeResponse implements Streamable, ToXContentFragment {
         XContentBuilder toXContentWithoutObject(XContentBuilder builder, Params params) throws IOException {
             builder.field(Fields.NAME, this.name);
             builder.startArray(AnalyzeResponse.Fields.TOKENS);
-            for (AnalyzeResponse.AnalyzeToken token : tokens) {
-                token.toXContent(builder, params);
+            if (tokens != null) {
+                for (AnalyzeResponse.AnalyzeToken token : tokens) {
+                    token.toXContent(builder, params);
+                }
             }
             builder.endArray();
             return builder;


### PR DESCRIPTION
Currently we loose information about whether a token list in an AnalyzeAction
response is null or an empty list, because we write a 0 value to the stream in
both cases and deserialize to a null value on the receiving side. This was fixed
in #44284 by a change in the serialization protocol starting in 7.3. However
this PR fixes the symptoms without changing the wire protocol which we cannot to
easily on 6.8 because we already released incompatible versions in the 7.x line.
This change adds special handling on xcontent output and if getToken() is
callled on either AnalyzeResponse or DetailedAnalyzeResponse to always return
empty lists instead of null values.

Relates to #44078