### PR TITLE
[DOCS] Add redirects for removed autogenerated anchors

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -640,3 +640,11 @@ See <<ml-get-filter>> and
 See <<ml-get-calendar-event>> and 
 {stack-ov}/ml-calendars.html[Calendars and scheduled events].
 
+[role="exclude",id="_repositories"]
+=== Snapshot repositories
+See <<snapshots-repositories>>.
+
+[role="exclude",id="_snapshot"]
+=== Snapshot
+See <<snapshots-take-snapshot>>.
+


### PR DESCRIPTION
With #43934, we replaced autogenerated anchors for the snapshot and repositories sections of the [Snapshot and Restore](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html) page with explicit anchors.

Unfortunately, our Kibana documentation linked to the autogenerated anchors. This causes the doc build to fail with a broken link.

This add redirects for the replaced anchors and points users to the right section. Should also fix the doc build failures.