### PR TITLE
Convert ClearScroll* to Writeable.

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/ClearScrollAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ClearScrollAction.java
@@ -19,19 +19,14 @@
 
 package org.elasticsearch.action.search;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class ClearScrollAction extends StreamableResponseActionType<ClearScrollResponse> {
+public class ClearScrollAction extends ActionType<ClearScrollResponse> {
 
     public static final ClearScrollAction INSTANCE = new ClearScrollAction();
     public static final String NAME = "indices:data/read/scroll/clear";
 
     private ClearScrollAction() {
-        super(NAME);
-    }
-
-    @Override
-    public ClearScrollResponse newResponse() {
-        return new ClearScrollResponse();
+        super(NAME, ClearScrollResponse::new);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/search/ClearScrollRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ClearScrollRequest.java
@@ -38,6 +38,13 @@ public class ClearScrollRequest extends ActionRequest implements ToXContentObjec
 
     private List<String> scrollIds;
 
+    public ClearScrollRequest() {}
+
+    public ClearScrollRequest(StreamInput in) throws IOException {
+        super(in);
+        scrollIds = Arrays.asList(in.readStringArray());
+    }
+    
     public List<String> getScrollIds() {
         return scrollIds;
     }
@@ -71,9 +78,8 @@ public class ClearScrollRequest extends ActionRequest implements ToXContentObjec
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        scrollIds = Arrays.asList(in.readStringArray());
+    public void readFrom(StreamInput in) {
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/search/ClearScrollResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ClearScrollResponse.java
@@ -48,15 +48,18 @@ public class ClearScrollResponse extends ActionResponse implements StatusToXCont
         PARSER.declareField(constructorArg(), (parser, context) -> parser.intValue(), NUMFREED, ObjectParser.ValueType.INT);
     }
 
-    private boolean succeeded;
-    private int numFreed;
+    private final boolean succeeded;
+    private final int numFreed;
 
     public ClearScrollResponse(boolean succeeded, int numFreed) {
         this.succeeded = succeeded;
         this.numFreed = numFreed;
     }
 
-    ClearScrollResponse() {
+    public ClearScrollResponse(StreamInput in) throws IOException {
+        super(in);
+        succeeded = in.readBoolean();
+        numFreed = in.readVInt();
     }
 
     /**
@@ -96,10 +99,8 @@ public class ClearScrollResponse extends ActionResponse implements StatusToXCont
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        succeeded = in.readBoolean();
-        numFreed = in.readVInt();
+    public void readFrom(StreamInput in) {
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/search/TransportClearScrollAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportClearScrollAction.java
@@ -35,7 +35,7 @@ public class TransportClearScrollAction extends HandledTransportAction<ClearScro
     @Inject
     public TransportClearScrollAction(TransportService transportService, ClusterService clusterService, ActionFilters actionFilters,
                                       SearchTransportService searchTransportService) {
-        super(ClearScrollAction.NAME, transportService, ClearScrollRequest::new, actionFilters);
+        super(ClearScrollAction.NAME, transportService, actionFilters, ClearScrollRequest::new);
         this.clusterService = clusterService;
         this.searchTransportService = searchTransportService;
     }


### PR DESCRIPTION
This PR converts `ClearScrollRequest` and `ClearScrollResponse` to
`Writeable`.

In future PRs I plan to convert more actions at once, but opened this small
'warm-up' PR to check I'm not missing anything.

Relates to #34389.