### PR TITLE
Fix unconverted ML Action Ctors to use Writeable

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutDataFrameAnalyticsAction.java
@@ -29,7 +29,7 @@ public class PutDataFrameAnalyticsAction extends ActionType<PutDataFrameAnalytic
     public static final String NAME = "cluster:admin/xpack/ml/data_frame/analytics/put";
 
     private PutDataFrameAnalyticsAction() {
-        super(NAME);
+        super(NAME, Response::new);
     }
 
     public static class Request extends AcknowledgedRequest<Request> implements ToXContentObject {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteFilterAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteFilterAction.java
@@ -44,8 +44,7 @@ public class TransportDeleteFilterAction extends HandledTransportAction<DeleteFi
     public TransportDeleteFilterAction(TransportService transportService,
                                        ActionFilters actionFilters, Client client,
                                        JobConfigProvider jobConfigProvider) {
-        super(DeleteFilterAction.NAME, transportService, DeleteFilterAction.Request::new, actionFilters
-        );
+        super(DeleteFilterAction.NAME, transportService, DeleteFilterAction.Request::new, actionFilters);
         this.client = client;
         this.jobConfigProvider = jobConfigProvider;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportEvaluateDataFrameAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportEvaluateDataFrameAction.java
@@ -30,7 +30,7 @@ public class TransportEvaluateDataFrameAction extends HandledTransportAction<Eva
     @Inject
     public TransportEvaluateDataFrameAction(TransportService transportService, ActionFilters actionFilters, ThreadPool threadPool,
                                             Client client) {
-        super(EvaluateDataFrameAction.NAME, transportService, EvaluateDataFrameAction.Request::new, actionFilters);
+        super(EvaluateDataFrameAction.NAME, transportService, actionFilters, EvaluateDataFrameAction.Request::new);
         this.threadPool = threadPool;
         this.client = client;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFindFileStructureAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFindFileStructureAction.java
@@ -27,7 +27,7 @@ public class TransportFindFileStructureAction
 
     @Inject
     public TransportFindFileStructureAction(TransportService transportService, ActionFilters actionFilters, ThreadPool threadPool) {
-        super(FindFileStructureAction.NAME, transportService, FindFileStructureAction.Request::new, actionFilters);
+        super(FindFileStructureAction.NAME, transportService, actionFilters, FindFileStructureAction.Request::new);
         this.threadPool = threadPool;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetBucketsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetBucketsAction.java
@@ -26,7 +26,7 @@ public class TransportGetBucketsAction extends HandledTransportAction<GetBuckets
     @Inject
     public TransportGetBucketsAction(TransportService transportService, ActionFilters actionFilters, JobResultsProvider jobResultsProvider,
                                      JobManager jobManager, Client client) {
-        super(GetBucketsAction.NAME, transportService, GetBucketsAction.Request::new, actionFilters);
+        super(GetBucketsAction.NAME, transportService, actionFilters, GetBucketsAction.Request::new);
         this.jobResultsProvider = jobResultsProvider;
         this.jobManager = jobManager;
         this.client = client;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetCalendarsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetCalendarsAction.java
@@ -27,7 +27,7 @@ public class TransportGetCalendarsAction extends HandledTransportAction<GetCalen
     @Inject
     public TransportGetCalendarsAction(TransportService transportService, ActionFilters actionFilters,
                                        JobResultsProvider jobResultsProvider) {
-        super(GetCalendarsAction.NAME, transportService, GetCalendarsAction.Request::new, actionFilters);
+        super(GetCalendarsAction.NAME, transportService, actionFilters, GetCalendarsAction.Request::new);
         this.jobResultsProvider = jobResultsProvider;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetCategoriesAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetCategoriesAction.java
@@ -25,8 +25,7 @@ public class TransportGetCategoriesAction extends HandledTransportAction<GetCate
     @Inject
     public TransportGetCategoriesAction(TransportService transportService, ActionFilters actionFilters,
                                         JobResultsProvider jobResultsProvider, Client client, JobManager jobManager) {
-        super(GetCategoriesAction.NAME, transportService, GetCategoriesAction.Request::new, actionFilters
-        );
+        super(GetCategoriesAction.NAME, transportService, actionFilters, GetCategoriesAction.Request::new);
         this.jobResultsProvider = jobResultsProvider;
         this.client = client;
         this.jobManager = jobManager;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetInfluencersAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetInfluencersAction.java
@@ -26,8 +26,7 @@ public class TransportGetInfluencersAction extends HandledTransportAction<GetInf
     @Inject
     public TransportGetInfluencersAction(TransportService transportService, ActionFilters actionFilters,
                                          JobResultsProvider jobResultsProvider, Client client, JobManager jobManager) {
-        super(GetInfluencersAction.NAME, transportService,  GetInfluencersAction.Request::new, actionFilters
-        );
+        super(GetInfluencersAction.NAME, transportService, actionFilters, GetInfluencersAction.Request::new);
         this.jobResultsProvider = jobResultsProvider;
         this.client = client;
         this.jobManager = jobManager;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetModelSnapshotsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetModelSnapshotsAction.java
@@ -28,7 +28,7 @@ public class TransportGetModelSnapshotsAction extends HandledTransportAction<Get
     @Inject
     public TransportGetModelSnapshotsAction(TransportService transportService, ActionFilters actionFilters,
                                             JobResultsProvider jobResultsProvider, JobManager jobManager) {
-        super(GetModelSnapshotsAction.NAME, transportService, GetModelSnapshotsAction.Request::new, actionFilters);
+        super(GetModelSnapshotsAction.NAME, transportService, actionFilters, GetModelSnapshotsAction.Request::new);
         this.jobResultsProvider = jobResultsProvider;
         this.jobManager = jobManager;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetOverallBucketsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetOverallBucketsAction.java
@@ -65,8 +65,7 @@ public class TransportGetOverallBucketsAction extends HandledTransportAction<Get
     @Inject
     public TransportGetOverallBucketsAction(ThreadPool threadPool, TransportService transportService, ActionFilters actionFilters,
                                             ClusterService clusterService, JobManager jobManager, Client client) {
-        super(GetOverallBucketsAction.NAME, transportService, GetOverallBucketsAction.Request::new, actionFilters
-        );
+        super(GetOverallBucketsAction.NAME, transportService, actionFilters, GetOverallBucketsAction.Request::new);
         this.threadPool = threadPool;
         this.clusterService = clusterService;
         this.client = client;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetRecordsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetRecordsAction.java
@@ -26,7 +26,7 @@ public class TransportGetRecordsAction extends HandledTransportAction<GetRecords
     @Inject
     public TransportGetRecordsAction(TransportService transportService, ActionFilters actionFilters, JobResultsProvider jobResultsProvider,
                                      JobManager jobManager, Client client) {
-        super(GetRecordsAction.NAME, transportService, GetRecordsAction.Request::new, actionFilters);
+        super(GetRecordsAction.NAME, transportService, actionFilters, GetRecordsAction.Request::new);
         this.jobResultsProvider = jobResultsProvider;
         this.jobManager = jobManager;
         this.client = client;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportMlInfoAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportMlInfoAction.java
@@ -34,8 +34,7 @@ public class TransportMlInfoAction extends HandledTransportAction<MlInfoAction.R
     @Inject
     public TransportMlInfoAction(TransportService transportService, ActionFilters actionFilters,
                                  ClusterService clusterService, MlControllerHolder mlControllerHolder) {
-        super(MlInfoAction.NAME, transportService, MlInfoAction.Request::new, actionFilters);
-
+        super(MlInfoAction.NAME, transportService, actionFilters, MlInfoAction.Request::new);
         this.clusterService = clusterService;
 
         try {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPostCalendarEventsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPostCalendarEventsAction.java
@@ -46,7 +46,7 @@ public class TransportPostCalendarEventsAction extends HandledTransportAction<Po
     @Inject
     public TransportPostCalendarEventsAction(TransportService transportService, ActionFilters actionFilters, Client client,
                                              JobResultsProvider jobResultsProvider, JobManager jobManager) {
-        super(PostCalendarEventsAction.NAME, transportService, PostCalendarEventsAction.Request::new, actionFilters);
+        super(PostCalendarEventsAction.NAME, transportService, actionFilters, PostCalendarEventsAction.Request::new);
         this.client = client;
         this.jobResultsProvider = jobResultsProvider;
         this.jobManager = jobManager;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
@@ -50,8 +50,7 @@ public class TransportPreviewDatafeedAction extends HandledTransportAction<Previ
                                           ActionFilters actionFilters, Client client, JobConfigProvider jobConfigProvider,
                                           DatafeedConfigProvider datafeedConfigProvider, JobResultsProvider jobResultsProvider,
                                           JobResultsPersister jobResultsPersister, NamedXContentRegistry xContentRegistry) {
-        super(PreviewDatafeedAction.NAME, transportService, PreviewDatafeedAction.Request::new, actionFilters
-        );
+        super(PreviewDatafeedAction.NAME, transportService, actionFilters, PreviewDatafeedAction.Request::new);
         this.threadPool = threadPool;
         this.client = client;
         this.jobConfigProvider = jobConfigProvider;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutCalendarAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutCalendarAction.java
@@ -39,8 +39,7 @@ public class TransportPutCalendarAction extends HandledTransportAction<PutCalend
 
     @Inject
     public TransportPutCalendarAction(TransportService transportService, ActionFilters actionFilters, Client client) {
-        super(PutCalendarAction.NAME, transportService, PutCalendarAction.Request::new, actionFilters
-        );
+        super(PutCalendarAction.NAME, transportService, actionFilters, PutCalendarAction.Request::new);
         this.client = client;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
@@ -72,8 +72,7 @@ public class TransportPutDataFrameAnalyticsAction
                                                 XPackLicenseState licenseState, Client client, ThreadPool threadPool,
                                                 ClusterService clusterService, IndexNameExpressionResolver indexNameExpressionResolver,
                                                 DataFrameAnalyticsConfigProvider configProvider) {
-        super(PutDataFrameAnalyticsAction.NAME, transportService, PutDataFrameAnalyticsAction.Request::new, actionFilters
-        );
+        super(PutDataFrameAnalyticsAction.NAME, transportService, actionFilters, PutDataFrameAnalyticsAction.Request::new);
         this.licenseState = licenseState;
         this.configProvider = configProvider;
         this.threadPool = threadPool;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutFilterAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutFilterAction.java
@@ -40,7 +40,7 @@ public class TransportPutFilterAction extends HandledTransportAction<PutFilterAc
 
     @Inject
     public TransportPutFilterAction(TransportService transportService, ActionFilters actionFilters, Client client) {
-        super(PutFilterAction.NAME, transportService, PutFilterAction.Request::new, actionFilters);
+        super(PutFilterAction.NAME, transportService, actionFilters, PutFilterAction.Request::new);
         this.client = client;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateCalendarJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateCalendarJobAction.java
@@ -27,7 +27,7 @@ public class TransportUpdateCalendarJobAction extends HandledTransportAction<Upd
     @Inject
     public TransportUpdateCalendarJobAction(TransportService transportService, ActionFilters actionFilters,
                                             JobResultsProvider jobResultsProvider, JobManager jobManager) {
-        super(UpdateCalendarJobAction.NAME, transportService, UpdateCalendarJobAction.Request::new, actionFilters);
+        super(UpdateCalendarJobAction.NAME, transportService, actionFilters, UpdateCalendarJobAction.Request::new);
         this.jobResultsProvider = jobResultsProvider;
         this.jobManager = jobManager;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateFilterAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateFilterAction.java
@@ -56,8 +56,7 @@ public class TransportUpdateFilterAction extends HandledTransportAction<UpdateFi
     @Inject
     public TransportUpdateFilterAction(TransportService transportService, ActionFilters actionFilters, Client client,
                                        JobManager jobManager, ClusterService clusterService) {
-        super(UpdateFilterAction.NAME, transportService, UpdateFilterAction.Request::new, actionFilters
-        );
+        super(UpdateFilterAction.NAME, transportService, actionFilters, UpdateFilterAction.Request::new);
         this.client = client;
         this.jobManager = jobManager;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateModelSnapshotAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateModelSnapshotAction.java
@@ -42,7 +42,7 @@ public class TransportUpdateModelSnapshotAction extends HandledTransportAction<U
     @Inject
     public TransportUpdateModelSnapshotAction(TransportService transportService, ActionFilters actionFilters,
                                               JobResultsProvider jobResultsProvider, Client client) {
-        super(UpdateModelSnapshotAction.NAME, transportService, UpdateModelSnapshotAction.Request::new, actionFilters);
+        super(UpdateModelSnapshotAction.NAME, transportService, actionFilters, UpdateModelSnapshotAction.Request::new);
         this.jobResultsProvider = jobResultsProvider;
         this.client = client;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportValidateDetectorAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportValidateDetectorAction.java
@@ -18,8 +18,7 @@ public class TransportValidateDetectorAction extends HandledTransportAction<Vali
 
     @Inject
     public TransportValidateDetectorAction(TransportService transportService, ActionFilters actionFilters) {
-        super(ValidateDetectorAction.NAME, transportService, ValidateDetectorAction.Request::new, actionFilters
-        );
+        super(ValidateDetectorAction.NAME, transportService, ValidateDetectorAction.Request::new, actionFilters);
     }
 
     @Override


### PR DESCRIPTION
I am not sure how this #44302 refactor passed tests without this.
This PR is a followup to clean up that mess. 

These changes are already included in the backport PR #44391.