### PR TITLE
[7.x] Migrate ML Actions to use writeable ActionType (#44302)

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/MlInfoActionResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/MlInfoActionResponseTests.java
@@ -18,35 +18,20 @@
  */
 package org.elasticsearch.client.ml;
 
+import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.client.AbstractHlrcStreamableXContentTestCase;
 import org.elasticsearch.xpack.core.ml.action.MlInfoAction.Response;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Predicate;
 
-public class MlInfoActionResponseTests extends
-    AbstractHlrcStreamableXContentTestCase<Response, MlInfoResponse> {
+import static org.hamcrest.Matchers.equalTo;
 
-    @Override
-    public MlInfoResponse doHlrcParseInstance(XContentParser parser) throws IOException {
-        return MlInfoResponse.fromXContent(parser);
-    }
+public class MlInfoActionResponseTests extends AbstractResponseTestCase<Response, MlInfoResponse> {
 
     @Override
-    public Response convertHlrcToInternal(MlInfoResponse instance) {
-        return new Response(instance.getInfo());
-    }
-
-    @Override
-    protected Predicate<String> getRandomFieldsExcludeFilter() {
-        return p -> true;
-    }
-
-    @Override
-    protected Response createTestInstance() {
+    protected Response createServerTestInstance() {
         int size = randomInt(10);
         Map<String, Object> info = new HashMap<>();
         for (int j = 0; j < size; j++) {
@@ -56,7 +41,12 @@ public class MlInfoActionResponseTests extends
     }
 
     @Override
-    protected Response createBlankInstance() {
-        return new Response();
+    protected MlInfoResponse doParseToClientInstance(XContentParser parser) throws IOException {
+        return MlInfoResponse.fromXContent(parser);
+    }
+
+    @Override
+    protected void assertInstances(Response serverTestInstance, MlInfoResponse clientInstance) {
+        assertThat(serverTestInstance.getInfo(), equalTo(clientInstance.getInfo()));
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/PutCalendarActionResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/PutCalendarActionResponseTests.java
@@ -19,8 +19,8 @@
 package org.elasticsearch.client.ml;
 
 import com.carrotsearch.randomizedtesting.generators.CodepointSetGenerator;
+import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.client.AbstractHlrcStreamableXContentTestCase;
 import org.elasticsearch.xpack.core.ml.action.PutCalendarAction;
 import org.elasticsearch.xpack.core.ml.calendars.Calendar;
 
@@ -28,46 +28,13 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class PutCalendarActionResponseTests
-    extends AbstractHlrcStreamableXContentTestCase<PutCalendarAction.Response, PutCalendarResponse> {
+import static org.hamcrest.Matchers.equalTo;
+
+public class PutCalendarActionResponseTests extends AbstractResponseTestCase<PutCalendarAction.Response, PutCalendarResponse> {
 
     @Override
-    protected PutCalendarAction.Response createTestInstance() {
-        return new PutCalendarAction.Response(testInstance());
-    }
-
-    @Override
-    protected PutCalendarAction.Response doParseInstance(XContentParser parser) throws IOException {
-        return new PutCalendarAction.Response(Calendar.LENIENT_PARSER.parse(parser, null).build());
-    }
-
-    @Override
-    protected boolean supportsUnknownFields() {
-        return true;
-    }
-
-    @Override
-    public PutCalendarResponse doHlrcParseInstance(XContentParser parser) throws IOException {
-        return PutCalendarResponse.fromXContent(parser);
-    }
-
-    @Override
-    public PutCalendarAction.Response convertHlrcToInternal(PutCalendarResponse instance) {
-        org.elasticsearch.client.ml.calendars.Calendar hlrcCalendar = instance.getCalendar();
-        Calendar internalCalendar = new Calendar(hlrcCalendar.getId(), hlrcCalendar.getJobIds(), hlrcCalendar.getDescription());
-        return new PutCalendarAction.Response(internalCalendar);
-    }
-
-    @Override
-    protected PutCalendarAction.Response createBlankInstance() {
-        return new PutCalendarAction.Response();
-    }
-
-    public static Calendar testInstance() {
-        return testInstance(new CodepointSetGenerator("abcdefghijklmnopqrstuvwxyz".toCharArray()).ofCodePointsLength(random(), 10, 10));
-    }
-
-    public static Calendar testInstance(String calendarId) {
+    protected PutCalendarAction.Response createServerTestInstance() {
+        String calendarId = new CodepointSetGenerator("abcdefghijklmnopqrstuvwxyz".toCharArray()).ofCodePointsLength(random(), 10, 10);
         int size = randomInt(10);
         List<String> items = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
@@ -77,6 +44,20 @@ public class PutCalendarActionResponseTests
         if (randomBoolean()) {
             description = randomAlphaOfLength(20);
         }
-        return new Calendar(calendarId, items, description);
+        Calendar calendar = new Calendar(calendarId, items, description);
+        return new PutCalendarAction.Response(calendar);
+    }
+
+    @Override
+    protected PutCalendarResponse doParseToClientInstance(XContentParser parser) throws IOException {
+        return PutCalendarResponse.fromXContent(parser);
+    }
+
+    @Override
+    protected void assertInstances(PutCalendarAction.Response serverTestInstance, PutCalendarResponse clientInstance) {
+        org.elasticsearch.client.ml.calendars.Calendar hlrcCalendar = clientInstance.getCalendar();
+        Calendar internalCalendar = new Calendar(hlrcCalendar.getId(), hlrcCalendar.getJobIds(), hlrcCalendar.getDescription());
+        PutCalendarAction.Response convertedServerTestInstance =new PutCalendarAction.Response(internalCalendar);
+        assertThat(convertedServerTestInstance, equalTo(serverTestInstance));
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/AbstractGetResourcesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/AbstractGetResourcesRequest.java
@@ -68,10 +68,7 @@ public abstract class AbstractGetResourcesRequest extends ActionRequest {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        resourceId = in.readOptionalString();
-        pageParams = in.readOptionalWriteable(PageParams::new);
-        allowNoResources = in.readBoolean();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/AbstractGetResourcesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/AbstractGetResourcesResponse.java
@@ -41,8 +41,7 @@ public abstract class AbstractGetResourcesResponse<T extends ToXContent & Writea
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        resources = new QueryPage<>(in, getReader());
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override
@@ -84,5 +83,6 @@ public abstract class AbstractGetResourcesResponse<T extends ToXContent & Writea
     public final String toString() {
         return Strings.toString(this);
     }
+
     protected abstract Reader<T> getReader();
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteDatafeedAction.java
@@ -51,6 +51,12 @@ public class DeleteDatafeedAction extends ActionType<AcknowledgedResponse> {
         public Request() {
         }
 
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            datafeedId = in.readString();
+            force = in.readBoolean();
+        }
+
         public String getDatafeedId() {
             return datafeedId;
         }
@@ -70,9 +76,7 @@ public class DeleteDatafeedAction extends ActionType<AcknowledgedResponse> {
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            datafeedId = in.readString();
-            force = in.readBoolean();
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteExpiredDataAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteExpiredDataAction.java
@@ -9,7 +9,7 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -20,18 +20,13 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.Objects;
 
-public class DeleteExpiredDataAction extends StreamableResponseActionType<DeleteExpiredDataAction.Response> {
+public class DeleteExpiredDataAction extends ActionType<DeleteExpiredDataAction.Response> {
 
     public static final DeleteExpiredDataAction INSTANCE = new DeleteExpiredDataAction();
     public static final String NAME = "cluster:admin/xpack/ml/delete_expired_data";
 
     private DeleteExpiredDataAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, Response::new);
     }
 
     public static class Request extends ActionRequest {
@@ -61,12 +56,14 @@ public class DeleteExpiredDataAction extends StreamableResponseActionType<Delete
             this.deleted = deleted;
         }
 
-        public Response() {}
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            deleted = in.readBoolean();
+        }
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            deleted = in.readBoolean();
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteJobAction.java
@@ -54,6 +54,12 @@ public class DeleteJobAction extends ActionType<AcknowledgedResponse> {
 
         public Request() {}
 
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            jobId = in.readString();
+            force = in.readBoolean();
+        }
+
         public String getJobId() {
             return jobId;
         }
@@ -94,9 +100,7 @@ public class DeleteJobAction extends ActionType<AcknowledgedResponse> {
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            jobId = in.readString();
-            force = in.readBoolean();
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/EvaluateDataFrameAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/EvaluateDataFrameAction.java
@@ -9,7 +9,7 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
@@ -29,18 +29,13 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-public class EvaluateDataFrameAction extends StreamableResponseActionType<EvaluateDataFrameAction.Response> {
+public class EvaluateDataFrameAction extends ActionType<EvaluateDataFrameAction.Response> {
 
     public static final EvaluateDataFrameAction INSTANCE = new EvaluateDataFrameAction();
     public static final String NAME = "cluster:monitor/xpack/ml/data_frame/evaluate";
 
     private EvaluateDataFrameAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, EvaluateDataFrameAction.Response::new);
     }
 
     public static class Request extends ActionRequest implements ToXContentObject {
@@ -79,6 +74,12 @@ public class EvaluateDataFrameAction extends StreamableResponseActionType<Evalua
         public Request() {
         }
 
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            indices = in.readStringArray();
+            evaluation = in.readNamedWriteable(Evaluation.class);
+        }
+
         public String[] getIndices() {
             return indices;
         }
@@ -106,9 +107,7 @@ public class EvaluateDataFrameAction extends StreamableResponseActionType<Evalua
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            indices = in.readStringArray();
-            evaluation = in.readNamedWriteable(Evaluation.class);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -155,7 +154,10 @@ public class EvaluateDataFrameAction extends StreamableResponseActionType<Evalua
         private String evaluationName;
         private List<EvaluationMetricResult> metrics;
 
-        public Response() {
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            this.evaluationName = in.readString();
+            this.metrics = in.readNamedWriteableList(EvaluationMetricResult.class);
         }
 
         public Response(String evaluationName, List<EvaluationMetricResult> metrics) {
@@ -165,9 +167,7 @@ public class EvaluateDataFrameAction extends StreamableResponseActionType<Evalua
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            this.evaluationName = in.readString();
-            this.metrics = in.readNamedWriteableList(EvaluationMetricResult.class);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/FinalizeJobExecutionAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/FinalizeJobExecutionAction.java
@@ -42,14 +42,18 @@ public class FinalizeJobExecutionAction extends ActionType<AcknowledgedResponse>
         public Request() {
         }
 
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            jobIds = in.readStringArray();
+        }
+
         public String[] getJobIds() {
             return jobIds;
         }
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            jobIds = in.readStringArray();
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/FindFileStructureAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/FindFileStructureAction.java
@@ -10,7 +10,7 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -31,18 +31,13 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class FindFileStructureAction extends StreamableResponseActionType<FindFileStructureAction.Response> {
+public class FindFileStructureAction extends ActionType<FindFileStructureAction.Response> {
 
     public static final FindFileStructureAction INSTANCE = new FindFileStructureAction();
     public static final String NAME = "cluster:monitor/xpack/ml/findfilestructure";
 
     private FindFileStructureAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, Response::new);
     }
 
     static class RequestBuilder extends ActionRequestBuilder<Request, Response> {
@@ -60,17 +55,14 @@ public class FindFileStructureAction extends StreamableResponseActionType<FindFi
             this.fileStructure = fileStructure;
         }
 
-        Response() {
-        }
-
-        public FileStructure getFileStructure() {
-            return fileStructure;
+        Response(StreamInput in) throws IOException {
+            super(in);
+            fileStructure = new FileStructure(in);
         }
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            fileStructure = new FileStructure(in);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -147,6 +139,27 @@ public class FindFileStructureAction extends StreamableResponseActionType<FindFi
 
         public Request() {
         }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            linesToSample = in.readOptionalVInt();
+            if (in.getVersion().onOrAfter(Version.V_7_3_0)) {
+                lineMergeSizeLimit = in.readOptionalVInt();
+            }
+            timeout = in.readOptionalTimeValue();
+            charset = in.readOptionalString();
+            format = in.readBoolean() ? in.readEnum(FileStructure.Format.class) : null;
+            columnNames = in.readBoolean() ? in.readStringList() : null;
+            hasHeaderRow = in.readOptionalBoolean();
+            delimiter = in.readBoolean() ? (char) in.readVInt() : null;
+            quote = in.readBoolean() ? (char) in.readVInt() : null;
+            shouldTrimFields = in.readOptionalBoolean();
+            grokPattern = in.readOptionalString();
+            timestampFormat = in.readOptionalString();
+            timestampField = in.readOptionalString();
+            sample = in.readBytesReference();
+        }
+
 
         public Integer getLinesToSample() {
             return linesToSample;
@@ -336,23 +349,7 @@ public class FindFileStructureAction extends StreamableResponseActionType<FindFi
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            linesToSample = in.readOptionalVInt();
-            if (in.getVersion().onOrAfter(Version.V_7_3_0)) {
-                lineMergeSizeLimit = in.readOptionalVInt();
-            }
-            timeout = in.readOptionalTimeValue();
-            charset = in.readOptionalString();
-            format = in.readBoolean() ? in.readEnum(FileStructure.Format.class) : null;
-            columnNames = in.readBoolean() ? in.readStringList() : null;
-            hasHeaderRow = in.readOptionalBoolean();
-            delimiter = in.readBoolean() ? (char) in.readVInt() : null;
-            quote = in.readBoolean() ? (char) in.readVInt() : null;
-            shouldTrimFields = in.readOptionalBoolean();
-            grokPattern = in.readOptionalString();
-            timestampFormat = in.readOptionalString();
-            timestampField = in.readOptionalString();
-            sample = in.readBytesReference();
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetBucketsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetBucketsAction.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.core.ml.action;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -28,18 +28,13 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import java.io.IOException;
 import java.util.Objects;
 
-public class GetBucketsAction extends StreamableResponseActionType<GetBucketsAction.Response> {
+public class GetBucketsAction extends ActionType<GetBucketsAction.Response> {
 
     public static final GetBucketsAction INSTANCE = new GetBucketsAction();
     public static final String NAME = "cluster:monitor/xpack/ml/job/results/buckets/get";
 
     private GetBucketsAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, Response::new);
     }
 
     public static class Request extends ActionRequest implements ToXContentObject {
@@ -88,6 +83,20 @@ public class GetBucketsAction extends StreamableResponseActionType<GetBucketsAct
         private boolean descending = false;
 
         public Request() {
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super.readFrom(in);
+            jobId = in.readString();
+            timestamp = in.readOptionalString();
+            expand = in.readBoolean();
+            excludeInterim = in.readBoolean();
+            start = in.readOptionalString();
+            end = in.readOptionalString();
+            anomalyScore = in.readOptionalDouble();
+            pageParams = in.readOptionalWriteable(PageParams::new);
+            sort = in.readString();
+            descending = in.readBoolean();
         }
 
         public Request(String jobId) {
@@ -201,17 +210,7 @@ public class GetBucketsAction extends StreamableResponseActionType<GetBucketsAct
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            jobId = in.readString();
-            timestamp = in.readOptionalString();
-            expand = in.readBoolean();
-            excludeInterim = in.readBoolean();
-            start = in.readOptionalString();
-            end = in.readOptionalString();
-            anomalyScore = in.readOptionalDouble();
-            pageParams = in.readOptionalWriteable(PageParams::new);
-            sort = in.readString();
-            descending = in.readBoolean();
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -292,7 +291,8 @@ public class GetBucketsAction extends StreamableResponseActionType<GetBucketsAct
 
     public static class Response extends AbstractGetResourcesResponse<Bucket> implements ToXContentObject {
 
-        public Response() {
+        public Response(StreamInput in) throws IOException {
+            super(in);
         }
 
         public Response(QueryPage<Bucket> buckets) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetCalendarEventsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetCalendarEventsAction.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.core.ml.action;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.ParseField;
@@ -29,17 +29,12 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import java.io.IOException;
 import java.util.Objects;
 
-public class GetCalendarEventsAction extends StreamableResponseActionType<GetCalendarEventsAction.Response> {
+public class GetCalendarEventsAction extends ActionType<GetCalendarEventsAction.Response> {
     public static final GetCalendarEventsAction INSTANCE = new GetCalendarEventsAction();
     public static final String NAME = "cluster:monitor/xpack/ml/calendars/events/get";
 
     private GetCalendarEventsAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, Response::new);
     }
 
     public static class Request extends ActionRequest implements ToXContentObject {
@@ -72,6 +67,15 @@ public class GetCalendarEventsAction extends StreamableResponseActionType<GetCal
         private PageParams pageParams = PageParams.defaultParams();
 
         public Request() {
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            calendarId = in.readString();
+            start = in.readOptionalString();
+            end = in.readOptionalString();
+            jobId = in.readOptionalString();
+            pageParams = new PageParams(in);
         }
 
         public Request(String calendarId) {
@@ -131,12 +135,7 @@ public class GetCalendarEventsAction extends StreamableResponseActionType<GetCal
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            calendarId = in.readString();
-            start = in.readOptionalString();
-            end = in.readOptionalString();
-            jobId = in.readOptionalString();
-            pageParams = new PageParams(in);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -196,7 +195,8 @@ public class GetCalendarEventsAction extends StreamableResponseActionType<GetCal
 
     public static class Response extends AbstractGetResourcesResponse<ScheduledEvent> implements ToXContentObject {
 
-        public Response() {
+        public Response(StreamInput in) throws IOException {
+            super(in);
         }
 
         public Response(QueryPage<ScheduledEvent> scheduledEvents) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetCalendarsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetCalendarsAction.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.core.ml.action;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -28,18 +28,13 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class GetCalendarsAction extends StreamableResponseActionType<GetCalendarsAction.Response> {
+public class GetCalendarsAction extends ActionType<GetCalendarsAction.Response> {
 
     public static final GetCalendarsAction INSTANCE = new GetCalendarsAction();
     public static final String NAME = "cluster:monitor/xpack/ml/calendars/get";
 
     private GetCalendarsAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, Response::new);
     }
 
     public static class Request extends ActionRequest implements ToXContentObject {
@@ -65,6 +60,12 @@ public class GetCalendarsAction extends StreamableResponseActionType<GetCalendar
         private PageParams pageParams;
 
         public Request() {
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            calendarId = in.readOptionalString();
+            pageParams = in.readOptionalWriteable(PageParams::new);
         }
 
         public void setCalendarId(String calendarId) {
@@ -98,9 +99,7 @@ public class GetCalendarsAction extends StreamableResponseActionType<GetCalendar
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            calendarId = in.readOptionalString();
-            pageParams = in.readOptionalWriteable(PageParams::new);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -154,7 +153,8 @@ public class GetCalendarsAction extends StreamableResponseActionType<GetCalendar
             super(calendars);
         }
 
-        public Response() {
+        public Response(StreamInput in) throws IOException {
+            super(in);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetCategoriesAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetCategoriesAction.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.core.ml.action;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -29,18 +29,13 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class GetCategoriesAction extends StreamableResponseActionType<GetCategoriesAction.Response> {
+public class GetCategoriesAction extends ActionType<GetCategoriesAction.Response> {
 
     public static final GetCategoriesAction INSTANCE = new GetCategoriesAction();
     public static final String NAME = "cluster:monitor/xpack/ml/job/results/categories/get";
 
     private GetCategoriesAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, Response::new);
     }
 
     public static class Request extends ActionRequest implements ToXContentObject {
@@ -74,6 +69,13 @@ public class GetCategoriesAction extends StreamableResponseActionType<GetCategor
         }
 
         public Request() {
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            jobId = in.readString();
+            categoryId = in.readOptionalLong();
+            pageParams = in.readOptionalWriteable(PageParams::new);
         }
 
         public String getJobId() { return jobId; }
@@ -111,10 +113,7 @@ public class GetCategoriesAction extends StreamableResponseActionType<GetCategor
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            jobId = in.readString();
-            categoryId = in.readOptionalLong();
-            pageParams = in.readOptionalWriteable(PageParams::new);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -170,7 +169,8 @@ public class GetCategoriesAction extends StreamableResponseActionType<GetCategor
             super(result);
         }
 
-        public Response() {
+        public Response(StreamInput in) throws IOException {
+            super(in);
         }
 
         public QueryPage<CategoryDefinition> getResult() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDataFrameAnalyticsAction.java
@@ -6,7 +6,7 @@
 package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.action.ActionRequestBuilder;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -16,20 +16,14 @@ import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 
 import java.io.IOException;
-import java.util.Collections;
 
-public class GetDataFrameAnalyticsAction extends StreamableResponseActionType<GetDataFrameAnalyticsAction.Response> {
+public class GetDataFrameAnalyticsAction extends ActionType<GetDataFrameAnalyticsAction.Response> {
 
     public static final GetDataFrameAnalyticsAction INSTANCE = new GetDataFrameAnalyticsAction();
     public static final String NAME = "cluster:monitor/xpack/ml/data_frame/analytics/get";
 
     private GetDataFrameAnalyticsAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response(new QueryPage<>(Collections.emptyList(), 0, Response.RESULTS_FIELD));
+        super(NAME, Response::new);
     }
 
     public static class Request extends AbstractGetResourcesRequest {
@@ -46,7 +40,7 @@ public class GetDataFrameAnalyticsAction extends StreamableResponseActionType<Ge
         }
 
         public Request(StreamInput in) throws IOException {
-            readFrom(in);
+            super(in);
         }
 
         @Override
@@ -59,7 +53,9 @@ public class GetDataFrameAnalyticsAction extends StreamableResponseActionType<Ge
 
         public static final ParseField RESULTS_FIELD = new ParseField("data_frame_analytics");
 
-        public Response() {}
+        public Response(StreamInput in) throws IOException {
+            super(in);
+        }
 
         public Response(QueryPage<DataFrameAnalyticsConfig> analytics) {
             super(analytics);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsAction.java
@@ -7,7 +7,7 @@ package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.client.ElasticsearchClient;
@@ -23,7 +23,7 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import java.io.IOException;
 import java.util.Objects;
 
-public class GetDatafeedsAction extends StreamableResponseActionType<GetDatafeedsAction.Response> {
+public class GetDatafeedsAction extends ActionType<GetDatafeedsAction.Response> {
 
     public static final GetDatafeedsAction INSTANCE = new GetDatafeedsAction();
     public static final String NAME = "cluster:monitor/xpack/ml/datafeeds/get";
@@ -31,12 +31,7 @@ public class GetDatafeedsAction extends StreamableResponseActionType<GetDatafeed
     public static final String ALL = "_all";
 
     private GetDatafeedsAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, Response::new);
     }
 
     public static class Request extends MasterNodeReadRequest<Request> {
@@ -125,7 +120,9 @@ public class GetDatafeedsAction extends StreamableResponseActionType<GetDatafeed
             super(datafeeds);
         }
 
-        public Response() {}
+        public Response(StreamInput in) throws IOException {
+            super(in);
+        }
 
         public QueryPage<DatafeedConfig> getResponse() {
             return getResources();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java
@@ -7,7 +7,7 @@ package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.client.ElasticsearchClient;
@@ -32,7 +32,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.Version.V_7_4_0;
 
-public class GetDatafeedsStatsAction extends StreamableResponseActionType<GetDatafeedsStatsAction.Response> {
+public class GetDatafeedsStatsAction extends ActionType<GetDatafeedsStatsAction.Response> {
 
     public static final GetDatafeedsStatsAction INSTANCE = new GetDatafeedsStatsAction();
     public static final String NAME = "cluster:monitor/xpack/ml/datafeeds/stats/get";
@@ -41,12 +41,7 @@ public class GetDatafeedsStatsAction extends StreamableResponseActionType<GetDat
     private static final String STATE = "state";
 
     private GetDatafeedsStatsAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, Response::new);
     }
 
     public static class Request extends MasterNodeReadRequest<Request> {
@@ -248,7 +243,9 @@ public class GetDatafeedsStatsAction extends StreamableResponseActionType<GetDat
             super(datafeedsStats);
         }
 
-        public Response() {}
+        public Response(StreamInput in) throws IOException {
+            super(in);
+        }
 
         public QueryPage<DatafeedStats> getResponse() {
             return getResources();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetFiltersAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetFiltersAction.java
@@ -7,8 +7,9 @@ package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.StatusToXContentObject;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.action.AbstractGetResourcesRequest;
@@ -17,21 +18,18 @@ import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.job.config.MlFilter;
 
+import java.io.IOException;
+
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 
-public class GetFiltersAction extends StreamableResponseActionType<GetFiltersAction.Response> {
+public class GetFiltersAction extends ActionType<GetFiltersAction.Response> {
 
     public static final GetFiltersAction INSTANCE = new GetFiltersAction();
     public static final String NAME = "cluster:admin/xpack/ml/filters/get";
 
     private GetFiltersAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, Response::new);
     }
 
     public static class Request extends AbstractGetResourcesRequest {
@@ -39,6 +37,10 @@ public class GetFiltersAction extends StreamableResponseActionType<GetFiltersAct
         public Request() {
             // Put our own defaults for backwards compatibility
             super(null, null, true);
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
         }
 
         public void setFilterId(String filterId) {
@@ -79,7 +81,8 @@ public class GetFiltersAction extends StreamableResponseActionType<GetFiltersAct
             super(filters);
         }
 
-        public Response() {
+        public Response(StreamInput in) throws IOException {
+            super(in);
         }
 
         public QueryPage<MlFilter> getFilters() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetInfluencersAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetInfluencersAction.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.core.ml.action;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -27,18 +27,13 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import java.io.IOException;
 import java.util.Objects;
 
-public class GetInfluencersAction extends StreamableResponseActionType<GetInfluencersAction.Response> {
+public class GetInfluencersAction extends ActionType<GetInfluencersAction.Response> {
 
     public static final GetInfluencersAction INSTANCE = new GetInfluencersAction();
     public static final String NAME = "cluster:monitor/xpack/ml/job/results/influencers/get";
 
     private GetInfluencersAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, Response::new);
     }
 
     public static class Request extends ActionRequest implements ToXContentObject {
@@ -81,6 +76,18 @@ public class GetInfluencersAction extends StreamableResponseActionType<GetInflue
         private boolean descending = true;
 
         public Request() {
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            jobId = in.readString();
+            excludeInterim = in.readBoolean();
+            pageParams = new PageParams(in);
+            start = in.readOptionalString();
+            end = in.readOptionalString();
+            sort = in.readOptionalString();
+            descending = in.readBoolean();
+            influencerScore = in.readDouble();
         }
 
         public Request(String jobId) {
@@ -154,15 +161,7 @@ public class GetInfluencersAction extends StreamableResponseActionType<GetInflue
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            jobId = in.readString();
-            excludeInterim = in.readBoolean();
-            pageParams = new PageParams(in);
-            start = in.readOptionalString();
-            end = in.readOptionalString();
-            sort = in.readOptionalString();
-            descending = in.readBoolean();
-            influencerScore = in.readDouble();
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -227,6 +226,10 @@ public class GetInfluencersAction extends StreamableResponseActionType<GetInflue
     public static class Response extends AbstractGetResourcesResponse<Influencer> implements ToXContentObject {
 
         public Response() {
+        }
+
+        public Response(StreamInput in) throws IOException {
+            super(in);
         }
 
         public Response(QueryPage<Influencer> influencers) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetJobsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetJobsAction.java
@@ -7,7 +7,7 @@ package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.client.ElasticsearchClient;
@@ -23,18 +23,13 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import java.io.IOException;
 import java.util.Objects;
 
-public class GetJobsAction extends StreamableResponseActionType<GetJobsAction.Response> {
+public class GetJobsAction extends ActionType<GetJobsAction.Response> {
 
     public static final GetJobsAction INSTANCE = new GetJobsAction();
     public static final String NAME = "cluster:monitor/xpack/ml/job/get";
 
     private GetJobsAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, Response::new);
     }
 
     public static class Request extends MasterNodeReadRequest<Request> {
@@ -123,7 +118,9 @@ public class GetJobsAction extends StreamableResponseActionType<GetJobsAction.Re
             super(jobs);
         }
 
-        public Response() {}
+        public Response(StreamInput in) throws IOException {
+            super(in);
+        }
 
         public QueryPage<Job> getResponse() {
             return getResources();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetModelSnapshotsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetModelSnapshotsAction.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.core.ml.action;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
@@ -28,18 +28,13 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import java.io.IOException;
 import java.util.Objects;
 
-public class GetModelSnapshotsAction extends StreamableResponseActionType<GetModelSnapshotsAction.Response> {
+public class GetModelSnapshotsAction extends ActionType<GetModelSnapshotsAction.Response> {
 
     public static final GetModelSnapshotsAction INSTANCE = new GetModelSnapshotsAction();
     public static final String NAME = "cluster:monitor/xpack/ml/job/model_snapshots/get";
 
     private GetModelSnapshotsAction() {
-        super(NAME);
-    }
-
-    @Override
-    public GetModelSnapshotsAction.Response newResponse() {
-        return new Response();
+        super(NAME, Response::new);
     }
 
     public static class Request extends ActionRequest implements ToXContentObject {
@@ -82,6 +77,17 @@ public class GetModelSnapshotsAction extends StreamableResponseActionType<GetMod
         private PageParams pageParams = new PageParams();
 
         public Request() {
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            jobId = in.readString();
+            snapshotId = in.readOptionalString();
+            sort = in.readOptionalString();
+            start = in.readOptionalString();
+            end = in.readOptionalString();
+            desc = in.readBoolean();
+            pageParams = new PageParams(in);
         }
 
         public Request(String jobId, String snapshotId) {
@@ -148,14 +154,7 @@ public class GetModelSnapshotsAction extends StreamableResponseActionType<GetMod
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            jobId = in.readString();
-            snapshotId = in.readOptionalString();
-            sort = in.readOptionalString();
-            start = in.readOptionalString();
-            end = in.readOptionalString();
-            desc = in.readBoolean();
-            pageParams = new PageParams(in);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -221,7 +220,8 @@ public class GetModelSnapshotsAction extends StreamableResponseActionType<GetMod
             super(page);
         }
 
-        public Response() {
+        public Response(StreamInput in) throws IOException {
+            super(in);
         }
 
         public QueryPage<ModelSnapshot> getPage() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetOverallBucketsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetOverallBucketsAction.java
@@ -9,7 +9,7 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -29,7 +29,6 @@ import org.elasticsearch.xpack.core.ml.job.results.OverallBucket;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Objects;
 import java.util.function.LongSupplier;
 
@@ -47,18 +46,13 @@ import java.util.function.LongSupplier;
  * the interval.
  * </p>
  */
-public class GetOverallBucketsAction extends StreamableResponseActionType<GetOverallBucketsAction.Response> {
+public class GetOverallBucketsAction extends ActionType<GetOverallBucketsAction.Response> {
 
     public static final GetOverallBucketsAction INSTANCE = new GetOverallBucketsAction();
     public static final String NAME = "cluster:monitor/xpack/ml/job/results/overall_buckets/get";
 
     private GetOverallBucketsAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, Response::new);
     }
 
     public static class Request extends ActionRequest implements ToXContentObject {
@@ -115,6 +109,18 @@ public class GetOverallBucketsAction extends StreamableResponseActionType<GetOve
         private boolean allowNoJobs = true;
 
         public Request() {
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            jobId = in.readString();
+            topN = in.readVInt();
+            bucketSpan = in.readOptionalTimeValue();
+            overallScore = in.readDouble();
+            excludeInterim = in.readBoolean();
+            start = in.readOptionalLong();
+            end = in.readOptionalLong();
+            allowNoJobs = in.readBoolean();
         }
 
         public Request(String jobId) {
@@ -203,15 +209,7 @@ public class GetOverallBucketsAction extends StreamableResponseActionType<GetOve
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            jobId = in.readString();
-            topN = in.readVInt();
-            bucketSpan = in.readOptionalTimeValue();
-            overallScore = in.readDouble();
-            excludeInterim = in.readBoolean();
-            start = in.readOptionalLong();
-            end = in.readOptionalLong();
-            allowNoJobs = in.readBoolean();
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -282,8 +280,8 @@ public class GetOverallBucketsAction extends StreamableResponseActionType<GetOve
 
     public static class Response extends AbstractGetResourcesResponse<OverallBucket> implements ToXContentObject {
 
-        public Response() {
-            super(new QueryPage<>(Collections.emptyList(), 0, OverallBucket.RESULTS_FIELD));
+        public Response(StreamInput in) throws IOException {
+            super(in);
         }
 
         public Response(QueryPage<OverallBucket> overallBuckets) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetRecordsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetRecordsAction.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.core.ml.action;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -27,18 +27,13 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import java.io.IOException;
 import java.util.Objects;
 
-public class GetRecordsAction extends StreamableResponseActionType<GetRecordsAction.Response> {
+public class GetRecordsAction extends ActionType<GetRecordsAction.Response> {
 
     public static final GetRecordsAction INSTANCE = new GetRecordsAction();
     public static final String NAME = "cluster:monitor/xpack/ml/job/results/records/get";
 
     private GetRecordsAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, Response::new);
     }
 
     public static class Request extends ActionRequest implements ToXContentObject {
@@ -81,6 +76,18 @@ public class GetRecordsAction extends StreamableResponseActionType<GetRecordsAct
         private boolean descending = true;
 
         public Request() {
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            jobId = in.readString();
+            excludeInterim = in.readBoolean();
+            pageParams = new PageParams(in);
+            start = in.readOptionalString();
+            end = in.readOptionalString();
+            sort = in.readOptionalString();
+            descending = in.readBoolean();
+            recordScoreFilter = in.readDouble();
         }
 
         public Request(String jobId) {
@@ -153,15 +160,7 @@ public class GetRecordsAction extends StreamableResponseActionType<GetRecordsAct
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            jobId = in.readString();
-            excludeInterim = in.readBoolean();
-            pageParams = new PageParams(in);
-            start = in.readOptionalString();
-            end = in.readOptionalString();
-            sort = in.readOptionalString();
-            descending = in.readBoolean();
-            recordScoreFilter = in.readDouble();
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -226,7 +225,8 @@ public class GetRecordsAction extends StreamableResponseActionType<GetRecordsAct
 
     public static class Response extends AbstractGetResourcesResponse<AnomalyRecord> implements ToXContentObject {
 
-        public Response() {
+        public Response(StreamInput in) throws IOException {
+            super(in);
         }
 
         public Response(QueryPage<AnomalyRecord> records) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/MlInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/MlInfoAction.java
@@ -9,7 +9,7 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -21,18 +21,13 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
-public class MlInfoAction extends StreamableResponseActionType<MlInfoAction.Response> {
+public class MlInfoAction extends ActionType<MlInfoAction.Response> {
 
     public static final MlInfoAction INSTANCE = new MlInfoAction();
     public static final String NAME = "cluster:monitor/xpack/ml/info/get";
 
     private MlInfoAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, Response::new);
     }
 
     public static class Request extends ActionRequest {
@@ -70,10 +65,18 @@ public class MlInfoAction extends StreamableResponseActionType<MlInfoAction.Resp
             this.info = Collections.emptyMap();
         }
 
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            info = in.readMap();
+        }
+
+        public Map<String, Object> getInfo() {
+            return info;
+        }
+
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            info = in.readMap();
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PostCalendarEventsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PostCalendarEventsAction.java
@@ -10,7 +10,7 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -30,19 +30,14 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-public class PostCalendarEventsAction extends StreamableResponseActionType<PostCalendarEventsAction.Response> {
+public class PostCalendarEventsAction extends ActionType<PostCalendarEventsAction.Response> {
     public static final PostCalendarEventsAction INSTANCE = new PostCalendarEventsAction();
     public static final String NAME = "cluster:admin/xpack/ml/calendars/events/post";
 
     public static final ParseField EVENTS = new ParseField("events");
 
     private PostCalendarEventsAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, Response::new);
     }
 
     public static class Request extends ActionRequest {
@@ -74,6 +69,12 @@ public class PostCalendarEventsAction extends StreamableResponseActionType<PostC
         public Request() {
         }
 
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            calendarId = in.readString();
+            scheduledEvents = in.readList(ScheduledEvent::new);
+        }
+
         public Request(String calendarId, List<ScheduledEvent> scheduledEvents) {
             this.calendarId = ExceptionsHelper.requireNonNull(calendarId, Calendar.ID.getPreferredName());
             this.scheduledEvents = ExceptionsHelper.requireNonNull(scheduledEvents, EVENTS.getPreferredName());
@@ -98,9 +99,7 @@ public class PostCalendarEventsAction extends StreamableResponseActionType<PostC
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            calendarId = in.readString();
-            scheduledEvents = in.readList(ScheduledEvent::new);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -139,7 +138,13 @@ public class PostCalendarEventsAction extends StreamableResponseActionType<PostC
 
         private List<ScheduledEvent> scheduledEvents;
 
-        public Response() {
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            if (in.getVersion().before(Version.V_6_3_0)) {
+                //the acknowledged flag was removed
+                in.readBoolean();
+            }
+            in.readList(ScheduledEvent::new);
         }
 
         public Response(List<ScheduledEvent> scheduledEvents) {
@@ -148,12 +153,7 @@ public class PostCalendarEventsAction extends StreamableResponseActionType<PostC
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            if (in.getVersion().before(Version.V_6_3_0)) {
-                //the acknowledged flag was removed
-                in.readBoolean();
-            }
-            in.readList(ScheduledEvent::new);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PreviewDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PreviewDatafeedAction.java
@@ -9,7 +9,7 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -25,18 +25,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Objects;
 
-public class PreviewDatafeedAction extends StreamableResponseActionType<PreviewDatafeedAction.Response> {
+public class PreviewDatafeedAction extends ActionType<PreviewDatafeedAction.Response> {
 
     public static final PreviewDatafeedAction INSTANCE = new PreviewDatafeedAction();
     public static final String NAME = "cluster:admin/xpack/ml/datafeeds/preview";
 
     private PreviewDatafeedAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, Response::new);
     }
 
     public static class Request extends ActionRequest implements ToXContentObject {
@@ -44,6 +39,11 @@ public class PreviewDatafeedAction extends StreamableResponseActionType<PreviewD
         private String datafeedId;
 
         public Request() {
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            datafeedId = in.readString();
         }
 
         public Request(String datafeedId) {
@@ -65,8 +65,7 @@ public class PreviewDatafeedAction extends StreamableResponseActionType<PreviewD
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            datafeedId = in.readString();
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -110,9 +109,11 @@ public class PreviewDatafeedAction extends StreamableResponseActionType<PreviewD
 
     public static class Response extends ActionResponse implements ToXContentObject {
 
-        private BytesReference preview;
+        private final BytesReference preview;
 
-        public Response() {
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            preview = in.readBytesReference();
         }
 
         public Response(BytesReference preview) {
@@ -121,8 +122,7 @@ public class PreviewDatafeedAction extends StreamableResponseActionType<PreviewD
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            preview = in.readBytesReference();
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutCalendarAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutCalendarAction.java
@@ -10,7 +10,7 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -28,17 +28,12 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class PutCalendarAction extends StreamableResponseActionType<PutCalendarAction.Response> {
+public class PutCalendarAction extends ActionType<PutCalendarAction.Response> {
     public static final PutCalendarAction INSTANCE = new PutCalendarAction();
     public static final String NAME = "cluster:admin/xpack/ml/calendars/put";
 
     private PutCalendarAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, Response::new);
     }
 
     public static class Request extends ActionRequest implements ToXContentObject {
@@ -59,6 +54,11 @@ public class PutCalendarAction extends StreamableResponseActionType<PutCalendarA
 
         public Request() {
 
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            calendar = new Calendar(in);
         }
 
         public Request(Calendar calendar) {
@@ -92,8 +92,7 @@ public class PutCalendarAction extends StreamableResponseActionType<PutCalendarA
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            calendar = new Calendar(in);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -137,7 +136,13 @@ public class PutCalendarAction extends StreamableResponseActionType<PutCalendarA
 
         private Calendar calendar;
 
-        public Response() {
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            if (in.getVersion().before(Version.V_6_3_0)) {
+                //the acknowledged flag was removed
+                in.readBoolean();
+            }
+            calendar = new Calendar(in);
         }
 
         public Response(Calendar calendar) {
@@ -146,13 +151,7 @@ public class PutCalendarAction extends StreamableResponseActionType<PutCalendarA
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            if (in.getVersion().before(Version.V_6_3_0)) {
-                //the acknowledged flag was removed
-                in.readBoolean();
-            }
-            calendar = new Calendar(in);
-
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutDataFrameAnalyticsAction.java
@@ -29,7 +29,7 @@ public class PutDataFrameAnalyticsAction extends ActionType<PutDataFrameAnalytic
     public static final String NAME = "cluster:admin/xpack/ml/data_frame/analytics/put";
 
     private PutDataFrameAnalyticsAction() {
-        super(NAME);
+        super(NAME, Response::new);
     }
 
     public static class Request extends AcknowledgedRequest<Request> implements ToXContentObject {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutDataFrameAnalyticsAction.java
@@ -7,7 +7,7 @@ package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
@@ -23,18 +23,13 @@ import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import java.io.IOException;
 import java.util.Objects;
 
-public class PutDataFrameAnalyticsAction extends StreamableResponseActionType<PutDataFrameAnalyticsAction.Response> {
+public class PutDataFrameAnalyticsAction extends ActionType<PutDataFrameAnalyticsAction.Response> {
 
     public static final PutDataFrameAnalyticsAction INSTANCE = new PutDataFrameAnalyticsAction();
     public static final String NAME = "cluster:admin/xpack/ml/data_frame/analytics/put";
 
     private PutDataFrameAnalyticsAction() {
         super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
     }
 
     public static class Request extends AcknowledgedRequest<Request> implements ToXContentObject {
@@ -56,14 +51,18 @@ public class PutDataFrameAnalyticsAction extends StreamableResponseActionType<Pu
 
         public Request() {}
 
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            config = new DataFrameAnalyticsConfig(in);
+        }
+
         public Request(DataFrameAnalyticsConfig config) {
             this.config = config;
         }
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            config = new DataFrameAnalyticsConfig(in);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -111,10 +110,14 @@ public class PutDataFrameAnalyticsAction extends StreamableResponseActionType<Pu
 
         Response() {}
 
+        Response(StreamInput in) throws IOException {
+            super(in);
+            config = new DataFrameAnalyticsConfig(in);
+        }
+
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            config = new DataFrameAnalyticsConfig(in);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutDatafeedAction.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.core.ml.action;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
@@ -22,18 +22,13 @@ import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import java.io.IOException;
 import java.util.Objects;
 
-public class PutDatafeedAction extends StreamableResponseActionType<PutDatafeedAction.Response> {
+public class PutDatafeedAction extends ActionType<PutDatafeedAction.Response> {
 
     public static final PutDatafeedAction INSTANCE = new PutDatafeedAction();
     public static final String NAME = "cluster:admin/xpack/ml/datafeeds/put";
 
     private PutDatafeedAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, Response::new);
     }
 
     public static class Request extends AcknowledgedRequest<Request> implements ToXContentObject {
@@ -53,6 +48,11 @@ public class PutDatafeedAction extends StreamableResponseActionType<PutDatafeedA
         public Request() {
         }
 
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            datafeed = new DatafeedConfig(in);
+        }
+
         public DatafeedConfig getDatafeed() {
             return datafeed;
         }
@@ -64,8 +64,7 @@ public class PutDatafeedAction extends StreamableResponseActionType<PutDatafeedA
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            datafeed = new DatafeedConfig(in);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -109,7 +108,13 @@ public class PutDatafeedAction extends StreamableResponseActionType<PutDatafeedA
             this.datafeed = datafeed;
         }
 
-        public Response() {
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            if (in.getVersion().before(Version.V_6_3_0)) {
+                //the acknowledged flag was removed
+                in.readBoolean();
+            }
+            datafeed = new DatafeedConfig(in);
         }
 
         public DatafeedConfig getResponse() {
@@ -118,12 +123,7 @@ public class PutDatafeedAction extends StreamableResponseActionType<PutDatafeedA
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            if (in.getVersion().before(Version.V_6_3_0)) {
-                //the acknowledged flag was removed
-                in.readBoolean();
-            }
-            datafeed = new DatafeedConfig(in);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutFilterAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutFilterAction.java
@@ -9,7 +9,7 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -25,18 +25,13 @@ import java.io.IOException;
 import java.util.Objects;
 
 
-public class PutFilterAction extends StreamableResponseActionType<PutFilterAction.Response> {
+public class PutFilterAction extends ActionType<PutFilterAction.Response> {
 
     public static final PutFilterAction INSTANCE = new PutFilterAction();
     public static final String NAME = "cluster:admin/xpack/ml/filters/put";
 
     private PutFilterAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, Response::new);
     }
 
     public static class Request extends ActionRequest implements ToXContentObject {
@@ -59,6 +54,11 @@ public class PutFilterAction extends StreamableResponseActionType<PutFilterActio
 
         }
 
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            filter = new MlFilter(in);
+        }
+
         public Request(MlFilter filter) {
             this.filter = ExceptionsHelper.requireNonNull(filter, "filter");
         }
@@ -74,8 +74,7 @@ public class PutFilterAction extends StreamableResponseActionType<PutFilterActio
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            filter = new MlFilter(in);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -122,14 +121,18 @@ public class PutFilterAction extends StreamableResponseActionType<PutFilterActio
         Response() {
         }
 
+        Response(StreamInput in) throws IOException {
+            super(in);
+            filter = new MlFilter(in);
+        }
+
         public Response(MlFilter filter) {
             this.filter = filter;
         }
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            filter = new MlFilter(in);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutJobAction.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.core.ml.action;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
@@ -25,18 +25,13 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
-public class PutJobAction extends StreamableResponseActionType<PutJobAction.Response> {
+public class PutJobAction extends ActionType<PutJobAction.Response> {
 
     public static final PutJobAction INSTANCE = new PutJobAction();
     public static final String NAME = "cluster:admin/xpack/ml/job/put";
 
     private PutJobAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, Response::new);
     }
 
     public static class Request extends AcknowledgedRequest<Request> implements ToXContentObject {
@@ -77,6 +72,11 @@ public class PutJobAction extends StreamableResponseActionType<PutJobAction.Resp
         public Request() {
         }
 
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            jobBuilder = new Job.Builder(in);
+        }
+
         public Job.Builder getJobBuilder() {
             return jobBuilder;
         }
@@ -88,8 +88,7 @@ public class PutJobAction extends StreamableResponseActionType<PutJobAction.Resp
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            jobBuilder = new Job.Builder(in);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -132,13 +131,19 @@ public class PutJobAction extends StreamableResponseActionType<PutJobAction.Resp
 
     public static class Response extends ActionResponse implements ToXContentObject {
 
-        private Job job;
+        private final Job job;
 
         public Response(Job job) {
             this.job = job;
         }
 
-        public Response() {
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            if (in.getVersion().before(Version.V_6_3_0)) {
+                //the acknowledged flag was removed
+                in.readBoolean();
+            }
+            job = new Job(in);
         }
 
         public Job getResponse() {
@@ -147,12 +152,7 @@ public class PutJobAction extends StreamableResponseActionType<PutJobAction.Resp
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            if (in.getVersion().before(Version.V_6_3_0)) {
-                //the acknowledged flag was removed
-                in.readBoolean();
-            }
-            job = new Job(in);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/RevertModelSnapshotAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/RevertModelSnapshotAction.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.core.ml.action;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
@@ -29,18 +29,13 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import java.io.IOException;
 import java.util.Objects;
 
-public class RevertModelSnapshotAction extends StreamableResponseActionType<RevertModelSnapshotAction.Response> {
+public class RevertModelSnapshotAction extends ActionType<RevertModelSnapshotAction.Response> {
 
     public static final RevertModelSnapshotAction INSTANCE = new RevertModelSnapshotAction();
     public static final String NAME = "cluster:admin/xpack/ml/job/model_snapshots/revert";
 
     private RevertModelSnapshotAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, Response::new);
     }
 
     public static class Request extends AcknowledgedRequest<Request> implements ToXContentObject {
@@ -74,6 +69,13 @@ public class RevertModelSnapshotAction extends StreamableResponseActionType<Reve
         public Request() {
         }
 
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            jobId = in.readString();
+            snapshotId = in.readString();
+            deleteInterveningResults = in.readBoolean();
+        }
+
         public Request(String jobId, String snapshotId) {
             this.jobId = ExceptionsHelper.requireNonNull(jobId, Job.ID.getPreferredName());
             this.snapshotId = ExceptionsHelper.requireNonNull(snapshotId, SNAPSHOT_ID.getPreferredName());
@@ -102,10 +104,7 @@ public class RevertModelSnapshotAction extends StreamableResponseActionType<Reve
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            jobId = in.readString();
-            snapshotId = in.readString();
-            deleteInterveningResults = in.readBoolean();
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -157,9 +156,15 @@ public class RevertModelSnapshotAction extends StreamableResponseActionType<Reve
         private static final ParseField MODEL = new ParseField("model");
         private ModelSnapshot model;
 
-        public Response() {
-
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            if (in.getVersion().before(Version.V_6_3_0)) {
+                //the acknowledged flag was removed
+                in.readBoolean();
+            }
+            model = new ModelSnapshot(in);
         }
+
 
         public Response(ModelSnapshot modelSnapshot) {
             model = modelSnapshot;
@@ -171,12 +176,7 @@ public class RevertModelSnapshotAction extends StreamableResponseActionType<Reve
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            if (in.getVersion().before(Version.V_6_3_0)) {
-                //the acknowledged flag was removed
-                in.readBoolean();
-            }
-            model = new ModelSnapshot(in);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateCalendarJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateCalendarJobAction.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.core.ml.action;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -18,17 +18,12 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import java.io.IOException;
 import java.util.Objects;
 
-public class UpdateCalendarJobAction extends StreamableResponseActionType<PutCalendarAction.Response> {
+public class UpdateCalendarJobAction extends ActionType<PutCalendarAction.Response> {
     public static final UpdateCalendarJobAction INSTANCE = new UpdateCalendarJobAction();
     public static final String NAME = "cluster:admin/xpack/ml/calendars/jobs/update";
 
     private UpdateCalendarJobAction() {
-        super(NAME);
-    }
-
-    @Override
-    public PutCalendarAction.Response newResponse() {
-        return new PutCalendarAction.Response();
+        super(NAME, PutCalendarAction.Response::new);
     }
 
     public static class Request extends ActionRequest {
@@ -38,6 +33,13 @@ public class UpdateCalendarJobAction extends StreamableResponseActionType<PutCal
         private String jobIdsToRemoveExpression;
 
         public Request() {
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            calendarId = in.readString();
+            jobIdsToAddExpression = in.readOptionalString();
+            jobIdsToRemoveExpression = in.readOptionalString();
         }
 
         /**
@@ -69,10 +71,7 @@ public class UpdateCalendarJobAction extends StreamableResponseActionType<PutCal
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            calendarId = in.readString();
-            jobIdsToAddExpression = in.readOptionalString();
-            jobIdsToRemoveExpression = in.readOptionalString();
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateDatafeedAction.java
@@ -6,7 +6,7 @@
 package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
@@ -20,18 +20,13 @@ import org.elasticsearch.xpack.core.ml.datafeed.DatafeedUpdate;
 import java.io.IOException;
 import java.util.Objects;
 
-public class UpdateDatafeedAction extends StreamableResponseActionType<PutDatafeedAction.Response> {
+public class UpdateDatafeedAction extends ActionType<PutDatafeedAction.Response> {
 
     public static final UpdateDatafeedAction INSTANCE = new UpdateDatafeedAction();
     public static final String NAME = "cluster:admin/xpack/ml/datafeeds/update";
 
     private UpdateDatafeedAction() {
-        super(NAME);
-    }
-
-    @Override
-    public PutDatafeedAction.Response newResponse() {
-        return new PutDatafeedAction.Response();
+        super(NAME, PutDatafeedAction.Response::new);
     }
 
     public static class Request extends AcknowledgedRequest<Request> implements ToXContentObject {
@@ -51,6 +46,11 @@ public class UpdateDatafeedAction extends StreamableResponseActionType<PutDatafe
         public Request() {
         }
 
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            update = new DatafeedUpdate(in);
+        }
+
         public DatafeedUpdate getUpdate() {
             return update;
         }
@@ -62,8 +62,7 @@ public class UpdateDatafeedAction extends StreamableResponseActionType<PutDatafe
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            update = new DatafeedUpdate(in);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateFilterAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateFilterAction.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.core.ml.action;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
@@ -32,18 +32,13 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 
-public class UpdateFilterAction extends StreamableResponseActionType<PutFilterAction.Response> {
+public class UpdateFilterAction extends ActionType<PutFilterAction.Response> {
 
     public static final UpdateFilterAction INSTANCE = new UpdateFilterAction();
     public static final String NAME = "cluster:admin/xpack/ml/filters/update";
 
     private UpdateFilterAction() {
-        super(NAME);
-    }
-
-    @Override
-    public PutFilterAction.Response newResponse() {
-        return new PutFilterAction.Response();
+        super(NAME, PutFilterAction.Response::new);
     }
 
     public static class Request extends ActionRequest implements ToXContentObject {
@@ -79,6 +74,14 @@ public class UpdateFilterAction extends StreamableResponseActionType<PutFilterAc
         private SortedSet<String> removeItems = Collections.emptySortedSet();
 
         public Request() {
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            filterId = in.readString();
+            description = in.readOptionalString();
+            addItems = new TreeSet<>(Arrays.asList(in.readStringArray()));
+            removeItems = new TreeSet<>(Arrays.asList(in.readStringArray()));
         }
 
         public Request(String filterId) {
@@ -124,11 +127,7 @@ public class UpdateFilterAction extends StreamableResponseActionType<PutFilterAc
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            filterId = in.readString();
-            description = in.readOptionalString();
-            addItems = new TreeSet<>(Arrays.asList(in.readStringArray()));
-            removeItems = new TreeSet<>(Arrays.asList(in.readStringArray()));
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateJobAction.java
@@ -7,7 +7,7 @@ package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
@@ -24,17 +24,12 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import java.io.IOException;
 import java.util.Objects;
 
-public class UpdateJobAction extends StreamableResponseActionType<PutJobAction.Response> {
+public class UpdateJobAction extends ActionType<PutJobAction.Response> {
     public static final UpdateJobAction INSTANCE = new UpdateJobAction();
     public static final String NAME = "cluster:admin/xpack/ml/job/update";
 
     private UpdateJobAction() {
-        super(NAME);
-    }
-
-    @Override
-    public PutJobAction.Response newResponse() {
-        return new PutJobAction.Response();
+        super(NAME, PutJobAction.Response::new);
     }
 
     public static class Request extends AcknowledgedRequest<UpdateJobAction.Request> implements ToXContentObject {
@@ -66,6 +61,20 @@ public class UpdateJobAction extends StreamableResponseActionType<PutJobAction.R
         public Request() {
         }
 
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            jobId = in.readString();
+            update = new JobUpdate(in);
+            if (in.getVersion().onOrAfter(Version.V_6_2_2)) {
+                isInternal = in.readBoolean();
+            } else {
+                isInternal = false;
+            }
+            if (in.getVersion().onOrAfter(Version.V_6_3_0) && in.getVersion().before(Version.V_7_0_0)) {
+                in.readBoolean(); // was waitForAck
+            }
+        }
+
         public static Request internal(String jobId, JobUpdate update) {
             return new Request(jobId, update, true);
         }
@@ -89,17 +98,7 @@ public class UpdateJobAction extends StreamableResponseActionType<PutJobAction.R
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            jobId = in.readString();
-            update = new JobUpdate(in);
-            if (in.getVersion().onOrAfter(Version.V_6_2_2)) {
-                isInternal = in.readBoolean();
-            } else {
-                isInternal = false;
-            }
-            if (in.getVersion().onOrAfter(Version.V_6_3_0) && in.getVersion().before(Version.V_7_0_0)) {
-                in.readBoolean(); // was waitForAck
-            }
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateModelSnapshotAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateModelSnapshotAction.java
@@ -9,7 +9,7 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
@@ -29,18 +29,13 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import java.io.IOException;
 import java.util.Objects;
 
-public class UpdateModelSnapshotAction extends StreamableResponseActionType<UpdateModelSnapshotAction.Response> {
+public class UpdateModelSnapshotAction extends ActionType<UpdateModelSnapshotAction.Response> {
 
     public static final UpdateModelSnapshotAction INSTANCE = new UpdateModelSnapshotAction();
     public static final String NAME = "cluster:admin/xpack/ml/job/model_snapshots/update";
 
     private UpdateModelSnapshotAction() {
-        super(NAME);
-    }
-
-    @Override
-    public UpdateModelSnapshotAction.Response newResponse() {
-        return new Response();
+        super(NAME, Response::new);
     }
 
     public static class Request extends ActionRequest implements ToXContentObject {
@@ -71,6 +66,14 @@ public class UpdateModelSnapshotAction extends StreamableResponseActionType<Upda
         private Boolean retain;
 
         public Request() {
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            jobId = in.readString();
+            snapshotId = in.readString();
+            description = in.readOptionalString();
+            retain = in.readOptionalBoolean();
         }
 
         public Request(String jobId, String snapshotId) {
@@ -109,11 +112,7 @@ public class UpdateModelSnapshotAction extends StreamableResponseActionType<Upda
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            jobId = in.readString();
-            snapshotId = in.readString();
-            description = in.readOptionalString();
-            retain = in.readOptionalBoolean();
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -166,10 +165,11 @@ public class UpdateModelSnapshotAction extends StreamableResponseActionType<Upda
         private static final ParseField ACKNOWLEDGED = new ParseField("acknowledged");
         private static final ParseField MODEL = new ParseField("model");
 
-        private ModelSnapshot model;
+        private final ModelSnapshot model;
 
-        public Response() {
-
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            model = new ModelSnapshot(in);
         }
 
         public Response(ModelSnapshot modelSnapshot) {
@@ -182,8 +182,7 @@ public class UpdateModelSnapshotAction extends StreamableResponseActionType<Upda
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            model = new ModelSnapshot(in);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/DeleteDatafeedRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/DeleteDatafeedRequestTests.java
@@ -5,10 +5,11 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.DeleteDatafeedAction.Request;
 
-public class DeleteDatafeedRequestTests extends AbstractStreamableTestCase<Request> {
+public class DeleteDatafeedRequestTests extends AbstractWireSerializingTestCase<Request> {
 
     @Override
     protected Request createTestInstance() {
@@ -16,7 +17,7 @@ public class DeleteDatafeedRequestTests extends AbstractStreamableTestCase<Reque
     }
 
     @Override
-    protected Request createBlankInstance() {
-        return new Request();
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/DeleteExpiredDataActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/DeleteExpiredDataActionResponseTests.java
@@ -5,10 +5,11 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.DeleteExpiredDataAction.Response;
 
-public class DeleteExpiredDataActionResponseTests extends AbstractStreamableTestCase<Response> {
+public class DeleteExpiredDataActionResponseTests extends AbstractWireSerializingTestCase<Response> {
 
     @Override
     protected Response createTestInstance() {
@@ -16,7 +17,7 @@ public class DeleteExpiredDataActionResponseTests extends AbstractStreamableTest
     }
 
     @Override
-    protected Response createBlankInstance() {
-        return new Response();
+    protected Writeable.Reader<Response> instanceReader() {
+        return Response::new;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/DeleteJobRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/DeleteJobRequestTests.java
@@ -5,10 +5,10 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.test.AbstractStreamableTestCase;
-import org.elasticsearch.xpack.core.ml.action.DeleteJobAction;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
-public class DeleteJobRequestTests extends AbstractStreamableTestCase<DeleteJobAction.Request> {
+public class DeleteJobRequestTests extends AbstractWireSerializingTestCase<DeleteJobAction.Request> {
 
     @Override
     protected DeleteJobAction.Request createTestInstance() {
@@ -18,7 +18,7 @@ public class DeleteJobRequestTests extends AbstractStreamableTestCase<DeleteJobA
     }
 
     @Override
-    protected DeleteJobAction.Request createBlankInstance() {
-        return new DeleteJobAction.Request();
+    protected Writeable.Reader<DeleteJobAction.Request> instanceReader() {
+        return DeleteJobAction.Request::new;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/EvaluateDataFrameActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/EvaluateDataFrameActionRequestTests.java
@@ -6,9 +6,10 @@
 package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.EvaluateDataFrameAction.Request;
 import org.elasticsearch.xpack.core.ml.dataframe.evaluation.MlEvaluationNamedXContentProvider;
 import org.elasticsearch.xpack.core.ml.dataframe.evaluation.softclassification.BinarySoftClassificationTests;
@@ -16,7 +17,7 @@ import org.elasticsearch.xpack.core.ml.dataframe.evaluation.softclassification.B
 import java.util.ArrayList;
 import java.util.List;
 
-public class EvaluateDataFrameActionRequestTests extends AbstractStreamableXContentTestCase<Request> {
+public class EvaluateDataFrameActionRequestTests extends AbstractSerializingTestCase<Request> {
 
     @Override
     protected NamedWriteableRegistry getNamedWriteableRegistry() {
@@ -42,13 +43,13 @@ public class EvaluateDataFrameActionRequestTests extends AbstractStreamableXCont
     }
 
     @Override
-    protected boolean supportsUnknownFields() {
-        return false;
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
     }
 
     @Override
-    protected Request createBlankInstance() {
-        return new Request();
+    protected boolean supportsUnknownFields() {
+        return false;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/FindFileStructureActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/FindFileStructureActionRequestTests.java
@@ -7,7 +7,8 @@ package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.filestructurefinder.FileStructure;
 
 import java.util.Arrays;
@@ -15,7 +16,7 @@ import java.util.Arrays;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.startsWith;
 
-public class FindFileStructureActionRequestTests extends AbstractStreamableTestCase<FindFileStructureAction.Request> {
+public class FindFileStructureActionRequestTests extends AbstractWireSerializingTestCase<FindFileStructureAction.Request> {
 
     @Override
     protected FindFileStructureAction.Request createTestInstance() {
@@ -73,8 +74,8 @@ public class FindFileStructureActionRequestTests extends AbstractStreamableTestC
     }
 
     @Override
-    protected FindFileStructureAction.Request createBlankInstance() {
-        return new FindFileStructureAction.Request();
+    protected Writeable.Reader<FindFileStructureAction.Request> instanceReader() {
+        return FindFileStructureAction.Request::new;
     }
 
     public void testValidateLinesToSample() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/FindFileStructureActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/FindFileStructureActionResponseTests.java
@@ -5,10 +5,11 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.filestructurefinder.FileStructureTests;
 
-public class FindFileStructureActionResponseTests extends AbstractStreamableTestCase<FindFileStructureAction.Response> {
+public class FindFileStructureActionResponseTests extends AbstractWireSerializingTestCase<FindFileStructureAction.Response> {
 
     @Override
     protected FindFileStructureAction.Response createTestInstance() {
@@ -16,7 +17,7 @@ public class FindFileStructureActionResponseTests extends AbstractStreamableTest
     }
 
     @Override
-    protected FindFileStructureAction.Response createBlankInstance() {
-        return new FindFileStructureAction.Response();
+    protected Writeable.Reader<FindFileStructureAction.Response> instanceReader() {
+        return FindFileStructureAction.Response::new;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetBucketActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetBucketActionRequestTests.java
@@ -5,12 +5,13 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
-import org.elasticsearch.xpack.core.ml.action.GetBucketsAction.Request;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.action.util.PageParams;
+import org.elasticsearch.xpack.core.ml.action.GetBucketsAction.Request;
 
-public class GetBucketActionRequestTests extends AbstractStreamableXContentTestCase<Request> {
+public class GetBucketActionRequestTests extends AbstractSerializingTestCase<Request> {
 
     @Override
     protected Request createTestInstance() {
@@ -51,13 +52,13 @@ public class GetBucketActionRequestTests extends AbstractStreamableXContentTestC
     }
 
     @Override
-    protected boolean supportsUnknownFields() {
-        return false;
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
     }
 
     @Override
-    protected Request createBlankInstance() {
-        return new GetBucketsAction.Request();
+    protected boolean supportsUnknownFields() {
+        return false;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetBucketActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetBucketActionResponseTests.java
@@ -5,7 +5,8 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.GetBucketsAction.Response;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.job.results.AnomalyRecord;
@@ -17,7 +18,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-public class GetBucketActionResponseTests extends AbstractStreamableTestCase<Response> {
+public class GetBucketActionResponseTests extends AbstractWireSerializingTestCase<Response> {
 
     @Override
     protected Response createTestInstance() {
@@ -75,8 +76,7 @@ public class GetBucketActionResponseTests extends AbstractStreamableTestCase<Res
     }
 
     @Override
-    protected Response createBlankInstance() {
-        return new GetBucketsAction.Response();
+    protected Writeable.Reader<Response> instanceReader() {
+        return Response::new;
     }
-
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetCalendarEventsActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetCalendarEventsActionRequestTests.java
@@ -6,12 +6,12 @@
 package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
-import org.elasticsearch.xpack.core.ml.action.GetCalendarEventsAction;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 
-public class GetCalendarEventsActionRequestTests extends AbstractStreamableXContentTestCase<GetCalendarEventsAction.Request> {
+public class GetCalendarEventsActionRequestTests extends AbstractSerializingTestCase<GetCalendarEventsAction.Request> {
 
     @Override
     protected GetCalendarEventsAction.Request createTestInstance() {
@@ -33,8 +33,8 @@ public class GetCalendarEventsActionRequestTests extends AbstractStreamableXCont
     }
 
     @Override
-    protected GetCalendarEventsAction.Request createBlankInstance() {
-        return new GetCalendarEventsAction.Request();
+    protected Writeable.Reader<GetCalendarEventsAction.Request> instanceReader() {
+        return GetCalendarEventsAction.Request::new;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetCalendarsActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetCalendarsActionRequestTests.java
@@ -5,12 +5,12 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
-import org.elasticsearch.xpack.core.ml.action.GetCalendarsAction;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 
-public class GetCalendarsActionRequestTests extends AbstractStreamableXContentTestCase<GetCalendarsAction.Request> {
+public class GetCalendarsActionRequestTests extends AbstractSerializingTestCase<GetCalendarsAction.Request> {
 
     @Override
     protected GetCalendarsAction.Request createTestInstance() {
@@ -25,8 +25,8 @@ public class GetCalendarsActionRequestTests extends AbstractStreamableXContentTe
     }
 
     @Override
-    protected GetCalendarsAction.Request createBlankInstance() {
-        return new GetCalendarsAction.Request();
+    protected Writeable.Reader<GetCalendarsAction.Request> instanceReader() {
+        return GetCalendarsAction.Request::new;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetCategoriesRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetCategoriesRequestTests.java
@@ -5,11 +5,12 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 
-public class GetCategoriesRequestTests extends AbstractStreamableXContentTestCase<GetCategoriesAction.Request> {
+public class GetCategoriesRequestTests extends AbstractSerializingTestCase<GetCategoriesAction.Request> {
 
     @Override
     protected GetCategoriesAction.Request createTestInstance() {
@@ -26,13 +27,13 @@ public class GetCategoriesRequestTests extends AbstractStreamableXContentTestCas
     }
 
     @Override
-    protected boolean supportsUnknownFields() {
-        return false;
+    protected Writeable.Reader<GetCategoriesAction.Request> instanceReader() {
+        return GetCategoriesAction.Request::new;
     }
 
     @Override
-    protected GetCategoriesAction.Request createBlankInstance() {
-        return new GetCategoriesAction.Request();
+    protected boolean supportsUnknownFields() {
+        return false;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetCategoriesResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetCategoriesResponseTests.java
@@ -5,13 +5,14 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.job.results.CategoryDefinition;
 
 import java.util.Collections;
 
-public class GetCategoriesResponseTests extends AbstractStreamableTestCase<GetCategoriesAction.Response> {
+public class GetCategoriesResponseTests extends AbstractWireSerializingTestCase<GetCategoriesAction.Response> {
 
     @Override
     protected GetCategoriesAction.Response createTestInstance() {
@@ -22,7 +23,7 @@ public class GetCategoriesResponseTests extends AbstractStreamableTestCase<GetCa
     }
 
     @Override
-    protected GetCategoriesAction.Response createBlankInstance() {
-        return new GetCategoriesAction.Response();
+    protected Writeable.Reader<GetCategoriesAction.Response> instanceReader() {
+        return GetCategoriesAction.Response::new;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDataFrameAnalyticsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDataFrameAnalyticsActionResponseTests.java
@@ -6,10 +6,11 @@
 package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.search.SearchModule;
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsAction.Response;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
@@ -20,7 +21,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class GetDataFrameAnalyticsActionResponseTests extends AbstractStreamableTestCase<Response> {
+public class GetDataFrameAnalyticsActionResponseTests extends AbstractWireSerializingTestCase<Response> {
 
     @Override
     protected NamedWriteableRegistry getNamedWriteableRegistry() {
@@ -49,7 +50,7 @@ public class GetDataFrameAnalyticsActionResponseTests extends AbstractStreamable
     }
 
     @Override
-    protected Response createBlankInstance() {
-        return new Response();
+    protected Writeable.Reader<Response> instanceReader() {
+        return Response::new;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedStatsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedStatsActionResponseTests.java
@@ -8,12 +8,13 @@ package org.elasticsearch.xpack.core.ml.action;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.action.GetDatafeedsStatsAction.Response;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
@@ -34,7 +35,7 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 
-public class GetDatafeedStatsActionResponseTests extends AbstractStreamableTestCase<Response> {
+public class GetDatafeedStatsActionResponseTests extends AbstractWireSerializingTestCase<Response> {
 
     @Override
     protected Response createTestInstance() {
@@ -61,8 +62,8 @@ public class GetDatafeedStatsActionResponseTests extends AbstractStreamableTestC
     }
 
     @Override
-    protected Response createBlankInstance() {
-        return new Response();
+    protected Writeable.Reader<Response> instanceReader() {
+        return Response::new;
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsActionResponseTests.java
@@ -6,9 +6,10 @@
 package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.search.SearchModule;
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.GetDatafeedsAction.Response;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
@@ -18,7 +19,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class GetDatafeedsActionResponseTests extends AbstractStreamableTestCase<Response> {
+public class GetDatafeedsActionResponseTests extends AbstractWireSerializingTestCase<Response> {
 
     @Override
     protected Response createTestInstance() {
@@ -31,8 +32,8 @@ public class GetDatafeedsActionResponseTests extends AbstractStreamableTestCase<
     }
 
     @Override
-    protected Response createBlankInstance() {
-        return new Response();
+    protected Writeable.Reader<Response> instanceReader() {
+        return Response::new;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetFiltersActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetFiltersActionRequestTests.java
@@ -5,11 +5,12 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.GetFiltersAction.Request;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 
-public class GetFiltersActionRequestTests extends AbstractStreamableTestCase<GetFiltersAction.Request> {
+public class GetFiltersActionRequestTests extends AbstractWireSerializingTestCase<Request> {
 
 
     @Override
@@ -28,8 +29,7 @@ public class GetFiltersActionRequestTests extends AbstractStreamableTestCase<Get
     }
 
     @Override
-    protected Request createBlankInstance() {
-        return new Request();
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
     }
-
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetFiltersActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetFiltersActionResponseTests.java
@@ -5,7 +5,8 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.GetFiltersAction.Response;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.job.config.MlFilter;
@@ -13,7 +14,7 @@ import org.elasticsearch.xpack.core.ml.job.config.MlFilterTests;
 
 import java.util.Collections;
 
-public class GetFiltersActionResponseTests extends AbstractStreamableTestCase<GetFiltersAction.Response> {
+public class GetFiltersActionResponseTests extends AbstractWireSerializingTestCase<Response> {
 
     @Override
     protected Response createTestInstance() {
@@ -24,8 +25,7 @@ public class GetFiltersActionResponseTests extends AbstractStreamableTestCase<Ge
     }
 
     @Override
-    protected Response createBlankInstance() {
-        return new Response();
+    protected Writeable.Reader<Response> instanceReader() {
+        return Response::new;
     }
-
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetInfluencersActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetInfluencersActionRequestTests.java
@@ -5,12 +5,13 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
-import org.elasticsearch.xpack.core.ml.action.GetInfluencersAction.Request;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.action.util.PageParams;
+import org.elasticsearch.xpack.core.ml.action.GetInfluencersAction.Request;
 
-public class GetInfluencersActionRequestTests extends AbstractStreamableXContentTestCase<Request> {
+public class GetInfluencersActionRequestTests extends AbstractSerializingTestCase<Request> {
 
     @Override
     protected Request doParseInstance(XContentParser parser) {
@@ -49,13 +50,12 @@ public class GetInfluencersActionRequestTests extends AbstractStreamableXContent
     }
 
     @Override
-    protected boolean supportsUnknownFields() {
-        return false;
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
     }
 
     @Override
-    protected Request createBlankInstance() {
-        return new Request();
+    protected boolean supportsUnknownFields() {
+        return false;
     }
-
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetInfluencersActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetInfluencersActionResponseTests.java
@@ -5,16 +5,17 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.test.AbstractStreamableTestCase;
-import org.elasticsearch.xpack.core.ml.action.GetInfluencersAction.Response;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
+import org.elasticsearch.xpack.core.ml.action.GetInfluencersAction.Response;
 import org.elasticsearch.xpack.core.ml.job.results.Influencer;
 
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-public class GetInfluencersActionResponseTests extends AbstractStreamableTestCase<GetInfluencersAction.Response> {
+public class GetInfluencersActionResponseTests extends AbstractWireSerializingTestCase<Response> {
 
     @Override
     protected Response createTestInstance() {
@@ -34,8 +35,7 @@ public class GetInfluencersActionResponseTests extends AbstractStreamableTestCas
     }
 
     @Override
-    protected Response createBlankInstance() {
-        return new Response();
+    protected Writeable.Reader<Response> instanceReader() {
+        return Response::new;
     }
-
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetJobsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetJobsActionResponseTests.java
@@ -5,7 +5,8 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.GetJobsAction.Response;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
@@ -14,7 +15,7 @@ import org.elasticsearch.xpack.core.ml.job.config.JobTests;
 import java.util.ArrayList;
 import java.util.List;
 
-public class GetJobsActionResponseTests extends AbstractStreamableTestCase<GetJobsAction.Response> {
+public class GetJobsActionResponseTests extends AbstractWireSerializingTestCase<GetJobsAction.Response> {
 
     @Override
     protected Response createTestInstance() {
@@ -32,8 +33,7 @@ public class GetJobsActionResponseTests extends AbstractStreamableTestCase<GetJo
     }
 
     @Override
-    protected Response createBlankInstance() {
-        return new Response();
+    protected Writeable.Reader<Response> instanceReader() {
+        return Response::new;
     }
-
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetModelSnapshotsActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetModelSnapshotsActionRequestTests.java
@@ -5,16 +5,17 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
-import org.elasticsearch.xpack.core.ml.action.GetModelSnapshotsAction.Request;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.action.util.PageParams;
+import org.elasticsearch.xpack.core.ml.action.GetModelSnapshotsAction.Request;
 
-public class GetModelSnapshotsActionRequestTests extends AbstractStreamableXContentTestCase<Request> {
+public class GetModelSnapshotsActionRequestTests extends AbstractSerializingTestCase<Request> {
 
     @Override
     protected Request doParseInstance(XContentParser parser) {
-        return GetModelSnapshotsAction.Request.parseRequest(null, null, parser);
+        return Request.parseRequest(null, null, parser);
     }
 
     @Override
@@ -41,13 +42,12 @@ public class GetModelSnapshotsActionRequestTests extends AbstractStreamableXCont
     }
 
     @Override
-    protected boolean supportsUnknownFields() {
-        return false;
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
     }
 
     @Override
-    protected Request createBlankInstance() {
-        return new Request();
+    protected boolean supportsUnknownFields() {
+        return false;
     }
-
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetModelSnapshotsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetModelSnapshotsActionResponseTests.java
@@ -5,7 +5,8 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.GetModelSnapshotsAction.Response;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
@@ -14,7 +15,7 @@ import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapsho
 import java.util.ArrayList;
 import java.util.List;
 
-public class GetModelSnapshotsActionResponseTests extends AbstractStreamableTestCase<GetModelSnapshotsAction.Response> {
+public class GetModelSnapshotsActionResponseTests extends AbstractWireSerializingTestCase<Response> {
 
     @Override
     protected Response createTestInstance() {
@@ -28,7 +29,7 @@ public class GetModelSnapshotsActionResponseTests extends AbstractStreamableTest
     }
 
     @Override
-    protected Response createBlankInstance() {
-        return new Response();
+    protected Writeable.Reader<Response> instanceReader() {
+        return Response::new;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetOverallBucketsActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetOverallBucketsActionRequestTests.java
@@ -5,12 +5,13 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.GetOverallBucketsAction.Request;
 
-public class GetOverallBucketsActionRequestTests extends AbstractStreamableXContentTestCase<Request> {
+public class GetOverallBucketsActionRequestTests extends AbstractSerializingTestCase<Request> {
 
     @Override
     protected Request createTestInstance() {
@@ -39,13 +40,13 @@ public class GetOverallBucketsActionRequestTests extends AbstractStreamableXCont
     }
 
     @Override
-    protected boolean supportsUnknownFields() {
-        return false;
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
     }
 
     @Override
-    protected Request createBlankInstance() {
-        return new Request();
+    protected boolean supportsUnknownFields() {
+        return false;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetOverallBucketsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetOverallBucketsActionResponseTests.java
@@ -5,7 +5,8 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.GetOverallBucketsAction.Response;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.job.results.OverallBucket;
@@ -14,7 +15,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-public class GetOverallBucketsActionResponseTests extends AbstractStreamableTestCase<Response> {
+public class GetOverallBucketsActionResponseTests extends AbstractWireSerializingTestCase<Response> {
 
     @Override
     protected Response createTestInstance() {
@@ -34,7 +35,7 @@ public class GetOverallBucketsActionResponseTests extends AbstractStreamableTest
     }
 
     @Override
-    protected Response createBlankInstance() {
-        return new Response();
+    protected Writeable.Reader<Response> instanceReader() {
+        return Response::new;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetRecordsActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetRecordsActionRequestTests.java
@@ -5,12 +5,13 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
-import org.elasticsearch.xpack.core.ml.action.GetRecordsAction.Request;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.action.util.PageParams;
+import org.elasticsearch.xpack.core.ml.action.GetRecordsAction.Request;
 
-public class GetRecordsActionRequestTests extends AbstractStreamableXContentTestCase<Request> {
+public class GetRecordsActionRequestTests extends AbstractSerializingTestCase<Request> {
 
     @Override
     protected Request doParseInstance(XContentParser parser) {
@@ -49,13 +50,12 @@ public class GetRecordsActionRequestTests extends AbstractStreamableXContentTest
     }
 
     @Override
-    protected boolean supportsUnknownFields() {
-        return false;
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
     }
 
     @Override
-    protected Request createBlankInstance() {
-        return new Request();
+    protected boolean supportsUnknownFields() {
+        return false;
     }
-
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetRecordsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetRecordsActionResponseTests.java
@@ -5,7 +5,8 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.GetRecordsAction.Response;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.job.results.AnomalyRecord;
@@ -14,7 +15,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-public class GetRecordsActionResponseTests extends AbstractStreamableTestCase<GetRecordsAction.Response> {
+public class GetRecordsActionResponseTests extends AbstractWireSerializingTestCase<Response> {
 
     @Override
     protected Response createTestInstance() {
@@ -30,8 +31,7 @@ public class GetRecordsActionResponseTests extends AbstractStreamableTestCase<Ge
     }
 
     @Override
-    protected Response createBlankInstance() {
-        return new Response();
+    protected Writeable.Reader<Response> instanceReader() {
+        return Response::new;
     }
-
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PostCalendarEventActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PostCalendarEventActionRequestTests.java
@@ -7,9 +7,10 @@ package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.calendars.ScheduledEvent;
 import org.elasticsearch.xpack.core.ml.calendars.ScheduledEventTests;
 
@@ -17,12 +18,17 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class PostCalendarEventActionRequestTests extends AbstractStreamableTestCase<PostCalendarEventsAction.Request> {
+public class PostCalendarEventActionRequestTests extends AbstractWireSerializingTestCase<PostCalendarEventsAction.Request> {
 
     @Override
     protected PostCalendarEventsAction.Request createTestInstance() {
         String id = randomAlphaOfLengthBetween(1, 20);
         return createTestInstance(id);
+    }
+
+    @Override
+    protected Writeable.Reader<PostCalendarEventsAction.Request> instanceReader() {
+        return PostCalendarEventsAction.Request::new;
     }
 
     private PostCalendarEventsAction.Request createTestInstance(String calendarId) {
@@ -35,12 +41,6 @@ public class PostCalendarEventActionRequestTests extends AbstractStreamableTestC
         PostCalendarEventsAction.Request request = new PostCalendarEventsAction.Request(calendarId, events);
         return request;
     }
-
-    @Override
-    protected PostCalendarEventsAction.Request createBlankInstance() {
-        return new PostCalendarEventsAction.Request();
-    }
-
 
     public void testParseRequest() throws IOException {
         PostCalendarEventsAction.Request sourceRequest = createTestInstance();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PreviewDatafeedActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PreviewDatafeedActionRequestTests.java
@@ -5,10 +5,11 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.PreviewDatafeedAction.Request;
 
-public class PreviewDatafeedActionRequestTests extends AbstractStreamableTestCase<Request> {
+public class PreviewDatafeedActionRequestTests extends AbstractWireSerializingTestCase<Request> {
 
     @Override
     protected Request createTestInstance() {
@@ -16,7 +17,7 @@ public class PreviewDatafeedActionRequestTests extends AbstractStreamableTestCas
     }
 
     @Override
-    protected Request createBlankInstance() {
-        return new Request();
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutCalendarActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutCalendarActionRequestTests.java
@@ -5,12 +5,13 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.calendars.CalendarTests;
 import org.elasticsearch.xpack.core.ml.job.config.JobTests;
 
-public class PutCalendarActionRequestTests extends AbstractStreamableXContentTestCase<PutCalendarAction.Request> {
+public class PutCalendarActionRequestTests extends AbstractSerializingTestCase<PutCalendarAction.Request> {
 
     private final String calendarId = JobTests.randomValidJobId();
 
@@ -20,13 +21,13 @@ public class PutCalendarActionRequestTests extends AbstractStreamableXContentTes
     }
 
     @Override
-    protected boolean supportsUnknownFields() {
-        return false;
+    protected Writeable.Reader<PutCalendarAction.Request> instanceReader() {
+        return PutCalendarAction.Request::new;
     }
 
     @Override
-    protected PutCalendarAction.Request createBlankInstance() {
-        return new PutCalendarAction.Request();
+    protected boolean supportsUnknownFields() {
+        return false;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutDataFrameAnalyticsActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutDataFrameAnalyticsActionRequestTests.java
@@ -6,11 +6,12 @@
 package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.SearchModule;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.PutDataFrameAnalyticsAction.Request;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfigTests;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.MlDataFrameAnalysisNamedXContentProvider;
@@ -20,7 +21,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class PutDataFrameAnalyticsActionRequestTests extends AbstractStreamableXContentTestCase<Request> {
+public class PutDataFrameAnalyticsActionRequestTests extends AbstractSerializingTestCase<Request> {
 
     private String id;
 
@@ -51,13 +52,13 @@ public class PutDataFrameAnalyticsActionRequestTests extends AbstractStreamableX
     }
 
     @Override
-    protected boolean supportsUnknownFields() {
-        return false;
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
     }
 
     @Override
-    protected Request createBlankInstance() {
-        return new Request();
+    protected boolean supportsUnknownFields() {
+        return false;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutDataFrameAnalyticsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutDataFrameAnalyticsActionResponseTests.java
@@ -6,10 +6,10 @@
 package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.search.SearchModule;
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.PutDataFrameAnalyticsAction.Response;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfigTests;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.MlDataFrameAnalysisNamedXContentProvider;
@@ -18,7 +18,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class PutDataFrameAnalyticsActionResponseTests extends AbstractStreamableTestCase<Response> {
+public class PutDataFrameAnalyticsActionResponseTests extends AbstractWireSerializingTestCase<Response> {
 
     @Override
     protected NamedWriteableRegistry getNamedWriteableRegistry() {
@@ -29,20 +29,12 @@ public class PutDataFrameAnalyticsActionResponseTests extends AbstractStreamable
     }
 
     @Override
-    protected NamedXContentRegistry xContentRegistry() {
-        List<NamedXContentRegistry.Entry> namedXContent = new ArrayList<>();
-        namedXContent.addAll(new MlDataFrameAnalysisNamedXContentProvider().getNamedXContentParsers());
-        namedXContent.addAll(new SearchModule(Settings.EMPTY, false, Collections.emptyList()).getNamedXContents());
-        return new NamedXContentRegistry(namedXContent);
-    }
-
-    @Override
     protected Response createTestInstance() {
         return new Response(DataFrameAnalyticsConfigTests.createRandom(DataFrameAnalyticsConfigTests.randomValidId()));
     }
 
     @Override
-    protected Response createBlankInstance() {
-        return new Response();
+    protected Writeable.Reader<Response> instanceReader() {
+        return Response::new;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutDatafeedActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutDatafeedActionRequestTests.java
@@ -6,11 +6,12 @@
 package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.SearchModule;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.PutDatafeedAction.Request;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfigTests;
@@ -18,7 +19,7 @@ import org.junit.Before;
 
 import java.util.Collections;
 
-public class PutDatafeedActionRequestTests extends AbstractStreamableXContentTestCase<Request> {
+public class PutDatafeedActionRequestTests extends AbstractSerializingTestCase<Request> {
 
     private String datafeedId;
 
@@ -35,13 +36,13 @@ public class PutDatafeedActionRequestTests extends AbstractStreamableXContentTes
     }
 
     @Override
-    protected boolean supportsUnknownFields() {
-        return false;
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
     }
 
     @Override
-    protected Request createBlankInstance() {
-        return new Request();
+    protected boolean supportsUnknownFields() {
+        return false;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutDatafeedActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutDatafeedActionResponseTests.java
@@ -6,9 +6,10 @@
 package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.search.SearchModule;
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.PutDatafeedAction.Response;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfigTests;
@@ -16,7 +17,7 @@ import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfigTests;
 import java.util.Arrays;
 import java.util.Collections;
 
-public class PutDatafeedActionResponseTests extends AbstractStreamableTestCase<Response> {
+public class PutDatafeedActionResponseTests extends AbstractWireSerializingTestCase<Response> {
 
     @Override
     protected Response createTestInstance() {
@@ -27,8 +28,8 @@ public class PutDatafeedActionResponseTests extends AbstractStreamableTestCase<R
     }
 
     @Override
-    protected Response createBlankInstance() {
-        return new Response();
+    protected Writeable.Reader<Response> instanceReader() {
+        return Response::new;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutFilterActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutFilterActionRequestTests.java
@@ -5,12 +5,13 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.PutFilterAction.Request;
 import org.elasticsearch.xpack.core.ml.job.config.MlFilterTests;
 
-public class PutFilterActionRequestTests extends AbstractStreamableXContentTestCase<Request> {
+public class PutFilterActionRequestTests extends AbstractSerializingTestCase<Request> {
 
     private final String filterId = MlFilterTests.randomValidFilterId();
 
@@ -20,13 +21,13 @@ public class PutFilterActionRequestTests extends AbstractStreamableXContentTestC
     }
 
     @Override
-    protected boolean supportsUnknownFields() {
-        return false;
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
     }
 
     @Override
-    protected Request createBlankInstance() {
-        return new PutFilterAction.Request();
+    protected boolean supportsUnknownFields() {
+        return false;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutFilterActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutFilterActionResponseTests.java
@@ -5,14 +5,15 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.job.config.MlFilter;
 import org.elasticsearch.xpack.core.ml.job.config.MlFilterTests;
 
 import java.io.IOException;
 
-public class PutFilterActionResponseTests extends AbstractStreamableXContentTestCase<PutFilterAction.Response> {
+public class PutFilterActionResponseTests extends AbstractSerializingTestCase<PutFilterAction.Response> {
 
     @Override
     protected PutFilterAction.Response createTestInstance() {
@@ -20,8 +21,8 @@ public class PutFilterActionResponseTests extends AbstractStreamableXContentTest
     }
 
     @Override
-    protected PutFilterAction.Response createBlankInstance() {
-        return new PutFilterAction.Response();
+    protected Writeable.Reader<PutFilterAction.Response> instanceReader() {
+        return PutFilterAction.Response::new;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutJobActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutJobActionRequestTests.java
@@ -6,10 +6,11 @@
 package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.PutJobAction.Request;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 
@@ -19,7 +20,7 @@ import java.util.Date;
 import static org.elasticsearch.xpack.core.ml.job.config.JobTests.buildJobBuilder;
 import static org.elasticsearch.xpack.core.ml.job.config.JobTests.randomValidJobId;
 
-public class PutJobActionRequestTests extends AbstractStreamableXContentTestCase<Request> {
+public class PutJobActionRequestTests extends AbstractSerializingTestCase<Request> {
 
     private final String jobId = randomValidJobId();
 
@@ -30,8 +31,8 @@ public class PutJobActionRequestTests extends AbstractStreamableXContentTestCase
     }
 
     @Override
-    protected Request createBlankInstance() {
-        return new Request();
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutJobActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutJobActionResponseTests.java
@@ -5,14 +5,15 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.PutJobAction.Response;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 
 import static org.elasticsearch.xpack.core.ml.job.config.JobTests.buildJobBuilder;
 import static org.elasticsearch.xpack.core.ml.job.config.JobTests.randomValidJobId;
 
-public class PutJobActionResponseTests extends AbstractStreamableTestCase<Response> {
+public class PutJobActionResponseTests extends AbstractWireSerializingTestCase<Response> {
 
     @Override
     protected Response createTestInstance() {
@@ -21,8 +22,7 @@ public class PutJobActionResponseTests extends AbstractStreamableTestCase<Respon
     }
 
     @Override
-    protected Response createBlankInstance() {
-        return new Response();
+    protected Writeable.Reader<Response> instanceReader() {
+        return Response::new;
     }
-
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/RevertModelSnapshotActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/RevertModelSnapshotActionRequestTests.java
@@ -5,12 +5,12 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
-import org.elasticsearch.xpack.core.ml.action.RevertModelSnapshotAction;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.RevertModelSnapshotAction.Request;
 
-public class RevertModelSnapshotActionRequestTests extends AbstractStreamableXContentTestCase<Request> {
+public class RevertModelSnapshotActionRequestTests extends AbstractSerializingTestCase<Request> {
 
     @Override
     protected Request createTestInstance() {
@@ -23,13 +23,13 @@ public class RevertModelSnapshotActionRequestTests extends AbstractStreamableXCo
     }
 
     @Override
-    protected boolean supportsUnknownFields() {
-        return false;
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
     }
 
     @Override
-    protected Request createBlankInstance() {
-        return new RevertModelSnapshotAction.Request();
+    protected boolean supportsUnknownFields() {
+        return false;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/RevertModelSnapshotActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/RevertModelSnapshotActionResponseTests.java
@@ -5,11 +5,12 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.RevertModelSnapshotAction.Response;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshotTests;
 
-public class RevertModelSnapshotActionResponseTests extends AbstractStreamableTestCase<RevertModelSnapshotAction.Response> {
+public class RevertModelSnapshotActionResponseTests extends AbstractWireSerializingTestCase<RevertModelSnapshotAction.Response> {
 
     @Override
     protected Response createTestInstance() {
@@ -17,8 +18,7 @@ public class RevertModelSnapshotActionResponseTests extends AbstractStreamableTe
     }
 
     @Override
-    protected Response createBlankInstance() {
-        return new RevertModelSnapshotAction.Response();
+    protected Writeable.Reader<Response> instanceReader() {
+        return Response::new;
     }
-
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/UpdateCalendarJobActionResquestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/UpdateCalendarJobActionResquestTests.java
@@ -5,9 +5,10 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
-public class UpdateCalendarJobActionResquestTests extends AbstractStreamableTestCase<UpdateCalendarJobAction.Request> {
+public class UpdateCalendarJobActionResquestTests extends AbstractWireSerializingTestCase<UpdateCalendarJobAction.Request> {
 
     @Override
     protected UpdateCalendarJobAction.Request createTestInstance() {
@@ -17,7 +18,7 @@ public class UpdateCalendarJobActionResquestTests extends AbstractStreamableTest
     }
 
     @Override
-    protected UpdateCalendarJobAction.Request  createBlankInstance() {
-        return new UpdateCalendarJobAction.Request();
+    protected Writeable.Reader<UpdateCalendarJobAction.Request> instanceReader() {
+        return UpdateCalendarJobAction.Request::new;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/UpdateDatafeedActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/UpdateDatafeedActionRequestTests.java
@@ -6,11 +6,12 @@
 package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.SearchModule;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.UpdateDatafeedAction.Request;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfigTests;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedUpdateTests;
@@ -18,7 +19,7 @@ import org.junit.Before;
 
 import java.util.Collections;
 
-public class UpdateDatafeedActionRequestTests extends AbstractStreamableXContentTestCase<Request> {
+public class UpdateDatafeedActionRequestTests extends AbstractSerializingTestCase<Request> {
 
     private String datafeedId;
 
@@ -33,13 +34,13 @@ public class UpdateDatafeedActionRequestTests extends AbstractStreamableXContent
     }
 
     @Override
-    protected boolean supportsUnknownFields() {
-        return false;
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
     }
 
     @Override
-    protected Request createBlankInstance() {
-        return new Request();
+    protected boolean supportsUnknownFields() {
+        return false;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/UpdateFilterActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/UpdateFilterActionRequestTests.java
@@ -5,15 +5,16 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.UpdateFilterAction.Request;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-public class UpdateFilterActionRequestTests extends AbstractStreamableXContentTestCase<Request> {
+public class UpdateFilterActionRequestTests extends AbstractSerializingTestCase<Request> {
 
     private String filterId = randomAlphaOfLength(20);
 
@@ -32,6 +33,11 @@ public class UpdateFilterActionRequestTests extends AbstractStreamableXContentTe
         return request;
     }
 
+    @Override
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
+    }
+
     private static Collection<String> generateRandomStrings() {
         int size = randomIntBetween(0, 10);
         List<String> strings = new ArrayList<>(size);
@@ -44,11 +50,6 @@ public class UpdateFilterActionRequestTests extends AbstractStreamableXContentTe
     @Override
     protected boolean supportsUnknownFields() {
         return false;
-    }
-
-    @Override
-    protected Request createBlankInstance() {
-        return new Request();
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/UpdateJobActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/UpdateJobActionRequestTests.java
@@ -5,12 +5,13 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisLimits;
 import org.elasticsearch.xpack.core.ml.job.config.JobUpdate;
 
 public class UpdateJobActionRequestTests
-        extends AbstractStreamableTestCase<UpdateJobAction.Request> {
+        extends AbstractWireSerializingTestCase<UpdateJobAction.Request> {
 
     @Override
     protected UpdateJobAction.Request createTestInstance() {
@@ -30,8 +31,7 @@ public class UpdateJobActionRequestTests
     }
 
     @Override
-    protected UpdateJobAction.Request createBlankInstance() {
-        return new UpdateJobAction.Request();
+    protected Writeable.Reader<UpdateJobAction.Request> instanceReader() {
+        return UpdateJobAction.Request::new;
     }
-
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/UpdateModelSnapshotActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/UpdateModelSnapshotActionRequestTests.java
@@ -5,12 +5,12 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.UpdateModelSnapshotAction.Request;
 
-public class UpdateModelSnapshotActionRequestTests
-        extends AbstractStreamableXContentTestCase<Request> {
+public class UpdateModelSnapshotActionRequestTests extends AbstractSerializingTestCase<Request> {
 
     @Override
     protected Request doParseInstance(XContentParser parser) {
@@ -31,12 +31,12 @@ public class UpdateModelSnapshotActionRequestTests
     }
 
     @Override
-    protected boolean supportsUnknownFields() {
-        return false;
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
     }
 
     @Override
-    protected Request createBlankInstance() {
-        return new Request();
+    protected boolean supportsUnknownFields() {
+        return false;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/UpdateModelSnapshotActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/UpdateModelSnapshotActionResponseTests.java
@@ -5,12 +5,13 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.UpdateModelSnapshotAction.Response;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshotTests;
 
 public class UpdateModelSnapshotActionResponseTests
-        extends AbstractStreamableTestCase<UpdateModelSnapshotAction.Response> {
+        extends AbstractWireSerializingTestCase<UpdateModelSnapshotAction.Response> {
 
     @Override
     protected Response createTestInstance() {
@@ -18,7 +19,7 @@ public class UpdateModelSnapshotActionResponseTests
     }
 
     @Override
-    protected Response createBlankInstance() {
-        return new Response();
+    protected Writeable.Reader<Response> instanceReader() {
+        return Response::new;
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteDatafeedAction.java
@@ -54,7 +54,7 @@ public class TransportDeleteDatafeedAction extends TransportMasterNodeAction<Del
                                          Client client, PersistentTasksService persistentTasksService,
                                          NamedXContentRegistry xContentRegistry) {
         super(DeleteDatafeedAction.NAME, transportService, clusterService, threadPool, actionFilters,
-                indexNameExpressionResolver, DeleteDatafeedAction.Request::new);
+                DeleteDatafeedAction.Request::new, indexNameExpressionResolver);
         this.client = client;
         this.datafeedConfigProvider = new DatafeedConfigProvider(client, xContentRegistry);
         this.persistentTasksService = persistentTasksService;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteFilterAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteFilterAction.java
@@ -44,8 +44,7 @@ public class TransportDeleteFilterAction extends HandledTransportAction<DeleteFi
     public TransportDeleteFilterAction(TransportService transportService,
                                        ActionFilters actionFilters, Client client,
                                        JobConfigProvider jobConfigProvider) {
-        super(DeleteFilterAction.NAME, transportService, DeleteFilterAction.Request::new, actionFilters
-        );
+        super(DeleteFilterAction.NAME, transportService, DeleteFilterAction.Request::new, actionFilters);
         this.client = client;
         this.jobConfigProvider = jobConfigProvider;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
@@ -117,7 +117,7 @@ public class TransportDeleteJobAction extends TransportMasterNodeAction<DeleteJo
                                     JobConfigProvider jobConfigProvider, DatafeedConfigProvider datafeedConfigProvider,
                                     MlMemoryTracker memoryTracker) {
         super(DeleteJobAction.NAME, transportService, clusterService, threadPool, actionFilters,
-                indexNameExpressionResolver, DeleteJobAction.Request::new);
+                DeleteJobAction.Request::new, indexNameExpressionResolver);
         this.client = client;
         this.persistentTasksService = persistentTasksService;
         this.auditor = auditor;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportEvaluateDataFrameAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportEvaluateDataFrameAction.java
@@ -30,7 +30,7 @@ public class TransportEvaluateDataFrameAction extends HandledTransportAction<Eva
     @Inject
     public TransportEvaluateDataFrameAction(TransportService transportService, ActionFilters actionFilters, ThreadPool threadPool,
                                             Client client) {
-        super(EvaluateDataFrameAction.NAME, transportService, EvaluateDataFrameAction.Request::new, actionFilters);
+        super(EvaluateDataFrameAction.NAME, transportService, actionFilters, EvaluateDataFrameAction.Request::new);
         this.threadPool = threadPool;
         this.client = client;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionAction.java
@@ -46,7 +46,7 @@ public class TransportFinalizeJobExecutionAction extends TransportMasterNodeActi
                                                ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
                                                Client client) {
         super(FinalizeJobExecutionAction.NAME, transportService, clusterService, threadPool, actionFilters,
-                indexNameExpressionResolver, FinalizeJobExecutionAction.Request::new);
+                FinalizeJobExecutionAction.Request::new, indexNameExpressionResolver);
         this.client = client;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFindFileStructureAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFindFileStructureAction.java
@@ -27,7 +27,7 @@ public class TransportFindFileStructureAction
 
     @Inject
     public TransportFindFileStructureAction(TransportService transportService, ActionFilters actionFilters, ThreadPool threadPool) {
-        super(FindFileStructureAction.NAME, transportService, FindFileStructureAction.Request::new, actionFilters);
+        super(FindFileStructureAction.NAME, transportService, actionFilters, FindFileStructureAction.Request::new);
         this.threadPool = threadPool;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetBucketsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetBucketsAction.java
@@ -26,7 +26,7 @@ public class TransportGetBucketsAction extends HandledTransportAction<GetBuckets
     @Inject
     public TransportGetBucketsAction(TransportService transportService, ActionFilters actionFilters, JobResultsProvider jobResultsProvider,
                                      JobManager jobManager, Client client) {
-        super(GetBucketsAction.NAME, transportService, GetBucketsAction.Request::new, actionFilters);
+        super(GetBucketsAction.NAME, transportService, actionFilters, GetBucketsAction.Request::new);
         this.jobResultsProvider = jobResultsProvider;
         this.jobManager = jobManager;
         this.client = client;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetCalendarsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetCalendarsAction.java
@@ -27,8 +27,7 @@ public class TransportGetCalendarsAction extends HandledTransportAction<GetCalen
     @Inject
     public TransportGetCalendarsAction(TransportService transportService, ActionFilters actionFilters,
                                        JobResultsProvider jobResultsProvider) {
-        super(GetCalendarsAction.NAME, transportService, GetCalendarsAction.Request::new, actionFilters
-        );
+        super(GetCalendarsAction.NAME, transportService, GetCalendarsAction.Request::new, actionFilters);
         this.jobResultsProvider = jobResultsProvider;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetCalendarsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetCalendarsAction.java
@@ -27,7 +27,7 @@ public class TransportGetCalendarsAction extends HandledTransportAction<GetCalen
     @Inject
     public TransportGetCalendarsAction(TransportService transportService, ActionFilters actionFilters,
                                        JobResultsProvider jobResultsProvider) {
-        super(GetCalendarsAction.NAME, transportService, GetCalendarsAction.Request::new, actionFilters);
+        super(GetCalendarsAction.NAME, transportService, actionFilters, GetCalendarsAction.Request::new);
         this.jobResultsProvider = jobResultsProvider;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetCategoriesAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetCategoriesAction.java
@@ -25,8 +25,7 @@ public class TransportGetCategoriesAction extends HandledTransportAction<GetCate
     @Inject
     public TransportGetCategoriesAction(TransportService transportService, ActionFilters actionFilters,
                                         JobResultsProvider jobResultsProvider, Client client, JobManager jobManager) {
-        super(GetCategoriesAction.NAME, transportService, GetCategoriesAction.Request::new, actionFilters
-        );
+        super(GetCategoriesAction.NAME, transportService, actionFilters, GetCategoriesAction.Request::new);
         this.jobResultsProvider = jobResultsProvider;
         this.client = client;
         this.jobManager = jobManager;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsAction.java
@@ -7,7 +7,7 @@ package org.elasticsearch.xpack.ml.action;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.StreamableTransportMasterNodeReadAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -15,15 +15,17 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.action.GetDatafeedsAction;
-import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -32,8 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class TransportGetDatafeedsAction extends
-    StreamableTransportMasterNodeReadAction<GetDatafeedsAction.Request, GetDatafeedsAction.Response> {
+public class TransportGetDatafeedsAction extends TransportMasterNodeReadAction<GetDatafeedsAction.Request, GetDatafeedsAction.Response> {
 
     private final DatafeedConfigProvider datafeedConfigProvider;
 
@@ -55,8 +56,8 @@ public class TransportGetDatafeedsAction extends
     }
 
     @Override
-    protected GetDatafeedsAction.Response newResponse() {
-        return new GetDatafeedsAction.Response();
+    protected GetDatafeedsAction.Response read(StreamInput in) throws IOException {
+        return new GetDatafeedsAction.Response(in);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsStatsAction.java
@@ -7,7 +7,7 @@ package org.elasticsearch.xpack.ml.action;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.StreamableTransportMasterNodeReadAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -15,22 +15,24 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.GetDatafeedsStatsAction;
-import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class TransportGetDatafeedsStatsAction extends StreamableTransportMasterNodeReadAction<GetDatafeedsStatsAction.Request,
+public class TransportGetDatafeedsStatsAction extends TransportMasterNodeReadAction<GetDatafeedsStatsAction.Request,
         GetDatafeedsStatsAction.Response> {
 
     private final DatafeedConfigProvider datafeedConfigProvider;
@@ -53,8 +55,8 @@ public class TransportGetDatafeedsStatsAction extends StreamableTransportMasterN
     }
 
     @Override
-    protected GetDatafeedsStatsAction.Response newResponse() {
-        return new GetDatafeedsStatsAction.Response();
+    protected GetDatafeedsStatsAction.Response read(StreamInput in) throws IOException {
+        return new GetDatafeedsStatsAction.Response(in);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetInfluencersAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetInfluencersAction.java
@@ -26,8 +26,7 @@ public class TransportGetInfluencersAction extends HandledTransportAction<GetInf
     @Inject
     public TransportGetInfluencersAction(TransportService transportService, ActionFilters actionFilters,
                                          JobResultsProvider jobResultsProvider, Client client, JobManager jobManager) {
-        super(GetInfluencersAction.NAME, transportService,  GetInfluencersAction.Request::new, actionFilters
-        );
+        super(GetInfluencersAction.NAME, transportService, actionFilters, GetInfluencersAction.Request::new);
         this.jobResultsProvider = jobResultsProvider;
         this.client = client;
         this.jobManager = jobManager;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsAction.java
@@ -7,19 +7,22 @@ package org.elasticsearch.xpack.ml.action;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.StreamableTransportMasterNodeReadAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ml.action.GetJobsAction;
 import org.elasticsearch.xpack.ml.job.JobManager;
 
-public class TransportGetJobsAction extends StreamableTransportMasterNodeReadAction<GetJobsAction.Request, GetJobsAction.Response> {
+import java.io.IOException;
+
+public class TransportGetJobsAction extends TransportMasterNodeReadAction<GetJobsAction.Request, GetJobsAction.Response> {
 
     private final JobManager jobManager;
 
@@ -39,8 +42,8 @@ public class TransportGetJobsAction extends StreamableTransportMasterNodeReadAct
     }
 
     @Override
-    protected GetJobsAction.Response newResponse() {
-        return new GetJobsAction.Response();
+    protected GetJobsAction.Response read(StreamInput in) throws IOException {
+        return new GetJobsAction.Response(in);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetModelSnapshotsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetModelSnapshotsAction.java
@@ -28,7 +28,7 @@ public class TransportGetModelSnapshotsAction extends HandledTransportAction<Get
     @Inject
     public TransportGetModelSnapshotsAction(TransportService transportService, ActionFilters actionFilters,
                                             JobResultsProvider jobResultsProvider, JobManager jobManager) {
-        super(GetModelSnapshotsAction.NAME, transportService, GetModelSnapshotsAction.Request::new, actionFilters);
+        super(GetModelSnapshotsAction.NAME, transportService, actionFilters, GetModelSnapshotsAction.Request::new);
         this.jobResultsProvider = jobResultsProvider;
         this.jobManager = jobManager;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetOverallBucketsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetOverallBucketsAction.java
@@ -43,6 +43,7 @@ import org.elasticsearch.xpack.ml.job.persistence.overallbuckets.OverallBucketsP
 import org.elasticsearch.xpack.ml.job.persistence.overallbuckets.OverallBucketsProvider;
 import org.elasticsearch.xpack.ml.utils.MlIndicesUtils;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -78,7 +79,8 @@ public class TransportGetOverallBucketsAction extends HandledTransportAction<Get
         jobManager.expandJobs(request.getJobId(), request.allowNoJobs(), ActionListener.wrap(
                 jobPage -> {
                     if (jobPage.count() == 0) {
-                        listener.onResponse(new GetOverallBucketsAction.Response());
+                        listener.onResponse(new GetOverallBucketsAction.Response(
+                            new QueryPage<>(Collections.emptyList(), 0, Job.RESULTS_FIELD)));
                         return;
                     }
 
@@ -107,7 +109,7 @@ public class TransportGetOverallBucketsAction extends HandledTransportAction<Get
 
         ActionListener<ChunkedBucketSearcher> chunkedBucketSearcherListener = ActionListener.wrap(searcher -> {
             if (searcher == null) {
-                listener.onResponse(new GetOverallBucketsAction.Response());
+                listener.onResponse(new GetOverallBucketsAction.Response(new QueryPage<>(Collections.emptyList(), 0, Job.RESULTS_FIELD)));
                 return;
             }
             searcher.searchAndComputeOverallBuckets(overallBucketsListener);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetOverallBucketsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetOverallBucketsAction.java
@@ -65,8 +65,7 @@ public class TransportGetOverallBucketsAction extends HandledTransportAction<Get
     @Inject
     public TransportGetOverallBucketsAction(ThreadPool threadPool, TransportService transportService, ActionFilters actionFilters,
                                             ClusterService clusterService, JobManager jobManager, Client client) {
-        super(GetOverallBucketsAction.NAME, transportService, GetOverallBucketsAction.Request::new, actionFilters
-        );
+        super(GetOverallBucketsAction.NAME, transportService, actionFilters, GetOverallBucketsAction.Request::new);
         this.threadPool = threadPool;
         this.clusterService = clusterService;
         this.client = client;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetRecordsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetRecordsAction.java
@@ -26,7 +26,7 @@ public class TransportGetRecordsAction extends HandledTransportAction<GetRecords
     @Inject
     public TransportGetRecordsAction(TransportService transportService, ActionFilters actionFilters, JobResultsProvider jobResultsProvider,
                                      JobManager jobManager, Client client) {
-        super(GetRecordsAction.NAME, transportService, GetRecordsAction.Request::new, actionFilters);
+        super(GetRecordsAction.NAME, transportService, actionFilters, GetRecordsAction.Request::new);
         this.jobResultsProvider = jobResultsProvider;
         this.jobManager = jobManager;
         this.client = client;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportMlInfoAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportMlInfoAction.java
@@ -38,7 +38,7 @@ public class TransportMlInfoAction extends HandledTransportAction<MlInfoAction.R
     @Inject
     public TransportMlInfoAction(TransportService transportService, ActionFilters actionFilters,
                                  ClusterService clusterService, Environment env) {
-        super(MlInfoAction.NAME, transportService, MlInfoAction.Request::new, actionFilters);
+        super(MlInfoAction.NAME, transportService, actionFilters, MlInfoAction.Request::new);
         this.clusterService = clusterService;
 
         try {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
@@ -95,8 +95,8 @@ public class TransportOpenJobAction extends TransportMasterNodeAction<OpenJobAct
                                   PersistentTasksService persistentTasksService, ActionFilters actionFilters,
                                   IndexNameExpressionResolver indexNameExpressionResolver,
                                   JobConfigProvider jobConfigProvider, MlMemoryTracker memoryTracker) {
-        super(OpenJobAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver,
-                OpenJobAction.Request::new);
+        super(OpenJobAction.NAME, transportService, clusterService, threadPool, actionFilters,OpenJobAction.Request::new,
+            indexNameExpressionResolver);
         this.licenseState = licenseState;
         this.persistentTasksService = persistentTasksService;
         this.jobConfigProvider = jobConfigProvider;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPostCalendarEventsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPostCalendarEventsAction.java
@@ -46,7 +46,7 @@ public class TransportPostCalendarEventsAction extends HandledTransportAction<Po
     @Inject
     public TransportPostCalendarEventsAction(TransportService transportService, ActionFilters actionFilters, Client client,
                                              JobResultsProvider jobResultsProvider, JobManager jobManager) {
-        super(PostCalendarEventsAction.NAME, transportService, PostCalendarEventsAction.Request::new, actionFilters);
+        super(PostCalendarEventsAction.NAME, transportService, actionFilters, PostCalendarEventsAction.Request::new);
         this.client = client;
         this.jobResultsProvider = jobResultsProvider;
         this.jobManager = jobManager;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
@@ -50,8 +50,7 @@ public class TransportPreviewDatafeedAction extends HandledTransportAction<Previ
                                           ActionFilters actionFilters, Client client, JobConfigProvider jobConfigProvider,
                                           DatafeedConfigProvider datafeedConfigProvider, JobResultsProvider jobResultsProvider,
                                           JobResultsPersister jobResultsPersister, NamedXContentRegistry xContentRegistry) {
-        super(PreviewDatafeedAction.NAME, transportService, PreviewDatafeedAction.Request::new, actionFilters
-        );
+        super(PreviewDatafeedAction.NAME, transportService, actionFilters, PreviewDatafeedAction.Request::new);
         this.threadPool = threadPool;
         this.client = client;
         this.jobConfigProvider = jobConfigProvider;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutCalendarAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutCalendarAction.java
@@ -39,8 +39,7 @@ public class TransportPutCalendarAction extends HandledTransportAction<PutCalend
 
     @Inject
     public TransportPutCalendarAction(TransportService transportService, ActionFilters actionFilters, Client client) {
-        super(PutCalendarAction.NAME, transportService, PutCalendarAction.Request::new, actionFilters
-        );
+        super(PutCalendarAction.NAME, transportService, actionFilters, PutCalendarAction.Request::new);
         this.client = client;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
@@ -72,8 +72,7 @@ public class TransportPutDataFrameAnalyticsAction
                                                 XPackLicenseState licenseState, Client client, ThreadPool threadPool,
                                                 ClusterService clusterService, IndexNameExpressionResolver indexNameExpressionResolver,
                                                 DataFrameAnalyticsConfigProvider configProvider) {
-        super(PutDataFrameAnalyticsAction.NAME, transportService, PutDataFrameAnalyticsAction.Request::new, actionFilters
-        );
+        super(PutDataFrameAnalyticsAction.NAME, transportService, actionFilters, PutDataFrameAnalyticsAction.Request::new);
         this.licenseState = licenseState;
         this.configProvider = configProvider;
         this.threadPool = threadPool;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDatafeedAction.java
@@ -11,7 +11,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.StreamableTransportMasterNodeAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -22,6 +22,7 @@ import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -60,7 +61,7 @@ import java.util.Map;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
-public class TransportPutDatafeedAction extends StreamableTransportMasterNodeAction<PutDatafeedAction.Request, PutDatafeedAction.Response> {
+public class TransportPutDatafeedAction extends TransportMasterNodeAction<PutDatafeedAction.Request, PutDatafeedAction.Response> {
 
     private static final Logger logger = LogManager.getLogger(TransportPutDatafeedAction.class);
 
@@ -78,7 +79,7 @@ public class TransportPutDatafeedAction extends StreamableTransportMasterNodeAct
                                       IndexNameExpressionResolver indexNameExpressionResolver,
                                       NamedXContentRegistry xContentRegistry) {
         super(PutDatafeedAction.NAME, transportService, clusterService, threadPool,
-                actionFilters, indexNameExpressionResolver, PutDatafeedAction.Request::new);
+                actionFilters, PutDatafeedAction.Request::new, indexNameExpressionResolver);
         this.licenseState = licenseState;
         this.client = client;
         this.securityContext = XPackSettings.SECURITY_ENABLED.get(settings) ?
@@ -94,8 +95,8 @@ public class TransportPutDatafeedAction extends StreamableTransportMasterNodeAct
     }
 
     @Override
-    protected PutDatafeedAction.Response newResponse() {
-        return new PutDatafeedAction.Response();
+    protected PutDatafeedAction.Response read(StreamInput in) throws IOException {
+        return new PutDatafeedAction.Response(in);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutFilterAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutFilterAction.java
@@ -40,7 +40,7 @@ public class TransportPutFilterAction extends HandledTransportAction<PutFilterAc
 
     @Inject
     public TransportPutFilterAction(TransportService transportService, ActionFilters actionFilters, Client client) {
-        super(PutFilterAction.NAME, transportService, PutFilterAction.Request::new, actionFilters);
+        super(PutFilterAction.NAME, transportService, actionFilters, PutFilterAction.Request::new);
         this.client = client;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutJobAction.java
@@ -7,13 +7,14 @@ package org.elasticsearch.xpack.ml.action;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.StreamableTransportMasterNodeAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
@@ -24,7 +25,9 @@ import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.ml.action.PutJobAction;
 import org.elasticsearch.xpack.ml.job.JobManager;
 
-public class TransportPutJobAction extends StreamableTransportMasterNodeAction<PutJobAction.Request, PutJobAction.Response> {
+import java.io.IOException;
+
+public class TransportPutJobAction extends TransportMasterNodeAction<PutJobAction.Request, PutJobAction.Response> {
 
     private final JobManager jobManager;
     private final XPackLicenseState licenseState;
@@ -35,8 +38,8 @@ public class TransportPutJobAction extends StreamableTransportMasterNodeAction<P
                                  ThreadPool threadPool, XPackLicenseState licenseState, ActionFilters actionFilters,
                                  IndexNameExpressionResolver indexNameExpressionResolver, JobManager jobManager,
                                  AnalysisRegistry analysisRegistry) {
-        super(PutJobAction.NAME, transportService, clusterService, threadPool, actionFilters,
-                indexNameExpressionResolver, PutJobAction.Request::new);
+        super(PutJobAction.NAME, transportService, clusterService, threadPool, actionFilters, PutJobAction.Request::new,
+            indexNameExpressionResolver);
         this.licenseState = licenseState;
         this.jobManager = jobManager;
         this.analysisRegistry = analysisRegistry;
@@ -48,8 +51,8 @@ public class TransportPutJobAction extends StreamableTransportMasterNodeAction<P
     }
 
     @Override
-    protected PutJobAction.Response newResponse() {
-        return new PutJobAction.Response();
+    protected PutJobAction.Response read(StreamInput in) throws IOException {
+        return new PutJobAction.Response(in);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.ml.action;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.StreamableTransportMasterNodeAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -33,10 +34,11 @@ import org.elasticsearch.xpack.ml.job.persistence.JobDataCountsPersister;
 import org.elasticsearch.xpack.ml.job.persistence.JobDataDeleter;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
 
+import java.io.IOException;
 import java.util.Date;
 import java.util.function.Consumer;
 
-public class TransportRevertModelSnapshotAction extends StreamableTransportMasterNodeAction<RevertModelSnapshotAction.Request,
+public class TransportRevertModelSnapshotAction extends TransportMasterNodeAction<RevertModelSnapshotAction.Request,
         RevertModelSnapshotAction.Response> {
 
     private final Client client;
@@ -51,7 +53,7 @@ public class TransportRevertModelSnapshotAction extends StreamableTransportMaste
                                               JobManager jobManager, JobResultsProvider jobResultsProvider,
                                               ClusterService clusterService, Client client, JobDataCountsPersister jobDataCountsPersister) {
         super(RevertModelSnapshotAction.NAME, transportService, clusterService, threadPool, actionFilters,
-                indexNameExpressionResolver, RevertModelSnapshotAction.Request::new);
+            RevertModelSnapshotAction.Request::new, indexNameExpressionResolver);
         this.client = client;
         this.jobManager = jobManager;
         this.jobResultsProvider = jobResultsProvider;
@@ -65,8 +67,8 @@ public class TransportRevertModelSnapshotAction extends StreamableTransportMaste
     }
 
     @Override
-    protected RevertModelSnapshotAction.Response newResponse() {
-        return new RevertModelSnapshotAction.Response();
+    protected RevertModelSnapshotAction.Response read(StreamInput in) throws IOException {
+        return new RevertModelSnapshotAction.Response(in);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportSetUpgradeModeAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportSetUpgradeModeAction.java
@@ -63,8 +63,8 @@ public class TransportSetUpgradeModeAction extends TransportMasterNodeAction<Set
                                          PersistentTasksClusterService persistentTasksClusterService, ActionFilters actionFilters,
                                          IndexNameExpressionResolver indexNameExpressionResolver, Client client,
                                          PersistentTasksService persistentTasksService) {
-        super(SetUpgradeModeAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver,
-            SetUpgradeModeAction.Request::new);
+        super(SetUpgradeModeAction.NAME, transportService, clusterService, threadPool, actionFilters, SetUpgradeModeAction.Request::new,
+            indexNameExpressionResolver);
         this.persistentTasksClusterService = persistentTasksClusterService;
         this.clusterService = clusterService;
         this.client = client;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -94,8 +94,8 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
                                         ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
                                         Client client, JobConfigProvider jobConfigProvider, DatafeedConfigProvider datafeedConfigProvider,
                                         JobResultsPersister jobResultsPersister, Auditor auditor, NamedXContentRegistry xContentRegistry) {
-        super(StartDatafeedAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver,
-                StartDatafeedAction.Request::new);
+        super(StartDatafeedAction.NAME, transportService, clusterService, threadPool, actionFilters, StartDatafeedAction.Request::new,
+            indexNameExpressionResolver);
         this.licenseState = licenseState;
         this.persistentTasksService = persistentTasksService;
         this.client = client;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateCalendarJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateCalendarJobAction.java
@@ -27,7 +27,7 @@ public class TransportUpdateCalendarJobAction extends HandledTransportAction<Upd
     @Inject
     public TransportUpdateCalendarJobAction(TransportService transportService, ActionFilters actionFilters,
                                             JobResultsProvider jobResultsProvider, JobManager jobManager) {
-        super(UpdateCalendarJobAction.NAME, transportService, UpdateCalendarJobAction.Request::new, actionFilters);
+        super(UpdateCalendarJobAction.NAME, transportService, actionFilters, UpdateCalendarJobAction.Request::new);
         this.jobResultsProvider = jobResultsProvider;
         this.jobManager = jobManager;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateDatafeedAction.java
@@ -7,7 +7,7 @@ package org.elasticsearch.xpack.ml.action;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.StreamableTransportMasterNodeAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
@@ -33,11 +34,12 @@ import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
 import org.elasticsearch.xpack.ml.job.persistence.JobDataDeleter;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
 public class TransportUpdateDatafeedAction extends
-    StreamableTransportMasterNodeAction<UpdateDatafeedAction.Request, PutDatafeedAction.Response> {
+    TransportMasterNodeAction<UpdateDatafeedAction.Request, PutDatafeedAction.Response> {
 
     private final Client client;
     private final DatafeedConfigProvider datafeedConfigProvider;
@@ -49,8 +51,8 @@ public class TransportUpdateDatafeedAction extends
                                          ThreadPool threadPool, ActionFilters actionFilters,
                                          IndexNameExpressionResolver indexNameExpressionResolver,
                                          Client client, NamedXContentRegistry xContentRegistry) {
-        super(UpdateDatafeedAction.NAME, transportService, clusterService, threadPool, actionFilters,
-                indexNameExpressionResolver, UpdateDatafeedAction.Request::new);
+        super(UpdateDatafeedAction.NAME, transportService, clusterService, threadPool, actionFilters, UpdateDatafeedAction.Request::new,
+                indexNameExpressionResolver);
 
         this.client = client;
         this.datafeedConfigProvider = new DatafeedConfigProvider(client, xContentRegistry);
@@ -64,8 +66,8 @@ public class TransportUpdateDatafeedAction extends
     }
 
     @Override
-    protected PutDatafeedAction.Response newResponse() {
-        return new PutDatafeedAction.Response();
+    protected PutDatafeedAction.Response read(StreamInput in) throws IOException {
+        return new PutDatafeedAction.Response(in);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateFilterAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateFilterAction.java
@@ -56,8 +56,7 @@ public class TransportUpdateFilterAction extends HandledTransportAction<UpdateFi
     @Inject
     public TransportUpdateFilterAction(TransportService transportService, ActionFilters actionFilters, Client client,
                                        JobManager jobManager, ClusterService clusterService) {
-        super(UpdateFilterAction.NAME, transportService, UpdateFilterAction.Request::new, actionFilters
-        );
+        super(UpdateFilterAction.NAME, transportService, actionFilters, UpdateFilterAction.Request::new);
         this.client = client;
         this.jobManager = jobManager;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateJobAction.java
@@ -7,20 +7,23 @@ package org.elasticsearch.xpack.ml.action;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.StreamableTransportMasterNodeAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ml.action.PutJobAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateJobAction;
 import org.elasticsearch.xpack.ml.job.JobManager;
 
-public class TransportUpdateJobAction extends StreamableTransportMasterNodeAction<UpdateJobAction.Request, PutJobAction.Response> {
+import java.io.IOException;
+
+public class TransportUpdateJobAction extends TransportMasterNodeAction<UpdateJobAction.Request, PutJobAction.Response> {
 
     private final JobManager jobManager;
 
@@ -28,8 +31,8 @@ public class TransportUpdateJobAction extends StreamableTransportMasterNodeActio
     public TransportUpdateJobAction(TransportService transportService, ClusterService clusterService,
                                     ThreadPool threadPool, ActionFilters actionFilters,
                                     IndexNameExpressionResolver indexNameExpressionResolver, JobManager jobManager) {
-        super(UpdateJobAction.NAME, transportService, clusterService, threadPool, actionFilters,
-                indexNameExpressionResolver, UpdateJobAction.Request::new);
+        super(UpdateJobAction.NAME, transportService, clusterService, threadPool, actionFilters, UpdateJobAction.Request::new,
+                indexNameExpressionResolver);
         this.jobManager = jobManager;
     }
 
@@ -39,8 +42,8 @@ public class TransportUpdateJobAction extends StreamableTransportMasterNodeActio
     }
 
     @Override
-    protected PutJobAction.Response newResponse() {
-        return new PutJobAction.Response();
+    protected PutJobAction.Response read(StreamInput in) throws IOException {
+        return new PutJobAction.Response(in);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateModelSnapshotAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateModelSnapshotAction.java
@@ -42,7 +42,7 @@ public class TransportUpdateModelSnapshotAction extends HandledTransportAction<U
     @Inject
     public TransportUpdateModelSnapshotAction(TransportService transportService, ActionFilters actionFilters,
                                               JobResultsProvider jobResultsProvider, Client client) {
-        super(UpdateModelSnapshotAction.NAME, transportService, UpdateModelSnapshotAction.Request::new, actionFilters);
+        super(UpdateModelSnapshotAction.NAME, transportService, actionFilters, UpdateModelSnapshotAction.Request::new);
         this.jobResultsProvider = jobResultsProvider;
         this.client = client;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportValidateDetectorAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportValidateDetectorAction.java
@@ -18,8 +18,7 @@ public class TransportValidateDetectorAction extends HandledTransportAction<Vali
 
     @Inject
     public TransportValidateDetectorAction(TransportService transportService, ActionFilters actionFilters) {
-        super(ValidateDetectorAction.NAME, transportService, ValidateDetectorAction.Request::new, actionFilters
-        );
+        super(ValidateDetectorAction.NAME, transportService, ValidateDetectorAction.Request::new, actionFilters);
     }
 
     @Override


### PR DESCRIPTION
This commit converts all the StreamableResponseActionType
actions in the ML core module to be ActionType and leverage
the Writeable infrastructure.

backport of #44302 