### PR TITLE
Fix Exceptions in EventHandler#postHandling Breaking Select Loop

### DIFF
--- a/libs/nio/src/main/java/org/elasticsearch/nio/EventHandler.java
+++ b/libs/nio/src/main/java/org/elasticsearch/nio/EventHandler.java
@@ -180,9 +180,15 @@ public class EventHandler {
                 closeException(context, e);
             }
         } else {
-            SelectionKey selectionKey = context.getSelectionKey();
-            boolean currentlyWriteInterested = SelectionKeyUtils.isWriteInterested(selectionKey);
             boolean pendingWrites = context.readyForFlush();
+            SelectionKey selectionKey = context.getSelectionKey();
+            if (selectionKey == null) {
+                if (pendingWrites) {
+                    writeException(context, new IllegalStateException("Tried to write to an not yet registered channel"));
+                }
+                return;
+            }
+            boolean currentlyWriteInterested = SelectionKeyUtils.isWriteInterested(selectionKey);
             if (currentlyWriteInterested == false && pendingWrites) {
                 SelectionKeyUtils.setWriteInterested(selectionKey);
             } else if (currentlyWriteInterested && pendingWrites == false) {

--- a/libs/nio/src/main/java/org/elasticsearch/nio/NioSelector.java
+++ b/libs/nio/src/main/java/org/elasticsearch/nio/NioSelector.java
@@ -354,11 +354,7 @@ public class NioSelector implements Closeable {
             if (context.selectorShouldClose() == false) {
                 handleWrite(context);
             }
-            try {
-                eventHandler.postHandling(context);
-            } catch (Exception e) {
-                executeFailedListener(writeOperation.getListener(), e);
-            }
+            eventHandler.postHandling(context);
         }
     }
 

--- a/libs/nio/src/main/java/org/elasticsearch/nio/NioSelector.java
+++ b/libs/nio/src/main/java/org/elasticsearch/nio/NioSelector.java
@@ -354,7 +354,11 @@ public class NioSelector implements Closeable {
             if (context.selectorShouldClose() == false) {
                 handleWrite(context);
             }
-            eventHandler.postHandling(context);
+            try {
+                eventHandler.postHandling(context);
+            } catch (Exception e) {
+                executeFailedListener(writeOperation.getListener(), e);
+            }
         }
     }
 


### PR DESCRIPTION
* We can run into the `write` path for SSL channels when they are not fully registered (if registration fails and a close message is attempted to be written) and thus into NPEs from missing selection keys
  * This is a quick fix to quiet down tests, we should still track down how the exception in #44343 (the incorrect state on the SSL Engine came about)
  * The issue isn't new, it's just that before #43653 the NPE was thrown on the redundant OP_WRITE interest setting inside the `try` and now it happens only in the post handling so we saw the NPE. For now handling the `null` selection key and failing the write unless it went through right away should fix tests and bring the old behavior back. 
* Relates #44343
