### PR TITLE
Do not use CancellableThreads for Zen1

### DIFF
--- a/server/src/main/java/org/elasticsearch/discovery/zen/UnicastZenPing.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/UnicastZenPing.java
@@ -101,8 +101,6 @@ public class UnicastZenPing implements ZenPing {
 
     private final AtomicInteger pingingRoundIdGenerator = new AtomicInteger();
 
-    private final CancellableThreads cancellableThreads = new CancellableThreads();
-
     private final Map<Integer, PingingRound> activePingingRounds = newConcurrentMap();
 
     // a list of temporal responses a node will return for a request (holds responses from other nodes)
@@ -149,13 +147,21 @@ public class UnicastZenPing implements ZenPing {
     }
 
     private SeedHostsProvider.HostsResolver createHostsResolver() {
-        return hosts -> SeedHostsResolver.resolveHostsLists(cancellableThreads, unicastZenPingExecutorService, logger, hosts,
-            transportService, resolveTimeout);
+        return hosts -> SeedHostsResolver.resolveHostsLists(
+            new CancellableThreads() {
+                public void execute(Interruptible interruptible) {
+                    try {
+                        interruptible.run();
+                    } catch (InterruptedException e) {
+                        throw new CancellableThreads.ExecutionCancelledException("interrupted by " + e);
+                    }
+                }
+            },
+            unicastZenPingExecutorService, logger, hosts, transportService, resolveTimeout);
     }
 
     @Override
     public void close() {
-        cancellableThreads.cancel("stopping UnicastZenPing");
         ThreadPool.terminate(unicastZenPingExecutorService, 10, TimeUnit.SECONDS);
         Releasables.close(activePingingRounds.values());
         closed = true;


### PR DESCRIPTION
Zen 1 stops pinging threads in `ZenDiscovery` by calling `Thread.interrupt()`. This is incompatible with the `CancellableThreads` that only allow threads to be interrupted through cancellation. The use of `CancellableThreads` was introduced in https://github.com/elastic/elasticsearch/pull/42844 and added to `UnicastZenPing` as part of the backport, as both Zen1 and Zen2 share the same `SeedHostsResolver` implementation. This PR effectively undoes the change in the backport while still allowing to share same implementation.

Closes #44425