### PR TITLE
Fix test for old cluster version >= 7.3.0

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlConfigIndexMappingsFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlConfigIndexMappingsFullClusterRestartIT.java
@@ -70,10 +70,14 @@ public class MlConfigIndexMappingsFullClusterRestartIT extends AbstractFullClust
             assertThatMlConfigIndexDoesNotExist();
             // trigger .ml-config index creation
             createAnomalyDetectorJob(OLD_CLUSTER_JOB_ID);
-            // .ml-config does not yet have correct mappings, it will need an update after cluster is upgraded
-            assertThat(mappingsForDataFrameAnalysis(), is(nullValue()));
+            if (getOldClusterVersion().onOrAfter(Version.V_7_3_0)) {
+                // .ml-config has correct mappings from the start
+                assertThat(mappingsForDataFrameAnalysis(), is(equalTo(EXPECTED_DATA_FRAME_ANALYSIS_MAPPINGS)));
+            } else {
+                // .ml-config does not yet have correct mappings, it will need an update after cluster is upgraded
+                assertThat(mappingsForDataFrameAnalysis(), is(nullValue()));
+            }
         } else {
-            assertThat(mappingsForDataFrameAnalysis(), is(nullValue()));
             // trigger .ml-config index mappings update
             createAnomalyDetectorJob(NEW_CLUSTER_JOB_ID);
             // assert that the mappings are updated


### PR DESCRIPTION
Followup to https://github.com/elastic/elasticsearch/pull/44368

This PR fixes the scenario of cluster upgrade from 7.3.0 to 7.3.1 in which it is expected that .ml-config index created by the old cluster contains data frame analytics mappings.