### PR TITLE
Tests for Range Fields on VST.ANY aggregations

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregatorTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.aggregations.bucket.missing;
 
+import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
@@ -30,11 +31,13 @@ import org.apache.lucene.store.Directory;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.index.mapper.RangeFieldMapper;
+import org.elasticsearch.index.mapper.RangeType;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
-import org.elasticsearch.search.aggregations.support.ValueType;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
@@ -85,6 +88,34 @@ public class MissingAggregatorTests extends AggregatorTestCase {
             });
     }
 
+    public void testMatchSparseRangeField() throws IOException {
+        int numDocs = randomIntBetween(100, 200);
+        final AtomicInteger count = new AtomicInteger();
+        final String fieldName = "field";
+        RangeType rangeType = RangeType.DOUBLE;
+        final BinaryDocValuesField field = new BinaryDocValuesField(fieldName, rangeType.encodeRanges(Collections.singleton(
+            new RangeFieldMapper.Range(rangeType, 1.0D, 5.0D, true, true))));
+        MappedFieldType fieldType = new RangeFieldMapper.Builder(fieldName, rangeType).fieldType();
+        fieldType.setName(fieldName);
+        testBothCases(numDocs,
+            fieldName,
+            Queries.newMatchAllQuery(),
+            doc -> {
+                if (randomBoolean()) {
+                    doc.add(new SortedNumericDocValuesField("another_field", randomLong()));
+                    count.incrementAndGet();
+                } else {
+                    doc.add(field);
+                }
+            },
+            internalMissing -> {
+                assertEquals(internalMissing.getDocCount(), count.get());
+                count.set(0);
+                assertTrue(AggregationInspectionHelper.hasValue(internalMissing));
+            }, fieldType);
+    }
+
+
     public void testMissingField() throws IOException {
         int numDocs = randomIntBetween(10, 20);
         testBothCases(numDocs,
@@ -104,8 +135,22 @@ public class MissingAggregatorTests extends AggregatorTestCase {
                                Query query,
                                Consumer<Document> consumer,
                                Consumer<InternalMissing> verify) throws IOException {
-        executeTestCase(numDocs, fieldName, query, consumer, verify, false);
-        executeTestCase(numDocs, fieldName, query, consumer, verify, true);
+        NumberFieldMapper.Builder mapperBuilder = new NumberFieldMapper.Builder("_name",
+            NumberFieldMapper.NumberType.LONG);
+        final MappedFieldType fieldType = mapperBuilder.fieldType();
+        fieldType.setHasDocValues(true);
+        fieldType.setName(fieldName);
+        testBothCases(numDocs, fieldName, query, consumer, verify, fieldType);
+    }
+
+    private void testBothCases(int numDocs,
+                               String fieldName,
+                               Query query,
+                               Consumer<Document> consumer,
+                               Consumer<InternalMissing> verify,
+                               MappedFieldType fieldType) throws IOException {
+        executeTestCase(numDocs, fieldName, query, consumer, verify, false, fieldType);
+        executeTestCase(numDocs, fieldName, query, consumer, verify, true, fieldType);
 
     }
 
@@ -114,7 +159,8 @@ public class MissingAggregatorTests extends AggregatorTestCase {
                                  Query query,
                                  Consumer<Document> consumer,
                                  Consumer<InternalMissing> verify,
-                                 boolean reduced) throws IOException {
+                                 boolean reduced,
+                                 MappedFieldType fieldType) throws IOException {
         try (Directory directory = newDirectory()) {
             try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
                 Document document = new Document();
@@ -131,15 +177,8 @@ public class MissingAggregatorTests extends AggregatorTestCase {
             try (IndexReader indexReader = DirectoryReader.open(directory)) {
                 IndexSearcher indexSearcher =
                     newSearcher(indexReader, true, true);
-                MissingAggregationBuilder builder =
-                    new MissingAggregationBuilder("_name", ValueType.LONG);
+                MissingAggregationBuilder builder = new MissingAggregationBuilder("_name", null);
                 builder.field(fieldName);
-
-                NumberFieldMapper.Builder mapperBuilder = new NumberFieldMapper.Builder("_name",
-                    NumberFieldMapper.NumberType.LONG);
-                MappedFieldType fieldType = mapperBuilder.fieldType();
-                fieldType.setHasDocValues(true);
-                fieldType.setName(builder.field());
 
                 InternalMissing missing;
                 if (reduced) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorTests.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.aggregations.bucket.terms;
 
+import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.LongPoint;
@@ -44,11 +45,14 @@ import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.index.mapper.RangeFieldMapper;
+import org.elasticsearch.index.mapper.RangeType;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.TypeFieldMapper;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
@@ -284,6 +288,36 @@ public class RareTermsAggregatorTests extends AggregatorTestCase {
             }
         }
     }
+
+    public void testRangeField() throws Exception {
+        RangeType rangeType = RangeType.DOUBLE;
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
+                for (RangeFieldMapper.Range range : new RangeFieldMapper.Range[] {
+                    new RangeFieldMapper.Range(rangeType, 1.0D, 5.0D, true, true), // bucket 0 5
+                    new RangeFieldMapper.Range(rangeType, -3.1, 4.2, true, true), // bucket -5, 0
+                    new RangeFieldMapper.Range(rangeType, 4.2, 13.3, true, true), // bucket 0, 5, 10
+                    new RangeFieldMapper.Range(rangeType, 42.5, 49.3, true, true), // bucket 40, 45
+                }) {
+                    Document doc = new Document();
+                    BytesRef encodedRange = rangeType.encodeRanges(Collections.singleton(range));
+                    doc.add(new BinaryDocValuesField("field", encodedRange));
+                    indexWriter.addDocument(doc);
+                }
+                MappedFieldType fieldType = new RangeFieldMapper.Builder("field", rangeType).fieldType();
+                fieldType.setName("field");
+
+                try (IndexReader indexReader = maybeWrapReaderEs(indexWriter.getReader())) {
+                    IndexSearcher indexSearcher = newIndexSearcher(indexReader);
+                    RareTermsAggregationBuilder aggregationBuilder = new RareTermsAggregationBuilder("_name", null)
+                        .field("field");
+                    expectThrows(AggregationExecutionException.class,
+                        () -> createAggregator(aggregationBuilder, indexSearcher, fieldType));
+                }
+            }
+        }
+    }
+
 
     public void testNestedTerms() throws IOException {
         Query query = new MatchAllDocsQuery();


### PR DESCRIPTION
This PR provides tests for the behavior of the range fields on aggregations that use ValuesSourceType.ANY.  This PR doesn't add support for ranges, merely checks that aggregations which we expect to "just work" with ranges do, and that the behavior of other "Any" type aggregations is consistent.

 - Missing Aggregation - Works with range fields - test included
 - Cardinality Aggregation - Works with range fields - test included
 - Value Count Aggregation - Works with range fields - test included
 - Terms Aggregation - Throws AggregationExecutionException on range fields - test included
 - Significant Terms Aggregation - Throws AEE - test included
 - Rare Terms Aggregation - Throws AEE - test included
 - Diversified Aggregation - Throws AEE - *test not included*

I didn't add a test for Diversified because (a) it's very clear what the behavior is from the code and (b) it's under-tested as is, so it'd be a lot of code to add in tests for this.  I still might, but wanted to get the easy tests up for review first.