### PR TITLE
[DOCS] Renames data frame APIs section

### DIFF
--- a/docs/reference/data-frames/apis/index.asciidoc
+++ b/docs/reference/data-frames/apis/index.asciidoc
@@ -1,13 +1,9 @@
 [role="xpack"]
 [testenv="basic"]
 [[data-frame-apis]]
-== {dataframe-cap} APIs
+== {dataframe-transform-cap} APIs
 
-See also {stack-ov}/ml-dataframes.html[{dataframes-cap}].
-
-[float]
-[[data-frame-transform-apis]]
-=== {dataframe-transforms-cap}
+See also {stack-ov}/ml-dataframes.html[{dataframe-transforms-cap}].
 
 * <<put-data-frame-transform>> 
 * <<delete-data-frame-transform>>


### PR DESCRIPTION
This PR renames the "Data frame APIs" section of the documentation to "Data frame transform APIs", since the APIs are not about data frames in general but specifically about how to create them via transforms.