### PR TITLE
Support log file rolling in jvm presence packaging tests

### DIFF
--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/ArchiveTestCase.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/ArchiveTestCase.java
@@ -31,7 +31,6 @@ import org.elasticsearch.packaging.util.ServerUtils;
 import org.elasticsearch.packaging.util.Shell;
 import org.elasticsearch.packaging.util.Shell.Result;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -169,8 +168,8 @@ public abstract class ArchiveTestCase extends PackagingTestCase {
         Archives.stopElasticsearch(installation);
 
         String systemJavaHome = sh.getEnv().get("JAVA_HOME");
-        Path log = installation.logs.resolve("elasticsearch.log");
-        assertThat(new String(Files.readAllBytes(log), StandardCharsets.UTF_8), containsString(systemJavaHome));
+        assertThat(FileUtils.slurpAllLogs(installation.logs, "elasticsearch.log", "*.log.gz"),
+            containsString(systemJavaHome));
     }
 
     public void test51JavaHomeOverride() throws Exception {

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/PackageTestCase.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/PackageTestCase.java
@@ -35,7 +35,6 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.StringJoiner;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.getRandom;
 import static org.elasticsearch.packaging.util.FileUtils.append;
@@ -125,15 +124,8 @@ public abstract class PackageTestCase extends PackagingTestCase {
             Files.write(installation.envFile, originalEnvFile);
         }
 
-        Path log = installation.logs.resolve("elasticsearch.log");
-        StringJoiner logFileJoiner = new StringJoiner("\n");
-        logFileJoiner.add(new String(Files.readAllBytes(log), StandardCharsets.UTF_8));
-
-        for (Path rotatedLogFile : FileUtils.lsGlob(installation.logs, "*.log.gz")) {
-            logFileJoiner.add(FileUtils.slurpGZ(rotatedLogFile));
-        }
-
-        assertThat(logFileJoiner.toString(), containsString(systemJavaHome));
+        assertThat(FileUtils.slurpAllLogs(installation.logs, "elasticsearch.log", "*.log.gz"),
+            containsString(systemJavaHome));
     }
 
     public void test32JavaHomeOverride() throws Exception {

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/PackageTestCase.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/PackageTestCase.java
@@ -35,6 +35,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.StringJoiner;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.getRandom;
 import static org.elasticsearch.packaging.util.FileUtils.append;
@@ -125,7 +126,14 @@ public abstract class PackageTestCase extends PackagingTestCase {
         }
 
         Path log = installation.logs.resolve("elasticsearch.log");
-        assertThat(new String(Files.readAllBytes(log), StandardCharsets.UTF_8), containsString(systemJavaHome));
+        StringJoiner logFileJoiner = new StringJoiner("\n");
+        logFileJoiner.add(new String(Files.readAllBytes(log), StandardCharsets.UTF_8));
+
+        for (Path rotatedLogFile : FileUtils.lsGlob(installation.logs, "*.log.gz")) {
+            logFileJoiner.add(FileUtils.slurpGZ(rotatedLogFile));
+        }
+
+        assertThat(logFileJoiner.toString(), containsString(systemJavaHome));
     }
 
     public void test32JavaHomeOverride() throws Exception {

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/util/FileUtils.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/util/FileUtils.java
@@ -25,8 +25,9 @@ import org.hamcrest.Matcher;
 
 import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -129,7 +130,8 @@ public class FileUtils {
 
     public static String slurpGZ(Path file) {
         ByteArrayOutputStream fileBuffer = new ByteArrayOutputStream();
-        try (GZIPInputStream in = new GZIPInputStream(new FileInputStream(file.toString()))){
+        try (GZIPInputStream in = new GZIPInputStream(Channels.newInputStream(FileChannel.open(file))))
+        {
             byte[] buffer = new byte[1024];
             int len;
 

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/util/FileUtils.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/util/FileUtils.java
@@ -130,6 +130,11 @@ public class FileUtils {
         }
     }
 
+    /**
+     * Returns the content a {@link java.nio.file.Path} file. The file can be in plain text or GZIP format.
+     * @param file The {@link java.nio.file.Path} to the file.
+     * @return The content of {@code file}.
+     */
     public static String slurpTxtorGz(Path file) {
         ByteArrayOutputStream fileBuffer = new ByteArrayOutputStream();
         try (GZIPInputStream in = new GZIPInputStream(Channels.newInputStream(FileChannel.open(file)))) {
@@ -151,6 +156,16 @@ public class FileUtils {
         }
     }
 
+    /**
+     * Returns combined content of a text log file and rotated log files matching a pattern. Order of rotated log files is
+     * not guaranteed.
+     * @param logPath Base directory where log files reside.
+     * @param activeLogFile The currently active log file. This file needs to be plain text under {@code logPath}.
+     * @param rotatedLogFilesGlob A glob pattern to match rotated log files under {@code logPath}.
+     *                            See {@link java.nio.file.FileSystem#getPathMatcher(String)} for glob examples.
+     * @return Merges contents of {@code activeLogFile} and contents of filenames matching {@code rotatedLogFilesGlob}.
+     * File contents are separated by a newline. The order of rotated log files matched by {@code rotatedLogFilesGlob} is not guaranteed.
+     */
     public static String slurpAllLogs(Path logPath, String activeLogFile, String rotatedLogFilesGlob) {
         StringJoiner logFileJoiner = new StringJoiner("\n");
         try {

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/util/FileUtils.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/util/FileUtils.java
@@ -24,6 +24,8 @@ import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
 import java.io.BufferedWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
@@ -38,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.zip.GZIPInputStream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyIterable;
@@ -119,6 +122,22 @@ public class FileUtils {
     public static String slurp(Path file) {
         try {
             return String.join("\n", Files.readAllLines(file, StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String slurpGZ(Path file) {
+        ByteArrayOutputStream fileBuffer = new ByteArrayOutputStream();
+        try (GZIPInputStream in = new GZIPInputStream(new FileInputStream(file.toString()))){
+            byte[] buffer = new byte[1024];
+            int len;
+
+            while((len = in.read(buffer)) != -1){
+                fileBuffer.write(buffer, 0, len);
+            }
+
+            return(new String(fileBuffer.toByteArray(), StandardCharsets.UTF_8));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Make JVM presence related packaging tests more resilient, by
also checking for entries in rolled over log files.

Closes #41436
