### PR TITLE
Unmute PemTrustConfigTests that seems to be fixed

### DIFF
--- a/libs/ssl-config/src/test/java/org/elasticsearch/common/ssl/PemTrustConfigTests.java
+++ b/libs/ssl-config/src/test/java/org/elasticsearch/common/ssl/PemTrustConfigTests.java
@@ -87,7 +87,6 @@ public class PemTrustConfigTests extends ESTestCase {
         assertFileNotFound(trustConfig, cert2);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/42509")
     public void testTrustConfigReloadsFileContents() throws Exception {
         final Path cert1 = getDataPath("/certs/ca1/ca.crt");
         final Path cert2 = getDataPath("/certs/ca2/ca.crt");


### PR DESCRIPTION
Since #42509 is closed and the fix seems to have been backported to 7.x (#43539)
so the test can be enabled again.