### PR TITLE
Convert core security actions to use writeable ActionType

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/security/hlrc/HasPrivilegesResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/security/hlrc/HasPrivilegesResponseTests.java
@@ -128,7 +128,8 @@ public class HasPrivilegesResponseTests extends AbstractResponseTestCase<
     }
 
     @Override
-    protected void assertInstances(org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse serverTestInstance, HasPrivilegesResponse hlrc) {
+    protected void assertInstances(org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse serverTestInstance,
+                                   HasPrivilegesResponse hlrc) {
         org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse other =
             new org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse(
                 hlrc.getUsername(),

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/security/hlrc/HasPrivilegesResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/security/hlrc/HasPrivilegesResponseTests.java
@@ -19,18 +19,15 @@
 
 package org.elasticsearch.client.security.hlrc;
 
-import org.elasticsearch.Version;
+import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.client.security.HasPrivilegesResponse;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.MapBuilder;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.client.AbstractHlrcStreamableXContentTestCase;
 import org.elasticsearch.xpack.core.security.authz.permission.ResourcePrivileges;
 import org.junit.Assert;
 
@@ -48,7 +45,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class HasPrivilegesResponseTests extends AbstractHlrcStreamableXContentTestCase<
+public class HasPrivilegesResponseTests extends AbstractResponseTestCase<
     org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse,
     HasPrivilegesResponse> {
 
@@ -85,58 +82,19 @@ public class HasPrivilegesResponseTests extends AbstractHlrcStreamableXContentTe
     }
 
     @Override
-    protected boolean supportsUnknownFields() {
-        // Because we have nested objects with { string : boolean }, unknown fields cause parsing problems
-        return false;
-    }
-
-    @Override
-    protected org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse createBlankInstance() {
-        return new org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse();
-    }
-
-    @Override
-    protected org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse createTestInstance() {
+    protected org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse createServerTestInstance() {
         return randomResponse();
     }
 
     @Override
-    public HasPrivilegesResponse doHlrcParseInstance(XContentParser parser) throws IOException {
+    protected HasPrivilegesResponse doParseToClientInstance(XContentParser parser) throws IOException {
         return HasPrivilegesResponse.fromXContent(parser);
-    }
-
-    @Override
-    public org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse convertHlrcToInternal(HasPrivilegesResponse hlrc) {
-        return new org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse(
-            hlrc.getUsername(),
-            hlrc.hasAllRequested(),
-            hlrc.getClusterPrivileges(),
-            toResourcePrivileges(hlrc.getIndexPrivileges()),
-            hlrc.getApplicationPrivileges().entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> toResourcePrivileges(e.getValue())))
-            );
     }
 
     private static List<ResourcePrivileges> toResourcePrivileges(Map<String, Map<String, Boolean>> map) {
         return map.entrySet().stream()
             .map(e -> ResourcePrivileges.builder(e.getKey()).addPrivileges(e.getValue()).build())
             .collect(Collectors.toList());
-    }
-
-    private org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse serializeAndDeserialize(
-        org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse original, Version version) throws IOException {
-        logger.info("Test serialize/deserialize with version {}", version);
-        final BytesStreamOutput out = new BytesStreamOutput();
-        out.setVersion(version);
-        original.writeTo(out);
-
-        final org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse copy =
-            new org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse();
-        final StreamInput in = out.bytes().streamInput();
-        in.setVersion(version);
-        copy.readFrom(in);
-        Assert.assertThat(in.read(), equalTo(-1));
-        return copy;
     }
 
     private org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse randomResponse() {
@@ -167,5 +125,19 @@ public class HasPrivilegesResponseTests extends AbstractHlrcStreamableXContentTe
             list.add(ResourcePrivileges.builder(resource).addPrivileges(privileges).build());
         }
         return list;
+    }
+
+    @Override
+    protected void assertInstances(org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse serverTestInstance, HasPrivilegesResponse hlrc) {
+        org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse other =
+            new org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse(
+                hlrc.getUsername(),
+                hlrc.hasAllRequested(),
+                hlrc.getClusterPrivileges(),
+                toResourcePrivileges(hlrc.getIndexPrivileges()),
+                hlrc.getApplicationPrivileges().entrySet().stream()
+                    .collect(Collectors.toMap(Map.Entry::getKey, e -> toResourcePrivileges(e.getValue())))
+        );
+        assertEquals(serverTestInstance, other);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/DeletePrivilegesAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/DeletePrivilegesAction.java
@@ -5,22 +5,17 @@
  */
 package org.elasticsearch.xpack.core.security.action.privilege;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * ActionType for deleting application privileges.
  */
-public final class DeletePrivilegesAction extends StreamableResponseActionType<DeletePrivilegesResponse> {
+public final class DeletePrivilegesAction extends ActionType<DeletePrivilegesResponse> {
 
     public static final DeletePrivilegesAction INSTANCE = new DeletePrivilegesAction();
     public static final String NAME = "cluster:admin/xpack/security/privilege/delete";
 
     private DeletePrivilegesAction() {
-        super(NAME);
-    }
-
-    @Override
-    public DeletePrivilegesResponse newResponse() {
-        return new DeletePrivilegesResponse();
+        super(NAME, DeletePrivilegesResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/DeletePrivilegesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/DeletePrivilegesResponse.java
@@ -24,7 +24,9 @@ public final class DeletePrivilegesResponse extends ActionResponse implements To
 
     private Set<String> found;
 
-    public DeletePrivilegesResponse() {
+    public DeletePrivilegesResponse(StreamInput in) throws IOException {
+        super(in);
+        this.found = Collections.unmodifiableSet(in.readSet(StreamInput::readString));
     }
 
     public DeletePrivilegesResponse(Collection<String> found) {
@@ -43,8 +45,7 @@ public final class DeletePrivilegesResponse extends ActionResponse implements To
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        this.found = Collections.unmodifiableSet(in.readSet(StreamInput::readString));
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/GetBuiltinPrivilegesAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/GetBuiltinPrivilegesAction.java
@@ -5,22 +5,17 @@
  */
 package org.elasticsearch.xpack.core.security.action.privilege;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * ActionType for retrieving builtin privileges from security
  */
-public final class GetBuiltinPrivilegesAction extends StreamableResponseActionType<GetBuiltinPrivilegesResponse> {
+public final class GetBuiltinPrivilegesAction extends ActionType<GetBuiltinPrivilegesResponse> {
 
     public static final GetBuiltinPrivilegesAction INSTANCE = new GetBuiltinPrivilegesAction();
     public static final String NAME = "cluster:admin/xpack/security/privilege/builtin/get";
 
     private GetBuiltinPrivilegesAction() {
-        super(NAME);
-    }
-
-    @Override
-    public GetBuiltinPrivilegesResponse newResponse() {
-        return new GetBuiltinPrivilegesResponse();
+        super(NAME, GetBuiltinPrivilegesResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/GetBuiltinPrivilegesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/GetBuiltinPrivilegesResponse.java
@@ -37,6 +37,12 @@ public final class GetBuiltinPrivilegesResponse extends ActionResponse {
         this(Collections.emptySet(), Collections.emptySet());
     }
 
+    public GetBuiltinPrivilegesResponse(StreamInput in) throws IOException {
+        super(in);
+        this.clusterPrivileges = in.readStringArray();
+        this.indexPrivileges = in.readStringArray();
+    }
+
     public String[] getClusterPrivileges() {
         return clusterPrivileges;
     }
@@ -47,9 +53,7 @@ public final class GetBuiltinPrivilegesResponse extends ActionResponse {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        this.clusterPrivileges = in.readStringArray();
-        this.indexPrivileges = in.readStringArray();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/GetPrivilegesAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/GetPrivilegesAction.java
@@ -5,22 +5,17 @@
  */
 package org.elasticsearch.xpack.core.security.action.privilege;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * ActionType for retrieving one or more application privileges from the security index
  */
-public final class GetPrivilegesAction extends StreamableResponseActionType<GetPrivilegesResponse> {
+public final class GetPrivilegesAction extends ActionType<GetPrivilegesResponse> {
 
     public static final GetPrivilegesAction INSTANCE = new GetPrivilegesAction();
     public static final String NAME = "cluster:admin/xpack/security/privilege/get";
 
     private GetPrivilegesAction() {
-        super(NAME);
-    }
-
-    @Override
-    public GetPrivilegesResponse newResponse() {
-        return new GetPrivilegesResponse();
+        super(NAME, GetPrivilegesResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/GetPrivilegesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/GetPrivilegesResponse.java
@@ -29,8 +29,9 @@ public final class GetPrivilegesResponse extends ActionResponse {
         this(privileges.toArray(new ApplicationPrivilegeDescriptor[0]));
     }
 
-    public GetPrivilegesResponse() {
-        this(new ApplicationPrivilegeDescriptor[0]);
+    public GetPrivilegesResponse(StreamInput in) throws IOException {
+        super(in);
+        this.privileges = in.readArray(ApplicationPrivilegeDescriptor::new, ApplicationPrivilegeDescriptor[]::new);
     }
 
     public ApplicationPrivilegeDescriptor[] privileges() {
@@ -39,8 +40,7 @@ public final class GetPrivilegesResponse extends ActionResponse {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        this.privileges = in.readArray(ApplicationPrivilegeDescriptor::new, ApplicationPrivilegeDescriptor[]::new);
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesAction.java
@@ -5,22 +5,17 @@
  */
 package org.elasticsearch.xpack.core.security.action.privilege;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * ActionType for putting (adding/updating) one or more application privileges.
  */
-public final class PutPrivilegesAction extends StreamableResponseActionType<PutPrivilegesResponse> {
+public final class PutPrivilegesAction extends ActionType<PutPrivilegesResponse> {
 
     public static final PutPrivilegesAction INSTANCE = new PutPrivilegesAction();
     public static final String NAME = "cluster:admin/xpack/security/privilege/put";
 
     private PutPrivilegesAction() {
-        super(NAME);
-    }
-
-    @Override
-    public PutPrivilegesResponse newResponse() {
-        return new PutPrivilegesResponse();
+        super(NAME, PutPrivilegesResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponse.java
@@ -24,8 +24,9 @@ public final class PutPrivilegesResponse extends ActionResponse implements ToXCo
 
     private Map<String, List<String>> created;
 
-    PutPrivilegesResponse() {
-        this(Collections.emptyMap());
+    public PutPrivilegesResponse(StreamInput in) throws IOException {
+        super(in);
+        this.created = Collections.unmodifiableMap(in.readMap(StreamInput::readString, StreamInput::readStringList));
     }
 
     public PutPrivilegesResponse(Map<String, List<String>> created) {
@@ -53,7 +54,6 @@ public final class PutPrivilegesResponse extends ActionResponse implements ToXCo
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        this.created = Collections.unmodifiableMap(in.readMap(StreamInput::readString, StreamInput::readStringList));
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/DeleteRoleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/DeleteRoleAction.java
@@ -5,23 +5,18 @@
  */
 package org.elasticsearch.xpack.core.security.action.role;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * ActionType for deleting a role from the security index
  */
-public class DeleteRoleAction extends StreamableResponseActionType<DeleteRoleResponse> {
+public class DeleteRoleAction extends ActionType<DeleteRoleResponse> {
 
     public static final DeleteRoleAction INSTANCE = new DeleteRoleAction();
     public static final String NAME = "cluster:admin/xpack/security/role/delete";
 
 
     protected DeleteRoleAction() {
-        super(NAME);
-    }
-
-    @Override
-    public DeleteRoleResponse newResponse() {
-        return new DeleteRoleResponse();
+        super(NAME, DeleteRoleResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/DeleteRoleResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/DeleteRoleResponse.java
@@ -20,7 +20,10 @@ public class DeleteRoleResponse extends ActionResponse implements ToXContentObje
 
     private boolean found = false;
 
-    public DeleteRoleResponse() {}
+    public DeleteRoleResponse(StreamInput in) throws IOException {
+        super(in);
+        found = in.readBoolean();
+    }
 
     public DeleteRoleResponse(boolean found) {
         this.found = found;
@@ -38,8 +41,7 @@ public class DeleteRoleResponse extends ActionResponse implements ToXContentObje
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        found = in.readBoolean();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/GetRolesAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/GetRolesAction.java
@@ -5,23 +5,18 @@
  */
 package org.elasticsearch.xpack.core.security.action.role;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * ActionType to retrieve a role from the security index
  */
-public class GetRolesAction extends StreamableResponseActionType<GetRolesResponse> {
+public class GetRolesAction extends ActionType<GetRolesResponse> {
 
     public static final GetRolesAction INSTANCE = new GetRolesAction();
     public static final String NAME = "cluster:admin/xpack/security/role/get";
 
 
     protected GetRolesAction() {
-        super(NAME);
-    }
-
-    @Override
-    public GetRolesResponse newResponse() {
-        return new GetRolesResponse();
+        super(NAME, GetRolesResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/GetRolesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/GetRolesResponse.java
@@ -19,6 +19,15 @@ public class GetRolesResponse extends ActionResponse {
 
     private RoleDescriptor[] roles;
 
+    public GetRolesResponse(StreamInput in) throws IOException {
+        super(in);
+        int size = in.readVInt();
+        roles = new RoleDescriptor[size];
+        for (int i = 0; i < size; i++) {
+            roles[i] = new RoleDescriptor(in);
+        }
+    }
+
     public GetRolesResponse(RoleDescriptor... roles) {
         this.roles = roles;
     }
@@ -33,12 +42,7 @@ public class GetRolesResponse extends ActionResponse {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        int size = in.readVInt();
-        roles = new RoleDescriptor[size];
-        for (int i = 0; i < size; i++) {
-            roles[i] = new RoleDescriptor(in);
-        }
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleAction.java
@@ -5,23 +5,18 @@
  */
 package org.elasticsearch.xpack.core.security.action.role;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * ActionType for adding a role to the security index
  */
-public class PutRoleAction extends StreamableResponseActionType<PutRoleResponse> {
+public class PutRoleAction extends ActionType<PutRoleResponse> {
 
     public static final PutRoleAction INSTANCE = new PutRoleAction();
     public static final String NAME = "cluster:admin/xpack/security/role/put";
 
 
     protected PutRoleAction() {
-        super(NAME);
-    }
-
-    @Override
-    public PutRoleResponse newResponse() {
-        return new PutRoleResponse();
+        super(NAME, PutRoleResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleResponse.java
@@ -21,7 +21,9 @@ public class PutRoleResponse extends ActionResponse implements ToXContentObject 
 
     private boolean created;
 
-    public PutRoleResponse() {
+    public PutRoleResponse(StreamInput in) throws IOException {
+        super(in);
+        this.created = in.readBoolean();
     }
     
     public PutRoleResponse(boolean created) {
@@ -45,7 +47,6 @@ public class PutRoleResponse extends ActionResponse implements ToXContentObject 
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        this.created = in.readBoolean();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/DeleteRoleMappingAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/DeleteRoleMappingAction.java
@@ -5,23 +5,18 @@
  */
 package org.elasticsearch.xpack.core.security.action.rolemapping;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * ActionType for deleting a role-mapping from the
  * org.elasticsearch.xpack.security.authc.support.mapper.NativeRoleMappingStore
  */
-public class DeleteRoleMappingAction extends StreamableResponseActionType<DeleteRoleMappingResponse> {
+public class DeleteRoleMappingAction extends ActionType<DeleteRoleMappingResponse> {
 
     public static final DeleteRoleMappingAction INSTANCE = new DeleteRoleMappingAction();
     public static final String NAME = "cluster:admin/xpack/security/role_mapping/delete";
 
     private DeleteRoleMappingAction() {
-        super(NAME);
-    }
-
-    @Override
-    public DeleteRoleMappingResponse newResponse() {
-        return new DeleteRoleMappingResponse();
+        super(NAME, DeleteRoleMappingResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/DeleteRoleMappingResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/DeleteRoleMappingResponse.java
@@ -21,10 +21,10 @@ public class DeleteRoleMappingResponse extends ActionResponse implements ToXCont
 
     private boolean found = false;
 
-    /**
-     * Package private for {@link DeleteRoleMappingAction#newResponse()}
-     */
-    public DeleteRoleMappingResponse() {}
+    public DeleteRoleMappingResponse(StreamInput in) throws IOException {
+        super(in);
+        found = in.readBoolean();
+    }
 
     public DeleteRoleMappingResponse(boolean found) {
         this.found = found;
@@ -46,8 +46,7 @@ public class DeleteRoleMappingResponse extends ActionResponse implements ToXCont
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        found = in.readBoolean();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/GetRoleMappingsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/GetRoleMappingsAction.java
@@ -5,24 +5,19 @@
  */
 package org.elasticsearch.xpack.core.security.action.rolemapping;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * ActionType to retrieve one or more role-mappings from X-Pack security
  *
  * see org.elasticsearch.xpack.security.authc.support.mapper.NativeRoleMappingStore
  */
-public class GetRoleMappingsAction extends StreamableResponseActionType<GetRoleMappingsResponse> {
+public class GetRoleMappingsAction extends ActionType<GetRoleMappingsResponse> {
 
     public static final GetRoleMappingsAction INSTANCE = new GetRoleMappingsAction();
     public static final String NAME = "cluster:admin/xpack/security/role_mapping/get";
 
     private GetRoleMappingsAction() {
-        super(NAME);
-    }
-
-    @Override
-    public GetRoleMappingsResponse newResponse() {
-        return new GetRoleMappingsResponse();
+        super(NAME, GetRoleMappingsResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/GetRoleMappingsResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/GetRoleMappingsResponse.java
@@ -21,6 +21,15 @@ public class GetRoleMappingsResponse extends ActionResponse {
 
     private ExpressionRoleMapping[] mappings;
 
+    public GetRoleMappingsResponse(StreamInput in) throws IOException {
+        super(in);
+        int size = in.readVInt();
+        mappings = new ExpressionRoleMapping[size];
+        for (int i = 0; i < size; i++) {
+            mappings[i] = new ExpressionRoleMapping(in);
+        }
+    }
+
     public GetRoleMappingsResponse(ExpressionRoleMapping... mappings) {
         this.mappings = mappings;
     }
@@ -35,12 +44,7 @@ public class GetRoleMappingsResponse extends ActionResponse {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        int size = in.readVInt();
-        mappings = new ExpressionRoleMapping[size];
-        for (int i = 0; i < size; i++) {
-            mappings[i] = new ExpressionRoleMapping(in);
-        }
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/PutRoleMappingAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/PutRoleMappingAction.java
@@ -5,22 +5,17 @@
  */
 package org.elasticsearch.xpack.core.security.action.rolemapping;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * ActionType for adding a role to the security index
  */
-public class PutRoleMappingAction extends StreamableResponseActionType<PutRoleMappingResponse> {
+public class PutRoleMappingAction extends ActionType<PutRoleMappingResponse> {
 
     public static final PutRoleMappingAction INSTANCE = new PutRoleMappingAction();
     public static final String NAME = "cluster:admin/xpack/security/role_mapping/put";
 
     private PutRoleMappingAction() {
-        super(NAME);
-    }
-
-    @Override
-    public PutRoleMappingResponse newResponse() {
-        return new PutRoleMappingResponse();
+        super(NAME, PutRoleMappingResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/PutRoleMappingResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/PutRoleMappingResponse.java
@@ -22,7 +22,9 @@ public class PutRoleMappingResponse extends ActionResponse implements ToXContent
 
     private boolean created;
 
-    public PutRoleMappingResponse() {
+    public PutRoleMappingResponse(StreamInput in) throws IOException {
+        super(in);
+        this.created = in.readBoolean();
     }
 
     public PutRoleMappingResponse(boolean created) {
@@ -46,7 +48,6 @@ public class PutRoleMappingResponse extends ActionResponse implements ToXContent
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        this.created = in.readBoolean();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlAuthenticateAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlAuthenticateAction.java
@@ -5,22 +5,17 @@
  */
 package org.elasticsearch.xpack.core.security.action.saml;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * ActionType for authenticating using SAML assertions
  */
-public final class SamlAuthenticateAction extends StreamableResponseActionType<SamlAuthenticateResponse> {
+public final class SamlAuthenticateAction extends ActionType<SamlAuthenticateResponse> {
 
     public static final String NAME = "cluster:admin/xpack/security/saml/authenticate";
     public static final SamlAuthenticateAction INSTANCE = new SamlAuthenticateAction();
 
     private SamlAuthenticateAction() {
-        super(NAME);
-    }
-
-    @Override
-    public SamlAuthenticateResponse newResponse() {
-        return new SamlAuthenticateResponse();
+        super(NAME, SamlAuthenticateResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlAuthenticateResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlAuthenticateResponse.java
@@ -23,7 +23,12 @@ public final class SamlAuthenticateResponse extends ActionResponse {
     private String refreshToken;
     private TimeValue expiresIn;
 
-    public SamlAuthenticateResponse() {
+    public SamlAuthenticateResponse(StreamInput in) throws IOException {
+        super(in);
+        principal = in.readString();
+        tokenString = in.readString();
+        refreshToken = in.readString();
+        expiresIn = in.readTimeValue();
     }
 
     public SamlAuthenticateResponse(String principal, String tokenString, String refreshToken, TimeValue expiresIn) {
@@ -59,10 +64,6 @@ public final class SamlAuthenticateResponse extends ActionResponse {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        principal = in.readString();
-        tokenString = in.readString();
-        refreshToken = in.readString();
-        expiresIn = in.readTimeValue();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlInvalidateSessionAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlInvalidateSessionAction.java
@@ -5,22 +5,17 @@
  */
 package org.elasticsearch.xpack.core.security.action.saml;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * ActionType to perform IdP-initiated logout for a SAML-SSO user
  */
-public final class SamlInvalidateSessionAction extends StreamableResponseActionType<SamlInvalidateSessionResponse> {
+public final class SamlInvalidateSessionAction extends ActionType<SamlInvalidateSessionResponse> {
 
     public static final String NAME = "cluster:admin/xpack/security/saml/invalidate";
     public static final SamlInvalidateSessionAction INSTANCE = new SamlInvalidateSessionAction();
 
     private SamlInvalidateSessionAction() {
-        super(NAME);
-    }
-
-    @Override
-    public SamlInvalidateSessionResponse newResponse() {
-        return new SamlInvalidateSessionResponse();
+        super(NAME, SamlInvalidateSessionResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlInvalidateSessionResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlInvalidateSessionResponse.java
@@ -20,7 +20,11 @@ public final class SamlInvalidateSessionResponse extends ActionResponse {
     private int count;
     private String redirectUrl;
 
-    public SamlInvalidateSessionResponse() {
+    public SamlInvalidateSessionResponse(StreamInput in) throws IOException {
+        super(in);
+        realmName = in.readString();
+        count = in.readInt();
+        redirectUrl = in.readString();
     }
 
     public SamlInvalidateSessionResponse(String realmName, int count, String redirectUrl) {
@@ -50,10 +54,7 @@ public final class SamlInvalidateSessionResponse extends ActionResponse {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        realmName = in.readString();
-        count = in.readInt();
-        redirectUrl = in.readString();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlLogoutAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlLogoutAction.java
@@ -5,22 +5,17 @@
  */
 package org.elasticsearch.xpack.core.security.action.saml;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * ActionType for initiating a logout process for a SAML-SSO user
  */
-public final class SamlLogoutAction extends StreamableResponseActionType<SamlLogoutResponse> {
+public final class SamlLogoutAction extends ActionType<SamlLogoutResponse> {
 
     public static final String NAME = "cluster:admin/xpack/security/saml/logout";
     public static final SamlLogoutAction INSTANCE = new SamlLogoutAction();
 
     private SamlLogoutAction() {
-        super(NAME);
-    }
-
-    @Override
-    public SamlLogoutResponse newResponse() {
-        return new SamlLogoutResponse();
+        super(NAME, SamlLogoutResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlLogoutResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlLogoutResponse.java
@@ -18,7 +18,9 @@ public final class SamlLogoutResponse extends ActionResponse {
 
     private String redirectUrl;
 
-    public SamlLogoutResponse() {
+    public SamlLogoutResponse(StreamInput in) throws IOException {
+        super(in);
+        redirectUrl = in.readString();
     }
 
     public SamlLogoutResponse(String redirectUrl) {
@@ -36,8 +38,7 @@ public final class SamlLogoutResponse extends ActionResponse {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        redirectUrl = in.readString();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlPrepareAuthenticationAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlPrepareAuthenticationAction.java
@@ -5,22 +5,17 @@
  */
 package org.elasticsearch.xpack.core.security.action.saml;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * ActionType for initiating an authentication process using SAML assertions
  */
-public final class SamlPrepareAuthenticationAction extends StreamableResponseActionType<SamlPrepareAuthenticationResponse> {
+public final class SamlPrepareAuthenticationAction extends ActionType<SamlPrepareAuthenticationResponse> {
 
     public static final String NAME = "cluster:admin/xpack/security/saml/prepare";
     public static final SamlPrepareAuthenticationAction INSTANCE = new SamlPrepareAuthenticationAction();
 
     private SamlPrepareAuthenticationAction() {
-        super(NAME);
-    }
-
-    @Override
-    public SamlPrepareAuthenticationResponse newResponse() {
-        return new SamlPrepareAuthenticationResponse();
+        super(NAME, SamlPrepareAuthenticationResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlPrepareAuthenticationResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlPrepareAuthenticationResponse.java
@@ -20,7 +20,9 @@ public final class SamlPrepareAuthenticationResponse extends ActionResponse {
     private String requestId;
     private String redirectUrl;
 
-    public SamlPrepareAuthenticationResponse() {
+    public SamlPrepareAuthenticationResponse(StreamInput in) throws IOException {
+        super(in);
+        redirectUrl = in.readString();
     }
 
     public SamlPrepareAuthenticationResponse(String realmName, String requestId, String redirectUrl) {
@@ -48,8 +50,7 @@ public final class SamlPrepareAuthenticationResponse extends ActionResponse {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        redirectUrl = in.readString();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/token/CreateTokenAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/token/CreateTokenAction.java
@@ -5,22 +5,17 @@
  */
 package org.elasticsearch.xpack.core.security.action.token;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * ActionType for creating a new token
  */
-public final class CreateTokenAction extends StreamableResponseActionType<CreateTokenResponse> {
+public final class CreateTokenAction extends ActionType<CreateTokenResponse> {
 
     public static final String NAME = "cluster:admin/xpack/security/token/create";
     public static final CreateTokenAction INSTANCE = new CreateTokenAction();
 
     private CreateTokenAction() {
-        super(NAME);
-    }
-
-    @Override
-    public CreateTokenResponse newResponse() {
-        return new CreateTokenResponse();
+        super(NAME, CreateTokenResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/token/CreateTokenResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/token/CreateTokenResponse.java
@@ -30,6 +30,15 @@ public final class CreateTokenResponse extends ActionResponse implements ToXCont
 
     CreateTokenResponse() {}
 
+    public CreateTokenResponse(StreamInput in) throws IOException {
+        super(in);
+        tokenString = in.readString();
+        expiresIn = in.readTimeValue();
+        scope = in.readOptionalString();
+        refreshToken = in.readOptionalString();
+        kerberosAuthenticationResponseToken = in.readOptionalString();
+    }
+
     public CreateTokenResponse(String tokenString, TimeValue expiresIn, String scope, String refreshToken,
                                String kerberosAuthenticationResponseToken) {
         this.tokenString = Objects.requireNonNull(tokenString);
@@ -70,12 +79,7 @@ public final class CreateTokenResponse extends ActionResponse implements ToXCont
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        tokenString = in.readString();
-        expiresIn = in.readTimeValue();
-        scope = in.readOptionalString();
-        refreshToken = in.readOptionalString();
-        kerberosAuthenticationResponseToken = in.readOptionalString();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/token/InvalidateTokenAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/token/InvalidateTokenAction.java
@@ -5,22 +5,17 @@
  */
 package org.elasticsearch.xpack.core.security.action.token;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * ActionType for invalidating one or more tokens
  */
-public final class InvalidateTokenAction extends StreamableResponseActionType<InvalidateTokenResponse> {
+public final class InvalidateTokenAction extends ActionType<InvalidateTokenResponse> {
 
     public static final String NAME = "cluster:admin/xpack/security/token/invalidate";
     public static final InvalidateTokenAction INSTANCE = new InvalidateTokenAction();
 
     private InvalidateTokenAction() {
-        super(NAME);
-    }
-
-    @Override
-    public InvalidateTokenResponse newResponse() {
-        return new InvalidateTokenResponse();
+        super(NAME, InvalidateTokenResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/token/InvalidateTokenResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/token/InvalidateTokenResponse.java
@@ -25,6 +25,11 @@ public final class InvalidateTokenResponse extends ActionResponse implements ToX
 
     public InvalidateTokenResponse() {}
 
+    public InvalidateTokenResponse(StreamInput in) throws IOException {
+        super(in);
+        result = new TokensInvalidationResult(in);
+    }
+
     public InvalidateTokenResponse(TokensInvalidationResult result) {
         this.result = result;
     }
@@ -40,8 +45,7 @@ public final class InvalidateTokenResponse extends ActionResponse implements ToX
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        result = new TokensInvalidationResult(in);
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/token/RefreshTokenAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/token/RefreshTokenAction.java
@@ -5,19 +5,14 @@
  */
 package org.elasticsearch.xpack.core.security.action.token;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public final class RefreshTokenAction extends StreamableResponseActionType<CreateTokenResponse> {
+public final class RefreshTokenAction extends ActionType<CreateTokenResponse> {
 
     public static final String NAME = "cluster:admin/xpack/security/token/refresh";
     public static final RefreshTokenAction INSTANCE = new RefreshTokenAction();
 
     private RefreshTokenAction() {
-        super(NAME);
-    }
-
-    @Override
-    public CreateTokenResponse newResponse() {
-        return new CreateTokenResponse();
+        super(NAME, CreateTokenResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/AuthenticateAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/AuthenticateAction.java
@@ -5,19 +5,14 @@
  */
 package org.elasticsearch.xpack.core.security.action.user;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class AuthenticateAction extends StreamableResponseActionType<AuthenticateResponse> {
+public class AuthenticateAction extends ActionType<AuthenticateResponse> {
 
     public static final String NAME = "cluster:admin/xpack/security/user/authenticate";
     public static final AuthenticateAction INSTANCE = new AuthenticateAction();
 
     public AuthenticateAction() {
-        super(NAME);
-    }
-
-    @Override
-    public AuthenticateResponse newResponse() {
-        return new AuthenticateResponse();
+        super(NAME, AuthenticateResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/AuthenticateResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/AuthenticateResponse.java
@@ -16,7 +16,10 @@ public class AuthenticateResponse extends ActionResponse {
 
     private Authentication authentication;
 
-    public AuthenticateResponse() {}
+    public AuthenticateResponse(StreamInput in) throws IOException {
+        super(in);
+        authentication = new Authentication(in);
+    }
 
     public AuthenticateResponse(Authentication authentication){
         this.authentication = authentication;
@@ -33,8 +36,7 @@ public class AuthenticateResponse extends ActionResponse {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        authentication = new Authentication(in);
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/ChangePasswordAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/ChangePasswordAction.java
@@ -5,19 +5,14 @@
  */
 package org.elasticsearch.xpack.core.security.action.user;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class ChangePasswordAction extends StreamableResponseActionType<ChangePasswordResponse> {
+public class ChangePasswordAction extends ActionType<ChangePasswordResponse> {
 
     public static final ChangePasswordAction INSTANCE = new ChangePasswordAction();
     public static final String NAME = "cluster:admin/xpack/security/user/change_password";
 
     protected ChangePasswordAction() {
-        super(NAME);
-    }
-
-    @Override
-    public ChangePasswordResponse newResponse() {
-        return new ChangePasswordResponse();
+        super(NAME, ChangePasswordResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/ChangePasswordResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/ChangePasswordResponse.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.core.security.action.user;
 
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
@@ -13,6 +14,10 @@ import java.io.IOException;
 public class ChangePasswordResponse extends ActionResponse {
 
     public ChangePasswordResponse() {}
+
+    public ChangePasswordResponse(StreamInput in) throws IOException {
+        super(in);
+    }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/DeleteUserAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/DeleteUserAction.java
@@ -5,22 +5,17 @@
  */
 package org.elasticsearch.xpack.core.security.action.user;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * ActionType for deleting a native user.
  */
-public class DeleteUserAction extends StreamableResponseActionType<DeleteUserResponse> {
+public class DeleteUserAction extends ActionType<DeleteUserResponse> {
 
     public static final DeleteUserAction INSTANCE = new DeleteUserAction();
     public static final String NAME = "cluster:admin/xpack/security/user/delete";
 
     protected DeleteUserAction() {
-        super(NAME);
-    }
-
-    @Override
-    public DeleteUserResponse newResponse() {
-        return new DeleteUserResponse();
+        super(NAME, DeleteUserResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/DeleteUserResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/DeleteUserResponse.java
@@ -21,7 +21,9 @@ public class DeleteUserResponse extends ActionResponse implements ToXContentObje
 
     private boolean found;
 
-    public DeleteUserResponse() {
+    public DeleteUserResponse(StreamInput in) throws IOException {
+        super(in);
+        found = in.readBoolean();
     }
 
     public DeleteUserResponse(boolean found) {
@@ -40,8 +42,7 @@ public class DeleteUserResponse extends ActionResponse implements ToXContentObje
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        found = in.readBoolean();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUserPrivilegesAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUserPrivilegesAction.java
@@ -5,22 +5,17 @@
  */
 package org.elasticsearch.xpack.core.security.action.user;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * ActionType that lists the set of privileges held by a user.
  */
-public final class GetUserPrivilegesAction extends StreamableResponseActionType<GetUserPrivilegesResponse> {
+public final class GetUserPrivilegesAction extends ActionType<GetUserPrivilegesResponse> {
 
     public static final GetUserPrivilegesAction INSTANCE = new GetUserPrivilegesAction();
     public static final String NAME = "cluster:admin/xpack/security/user/list_privileges";
 
     private GetUserPrivilegesAction() {
-        super(NAME);
-    }
-
-    @Override
-    public GetUserPrivilegesResponse newResponse() {
-        return new GetUserPrivilegesResponse();
+        super(NAME, GetUserPrivilegesResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUserPrivilegesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUserPrivilegesResponse.java
@@ -37,8 +37,13 @@ public final class GetUserPrivilegesResponse extends ActionResponse {
     private Set<RoleDescriptor.ApplicationResourcePrivileges> application;
     private Set<String> runAs;
 
-    public GetUserPrivilegesResponse() {
-        this(Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
+    public GetUserPrivilegesResponse(StreamInput in) throws IOException {
+        super(in);
+        cluster = Collections.unmodifiableSet(in.readSet(StreamInput::readString));
+        conditionalCluster = Collections.unmodifiableSet(in.readSet(ConditionalClusterPrivileges.READER));
+        index = Collections.unmodifiableSet(in.readSet(Indices::new));
+        application = Collections.unmodifiableSet(in.readSet(RoleDescriptor.ApplicationResourcePrivileges::new));
+        runAs = Collections.unmodifiableSet(in.readSet(StreamInput::readString));
     }
 
     public GetUserPrivilegesResponse(Set<String> cluster, Set<ConditionalClusterPrivilege> conditionalCluster,
@@ -73,12 +78,7 @@ public final class GetUserPrivilegesResponse extends ActionResponse {
     }
 
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        cluster = Collections.unmodifiableSet(in.readSet(StreamInput::readString));
-        conditionalCluster = Collections.unmodifiableSet(in.readSet(ConditionalClusterPrivileges.READER));
-        index = Collections.unmodifiableSet(in.readSet(Indices::new));
-        application = Collections.unmodifiableSet(in.readSet(RoleDescriptor.ApplicationResourcePrivileges::new));
-        runAs = Collections.unmodifiableSet(in.readSet(StreamInput::readString));
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUsersAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUsersAction.java
@@ -5,22 +5,17 @@
  */
 package org.elasticsearch.xpack.core.security.action.user;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * ActionType for retrieving a user from the security index
  */
-public class GetUsersAction extends StreamableResponseActionType<GetUsersResponse> {
+public class GetUsersAction extends ActionType<GetUsersResponse> {
 
     public static final GetUsersAction INSTANCE = new GetUsersAction();
     public static final String NAME = "cluster:admin/xpack/security/user/get";
 
     protected GetUsersAction() {
-        super(NAME);
-    }
-
-    @Override
-    public GetUsersResponse newResponse() {
-        return new GetUsersResponse();
+        super(NAME, GetUsersResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUsersResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUsersResponse.java
@@ -20,6 +20,19 @@ public class GetUsersResponse extends ActionResponse {
 
     private User[] users;
 
+    public GetUsersResponse(StreamInput in) throws IOException {
+        super(in);
+        int size = in.readVInt();
+        if (size < 0) {
+            users = null;
+        } else {
+            users = new User[size];
+            for (int i = 0; i < size; i++) {
+                users[i] = User.readFrom(in);
+            }
+        }
+    }
+
     public GetUsersResponse(User... users) {
         this.users = users;
     }
@@ -38,16 +51,7 @@ public class GetUsersResponse extends ActionResponse {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        int size = in.readVInt();
-        if (size < 0) {
-            users = null;
-        } else {
-            users = new User[size];
-            for (int i = 0; i < size; i++) {
-                users[i] = User.readFrom(in);
-            }
-        }
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/HasPrivilegesAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/HasPrivilegesAction.java
@@ -5,24 +5,19 @@
  */
 package org.elasticsearch.xpack.core.security.action.user;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 
 /**
  * This action is testing whether a user has the specified
  * {@link RoleDescriptor.IndicesPrivileges privileges}
  */
-public class HasPrivilegesAction extends StreamableResponseActionType<HasPrivilegesResponse> {
+public class HasPrivilegesAction extends ActionType<HasPrivilegesResponse> {
 
     public static final HasPrivilegesAction INSTANCE = new HasPrivilegesAction();
     public static final String NAME = "cluster:admin/xpack/security/user/has_privileges";
 
     private HasPrivilegesAction() {
-        super(NAME);
-    }
-
-    @Override
-    public HasPrivilegesResponse newResponse() {
-        return new HasPrivilegesResponse();
+        super(NAME, HasPrivilegesResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/HasPrivilegesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/HasPrivilegesResponse.java
@@ -36,6 +36,15 @@ public class HasPrivilegesResponse extends ActionResponse implements ToXContentO
         this("", true, Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap());
     }
 
+    public HasPrivilegesResponse(StreamInput in) throws IOException {
+        super(in);
+        completeMatch = in.readBoolean();
+        cluster = in.readMap(StreamInput::readString, StreamInput::readBoolean);
+        index = readResourcePrivileges(in);
+        application = in.readMap(StreamInput::readString, HasPrivilegesResponse::readResourcePrivileges);
+        username = in.readString();
+    }
+
     public HasPrivilegesResponse(String username, boolean completeMatch, Map<String, Boolean> cluster, Collection<ResourcePrivileges> index,
                                  Map<String, Collection<ResourcePrivileges>> application) {
         super();
@@ -100,12 +109,7 @@ public class HasPrivilegesResponse extends ActionResponse implements ToXContentO
     }
 
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        completeMatch = in.readBoolean();
-        cluster = in.readMap(StreamInput::readString, StreamInput::readBoolean);
-        index = readResourcePrivileges(in);
-        application = in.readMap(StreamInput::readString, HasPrivilegesResponse::readResourcePrivileges);
-        username = in.readString();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     private static Set<ResourcePrivileges> readResourcePrivileges(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/PutUserAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/PutUserAction.java
@@ -5,22 +5,17 @@
  */
 package org.elasticsearch.xpack.core.security.action.user;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * ActionType for putting (adding/updating) a native user.
  */
-public class PutUserAction extends StreamableResponseActionType<PutUserResponse> {
+public class PutUserAction extends ActionType<PutUserResponse> {
 
     public static final PutUserAction INSTANCE = new PutUserAction();
     public static final String NAME = "cluster:admin/xpack/security/user/put";
 
     protected PutUserAction() {
-        super(NAME);
-    }
-
-    @Override
-    public PutUserResponse newResponse() {
-        return new PutUserResponse();
+        super(NAME, PutUserResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/PutUserResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/PutUserResponse.java
@@ -22,7 +22,9 @@ public class PutUserResponse extends ActionResponse implements ToXContentObject 
 
     private boolean created;
 
-    public PutUserResponse() {
+    public PutUserResponse(StreamInput in) throws IOException {
+        super(in);
+        this.created = in.readBoolean();
     }
 
     public PutUserResponse(boolean created) {
@@ -40,8 +42,7 @@ public class PutUserResponse extends ActionResponse implements ToXContentObject 
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        this.created = in.readBoolean();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/SetEnabledAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/SetEnabledAction.java
@@ -5,22 +5,17 @@
  */
 package org.elasticsearch.xpack.core.security.action.user;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * This action is for setting the enabled flag on a native or reserved user
  */
-public class SetEnabledAction extends StreamableResponseActionType<SetEnabledResponse> {
+public class SetEnabledAction extends ActionType<SetEnabledResponse> {
 
     public static final SetEnabledAction INSTANCE = new SetEnabledAction();
     public static final String NAME = "cluster:admin/xpack/security/user/set_enabled";
 
     private SetEnabledAction() {
-        super(NAME);
-    }
-
-    @Override
-    public SetEnabledResponse newResponse() {
-        return new SetEnabledResponse();
+        super(NAME, SetEnabledResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/SetEnabledResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/SetEnabledResponse.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.core.security.action.user;
 
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
@@ -14,6 +15,12 @@ import java.io.IOException;
  * Empty response for a {@link SetEnabledRequest}
  */
 public class SetEnabledResponse extends ActionResponse {
+
+    public SetEnabledResponse() {}
+
+    public SetEnabledResponse(StreamInput in) throws IOException {
+        super(in);
+    }
     @Override
     public void writeTo(StreamOutput out) throws IOException {}
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/DeletePrivilegesResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/DeletePrivilegesResponseTests.java
@@ -23,8 +23,7 @@ public class DeletePrivilegesResponseTests extends ESTestCase {
         final BytesStreamOutput output = new BytesStreamOutput();
         original.writeTo(output);
         output.flush();
-        final DeletePrivilegesResponse copy = new DeletePrivilegesResponse();
-        copy.readFrom(output.bytes().streamInput());
+        final DeletePrivilegesResponse copy = new DeletePrivilegesResponse(output.bytes().streamInput());
         assertThat(copy.found(), equalTo(original.found()));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/GetBuiltinPrivilegesResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/GetBuiltinPrivilegesResponseTests.java
@@ -22,8 +22,7 @@ public class GetBuiltinPrivilegesResponseTests extends ESTestCase {
         final BytesStreamOutput out = new BytesStreamOutput();
         original.writeTo(out);
 
-        final GetBuiltinPrivilegesResponse copy = new GetBuiltinPrivilegesResponse();
-        copy.readFrom(out.bytes().streamInput());
+        final GetBuiltinPrivilegesResponse copy = new GetBuiltinPrivilegesResponse(out.bytes().streamInput());
 
         assertThat(copy.getClusterPrivileges(), Matchers.equalTo(cluster));
         assertThat(copy.getIndexPrivileges(), Matchers.equalTo(index));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/GetPrivilegesResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/GetPrivilegesResponseTests.java
@@ -24,8 +24,7 @@ public class GetPrivilegesResponseTests extends ESTestCase {
         final BytesStreamOutput out = new BytesStreamOutput();
         original.writeTo(out);
 
-        final GetPrivilegesResponse copy = new GetPrivilegesResponse();
-        copy.readFrom(out.bytes().streamInput());
+        final GetPrivilegesResponse copy = new GetPrivilegesResponse(out.bytes().streamInput());
 
         assertThat(copy.privileges(), Matchers.equalTo(original.privileges()));
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponseTests.java
@@ -33,8 +33,7 @@ public class PutPrivilegesResponseTests extends ESTestCase {
         final BytesStreamOutput output = new BytesStreamOutput();
         original.writeTo(output);
         output.flush();
-        final PutPrivilegesResponse copy = new PutPrivilegesResponse();
-        copy.readFrom(output.bytes().streamInput());
+        final PutPrivilegesResponse copy = new PutPrivilegesResponse(output.bytes().streamInput());
         assertThat(copy.created(), equalTo(original.created()));
         assertThat(Strings.toString(copy), equalTo(Strings.toString(original)));
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/token/CreateTokenResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/token/CreateTokenResponseTests.java
@@ -18,8 +18,7 @@ public class CreateTokenResponseTests extends ESTestCase {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             response.writeTo(output);
             try (StreamInput input = output.bytes().streamInput()) {
-                CreateTokenResponse serialized = new CreateTokenResponse();
-                serialized.readFrom(input);
+                CreateTokenResponse serialized = new CreateTokenResponse(input);
                 assertEquals(response, serialized);
             }
         }
@@ -29,8 +28,7 @@ public class CreateTokenResponseTests extends ESTestCase {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             response.writeTo(output);
             try (StreamInput input = output.bytes().streamInput()) {
-                CreateTokenResponse serialized = new CreateTokenResponse();
-                serialized.readFrom(input);
+                CreateTokenResponse serialized = new CreateTokenResponse(input);
                 assertEquals(response, serialized);
             }
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/token/InvalidateTokenResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/token/InvalidateTokenResponseTests.java
@@ -34,8 +34,7 @@ public class InvalidateTokenResponseTests extends ESTestCase {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             response.writeTo(output);
             try (StreamInput input = output.bytes().streamInput()) {
-                InvalidateTokenResponse serialized = new InvalidateTokenResponse();
-                serialized.readFrom(input);
+                InvalidateTokenResponse serialized = new InvalidateTokenResponse(input);
                 assertThat(serialized.getResult().getInvalidatedTokens(), equalTo(response.getResult().getInvalidatedTokens()));
                 assertThat(serialized.getResult().getPreviouslyInvalidatedTokens(),
                     equalTo(response.getResult().getPreviouslyInvalidatedTokens()));
@@ -51,8 +50,7 @@ public class InvalidateTokenResponseTests extends ESTestCase {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             response.writeTo(output);
             try (StreamInput input = output.bytes().streamInput()) {
-                InvalidateTokenResponse serialized = new InvalidateTokenResponse();
-                serialized.readFrom(input);
+                InvalidateTokenResponse serialized = new InvalidateTokenResponse(input);
                 assertThat(serialized.getResult().getInvalidatedTokens(), equalTo(response.getResult().getInvalidatedTokens()));
                 assertThat(serialized.getResult().getPreviouslyInvalidatedTokens(),
                     equalTo(response.getResult().getPreviouslyInvalidatedTokens()));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/user/GetUserPrivilegesResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/user/GetUserPrivilegesResponseTests.java
@@ -48,10 +48,10 @@ public class GetUserPrivilegesResponseTests extends ESTestCase {
         final BytesStreamOutput out = new BytesStreamOutput();
         original.writeTo(out);
 
-        final GetUserPrivilegesResponse copy = new GetUserPrivilegesResponse();
+
         final NamedWriteableRegistry registry = new NamedWriteableRegistry(new XPackClientPlugin(Settings.EMPTY).getNamedWriteables());
         StreamInput in = new NamedWriteableAwareStreamInput(ByteBufferStreamInput.wrap(BytesReference.toBytes(out.bytes())), registry);
-        copy.readFrom(in);
+        final GetUserPrivilegesResponse copy = new GetUserPrivilegesResponse(in);
 
         assertThat(copy.getClusterPrivileges(), equalTo(original.getClusterPrivileges()));
         assertThat(copy.getConditionalClusterPrivileges(), equalTo(original.getConditionalClusterPrivileges()));

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutAction.java
@@ -112,7 +112,7 @@ public final class TransportSamlLogoutAction
         final String session = getMetadataString(tokenMetadata, SamlRealm.TOKEN_METADATA_SESSION);
         final LogoutRequest logout = realm.buildLogoutRequest(nameId.asXml(), session);
         if (logout == null) {
-            return new SamlLogoutResponse(null);
+            return new SamlLogoutResponse((String)null);
         }
         final String uri = new SamlRedirect(logout, realm.getSigningConfiguration()).getRedirectUrl();
         return new SamlLogoutResponse(uri);


### PR DESCRIPTION
This commit converts all the StreamableResponseActionType security
classes in xpack core to ActionType, implementing Writeable for their
response classes.

relates #34389