### PR TITLE
Remove legacy index.query.bool.max_clause_count did-you-mean

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/SettingsModule.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/SettingsModule.java
@@ -19,8 +19,8 @@
 
 package org.elasticsearch.common.settings;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Binder;
 import org.elasticsearch.common.inject.Module;
@@ -90,12 +90,7 @@ public class SettingsModule implements Module {
         }
         this.indexScopedSettings = new IndexScopedSettings(settings, new HashSet<>(this.indexSettings.values()));
         this.clusterSettings = new ClusterSettings(settings, new HashSet<>(this.nodeSettings.values()), clusterSettingUpgraders);
-        Settings indexSettings = settings.filter((s) -> (s.startsWith("index.") &&
-            // special case - we want to get Did you mean indices.query.bool.max_clause_count
-            // which means we need to by-pass this check for this setting
-            // TODO remove in 6.0!!
-            "index.query.bool.max_clause_count".equals(s) == false)
-            && clusterSettings.get(s) == null);
+        Settings indexSettings = settings.filter((s) -> s.startsWith("index.") && clusterSettings.get(s) == null);
         if (indexSettings.isEmpty() == false) {
             try {
                 String separator = IntStream.range(0, 85).mapToObj(s -> "*").collect(Collectors.joining("")).trim();

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingsModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingsModuleTests.java
@@ -185,12 +185,4 @@ public class SettingsModuleTests extends ModuleTestCase {
             assertThat(e.getMessage(), containsString("Cannot register setting [foo.bar] twice"));
         }
     }
-
-    public void testOldMaxClauseCountSetting() {
-            Settings settings = Settings.builder().put("index.query.bool.max_clause_count", 1024).build();
-            IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
-                () -> new SettingsModule(settings));
-            assertEquals("unknown setting [index.query.bool.max_clause_count] did you mean [indices.query.bool.max_clause_count]?",
-                ex.getMessage());
-    }
 }


### PR DESCRIPTION
The `index.query.bool.max_clause_count` was replaced by its
`indices.query.bool.max_clause_count` counterpart in 5.0 but in order to ease
migration we continued issuing "did-you-mean" type settings suggestions in the
SettingsModule. This change removes the special handling of this setting and
with it the did-you-mean support.