### PR TITLE
[DOCS] Removes allow_no_match query parameter from a wrong section

### DIFF
--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
@@ -45,10 +45,6 @@ You can get information for all {dfanalytics-jobs} by using _all, by specifying
   (Optional, string) Identifier for the {dfanalytics-job}. If you do not specify
   one of these options, the API returns information for the first hundred
   {dfanalytics-jobs}.
-  
-`allow_no_match` (Optional)::
-  (boolean) If `false` and the `data_frame_analytics_id` does not match any 
-  {dfanalytics-job} an error will be returned. The default value is `true`.
 
 [[ml-get-dfanalytics-query-params]]
 ==== {api-query-parms-title}


### PR DESCRIPTION
The `allow_no_match` query parameter was featured twice in the GET DFA API document. This PR removes the param from the wrong section (path parameters).

Related issue: https://github.com/elastic/elasticsearch/issues/44093