### PR TITLE
Introduce test issue logging

### DIFF
--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/ESLoggingHandlerIT.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/ESLoggingHandlerIT.java
@@ -30,7 +30,9 @@ import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.transport.TransportLogger;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2)
-@TestLogging(value = "org.elasticsearch.transport.netty4.ESLoggingHandler:trace,org.elasticsearch.transport.TransportLogger:trace")
+@TestLogging(
+    value = "org.elasticsearch.transport.netty4.ESLoggingHandler:trace,org.elasticsearch.transport.TransportLogger:trace",
+    reason = "to ensure we log network events on TRACE level")
 public class ESLoggingHandlerIT extends ESNetty4IntegTestCase {
 
     private MockLogAppender appender;

--- a/plugins/transport-nio/src/test/java/org/elasticsearch/transport/nio/NioTransportLoggingIT.java
+++ b/plugins/transport-nio/src/test/java/org/elasticsearch/transport/nio/NioTransportLoggingIT.java
@@ -30,7 +30,7 @@ import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.transport.TransportLogger;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2)
-@TestLogging(value = "org.elasticsearch.transport.TransportLogger:trace")
+@TestLogging(value = "org.elasticsearch.transport.TransportLogger:trace", reason = "to ensure we log network events on TRACE level")
 public class NioTransportLoggingIT extends NioIntegTestCase {
 
     private MockLogAppender appender;
@@ -77,4 +77,5 @@ public class NioTransportLoggingIT extends NioIntegTestCase {
         client().admin().cluster().nodesHotThreads(new NodesHotThreadsRequest()).actionGet();
         appender.assertAllExpectationsMatched();
     }
+
 }

--- a/server/src/test/java/org/elasticsearch/action/support/master/IndexingMasterFailoverIT.java
+++ b/server/src/test/java/org/elasticsearch/action/support/master/IndexingMasterFailoverIT.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.elasticsearch.action.support.master;
 
 import org.elasticsearch.action.DocWriteResponse;
@@ -26,7 +27,6 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.disruption.NetworkDisruption;
 import org.elasticsearch.test.disruption.NetworkDisruption.NetworkDisconnect;
 import org.elasticsearch.test.disruption.NetworkDisruption.TwoPartitions;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
 
 import java.util.Arrays;
@@ -54,7 +54,6 @@ public class IndexingMasterFailoverIT extends ESIntegTestCase {
      * If the master node is being disrupted or if it cannot commit cluster state changes, it needs to retry within timeout limits.
      * This retry logic is implemented in TransportMasterNodeAction and tested by the following master failover scenario.
      */
-    @TestLogging("_root:DEBUG")
     public void testMasterFailoverDuringIndexingWithMappingChanges() throws Throwable {
         logger.info("--> start 4 nodes, 3 master, 1 data");
 
@@ -129,4 +128,5 @@ public class IndexingMasterFailoverIT extends ESIntegTestCase {
         refresh();
         assertThat(client().prepareSearch("myindex").get().getHits().getTotalHits().value, equalTo(10L));
     }
+
 }

--- a/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierServiceTests.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.elasticsearch.cluster.service;
 
 import org.apache.logging.log4j.Level;
@@ -105,7 +106,7 @@ public class ClusterApplierServiceTests extends ESTestCase {
         return timedClusterApplierService;
     }
 
-    @TestLogging("org.elasticsearch.cluster.service:TRACE") // To ensure that we log cluster state events on TRACE level
+    @TestLogging(value = "org.elasticsearch.cluster.service:TRACE", reason = "to ensure that we log cluster state events on TRACE level")
     public void testClusterStateUpdateLogging() throws Exception {
         MockLogAppender mockAppender = new MockLogAppender();
         mockAppender.start();
@@ -176,7 +177,7 @@ public class ClusterApplierServiceTests extends ESTestCase {
         }
     }
 
-    @TestLogging("org.elasticsearch.cluster.service:WARN") // To ensure that we log cluster state events on WARN level
+    @TestLogging(value = "org.elasticsearch.cluster.service:WARN", reason = "to ensure that we log cluster state events on WARN level")
     public void testLongClusterStateUpdateLogging() throws Exception {
         MockLogAppender mockAppender = new MockLogAppender();
         mockAppender.start();
@@ -507,4 +508,5 @@ public class ClusterApplierServiceTests extends ESTestCase {
             return super.currentTimeInMillis();
         }
     }
+
 }

--- a/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
@@ -16,11 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.elasticsearch.cluster.service;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterChangedEvent;
@@ -32,6 +33,8 @@ import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.LocalClusterUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.coordination.ClusterStatePublisher;
+import org.elasticsearch.cluster.coordination.FailedToCommitClusterStateException;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.Nullable;
@@ -42,8 +45,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.BaseFuture;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.cluster.coordination.ClusterStatePublisher;
-import org.elasticsearch.cluster.coordination.FailedToCommitClusterStateException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.junit.annotations.TestLogging;
@@ -305,7 +306,7 @@ public class MasterServiceTests extends ESTestCase {
         assertTrue(published.get());
     }
 
