### PR TITLE
allow CircleBuilder to build Circle

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/geo/builders/CircleBuilder.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/builders/CircleBuilder.java
@@ -165,7 +165,7 @@ public class CircleBuilder extends ShapeBuilder<Circle, org.elasticsearch.geo.ge
 
     @Override
     public org.elasticsearch.geo.geometry.Circle buildGeometry() {
-        throw new UnsupportedOperationException("CIRCLE geometry is not supported");
+        return new org.elasticsearch.geo.geometry.Circle(center.y, center.x, radius);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/common/geo/builders/CircleBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/builders/CircleBuilderTests.java
@@ -20,12 +20,23 @@
 package org.elasticsearch.common.geo.builders;
 
 import org.elasticsearch.common.unit.DistanceUnit;
+import org.elasticsearch.geo.geometry.Circle;
 import org.locationtech.jts.geom.Coordinate;
 
 import java.io.IOException;
 
+import static org.hamcrest.Matchers.equalTo;
+
 public class CircleBuilderTests extends AbstractShapeBuilderTestCase<CircleBuilder> {
 
+    public void testBuildGeometry() {
+        CircleBuilder builder = createRandomShape();
+        Circle circle = builder.buildGeometry();
+        assertThat(circle.getLon(), equalTo(builder.center().x));
+        assertThat(circle.getLat(), equalTo(builder.center().y));
+        assertThat(circle.getAlt(), equalTo(builder.center().z));
+        assertThat(circle.getRadiusMeters(), equalTo(builder.radius()));
+    }
     @Override
     protected CircleBuilder createTestShapeBuilder() {
         return createRandomShape();


### PR DESCRIPTION
It would be nice to re-use ES's shape parsing in the CircleProcessor #43851.

To do this, we need to support building a circle