### PR TITLE
[DOCS] Adds allow no jobs param to the GET, GET stats and Close APIs

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
@@ -65,8 +65,18 @@ results the job might have recently produced or might produce in the future.
 ==== {api-query-parms-title}
 
 `allow_no_jobs`::
-  (Optional, boolean) If `false` and the `job_id` does not match any job an 
-  error will be returned. The default value is `true`.
+  (Optional, boolean) Specifies what to do when the request:
++
+--
+* Contains wildcard expressions and there are no jobs that match.
+* Contains the `_all` string or no identifiers and there are no matches.
+* Contains wildcard expressions and there are only partial matches.
+
+The default value is `true`, which returns an empty `jobs` array 
+when there are no matches and the subset of results when there are partial 
+matches. If this parameter is `false`, the request returns a `404` status code
+when there are no matches or only partial matches.
+--
 
 `force`::
   (Optional, boolean) Use to close a failed job, or to forcefully close a job

--- a/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
@@ -64,6 +64,10 @@ results the job might have recently produced or might produce in the future.
 [[ml-close-job-query-parms]]
 ==== {api-query-parms-title}
 
+`allow_no_jobs`::
+  (Optional, boolean) If `false` and the `job_id` does not match any job an 
+  error will be returned. The default value is `true`.
+
 `force`::
   (Optional, boolean) Use to close a failed job, or to forcefully close a job
   which has not responded to its initial close request.
@@ -71,6 +75,13 @@ results the job might have recently produced or might produce in the future.
 `timeout`::
   (Optional, time units) Controls the time to wait until a job has closed.
   The default value is 30 minutes.
+
+[[ml-close-job-response-codes]]
+==== {api-response-codes-title}
+
+`404` (Missing resources)::
+  If `allow_no_jobs` is `false`, this code indicates that there are no 
+  resources that match the request or only partial matches for the request.
 
 [[ml-close-job-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
@@ -48,8 +48,18 @@ IMPORTANT: This API returns a maximum of 10,000 jobs.
 ==== {api-query-parms-title}
 
 `allow_no_jobs`::
-  (Optional, boolean) If `false` and the `job_id` does not match any job an 
-  error will be returned. The default value is `true`.
+  (Optional, boolean) Specifies what to do when the request:
++
+--
+* Contains wildcard expressions and there are no jobs that match.
+* Contains the `_all` string or no identifiers and there are no matches.
+* Contains wildcard expressions and there are only partial matches.
+
+The default value is `true`, which returns an empty `jobs` array 
+when there are no matches and the subset of results when there are partial 
+matches. If this parameter is `false`, the request returns a `404` status code
+when there are no matches or only partial matches.
+--
 
 [[ml-get-job-stats-results]]
 ==== {api-response-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
@@ -44,6 +44,13 @@ IMPORTANT: This API returns a maximum of 10,000 jobs.
   group name, or a wildcard expression. If you do not specify one of these
   options, the API returns statistics for all jobs.
 
+[[ml-get-job-stats-query-parms]]
+==== {api-query-parms-title}
+
+`allow_no_jobs`::
+  (Optional, boolean) If `false` and the `job_id` does not match any job an 
+  error will be returned. The default value is `true`.
+
 [[ml-get-job-stats-results]]
 ==== {api-response-body-title}
 
@@ -52,6 +59,13 @@ The API returns the following information:
 `jobs`::
   (array) An array of job statistics objects.
   For more information, see <<ml-jobstats,Job Statistics>>.
+
+[[ml-get-job-stats-response-codes]]
+==== {api-response-codes-title}
+
+`404` (Missing resources)::
+  If `allow_no_jobs` is `false`, this code indicates that there are no 
+  resources that match the request or only partial matches for the request.
 
 [[ml-get-job-stats-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
@@ -44,6 +44,13 @@ IMPORTANT: This API returns a maximum of 10,000 jobs.
   name, or a wildcard expression. If you do not specify one of these options,
   the API returns information for all jobs.
 
+[[ml-get-job-query-parms]]
+==== {api-query-parms-title}
+
+`allow_no_jobs`::
+  (Optional, boolean) If `false` and the `job_id` does not match any job an 
+  error will be returned. The default value is `true`.
+
 [[ml-get-job-results]]
 ==== {api-response-body-title}
 
@@ -52,6 +59,13 @@ The API returns the following information:
 `jobs`::
   (array) An array of job resources.
   For more information, see <<ml-job-resource,Job Resources>>.
+
+[[ml-get-job-response-codes]]
+==== {api-response-codes-title}
+
+`404` (Missing resources)::
+  If `allow_no_jobs` is `false`, this code indicates that there are no 
+  resources that match the request or only partial matches for the request.
 
 [[ml-get-job-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
@@ -48,8 +48,18 @@ IMPORTANT: This API returns a maximum of 10,000 jobs.
 ==== {api-query-parms-title}
 
 `allow_no_jobs`::
-  (Optional, boolean) If `false` and the `job_id` does not match any job an 
-  error will be returned. The default value is `true`.
+  (Optional, boolean) Specifies what to do when the request:
++
+--
+* Contains wildcard expressions and there are no jobs that match.
+* Contains the `_all` string or no identifiers and there are no matches.
+* Contains wildcard expressions and there are only partial matches.
+
+The default value is `true`, which returns an empty `jobs` array 
+when there are no matches and the subset of results when there are partial 
+matches. If this parameter is `false`, the request returns a `404` status code
+when there are no matches or only partial matches.
+--
 
 [[ml-get-job-results]]
 ==== {api-response-body-title}


### PR DESCRIPTION
This PR adds the `allow_no_jobs` parameter under the query parameters section to the GET, GET stats, and Close jobs APIs.

Related issue: https://github.com/elastic/elasticsearch/issues/44093