-    @TestLogging("org.elasticsearch.cluster.service:TRACE") // To ensure that we log cluster state events on TRACE level
+    @TestLogging(value = "org.elasticsearch.cluster.service:TRACE", reason = "to ensure that we log cluster state events on TRACE level")
     public void testClusterStateUpdateLogging() throws Exception {
         MockLogAppender mockAppender = new MockLogAppender();
         mockAppender.start();
@@ -642,7 +643,7 @@ public class MasterServiceTests extends ESTestCase {
             containsString("Reason: [Blocking operation]"));
     }
 
-    @TestLogging("org.elasticsearch.cluster.service:WARN") // To ensure that we log cluster state events on WARN level
+    @TestLogging(value = "org.elasticsearch.cluster.service:WARN", reason = "to ensure that we log cluster state events on WARN level")
     public void testLongClusterStateUpdateLogging() throws Exception {
         MockLogAppender mockAppender = new MockLogAppender();
         mockAppender.start();
@@ -923,4 +924,5 @@ public class MasterServiceTests extends ESTestCase {
     public static ClusterState discoveryState(MasterService masterService) {
         return masterService.state();
     }
+
 }

--- a/server/src/test/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
+++ b/server/src/test/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
@@ -52,7 +52,7 @@ import org.elasticsearch.test.disruption.NetworkDisruption.NetworkDisconnect;
 import org.elasticsearch.test.disruption.NetworkDisruption.NetworkLinkDisruptionType;
 import org.elasticsearch.test.disruption.NetworkDisruption.TwoPartitions;
 import org.elasticsearch.test.disruption.ServiceDisruptionScheme;
-import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.elasticsearch.test.junit.annotations.TestIssueLogging;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -105,11 +105,11 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
      * <p>
      * This test is a superset of tests run in the Jepsen test suite, with the exception of versioned updates
      */
-    @TestLogging("_root:DEBUG,org.elasticsearch.action.bulk:TRACE,org.elasticsearch.action.get:TRACE," +
+    @TestIssueLogging(value = "_root:DEBUG,org.elasticsearch.action.bulk:TRACE,org.elasticsearch.action.get:TRACE," +
         "org.elasticsearch.discovery:TRACE,org.elasticsearch.action.support.replication:TRACE," +
         "org.elasticsearch.cluster.service:TRACE,org.elasticsearch.indices.recovery:TRACE," +
-        "org.elasticsearch.indices.cluster:TRACE,org.elasticsearch.index.shard:TRACE")
-    // TestLogging for https://github.com/elastic/elasticsearch/issues/41068
+        "org.elasticsearch.indices.cluster:TRACE,org.elasticsearch.index.shard:TRACE",
+        issueUrl = "https://github.com/elastic/elasticsearch/issues/41068")
     public void testAckedIndexing() throws Exception {
 
         final int seconds = !(TEST_NIGHTLY && rarely()) ? 1 : 5;
@@ -507,4 +507,5 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
                 ackedDocs, everyItem(isIn(docs)));
         }
     }
+
 }

--- a/server/src/test/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
+++ b/server/src/test/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.elasticsearch.discovery;
 
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -41,7 +42,6 @@ import org.elasticsearch.test.disruption.NetworkDisruption.NetworkLinkDisruption
 import org.elasticsearch.test.disruption.NetworkDisruption.NetworkUnresponsive;
 import org.elasticsearch.test.disruption.NetworkDisruption.TwoPartitions;
 import org.elasticsearch.test.disruption.SingleNodeDisruption;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
 
 import java.util.ArrayList;
