### PR TITLE
[DOCS] Remove :edit_url: overrides

### DIFF
--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -22,7 +22,6 @@ include::{xes-repo-dir}/security/configuring-es.asciidoc[]
 
 include::setup/bootstrap-checks-xes.asciidoc[]
 
-:edit_url:
 include::upgrade.asciidoc[]
 
 include::api-conventions.asciidoc[]
@@ -67,7 +66,6 @@ include::administering.asciidoc[]
 
 include::commands/index.asciidoc[]
 
-:edit_url:
 include::how-to.asciidoc[]
 
 include::testing.asciidoc[]

--- a/docs/reference/ml/configuring.asciidoc
+++ b/docs/reference/ml/configuring.asciidoc
@@ -37,23 +37,16 @@ The scenarios in this section describe some best practices for generating useful
 * <<ml-configuring-transform>>
 * <<ml-delayed-data-detection>>
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/ml/customurl.asciidoc
 include::customurl.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/ml/aggregations.asciidoc
 include::aggregations.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/ml/detector-custom-rules.asciidoc
 include::detector-custom-rules.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/ml/categories.asciidoc
 include::categories.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/ml/populations.asciidoc
 include::populations.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/ml/transforms.asciidoc
 include::transforms.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/ml/delayed-data-detection.asciidoc
 include::delayed-data-detection.asciidoc[]

--- a/docs/reference/ml/functions.asciidoc
+++ b/docs/reference/ml/functions.asciidoc
@@ -44,23 +44,16 @@ These functions effectively ignore empty buckets.
 * <<ml-sum-functions>>
 * <<ml-time-functions>>
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/functions/count.asciidoc
 include::functions/count.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/functions/geo.asciidoc
 include::functions/geo.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/functions/info.asciidoc
 include::functions/info.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/functions/metric.asciidoc
 include::functions/metric.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/functions/rare.asciidoc
 include::functions/rare.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/functions/sum.asciidoc
 include::functions/sum.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/functions/time.asciidoc
 include::functions/time.asciidoc[]

--- a/docs/reference/modules.asciidoc
+++ b/docs/reference/modules.asciidoc
@@ -89,7 +89,6 @@ include::modules/network.asciidoc[]
 
 include::modules/node.asciidoc[]
 
-:edit_url:
 include::modules/plugins.asciidoc[]
 
 include::modules/snapshots.asciidoc[]

--- a/docs/reference/security/securing-communications/securing-elasticsearch.asciidoc
+++ b/docs/reference/security/securing-communications/securing-elasticsearch.asciidoc
@@ -31,17 +31,12 @@ information, see <<security-settings>>.
 For more information about encrypting communications across the Elastic Stack,
 see {stack-ov}/encrypting-communications.html[Encrypting Communications].
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/security/securing-communications/node-certificates.asciidoc
 include::node-certificates.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/security/securing-communications/tls-transport.asciidoc
 include::tls-transport.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/security/securing-communications/tls-http.asciidoc
 include::tls-http.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/security/securing-communications/tls-ad.asciidoc
 include::tls-ad.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/security/securing-communications/tls-ldap.asciidoc
 include::tls-ldap.asciidoc[]

--- a/x-pack/docs/en/security/auditing/index.asciidoc
+++ b/x-pack/docs/en/security/auditing/index.asciidoc
@@ -1,12 +1,7 @@
-
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/auditing/overview.asciidoc
 include::overview.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/auditing/event-types.asciidoc
 include::event-types.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/auditing/output-logfile.asciidoc
 include::output-logfile.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/auditing/auditing-search-queries.asciidoc
 include::auditing-search-queries.asciidoc[]

