### PR TITLE
Convert remaining ActionTypes to writeable in xpack core (#44467)

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/XPackInfoResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/XPackInfoResponseTests.java
@@ -27,7 +27,9 @@ import org.elasticsearch.protocol.xpack.XPackInfoResponse.LicenseInfo;
 import org.elasticsearch.protocol.xpack.license.LicenseStatus;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/XPackInfoResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/XPackInfoResponseTests.java
@@ -18,42 +18,20 @@
  */
 package org.elasticsearch.client;
 
-import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.protocol.xpack.XPackInfoResponse;
 import org.elasticsearch.protocol.xpack.XPackInfoResponse.BuildInfo;
-import org.elasticsearch.protocol.xpack.XPackInfoResponse.LicenseInfo;
 import org.elasticsearch.protocol.xpack.XPackInfoResponse.FeatureSetsInfo;
 import org.elasticsearch.protocol.xpack.XPackInfoResponse.FeatureSetsInfo.FeatureSet;
+import org.elasticsearch.protocol.xpack.XPackInfoResponse.LicenseInfo;
 import org.elasticsearch.protocol.xpack.license.LicenseStatus;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.function.Predicate;
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 
-public class XPackInfoResponseTests extends
-        AbstractHlrcStreamableXContentTestCase<XPackInfoResponse, org.elasticsearch.client.xpack.XPackInfoResponse> {
-
-    @Override
-    protected XPackInfoResponse createBlankInstance() {
-        return new XPackInfoResponse();
-    }
-
-    @Override
-    public org.elasticsearch.client.xpack.XPackInfoResponse doHlrcParseInstance(XContentParser parser) throws IOException {
-        return org.elasticsearch.client.xpack.XPackInfoResponse.fromXContent(parser);
-    }
-
-    @Override
-    public XPackInfoResponse convertHlrcToInternal(org.elasticsearch.client.xpack.XPackInfoResponse instance) {
-        return new XPackInfoResponse(convertHlrcToInternal(instance.getBuildInfo()),
-            convertHlrcToInternal(instance.getLicenseInfo()), convertHlrcToInternal(instance.getFeatureSetsInfo()));
-    }
+public class XPackInfoResponseTests extends AbstractResponseTestCase<XPackInfoResponse, org.elasticsearch.client.xpack.XPackInfoResponse> {
 
     private BuildInfo convertHlrcToInternal(org.elasticsearch.client.xpack.XPackInfoResponse.BuildInfo buildInfo) {
         return buildInfo != null ? new BuildInfo(buildInfo.getHash(), buildInfo.getTimestamp()) : null;
@@ -75,62 +53,10 @@ public class XPackInfoResponseTests extends
             : null;
     }
 
-    @Override
-    protected Predicate<String> getRandomFieldsExcludeFilter() {
-        return path -> path.equals("features")
-                || (path.startsWith("features") && path.endsWith("native_code_info"));
-    }
-
-    @Override
-    protected ToXContent.Params getToXContentParams() {
-        Map<String, String> params = new HashMap<>();
-        if (randomBoolean()) {
-            params.put("human", randomBoolean() ? "true" : "false");
-        }
-        if (randomBoolean()) {
-            params.put("categories", "_none");
-        }
-        return new ToXContent.MapParams(params);
-    }
-
-    @Override
-    protected XPackInfoResponse createTestInstance() {
-        return new XPackInfoResponse(
-            randomBoolean() ? null : randomBuildInfo(),
-            randomBoolean() ? null : randomLicenseInfo(),
-            randomBoolean() ? null : randomFeatureSetsInfo());
-    }
-
-    @Override
-    protected XPackInfoResponse mutateInstance(XPackInfoResponse response) {
-        @SuppressWarnings("unchecked")
-        Function<XPackInfoResponse, XPackInfoResponse> mutator = randomFrom(
-            r -> new XPackInfoResponse(
-                    mutateBuildInfo(r.getBuildInfo()),
-                    r.getLicenseInfo(),
-                    r.getFeatureSetsInfo()),
-            r -> new XPackInfoResponse(
-                    r.getBuildInfo(),
-                    mutateLicenseInfo(r.getLicenseInfo()),
-                    r.getFeatureSetsInfo()),
-            r -> new XPackInfoResponse(
-                    r.getBuildInfo(),
-                    r.getLicenseInfo(),
-                    mutateFeatureSetsInfo(r.getFeatureSetsInfo())));
-        return mutator.apply(response);
-    }
-
     private BuildInfo randomBuildInfo() {
         return new BuildInfo(
             randomAlphaOfLength(10),
             randomAlphaOfLength(15));
-    }
-
-    private BuildInfo mutateBuildInfo(BuildInfo buildInfo) {
-        if (buildInfo == null) {
-            return randomBuildInfo();
-        }
-        return null;
     }
 
     private LicenseInfo randomLicenseInfo() {
@@ -142,13 +68,6 @@ public class XPackInfoResponseTests extends
             randomLong());
     }
 
-    private LicenseInfo mutateLicenseInfo(LicenseInfo licenseInfo) {
-        if (licenseInfo == null) {
-            return randomLicenseInfo();
-        }
-        return null;
-    }
-
     private FeatureSetsInfo randomFeatureSetsInfo() {
         int size = between(0, 10);
         Set<FeatureSet> featureSets = new HashSet<>(size);
@@ -156,13 +75,6 @@ public class XPackInfoResponseTests extends
             featureSets.add(randomFeatureSet());
         }
         return new FeatureSetsInfo(featureSets);
-    }
-
-    private FeatureSetsInfo mutateFeatureSetsInfo(FeatureSetsInfo featureSetsInfo) {
-        if (featureSetsInfo == null) {
-            return randomFeatureSetsInfo();
-        }
-        return null;
     }
 
     private FeatureSet randomFeatureSet() {
@@ -183,5 +95,25 @@ public class XPackInfoResponseTests extends
             nativeCodeInfo.put(randomAlphaOfLength(5), randomAlphaOfLength(5));
         }
         return nativeCodeInfo;
+    }
+
+    @Override
+    protected XPackInfoResponse createServerTestInstance() {
+        return new XPackInfoResponse(
+            randomBoolean() ? null : randomBuildInfo(),
+            randomBoolean() ? null : randomLicenseInfo(),
+            randomBoolean() ? null : randomFeatureSetsInfo());
+    }
+
+    @Override
+    protected org.elasticsearch.client.xpack.XPackInfoResponse doParseToClientInstance(XContentParser parser) throws IOException {
+        return org.elasticsearch.client.xpack.XPackInfoResponse.fromXContent(parser);
+    }
+
+    @Override
+    protected void assertInstances(XPackInfoResponse serverTestInstance, org.elasticsearch.client.xpack.XPackInfoResponse clientInstance) {
+        XPackInfoResponse serverInstance = new XPackInfoResponse(convertHlrcToInternal(clientInstance.getBuildInfo()),
+            convertHlrcToInternal(clientInstance.getLicenseInfo()), convertHlrcToInternal(clientInstance.getFeatureSetsInfo()));
+        assertEquals(serverTestInstance, serverInstance);
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/license/GetBasicStatusResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/license/GetBasicStatusResponseTests.java
@@ -18,28 +18,29 @@
  */
 package org.elasticsearch.client.license;
 
+import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.client.AbstractHlrcStreamableXContentTestCase;
+
+import java.io.IOException;
 
 public class GetBasicStatusResponseTests
-    extends AbstractHlrcStreamableXContentTestCase<org.elasticsearch.license.GetBasicStatusResponse, GetBasicStatusResponse> {
+    extends AbstractResponseTestCase<org.elasticsearch.license.GetBasicStatusResponse, GetBasicStatusResponse> {
+
     @Override
-    public GetBasicStatusResponse doHlrcParseInstance(XContentParser parser) {
+    protected org.elasticsearch.license.GetBasicStatusResponse createServerTestInstance() {
+        return new org.elasticsearch.license.GetBasicStatusResponse(randomBoolean());
+    }
+
+    @Override
+    protected GetBasicStatusResponse doParseToClientInstance(XContentParser parser) throws IOException {
         return GetBasicStatusResponse.fromXContent(parser);
     }
 
     @Override
-    public org.elasticsearch.license.GetBasicStatusResponse convertHlrcToInternal(GetBasicStatusResponse instance) {
-        return new org.elasticsearch.license.GetBasicStatusResponse(instance.isEligibleToStartBasic());
-    }
-
-    @Override
-    protected org.elasticsearch.license.GetBasicStatusResponse createBlankInstance() {
-        return new org.elasticsearch.license.GetBasicStatusResponse(false);
-    }
-
-    @Override
-    protected org.elasticsearch.license.GetBasicStatusResponse createTestInstance() {
-        return new org.elasticsearch.license.GetBasicStatusResponse(randomBoolean());
+    protected void assertInstances(org.elasticsearch.license.GetBasicStatusResponse serverTestInstance,
+                                   GetBasicStatusResponse clientInstance) {
+        org.elasticsearch.license.GetBasicStatusResponse serverInstance =
+            new org.elasticsearch.license.GetBasicStatusResponse(clientInstance.isEligibleToStartBasic());
+        assertEquals(serverTestInstance, serverInstance);
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/license/GetTrialStatusResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/license/GetTrialStatusResponseTests.java
@@ -18,29 +18,29 @@
  */
 package org.elasticsearch.client.license;
 
+import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.client.AbstractHlrcStreamableXContentTestCase;
+
+import java.io.IOException;
 
 public class GetTrialStatusResponseTests extends
-    AbstractHlrcStreamableXContentTestCase<org.elasticsearch.license.GetTrialStatusResponse, GetTrialStatusResponse> {
+    AbstractResponseTestCase<org.elasticsearch.license.GetTrialStatusResponse, GetTrialStatusResponse> {
 
     @Override
-    public GetTrialStatusResponse doHlrcParseInstance(XContentParser parser) {
+    protected org.elasticsearch.license.GetTrialStatusResponse createServerTestInstance() {
+        return new org.elasticsearch.license.GetTrialStatusResponse(randomBoolean());
+    }
+
+    @Override
+    protected GetTrialStatusResponse doParseToClientInstance(XContentParser parser) throws IOException {
         return GetTrialStatusResponse.fromXContent(parser);
     }
 
     @Override
-    public org.elasticsearch.license.GetTrialStatusResponse convertHlrcToInternal(GetTrialStatusResponse instance) {
-        return new org.elasticsearch.license.GetTrialStatusResponse(instance.isEligibleToStartTrial());
-    }
-
-    @Override
-    protected org.elasticsearch.license.GetTrialStatusResponse createBlankInstance() {
-        return new org.elasticsearch.license.GetTrialStatusResponse(false);
-    }
-
-    @Override
-    protected org.elasticsearch.license.GetTrialStatusResponse createTestInstance() {
-        return new org.elasticsearch.license.GetTrialStatusResponse(randomBoolean());
+    protected void assertInstances(org.elasticsearch.license.GetTrialStatusResponse serverTestInstance,
+                                   GetTrialStatusResponse clientInstance) {
+        org.elasticsearch.license.GetTrialStatusResponse serverInstance =
+            new org.elasticsearch.license.GetTrialStatusResponse(clientInstance.isEligibleToStartTrial());
+        assertEquals(serverInstance, serverTestInstance);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexAction.java
@@ -19,19 +19,14 @@
 
 package org.elasticsearch.action.admin.indices.get;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class GetIndexAction extends StreamableResponseActionType<GetIndexResponse> {
+public class GetIndexAction extends ActionType<GetIndexResponse> {
 
     public static final GetIndexAction INSTANCE = new GetIndexAction();
     public static final String NAME = "indices:admin/get";
 
     private GetIndexAction() {
-        super(NAME);
-    }
-
-    @Override
-    public GetIndexResponse newResponse() {
-        return new GetIndexResponse();
+        super(NAME, GetIndexResponse::new);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
@@ -82,7 +82,52 @@ public class GetIndexResponse extends ActionResponse implements ToXContentObject
         }
     }
 
-    GetIndexResponse() {
+    GetIndexResponse(StreamInput in) throws IOException {
+        super(in);
+        this.indices = in.readStringArray();
+
+        int mappingsSize = in.readVInt();
+        ImmutableOpenMap.Builder<String, ImmutableOpenMap<String, MappingMetaData>> mappingsMapBuilder = ImmutableOpenMap.builder();
+        for (int i = 0; i < mappingsSize; i++) {
+            String key = in.readString();
+            int valueSize = in.readVInt();
+            ImmutableOpenMap.Builder<String, MappingMetaData> mappingEntryBuilder = ImmutableOpenMap.builder();
+            for (int j = 0; j < valueSize; j++) {
+                mappingEntryBuilder.put(in.readString(), new MappingMetaData(in));
+            }
+            mappingsMapBuilder.put(key, mappingEntryBuilder.build());
+        }
+        mappings = mappingsMapBuilder.build();
+
+        int aliasesSize = in.readVInt();
+        ImmutableOpenMap.Builder<String, List<AliasMetaData>> aliasesMapBuilder = ImmutableOpenMap.builder();
+        for (int i = 0; i < aliasesSize; i++) {
+            String key = in.readString();
+            int valueSize = in.readVInt();
+            List<AliasMetaData> aliasEntryBuilder = new ArrayList<>(valueSize);
+            for (int j = 0; j < valueSize; j++) {
+                aliasEntryBuilder.add(new AliasMetaData(in));
+            }
+            aliasesMapBuilder.put(key, Collections.unmodifiableList(aliasEntryBuilder));
+        }
+        aliases = aliasesMapBuilder.build();
+
+        int settingsSize = in.readVInt();
+        ImmutableOpenMap.Builder<String, Settings> settingsMapBuilder = ImmutableOpenMap.builder();
+        for (int i = 0; i < settingsSize; i++) {
+            String key = in.readString();
+            settingsMapBuilder.put(key, Settings.readSettingsFromStream(in));
+        }
+        settings = settingsMapBuilder.build();
+
+        ImmutableOpenMap.Builder<String, Settings> defaultSettingsMapBuilder = ImmutableOpenMap.builder();
+        if (in.getVersion().onOrAfter(Version.V_6_4_0)) {
+            int defaultSettingsSize = in.readVInt();
+            for (int i = 0; i < defaultSettingsSize ; i++) {
+                defaultSettingsMapBuilder.put(in.readString(), Settings.readSettingsFromStream(in));
+            }
+        }
+        defaultSettings = defaultSettingsMapBuilder.build();
     }
 
     public String[] indices() {
@@ -155,51 +200,7 @@ public class GetIndexResponse extends ActionResponse implements ToXContentObject
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        this.indices = in.readStringArray();
-
-        int mappingsSize = in.readVInt();
-        ImmutableOpenMap.Builder<String, ImmutableOpenMap<String, MappingMetaData>> mappingsMapBuilder = ImmutableOpenMap.builder();
-        for (int i = 0; i < mappingsSize; i++) {
-            String key = in.readString();
-            int valueSize = in.readVInt();
-            ImmutableOpenMap.Builder<String, MappingMetaData> mappingEntryBuilder = ImmutableOpenMap.builder();
-            for (int j = 0; j < valueSize; j++) {
-                mappingEntryBuilder.put(in.readString(), new MappingMetaData(in));
-            }
-            mappingsMapBuilder.put(key, mappingEntryBuilder.build());
-        }
-        mappings = mappingsMapBuilder.build();
-
-        int aliasesSize = in.readVInt();
-        ImmutableOpenMap.Builder<String, List<AliasMetaData>> aliasesMapBuilder = ImmutableOpenMap.builder();
-        for (int i = 0; i < aliasesSize; i++) {
-            String key = in.readString();
-            int valueSize = in.readVInt();
-            List<AliasMetaData> aliasEntryBuilder = new ArrayList<>(valueSize);
-            for (int j = 0; j < valueSize; j++) {
-                aliasEntryBuilder.add(new AliasMetaData(in));
-            }
-            aliasesMapBuilder.put(key, Collections.unmodifiableList(aliasEntryBuilder));
-        }
-        aliases = aliasesMapBuilder.build();
-
-        int settingsSize = in.readVInt();
-        ImmutableOpenMap.Builder<String, Settings> settingsMapBuilder = ImmutableOpenMap.builder();
-        for (int i = 0; i < settingsSize; i++) {
-            String key = in.readString();
-            settingsMapBuilder.put(key, Settings.readSettingsFromStream(in));
-        }
-        settings = settingsMapBuilder.build();
-
-        ImmutableOpenMap.Builder<String, Settings> defaultSettingsMapBuilder = ImmutableOpenMap.builder();
-        if (in.getVersion().onOrAfter(Version.V_6_4_0)) {
-            int defaultSettingsSize = in.readVInt();
-            for (int i = 0; i < defaultSettingsSize ; i++) {
-                defaultSettingsMapBuilder.put(in.readString(), Settings.readSettingsFromStream(in));
-            }
-        }
-        defaultSettings = defaultSettingsMapBuilder.build();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/TransportGetIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/TransportGetIndexAction.java
@@ -34,6 +34,7 @@ import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
@@ -78,8 +79,8 @@ public class TransportGetIndexAction extends TransportClusterInfoAction<GetIndex
     }
 
     @Override
-    protected GetIndexResponse newResponse() {
-        return new GetIndexResponse();
+    protected GetIndexResponse read(StreamInput in) throws IOException {
+        return new GetIndexResponse(in);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsAction.java
@@ -19,19 +19,14 @@
 
 package org.elasticsearch.action.admin.indices.mapping.get;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class GetMappingsAction extends StreamableResponseActionType<GetMappingsResponse> {
+public class GetMappingsAction extends ActionType<GetMappingsResponse> {
 
     public static final GetMappingsAction INSTANCE = new GetMappingsAction();
     public static final String NAME = "indices:admin/mappings/get";
 
     private GetMappingsAction() {
-        super(NAME);
-    }
-
-    @Override
-    public GetMappingsResponse newResponse() {
-        return new GetMappingsResponse();
+        super(NAME, GetMappingsResponse::new);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsResponse.java
@@ -47,20 +47,8 @@ public class GetMappingsResponse extends ActionResponse implements ToXContentFra
         this.mappings = mappings;
     }
 
-    GetMappingsResponse() {
-    }
-
-    public ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> mappings() {
-        return mappings;
-    }
-
-    public ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> getMappings() {
-        return mappings();
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
+    GetMappingsResponse(StreamInput in) throws IOException {
+        super(in);
         int size = in.readVInt();
         ImmutableOpenMap.Builder<String, ImmutableOpenMap<String, MappingMetaData>> indexMapBuilder = ImmutableOpenMap.builder();
         for (int i = 0; i < size; i++) {
@@ -73,6 +61,19 @@ public class GetMappingsResponse extends ActionResponse implements ToXContentFra
             indexMapBuilder.put(key, typeMapBuilder.build());
         }
         mappings = indexMapBuilder.build();
+    }
+
+    public ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> mappings() {
+        return mappings;
+    }
+
+    public ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> getMappings() {
+        return mappings();
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetMappingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetMappingsAction.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -62,8 +63,8 @@ public class TransportGetMappingsAction extends TransportClusterInfoAction<GetMa
     }
 
     @Override
-    protected GetMappingsResponse newResponse() {
-        return new GetMappingsResponse();
+    protected GetMappingsResponse read(StreamInput in) throws IOException {
+        return new GetMappingsResponse(in);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/support/master/info/TransportClusterInfoAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/info/TransportClusterInfoAction.java
@@ -21,7 +21,7 @@ package org.elasticsearch.action.support.master.info;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.StreamableTransportMasterNodeReadAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -31,7 +31,7 @@ import org.elasticsearch.transport.TransportService;
 
 
 public abstract class TransportClusterInfoAction<Request extends ClusterInfoRequest<Request>, Response extends ActionResponse>
-        extends StreamableTransportMasterNodeReadAction<Request, Response> {
+        extends TransportMasterNodeReadAction<Request, Response> {
 
     public TransportClusterInfoAction(String actionName, TransportService transportService,
                                       ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters,

--- a/server/src/main/java/org/elasticsearch/index/reindex/BulkByScrollResponse.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/BulkByScrollResponse.java
@@ -78,7 +78,13 @@ public class BulkByScrollResponse extends ActionResponse implements ToXContentFr
         Status.declareFields(PARSER);
     }
 
-    public BulkByScrollResponse() {
+    public BulkByScrollResponse(StreamInput in) throws IOException {
+        super(in);
+        took = in.readTimeValue();
+        status = new BulkByScrollTask.Status(in);
+        bulkFailures = in.readList(Failure::new);
+        searchFailures = in.readList(ScrollableHitSource.SearchFailure::new);
+        timedOut = in.readBoolean();
     }
 
     public BulkByScrollResponse(TimeValue took, BulkByScrollTask.Status status, List<Failure> bulkFailures,
@@ -195,12 +201,7 @@ public class BulkByScrollResponse extends ActionResponse implements ToXContentFr
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        took = in.readTimeValue();
-        status = new BulkByScrollTask.Status(in);
-        bulkFailures = in.readList(Failure::new);
-        searchFailures = in.readList(ScrollableHitSource.SearchFailure::new);
-        timedOut = in.readBoolean();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/reindex/DeleteByQueryAction.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/DeleteByQueryAction.java
@@ -19,19 +19,14 @@
 
 package org.elasticsearch.index.reindex;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class DeleteByQueryAction extends StreamableResponseActionType<BulkByScrollResponse> {
+public class DeleteByQueryAction extends ActionType<BulkByScrollResponse> {
 
     public static final DeleteByQueryAction INSTANCE = new DeleteByQueryAction();
     public static final String NAME = "indices:data/write/delete/byquery";
 
     private DeleteByQueryAction() {
-        super(NAME);
-    }
-
-    @Override
-    public BulkByScrollResponse newResponse() {
-        return new BulkByScrollResponse();
+        super(NAME, BulkByScrollResponse::new);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/reindex/ReindexAction.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/ReindexAction.java
@@ -19,18 +19,13 @@
 
 package org.elasticsearch.index.reindex;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class ReindexAction extends StreamableResponseActionType<BulkByScrollResponse> {
+public class ReindexAction extends ActionType<BulkByScrollResponse> {
     public static final ReindexAction INSTANCE = new ReindexAction();
     public static final String NAME = "indices:data/write/reindex";
 
     private ReindexAction() {
-        super(NAME);
-    }
-
-    @Override
-    public BulkByScrollResponse newResponse() {
-        return new BulkByScrollResponse();
+        super(NAME, BulkByScrollResponse::new);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/reindex/UpdateByQueryAction.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/UpdateByQueryAction.java
@@ -19,18 +19,13 @@
 
 package org.elasticsearch.index.reindex;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class UpdateByQueryAction extends StreamableResponseActionType<BulkByScrollResponse> {
+public class UpdateByQueryAction extends ActionType<BulkByScrollResponse> {
     public static final UpdateByQueryAction INSTANCE = new UpdateByQueryAction();
     public static final String NAME = "indices:data/write/update/byquery";
 
     private UpdateByQueryAction() {
-        super(NAME);
-    }
-
-    @Override
-    public BulkByScrollResponse newResponse() {
-        return new BulkByScrollResponse();
+        super(NAME, BulkByScrollResponse::new);
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexResponseTests.java
@@ -29,14 +29,15 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.RandomCreateIndexGenerator;
 import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
 import org.junit.Assert;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -51,7 +52,7 @@ import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.index.IndexSettings.INDEX_REFRESH_INTERVAL_SETTING;
 
-public class GetIndexResponseTests extends AbstractStreamableXContentTestCase<GetIndexResponse> {
+public class GetIndexResponseTests extends AbstractSerializingTestCase<GetIndexResponse> {
 
     /**
      * The following byte response was generated from the v6.3.0 tag
@@ -68,8 +69,8 @@ public class GetIndexResponseTests extends AbstractStreamableXContentTestCase<Ge
     }
 
     @Override
-    protected GetIndexResponse createBlankInstance() {
-        return new GetIndexResponse();
+    protected Writeable.Reader<GetIndexResponse> instanceReader() {
+        return GetIndexResponse::new;
     }
 
     @Override
@@ -179,8 +180,7 @@ public class GetIndexResponseTests extends AbstractStreamableXContentTestCase<Ge
     public void testCanDecode622Response() throws IOException {
         StreamInput si = StreamInput.wrap(Base64.getDecoder().decode(TEST_6_3_0_RESPONSE_BYTES));
         si.setVersion(Version.V_6_3_0);
-        GetIndexResponse response = new GetIndexResponse();
-        response.readFrom(si);
+        GetIndexResponse response = new GetIndexResponse(si);
 
         Assert.assertEquals(TEST_6_3_0_RESPONSE_INSTANCE, response);
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsResponseTests.java
@@ -22,12 +22,13 @@ package org.elasticsearch.action.admin.indices.mapping.get;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
 
 import java.io.IOException;
@@ -39,7 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-public class GetMappingsResponseTests extends AbstractStreamableXContentTestCase<GetMappingsResponse> {
+public class GetMappingsResponseTests extends AbstractSerializingTestCase<GetMappingsResponse> {
 
     @Override
     protected boolean supportsUnknownFields() {
@@ -57,8 +58,8 @@ public class GetMappingsResponseTests extends AbstractStreamableXContentTestCase
     }
 
     @Override
-    protected GetMappingsResponse createBlankInstance() {
-        return new GetMappingsResponse();
+    protected Writeable.Reader<GetMappingsResponse> instanceReader() {
+        return GetMappingsResponse::new;
     }
 
     private static GetMappingsResponse mutate(GetMappingsResponse original) throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/reindex/BulkByScrollResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/BulkByScrollResponseTests.java
@@ -48,11 +48,11 @@ public class BulkByScrollResponseTests extends AbstractXContentTestCase<BulkBySc
     public void testRountTrip() throws IOException {
         BulkByScrollResponse response = new BulkByScrollResponse(timeValueMillis(randomNonNegativeLong()),
                 BulkByScrollTaskStatusTests.randomStatus(), randomIndexingFailures(), randomSearchFailures(), randomBoolean());
-        BulkByScrollResponse tripped = new BulkByScrollResponse();
+        BulkByScrollResponse tripped;
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             response.writeTo(out);
             try (StreamInput in = out.bytes().streamInput()) {
-                tripped.readFrom(in);
+                tripped = new BulkByScrollResponse(in);
             }
         }
         assertResponseEquals(response, tripped);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetBasicStatusAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetBasicStatusAction.java
@@ -5,19 +5,14 @@
  */
 package org.elasticsearch.license;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class GetBasicStatusAction extends StreamableResponseActionType<GetBasicStatusResponse> {
+public class GetBasicStatusAction extends ActionType<GetBasicStatusResponse> {
 
     public static final GetBasicStatusAction INSTANCE = new GetBasicStatusAction();
     public static final String NAME = "cluster:admin/xpack/license/basic_status";
 
     private GetBasicStatusAction() {
-        super(NAME);
-    }
-
-    @Override
-    public GetBasicStatusResponse newResponse() {
-        return new GetBasicStatusResponse();
+        super(NAME, GetBasicStatusResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetBasicStatusResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetBasicStatusResponse.java
@@ -18,7 +18,9 @@ public class GetBasicStatusResponse extends ActionResponse implements ToXContent
 
     private boolean eligibleToStartBasic;
 
-    GetBasicStatusResponse() {
+    GetBasicStatusResponse(StreamInput in) throws IOException {
+        super(in);
+        eligibleToStartBasic = in.readBoolean();
     }
 
     public GetBasicStatusResponse(boolean eligibleToStartBasic) {
@@ -31,7 +33,7 @@ public class GetBasicStatusResponse extends ActionResponse implements ToXContent
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        eligibleToStartBasic = in.readBoolean();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetLicenseAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetLicenseAction.java
@@ -5,19 +5,14 @@
  */
 package org.elasticsearch.license;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class GetLicenseAction extends StreamableResponseActionType<GetLicenseResponse> {
+public class GetLicenseAction extends ActionType<GetLicenseResponse> {
 
     public static final GetLicenseAction INSTANCE = new GetLicenseAction();
     public static final String NAME = "cluster:monitor/xpack/license/get";
 
     private GetLicenseAction() {
-        super(NAME);
-    }
-
-    @Override
-    public GetLicenseResponse newResponse() {
-        return new GetLicenseResponse();
+        super(NAME, GetLicenseResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetLicenseResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetLicenseResponse.java
@@ -15,7 +15,11 @@ public class GetLicenseResponse extends ActionResponse {
 
     private License license;
 
-    GetLicenseResponse() {
+    GetLicenseResponse(StreamInput in) throws IOException {
+        super(in);
+        if (in.readBoolean()) {
+            license = License.readLicense(in);
+        }
     }
 
     GetLicenseResponse(License license) {
@@ -28,10 +32,7 @@ public class GetLicenseResponse extends ActionResponse {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        if (in.readBoolean()) {
-            license = License.readLicense(in);
-        }
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetTrialStatusAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetTrialStatusAction.java
@@ -5,19 +5,14 @@
  */
 package org.elasticsearch.license;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class GetTrialStatusAction extends StreamableResponseActionType<GetTrialStatusResponse> {
+public class GetTrialStatusAction extends ActionType<GetTrialStatusResponse> {
 
     public static final GetTrialStatusAction INSTANCE = new GetTrialStatusAction();
     public static final String NAME = "cluster:admin/xpack/license/trial_status";
 
     private GetTrialStatusAction() {
-        super(NAME);
-    }
-
-    @Override
-    public GetTrialStatusResponse newResponse() {
-        return new GetTrialStatusResponse();
+        super(NAME, GetTrialStatusResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetTrialStatusResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetTrialStatusResponse.java
@@ -18,7 +18,9 @@ public class GetTrialStatusResponse extends ActionResponse implements ToXContent
 
     private boolean eligibleToStartTrial;
 
-    GetTrialStatusResponse() {
+    GetTrialStatusResponse(StreamInput in) throws IOException {
+        super(in);
+        eligibleToStartTrial = in.readBoolean();
     }
 
     public GetTrialStatusResponse(boolean eligibleToStartTrial) {
@@ -31,7 +33,7 @@ public class GetTrialStatusResponse extends ActionResponse implements ToXContent
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        eligibleToStartTrial = in.readBoolean();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/PostStartTrialAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/PostStartTrialAction.java
@@ -5,19 +5,14 @@
  */
 package org.elasticsearch.license;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class PostStartTrialAction extends StreamableResponseActionType<PostStartTrialResponse> {
+public class PostStartTrialAction extends ActionType<PostStartTrialResponse> {
 
     public static final PostStartTrialAction INSTANCE = new PostStartTrialAction();
     public static final String NAME = "cluster:admin/xpack/license/start_trial";
 
     private PostStartTrialAction() {
-        super(NAME);
-    }
-
-    @Override
-    public PostStartTrialResponse newResponse() {
-        return new PostStartTrialResponse();
+        super(NAME, PostStartTrialResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/PostStartTrialResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/PostStartTrialResponse.java
@@ -56,25 +56,8 @@ class PostStartTrialResponse extends ActionResponse {
     private Map<String, String[]> acknowledgeMessages;
     private String acknowledgeMessage;
 
-    PostStartTrialResponse() {
-    }
-
-    PostStartTrialResponse(Status status) {
-        this(status, Collections.emptyMap(), null);
-    }
-
-    PostStartTrialResponse(Status status, Map<String, String[]> acknowledgeMessages, String acknowledgeMessage) {
-        this.status = status;
-        this.acknowledgeMessages = acknowledgeMessages;
-        this.acknowledgeMessage = acknowledgeMessage;
-    }
-
-    public Status getStatus() {
-        return status;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
+    PostStartTrialResponse(StreamInput in) throws IOException {
+        super(in);
         status = in.readEnum(Status.class);
         if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
             acknowledgeMessage = in.readOptionalString();
@@ -93,6 +76,25 @@ class PostStartTrialResponse extends ActionResponse {
         } else {
             this.acknowledgeMessages = Collections.emptyMap();
         }
+    }
+
+    PostStartTrialResponse(Status status) {
+        this(status, Collections.emptyMap(), null);
+    }
+
+    PostStartTrialResponse(Status status, Map<String, String[]> acknowledgeMessages, String acknowledgeMessage) {
+        this.status = status;
+        this.acknowledgeMessages = acknowledgeMessages;
+        this.acknowledgeMessage = acknowledgeMessage;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/TransportGetBasicStatusAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/TransportGetBasicStatusAction.java
@@ -7,17 +7,20 @@ package org.elasticsearch.license;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.StreamableTransportMasterNodeReadAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-public class TransportGetBasicStatusAction extends StreamableTransportMasterNodeReadAction<GetBasicStatusRequest, GetBasicStatusResponse> {
+import java.io.IOException;
+
+public class TransportGetBasicStatusAction extends TransportMasterNodeReadAction<GetBasicStatusRequest, GetBasicStatusResponse> {
 
     @Inject
     public TransportGetBasicStatusAction(TransportService transportService, ClusterService clusterService,
@@ -33,8 +36,8 @@ public class TransportGetBasicStatusAction extends StreamableTransportMasterNode
     }
 
     @Override
-    protected GetBasicStatusResponse newResponse() {
-        return new GetBasicStatusResponse();
+    protected GetBasicStatusResponse read(StreamInput in) throws IOException {
+        return new GetBasicStatusResponse(in);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/TransportGetLicenseAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/TransportGetLicenseAction.java
@@ -8,18 +8,21 @@ package org.elasticsearch.license;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.StreamableTransportMasterNodeReadAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.protocol.xpack.license.GetLicenseRequest;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-public class TransportGetLicenseAction extends StreamableTransportMasterNodeReadAction<GetLicenseRequest, GetLicenseResponse> {
+import java.io.IOException;
+
+public class TransportGetLicenseAction extends TransportMasterNodeReadAction<GetLicenseRequest, GetLicenseResponse> {
 
     private final LicenseService licenseService;
 
@@ -38,8 +41,8 @@ public class TransportGetLicenseAction extends StreamableTransportMasterNodeRead
     }
 
     @Override
-    protected GetLicenseResponse newResponse() {
-        return new GetLicenseResponse();
+    protected GetLicenseResponse read(StreamInput in) throws IOException {
+        return new GetLicenseResponse(in);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/TransportGetTrialStatusAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/TransportGetTrialStatusAction.java
@@ -7,17 +7,20 @@ package org.elasticsearch.license;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.StreamableTransportMasterNodeReadAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-public class TransportGetTrialStatusAction extends StreamableTransportMasterNodeReadAction<GetTrialStatusRequest, GetTrialStatusResponse> {
+import java.io.IOException;
+
+public class TransportGetTrialStatusAction extends TransportMasterNodeReadAction<GetTrialStatusRequest, GetTrialStatusResponse> {
 
     @Inject
     public TransportGetTrialStatusAction(TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
@@ -32,8 +35,8 @@ public class TransportGetTrialStatusAction extends StreamableTransportMasterNode
     }
 
     @Override
-    protected GetTrialStatusResponse newResponse() {
-        return new GetTrialStatusResponse();
+    protected GetTrialStatusResponse read(StreamInput in) throws IOException {
+        return new GetTrialStatusResponse(in);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/TransportPostStartTrialAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/TransportPostStartTrialAction.java
@@ -7,17 +7,20 @@ package org.elasticsearch.license;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.StreamableTransportMasterNodeAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-public class TransportPostStartTrialAction extends StreamableTransportMasterNodeAction<PostStartTrialRequest, PostStartTrialResponse> {
+import java.io.IOException;
+
+public class TransportPostStartTrialAction extends TransportMasterNodeAction<PostStartTrialRequest, PostStartTrialResponse> {
 
     private final LicenseService licenseService;
 
@@ -36,8 +39,8 @@ public class TransportPostStartTrialAction extends StreamableTransportMasterNode
     }
 
     @Override
-    protected PostStartTrialResponse newResponse() {
-        return new PostStartTrialResponse();
+    protected PostStartTrialResponse read(StreamInput in) throws IOException {
+        return new PostStartTrialResponse(in);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/XPackInfoResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/XPackInfoResponse.java
@@ -43,7 +43,12 @@ public class XPackInfoResponse extends ActionResponse implements ToXContentObjec
     @Nullable private LicenseInfo licenseInfo;
     @Nullable private FeatureSetsInfo featureSetsInfo;
 
-    public XPackInfoResponse() {}
+    public XPackInfoResponse(StreamInput in) throws IOException {
+        super(in);
+        this.buildInfo = in.readOptionalWriteable(BuildInfo::new);
+        this.licenseInfo = in.readOptionalWriteable(LicenseInfo::new);
+        this.featureSetsInfo = in.readOptionalWriteable(FeatureSetsInfo::new);
+    }
 
     public XPackInfoResponse(@Nullable BuildInfo buildInfo, @Nullable LicenseInfo licenseInfo, @Nullable FeatureSetsInfo featureSetsInfo) {
         this.buildInfo = buildInfo;
@@ -82,9 +87,7 @@ public class XPackInfoResponse extends ActionResponse implements ToXContentObjec
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        this.buildInfo = in.readOptionalWriteable(BuildInfo::new);
-        this.licenseInfo = in.readOptionalWriteable(LicenseInfo::new);
-        this.featureSetsInfo = in.readOptionalWriteable(FeatureSetsInfo::new);
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/graph/GraphExploreResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/graph/GraphExploreResponse.java
@@ -48,7 +48,40 @@ public class GraphExploreResponse extends ActionResponse implements ToXContentOb
     private boolean returnDetailedInfo;
     static final String RETURN_DETAILED_INFO_PARAM = "returnDetailedInfo";
 
-    public GraphExploreResponse() {
+    public GraphExploreResponse() {}
+
+    public GraphExploreResponse(StreamInput in) throws IOException {
+        super(in);
+        tookInMillis = in.readVLong();
+        timedOut = in.readBoolean();
+
+        int size = in.readVInt();
+        if (size == 0) {
+            shardFailures = ShardSearchFailure.EMPTY_ARRAY;
+        } else {
+            shardFailures = new ShardSearchFailure[size];
+            for (int i = 0; i < shardFailures.length; i++) {
+                shardFailures[i] = readShardSearchFailure(in);
+            }
+        }
+        // read vertices
+        size = in.readVInt();
+        vertices = new HashMap<>();
+        for (int i = 0; i < size; i++) {
+            Vertex n = Vertex.readFrom(in);
+            vertices.put(n.getId(), n);
+        }
+
+        size = in.readVInt();
+
+        connections = new HashMap<>();
+        for (int i = 0; i < size; i++) {
+            Connection e = new Connection(in, vertices);
+            connections.put(e.getId(), e);
+        }
+
+        returnDetailedInfo = in.readBoolean();
+
     }
 
     public GraphExploreResponse(long tookInMillis, boolean timedOut, ShardOperationFailedException[] shardFailures,
@@ -83,37 +116,7 @@ public class GraphExploreResponse extends ActionResponse implements ToXContentOb
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        tookInMillis = in.readVLong();
-        timedOut = in.readBoolean();
-
-        int size = in.readVInt();
-        if (size == 0) {
-            shardFailures = ShardSearchFailure.EMPTY_ARRAY;
-        } else {
-            shardFailures = new ShardSearchFailure[size];
-            for (int i = 0; i < shardFailures.length; i++) {
-                shardFailures[i] = readShardSearchFailure(in);
-            }
-        }
-        // read vertices
-        size = in.readVInt();
-        vertices = new HashMap<>();
-        for (int i = 0; i < size; i++) {
-            Vertex n = Vertex.readFrom(in);
-            vertices.put(n.getId(), n);
-        }
-
-        size = in.readVInt();
-
-        connections = new HashMap<>();
-        for (int i = 0; i < size; i++) {
-            Connection e = new Connection(in, vertices);
-            connections.put(e.getId(), e);
-        }
-        
-        returnDetailedInfo = in.readBoolean();
-
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     public Collection<Connection> getConnections() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/license/GetLicenseResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/license/GetLicenseResponse.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.protocol.xpack.license;
 
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
@@ -14,7 +15,8 @@ public class GetLicenseResponse extends ActionResponse {
 
     private String license;
 
-    GetLicenseResponse() {
+    public GetLicenseResponse(StreamInput in) throws IOException {
+        super(in);
     }
 
     public GetLicenseResponse(String license) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/migration/IndexUpgradeInfoResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/migration/IndexUpgradeInfoResponse.java
@@ -23,8 +23,9 @@ public class IndexUpgradeInfoResponse extends ActionResponse implements ToXConte
 
     private Map<String, UpgradeActionRequired> actions;
 
-    public IndexUpgradeInfoResponse() {
-
+    public IndexUpgradeInfoResponse(StreamInput in) throws IOException {
+        super(in);
+        actions = in.readMap(StreamInput::readString, UpgradeActionRequired::readFromStream);
     }
 
     public IndexUpgradeInfoResponse(Map<String, UpgradeActionRequired> actions) {
@@ -33,8 +34,7 @@ public class IndexUpgradeInfoResponse extends ActionResponse implements ToXConte
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        actions = in.readMap(StreamInput::readString, UpgradeActionRequired::readFromStream);
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/watcher/DeleteWatchResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/watcher/DeleteWatchResponse.java
@@ -31,7 +31,13 @@ public class DeleteWatchResponse extends ActionResponse implements ToXContentObj
     private long version;
     private boolean found;
 
-    public DeleteWatchResponse() {
+    public DeleteWatchResponse() {}
+
+    public DeleteWatchResponse(StreamInput in) throws IOException {
+        super(in);
+        id = in.readString();
+        version = in.readVLong();
+        found = in.readBoolean();
     }
 
     public DeleteWatchResponse(String id, long version, boolean found) {
@@ -81,10 +87,7 @@ public class DeleteWatchResponse extends ActionResponse implements ToXContentObj
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        id = in.readString();
-        version = in.readVLong();
-        found = in.readBoolean();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/watcher/PutWatchResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/watcher/PutWatchResponse.java
@@ -36,7 +36,15 @@ public class PutWatchResponse extends ActionResponse implements ToXContentObject
     private long primaryTerm = SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
     private boolean created;
 
-    public PutWatchResponse() {
+    public PutWatchResponse() {}
+
+    public PutWatchResponse(StreamInput in) throws IOException {
+        super(in);
+        id = in.readString();
+        version = in.readVLong();
+        seqNo = in.readZLong();
+        primaryTerm = in.readVLong();
+        created = in.readBoolean();
     }
 
     public PutWatchResponse(String id, long version, long seqNo, long primaryTerm, boolean created) {
@@ -115,12 +123,7 @@ public class PutWatchResponse extends ActionResponse implements ToXContentObject
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        id = in.readString();
-        version = in.readVLong();
-        seqNo = in.readZLong();
-        primaryTerm = in.readVLong();
-        created = in.readBoolean();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/ReloadAnalyzerAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/ReloadAnalyzerAction.java
@@ -5,19 +5,14 @@
  */
 package org.elasticsearch.xpack.core.action;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class ReloadAnalyzerAction extends StreamableResponseActionType<ReloadAnalyzersResponse> {
+public class ReloadAnalyzerAction extends ActionType<ReloadAnalyzersResponse> {
 
     public static final ReloadAnalyzerAction INSTANCE = new ReloadAnalyzerAction();
     public static final String NAME = "indices:admin/reload_analyzers";
 
     private ReloadAnalyzerAction() {
-        super(NAME);
-    }
-
-    @Override
-    public ReloadAnalyzersResponse newResponse() {
-        return new ReloadAnalyzersResponse();
+        super(NAME, ReloadAnalyzersResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/ReloadAnalyzersResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/ReloadAnalyzersResponse.java
@@ -16,7 +16,6 @@ import org.elasticsearch.xpack.core.action.TransportReloadAnalyzersAction.Reload
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -36,11 +35,6 @@ public class ReloadAnalyzersResponse extends BroadcastResponse  {
     private static final ParseField INDEX_FIELD = new ParseField("index");
     private static final ParseField RELOADED_ANALYZERS_FIELD = new ParseField("reloaded_analyzers");
     private static final ParseField RELOADED_NODE_IDS_FIELD = new ParseField("reloaded_node_ids");
-
-
-    public ReloadAnalyzersResponse() {
-        reloadDetails = Collections.emptyMap();
-    }
 
     public ReloadAnalyzersResponse(StreamInput in) throws IOException {
         super(in);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportXPackUsageAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportXPackUsageAction.java
@@ -7,12 +7,13 @@ package org.elasticsearch.xpack.core.action;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.StreamableTransportMasterNodeAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.protocol.xpack.XPackUsageRequest;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -20,6 +21,7 @@ import org.elasticsearch.xpack.core.XPackFeatureSet;
 import org.elasticsearch.xpack.core.XPackFeatureSet.Usage;
 import org.elasticsearch.xpack.core.common.IteratingActionListener;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -28,7 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.function.BiConsumer;
 
-public class TransportXPackUsageAction extends StreamableTransportMasterNodeAction<XPackUsageRequest, XPackUsageResponse> {
+public class TransportXPackUsageAction extends TransportMasterNodeAction<XPackUsageRequest, XPackUsageResponse> {
 
     private final List<XPackFeatureSet> featureSets;
 
@@ -47,8 +49,8 @@ public class TransportXPackUsageAction extends StreamableTransportMasterNodeActi
     }
 
     @Override
-    protected XPackUsageResponse newResponse() {
-        return new XPackUsageResponse();
+    protected XPackUsageResponse read(StreamInput in) throws IOException {
+        return new XPackUsageResponse(in);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackInfoAction.java
@@ -5,20 +5,15 @@
  */
 package org.elasticsearch.xpack.core.action;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.protocol.xpack.XPackInfoResponse;
 
-public class XPackInfoAction extends StreamableResponseActionType<XPackInfoResponse> {
+public class XPackInfoAction extends ActionType<XPackInfoResponse> {
 
     public static final String NAME = "cluster:monitor/xpack/info";
     public static final XPackInfoAction INSTANCE = new XPackInfoAction();
 
     public XPackInfoAction() {
-        super(NAME);
-    }
-
-    @Override
-    public XPackInfoResponse newResponse() {
-        return new XPackInfoResponse();
+        super(NAME, XPackInfoResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageAction.java
@@ -5,19 +5,14 @@
  */
 package org.elasticsearch.xpack.core.action;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class XPackUsageAction extends StreamableResponseActionType<XPackUsageResponse> {
+public class XPackUsageAction extends ActionType<XPackUsageResponse> {
 
     public static final String NAME = "cluster:monitor/xpack/usage";
     public static final XPackUsageAction INSTANCE = new XPackUsageAction();
 
     public XPackUsageAction() {
-        super(NAME);
-    }
-
-    @Override
-    public XPackUsageResponse newResponse() {
-        return new XPackUsageResponse();
+        super(NAME, XPackUsageResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageResponse.java
@@ -18,7 +18,14 @@ public class XPackUsageResponse extends ActionResponse {
 
     private List<XPackFeatureSet.Usage> usages;
 
-    public XPackUsageResponse() {}
+    public XPackUsageResponse(StreamInput in) throws IOException {
+        super(in);
+        int size = in.readVInt();
+        usages = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            usages.add(in.readNamedWriteable(XPackFeatureSet.Usage.class));
+        }
+    }
 
     public XPackUsageResponse(List<XPackFeatureSet.Usage> usages) {
         this.usages = usages;
@@ -38,11 +45,6 @@ public class XPackUsageResponse extends ActionResponse {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        int size = in.readVInt();
-        usages = new ArrayList<>(size);
-        for (int i = 0; i < size; i++) {
-            usages.add(in.readNamedWriteable(XPackFeatureSet.Usage.class));
-        }
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/graph/action/GraphExploreAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/graph/action/GraphExploreAction.java
@@ -5,20 +5,15 @@
  */
 package org.elasticsearch.xpack.core.graph.action;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.protocol.xpack.graph.GraphExploreResponse;
 
-public class GraphExploreAction extends StreamableResponseActionType<GraphExploreResponse> {
+public class GraphExploreAction extends ActionType<GraphExploreResponse> {
 
     public static final GraphExploreAction INSTANCE = new GraphExploreAction();
     public static final String NAME = "indices:data/read/xpack/graph/explore";
 
     private GraphExploreAction() {
-        super(NAME);
-    }
-
-    @Override
-    public GraphExploreResponse newResponse() {
-        return new GraphExploreResponse();
+        super(NAME, GraphExploreResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ExplainLifecycleResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ExplainLifecycleResponse.java
@@ -49,7 +49,15 @@ public class ExplainLifecycleResponse extends ActionResponse implements ToXConte
         return PARSER.apply(parser, null);
     }
 
-    public ExplainLifecycleResponse() {
+    public ExplainLifecycleResponse(StreamInput in) throws IOException {
+        super(in);
+        int size = in.readVInt();
+        Map<String, IndexLifecycleExplainResponse> indexResponses = new HashMap<>(size);
+        for (int i = 0; i < size; i++) {
+            IndexLifecycleExplainResponse indexResponse = new IndexLifecycleExplainResponse(in);
+            indexResponses.put(indexResponse.getIndex(), indexResponse);
+        }
+        this.indexResponses = indexResponses;
     }
 
     public ExplainLifecycleResponse(Map<String, IndexLifecycleExplainResponse> indexResponses) {
@@ -80,13 +88,7 @@ public class ExplainLifecycleResponse extends ActionResponse implements ToXConte
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        int size = in.readVInt();
-        Map<String, IndexLifecycleExplainResponse> indexResponses = new HashMap<>(size);
-        for (int i = 0; i < size; i++) {
-            IndexLifecycleExplainResponse indexResponse = new IndexLifecycleExplainResponse(in);
-            indexResponses.put(indexResponse.getIndex(), indexResponse);
-        }
-        this.indexResponses = indexResponses;
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/action/ExplainLifecycleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/action/ExplainLifecycleAction.java
@@ -6,20 +6,15 @@
 
 package org.elasticsearch.xpack.core.indexlifecycle.action;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.xpack.core.indexlifecycle.ExplainLifecycleResponse;
 
-public class ExplainLifecycleAction extends StreamableResponseActionType<ExplainLifecycleResponse> {
+public class ExplainLifecycleAction extends ActionType<ExplainLifecycleResponse> {
     public static final ExplainLifecycleAction INSTANCE = new ExplainLifecycleAction();
     public static final String NAME = "indices:admin/ilm/explain";
 
     protected ExplainLifecycleAction() {
-        super(NAME);
-    }
-
-    @Override
-    public ExplainLifecycleResponse newResponse() {
-        return new ExplainLifecycleResponse();
+        super(NAME, ExplainLifecycleResponse::new);
     }
 
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/action/GetLifecycleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/action/GetLifecycleAction.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.core.indexlifecycle.action;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -23,24 +23,21 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-public class GetLifecycleAction extends StreamableResponseActionType<GetLifecycleAction.Response> {
+public class GetLifecycleAction extends ActionType<GetLifecycleAction.Response> {
     public static final GetLifecycleAction INSTANCE = new GetLifecycleAction();
     public static final String NAME = "cluster:admin/ilm/get";
 
     protected GetLifecycleAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, GetLifecycleAction.Response::new);
     }
 
     public static class Response extends ActionResponse implements ToXContentObject {
 
         private List<LifecyclePolicyResponseItem> policies;
 
-        public Response() {
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            this.policies = in.readList(LifecyclePolicyResponseItem::new);
         }
 
         public Response(List<LifecyclePolicyResponseItem> policies) {
@@ -67,7 +64,7 @@ public class GetLifecycleAction extends StreamableResponseActionType<GetLifecycl
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            this.policies = in.readList(LifecyclePolicyResponseItem::new);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/action/GetStatusAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/action/GetStatusAction.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.core.indexlifecycle.action;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -20,24 +20,21 @@ import org.elasticsearch.xpack.core.indexlifecycle.OperationMode;
 import java.io.IOException;
 import java.util.Objects;
 
-public class GetStatusAction extends StreamableResponseActionType<GetStatusAction.Response> {
+public class GetStatusAction extends ActionType<GetStatusAction.Response> {
     public static final GetStatusAction INSTANCE = new GetStatusAction();
     public static final String NAME = "cluster:admin/ilm/operation_mode/get";
 
     protected GetStatusAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, GetStatusAction.Response::new);
     }
 
     public static class Response extends ActionResponse implements ToXContentObject {
 
         private OperationMode mode;
 
-        public Response() {
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            mode = in.readEnum(OperationMode.class);
         }
 
         public Response(OperationMode mode) {
@@ -58,7 +55,7 @@ public class GetStatusAction extends StreamableResponseActionType<GetStatusActio
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            mode = in.readEnum(OperationMode.class);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/action/RemoveIndexLifecyclePolicyAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/action/RemoveIndexLifecyclePolicyAction.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.core.indexlifecycle.action;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.IndicesRequest;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.ParseField;
@@ -24,17 +24,12 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-public class RemoveIndexLifecyclePolicyAction extends StreamableResponseActionType<RemoveIndexLifecyclePolicyAction.Response> {
+public class RemoveIndexLifecyclePolicyAction extends ActionType<RemoveIndexLifecyclePolicyAction.Response> {
     public static final RemoveIndexLifecyclePolicyAction INSTANCE = new RemoveIndexLifecyclePolicyAction();
     public static final String NAME = "indices:admin/ilm/remove_policy";
 
     protected RemoveIndexLifecyclePolicyAction() {
-        super(NAME);
-    }
-
-    @Override
-    public RemoveIndexLifecyclePolicyAction.Response newResponse() {
-        return new Response();
+        super(NAME, RemoveIndexLifecyclePolicyAction.Response::new);
     }
 
     public static class Response extends ActionResponse implements ToXContentObject {
@@ -52,7 +47,9 @@ public class RemoveIndexLifecyclePolicyAction extends StreamableResponseActionTy
 
         private List<String> failedIndexes;
 
-        public Response() {
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            failedIndexes = in.readStringList();
         }
 
         public Response(List<String> failedIndexes) {
@@ -81,8 +78,7 @@ public class RemoveIndexLifecyclePolicyAction extends StreamableResponseActionTy
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            failedIndexes = in.readStringList();
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/action/MonitoringBulkAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/action/MonitoringBulkAction.java
@@ -5,20 +5,15 @@
  */
 package org.elasticsearch.xpack.core.monitoring.action;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class MonitoringBulkAction extends StreamableResponseActionType<MonitoringBulkResponse> {
+public class MonitoringBulkAction extends ActionType<MonitoringBulkResponse> {
 
     public static final MonitoringBulkAction INSTANCE = new MonitoringBulkAction();
     public static final String NAME = "cluster:admin/xpack/monitoring/bulk";
 
     private MonitoringBulkAction() {
-        super(NAME);
-    }
-
-    @Override
-    public MonitoringBulkResponse newResponse() {
-        return new MonitoringBulkResponse();
+        super(NAME, MonitoringBulkResponse::new);
     }
 }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/action/MonitoringBulkResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/action/MonitoringBulkResponse.java
@@ -26,7 +26,14 @@ public class MonitoringBulkResponse extends ActionResponse {
     private Error error;
     private boolean ignored;
 
-    public MonitoringBulkResponse() {
+    public MonitoringBulkResponse(StreamInput in) throws IOException {
+        super(in);
+        tookInMillis = in.readVLong();
+        error = in.readOptionalWriteable(Error::new);
+
+        if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
+            ignored = in.readBoolean();
+        }
     }
 
     public MonitoringBulkResponse(final long tookInMillis, final boolean ignored) {
@@ -78,13 +85,7 @@ public class MonitoringBulkResponse extends ActionResponse {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        tookInMillis = in.readVLong();
-        error = in.readOptionalWriteable(Error::new);
-
-        if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
-            ignored = in.readBoolean();
-        }
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupCapsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupCapsAction.java
@@ -9,7 +9,7 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.ParseField;
@@ -27,7 +27,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
-public class GetRollupCapsAction extends StreamableResponseActionType<GetRollupCapsAction.Response> {
+public class GetRollupCapsAction extends ActionType<GetRollupCapsAction.Response> {
 
     public static final GetRollupCapsAction INSTANCE = new GetRollupCapsAction();
     public static final String NAME = "cluster:monitor/xpack/rollup/get/caps";
@@ -35,12 +35,7 @@ public class GetRollupCapsAction extends StreamableResponseActionType<GetRollupC
     public static final ParseField STATUS = new ParseField("status");
 
     private GetRollupCapsAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, GetRollupCapsAction.Response::new);
     }
 
     public static class Request extends ActionRequest implements ToXContentFragment {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupIndexCapsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupIndexCapsAction.java
@@ -11,7 +11,7 @@ import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.IndicesRequest;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.ParseField;
@@ -30,7 +30,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
-public class GetRollupIndexCapsAction extends StreamableResponseActionType<GetRollupIndexCapsAction.Response> {
+public class GetRollupIndexCapsAction extends ActionType<GetRollupIndexCapsAction.Response> {
 
     public static final GetRollupIndexCapsAction INSTANCE = new GetRollupIndexCapsAction();
     public static final String NAME = "indices:data/read/xpack/rollup/get/index/caps";
@@ -39,12 +39,7 @@ public class GetRollupIndexCapsAction extends StreamableResponseActionType<GetRo
     private static final ParseField INDICES_OPTIONS = new ParseField("indices_options");
 
     private GetRollupIndexCapsAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Response newResponse() {
-        return new Response();
+        super(NAME, GetRollupIndexCapsAction.Response::new);
     }
 
     public static class Request extends ActionRequest implements IndicesRequest.Replaceable, ToXContentFragment {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/action/GetCertificateInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/action/GetCertificateInfoAction.java
@@ -9,7 +9,7 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -25,18 +25,13 @@ import java.util.Collection;
  * ActionType to obtain information about X.509 (SSL/TLS) certificates that are being used by X-Pack.
  * The primary use case is for tracking the expiry dates of certificates.
  */
-public class GetCertificateInfoAction extends StreamableResponseActionType<GetCertificateInfoAction.Response> {
+public class GetCertificateInfoAction extends ActionType<GetCertificateInfoAction.Response> {
 
     public static final GetCertificateInfoAction INSTANCE = new GetCertificateInfoAction();
     public static final String NAME = "cluster:monitor/xpack/ssl/certificates/get";
 
     private GetCertificateInfoAction() {
-        super(NAME);
-    }
-
-    @Override
-    public GetCertificateInfoAction.Response newResponse() {
-        return new GetCertificateInfoAction.Response();
+        super(NAME, GetCertificateInfoAction.Response::new);
     }
 
     public static class Request extends ActionRequest {
@@ -52,7 +47,13 @@ public class GetCertificateInfoAction extends StreamableResponseActionType<GetCe
 
         private Collection<CertificateInfo> certificates;
 
-        public Response() {
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            this.certificates = new ArrayList<>();
+            int count = in.readVInt();
+            for (int i = 0; i < count; i++) {
+                certificates.add(new CertificateInfo(in));
+            }
         }
 
         public Response(Collection<CertificateInfo> certificates) {
@@ -78,12 +79,7 @@ public class GetCertificateInfoAction extends StreamableResponseActionType<GetCe
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            this.certificates = new ArrayList<>();
-            int count = in.readVInt();
-            for (int i = 0; i < count; i++) {
-                certificates.add(new CertificateInfo(in));
-            }
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/upgrade/actions/IndexUpgradeAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/upgrade/actions/IndexUpgradeAction.java
@@ -7,7 +7,7 @@ package org.elasticsearch.xpack.core.upgrade.actions;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.action.support.master.MasterNodeReadRequest;
@@ -26,18 +26,13 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xpack.core.upgrade.IndexUpgradeServiceFields.UPGRADE_INDEX_OPTIONS;
 
-public class IndexUpgradeAction extends StreamableResponseActionType<BulkByScrollResponse> {
+public class IndexUpgradeAction extends ActionType<BulkByScrollResponse> {
 
     public static final IndexUpgradeAction INSTANCE = new IndexUpgradeAction();
     public static final String NAME = "cluster:admin/xpack/upgrade";
 
     private IndexUpgradeAction() {
-        super(NAME);
-    }
-
-    @Override
-    public BulkByScrollResponse newResponse() {
-        return new BulkByScrollResponse();
+        super(NAME, BulkByScrollResponse::new);
     }
 
     public static class Request extends MasterNodeReadRequest<Request> implements IndicesRequest {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/upgrade/actions/IndexUpgradeInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/upgrade/actions/IndexUpgradeInfoAction.java
@@ -5,25 +5,20 @@
  */
 package org.elasticsearch.xpack.core.upgrade.actions;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.protocol.xpack.migration.IndexUpgradeInfoRequest;
 import org.elasticsearch.protocol.xpack.migration.IndexUpgradeInfoResponse;
 
-public class IndexUpgradeInfoAction extends StreamableResponseActionType<IndexUpgradeInfoResponse> {
+public class IndexUpgradeInfoAction extends ActionType<IndexUpgradeInfoResponse> {
 
     public static final IndexUpgradeInfoAction INSTANCE = new IndexUpgradeInfoAction();
     public static final String NAME = "cluster:admin/xpack/upgrade/info";
 
     private IndexUpgradeInfoAction() {
-        super(NAME);
-    }
-
-    @Override
-    public IndexUpgradeInfoResponse newResponse() {
-        return new IndexUpgradeInfoResponse();
+        super(NAME, IndexUpgradeInfoResponse::new);
     }
 
     public static class RequestBuilder

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/ack/AckWatchAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/ack/AckWatchAction.java
@@ -5,22 +5,17 @@
  */
 package org.elasticsearch.xpack.core.watcher.transport.actions.ack;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * This action acks a watch in memory, and the index
  */
-public class AckWatchAction extends StreamableResponseActionType<AckWatchResponse> {
+public class AckWatchAction extends ActionType<AckWatchResponse> {
 
     public static final AckWatchAction INSTANCE = new AckWatchAction();
     public static final String NAME = "cluster:admin/xpack/watcher/watch/ack";
 
     private AckWatchAction() {
-        super(NAME);
-    }
-
-    @Override
-    public AckWatchResponse newResponse() {
-        return new AckWatchResponse();
+        super(NAME, AckWatchResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/ack/AckWatchResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/ack/AckWatchResponse.java
@@ -21,7 +21,9 @@ public class AckWatchResponse extends ActionResponse {
 
     private WatchStatus status;
 
-    public AckWatchResponse() {
+    public AckWatchResponse(StreamInput in) throws IOException {
+        super(in);
+        status = in.readBoolean() ? new WatchStatus(in) : null;
     }
 
     public AckWatchResponse(@Nullable WatchStatus status) {
@@ -37,8 +39,7 @@ public class AckWatchResponse extends ActionResponse {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        status = in.readBoolean() ? new WatchStatus(in) : null;
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/activate/ActivateWatchAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/activate/ActivateWatchAction.java
@@ -5,22 +5,17 @@
  */
 package org.elasticsearch.xpack.core.watcher.transport.actions.activate;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * This action acks a watch in memory, and the index
  */
-public class ActivateWatchAction extends StreamableResponseActionType<ActivateWatchResponse> {
+public class ActivateWatchAction extends ActionType<ActivateWatchResponse> {
 
     public static final ActivateWatchAction INSTANCE = new ActivateWatchAction();
     public static final String NAME = "cluster:admin/xpack/watcher/watch/activate";
 
     private ActivateWatchAction() {
-        super(NAME);
-    }
-
-    @Override
-    public ActivateWatchResponse newResponse() {
-        return new ActivateWatchResponse();
+        super(NAME, ActivateWatchResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/activate/ActivateWatchResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/activate/ActivateWatchResponse.java
@@ -21,7 +21,9 @@ public class ActivateWatchResponse extends ActionResponse {
 
     private WatchStatus status;
 
-    public ActivateWatchResponse() {
+    public ActivateWatchResponse(StreamInput in) throws IOException {
+        super(in);
+        status = in.readBoolean() ? new WatchStatus(in) : null;
     }
 
     public ActivateWatchResponse(@Nullable WatchStatus status) {
@@ -37,8 +39,7 @@ public class ActivateWatchResponse extends ActionResponse {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        status = in.readBoolean() ? new WatchStatus(in) : null;
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/delete/DeleteWatchAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/delete/DeleteWatchAction.java
@@ -5,23 +5,18 @@
  */
 package org.elasticsearch.xpack.core.watcher.transport.actions.delete;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.protocol.xpack.watcher.DeleteWatchResponse;
 
 /**
  * This action deletes an watch from in memory, the scheduler and the index
  */
-public class DeleteWatchAction extends StreamableResponseActionType<DeleteWatchResponse> {
+public class DeleteWatchAction extends ActionType<DeleteWatchResponse> {
 
     public static final DeleteWatchAction INSTANCE = new DeleteWatchAction();
     public static final String NAME = "cluster:admin/xpack/watcher/watch/delete";
 
     private DeleteWatchAction() {
-        super(NAME);
-    }
-
-    @Override
-    public DeleteWatchResponse newResponse() {
-        return new DeleteWatchResponse();
+        super(NAME, DeleteWatchResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/execute/ExecuteWatchAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/execute/ExecuteWatchAction.java
@@ -5,23 +5,18 @@
  */
 package org.elasticsearch.xpack.core.watcher.transport.actions.execute;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * This action executes a watch, either ignoring the schedule and condition or just the schedule and can execute a subset of the actions,
  * optionally persisting the history entry
  */
-public class ExecuteWatchAction extends StreamableResponseActionType<ExecuteWatchResponse> {
+public class ExecuteWatchAction extends ActionType<ExecuteWatchResponse> {
 
     public static final ExecuteWatchAction INSTANCE = new ExecuteWatchAction();
     public static final String NAME = "cluster:admin/xpack/watcher/watch/execute";
 
     private ExecuteWatchAction() {
-        super(NAME);
-    }
-
-    @Override
-    public ExecuteWatchResponse newResponse() {
-        return new ExecuteWatchResponse();
+        super(NAME, ExecuteWatchResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/execute/ExecuteWatchResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/execute/ExecuteWatchResponse.java
@@ -32,7 +32,10 @@ public class ExecuteWatchResponse extends ActionResponse implements ToXContentOb
     private String recordId;
     private XContentSource recordSource;
 
-    public ExecuteWatchResponse() {
+    public ExecuteWatchResponse(StreamInput in) throws IOException {
+        super(in);
+        recordId = in.readString();
+        recordSource = XContentSource.readFrom(in);
     }
 
     public ExecuteWatchResponse(String recordId, BytesReference recordSource, XContentType contentType) {
@@ -75,9 +78,7 @@ public class ExecuteWatchResponse extends ActionResponse implements ToXContentOb
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        recordId = in.readString();
-        recordSource = XContentSource.readFrom(in);
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/get/GetWatchAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/get/GetWatchAction.java
@@ -5,22 +5,17 @@
  */
 package org.elasticsearch.xpack.core.watcher.transport.actions.get;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * This action gets an watch by name
  */
-public class GetWatchAction extends StreamableResponseActionType<GetWatchResponse> {
+public class GetWatchAction extends ActionType<GetWatchResponse> {
 
     public static final GetWatchAction INSTANCE = new GetWatchAction();
     public static final String NAME = "cluster:monitor/xpack/watcher/watch/get";
 
     private GetWatchAction() {
-        super(NAME);
-    }
-
-    @Override
-    public GetWatchResponse newResponse() {
-        return new GetWatchResponse();
+        super(NAME, GetWatchResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/get/GetWatchResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/get/GetWatchResponse.java
@@ -29,7 +29,23 @@ public class GetWatchResponse extends ActionResponse implements ToXContentObject
     private long seqNo;
     private long primaryTerm;
 
-    public GetWatchResponse() {
+    public GetWatchResponse(StreamInput in) throws IOException {
+        super(in);
+        id = in.readString();
+        found = in.readBoolean();
+        if (found) {
+            status = new WatchStatus(in);
+            source = XContentSource.readFrom(in);
+            version = in.readZLong();
+            seqNo = in.readZLong();
+            primaryTerm = in.readVLong();
+        } else {
+            status = null;
+            source = null;
+            version = Versions.NOT_FOUND;
+            seqNo = SequenceNumbers.UNASSIGNED_SEQ_NO;
+            primaryTerm = SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
+        }
     }
 
     /**
@@ -88,22 +104,7 @@ public class GetWatchResponse extends ActionResponse implements ToXContentObject
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        id = in.readString();
-        found = in.readBoolean();
-        if (found) {
-            status = new WatchStatus(in);
-            source = XContentSource.readFrom(in);
-            version = in.readZLong();
-            seqNo = in.readZLong();
-            primaryTerm = in.readVLong();
-        } else {
-            status = null;
-            source = null;
-            version = Versions.NOT_FOUND;
-            seqNo = SequenceNumbers.UNASSIGNED_SEQ_NO;
-            primaryTerm = SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
-        }
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/put/PutWatchAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/put/PutWatchAction.java
@@ -5,23 +5,18 @@
  */
 package org.elasticsearch.xpack.core.watcher.transport.actions.put;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.protocol.xpack.watcher.PutWatchResponse;
 
 /**
  * This action puts an watch into the watch index and adds it to the scheduler
  */
-public class PutWatchAction extends StreamableResponseActionType<PutWatchResponse> {
+public class PutWatchAction extends ActionType<PutWatchResponse> {
 
     public static final PutWatchAction INSTANCE = new PutWatchAction();
     public static final String NAME = "cluster:admin/xpack/watcher/watch/put";
 
     private PutWatchAction() {
-        super(NAME);
-    }
-
-    @Override
-    public PutWatchResponse newResponse() {
-        return new PutWatchResponse();
+        super(NAME, PutWatchResponse::new);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/deprecation/DeprecationInfoActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/deprecation/DeprecationInfoActionResponseTests.java
@@ -14,12 +14,13 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfigTests;
 
@@ -38,7 +39,7 @@ import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-public class DeprecationInfoActionResponseTests extends AbstractStreamableTestCase<DeprecationInfoAction.Response> {
+public class DeprecationInfoActionResponseTests extends AbstractWireSerializingTestCase<DeprecationInfoAction.Response> {
 
     @Override
     protected DeprecationInfoAction.Response createTestInstance() {
@@ -58,8 +59,8 @@ public class DeprecationInfoActionResponseTests extends AbstractStreamableTestCa
     }
 
     @Override
-    protected DeprecationInfoAction.Response createBlankInstance() {
-        return new DeprecationInfoAction.Response();
+    protected Writeable.Reader<DeprecationInfoAction.Response> instanceReader() {
+        return DeprecationInfoAction.Response::new;
     }
 
     public void testFrom() throws IOException {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ExplainLifecycleResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ExplainLifecycleResponseTests.java
@@ -9,9 +9,10 @@ package org.elasticsearch.xpack.core.indexlifecycle;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -20,7 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class ExplainLifecycleResponseTests extends AbstractStreamableXContentTestCase<ExplainLifecycleResponse> {
+public class ExplainLifecycleResponseTests extends AbstractSerializingTestCase<ExplainLifecycleResponse> {
 
     @Override
     protected ExplainLifecycleResponse createTestInstance() {
@@ -33,8 +34,8 @@ public class ExplainLifecycleResponseTests extends AbstractStreamableXContentTes
     }
 
     @Override
-    protected ExplainLifecycleResponse createBlankInstance() {
-        return new ExplainLifecycleResponse();
+    protected Writeable.Reader<ExplainLifecycleResponse> instanceReader() {
+        return ExplainLifecycleResponse::new;
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/action/GetLifecycleResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/action/GetLifecycleResponseTests.java
@@ -6,7 +6,8 @@
 package org.elasticsearch.xpack.core.indexlifecycle.action;
 
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
-import org.elasticsearch.test.AbstractStreamableTestCase;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.indexlifecycle.LifecycleAction;
 import org.elasticsearch.xpack.core.indexlifecycle.LifecycleType;
 import org.elasticsearch.xpack.core.indexlifecycle.MockAction;
@@ -20,7 +21,7 @@ import java.util.List;
 
 import static org.elasticsearch.xpack.core.indexlifecycle.LifecyclePolicyTests.randomTestLifecyclePolicy;
 
-public class GetLifecycleResponseTests extends AbstractStreamableTestCase<GetLifecycleAction.Response> {
+public class GetLifecycleResponseTests extends AbstractWireSerializingTestCase<Response> {
 
     @Override
     protected Response createTestInstance() {
@@ -34,8 +35,8 @@ public class GetLifecycleResponseTests extends AbstractStreamableTestCase<GetLif
     }
 
     @Override
-    protected Response createBlankInstance() {
-        return new Response();
+    protected Writeable.Reader<Response> instanceReader() {
+        return Response::new;
     }
 
     protected NamedWriteableRegistry getNamedWriteableRegistry() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/action/RemoveIndexLifecyclePolicyResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/action/RemoveIndexLifecyclePolicyResponseTests.java
@@ -6,8 +6,9 @@
 
 package org.elasticsearch.xpack.core.indexlifecycle.action;
 
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.indexlifecycle.action.RemoveIndexLifecyclePolicyAction.Response;
 
 import java.io.IOException;
@@ -16,17 +17,17 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class RemoveIndexLifecyclePolicyResponseTests extends AbstractStreamableXContentTestCase<RemoveIndexLifecyclePolicyAction.Response> {
-
-    @Override
-    protected Response createBlankInstance() {
-        return new Response();
-    }
+public class RemoveIndexLifecyclePolicyResponseTests extends AbstractSerializingTestCase<Response> {
 
     @Override
     protected Response createTestInstance() {
         List<String> failedIndexes = Arrays.asList(generateRandomStringArray(20, 20, false));
         return new Response(failedIndexes);
+    }
+
+    @Override
+    protected Writeable.Reader<Response> instanceReader() {
+        return Response::new;
     }
 
     @Override

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
@@ -10,7 +10,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.StreamableTransportMasterNodeReadAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.license.LicenseUtils;
@@ -33,6 +34,7 @@ import org.elasticsearch.xpack.core.deprecation.NodesDeprecationCheckRequest;
 import org.elasticsearch.xpack.core.ml.action.GetDatafeedsAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -41,7 +43,7 @@ import static org.elasticsearch.xpack.deprecation.DeprecationChecks.CLUSTER_SETT
 import static org.elasticsearch.xpack.deprecation.DeprecationChecks.INDEX_SETTINGS_CHECKS;
 import static org.elasticsearch.xpack.deprecation.DeprecationChecks.ML_SETTINGS_CHECKS;
 
-public class TransportDeprecationInfoAction extends StreamableTransportMasterNodeReadAction<DeprecationInfoAction.Request,
+public class TransportDeprecationInfoAction extends TransportMasterNodeReadAction<DeprecationInfoAction.Request,
         DeprecationInfoAction.Response> {
     private static final Logger logger = LogManager.getLogger(TransportDeprecationInfoAction.class);
 
@@ -71,8 +73,8 @@ public class TransportDeprecationInfoAction extends StreamableTransportMasterNod
     }
 
     @Override
-    protected DeprecationInfoAction.Response newResponse() {
-        return new DeprecationInfoAction.Response();
+    protected DeprecationInfoAction.Response read(StreamInput in) throws IOException {
+        return new DeprecationInfoAction.Response(in);
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/TransportExplainLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/TransportExplainLifecycleAction.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -53,14 +54,14 @@ public class TransportExplainLifecycleAction
     }
 
     @Override
-    protected ExplainLifecycleResponse newResponse() {
-        return new ExplainLifecycleResponse();
-    }
-
-    @Override
     protected String executor() {
         // very lightweight operation, no need to fork
         return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    protected ExplainLifecycleResponse read(StreamInput in) throws IOException {
+        return new ExplainLifecycleResponse(in);
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/TransportGetLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/TransportGetLifecycleAction.java
@@ -9,13 +9,14 @@ package org.elasticsearch.xpack.indexlifecycle.action;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.StreamableTransportMasterNodeAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.indexlifecycle.IndexLifecycleMetadata;
@@ -25,12 +26,13 @@ import org.elasticsearch.xpack.core.indexlifecycle.action.GetLifecycleAction.Lif
 import org.elasticsearch.xpack.core.indexlifecycle.action.GetLifecycleAction.Request;
 import org.elasticsearch.xpack.core.indexlifecycle.action.GetLifecycleAction.Response;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class TransportGetLifecycleAction extends StreamableTransportMasterNodeAction<Request, Response> {
+public class TransportGetLifecycleAction extends TransportMasterNodeAction<Request, Response> {
 
     @Inject
     public TransportGetLifecycleAction(TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
@@ -45,8 +47,8 @@ public class TransportGetLifecycleAction extends StreamableTransportMasterNodeAc
     }
 
     @Override
-    protected Response newResponse() {
-        return new Response();
+    protected Response read(StreamInput in) throws IOException {
+        return new Response(in);
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/TransportGetStatusAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/TransportGetStatusAction.java
@@ -8,13 +8,14 @@ package org.elasticsearch.xpack.indexlifecycle.action;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.StreamableTransportMasterNodeAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.indexlifecycle.IndexLifecycleMetadata;
@@ -23,7 +24,9 @@ import org.elasticsearch.xpack.core.indexlifecycle.action.GetStatusAction;
 import org.elasticsearch.xpack.core.indexlifecycle.action.GetStatusAction.Request;
 import org.elasticsearch.xpack.core.indexlifecycle.action.GetStatusAction.Response;
 
-public class TransportGetStatusAction extends StreamableTransportMasterNodeAction<Request, Response> {
+import java.io.IOException;
+
+public class TransportGetStatusAction extends TransportMasterNodeAction<Request, Response> {
 
     @Inject
     public TransportGetStatusAction(TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
@@ -38,8 +41,8 @@ public class TransportGetStatusAction extends StreamableTransportMasterNodeActio
     }
 
     @Override
-    protected Response newResponse() {
-        return new Response();
+    protected Response read(StreamInput in) throws IOException {
+        return new Response(in);
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/TransportRemoveIndexLifecyclePolicyAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/TransportRemoveIndexLifecyclePolicyAction.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.indexlifecycle.action;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.StreamableTransportMasterNodeAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -24,10 +25,11 @@ import org.elasticsearch.xpack.core.indexlifecycle.action.RemoveIndexLifecyclePo
 import org.elasticsearch.xpack.core.indexlifecycle.action.RemoveIndexLifecyclePolicyAction.Response;
 import org.elasticsearch.xpack.indexlifecycle.IndexLifecycleRunner;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class TransportRemoveIndexLifecyclePolicyAction extends StreamableTransportMasterNodeAction<Request, Response> {
+public class TransportRemoveIndexLifecyclePolicyAction extends TransportMasterNodeAction<Request, Response> {
 
     @Inject
     public TransportRemoveIndexLifecyclePolicyAction(TransportService transportService, ClusterService clusterService,
@@ -43,8 +45,8 @@ public class TransportRemoveIndexLifecyclePolicyAction extends StreamableTranspo
     }
 
     @Override
-    protected Response newResponse() {
-        return new Response();
+    protected Response read(StreamInput in) throws IOException {
+        return new Response(in);
     }
 
     @Override

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/MonitoringBulkResponseTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/MonitoringBulkResponseTests.java
@@ -70,9 +70,7 @@ public class MonitoringBulkResponseTests extends ESTestCase {
 
             StreamInput streamInput = output.bytes().streamInput();
             streamInput.setVersion(version);
-            MonitoringBulkResponse response2 = new MonitoringBulkResponse();
-            response2.readFrom(streamInput);
-
+            MonitoringBulkResponse response2 = new MonitoringBulkResponse(streamInput);
             assertThat(response2.getTookInMillis(), equalTo(response.getTookInMillis()));
             if (response.getError() == null) {
                 assertThat(response2.getError(), is(nullValue()));


### PR DESCRIPTION
This commit converts all remaining ActionType response classes to
writeable in xpack core. It also converts a few from server which were
used by xpack core.

relates #34389