### PR TITLE
Disable WildFly testing conventions on Windows (#43532)

### DIFF
--- a/qa/wildfly/build.gradle
+++ b/qa/wildfly/build.gradle
@@ -210,6 +210,7 @@ if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
     integTestRunner.finalizedBy(stopWildfly)
 } else {
     integTest.enabled = false
+    testingConventions.enabled = false
 }
 
 check.dependsOn(integTest)


### PR DESCRIPTION
Tests are disabled on Windows. Conventions also need to be disabled.

backport of #43532