--- a/x-pack/docs/en/security/ccs-clients-integrations.asciidoc
+++ b/x-pack/docs/en/security/ccs-clients-integrations.asciidoc
@@ -31,17 +31,12 @@ be secured as well, or at least communicate with the cluster in a secured way:
 * {kibana-ref}/secure-reporting.html[Reporting]
 * {winlogbeat-ref}/securing-beats.html[Winlogbeat]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/ccs-clients-integrations/cross-cluster.asciidoc
 include::ccs-clients-integrations/cross-cluster.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/ccs-clients-integrations/http.asciidoc
 include::ccs-clients-integrations/http.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/ccs-clients-integrations/hadoop.asciidoc
 include::ccs-clients-integrations/hadoop.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/ccs-clients-integrations/beats.asciidoc
 include::ccs-clients-integrations/beats.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/ccs-clients-integrations/monitoring.asciidoc
 include::ccs-clients-integrations/monitoring.asciidoc[]

--- a/x-pack/docs/en/security/ccs-clients-integrations/cross-cluster.asciidoc
+++ b/x-pack/docs/en/security/ccs-clients-integrations/cross-cluster.asciidoc
@@ -156,5 +156,4 @@ GET two:logs-2017.04/_search <1>
 // TEST[skip:todo]
 //TBD: Is there a missing description of the <1> callout above?
 
-:edit_url: https://github.com/elastic/kibana/edit/{branch}/docs/security/cross-cluster-kibana.asciidoc
 include::{kib-repo-dir}/security/cross-cluster-kibana.asciidoc[]

--- a/x-pack/docs/en/security/configuring-es.asciidoc
+++ b/x-pack/docs/en/security/configuring-es.asciidoc
@@ -139,16 +139,12 @@ Events are logged to a dedicated `<clustername>_audit.json` file in
 To walk through the configuration of {security-features} in {es}, {kib}, {ls}, and {metricbeat}, see
 {stack-ov}/security-getting-started.html[Getting started with security].
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/security/securing-communications/securing-elasticsearch.asciidoc
 include::{es-repo-dir}/security/securing-communications/securing-elasticsearch.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/security/securing-communications/configuring-tls-docker.asciidoc
 include::{es-repo-dir}/security/securing-communications/configuring-tls-docker.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/security/securing-communications/enabling-cipher-suites.asciidoc
 include::{es-repo-dir}/security/securing-communications/enabling-cipher-suites.asciidoc[]
 
-:edit_url:
 include::authentication/configuring-active-directory-realm.asciidoc[]
 include::authentication/configuring-file-realm.asciidoc[]
 include::authentication/configuring-ldap-realm.asciidoc[]
@@ -156,10 +152,8 @@ include::authentication/configuring-native-realm.asciidoc[]
 include::authentication/configuring-pki-realm.asciidoc[]
 include::authentication/configuring-saml-realm.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authentication/configuring-kerberos-realm.asciidoc
 include::authentication/configuring-kerberos-realm.asciidoc[]
 
-:edit_url:
 include::{es-repo-dir}/security/reference/files.asciidoc[]
 include::fips-140-compliance.asciidoc[]
 

--- a/x-pack/docs/en/security/securing-communications.asciidoc
+++ b/x-pack/docs/en/security/securing-communications.asciidoc
@@ -17,7 +17,6 @@ This section shows how to:
 The authentication of new nodes helps prevent a rogue node from joining the
 cluster and receiving data through replication.
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/security/securing-communications/setting-up-ssl.asciidoc
 include::{es-repo-dir}/security/securing-communications/setting-up-ssl.asciidoc[]
 
 [[ciphers]]

--- a/x-pack/docs/en/watcher/actions.asciidoc
+++ b/x-pack/docs/en/watcher/actions.asciidoc
@@ -302,25 +302,18 @@ PUT _watcher/watch/log_event_watch
 <1> A `condition` that only applies to the `notify_pager` action, which
     restricts its execution to when the condition succeeds (at least 5 hits in this case).
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/actions/email.asciidoc
 include::actions/email.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/actions/webhook.asciidoc
 include::actions/webhook.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/actions/index.asciidoc
 include::actions/index.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/actions/logging.asciidoc
 include::actions/logging.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/actions/slack.asciidoc
 include::actions/slack.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/actions/pagerduty.asciidoc
 include::actions/pagerduty.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/actions/jira.asciidoc
 include::actions/jira.asciidoc[]
 
 [float]