@@ -173,8 +173,6 @@ public class StableMasterDisruptionIT extends ESIntegTestCase {
      * Tests that emulates a frozen elected master node that unfreezes and pushes its cluster state to other nodes that already are
      * following another elected master node. These nodes should reject this cluster state and prevent them from following the stale master.
      */
-    @TestLogging("_root:DEBUG,org.elasticsearch.cluster.service:TRACE")
-    // TestLogging for https://github.com/elastic/elasticsearch/issues/43392
     public void testStaleMasterNotHijackingMajority() throws Exception {
         final List<String> nodes = internalCluster().startNodes(3, Settings.builder()
             .put(LeaderChecker.LEADER_CHECK_TIMEOUT_SETTING.getKey(), "1s")

--- a/server/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -71,7 +71,6 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 import org.elasticsearch.test.InternalTestCluster;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.store.MockFSIndexStore;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.test.transport.StubbableTransport;
@@ -291,12 +290,6 @@ public class IndexRecoveryIT extends ESIntegTestCase {
         assertHitCount(client().prepareSearch(INDEX_NAME).setSize(0).get(), numOfDocs);
     }
 
-    @TestLogging(
-            "_root:DEBUG,"
-                    + "org.elasticsearch.cluster.service:TRACE,"
-                    + "org.elasticsearch.indices.cluster:TRACE,"
-                    + "org.elasticsearch.indices.recovery:TRACE,"
-                    + "org.elasticsearch.index.shard:TRACE")
     public void testRerouteRecovery() throws Exception {
         logger.info("--> start node A");
         final String nodeA = internalCluster().startNode();
@@ -713,7 +706,6 @@ public class IndexRecoveryIT extends ESIntegTestCase {
      * Tests scenario where recovery target successfully sends recovery request to source but then the channel gets closed while
      * the source is working on the recovery process.
      */
-    @TestLogging("_root:DEBUG,org.elasticsearch.indices.recovery:TRACE")
     public void testDisconnectsDuringRecovery() throws Exception {
         boolean primaryRelocation = randomBoolean();
         final String indexName = "test";
@@ -1015,4 +1007,5 @@ public class IndexRecoveryIT extends ESIntegTestCase {
                 });
         }
     }
+
 }

--- a/server/src/test/java/org/elasticsearch/transport/TransportLoggerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportLoggerTests.java
@@ -37,7 +37,7 @@ import java.io.IOException;
 
 import static org.mockito.Mockito.mock;
 
-@TestLogging(value = "org.elasticsearch.transport.TransportLogger:trace")
+@TestLogging(value = "org.elasticsearch.transport.TransportLogger:trace", reason = "to ensure we log network events on TRACE level")
 public class TransportLoggerTests extends ESTestCase {
 
     private MockLogAppender appender;

--- a/test/framework/src/main/java/org/elasticsearch/test/junit/annotations/TestIssueLogging.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/junit/annotations/TestIssueLogging.java
@@ -29,7 +29,7 @@ import static java.lang.annotation.ElementType.TYPE;
 
 /**
  * Annotation used to set a custom log level when investigating test failures. Do not use this annotation to explicitly
- * control the logging level in tests.
+ * control the logging level in tests; instead, use {@link TestLogging}.
  *
  * It supports multiple logger:level comma-separated key-value pairs of logger:level (e.g.,
  * org.elasticsearch.cluster.metadata:TRACE). Use the _root keyword to set the root logger level.

--- a/test/framework/src/main/java/org/elasticsearch/test/junit/annotations/TestIssueLogging.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/junit/annotations/TestIssueLogging.java
@@ -28,15 +28,15 @@ import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 
 /**
- * Annotation used to set a custom log level for controlling logging behavior in tests. Do not use this annotation when
- * investigating test failures.
+ * Annotation used to set a custom log level when investigating test failures. Do not use this annotation to explicitly
+ * control the logging level in tests.
  *
  * It supports multiple logger:level comma-separated key-value pairs of logger:level (e.g.,
  * org.elasticsearch.cluster.metadata:TRACE). Use the _root keyword to set the root logger level.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({PACKAGE, TYPE, METHOD})
-public @interface TestLogging {
+public @interface TestIssueLogging {
 
     /**
      * A comma-separated list of key-value pairs of logger:level. For each key-value pair of logger:level, the test
@@ -47,10 +47,10 @@ public @interface TestLogging {
     String value();
 
     /**
-     * The reason this annotation is used to control logger behavior during a test.
+     * This property is used to link to the open test issue under investigation.
      *
-     * @return the reason for adding the annotation
+     * @return the issue link
      */
-    String reason() default "";
+    String issueUrl();
 
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/junit/annotations/TestLogging.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/junit/annotations/TestLogging.java
@@ -51,6 +51,6 @@ public @interface TestLogging {
      *
      * @return the reason for adding the annotation
      */
-    String reason() default "";
+    String reason();
 
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/junit/annotations/TestLogging.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/junit/annotations/TestLogging.java
@@ -29,7 +29,7 @@ import static java.lang.annotation.ElementType.TYPE;
 
 /**
  * Annotation used to set a custom log level for controlling logging behavior in tests. Do not use this annotation when
- * investigating test failures.
+ * investigating test failures; instead, use {@link TestIssueLogging}.
  *
  * It supports multiple logger:level comma-separated key-value pairs of logger:level (e.g.,
  * org.elasticsearch.cluster.metadata:TRACE). Use the _root keyword to set the root logger level.

--- a/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/LoggingListener.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/LoggingListener.java
@@ -22,14 +22,19 @@ package org.elasticsearch.test.junit.listeners;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.test.junit.annotations.TestIssueLogging;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.runner.Description;
 import org.junit.runner.Result;
 import org.junit.runner.notification.RunListener;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A {@link RunListener} that allows changing the log level for a specific test method. When a test method is annotated with the
@@ -49,8 +54,12 @@ public class LoggingListener extends RunListener {
     @Override
     public void testRunStarted(final Description description) throws Exception {
         Package testClassPackage = description.getTestClass().getPackage();
-        previousPackageLoggingMap = processTestLogging(testClassPackage != null ? testClassPackage.getAnnotation(TestLogging.class) : null);
-        previousClassLoggingMap = processTestLogging(description.getAnnotation(TestLogging.class));
+        previousPackageLoggingMap = processTestLogging(
+            testClassPackage != null ? testClassPackage.getAnnotation(TestLogging.class) : null,
+            testClassPackage != null ? testClassPackage.getAnnotation(TestIssueLogging.class) : null);
+        previousClassLoggingMap = processTestLogging(
+            description.getAnnotation(TestLogging.class),
+            description.getAnnotation(TestIssueLogging.class));
     }
 
     @Override
@@ -62,7 +71,8 @@ public class LoggingListener extends RunListener {
     @Override
     public void testStarted(final Description description) throws Exception {
         final TestLogging testLogging = description.getAnnotation(TestLogging.class);
-        previousLoggingMap = processTestLogging(testLogging);
+        final TestIssueLogging testIssueLogging = description.getAnnotation(TestIssueLogging.class);
+        previousLoggingMap = processTestLogging(testLogging, testIssueLogging);
     }
 
     @Override
@@ -89,22 +99,35 @@ public class LoggingListener extends RunListener {
      * @param testLogging the test logging annotation to apply
      * @return the existing logging levels
      */
-    private Map<String, String> processTestLogging(final TestLogging testLogging) {
-        final Map<String, String> map = getLoggersAndLevelsFromAnnotation(testLogging);
+    private Map<String, String> processTestLogging(final TestLogging testLogging, final TestIssueLogging testIssueLogging) {
+        final Map<String, String> testLoggingMap = getLoggersAndLevelsFromAnnotation(testLogging);
+        final Map<String, String> testIssueLoggingMap = getLoggersAndLevelsFromAnnotation(testIssueLogging);
 
-        if (map == null) {
-            return Collections.emptyMap();
+        final Set<String> testLoggingKeys = new HashSet<>(testLoggingMap.keySet());
+        testLoggingKeys.retainAll(testIssueLoggingMap.keySet());
+        if (testLoggingKeys.isEmpty() == false) {
+            throw new IllegalArgumentException("found intersection " + testLoggingKeys + " between TestLogging and TestIssueLogging");
         }
 
-        // obtain the existing logging levels so that we can restore them at the end of the test; we have to do this separately from setting
-        // the logging levels so that setting foo does not impact the logging level for foo.bar when we check the existing logging level for
-        // for.bar
+        /*
+         * Use a sorted set so that we apply a parent logger before its children thus not overwriting the child setting when processing the
+         * parent setting.
+         */
+        final Map<String, String> loggingLevels =
+            new TreeMap<>(Stream.concat(testLoggingMap.entrySet().stream(), testIssueLoggingMap.entrySet().stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+
+        /*
+         * Obtain the existing logging levels so that we can restore them at the end of the test. We have to do this separately from
+         * setting the logging levels so that setting foo does not impact the logging level for for.bar when we check the existing logging
+         * level for foo.bar.
+         */
         final Map<String, String> existing = new TreeMap<>();
-        for (final Map.Entry<String, String> entry : map.entrySet()) {
+        for (final Map.Entry<String, String> entry : loggingLevels.entrySet()) {
             final Logger logger = resolveLogger(entry.getKey());
             existing.put(entry.getKey(), logger.getLevel().toString());
         }
-        for (final Map.Entry<String, String> entry : map.entrySet()) {
+        for (final Map.Entry<String, String> entry : loggingLevels.entrySet()) {
             final Logger logger = resolveLogger(entry.getKey());
             Loggers.setLevel(logger, entry.getValue());
         }
@@ -121,10 +144,25 @@ public class LoggingListener extends RunListener {
         if (testLogging == null) {
             return Collections.emptyMap();
         }
-        // use a sorted set so that we apply a parent logger before its children thus not overwriting the child setting when processing the
-        // parent setting
+
+        return getLoggersAndLevelsFromAnnotationValue(testLogging.value());
+    }
+
+    private static Map<String, String> getLoggersAndLevelsFromAnnotation(final TestIssueLogging testIssueLogging) {
+        if (testIssueLogging == null) {
+            return Collections.emptyMap();
+        }
+
+        return getLoggersAndLevelsFromAnnotationValue(testIssueLogging.value());
+    }
+
+    private static Map<String, String> getLoggersAndLevelsFromAnnotationValue(final String value) {
+        /*
+         * Use a sorted set so that we apply a parent logger before its children thus not overwriting the child setting when processing the
+         * parent setting.
+         */
         final Map<String, String> map = new TreeMap<>();
-        final String[] loggersAndLevels = testLogging.value().split(",");
+        final String[] loggersAndLevels = value.split(",");
         for (final String loggerAndLevel : loggersAndLevels) {
             final String[] loggerAndLevelArray = loggerAndLevel.split(":");
             if (loggerAndLevelArray.length == 2) {

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -997,7 +997,9 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         assertTrue(inFlight.tryAcquire(Integer.MAX_VALUE, 10, TimeUnit.SECONDS));
     }
 
-    @TestLogging(value = "org.elasticsearch.transport.TransportService.tracer:trace")
+    @TestLogging(
+        value = "org.elasticsearch.transport.TransportService.tracer:trace",
+        reason = "to ensure we log network events on TRACE level")
     public void testTracerLog() throws Exception {
         TransportRequestHandler<TransportRequest> handler = (request, channel, task) -> channel.sendResponse(new StringMessageResponse(""));
         TransportRequestHandler<StringMessageRequest> handlerWithError = (request, channel, task) -> {
@@ -2717,4 +2719,5 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
     protected Set<TcpChannel> getAcceptedChannels(TcpTransport transport) {
         return transport.getAcceptedChannels();
     }
+
 }

--- a/test/framework/src/test/java/org/elasticsearch/test/test/LoggingListenerTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/LoggingListenerTests.java
@@ -23,14 +23,20 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.junit.annotations.TestIssueLogging;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.junit.listeners.LoggingListener;
 import org.junit.runner.Description;
 import org.junit.runner.Result;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.util.Objects;
+import java.util.stream.Stream;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.hasToString;
 
 public class LoggingListenerTests extends ESTestCase {
 
@@ -43,9 +49,21 @@ public class LoggingListenerTests extends ESTestCase {
     }
 
     public void testCustomLevelPerMethod() throws Exception {
+        runTestCustomLevelPerMethod(TestClass.class);
+    }
+
+    public void testIssueCustomLevelPerMethod() throws Exception {
+        runTestCustomLevelPerMethod(TestIssueClass.class);
+    }
+
+    public void testMixedCustomLevelPerMethod() throws Exception {
+        runTestCustomLevelPerMethod(TestMixedClass.class);
+    }
+
+    private void runTestCustomLevelPerMethod(final Class<?> clazz) throws Exception {
         LoggingListener loggingListener = new LoggingListener();
 
-        Description suiteDescription = Description.createSuiteDescription(TestClass.class);
+        Description suiteDescription = Description.createSuiteDescription(clazz);
 
         Logger xyzLogger = LogManager.getLogger("xyz");
         Logger abcLogger = LogManager.getLogger("abc");
@@ -58,9 +76,11 @@ public class LoggingListenerTests extends ESTestCase {
         assertThat(xyzLogger.getLevel(), equalTo(level));
         assertThat(abcLogger.getLevel(), equalTo(level));
 
-        Method method = TestClass.class.getMethod("annotatedTestMethod");
-        TestLogging annotation = method.getAnnotation(TestLogging.class);
-        Description testDescription = Description.createTestDescription(LoggingListenerTests.class, "annotatedTestMethod", annotation);
+        Method method = clazz.getMethod("annotatedTestMethod");
+        TestLogging testLogging = method.getAnnotation(TestLogging.class);
+        TestIssueLogging testIssueLogging = method.getAnnotation(TestIssueLogging.class);
+        Annotation[] annotations = Stream.of(testLogging, testIssueLogging).filter(Objects::nonNull).toArray(Annotation[]::new);
+        Description testDescription = Description.createTestDescription(LoggingListenerTests.class, "annotatedTestMethod", annotations);
         loggingListener.testStarted(testDescription);
         assertThat(xyzLogger.getLevel(), equalTo(Level.TRACE));
         assertThat(abcLogger.getLevel(), equalTo(level));
@@ -75,15 +95,29 @@ public class LoggingListenerTests extends ESTestCase {
     }
 
     public void testCustomLevelPerClass() throws Exception {
+        runTestCustomLevelPerClass(AnnotatedTestClass.class);
+    }
+
+    public void testIssueCustomLevelPerClass() throws Exception {
+        runTestCustomLevelPerClass(AnnotatedTestIssueClass.class);
+    }
+
+    public void testCustomLevelPerClassMixed() throws Exception {
+        runTestCustomLevelPerClass(AnnotatedTestMixedClass.class);
+    }
+
+    private void runTestCustomLevelPerClass(final Class<?> clazz) throws Exception {
         LoggingListener loggingListener = new LoggingListener();
 
-        Description suiteDescription = Description.createSuiteDescription(AnnotatedTestClass.class);
+        Description suiteDescription = Description.createSuiteDescription(clazz);
 
         Logger abcLogger = LogManager.getLogger("abc");
         Logger xyzLogger = LogManager.getLogger("xyz");
-        // we include foo and foo.bar to maintain that logging levels are applied from the top of the hierarchy down; this ensures that
-        // setting the logging level for a parent logger and a child logger applies the parent level first and then the child as otherwise
-        // setting the parent level would overwrite the child level
+        /*
+         * We include foo and foo.bar to maintain that logging levels are applied from the top of the hierarchy down. This ensures that
+         * setting the logging level for a parent logger and a child logger applies the parent level first and then the child as otherwise
+         * setting the parent level would overwrite the child level.
+         */
         Logger fooLogger = LogManager.getLogger("foo");
         Logger fooBarLogger = LogManager.getLogger("foo.bar");
 
@@ -120,9 +154,21 @@ public class LoggingListenerTests extends ESTestCase {
     }
 
     public void testCustomLevelPerClassAndPerMethod() throws Exception {
+        runTestCustomLevelPerClassAndPerMethod(AnnotatedTestClass.class);
+    }
+
+    public void testIssueCustomLevelPerClassAndPerMethod() throws Exception {
+        runTestCustomLevelPerClassAndPerMethod(AnnotatedTestIssueClass.class);
+    }
+
+    public void testCustomLevelPerClassAndPerMethodMixed() throws Exception {
+        runTestCustomLevelPerClassAndPerMethod(AnnotatedTestMixedClass.class);
+    }
+
+    private void runTestCustomLevelPerClassAndPerMethod(final Class<?> clazz) throws Exception {
         LoggingListener loggingListener = new LoggingListener();
 
-        Description suiteDescription = Description.createSuiteDescription(AnnotatedTestClass.class);
+        Description suiteDescription = Description.createSuiteDescription(clazz);
 
         Logger abcLogger = LogManager.getLogger("abc");
         Logger xyzLogger = LogManager.getLogger("xyz");
@@ -136,8 +182,10 @@ public class LoggingListenerTests extends ESTestCase {
         assertThat(abcLogger.getLevel(), equalTo(Level.WARN));
 
         Method method = TestClass.class.getMethod("annotatedTestMethod");
-        TestLogging annotation = method.getAnnotation(TestLogging.class);
-        Description testDescription = Description.createTestDescription(LoggingListenerTests.class, "annotatedTestMethod", annotation);
+        TestLogging testLogging = method.getAnnotation(TestLogging.class);
+        TestIssueLogging testIssueLogging = method.getAnnotation(TestIssueLogging.class);
+        Annotation[] annotations = Stream.of(testLogging, testIssueLogging).filter(Objects::nonNull).toArray(Annotation[]::new);
+        Description testDescription = Description.createTestDescription(LoggingListenerTests.class, "annotatedTestMethod", annotations);
         loggingListener.testStarted(testDescription);
         assertThat(xyzLogger.getLevel(), equalTo(Level.TRACE));
         assertThat(abcLogger.getLevel(), equalTo(Level.WARN));
@@ -147,8 +195,10 @@ public class LoggingListenerTests extends ESTestCase {
         assertThat(abcLogger.getLevel(), equalTo(Level.WARN));
 
         Method method2 = TestClass.class.getMethod("annotatedTestMethod2");
-        TestLogging annotation2 = method2.getAnnotation(TestLogging.class);
-        Description testDescription2 = Description.createTestDescription(LoggingListenerTests.class, "annotatedTestMethod2", annotation2);
+        TestLogging testLogging2 = method2.getAnnotation(TestLogging.class);
+        TestIssueLogging testIssueLogging2 = method2.getAnnotation(TestIssueLogging.class);
+        Annotation[] annotations2 = Stream.of(testLogging2, testIssueLogging2).filter(Objects::nonNull).toArray(Annotation[]::new);
+        Description testDescription2 = Description.createTestDescription(LoggingListenerTests.class, "annotatedTestMethod2", annotations2);
         loggingListener.testStarted(testDescription2);
         assertThat(xyzLogger.getLevel(), equalTo(Level.DEBUG));
         assertThat(abcLogger.getLevel(), equalTo(Level.TRACE));
@@ -163,9 +213,17 @@ public class LoggingListenerTests extends ESTestCase {
     }
 
     public void testInvalidClassTestLoggingAnnotation() throws Exception {
+        runTestInvalidClassTestLoggingAnnotation(InvalidClass.class);
+    }
+
+    public void testInvalidClassTestIssueLoggingAnnotation() throws Exception {
+        runTestInvalidClassTestLoggingAnnotation(InvalidIssueClass.class);
+    }
+
+    private void runTestInvalidClassTestLoggingAnnotation(final Class<?> clazz) {
         final LoggingListener loggingListener = new LoggingListener();
 
-        final Description suiteDescription = Description.createSuiteDescription(InvalidClass.class);
+        final Description suiteDescription = Description.createSuiteDescription(clazz);
 
         final IllegalArgumentException e =
             expectThrows(IllegalArgumentException.class, () -> loggingListener.testRunStarted(suiteDescription));
@@ -173,25 +231,62 @@ public class LoggingListenerTests extends ESTestCase {
     }
 
     public void testInvalidMethodTestLoggingAnnotation() throws Exception {
+        runTestInvalidMethodTestLoggingAnnotation(InvalidTestLoggingMethod.class);
+    }
+
+    public void testInvalidMethodTestIssueLoggingAnnotation() throws Exception {
+        runTestInvalidMethodTestLoggingAnnotation(InvalidTestIssueLoggingMethod.class);
+    }
+
+    private void runTestInvalidMethodTestLoggingAnnotation(final Class<?> clazz) throws Exception {
         final LoggingListener loggingListener = new LoggingListener();
 
-        final Description suiteDescription = Description.createSuiteDescription(InvalidMethod.class);
+        final Description suiteDescription = Description.createSuiteDescription(clazz);
 
         loggingListener.testRunStarted(suiteDescription);
 
-        final Method method = InvalidMethod.class.getMethod("invalidMethod");
-        final TestLogging annotation = method.getAnnotation(TestLogging.class);
-        Description testDescription = Description.createTestDescription(InvalidMethod.class, "invalidMethod", annotation);
+        final Method method = clazz.getMethod("invalidMethod");
+        final TestLogging testLogging = method.getAnnotation(TestLogging.class);
+        final TestIssueLogging testIssueLogging = method.getAnnotation(TestIssueLogging.class);
+        final Annotation[] annotations = Stream.of(testLogging, testIssueLogging).filter(Objects::nonNull).toArray(Annotation[]::new);
+        Description testDescription = Description.createTestDescription(clazz, "invalidMethod", annotations);
         final IllegalArgumentException e =
             expectThrows(IllegalArgumentException.class, () -> loggingListener.testStarted(testDescription));
         assertThat(e.getMessage(), equalTo("invalid test logging annotation [abc:INFO:WARN]"));
     }
 
+    public void testDuplicateLoggerBetweenTestLoggingAndTestIssueLogging() throws Exception {
+        final LoggingListener loggingListener = new LoggingListener();
+
+        final Description suiteDescription = Description.createSuiteDescription(DuplicateLoggerBetweenTestLoggingAndTestIssueLogging.class);
+
+        final IllegalArgumentException e =
+            expectThrows(IllegalArgumentException.class, () -> loggingListener.testRunStarted(suiteDescription));
+        assertThat(e, hasToString(containsString("found intersection [abc] between TestLogging and TestIssueLogging")));
+    }
+
     /**
      * Dummy class used to create a JUnit suite description that has the {@link TestLogging} annotation.
      */
-    @TestLogging("abc:WARN,foo:WARN,foo.bar:ERROR")
+    @TestLogging(value = "abc:WARN,foo:WARN,foo.bar:ERROR", reason = "testing TestLogging class annotations")
     public static class AnnotatedTestClass {
+
+    }
+
+    /**
+     * Dummy class used to create a JUnit suite description that has the {@link TestIssueLogging} annotation.
+     */
+    @TestIssueLogging(value = "abc:WARN,foo:WARN,foo.bar:ERROR", issueUrl = "https://example.com")
+    public static class AnnotatedTestIssueClass {
+
+    }
+
+    /**
+     * Dummy class used to create a JUnit suite description that has the {@link TestLogging} and {@link TestIssueLogging} annotations.
+     */
+    @TestLogging(value = "abc:WARN,foo:WARN", reason = "testing TestLogging class annotations")
+    @TestIssueLogging(value = "foo.bar:ERROR", issueUrl = "https://example.com")
+    public static class AnnotatedTestMixedClass {
 
     }
 
@@ -202,13 +297,55 @@ public class LoggingListenerTests extends ESTestCase {
     public static class TestClass {
 
         @SuppressWarnings("unused")
-        @TestLogging("xyz:TRACE,foo:WARN,foo.bar:ERROR")
+        @TestLogging(value = "xyz:TRACE,foo:WARN,foo.bar:ERROR", reason = "testing TestLogging method annotations")
         public void annotatedTestMethod() {
 
         }
 
         @SuppressWarnings("unused")
-        @TestLogging("abc:TRACE,xyz:DEBUG")
+        @TestLogging(value = "abc:TRACE,xyz:DEBUG", reason = "testing TestLogging method annotations")
+        public void annotatedTestMethod2() {
+
+        }
+
+    }
+
+    /**
+     * Dummy class used to create a JUnit suite description that doesn't have the {@link TestIssueLogging} annotation, but its test methods
+     * have it.
+     */
+    public static class TestIssueClass {
+
+        @SuppressWarnings("unused")
+        @TestIssueLogging(value = "xyz:TRACE,foo:WARN,foo.bar:ERROR", issueUrl = "https://example.com")
+        public void annotatedTestMethod() {
+
+        }
+
+        @SuppressWarnings("unused")
+        @TestIssueLogging(value = "abc:TRACE,xyz:DEBUG", issueUrl = "https://example.com")
+        public void annotatedTestMethod2() {
+
+        }
+
+    }
+
+    /**
+     * Dummy class used to create a JUnit suite description that doesn't have the {@link TestLogging} annotation nor
+     * {@link TestIssueLogging}, but its test method have both.
+     */
+    public static class TestMixedClass {
+
+        @SuppressWarnings("unused")
+        @TestLogging(value = "xyz:TRACE,foo:WARN", reason = "testing TestLogging method annotations")
+        @TestIssueLogging(value ="foo.bar:ERROR", issueUrl = "https://example.com")
+        public void annotatedTestMethod() {
+
+        }
+
+        @SuppressWarnings("unused")
+        @TestLogging(value = "abc:TRACE", reason = "testing TestLogging method annotations")
+        @TestIssueLogging(value = "xyz:DEBUG", issueUrl = "https://example.com")
         public void annotatedTestMethod2() {
 
         }
@@ -218,21 +355,51 @@ public class LoggingListenerTests extends ESTestCase {
     /**
      * Dummy class with an invalid {@link TestLogging} annotation.
      */
-    @TestLogging("abc")
+    @TestLogging(value = "abc", reason = "testing an invalid TestLogging class annotation")
     public static class InvalidClass {
+
+    }
+
+    /**
+     * Dummy class with an invalid {@link TestIssueLogging} annotation.
+     */
+    @TestIssueLogging(value = "abc", issueUrl = "https://example.com")
+    public static class InvalidIssueClass {
 
     }
 
     /**
      * Dummy class with an invalid {@link TestLogging} annotation on a method.
      */
-    public static class InvalidMethod {
+    public static class InvalidTestLoggingMethod {
 
         @SuppressWarnings("unused")
-        @TestLogging("abc:INFO:WARN")
+        @TestLogging(value = "abc:INFO:WARN", reason = "testing an invalid TestLogging method annotation")
         public void invalidMethod() {
 
         }
+
+    }
+
+    /**
+     * Dummy class with an invalid {@link TestIssueLogging} annotation on a method.
+     */
+    public static class InvalidTestIssueLoggingMethod {
+
+        @SuppressWarnings("unused")
+        @TestIssueLogging(value = "abc:INFO:WARN", issueUrl = "https://example.com")
+        public void invalidMethod() {
+
+        }
+
+    }
+
+    /**
+     * Dummy class with duplicate logging levels between {@link TestLogging} and {@link TestIssueLogging} annotations.
+     */
+    @TestLogging("abc:INFO")
+    @TestIssueLogging(value = "abc:DEBUG", issueUrl = "https://example.com")
+    public static class DuplicateLoggerBetweenTestLoggingAndTestIssueLogging {
 
     }
 

--- a/test/framework/src/test/java/org/elasticsearch/test/test/LoggingListenerTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/LoggingListenerTests.java
@@ -397,7 +397,7 @@ public class LoggingListenerTests extends ESTestCase {
     /**
      * Dummy class with duplicate logging levels between {@link TestLogging} and {@link TestIssueLogging} annotations.
      */
-    @TestLogging("abc:INFO")
+    @TestLogging(value = "abc:INFO", reason = "testing a duplicate logger level between TestLogging and TestIssueLogging annotations")
     @TestIssueLogging(value = "abc:DEBUG", issueUrl = "https://example.com")
     public static class DuplicateLoggerBetweenTestLoggingAndTestIssueLogging {
 

--- a/x-pack/plugin/ilm/qa/with-security/src/test/java/org/elasticsearch/xpack/security/PermissionsIT.java
+++ b/x-pack/plugin/ilm/qa/with-security/src/test/java/org/elasticsearch/xpack/security/PermissionsIT.java
@@ -3,6 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.xpack.security;
 
 import org.apache.http.entity.ContentType;
@@ -36,7 +37,7 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.elasticsearch.test.junit.annotations.TestIssueLogging;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xpack.core.indexlifecycle.DeleteAction;
 import org.elasticsearch.xpack.core.indexlifecycle.LifecycleAction;
@@ -59,6 +60,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class PermissionsIT extends ESRestTestCase {
+
     private static final String jsonDoc = "{ \"name\" : \"elasticsearch\", \"body\": \"foo bar\" }";
 
     private String deletePolicy = "deletePolicy";
@@ -241,7 +243,7 @@ public class PermissionsIT extends ESRestTestCase {
      * Tests when the user is limited by alias of an index is able to write to index
      * which was rolled over by an ILM policy.
      */
-    @TestLogging("org.elasticsearch:DEBUG")
+    @TestIssueLogging(value = "org.elasticsearch:DEBUG", issueUrl = "https://github.com/elastic/elasticsearch/issues/41440")
     public void testWhenUserLimitedByOnlyAliasOfIndexCanWriteToIndexWhichWasRolledoverByILMPolicy()
             throws IOException, InterruptedException {
         /*
@@ -372,4 +374,5 @@ public class PermissionsIT extends ESRestTestCase {
             super(restClient, (client) -> {}, Collections.emptyList());
         }
     }
+
 }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/action/activate/ActivateWatchTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/action/activate/ActivateWatchTests.java
@@ -3,8 +3,8 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-package org.elasticsearch.xpack.watcher.transport.action.activate;
 
+package org.elasticsearch.xpack.watcher.transport.action.activate;
 
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexResponse;
@@ -16,7 +16,6 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.protocol.xpack.watcher.PutWatchResponse;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.xpack.core.watcher.execution.ExecutionState;
 import org.elasticsearch.xpack.core.watcher.support.xcontent.XContentSource;
 import org.elasticsearch.xpack.core.watcher.transport.actions.activate.ActivateWatchRequestBuilder;
@@ -43,8 +42,6 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
-@TestLogging("org.elasticsearch.xpack.watcher:DEBUG,org.elasticsearch.xpack.core.watcher:DEBUG," +
-    "org.elasticsearch.xpack.watcher.WatcherIndexingListener:TRACE")
 public class ActivateWatchTests extends AbstractWatcherIntegrationTestCase {
 
     @Override
@@ -163,4 +160,5 @@ public class ActivateWatchTests extends AbstractWatcherIntegrationTestCase {
         assertThat(getWatchResponse.getStatus().state(), notNullValue());
         assertThat(getWatchResponse.getStatus().state().isActive(), is(true));
     }
+
 }


### PR DESCRIPTION
Today we have an annotation for controlling logging levels in tests. This annotation serves two purposes, one is to control the logging level used in tests, when such control is needed to impact and assert the behavior of loggers in tests. The other use is when a test is failing and additional logging is needed. This commit separates these two concerns into separate annotations.

The primary motivation for this is that we have a history of leaving behind the annotation for the purpose of investigating test failures long after the test failure is resolved. The accumulation of these stale logging annotations has led to excessive disk consumption. Having recently cleaned this up, we would like to avoid falling into this state again. To do this, we are adding a link to the test failure under investigation to the annotation when used for the purpose of investigating test failures. We will add tooling to inspect these annotations, in the same way that we have tooling on awaits fix annotations. This will enable us to report on the use of these annotations, and report when stale uses of the annotation exist.
