### PR TITLE
Don't use TypeField for nested filters

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/lucene/search/Queries.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/Queries.java
@@ -19,20 +19,16 @@
 
 package org.elasticsearch.common.lucene.search;
 
-import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
-import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
-import org.elasticsearch.index.mapper.TypeFieldMapper;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/Queries.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/Queries.java
@@ -65,7 +65,7 @@ public class Queries {
     }
 
     public static Query newNestedFilter() {
-        return new PrefixQuery(new Term(TypeFieldMapper.NAME, new BytesRef("__")));
+        return filtered(new MatchAllDocsQuery(), newNonNestedFilter());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/Queries.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/Queries.java
@@ -65,7 +65,7 @@ public class Queries {
     }
 
     public static Query newNestedFilter() {
-        return filtered(new MatchAllDocsQuery(), newNonNestedFilter());
+        return not(newNonNestedFilter());
     }
 
     /**


### PR DESCRIPTION
We changed things in https://github.com/elastic/elasticsearch/pull/27469 to filter parent
docs by using an exists query on the `primary_term` field.  However, the equivalent query
for nested documents is still using the type field.  This commit makes `newNestedFilter` 
build the complement of `newNonNestedFilter` instead.