--- a/x-pack/docs/en/watcher/condition.asciidoc
+++ b/x-pack/docs/en/watcher/condition.asciidoc
@@ -28,17 +28,12 @@ conditions are met.
 In addition to the watch wide condition, you can also configure conditions
 per <<action-conditions, action>>.
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/condition/always.asciidoc
 include::condition/always.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/condition/never.asciidoc
 include::condition/never.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/condition/compare.asciidoc
 include::condition/compare.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/condition/array-compare.asciidoc
 include::condition/array-compare.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/condition/script.asciidoc
 include::condition/script.asciidoc[]

--- a/x-pack/docs/en/watcher/example-watches.asciidoc
+++ b/x-pack/docs/en/watcher/example-watches.asciidoc
@@ -9,8 +9,6 @@ For more example watches you can use as a starting point for building custom
 watches, see the https://github.com/elastic/examples/tree/master/Alerting[Example
 Watches] in the Elastic Examples repo.
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/example-watches/example-watch-clusterstatus.asciidoc
 include::example-watches/example-watch-clusterstatus.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/example-watches/example-watch-meetupdata.asciidoc
 include::example-watches/example-watch-meetupdata.asciidoc[]

--- a/x-pack/docs/en/watcher/input.asciidoc
+++ b/x-pack/docs/en/watcher/input.asciidoc
@@ -19,14 +19,10 @@ execution context.
 NOTE: If you don't define an input for a watch, an empty payload is loaded
       into the execution context.
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/input/simple.asciidoc
 include::input/simple.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/input/search.asciidoc
 include::input/search.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/input/http.asciidoc
 include::input/http.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/input/chain.asciidoc
 include::input/chain.asciidoc[]

--- a/x-pack/docs/en/watcher/transform.asciidoc
+++ b/x-pack/docs/en/watcher/transform.asciidoc
@@ -56,11 +56,8 @@ part of the definition of the `my_webhook` action.
 <1> A watch level `transform`
 <2> An action level `transform`
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/transform/search.asciidoc
 include::transform/search.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/transform/script.asciidoc
 include::transform/script.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/transform/chain.asciidoc
 include::transform/chain.asciidoc[]

--- a/x-pack/docs/en/watcher/trigger.asciidoc
+++ b/x-pack/docs/en/watcher/trigger.asciidoc
@@ -9,5 +9,4 @@ the trigger and triggering the watch when needed.
 {watcher} is designed to support different types of triggers, but only time-based
 <<trigger-schedule, `schedule`>> triggers are currently available.
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/trigger/schedule.asciidoc
 include::trigger/schedule.asciidoc[]

--- a/x-pack/docs/en/watcher/trigger/schedule.asciidoc
+++ b/x-pack/docs/en/watcher/trigger/schedule.asciidoc
@@ -26,23 +26,16 @@ once per minute. For more information about throttling, see
 * <<schedule-cron, `cron`>>
 * <<schedule-interval, `interval`>>
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/schedule/hourly.asciidoc
 include::schedule/hourly.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/schedule/daily.asciidoc
 include::schedule/daily.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/schedule/weekly.asciidoc
 include::schedule/weekly.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/schedule/monthly.asciidoc
 include::schedule/monthly.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/schedule/yearly.asciidoc
 include::schedule/yearly.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/schedule/cron.asciidoc
 include::schedule/cron.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/schedule/interval.asciidoc
 include::schedule/interval.asciidoc[]


### PR DESCRIPTION
Removes `:edit_url:` overrides throughout ES documentation. These overrides no longer work in Asciidoctor.

Resolves #44442.

Will backport to 6.8.