### PR TITLE
Fix Exceptions in EventHandler#postHandling Breaking Select Loop (#44347)

### DIFF
--- a/libs/nio/src/main/java/org/elasticsearch/nio/EventHandler.java
+++ b/libs/nio/src/main/java/org/elasticsearch/nio/EventHandler.java
@@ -180,9 +180,15 @@ public class EventHandler {
                 closeException(context, e);
             }
         } else {
-            SelectionKey selectionKey = context.getSelectionKey();
-            boolean currentlyWriteInterested = SelectionKeyUtils.isWriteInterested(selectionKey);
             boolean pendingWrites = context.readyForFlush();
+            SelectionKey selectionKey = context.getSelectionKey();
+            if (selectionKey == null) {
+                if (pendingWrites) {
+                    writeException(context, new IllegalStateException("Tried to write to an not yet registered channel"));
+                }
+                return;
+            }
+            boolean currentlyWriteInterested = SelectionKeyUtils.isWriteInterested(selectionKey);
             if (currentlyWriteInterested == false && pendingWrites) {
                 SelectionKeyUtils.setWriteInterested(selectionKey);
             } else if (currentlyWriteInterested && pendingWrites == false) {


### PR DESCRIPTION
* We can run into the `write` path for SSL channels when they are not fully registered (if registration fails and a close message is attempted to be written) and thus into NPEs from missing selection keys
  * This is a quick fix to quiet down tests, a cleaner solution will be incoming for #44343
* Relates #44343

backport of #44347