### PR TITLE
Enable XLint warnings for ML 

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlTasks.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlTasks.java
@@ -193,7 +193,7 @@ public final class MlTasks {
      * @param nodes The cluster nodes
      * @return Unallocated job tasks
      */
-    public static Collection<PersistentTasksCustomMetaData.PersistentTask> unallocatedJobTasks(
+    public static Collection<PersistentTasksCustomMetaData.PersistentTask<?>> unallocatedJobTasks(
             @Nullable PersistentTasksCustomMetaData tasks,
             DiscoveryNodes nodes) {
         if (tasks == null) {
@@ -247,7 +247,7 @@ public final class MlTasks {
      * @param nodes The cluster nodes
      * @return Unallocated datafeed tasks
      */
-    public static Collection<PersistentTasksCustomMetaData.PersistentTask> unallocatedDatafeedTasks(
+    public static Collection<PersistentTasksCustomMetaData.PersistentTask<?>> unallocatedDatafeedTasks(
             @Nullable PersistentTasksCustomMetaData tasks,
             DiscoveryNodes nodes) {
         if (tasks == null) {

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -46,9 +46,6 @@ bundlePlugin {
     exclude 'platform/licenses/**'
 }
 
-compileJava.options.compilerArgs << "-Xlint:-deprecation,-rawtypes,-serial,-try,-unchecked"
-compileTestJava.options.compilerArgs << "-Xlint:-deprecation,-rawtypes,-serial,-try,-unchecked"
-
 dependencies {
     compileOnly project(':modules:lang-painless:spi')
     compileOnly project(path: xpackModule('core'), configuration: 'default')

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlConfigMigrator.java
@@ -295,8 +295,8 @@ public class MlConfigMigrator {
                                                                             PersistentTasksCustomMetaData currentTasks,
                                                                             DiscoveryNodes nodes) {
 
-        Collection<PersistentTasksCustomMetaData.PersistentTask> unallocatedJobTasks = MlTasks.unallocatedJobTasks(currentTasks, nodes);
-        Collection<PersistentTasksCustomMetaData.PersistentTask> unallocatedDatafeedsTasks =
+        Collection<PersistentTasksCustomMetaData.PersistentTask<?>> unallocatedJobTasks = MlTasks.unallocatedJobTasks(currentTasks, nodes);
+        Collection<PersistentTasksCustomMetaData.PersistentTask<?>> unallocatedDatafeedsTasks =
                 MlTasks.unallocatedDatafeedTasks(currentTasks, nodes);
 
         if (unallocatedJobTasks.isEmpty() && unallocatedDatafeedsTasks.isEmpty()) {
@@ -305,7 +305,7 @@ public class MlConfigMigrator {
 
         PersistentTasksCustomMetaData.Builder taskBuilder = PersistentTasksCustomMetaData.builder(currentTasks);
 
-        for (PersistentTasksCustomMetaData.PersistentTask jobTask : unallocatedJobTasks) {
+        for (PersistentTasksCustomMetaData.PersistentTask<?> jobTask : unallocatedJobTasks) {
             OpenJobAction.JobParams originalParams = (OpenJobAction.JobParams) jobTask.getParams();
             if (originalParams.getJob() == null) {
                 Job job = jobs.get(originalParams.getJobId());
@@ -326,7 +326,7 @@ public class MlConfigMigrator {
             }
         }
 
-        for (PersistentTasksCustomMetaData.PersistentTask datafeedTask : unallocatedDatafeedsTasks) {
+        for (PersistentTasksCustomMetaData.PersistentTask<?> datafeedTask : unallocatedDatafeedsTasks) {
             StartDatafeedAction.DatafeedParams originalParams = (StartDatafeedAction.DatafeedParams) datafeedTask.getParams();
 
             if (originalParams.getJobId() == null) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateModelSnapshotAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateModelSnapshotAction.java
@@ -75,7 +75,7 @@ public class TransportUpdateModelSnapshotAction extends HandledTransportAction<U
         if (request.getRetain() != null) {
             updatedSnapshotBuilder.setRetain(request.getRetain());
         }
-        return new Result(target.index, updatedSnapshotBuilder.build());
+        return new Result<>(target.index, updatedSnapshotBuilder.build());
     }
 
     private void indexModelSnapshot(Result<ModelSnapshot> modelSnapshot, Consumer<Boolean> handler, Consumer<Exception> errorHandler) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/RollupDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/RollupDataExtractorFactory.java
@@ -117,7 +117,7 @@ public class RollupDataExtractorFactory implements DataExtractorFactory {
             );
             return;
         }
-        final List<ValuesSourceAggregationBuilder> flattenedAggs = new ArrayList<>();
+        final List<ValuesSourceAggregationBuilder<?, ?>> flattenedAggs = new ArrayList<>();
         flattenAggregations(datafeed.getParsedAggregations(xContentRegistry)
             .getAggregatorFactories(), datafeedHistogramAggregation, flattenedAggs);
 
@@ -148,7 +148,7 @@ public class RollupDataExtractorFactory implements DataExtractorFactory {
 
     private static void flattenAggregations(final Collection<AggregationBuilder> datafeedAggregations,
                                             final AggregationBuilder datafeedHistogramAggregation,
-                                            final List<ValuesSourceAggregationBuilder> flattenedAggregations) {
+                                            final List<ValuesSourceAggregationBuilder<?, ?>> flattenedAggregations) {
         for (AggregationBuilder aggregationBuilder : datafeedAggregations) {
             if (aggregationBuilder.equals(datafeedHistogramAggregation) == false) {
                 flattenedAggregations.add((ValuesSourceAggregationBuilder)aggregationBuilder);
@@ -157,8 +157,8 @@ public class RollupDataExtractorFactory implements DataExtractorFactory {
         }
     }
 
-    private static boolean hasAggregations(ParsedRollupCaps rollupCaps, List<ValuesSourceAggregationBuilder> datafeedAggregations) {
-        for (ValuesSourceAggregationBuilder aggregationBuilder : datafeedAggregations) {
+    private static boolean hasAggregations(ParsedRollupCaps rollupCaps, List<ValuesSourceAggregationBuilder<?,?>> datafeedAggregations) {
+        for (ValuesSourceAggregationBuilder<?,?> aggregationBuilder : datafeedAggregations) {
             String type = aggregationBuilder.getType();
             String field = aggregationBuilder.field();
             if (aggregationBuilder instanceof TermsAggregationBuilder) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsIndex.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsIndex.java
@@ -173,6 +173,7 @@ public final class DataFrameAnalyticsIndex {
         metadata.put(ANALYTICS, analyticsId);
     }
 
+    @SuppressWarnings("unchecked")
     private static <K, V> V getOrPutDefault(Map<K, Object> map, K key, Supplier<V> valueSupplier) {
         V value = (V) map.get(key);
         if (value == null) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoiner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoiner.java
@@ -104,7 +104,7 @@ class DataFrameRowsJoiner implements AutoCloseable {
     }
 
     private IndexRequest createIndexRequest(RowResults result, SearchHit hit) {
-        Map<String, Object> source = new LinkedHashMap(hit.getSourceAsMap());
+        Map<String, Object> source = new LinkedHashMap<>(hit.getSourceAsMap());
         source.putAll(result.getResults());
         IndexRequest indexRequest = new IndexRequest(hit.getIndex());
         indexRequest.id(hit.getId());

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/results/RowResults.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/results/RowResults.java
@@ -20,6 +20,7 @@ public class RowResults implements ToXContentObject {
     public static final ParseField CHECKSUM = new ParseField("checksum");
     public static final ParseField RESULTS = new ParseField("results");
 
+    @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<RowResults, Void> PARSER = new ConstructingObjectParser<>(TYPE.getPreferredName(),
             a -> new RowResults((Integer) a[0], (Map<String, Object>) a[1]));
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestDeleteJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestDeleteJobAction.java
@@ -73,10 +73,10 @@ public class RestDeleteJobAction extends BaseRestHandler {
     // We do not want to log anything due to a delete action
     // The response or error will be returned to the client when called synchronously
     // or it will be stored in the task result when called asynchronously
-    private static TaskListener nullTaskListener() {
-        return new TaskListener() {
+    private static <T> TaskListener<T> nullTaskListener() {
+        return new TaskListener<T>() {
             @Override
-            public void onResponse(Task task, Object o) {}
+            public void onResponse(Task task, T o) {}
 
             @Override
             public void onFailure(Task task, Throwable e) {}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSetTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSetTests.java
@@ -364,7 +364,7 @@ public class MachineLearningFeatureSetTests extends ESTestCase {
             jobListener.onResponse(
                     new QueryPage<>(jobs, jobs.size(), Job.RESULTS_FIELD));
             return Void.TYPE;
-        }).when(jobManager).expandJobs(eq(MetaData.ALL), eq(true), any(ActionListener.class));
+        }).when(jobManager).expandJobs(eq(MetaData.ALL), eq(true), any());
 
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportCloseJobActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportCloseJobActionTests.java
@@ -279,6 +279,7 @@ public class TransportCloseJobActionTests extends ESTestCase {
                 jobConfigProvider, datafeedConfigProvider);
     }
 
+    @SuppressWarnings("unchecked")
     private void mockDatafeedConfigFindDatafeeds(Set<String> datafeedIds) {
         doAnswer(invocation -> {
             ActionListener<Set<String>> listener = (ActionListener<Set<String>>) invocation.getArguments()[1];
@@ -288,6 +289,7 @@ public class TransportCloseJobActionTests extends ESTestCase {
         }).when(datafeedConfigProvider).findDatafeedsForJobIds(any(), any(ActionListener.class));
     }
 
+    @SuppressWarnings("unchecked")
     private void mockJobConfigProviderExpandIds(Set<String> expandedIds) {
         doAnswer(invocation -> {
             ActionListener<Set<String>> listener = (ActionListener<Set<String>>) invocation.getArguments()[3];

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionActionTests.java
@@ -42,7 +42,7 @@ public class TransportFinalizeJobExecutionActionTests extends ESTestCase {
     private Client client;
 
     @Before
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "rawtypes"})
     private void setupMocks() {
         ExecutorService executorService = mock(ExecutorService.class);
         threadPool = mock(ThreadPool.class);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedActionTests.java
@@ -45,6 +45,7 @@ public class TransportPreviewDatafeedActionTests extends ESTestCase {
     private Exception capturedFailure;
 
     @Before
+    @SuppressWarnings("unchecked")
     public void setUpTests() {
         dataExtractor = mock(DataExtractor.class);
         actionListener = mock(ActionListener.class);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilderTests.java
@@ -54,6 +54,7 @@ public class DatafeedJobBuilderTests extends ESTestCase {
     private DatafeedJobBuilder datafeedJobBuilder;
 
     @Before
+    @SuppressWarnings("unchecked")
     public void init() {
         client = mock(Client.class);
         ThreadPool threadPool = mock(ThreadPool.class);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManagerTests.java
@@ -428,13 +428,13 @@ public class DatafeedManagerTests extends ESTestCase {
         return builder;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     private static DatafeedTask createDatafeedTask(String datafeedId, long startTime, Long endTime) {
         DatafeedTask task = mock(DatafeedTask.class);
         when(task.getDatafeedId()).thenReturn(datafeedId);
         when(task.getDatafeedStartTime()).thenReturn(startTime);
         when(task.getEndTime()).thenReturn(endTime);
         doAnswer(invocationOnMock -> {
-            @SuppressWarnings("rawtypes")
             ActionListener listener = (ActionListener) invocationOnMock.getArguments()[1];
             listener.onResponse(mock(PersistentTask.class));
             return null;
@@ -447,10 +447,10 @@ public class DatafeedManagerTests extends ESTestCase {
         return mock(Consumer.class);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     private DatafeedTask spyDatafeedTask(DatafeedTask task) {
         task = spy(task);
         doAnswer(invocationOnMock -> {
-            @SuppressWarnings("rawtypes")
             ActionListener listener = (ActionListener) invocationOnMock.getArguments()[1];
             listener.onResponse(mock(PersistentTask.class));
             return null;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/DataExtractorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/DataExtractorFactoryTests.java
@@ -72,6 +72,7 @@ public class DataExtractorFactoryTests extends ESTestCase {
     }
 
     @Before
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public void setUpTests() {
         client = mock(Client.class);
         timingStatsReporter = mock(DatafeedTimingStatsReporter.class);
@@ -86,14 +87,12 @@ public class DataExtractorFactoryTests extends ESTestCase {
         when(getRollupIndexResponse.getJobs()).thenReturn(new HashMap<>());
 
         doAnswer(invocationMock -> {
-            @SuppressWarnings("raw_types")
             ActionListener listener = (ActionListener) invocationMock.getArguments()[2];
             listener.onResponse(fieldsCapabilities);
             return null;
         }).when(client).execute(same(FieldCapabilitiesAction.INSTANCE), any(), any());
 
         doAnswer(invocationMock -> {
-            @SuppressWarnings("raw_types")
             ActionListener listener = (ActionListener) invocationMock.getArguments()[2];
             listener.onResponse(getRollupIndexResponse);
             return null;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractorTests.java
@@ -126,6 +126,7 @@ public class ScrollDataExtractorTests extends ESTestCase {
     }
 
     @Before
+    @SuppressWarnings("unchecked")
     public void setUpTests() {
         ThreadPool threadPool = mock(ThreadPool.class);
         when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorTests.java
@@ -61,6 +61,7 @@ public class DataFrameDataExtractorTests extends ESTestCase {
     private ActionFuture<ClearScrollResponse> clearScrollFuture;
 
     @Before
+    @SuppressWarnings("unchecked")
     public void setUpTests() {
         ThreadPool threadPool = mock(ThreadPool.class);
         when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoinerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoinerTests.java
@@ -67,7 +67,7 @@ public class DataFrameRowsJoinerTests extends ESTestCase {
         String dataDoc = "{\"f_1\": \"foo\", \"f_2\": 42.0}";
         String[] dataValues = {"42.0"};
         DataFrameDataExtractor.Row row = newRow(newHit(dataDoc), dataValues, 1);
-        givenDataFrameBatches(Arrays.asList(row));
+        givenDataFrameBatches(Arrays.asList(Arrays.asList(row)));
 
         Map<String, Object> resultFields = new HashMap<>();
         resultFields.put("a", "1");
@@ -97,7 +97,7 @@ public class DataFrameRowsJoinerTests extends ESTestCase {
         IntStream.range(0, 1000).forEach(i -> firstBatch.add(newRow(newHit(dataDoc), dataValues, i)));
         List<DataFrameDataExtractor.Row> secondBatch = new ArrayList<>(1);
         secondBatch.add(newRow(newHit(dataDoc), dataValues, 1000));
-        givenDataFrameBatches(firstBatch, secondBatch);
+        givenDataFrameBatches(Arrays.asList(firstBatch, secondBatch));
 
         Map<String, Object> resultFields = new HashMap<>();
         resultFields.put("a", "1");
@@ -118,7 +118,7 @@ public class DataFrameRowsJoinerTests extends ESTestCase {
         String dataDoc = "{\"f_1\": \"foo\", \"f_2\": 42.0}";
         String[] dataValues = {"42.0"};
         DataFrameDataExtractor.Row row = newRow(newHit(dataDoc), dataValues, 1);
-        givenDataFrameBatches(Arrays.asList(row));
+        givenDataFrameBatches(Arrays.asList(Arrays.asList(row)));
 
         Map<String, Object> resultFields = new HashMap<>();
         resultFields.put("a", "1");
@@ -136,7 +136,7 @@ public class DataFrameRowsJoinerTests extends ESTestCase {
         String dataDoc = "{\"f_1\": \"foo\", \"f_2\": 42.0}";
         String[] dataValues = {"42.0"};
         DataFrameDataExtractor.Row normalRow = newRow(newHit(dataDoc), dataValues, 2);
-        givenDataFrameBatches(Arrays.asList(skippedRow, normalRow));
+        givenDataFrameBatches(Arrays.asList(Arrays.asList(skippedRow, normalRow)));
 
         Map<String, Object> resultFields = new HashMap<>();
         resultFields.put("a", "1");
@@ -166,7 +166,7 @@ public class DataFrameRowsJoinerTests extends ESTestCase {
         DataFrameDataExtractor.Row normalRow2 = newRow(newHit(dataDoc), dataValues, 2);
         DataFrameDataExtractor.Row skippedRow = newRow(newHit("{}"), null, 3);
         DataFrameDataExtractor.Row normalRow3 = newRow(newHit(dataDoc), dataValues, 4);
-        givenDataFrameBatches(Arrays.asList(normalRow1, normalRow2, skippedRow), Arrays.asList(normalRow3));
+        givenDataFrameBatches(Arrays.asList(Arrays.asList(normalRow1, normalRow2, skippedRow), Arrays.asList(normalRow3)));
 
         Map<String, Object> resultFields = new HashMap<>();
         resultFields.put("a", "1");
@@ -195,7 +195,7 @@ public class DataFrameRowsJoinerTests extends ESTestCase {
         String dataDoc = "{\"f_1\": \"foo\", \"f_2\": 42.0}";
         String[] dataValues = {"42.0"};
         DataFrameDataExtractor.Row row = newRow(newHit(dataDoc), dataValues, 1);
-        givenDataFrameBatches(Arrays.asList(row));
+        givenDataFrameBatches(Arrays.asList(Arrays.asList(row)));
 
         Map<String, Object> resultFields = new HashMap<>();
         resultFields.put("a", "1");
@@ -214,7 +214,7 @@ public class DataFrameRowsJoinerTests extends ESTestCase {
         String[] dataValues = {"42.0"};
         DataFrameDataExtractor.Row row1 = newRow(newHit(dataDoc), dataValues, 1);
         DataFrameDataExtractor.Row row2 = newRow(newHit(dataDoc), dataValues, 1);
-        givenDataFrameBatches(Arrays.asList(row1), Arrays.asList(row2));
+        givenDataFrameBatches(Arrays.asList(Arrays.asList(row1), Arrays.asList(row2)));
 
         givenProcessResults(Collections.emptyList());
 
@@ -229,8 +229,8 @@ public class DataFrameRowsJoinerTests extends ESTestCase {
         }
     }
 
-    private void givenDataFrameBatches(List<DataFrameDataExtractor.Row>... batches) throws IOException {
-        DelegateStubDataExtractor delegateStubDataExtractor = new DelegateStubDataExtractor(Arrays.asList(batches));
+    private void givenDataFrameBatches(List<List<DataFrameDataExtractor.Row>> batches) throws IOException {
+        DelegateStubDataExtractor delegateStubDataExtractor = new DelegateStubDataExtractor(batches);
         when(dataExtractor.hasNext()).thenAnswer(a -> delegateStubDataExtractor.hasNext());
         when(dataExtractor.next()).thenAnswer(a -> delegateStubDataExtractor.next());
     }
@@ -254,6 +254,7 @@ public class DataFrameRowsJoinerTests extends ESTestCase {
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         ThreadPool threadPool = mock(ThreadPool.class);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
+        @SuppressWarnings("unchecked")
         ActionFuture<BulkResponse> responseFuture = mock(ActionFuture.class);
         when(responseFuture.actionGet()).thenReturn(new BulkResponse(new BulkItemResponse[0], 0));
         when(client.execute(same(BulkAction.INSTANCE), bulkRequestCaptor.capture())).thenReturn(responseFuture);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/TooManyJobsIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/TooManyJobsIT.java
@@ -58,7 +58,7 @@ public class TooManyJobsIT extends BaseMlIntegTestCase {
         PersistentTasksCustomMetaData tasks = state.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
         assertEquals(1, tasks.taskMap().size());
         // now just double check that the first job is still opened:
-        PersistentTasksCustomMetaData.PersistentTask task = tasks.getTask(MlTasks.jobTaskId("close-failed-job-1"));
+        PersistentTasksCustomMetaData.PersistentTask<?> task = tasks.getTask(MlTasks.jobTaskId("close-failed-job-1"));
         assertEquals(JobState.OPENED, ((JobTaskState) task.getState()).getState());
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
@@ -323,6 +323,7 @@ public class JobManagerTests extends ESTestCase {
         Mockito.verifyNoMoreInteractions(auditor, updateJobProcessNotifier);
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public void testNotifyFilterChanged() throws IOException {
         Detector.Builder detectorReferencingFilter = new Detector.Builder("count", null);
         detectorReferencingFilter.setByFieldName("foo");
@@ -531,7 +532,7 @@ public class JobManagerTests extends ESTestCase {
                 ));
 
         ArgumentCaptor<UpdateParams> updateParamsCaptor = ArgumentCaptor.forClass(UpdateParams.class);
-        verify(updateJobProcessNotifier, times(2)).submitJobUpdate(updateParamsCaptor.capture(), any(ActionListener.class));
+        verify(updateJobProcessNotifier, times(2)).submitJobUpdate(updateParamsCaptor.capture(), any());
 
         List<UpdateParams> capturedUpdateParams = updateParamsCaptor.getAllValues();
         assertThat(capturedUpdateParams.size(), equalTo(2));
@@ -573,7 +574,7 @@ public class JobManagerTests extends ESTestCase {
                 ));
 
         ArgumentCaptor<UpdateParams> updateParamsCaptor = ArgumentCaptor.forClass(UpdateParams.class);
-        verify(updateJobProcessNotifier, times(2)).submitJobUpdate(updateParamsCaptor.capture(), any(ActionListener.class));
+        verify(updateJobProcessNotifier, times(2)).submitJobUpdate(updateParamsCaptor.capture(), any());
 
         List<UpdateParams> capturedUpdateParams = updateParamsCaptor.getAllValues();
         assertThat(capturedUpdateParams.size(), equalTo(2));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/BatchedDocumentsIteratorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/BatchedDocumentsIteratorTests.java
@@ -163,7 +163,7 @@ public class BatchedDocumentsIteratorTests extends ESTestCase {
             return this;
         }
 
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings({"unchecked", "rawtypes"})
         void finishMock() {
             if (batches.isEmpty()) {
                 givenInitialResponse();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleterTests.java
@@ -48,7 +48,7 @@ public class JobDataDeleterTests extends ESTestCase {
 
         ArgumentCaptor<DeleteByQueryRequest> deleteRequestCaptor = ArgumentCaptor.forClass(DeleteByQueryRequest.class);
         verify(client).threadPool();
-        verify(client).execute(eq(DeleteByQueryAction.INSTANCE), deleteRequestCaptor.capture(), any(ActionListener.class));
+        verify(client).execute(eq(DeleteByQueryAction.INSTANCE), deleteRequestCaptor.capture(), any());
         verifyNoMoreInteractions(client);
 
         DeleteByQueryRequest deleteRequest = deleteRequestCaptor.getValue();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
@@ -231,6 +231,7 @@ public class JobResultsPersisterTests extends ESTestCase {
         verifyNoMoreInteractions(client);
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public void testPersistDatafeedTimingStats() {
         Client client = mockClient(ArgumentCaptor.forClass(BulkRequest.class));
         doAnswer(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
@@ -263,7 +263,7 @@ public class JobResultsProviderTests extends ESTestCase {
 
         BucketsQueryBuilder bq = new BucketsQueryBuilder().from(from).size(size).anomalyScoreThreshold(1.0);
 
-        @SuppressWarnings({"unchecked"})
+        @SuppressWarnings({"unchecked", "rawtypes"})
         QueryPage<Bucket>[] holder = new QueryPage[1];
         provider.buckets(jobId, bq, r -> holder[0] = r, e -> {throw new RuntimeException(e);}, client);
         QueryPage<Bucket> buckets = holder[0];
@@ -297,7 +297,7 @@ public class JobResultsProviderTests extends ESTestCase {
         BucketsQueryBuilder bq = new BucketsQueryBuilder().from(from).size(size).anomalyScoreThreshold(5.1)
                 .includeInterim(true);
 
-        @SuppressWarnings({"unchecked"})
+        @SuppressWarnings({"unchecked", "rawtypes"})
         QueryPage<Bucket>[] holder = new QueryPage[1];
         provider.buckets(jobId, bq, r -> holder[0] = r, e -> {throw new RuntimeException(e);}, client);
         QueryPage<Bucket> buckets = holder[0];
@@ -333,7 +333,7 @@ public class JobResultsProviderTests extends ESTestCase {
         bq.anomalyScoreThreshold(5.1);
         bq.includeInterim(true);
 
-        @SuppressWarnings({"unchecked"})
+        @SuppressWarnings({"unchecked", "rawtypes"})
         QueryPage<Bucket>[] holder = new QueryPage[1];
         provider.buckets(jobId, bq, r -> holder[0] = r, e -> {throw new RuntimeException(e);}, client);
         QueryPage<Bucket> buckets = holder[0];
@@ -379,7 +379,7 @@ public class JobResultsProviderTests extends ESTestCase {
         BucketsQueryBuilder bq = new BucketsQueryBuilder();
         bq.timestamp(Long.toString(now.getTime()));
 
-        @SuppressWarnings({"unchecked"})
+        @SuppressWarnings({"unchecked", "rawtypes"})
         QueryPage<Bucket>[] bucketHolder = new QueryPage[1];
         provider.buckets(jobId, bq, q -> bucketHolder[0] = q, e -> {}, client);
         assertThat(bucketHolder[0].count(), equalTo(1L));
@@ -420,7 +420,7 @@ public class JobResultsProviderTests extends ESTestCase {
                 .epochEnd(String.valueOf(now.getTime())).includeInterim(true).sortField(sortfield)
                 .recordScore(2.2);
 
-        @SuppressWarnings({"unchecked"})
+        @SuppressWarnings({"unchecked", "rawtypes"})
         QueryPage<AnomalyRecord>[] holder = new QueryPage[1];
         provider.records(jobId, rqb, page -> holder[0] = page, RuntimeException::new, client);
         QueryPage<AnomalyRecord> recordPage = holder[0];
@@ -473,7 +473,7 @@ public class JobResultsProviderTests extends ESTestCase {
         rqb.sortField(sortfield);
         rqb.recordScore(2.2);
 
-        @SuppressWarnings({"unchecked"})
+        @SuppressWarnings({"unchecked", "rawtypes"})
         QueryPage<AnomalyRecord>[] holder = new QueryPage[1];
         provider.records(jobId, rqb, page -> holder[0] = page, RuntimeException::new, client);
         QueryPage<AnomalyRecord> recordPage = holder[0];
@@ -518,7 +518,7 @@ public class JobResultsProviderTests extends ESTestCase {
         Client client = getMockedClient(qb -> {}, response);
         JobResultsProvider provider = createProvider(client);
 
-        @SuppressWarnings({"unchecked"})
+        @SuppressWarnings({"unchecked", "rawtypes"})
         QueryPage<AnomalyRecord>[] holder = new QueryPage[1];
         provider.bucketRecords(jobId, bucket, from, size, true, sortfield, true, page -> holder[0] = page, RuntimeException::new,
                 client);
@@ -579,7 +579,7 @@ public class JobResultsProviderTests extends ESTestCase {
         Client client = getMockedClient(q -> {}, response);
 
         JobResultsProvider provider = createProvider(client);
-        @SuppressWarnings({"unchecked"})
+        @SuppressWarnings({"unchecked", "rawtypes"})
         QueryPage<CategoryDefinition>[] holder = new QueryPage[1];
         provider.categoryDefinitions(jobId, null, false, from, size, r -> holder[0] = r,
                 e -> {throw new RuntimeException(e);}, client);
@@ -601,7 +601,7 @@ public class JobResultsProviderTests extends ESTestCase {
         SearchResponse response = createSearchResponse(Collections.singletonList(source));
         Client client = getMockedClient(q -> {}, response);
         JobResultsProvider provider = createProvider(client);
-        @SuppressWarnings({"unchecked"})
+        @SuppressWarnings({"unchecked", "rawtypes"})
         QueryPage<CategoryDefinition>[] holder = new QueryPage[1];
         provider.categoryDefinitions(jobId, categoryId, false, null, null,
                 r -> holder[0] = r, e -> {throw new RuntimeException(e);}, client);
@@ -643,7 +643,7 @@ public class JobResultsProviderTests extends ESTestCase {
         Client client = getMockedClient(q -> qbHolder[0] = q, response);
         JobResultsProvider provider = createProvider(client);
 
-        @SuppressWarnings({"unchecked"})
+        @SuppressWarnings({"unchecked", "rawtypes"})
         QueryPage<Influencer>[] holder = new QueryPage[1];
         InfluencersQuery query = new InfluencersQueryBuilder().from(from).size(size).includeInterim(false).build();
         provider.influencers(jobId, query, page -> holder[0] = page, RuntimeException::new, client);
@@ -703,7 +703,7 @@ public class JobResultsProviderTests extends ESTestCase {
         Client client = getMockedClient(q -> qbHolder[0] = q, response);
         JobResultsProvider provider = createProvider(client);
 
-        @SuppressWarnings({"unchecked"})
+        @SuppressWarnings({"unchecked", "rawtypes"})
         QueryPage<Influencer>[] holder = new QueryPage[1];
         InfluencersQuery query = new InfluencersQueryBuilder().from(from).size(size).start("0").end("0").sortField("sort")
                 .sortDescending(true).influencerScoreThreshold(0.0).includeInterim(true).build();
@@ -758,7 +758,7 @@ public class JobResultsProviderTests extends ESTestCase {
         Client client = getMockedClient(qb -> {}, response);
         JobResultsProvider provider = createProvider(client);
 
-        @SuppressWarnings({"unchecked"})
+        @SuppressWarnings({"unchecked", "rawtypes"})
         QueryPage<ModelSnapshot>[] holder = new QueryPage[1];
         provider.modelSnapshots(jobId, from, size, r -> holder[0] = r, RuntimeException::new);
         QueryPage<ModelSnapshot> page = holder[0];
@@ -861,7 +861,7 @@ public class JobResultsProviderTests extends ESTestCase {
 
         verify(client).prepareSearch(indexName);
         verify(client).threadPool();
-        verify(client).search(any(SearchRequest.class), any(ActionListener.class));
+        verify(client).search(any(SearchRequest.class), any());
         verifyNoMoreInteractions(client);
     }
 
@@ -882,7 +882,7 @@ public class JobResultsProviderTests extends ESTestCase {
 
         verify(client).prepareSearch(indexName);
         verify(client).threadPool();
-        verify(client).search(any(SearchRequest.class), any(ActionListener.class));
+        verify(client).search(any(SearchRequest.class), any());
         verifyNoMoreInteractions(client);
     }
 
@@ -949,7 +949,7 @@ public class JobResultsProviderTests extends ESTestCase {
 
         verify(client).threadPool();
         verify(client).prepareMultiSearch();
-        verify(client).multiSearch(any(MultiSearchRequest.class), any(ActionListener.class));
+        verify(client).multiSearch(any(MultiSearchRequest.class), any());
         verify(client).prepareSearch(AnomalyDetectorsIndex.jobResultsAliasedName("foo"));
         verify(client).prepareSearch(AnomalyDetectorsIndex.jobResultsAliasedName("bar"));
         verifyNoMoreInteractions(client);
@@ -976,7 +976,7 @@ public class JobResultsProviderTests extends ESTestCase {
 
         verify(client).prepareSearch(indexName);
         verify(client).threadPool();
-        verify(client).search(any(SearchRequest.class), any(ActionListener.class));
+        verify(client).search(any(SearchRequest.class), any());
         verifyNoMoreInteractions(client);
     }
 
@@ -997,7 +997,7 @@ public class JobResultsProviderTests extends ESTestCase {
 
         verify(client).prepareSearch(indexName);
         verify(client).threadPool();
-        verify(client).search(any(SearchRequest.class), any(ActionListener.class));
+        verify(client).search(any(SearchRequest.class), any());
         verifyNoMoreInteractions(client);
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/MockClientBuilder.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/MockClientBuilder.java
@@ -168,6 +168,7 @@ public class MockClientBuilder {
         return this;
     }
 
+    @SuppressWarnings("unchecked")
     public MockClientBuilder get(GetResponse response) {
         doAnswer(new Answer<Void>() {
             @Override
@@ -401,6 +402,7 @@ public class MockClientBuilder {
         return this;
     }
 
+    @SuppressWarnings("unchecked")
     public MockClientBuilder preparePutMapping(AcknowledgedResponse response, String type) {
         PutMappingRequestBuilder requestBuilder = mock(PutMappingRequestBuilder.class);
         when(requestBuilder.setType(eq(type))).thenReturn(requestBuilder);
@@ -419,6 +421,7 @@ public class MockClientBuilder {
         return this;
     }
 
+    @SuppressWarnings("unchecked")
     public MockClientBuilder prepareGetMapping(GetMappingsResponse response) {
         GetMappingsRequestBuilder builder = mock(GetMappingsRequestBuilder.class);
 
@@ -436,6 +439,7 @@ public class MockClientBuilder {
         return this;
     }
 
+    @SuppressWarnings("unchecked")
     public MockClientBuilder putTemplate(ArgumentCaptor<PutIndexTemplateRequest> requestCaptor) {
         doAnswer(new Answer<Void>() {
             @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/NativeAutodetectProcessTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/NativeAutodetectProcessTests.java
@@ -52,6 +52,7 @@ public class NativeAutodetectProcessTests extends ESTestCase {
         when(executorService.submit(any(Runnable.class))).thenReturn(mock(Future.class));
     }
 
+    @SuppressWarnings("unchecked")
     public void testProcessStartTime() throws Exception {
         InputStream logStream = mock(InputStream.class);
         when(logStream.read(new byte[1024])).thenReturn(-1);
@@ -73,6 +74,7 @@ public class NativeAutodetectProcessTests extends ESTestCase {
         }
     }
 
+    @SuppressWarnings("unchecked")
     public void testWriteRecord() throws IOException {
         InputStream logStream = mock(InputStream.class);
         when(logStream.read(new byte[1024])).thenReturn(-1);
@@ -108,6 +110,7 @@ public class NativeAutodetectProcessTests extends ESTestCase {
         }
     }
 
+    @SuppressWarnings("unchecked")
     public void testFlush() throws IOException {
         InputStream logStream = mock(InputStream.class);
         when(logStream.read(new byte[1024])).thenReturn(-1);
@@ -140,6 +143,7 @@ public class NativeAutodetectProcessTests extends ESTestCase {
         testWriteMessage(p -> p.persistState(), AutodetectControlMsgWriter.BACKGROUND_PERSIST_MESSAGE_CODE);
     }
 
+    @SuppressWarnings("unchecked")
     public void testConsumeAndCloseOutputStream() throws IOException {
         InputStream logStream = mock(InputStream.class);
         when(logStream.read(new byte[1024])).thenReturn(-1);
@@ -156,6 +160,7 @@ public class NativeAutodetectProcessTests extends ESTestCase {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private void testWriteMessage(CheckedConsumer<NativeAutodetectProcess> writeFunction, String expectedMessageCode) throws IOException {
         InputStream logStream = mock(InputStream.class);
         when(logStream.read(new byte[1024])).thenReturn(-1);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/CsvDataToProcessWriterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/CsvDataToProcessWriterTests.java
@@ -265,6 +265,7 @@ public class CsvDataToProcessWriterTests extends ESTestCase {
         verify(dataCountsReporter).finishReporting(any());
     }
 
+    @SuppressWarnings("unchecked")
     public void testWrite_EmptyInput() throws IOException {
         AnalysisConfig.Builder builder =
                 new AnalysisConfig.Builder(Collections.singletonList(new Detector.Builder("metric", "value").build()));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemoverTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemoverTests.java
@@ -86,6 +86,7 @@ public class AbstractExpiredJobDataRemoverTests extends ESTestCase {
         return searchResponse;
     }
 
+    @SuppressWarnings("unchecked")
     public void testRemoveGivenNoJobs() throws IOException {
         SearchResponse response = createSearchResponse(Collections.emptyList());
 
@@ -102,7 +103,7 @@ public class AbstractExpiredJobDataRemoverTests extends ESTestCase {
         assertEquals(remover.getRetentionDaysCallCount, 0);
     }
 
-
+    @SuppressWarnings("unchecked")
     public void testRemoveGivenMulipleBatches() throws IOException {
         // This is testing AbstractExpiredJobDataRemover.WrappedBatchedJobsIterator
         int totalHits = 7;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/ExpiredModelSnapshotsRemoverTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/ExpiredModelSnapshotsRemoverTests.java
@@ -192,6 +192,7 @@ public class ExpiredModelSnapshotsRemoverTests extends ESTestCase {
         assertThat(deleteSnapshotRequest.getSnapshotId(), equalTo("snapshots-1_1"));
     }
 
+    @SuppressWarnings("unchecked")
     private void givenJobs(List<Job> jobs) throws IOException {
         SearchResponse response = AbstractExpiredJobDataRemoverTests.createSearchResponse(jobs);
 
@@ -234,6 +235,7 @@ public class ExpiredModelSnapshotsRemoverTests extends ESTestCase {
         givenClientRequests(true, false);
     }
 
+    @SuppressWarnings("unchecked")
     private void givenClientRequests(boolean shouldSearchRequestsSucceed, boolean shouldDeleteSnapshotRequestsSucceed) {
         doAnswer(new Answer<Void>() {
             int callCount = 0;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/ExpiredResultsRemoverTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/ExpiredResultsRemoverTests.java
@@ -46,6 +46,7 @@ public class ExpiredResultsRemoverTests extends ESTestCase {
     private ActionListener<Boolean> listener;
 
     @Before
+    @SuppressWarnings("unchecked")
     public void setUpTests() {
         capturedDeleteByQueryRequests = new ArrayList<>();
         client = mock(Client.class);
@@ -132,6 +133,7 @@ public class ExpiredResultsRemoverTests extends ESTestCase {
         givenClientRequests(false);
     }
 
+    @SuppressWarnings("unchecked")
     private void givenClientRequests(boolean shouldSucceed) {
         doAnswer(new Answer<Void>() {
             @Override
@@ -151,6 +153,7 @@ public class ExpiredResultsRemoverTests extends ESTestCase {
         }).when(client).execute(same(DeleteByQueryAction.INSTANCE), any(), any());
     }
 
+    @SuppressWarnings("unchecked")
     private void givenJobs(List<Job> jobs) throws IOException {
         SearchResponse response = AbstractExpiredJobDataRemoverTests.createSearchResponse(jobs);
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/MlMemoryTrackerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/MlMemoryTrackerTests.java
@@ -113,7 +113,7 @@ public class MlMemoryTrackerTests extends ESTestCase {
             Consumer<Long> listener = (Consumer<Long>) invocation.getArguments()[3];
             listener.accept(randomLongBetween(1000, 1000000));
             return null;
-        }).when(jobResultsProvider).getEstablishedMemoryUsage(anyString(), any(), any(), any(Consumer.class), any());
+        }).when(jobResultsProvider).getEstablishedMemoryUsage(anyString(), any(), any(), any(), any());
 
         memoryTracker.refresh(persistentTasks, ActionListener.wrap(aVoid -> {}, ESTestCase::assertNull));
 
@@ -122,7 +122,7 @@ public class MlMemoryTrackerTests extends ESTestCase {
                 String jobId = "job" + i;
                 verify(jobResultsProvider, times(1)).getEstablishedMemoryUsage(eq(jobId), any(), any(), any(), any());
             }
-            verify(configProvider, times(1)).getMultiple(eq(String.join(",", allIds)), eq(false), any(ActionListener.class));
+            verify(configProvider, times(1)).getMultiple(eq(String.join(",", allIds)), eq(false), any());
         } else {
             verify(jobResultsProvider, never()).getEstablishedMemoryUsage(anyString(), any(), any(), any(), any());
         }
@@ -154,7 +154,7 @@ public class MlMemoryTrackerTests extends ESTestCase {
             Consumer<Long> listener = (Consumer<Long>) invocation.getArguments()[3];
             listener.accept(randomLongBetween(1000, 1000000));
             return null;
-        }).when(jobResultsProvider).getEstablishedMemoryUsage(anyString(), any(), any(), any(Consumer.class), any());
+        }).when(jobResultsProvider).getEstablishedMemoryUsage(anyString(), any(), any(), any(), any());
 
         // First run a refresh using a component that calls the onFailure method of the listener
 
@@ -164,7 +164,7 @@ public class MlMemoryTrackerTests extends ESTestCase {
                 (ActionListener<List<DataFrameAnalyticsConfig>>) invocation.getArguments()[2];
             listener.onFailure(new IllegalArgumentException("computer says no"));
             return null;
-        }).when(configProvider).getMultiple(anyString(), anyBoolean(), any(ActionListener.class));
+        }).when(configProvider).getMultiple(anyString(), anyBoolean(), any());
 
         AtomicBoolean gotErrorResponse = new AtomicBoolean(false);
         memoryTracker.refresh(persistentTasks,
@@ -180,7 +180,7 @@ public class MlMemoryTrackerTests extends ESTestCase {
                 (ActionListener<List<DataFrameAnalyticsConfig>>) invocation.getArguments()[2];
             listener.onResponse(Collections.emptyList());
             return null;
-        }).when(configProvider).getMultiple(anyString(), anyBoolean(), any(ActionListener.class));
+        }).when(configProvider).getMultiple(anyString(), anyBoolean(), any());
 
         AtomicBoolean gotSuccessResponse = new AtomicBoolean(false);
         memoryTracker.refresh(persistentTasks,
@@ -206,7 +206,7 @@ public class MlMemoryTrackerTests extends ESTestCase {
             Consumer<Long> listener = (Consumer<Long>) invocation.getArguments()[3];
             listener.accept(haveEstablishedModelMemory ? modelBytes : 0L);
             return null;
-        }).when(jobResultsProvider).getEstablishedMemoryUsage(eq(jobId), any(), any(), any(Consumer.class), any());
+        }).when(jobResultsProvider).getEstablishedMemoryUsage(eq(jobId), any(), any(), any(), any());
 
         boolean simulateVeryOldJob = randomBoolean();
         long recentJobModelMemoryLimitMb = 2;
@@ -217,7 +217,7 @@ public class MlMemoryTrackerTests extends ESTestCase {
             ActionListener<Job> listener = (ActionListener<Job>) invocation.getArguments()[1];
             listener.onResponse(job);
             return null;
-        }).when(jobManager).getJob(eq(jobId), any(ActionListener.class));
+        }).when(jobManager).getJob(eq(jobId), any());
 
         AtomicReference<Long> refreshedMemoryRequirement = new AtomicReference<>();
         memoryTracker.refreshAnomalyDetectorJobMemory(jobId, ActionListener.wrap(refreshedMemoryRequirement::set, ESTestCase::assertNull));


### PR DESCRIPTION
Removes the warning suppression -Xlint:-deprecation,-rawtypes,-serial,-try,-unchecked.
Many warnings were unchecked warnings in the test code often because of the use of mocks.
These are suppressed with @SuppressWarning

Backport of #44285