### PR TITLE
[Backport 7.3] Improve CryptoService error message on missing secure file (#43623)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/watcher/crypto/CryptoServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/watcher/crypto/CryptoServiceTests.java
@@ -54,6 +54,11 @@ public class CryptoServiceTests extends ESTestCase {
         assertThat(service.isEncrypted(service.encrypt(randomAlphaOfLength(10).toCharArray())), is(true));
     }
 
+    public void testErrorMessageWhenSecureEncryptionKeySettingDoesNotExist() throws Exception {
+        final ElasticsearchException e = expectThrows(ElasticsearchException.class, () -> new CryptoService(Settings.EMPTY));
+        assertThat(e.getMessage(), is("setting [" + WatcherField.ENCRYPTION_KEY_SETTING.getKey() + "] must be set in keystore"));
+    }
+
     public static byte[] generateKey() {
         try {
             KeyGenerator generator = KeyGenerator.getInstance(CryptoService.KEY_ALGO);


### PR DESCRIPTION
Backport of #43623 

This improves the error message when encrypting of sensitive watcher
data is configured, but no system file was specified in the keystore.
This error message is displayed on startup.

This also closes the input stream of the secure file properly.

Closes #43619

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
