### PR TITLE
Do not write if connect incomplete

### DIFF
--- a/libs/nio/src/main/java/org/elasticsearch/nio/NioSelector.java
+++ b/libs/nio/src/main/java/org/elasticsearch/nio/NioSelector.java
@@ -359,7 +359,9 @@ public class NioSelector implements Closeable {
             }
 
             if (shouldFlushAfterQueuing) {
-                if (context.selectorShouldClose() == false) {
+                // We only attempt the write if the connect process is complete and the context is not
+                // signally that it should be closed.
+                if (context.isConnectComplete() && context.selectorShouldClose() == false) {
                     handleWrite(context);
                 }
                 eventHandler.postHandling(context);

--- a/libs/nio/src/main/java/org/elasticsearch/nio/NioSelector.java
+++ b/libs/nio/src/main/java/org/elasticsearch/nio/NioSelector.java
@@ -360,7 +360,7 @@ public class NioSelector implements Closeable {
 
             if (shouldFlushAfterQueuing) {
                 // We only attempt the write if the connect process is complete and the context is not
-                // signally that it should be closed.
+                // signalling that it should be closed.
                 if (context.isConnectComplete() && context.selectorShouldClose() == false) {
                     handleWrite(context);
                 }


### PR DESCRIPTION
Currently, we do not handle READ or WRITE events until the channel
connection process is complete. However, the external write queue path
allows a write to be attempted when the conneciton is not complete. This
commit closes the loophole and only queues write operations when the
connection process is not complete.