### PR TITLE
[DOCS] Improves description of dest data frame transform object

### DIFF
--- a/docs/reference/data-frames/apis/put-transform.asciidoc
+++ b/docs/reference/data-frames/apis/put-transform.asciidoc
@@ -52,8 +52,14 @@ IMPORTANT:  You must use {kib} or this API to create a {dataframe-transform}.
   (Optional, string) Free text description of the {dataframe-transform}.
 
 `dest`::
-  (Required, object) Required. The destination configuration, which consists of `index`
-  and optionally a `pipeline` id. See <<data-frame-transform-dest>>.
+  (Required, object) Required. The destination configuration, which has the
+  following properties:
+  
+  `index`:::
+    (Required, string) The _destination index_ for the {dataframe-transform}.
+
+  `pipeline`:::
+    (Optional, string) The unique identifier for a <<pipeline,pipeline>>.
 
 `frequency`::
   (Optional, time units) The interval between checks for changes in the source indices


### PR DESCRIPTION
This PR copies the properties of the dest object into the create data frame transform API, so that users don't need to follow a link to get those two pieces of information.