### PR TITLE
Ensure field caps doesn't error on rank feature fields.

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeatureFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeatureFieldMapper.java
@@ -164,12 +164,12 @@ public class RankFeatureFieldMapper extends FieldMapper {
 
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
-            throw new UnsupportedOperationException("[rank_feature] fields do not support sorting, scripting or aggregating");
+            throw new IllegalArgumentException("[rank_feature] fields do not support sorting, scripting or aggregating");
         }
 
         @Override
         public Query termQuery(Object value, QueryShardContext context) {
-            throw new UnsupportedOperationException("Queries on [rank_feature] fields are not supported");
+            throw new IllegalArgumentException("Queries on [rank_feature] fields are not supported");
         }
     }
 

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeaturesFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeaturesFieldMapper.java
@@ -104,17 +104,17 @@ public class RankFeaturesFieldMapper extends FieldMapper {
 
         @Override
         public Query existsQuery(QueryShardContext context) {
-            throw new UnsupportedOperationException("[rank_features] fields do not support [exists] queries");
+            throw new IllegalArgumentException("[rank_features] fields do not support [exists] queries");
         }
 
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
-            throw new UnsupportedOperationException("[rank_features] fields do not support sorting, scripting or aggregating");
+            throw new IllegalArgumentException("[rank_features] fields do not support sorting, scripting or aggregating");
         }
 
         @Override
         public Query termQuery(Object value, QueryShardContext context) {
-            throw new UnsupportedOperationException("Queries on [rank_features] fields are not supported");
+            throw new IllegalArgumentException("Queries on [rank_features] fields are not supported");
         }
     }
 

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/RankFeatureFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/RankFeatureFieldTypeTests.java
@@ -43,4 +43,9 @@ public class RankFeatureFieldTypeTests extends FieldTypeTestCase {
             }
         });
     }
+
+    public void testIsAggregatable() {
+        MappedFieldType fieldType = createDefaultFieldType();
+        assertFalse(fieldType.isAggregatable());
+    }
 }

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/RankFeaturesFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/RankFeaturesFieldTypeTests.java
@@ -26,4 +26,8 @@ public class RankFeaturesFieldTypeTests extends FieldTypeTestCase {
         return new RankFeaturesFieldMapper.RankFeaturesFieldType();
     }
 
+    public void testIsAggregatable() {
+        MappedFieldType fieldType = createDefaultFieldType();
+        assertFalse(fieldType.isAggregatable());
+    }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -99,13 +99,15 @@ public abstract class MappedFieldType extends FieldType {
     @Override
     public abstract MappedFieldType clone();
 
-    /** Return a fielddata builder for this field
-     *  @throws IllegalArgumentException if the fielddata is not supported on this type.
-     *  An IllegalArgumentException is needed in order to return an http error 400
-     *  when this error occurs in a request. see: {@link org.elasticsearch.ExceptionsHelper#status}
+    /**
+     * Return a fielddata builder for this field
      *
      * @param fullyQualifiedIndexName the name of the index this field-data is build for
-     * */
+     *
+     * @throws IllegalArgumentException if the fielddata is not supported on this type.
+     * An IllegalArgumentException is needed in order to return an http error 400
+     * when this error occurs in a request. see: {@link org.elasticsearch.ExceptionsHelper#status}
+     */
     public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
         throw new IllegalArgumentException("Fielddata is not supported on field [" + name() + "] of type [" + typeName() + "]");
     }


### PR DESCRIPTION
The contract for `MappedFieldType#fielddataBuilder` is to throw an
`IllegalArgumentException` if fielddata is not supported. The rank feature mappers
were instead throwing an `UnsupportedOperationException`, which causes
`MappedFieldType#isAggregatable` to fail.

Addresses #44330.