### PR TITLE
[DOCS] Reformat `has_parent` query docs

### DIFF
--- a/docs/reference/query-dsl/has-parent-query.asciidoc
+++ b/docs/reference/query-dsl/has-parent-query.asciidoc
@@ -85,7 +85,9 @@ its child documents.
 score>> of a matching parent document is aggregated into its child documents.
 Defaults to `false`.
 
-If `false`, {es} ignores the relevance score of the parent document.
+If `false`, {es} ignores the relevance score of the parent document. {es} also
+assigns each child document a relevance score equal to the `query`'s `boost`,
+which defaults to `1`.
 
 If `true`, the relevance score of the matching parent document is aggregated
 into its child documents' relevance scores.

--- a/docs/reference/query-dsl/has-parent-query.asciidoc
+++ b/docs/reference/query-dsl/has-parent-query.asciidoc
@@ -22,7 +22,7 @@ field mapping. For example:
 
 [source,js]
 ----
-PUT /my_index
+PUT /my-index
 {
     "mappings": {
         "properties" : {
@@ -31,6 +31,9 @@ PUT /my_index
                 "relations": {
                     "parent": "child"
                 }
+            },
+            "tag" : {
+                "type" : "keyword"
             }
         }
     }
@@ -45,13 +48,17 @@ PUT /my_index
 
 [source,js]
 ----
-GET /_search
+GET /my-index/_search
 {
     "query": {
         "has_parent" : {
             "parent_type" : "parent",
             "query" : {
-                "match_all" : {}
+                "term" : {
+                    "tag" : {
+                        "value" : "Elasticsearch"
+                    }
+                }
             }
         }
     }

--- a/docs/reference/query-dsl/has-parent-query.asciidoc
+++ b/docs/reference/query-dsl/has-parent-query.asciidoc
@@ -1,93 +1,120 @@
 [[query-dsl-has-parent-query]]
 === Has Parent Query
 
-The `has_parent` query accepts a query and a parent type. The query is
-executed in the parent document space, which is specified by the parent
-type. This query returns child documents which associated parents have
-matched. For the rest `has_parent` query has the same options and works
-in the same manner as the `has_child` query.
+Returns child documents whose <<parent-join,joined>> parent document matches a
+provided query. You can create parent-child relationships between documents in
+the same index using a <<parent-join,join>> field mapping.
+
+[WARNING]
+====
+Because it performs a join, the `has_parent` query is slow compared to other queries.
+Its performance degrades as the number of matching parent documents increases.
+Each `has_parent` query in a search can increase query time significantly.
+====
+
+[[has-parent-query-ex-request]]
+==== Example request
+
+[[has-parent-index-setup]]
+===== Index setup
+To use the `has_parent` query, your index must include a <<parent-join,join>>
+field mapping. For example:
 
 [source,js]
---------------------------------------------------
-GET /_search
+----
+PUT /my_index
 {
-    "query": {
-        "has_parent" : {
-            "parent_type" : "blog",
-            "query" : {
-                "term" : {
-                    "tag" : "something"
+    "mappings": {
+        "properties" : {
+            "my-join-field" : {
+                "type" : "join",
+                "relations": {
+                    "parent": "child"
                 }
             }
         }
     }
 }
---------------------------------------------------
+
+----
 // CONSOLE
+// TESTSETUP
 
-Note that the `has_parent` is a slow query compared to other queries in the
-query dsl due to the fact that it performs a join. The performance degrades
-as the number of matching parent documents increases. If you care about query
-performance you should not use this query. However if you do happen to use
-this query then use it as less as possible. Each `has_parent` query that gets
-added to a search request can increase query time significantly.
-
-[float]
-==== Scoring capabilities
-
-The `has_parent` also has scoring support. The default is `false` which
-ignores the score from the parent document. The score is in this
-case equal to the boost on the `has_parent` query (Defaults to 1). If
-the score is set to `true`, then the score of the matching parent
-document is aggregated into the child documents belonging to the
-matching parent document. The score mode can be specified with the
-`score` field inside the `has_parent` query:
+[[has-parent-query-ex-query]]
+===== Example query
 
 [source,js]
---------------------------------------------------
+----
 GET /_search
 {
     "query": {
         "has_parent" : {
-            "parent_type" : "blog",
-            "score" : true,
+            "parent_type" : "parent",
             "query" : {
-                "term" : {
-                    "tag" : "something"
-                }
+                "match_all" : {}
             }
         }
     }
 }
---------------------------------------------------
+----
 // CONSOLE
 
-[float]
-==== Ignore Unmapped
+[[has-parent-top-level-params]]
+==== Top-level parameters for `has_parent`
 
-When set to `true` the `ignore_unmapped` option will ignore an unmapped `type`
-and will not match any documents for this query. This can be useful when
-querying multiple indexes which might have different mappings. When set to
-`false` (the default value) the query will throw an exception if the `type`
-is not mapped.
+`parent_type`::
+(Required, string) Name of the parent relationship mapped for the
+<<parent-join,join>> field.
 
-[float]
-==== Sorting
+`query`::
+(Required, query object) Query you wish to run on parent documents of the
+`parent_type` field. If a parent document matches the search, the query returns
+its child documents.
 
-Child documents can't be sorted by fields in matching parent documents via the
-regular sort options. If you need to sort child documents by field in the parent
-documents then you should use the `function_score` query and then just sort
-by `_score`.
+`score`::
++
+--
+(Optional, boolean) Indicates whether the <<query-filter-context,relevance
+score>> of a matching parent document is aggregated into its child documents.
+Defaults to `false`.
 
-Sorting tags by parent document' `view_count` field:
+If `false`, {es} ignores the relevance score of the parent document.
+
+If `true`, the relevance score of the matching parent document is aggregated
+into its child documents' relevance scores.
+--
+
+`ignore_unmapped`::
++
+--
+(Optional, boolean) Indicates whether to ignore an unmapped `parent_type` and
+not return any documents instead of an error. Defaults to `false`.
+
+If `false`, {es} returns an error if the `parent_type` is unmapped.
+
+You can use this parameter to query multiple indices that may not contain the
+`parent_type`.
+--
+
+[[has-parent-query-notes]]
+==== Notes
+
+[[has-parent-query-performance]]
+===== Sorting
+You cannot sort the results of a `has_parent` query using standard
+<<search-request-sort,sort options>>.
+
+If you need to sort returned documents by a field in their parent documents, use
+a `function_score` query and sort by `_score`. For example, the following query
+sorts returned documents by the `view_count` field of their parent documents.
 
 [source,js]
---------------------------------------------------
+----
 GET /_search
 {
     "query": {
         "has_parent" : {
-            "parent_type" : "blog",
+            "parent_type" : "parent",
             "score" : true,
             "query" : {
                 "function_score" : {
@@ -99,5 +126,5 @@ GET /_search
         }
     }
 }
---------------------------------------------------
+----
 // CONSOLE


### PR DESCRIPTION
Rewrites the `has_parent` query to use the new query format.

This creates separate sections for example requests, parameters, and notes.

This is part of #40977, an effort to standardize documentation for query types.

## Before
<details>
 <summary>Before image</summary>
<img width="777" alt="Has Parent Query - Before" src="https://user-images.githubusercontent.com/40268737/61310274-f5731f00-a7c1-11e9-9f50-0f3ce8e75aab.png">
</details>


## After
<details>
 <summary>After image</summary>
<img width="777" alt="Has Parent Query - After" src="https://user-images.githubusercontent.com/40268737/61310347-1e93af80-a7c2-11e9-92d9-510f216786cc.png">
</details>