### PR TITLE
[DOCS] Adds allow no datafeeds query param to the GET, GET stats and STOP datafeed APIs

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
@@ -53,8 +53,18 @@ IMPORTANT: This API returns a maximum of 10,000 {dfeeds}.
 ==== {api-query-parms-title}
 
 `allow_no_datafeeds`::
-  (Optional, boolean) If `false` and the `feed_id` does not match any {dfeed} an 
-  error will be returned. The default value is `true`.
+  (Optional, boolean) Specifies what to do when the request:
++
+--
+* Contains wildcard expressions and there are no {datafeeds} that match.
+* Contains the `_all` string or no identifiers and there are no matches.
+* Contains wildcard expressions and there are only partial matches. 
+
+The default value is `true`, which returns an empty `datafeeds` array when
+there are no matches and the subset of results when there are partial matches.
+If this parameter is `false`, the request returns a `404` status code when there
+are no matches or only partial matches.
+--
 
 
 [[ml-get-datafeed-stats-results]]
@@ -65,6 +75,13 @@ The API returns the following information:
 `datafeeds`::
   (array) An array of {dfeed} count objects.
   For more information, see <<ml-datafeed-counts>>.
+
+[[ml-get-datafeed-stats-response-codes]]
+==== {api-response-codes-title}
+
+`404` (Missing resources)::
+  If `allow_no_datafeeds` is `false`, this code indicates that there are no
+  resources that match the request or only partial matches for the request. 
 
 [[ml-get-datafeed-stats-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
@@ -49,6 +49,14 @@ IMPORTANT: This API returns a maximum of 10,000 {dfeeds}.
   or a wildcard expression. If you do not specify one of these options, the API
   returns statistics for all {dfeeds}.
 
+[[ml-get-datafeed-stats-query-parms]]
+==== {api-query-parms-title}
+
+`allow_no_datafeeds`::
+  (Optional, boolean) If `false` and the `feed_id` does not match any {dfeed} an 
+  error will be returned. The default value is `true`.
+
+
 [[ml-get-datafeed-stats-results]]
 ==== {api-response-body-title}
 

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
@@ -50,8 +50,18 @@ IMPORTANT: This API returns a maximum of 10,000 {dfeeds}.
 ==== {api-query-parms-title}
 
 `allow_no_datafeeds`::
-  (Optional, boolean) If `false` and the `feed_id` does not match any {dfeed} an 
-  error will be returned. The default value is `true`.
+  (Optional, boolean) Specifies what to do when the request:
++
+--
+* Contains wildcard expressions and there are no {datafeeds} that match.
+* Contains the `_all` string or no identifiers and there are no matches.
+* Contains wildcard expressions and there are only partial matches. 
+
+The default value is `true`, which returns an empty `datafeeds` array when
+there are no matches and the subset of results when there are partial matches.
+If this parameter is `false`, the request returns a `404` status code when there
+are no matches or only partial matches.
+--
 
 [[ml-get-datafeed-results]]
 ==== {api-response-body-title}
@@ -61,6 +71,13 @@ The API returns the following information:
 `datafeeds`::
   (array) An array of {dfeed} objects.
   For more information, see <<ml-datafeed-resource>>.
+
+[[ml-get-datafeed-response-codes]]
+==== {api-response-codes-title}
+
+`404` (Missing resources)::
+  If `allow_no_datafeeds` is `false`, this code indicates that there are no
+  resources that match the request or only partial matches for the request.
 
 [[ml-get-datafeed-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
@@ -46,6 +46,13 @@ IMPORTANT: This API returns a maximum of 10,000 {dfeeds}.
   or a wildcard expression. If you do not specify one of these options, the API
   returns information about all {dfeeds}.
 
+[[ml-get-datafeed-query-parms]]
+==== {api-query-parms-title}
+
+`allow_no_datafeeds`::
+  (Optional, boolean) If `false` and the `feed_id` does not match any {dfeed} an 
+  error will be returned. The default value is `true`.
+
 [[ml-get-datafeed-results]]
 ==== {api-response-body-title}
 

--- a/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
@@ -43,6 +43,13 @@ comma-separated list of {dfeeds} or a wildcard expression. You can close all
   (Required, string) Identifier for the {dfeed}. It can be a {dfeed} identifier
   or a wildcard expression.
 
+[[ml-stop-datafeed-query-parms]]
+==== {api-query-parms-title}
+
+`allow_no_datafeeds`::
+  (Optional, boolean) If `false` and the `feed_id` does not match any {dfeed} an 
+  error will be returned. The default value is `true`.
+
 [[ml-stop-datafeed-request-body]]
 ==== {api-request-body-title}
 

--- a/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
@@ -47,8 +47,18 @@ comma-separated list of {dfeeds} or a wildcard expression. You can close all
 ==== {api-query-parms-title}
 
 `allow_no_datafeeds`::
-  (Optional, boolean) If `false` and the `feed_id` does not match any {dfeed} an 
-  error will be returned. The default value is `true`.
+  (Optional, boolean) Specifies what to do when the request:
++
+--
+* Contains wildcard expressions and there are no {datafeeds} that match.
+* Contains the `_all` string or no identifiers and there are no matches.
+* Contains wildcard expressions and there are only partial matches. 
+
+The default value is `true`, which returns an empty `datafeeds` array when
+there are no matches and the subset of results when there are partial matches.
+If this parameter is `false`, the request returns a `404` status code when there
+are no matches or only partial matches.
+--
 
 [[ml-stop-datafeed-request-body]]
 ==== {api-request-body-title}
@@ -59,6 +69,13 @@ comma-separated list of {dfeeds} or a wildcard expression. You can close all
 `timeout`::
   (Optional, time) Controls the amount of time to wait until a {dfeed} stops.
   The default value is 20 seconds.
+
+[[ml-stop-datafeed-response-codes]]
+==== {api-response-codes-title}
+
+`404` (Missing resources)::
+  If `allow_no_datafeeds` is `false`, this code indicates that there are no
+  resources that match the request or only partial matches for the request.
 
 [[ml-stop-datafeed-example]]
 ==== {api-examples-title}


### PR DESCRIPTION
This PR adds the `allow_no_datafeeds` parameter under the query parameters section to the GET, GET stats, and STOP datafeed APIs.

Related issue: https://github.com/elastic/elasticsearch/issues/44093