### PR TITLE
Parse early access java versions

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/bootstrap/JavaVersion.java
+++ b/libs/core/src/main/java/org/elasticsearch/bootstrap/JavaVersion.java
@@ -45,12 +45,15 @@ public class JavaVersion implements Comparable<JavaVersion> {
     public static JavaVersion parse(String value) {
         Objects.requireNonNull(value);
         if (!isValid(value)) {
-            throw new IllegalArgumentException("value");
+            throw new IllegalArgumentException(value);
         }
 
         List<Integer> version = new ArrayList<>();
-        String[] components = value.split("\\.");
+        String[] components = value.split("[.-]");
         for (String component : components) {
+            if (component.equals("ea")) {
+                continue;
+            }
             version.add(Integer.valueOf(component));
         }
 
@@ -58,7 +61,7 @@ public class JavaVersion implements Comparable<JavaVersion> {
     }
 
     public static boolean isValid(String value) {
-        return value.matches("^0*[0-9]+(\\.[0-9]+)*$");
+        return value.matches("^0*[0-9]+(\\.[0-9]+)*(-ea)?$");
     }
 
     private static final JavaVersion CURRENT = parse(System.getProperty("java.specification.version"));

--- a/server/src/test/java/org/elasticsearch/bootstrap/JavaVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/JavaVersionTests.java
@@ -33,6 +33,7 @@ public class JavaVersionTests extends ESTestCase {
         assertThat(1, is(version.get(0)));
         assertThat(7, is(version.get(1)));
         assertThat(0, is(version.get(2)));
+        assertThat(13, is(JavaVersion.parse("13-ea").getVersion().get(0)));
     }
 
     public void testToString() {


### PR DESCRIPTION
We sometimes run with early access releases such as `13-ea` in CI.
Handle parsing these versions.

