### PR TITLE
Update SLM minimal supported version

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/snapshotlifecycle/SnapshotLifecycleMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/snapshotlifecycle/SnapshotLifecycleMetadata.java
@@ -96,7 +96,7 @@ public class SnapshotLifecycleMetadata implements XPackMetaDataCustom {
 
     @Override
     public Version getMinimalSupportedVersion() {
-        return Version.V_8_0_0; // TODO: revisit this when we figure out where this goes
+        return Version.V_7_4_0;
     }
 
     @Override


### PR DESCRIPTION
Now that snapshot lifecycle management has been merged and backported to
the 7.x branch, this commit updates the `getMinimalSupportedVersion` to
return 7.4.0.

Relates to #38461
