### PR TITLE
[DOCS] Adds ml-cpp PRs to release notes

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.2.1>>
 * <<release-notes-7.2.0>>
 * <<release-notes-7.1.1>>
 * <<release-notes-7.1.0>>

--- a/docs/reference/release-notes/7.2.asciidoc
+++ b/docs/reference/release-notes/7.2.asciidoc
@@ -13,10 +13,7 @@ Machine Learning::
 * Don't persist model state at the end of lookback if the lookback did not
 generate any input {ml-pull}527[#527] (issue: {ml-issue}519[#519])
 * Don't write model size stats when job is closed without any input
-{ml-pull}516[#512] (issue: {ml-issue}394[#394])
-* Fix an edge case causing spurious anomalies (false positives) if the variance
-in the count of events changed significantly throughout the period of a seasonal
-quantity {ml-pull}489[#489]
+{ml-pull}516[#516] (issue: {ml-issue}394[#394])
 
 [[release-notes-7.2.0]]
 == {es} version 7.2.0

--- a/docs/reference/release-notes/7.2.asciidoc
+++ b/docs/reference/release-notes/7.2.asciidoc
@@ -1,3 +1,23 @@
+[[release-notes-7.2.1]]
+== {es} version 7.2.1
+
+coming[7.2.1]
+
+Also see <<breaking-changes-7.2,Breaking changes in 7.2>>.
+
+[discrete]
+[[bug-7.2.1]]
+=== Bug fixes
+
+Machine Learning::
+* Don't persist model state at the end of lookback if the lookback did not
+generate any input {ml-pull}527[#527] (issue: {ml-issue}519[#519])
+* Don't write model size stats when job is closed without any input
+{ml-pull}516[#512] (issue: {ml-issue}394[#394])
+* Fix an edge case causing spurious anomalies (false positives) if the variance
+in the count of events changed significantly throughout the period of a seasonal
+quantity {ml-pull}489[#489]
+
 [[release-notes-7.2.0]]
 == {es} version 7.2.0
 


### PR DESCRIPTION
Related to https://github.com/elastic/ml-cpp/pull/546

This PR adds machine learning PRs to the 7.2.1 release notes.