### PR TITLE
Convert remaining request classes in xpack core to writeable.reader (#44524)

### DIFF
--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalAction.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalAction.java
@@ -19,22 +19,17 @@
 
 package org.elasticsearch.index.rankeval;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * ActionType for explaining evaluating search ranking results.
  */
-public class RankEvalAction extends StreamableResponseActionType<RankEvalResponse> {
+public class RankEvalAction extends ActionType<RankEvalResponse> {
 
     public static final RankEvalAction INSTANCE = new RankEvalAction();
     public static final String NAME = "indices:data/read/rank_eval";
 
     private RankEvalAction() {
-        super(NAME);
-    }
-
-    @Override
-    public RankEvalResponse newResponse() {
-        return new RankEvalResponse();
+        super(NAME, RankEvalResponse::new);
     }
 }

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalResponse.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalResponse.java
@@ -61,8 +61,22 @@ public class RankEvalResponse extends ActionResponse implements ToXContentObject
         this.failures = new HashMap<>(failures);
     }
 
-    RankEvalResponse() {
-        // only used in RankEvalAction#newResponse()
+    RankEvalResponse(StreamInput in) throws IOException {
+        super(in);
+        this.metricScore = in.readDouble();
+        int partialResultSize = in.readVInt();
+        this.details = new HashMap<>(partialResultSize);
+        for (int i = 0; i < partialResultSize; i++) {
+            String queryId = in.readString();
+            EvalQueryQuality partial = new EvalQueryQuality(in);
+            this.details.put(queryId, partial);
+        }
+        int failuresSize = in.readVInt();
+        this.failures = new HashMap<>(failuresSize);
+        for (int i = 0; i < failuresSize; i++) {
+            String queryId = in.readString();
+            this.failures.put(queryId, in.readException());
+        }
     }
 
     public double getMetricScore() {
@@ -99,21 +113,7 @@ public class RankEvalResponse extends ActionResponse implements ToXContentObject
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        this.metricScore = in.readDouble();
-        int partialResultSize = in.readVInt();
-        this.details = new HashMap<>(partialResultSize);
-        for (int i = 0; i < partialResultSize; i++) {
-            String queryId = in.readString();
-            EvalQueryQuality partial = new EvalQueryQuality(in);
-            this.details.put(queryId, partial);
-        }
-        int failuresSize = in.readVInt();
-        this.failures = new HashMap<>(failuresSize);
-        for (int i = 0; i < failuresSize; i++) {
-            String queryId = in.readString();
-            this.failures.put(queryId, in.readException());
-        }
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalResponseTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalResponseTests.java
@@ -103,8 +103,7 @@ public class RankEvalResponseTests extends ESTestCase {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             randomResponse.writeTo(output);
             try (StreamInput in = output.bytes().streamInput()) {
-                RankEvalResponse deserializedResponse = new RankEvalResponse();
-                deserializedResponse.readFrom(in);
+                RankEvalResponse deserializedResponse = new RankEvalResponse(in);
                 assertEquals(randomResponse.getMetricScore(), deserializedResponse.getMetricScore(), Double.MIN_VALUE);
                 assertEquals(randomResponse.getPartialResults(), deserializedResponse.getPartialResults());
                 assertEquals(randomResponse.getFailures().keySet(), deserializedResponse.getFailures().keySet());

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/bulk/BulkShardOperationsAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/bulk/BulkShardOperationsAction.java
@@ -5,20 +5,14 @@
  */
 package org.elasticsearch.xpack.ccr.action.bulk;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class BulkShardOperationsAction extends StreamableResponseActionType<BulkShardOperationsResponse> {
+public class BulkShardOperationsAction extends ActionType<BulkShardOperationsResponse> {
 
     public static final BulkShardOperationsAction INSTANCE = new BulkShardOperationsAction();
     public static final String NAME = "indices:data/write/bulk_shard_operations[s]";
 
     private BulkShardOperationsAction() {
-        super(NAME);
+        super(NAME, BulkShardOperationsResponse::new);
     }
-
-    @Override
-    public BulkShardOperationsResponse newResponse() {
-        return new BulkShardOperationsResponse();
-    }
-
 }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/PutCcrRestoreSessionAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/PutCcrRestoreSessionAction.java
@@ -36,12 +36,7 @@ public class PutCcrRestoreSessionAction extends ActionType<PutCcrRestoreSessionA
     public static final String NAME = "internal:admin/ccr/restore/session/put";
 
     private PutCcrRestoreSessionAction() {
-        super(NAME);
-    }
-
-    @Override
-    public Writeable.Reader<PutCcrRestoreSessionAction.PutCcrRestoreSessionResponse> getResponseReader() {
-        return PutCcrRestoreSessionAction.PutCcrRestoreSessionResponse::new;
+        super(NAME, PutCcrRestoreSessionResponse::new);
     }
 
     public static class TransportPutCcrRestoreSessionAction
@@ -95,9 +90,6 @@ public class PutCcrRestoreSessionAction extends ActionType<PutCcrRestoreSessionA
         private Store.MetadataSnapshot storeFileMetaData;
         private long mappingVersion;
 
-        PutCcrRestoreSessionResponse() {
-        }
-
         PutCcrRestoreSessionResponse(DiscoveryNode node, Store.MetadataSnapshot storeFileMetaData, long mappingVersion) {
             this.node = node;
             this.storeFileMetaData = storeFileMetaData;
@@ -113,10 +105,7 @@ public class PutCcrRestoreSessionAction extends ActionType<PutCcrRestoreSessionA
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            node = new DiscoveryNode(in);
-            storeFileMetaData = new Store.MetadataSnapshot(in);
-            mappingVersion = in.readVLong();
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/DeletePrivilegesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/DeletePrivilegesRequest.java
@@ -29,6 +29,13 @@ public final class DeletePrivilegesRequest extends ActionRequest
     private String[] privileges;
     private RefreshPolicy refreshPolicy = RefreshPolicy.IMMEDIATE;
 
+    public DeletePrivilegesRequest(StreamInput in) throws IOException {
+        super(in);
+        application = in.readString();
+        privileges = in.readStringArray();
+        refreshPolicy = RefreshPolicy.readFrom(in);
+    }
+
     public DeletePrivilegesRequest() {
         this(null, Strings.EMPTY_ARRAY);
     }
@@ -84,10 +91,7 @@ public final class DeletePrivilegesRequest extends ActionRequest
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        application = in.readString();
-        privileges = in.readStringArray();
-        refreshPolicy = RefreshPolicy.readFrom(in);
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/GetBuiltinPrivilegesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/GetBuiltinPrivilegesRequest.java
@@ -7,11 +7,18 @@ package org.elasticsearch.xpack.core.security.action.privilege;
 
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
 
 /**
  * Request to retrieve built-in (cluster/index) privileges.
  */
 public final class GetBuiltinPrivilegesRequest extends ActionRequest {
+
+    public GetBuiltinPrivilegesRequest(StreamInput in) throws IOException {
+        super(in);
+    }
 
     public GetBuiltinPrivilegesRequest() {
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/GetPrivilegesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/GetPrivilegesRequest.java
@@ -27,6 +27,12 @@ public final class GetPrivilegesRequest extends ActionRequest implements Applica
     private String application;
     private String[] privileges;
 
+    public GetPrivilegesRequest(StreamInput in) throws IOException {
+        super(in);
+        application = in.readOptionalString();
+        privileges = in.readStringArray();
+    }
+
     public GetPrivilegesRequest() {
         privileges = Strings.EMPTY_ARRAY;
     }
@@ -63,9 +69,7 @@ public final class GetPrivilegesRequest extends ActionRequest implements Applica
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        application = in.readOptionalString();
-        privileges = in.readStringArray();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesRequest.java
@@ -32,6 +32,12 @@ public final class PutPrivilegesRequest extends ActionRequest implements Applica
     private List<ApplicationPrivilegeDescriptor> privileges;
     private RefreshPolicy refreshPolicy = RefreshPolicy.IMMEDIATE;
 
+    public PutPrivilegesRequest(StreamInput in) throws IOException {
+        super(in);
+        privileges = Collections.unmodifiableList(in.readList(ApplicationPrivilegeDescriptor::new));
+        refreshPolicy = RefreshPolicy.readFrom(in);
+    }
+
     public PutPrivilegesRequest() {
         privileges = Collections.emptyList();
     }
@@ -114,9 +120,7 @@ public final class PutPrivilegesRequest extends ActionRequest implements Applica
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        privileges = Collections.unmodifiableList(in.readList(ApplicationPrivilegeDescriptor::new));
-        refreshPolicy = RefreshPolicy.readFrom(in);
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/DeleteRoleRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/DeleteRoleRequest.java
@@ -23,6 +23,12 @@ public class DeleteRoleRequest extends ActionRequest implements WriteRequest<Del
     private String name;
     private RefreshPolicy refreshPolicy = RefreshPolicy.IMMEDIATE;
 
+    public DeleteRoleRequest(StreamInput in) throws IOException {
+        super(in);
+        name = in.readString();
+        refreshPolicy = RefreshPolicy.readFrom(in);
+    }
+
     public DeleteRoleRequest() {
     }
 
@@ -56,9 +62,7 @@ public class DeleteRoleRequest extends ActionRequest implements WriteRequest<Del
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        name = in.readString();
-        refreshPolicy = RefreshPolicy.readFrom(in);
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/GetRolesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/GetRolesRequest.java
@@ -22,6 +22,11 @@ public class GetRolesRequest extends ActionRequest {
 
     private String[] names = Strings.EMPTY_ARRAY;
 
+    public GetRolesRequest(StreamInput in) throws IOException {
+        super(in);
+        names = in.readStringArray();
+    }
+
     public GetRolesRequest() {
     }
 
@@ -44,8 +49,7 @@ public class GetRolesRequest extends ActionRequest {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        names = in.readStringArray();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequest.java
@@ -43,6 +43,24 @@ public class PutRoleRequest extends ActionRequest implements WriteRequest<PutRol
     private RefreshPolicy refreshPolicy = RefreshPolicy.IMMEDIATE;
     private Map<String, Object> metadata;
 
+    public PutRoleRequest(StreamInput in) throws IOException {
+        super(in);
+        name = in.readString();
+        clusterPrivileges = in.readStringArray();
+        int indicesSize = in.readVInt();
+        indicesPrivileges = new ArrayList<>(indicesSize);
+        for (int i = 0; i < indicesSize; i++) {
+            indicesPrivileges.add(new RoleDescriptor.IndicesPrivileges(in));
+        }
+        if (in.getVersion().onOrAfter(Version.V_6_4_0)) {
+            applicationPrivileges = in.readList(RoleDescriptor.ApplicationResourcePrivileges::new);
+            conditionalClusterPrivileges = ConditionalClusterPrivileges.readArray(in);
+        }
+        runAs = in.readStringArray();
+        refreshPolicy = RefreshPolicy.readFrom(in);
+        metadata = in.readMap();
+    }
+
     public PutRoleRequest() {
     }
 
@@ -160,21 +178,7 @@ public class PutRoleRequest extends ActionRequest implements WriteRequest<PutRol
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        name = in.readString();
-        clusterPrivileges = in.readStringArray();
-        int indicesSize = in.readVInt();
-        indicesPrivileges = new ArrayList<>(indicesSize);
-        for (int i = 0; i < indicesSize; i++) {
-            indicesPrivileges.add(new RoleDescriptor.IndicesPrivileges(in));
-        }
-        if (in.getVersion().onOrAfter(Version.V_6_4_0)) {
-            applicationPrivileges = in.readList(RoleDescriptor.ApplicationResourcePrivileges::new);
-            conditionalClusterPrivileges = ConditionalClusterPrivileges.readArray(in);
-        }
-        runAs = in.readStringArray();
-        refreshPolicy = RefreshPolicy.readFrom(in);
-        metadata = in.readMap();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/DeleteRoleMappingRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/DeleteRoleMappingRequest.java
@@ -23,6 +23,12 @@ public class DeleteRoleMappingRequest extends ActionRequest implements WriteRequ
     private String name;
     private RefreshPolicy refreshPolicy = RefreshPolicy.IMMEDIATE;
 
+    public DeleteRoleMappingRequest(StreamInput in) throws IOException {
+        super(in);
+        name = in.readString();
+        refreshPolicy = RefreshPolicy.readFrom(in);
+    }
+
     public DeleteRoleMappingRequest() {
     }
 
@@ -56,9 +62,7 @@ public class DeleteRoleMappingRequest extends ActionRequest implements WriteRequ
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        name = in.readString();
-        refreshPolicy = RefreshPolicy.readFrom(in);
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/GetRoleMappingsRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/GetRoleMappingsRequest.java
@@ -25,6 +25,11 @@ public class GetRoleMappingsRequest extends ActionRequest {
 
     private String[] names = Strings.EMPTY_ARRAY;
 
+    public GetRoleMappingsRequest(StreamInput in) throws IOException {
+        super(in);
+        names = in.readStringArray();
+    }
+
     public GetRoleMappingsRequest() {
     }
 
@@ -55,8 +60,7 @@ public class GetRoleMappingsRequest extends ActionRequest {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        names = in.readStringArray();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/PutRoleMappingRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/PutRoleMappingRequest.java
@@ -42,6 +42,19 @@ public class PutRoleMappingRequest extends ActionRequest
     private Map<String, Object> metadata = Collections.emptyMap();
     private RefreshPolicy refreshPolicy = RefreshPolicy.IMMEDIATE;
 
+    public PutRoleMappingRequest(StreamInput in) throws IOException {
+        super(in);
+        this.name = in.readString();
+        this.enabled = in.readBoolean();
+        this.roles = in.readStringList();
+        if (in.getVersion().onOrAfter(Version.V_7_2_0)) {
+            this.roleTemplates = in.readList(TemplateRoleName::new);
+        }
+        this.rules = ExpressionParser.readExpression(in);
+        this.metadata = in.readMap();
+        this.refreshPolicy = RefreshPolicy.readFrom(in);
+    }
+
     public PutRoleMappingRequest() {
     }
 
@@ -133,16 +146,7 @@ public class PutRoleMappingRequest extends ActionRequest
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        this.name = in.readString();
-        this.enabled = in.readBoolean();
-        this.roles = in.readStringList();
-        if (in.getVersion().onOrAfter(Version.V_7_2_0)) {
-            this.roleTemplates = in.readList(TemplateRoleName::new);
-        }
-        this.rules = ExpressionParser.readExpression(in);
-        this.metadata = in.readMap();
-        this.refreshPolicy = RefreshPolicy.readFrom(in);
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlAuthenticateRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlAuthenticateRequest.java
@@ -5,10 +5,12 @@
  */
 package org.elasticsearch.xpack.core.security.action.saml;
 
-import java.util.List;
-
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+import java.util.List;
 
 /**
  * Represents a request to authenticate using SAML assertions.
@@ -17,6 +19,10 @@ public final class SamlAuthenticateRequest extends ActionRequest {
 
     private byte[] saml;
     private List<String> validRequestIds;
+
+    public SamlAuthenticateRequest(StreamInput in) throws IOException {
+        super(in);
+    }
 
     public SamlAuthenticateRequest() {
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlInvalidateSessionRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlInvalidateSessionRequest.java
@@ -9,6 +9,9 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
@@ -24,6 +27,10 @@ public final class SamlInvalidateSessionRequest extends ActionRequest {
     private String assertionConsumerServiceURL;
 
     private String queryString;
+
+    public SamlInvalidateSessionRequest(StreamInput in) throws IOException {
+        super(in);
+    }
 
     public SamlInvalidateSessionRequest() {
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlLogoutRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlLogoutRequest.java
@@ -9,6 +9,9 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
@@ -20,6 +23,10 @@ public final class SamlLogoutRequest extends ActionRequest {
     private String token;
     @Nullable
     private String refreshToken;
+
+    public SamlLogoutRequest(StreamInput in) throws IOException {
+        super(in);
+    }
 
     public SamlLogoutRequest() {
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlPrepareAuthenticationRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlPrepareAuthenticationRequest.java
@@ -24,6 +24,12 @@ public final class SamlPrepareAuthenticationRequest extends ActionRequest {
     @Nullable
     private String assertionConsumerServiceURL;
 
+    public SamlPrepareAuthenticationRequest(StreamInput in) throws IOException {
+        super(in);
+        realmName = in.readOptionalString();
+        assertionConsumerServiceURL = in.readOptionalString();
+    }
+
     public SamlPrepareAuthenticationRequest() {
     }
 
@@ -58,9 +64,7 @@ public final class SamlPrepareAuthenticationRequest extends ActionRequest {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        realmName = in.readOptionalString();
-        assertionConsumerServiceURL = in.readOptionalString();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/token/CreateTokenRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/token/CreateTokenRequest.java
@@ -69,6 +69,21 @@ public final class CreateTokenRequest extends ActionRequest {
     private String scope;
     private String refreshToken;
 
+    public CreateTokenRequest(StreamInput in) throws IOException {
+        super(in);
+        grantType = in.readString();
+        if (in.getVersion().onOrAfter(Version.V_6_2_0)) {
+            username = in.readOptionalString();
+            password = in.readOptionalSecureString();
+            refreshToken = in.readOptionalString();
+            kerberosTicket = in.readOptionalSecureString();
+        } else {
+            username = in.readString();
+            password = in.readSecureString();
+        }
+        scope = in.readOptionalString();
+    }
+
     public CreateTokenRequest() {}
 
     public CreateTokenRequest(String grantType, @Nullable String username, @Nullable SecureString password,
@@ -234,17 +249,6 @@ public final class CreateTokenRequest extends ActionRequest {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        grantType = in.readString();
-        if (in.getVersion().onOrAfter(Version.V_6_2_0)) {
-            username = in.readOptionalString();
-            password = in.readOptionalSecureString();
-            refreshToken = in.readOptionalString();
-            kerberosTicket = in.readOptionalSecureString();
-        } else {
-            username = in.readString();
-            password = in.readSecureString();
-        }
-        scope = in.readOptionalString();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/token/InvalidateTokenRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/token/InvalidateTokenRequest.java
@@ -52,6 +52,15 @@ public final class InvalidateTokenRequest extends ActionRequest {
     private String realmName;
     private String userName;
 
+    public InvalidateTokenRequest(StreamInput in) throws IOException {
+        super(in);
+        tokenString = in.readOptionalString();
+        Integer type = in.readOptionalVInt();
+        tokenType = type == null ? null : Type.values()[type];
+        realmName = in.readOptionalString();
+        userName = in.readOptionalString();
+    }
+
     public InvalidateTokenRequest() {}
 
     /**
@@ -144,11 +153,6 @@ public final class InvalidateTokenRequest extends ActionRequest {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        tokenString = in.readOptionalString();
-        Integer type = in.readOptionalVInt();
-        tokenType = type == null ? null : Type.values()[type];
-        realmName = in.readOptionalString();
-        userName = in.readOptionalString();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/AuthenticateRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/AuthenticateRequest.java
@@ -16,6 +16,11 @@ public class AuthenticateRequest extends ActionRequest implements UserRequest {
 
     private String username;
 
+    public AuthenticateRequest(StreamInput in) throws IOException {
+        super(in);
+        username = in.readString();
+    }
+
     public AuthenticateRequest() {}
 
     public AuthenticateRequest(String username) {
@@ -43,8 +48,7 @@ public class AuthenticateRequest extends ActionRequest implements UserRequest {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        username = in.readString();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/ChangePasswordRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/ChangePasswordRequest.java
@@ -28,6 +28,15 @@ public class ChangePasswordRequest extends ActionRequest
     private char[] passwordHash;
     private RefreshPolicy refreshPolicy = RefreshPolicy.IMMEDIATE;
 
+    public ChangePasswordRequest() {}
+
+    public ChangePasswordRequest(StreamInput in) throws IOException {
+        super(in);
+        username = in.readString();
+        passwordHash = CharArrays.utf8BytesToChars(BytesReference.toBytes(in.readBytesReference()));
+        refreshPolicy = RefreshPolicy.readFrom(in);
+    }
+
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
@@ -78,10 +87,7 @@ public class ChangePasswordRequest extends ActionRequest
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        username = in.readString();
-        passwordHash = CharArrays.utf8BytesToChars(BytesReference.toBytes(in.readBytesReference()));
-        refreshPolicy = RefreshPolicy.readFrom(in);
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/DeleteUserRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/DeleteUserRequest.java
@@ -23,6 +23,12 @@ public class DeleteUserRequest extends ActionRequest implements UserRequest, Wri
     private String username;
     private RefreshPolicy refreshPolicy = RefreshPolicy.IMMEDIATE;
 
+    public DeleteUserRequest(StreamInput in) throws IOException {
+        super(in);
+        username = in.readString();
+        refreshPolicy = RefreshPolicy.readFrom(in);
+    }
+
     public DeleteUserRequest() {
     }
 
@@ -65,9 +71,7 @@ public class DeleteUserRequest extends ActionRequest implements UserRequest, Wri
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        username = in.readString();
-        refreshPolicy = RefreshPolicy.readFrom(in);
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUsersRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUsersRequest.java
@@ -22,6 +22,11 @@ public class GetUsersRequest extends ActionRequest implements UserRequest {
 
     private String[] usernames;
 
+    public GetUsersRequest(StreamInput in) throws IOException {
+        super(in);
+        usernames = in.readStringArray();
+    }
+
     public GetUsersRequest() {
         usernames = Strings.EMPTY_ARRAY;
     }
@@ -46,8 +51,7 @@ public class GetUsersRequest extends ActionRequest implements UserRequest {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        usernames = in.readStringArray();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/HasPrivilegesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/HasPrivilegesRequest.java
@@ -28,6 +28,22 @@ public class HasPrivilegesRequest extends ActionRequest implements UserRequest {
     private RoleDescriptor.IndicesPrivileges[] indexPrivileges;
     private ApplicationResourcePrivileges[] applicationPrivileges;
 
+    public HasPrivilegesRequest() {}
+
+    public HasPrivilegesRequest(StreamInput in) throws IOException {
+        super(in);
+        this.username = in.readString();
+        this.clusterPrivileges = in.readStringArray();
+        int indexSize = in.readVInt();
+        indexPrivileges = new RoleDescriptor.IndicesPrivileges[indexSize];
+        for (int i = 0; i < indexSize; i++) {
+            indexPrivileges[i] = new RoleDescriptor.IndicesPrivileges(in);
+        }
+        if (in.getVersion().onOrAfter(Version.V_6_4_0)) {
+            applicationPrivileges = in.readArray(ApplicationResourcePrivileges::new, ApplicationResourcePrivileges[]::new);
+        }
+    }
+
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
@@ -101,17 +117,7 @@ public class HasPrivilegesRequest extends ActionRequest implements UserRequest {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        this.username = in.readString();
-        this.clusterPrivileges = in.readStringArray();
-        int indexSize = in.readVInt();
-        indexPrivileges = new RoleDescriptor.IndicesPrivileges[indexSize];
-        for (int i = 0; i < indexSize; i++) {
-            indexPrivileges[i] = new RoleDescriptor.IndicesPrivileges(in);
-        }
-        if (in.getVersion().onOrAfter(Version.V_6_4_0)) {
-            applicationPrivileges = in.readArray(ApplicationResourcePrivileges::new, ApplicationResourcePrivileges[]::new);
-        }
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/PutUserRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/PutUserRequest.java
@@ -36,6 +36,18 @@ public class PutUserRequest extends ActionRequest implements UserRequest, WriteR
     private boolean enabled = true;
     private RefreshPolicy refreshPolicy = RefreshPolicy.IMMEDIATE;
 
+    public PutUserRequest(StreamInput in) throws IOException {
+        super(in);
+        username = in.readString();
+        passwordHash = readCharArrayFromStream(in);
+        roles = in.readStringArray();
+        fullName = in.readOptionalString();
+        email = in.readOptionalString();
+        metadata = in.readBoolean() ? in.readMap() : null;
+        refreshPolicy = RefreshPolicy.readFrom(in);
+        enabled = in.readBoolean();
+    }
+
     public PutUserRequest() {
     }
 
@@ -134,15 +146,7 @@ public class PutUserRequest extends ActionRequest implements UserRequest, WriteR
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        username = in.readString();
-        passwordHash = readCharArrayFromStream(in);
-        roles = in.readStringArray();
-        fullName = in.readOptionalString();
-        email = in.readOptionalString();
-        metadata = in.readBoolean() ? in.readMap() : null;
-        refreshPolicy = RefreshPolicy.readFrom(in);
-        enabled = in.readBoolean();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/SetEnabledRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/SetEnabledRequest.java
@@ -27,6 +27,15 @@ public class SetEnabledRequest extends ActionRequest implements UserRequest, Wri
     private String username;
     private RefreshPolicy refreshPolicy = RefreshPolicy.IMMEDIATE;
 
+    public SetEnabledRequest() {}
+
+    public SetEnabledRequest(StreamInput in) throws IOException {
+        super(in);
+        this.enabled = in.readBoolean();
+        this.username = in.readString();
+        this.refreshPolicy = RefreshPolicy.readFrom(in);
+    }
+
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
@@ -90,10 +99,7 @@ public class SetEnabledRequest extends ActionRequest implements UserRequest, Wri
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        this.enabled = in.readBoolean();
-        this.username = in.readString();
-        this.refreshPolicy = RefreshPolicy.readFrom(in);
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/DeletePrivilegesRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/DeletePrivilegesRequestTests.java
@@ -29,8 +29,7 @@ public class DeletePrivilegesRequestTests extends ESTestCase {
         final BytesStreamOutput output = new BytesStreamOutput();
         original.writeTo(output);
         output.flush();
-        final DeletePrivilegesRequest copy = new DeletePrivilegesRequest();
-        copy.readFrom(output.bytes().streamInput());
+        final DeletePrivilegesRequest copy = new DeletePrivilegesRequest(output.bytes().streamInput());
         assertThat(copy.application(), equalTo(original.application()));
         assertThat(copy.privileges(), equalTo(original.privileges()));
         assertThat(copy.getRefreshPolicy(), equalTo(original.getRefreshPolicy()));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/GetPrivilegesRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/GetPrivilegesRequestTests.java
@@ -29,8 +29,7 @@ public class GetPrivilegesRequestTests extends ESTestCase {
         final BytesStreamOutput out = new BytesStreamOutput();
         original.writeTo(out);
 
-        final GetPrivilegesRequest copy = new GetPrivilegesRequest();
-        copy.readFrom(out.bytes().streamInput());
+        final GetPrivilegesRequest copy = new GetPrivilegesRequest(out.bytes().streamInput());
 
         assertThat(original.application(), Matchers.equalTo(copy.application()));
         assertThat(original.privileges(), Matchers.equalTo(copy.privileges()));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesRequestTests.java
@@ -39,8 +39,7 @@ public class PutPrivilegesRequestTests extends ESTestCase {
         final BytesStreamOutput out = new BytesStreamOutput();
         original.writeTo(out);
 
-        final PutPrivilegesRequest copy = new PutPrivilegesRequest();
-        copy.readFrom(out.bytes().streamInput());
+        final PutPrivilegesRequest copy = new PutPrivilegesRequest(out.bytes().streamInput());
 
         assertThat(original.getPrivileges(), Matchers.equalTo(copy.getPrivileges()));
         assertThat(original.getRefreshPolicy(), Matchers.equalTo(copy.getRefreshPolicy()));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequestTests.java
@@ -66,11 +66,10 @@ public class PutRoleRequestTests extends ESTestCase {
         }
         original.writeTo(out);
 
-        final PutRoleRequest copy = new PutRoleRequest();
         final NamedWriteableRegistry registry = new NamedWriteableRegistry(new XPackClientPlugin(Settings.EMPTY).getNamedWriteables());
         StreamInput in = new NamedWriteableAwareStreamInput(ByteBufferStreamInput.wrap(BytesReference.toBytes(out.bytes())), registry);
         in.setVersion(out.getVersion());
-        copy.readFrom(in);
+        final PutRoleRequest copy = new PutRoleRequest(in);
 
         assertThat(copy.roleDescriptor(), equalTo(original.roleDescriptor()));
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequestTests.java
@@ -82,11 +82,10 @@ public class PutRoleRequestTests extends ESTestCase {
         out.setVersion(version);
         original.writeTo(out);
 
-        final PutRoleRequest copy = new PutRoleRequest();
         final NamedWriteableRegistry registry = new NamedWriteableRegistry(new XPackClientPlugin(Settings.EMPTY).getNamedWriteables());
         StreamInput in = new NamedWriteableAwareStreamInput(ByteBufferStreamInput.wrap(BytesReference.toBytes(out.bytes())), registry);
         in.setVersion(version);
-        copy.readFrom(in);
+        final PutRoleRequest copy = new PutRoleRequest(in);
 
         assertThat(copy.name(), equalTo(original.name()));
         assertThat(copy.cluster(), equalTo(original.cluster()));
@@ -107,10 +106,9 @@ public class PutRoleRequestTests extends ESTestCase {
         out.setVersion(version);
         original.writeTo(out);
 
-        final PutRoleRequest copy = new PutRoleRequest();
         final StreamInput in = out.bytes().streamInput();
         in.setVersion(version);
-        copy.readFrom(in);
+        final PutRoleRequest copy = new PutRoleRequest(in);
 
         assertThat(copy.name(), equalTo(original.name()));
         assertThat(copy.cluster(), equalTo(original.cluster()));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/token/CreateTokenRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/token/CreateTokenRequestTests.java
@@ -126,8 +126,7 @@ public class CreateTokenRequestTests extends ESTestCase {
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             request.writeTo(out);
             try (StreamInput in = out.bytes().streamInput()) {
-                final CreateTokenRequest serialized = new CreateTokenRequest();
-                serialized.readFrom(in);
+                final CreateTokenRequest serialized = new CreateTokenRequest(in);
                 assertEquals(grantType, serialized.getGrantType());
                 if (scope != null) {
                     assertEquals(scope, serialized.getScope());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/user/HasPrivilegesRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/user/HasPrivilegesRequestTests.java
@@ -86,10 +86,10 @@ public class HasPrivilegesRequestTests extends ESTestCase {
         out.setVersion(version);
         original.writeTo(out);
 
-        final HasPrivilegesRequest copy = new HasPrivilegesRequest();
+
         final StreamInput in = out.bytes().streamInput();
         in.setVersion(version);
-        copy.readFrom(in);
+        final HasPrivilegesRequest copy = new HasPrivilegesRequest(in);
         assertThat(in.read(), equalTo(-1));
         return copy;
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportDeletePrivilegesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportDeletePrivilegesAction.java
@@ -30,7 +30,7 @@ public class TransportDeletePrivilegesAction extends HandledTransportAction<Dele
     @Inject
     public TransportDeletePrivilegesAction(ActionFilters actionFilters, NativePrivilegeStore privilegeStore,
                                            TransportService transportService) {
-        super(DeletePrivilegesAction.NAME, transportService, DeletePrivilegesRequest::new, actionFilters);
+        super(DeletePrivilegesAction.NAME, transportService, actionFilters, DeletePrivilegesRequest::new);
         this.privilegeStore = privilegeStore;
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportGetBuiltinPrivilegesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportGetBuiltinPrivilegesAction.java
@@ -26,7 +26,7 @@ public class TransportGetBuiltinPrivilegesAction extends HandledTransportAction<
 
     @Inject
     public TransportGetBuiltinPrivilegesAction(ActionFilters actionFilters, TransportService transportService) {
-        super(GetBuiltinPrivilegesAction.NAME, transportService, GetBuiltinPrivilegesRequest::new, actionFilters);
+        super(GetBuiltinPrivilegesAction.NAME, transportService, actionFilters, GetBuiltinPrivilegesRequest::new);
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportGetPrivilegesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportGetPrivilegesAction.java
@@ -34,7 +34,7 @@ public class TransportGetPrivilegesAction extends HandledTransportAction<GetPriv
     @Inject
     public TransportGetPrivilegesAction(ActionFilters actionFilters, NativePrivilegeStore privilegeStore,
                                         TransportService transportService) {
-        super(GetPrivilegesAction.NAME, transportService, GetPrivilegesRequest::new, actionFilters);
+        super(GetPrivilegesAction.NAME, transportService, actionFilters, GetPrivilegesRequest::new);
         this.privilegeStore = privilegeStore;
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportPutPrivilegesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportPutPrivilegesAction.java
@@ -28,7 +28,7 @@ public class TransportPutPrivilegesAction extends HandledTransportAction<PutPriv
     @Inject
     public TransportPutPrivilegesAction(ActionFilters actionFilters, NativePrivilegeStore privilegeStore,
                                         TransportService transportService) {
-        super(PutPrivilegesAction.NAME, transportService, PutPrivilegesRequest::new, actionFilters);
+        super(PutPrivilegesAction.NAME, transportService, actionFilters, PutPrivilegesRequest::new);
         this.privilegeStore = privilegeStore;
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportDeleteRoleAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportDeleteRoleAction.java
@@ -25,7 +25,7 @@ public class TransportDeleteRoleAction extends HandledTransportAction<DeleteRole
 
     @Inject
     public TransportDeleteRoleAction(ActionFilters actionFilters, NativeRolesStore rolesStore, TransportService transportService) {
-        super(DeleteRoleAction.NAME, transportService, DeleteRoleRequest::new, actionFilters);
+        super(DeleteRoleAction.NAME, transportService, actionFilters, DeleteRoleRequest::new);
         this.rolesStore = rolesStore;
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportGetRolesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportGetRolesAction.java
@@ -31,7 +31,7 @@ public class TransportGetRolesAction extends HandledTransportAction<GetRolesRequ
     @Inject
     public TransportGetRolesAction(ActionFilters actionFilters, NativeRolesStore nativeRolesStore, TransportService transportService,
                                    ReservedRolesStore reservedRolesStore) {
-        super(GetRolesAction.NAME, transportService, GetRolesRequest::new, actionFilters);
+        super(GetRolesAction.NAME, transportService, actionFilters, GetRolesRequest::new);
         this.nativeRolesStore = nativeRolesStore;
         this.reservedRolesStore = reservedRolesStore;
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportPutRoleAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportPutRoleAction.java
@@ -23,7 +23,7 @@ public class TransportPutRoleAction extends HandledTransportAction<PutRoleReques
 
     @Inject
     public TransportPutRoleAction(ActionFilters actionFilters, NativeRolesStore rolesStore, TransportService transportService) {
-        super(PutRoleAction.NAME, transportService, PutRoleRequest::new, actionFilters);
+        super(PutRoleAction.NAME, transportService, actionFilters, PutRoleRequest::new);
         this.rolesStore = rolesStore;
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportDeleteRoleMappingAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportDeleteRoleMappingAction.java
@@ -24,7 +24,7 @@ public class TransportDeleteRoleMappingAction
     @Inject
     public TransportDeleteRoleMappingAction(ActionFilters actionFilters, TransportService transportService,
                                             NativeRoleMappingStore roleMappingStore) {
-        super(DeleteRoleMappingAction.NAME, transportService, DeleteRoleMappingRequest::new, actionFilters);
+        super(DeleteRoleMappingAction.NAME, transportService, actionFilters, DeleteRoleMappingRequest::new);
         this.roleMappingStore = roleMappingStore;
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportGetRoleMappingsAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportGetRoleMappingsAction.java
@@ -29,7 +29,7 @@ public class TransportGetRoleMappingsAction
     @Inject
     public TransportGetRoleMappingsAction(ActionFilters actionFilters, TransportService transportService,
                                           NativeRoleMappingStore nativeRoleMappingStore) {
-        super(GetRoleMappingsAction.NAME, transportService, GetRoleMappingsRequest::new, actionFilters);
+        super(GetRoleMappingsAction.NAME, transportService, actionFilters, GetRoleMappingsRequest::new);
         this.roleMappingStore = nativeRoleMappingStore;
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportPutRoleMappingAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportPutRoleMappingAction.java
@@ -24,7 +24,7 @@ public class TransportPutRoleMappingAction
     @Inject
     public TransportPutRoleMappingAction(ActionFilters actionFilters, TransportService transportService,
                                          NativeRoleMappingStore roleMappingStore) {
-        super(PutRoleMappingAction.NAME, transportService, PutRoleMappingRequest::new, actionFilters);
+        super(PutRoleMappingAction.NAME, transportService, actionFilters, PutRoleMappingRequest::new);
         this.roleMappingStore = roleMappingStore;
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlAuthenticateAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlAuthenticateAction.java
@@ -40,7 +40,7 @@ public final class TransportSamlAuthenticateAction extends HandledTransportActio
     public TransportSamlAuthenticateAction(ThreadPool threadPool, TransportService transportService,
                                            ActionFilters actionFilters, AuthenticationService authenticationService,
                                            TokenService tokenService) {
-        super(SamlAuthenticateAction.NAME, transportService, SamlAuthenticateRequest::new, actionFilters);
+        super(SamlAuthenticateAction.NAME, transportService, actionFilters, SamlAuthenticateRequest::new);
         this.threadPool = threadPool;
         this.authenticationService = authenticationService;
         this.tokenService = tokenService;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionAction.java
@@ -47,7 +47,7 @@ public final class TransportSamlInvalidateSessionAction
     @Inject
     public TransportSamlInvalidateSessionAction(TransportService transportService, ActionFilters actionFilters, TokenService tokenService,
                                                 Realms realms) {
-        super(SamlInvalidateSessionAction.NAME, transportService, SamlInvalidateSessionRequest::new, actionFilters);
+        super(SamlInvalidateSessionAction.NAME, transportService, actionFilters, SamlInvalidateSessionRequest::new);
         this.tokenService = tokenService;
         this.realms = realms;
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutAction.java
@@ -42,7 +42,7 @@ public final class TransportSamlLogoutAction
     @Inject
     public TransportSamlLogoutAction(TransportService transportService, ActionFilters actionFilters, Realms realms,
                                      TokenService tokenService) {
-        super(SamlLogoutAction.NAME, transportService, SamlLogoutRequest::new, actionFilters);
+        super(SamlLogoutAction.NAME, transportService, actionFilters, SamlLogoutRequest::new);
         this.realms = realms;
         this.tokenService = tokenService;
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlPrepareAuthenticationAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlPrepareAuthenticationAction.java
@@ -35,7 +35,7 @@ public final class TransportSamlPrepareAuthenticationAction
 
     @Inject
     public TransportSamlPrepareAuthenticationAction(TransportService transportService, ActionFilters actionFilters, Realms realms) {
-        super(SamlPrepareAuthenticationAction.NAME, transportService, SamlPrepareAuthenticationRequest::new, actionFilters
+        super(SamlPrepareAuthenticationAction.NAME, transportService, actionFilters, SamlPrepareAuthenticationRequest::new
         );
         this.realms = realms;
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenAction.java
@@ -45,7 +45,7 @@ public final class TransportCreateTokenAction extends HandledTransportAction<Cre
     @Inject
     public TransportCreateTokenAction(ThreadPool threadPool, TransportService transportService, ActionFilters actionFilters,
                                       TokenService tokenService, AuthenticationService authenticationService) {
-        super(CreateTokenAction.NAME, transportService, CreateTokenRequest::new, actionFilters);
+        super(CreateTokenAction.NAME, transportService, actionFilters, CreateTokenRequest::new);
         this.threadPool = threadPool;
         this.tokenService = tokenService;
         this.authenticationService = authenticationService;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportInvalidateTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportInvalidateTokenAction.java
@@ -27,7 +27,7 @@ public final class TransportInvalidateTokenAction extends HandledTransportAction
 
     @Inject
     public TransportInvalidateTokenAction(TransportService transportService, ActionFilters actionFilters, TokenService tokenService) {
-        super(InvalidateTokenAction.NAME, transportService, InvalidateTokenRequest::new, actionFilters);
+        super(InvalidateTokenAction.NAME, transportService, actionFilters, InvalidateTokenRequest::new);
         this.tokenService = tokenService;
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportRefreshTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportRefreshTokenAction.java
@@ -24,7 +24,7 @@ public class TransportRefreshTokenAction extends HandledTransportAction<CreateTo
 
     @Inject
     public TransportRefreshTokenAction(TransportService transportService, ActionFilters actionFilters, TokenService tokenService) {
-        super(RefreshTokenAction.NAME, transportService, CreateTokenRequest::new, actionFilters);
+        super(RefreshTokenAction.NAME, transportService, actionFilters, CreateTokenRequest::new);
         this.tokenService = tokenService;
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportAuthenticateAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportAuthenticateAction.java
@@ -27,7 +27,7 @@ public class TransportAuthenticateAction extends HandledTransportAction<Authenti
 
     @Inject
     public TransportAuthenticateAction(TransportService transportService, ActionFilters actionFilters, SecurityContext securityContext) {
-        super(AuthenticateAction.NAME, transportService, AuthenticateRequest::new, actionFilters);
+        super(AuthenticateAction.NAME, transportService, actionFilters, AuthenticateRequest::new);
         this.securityContext = securityContext;
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportChangePasswordAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportChangePasswordAction.java
@@ -30,7 +30,7 @@ public class TransportChangePasswordAction extends HandledTransportAction<Change
     @Inject
     public TransportChangePasswordAction(Settings settings, TransportService transportService,
                                          ActionFilters actionFilters, NativeUsersStore nativeUsersStore) {
-        super(ChangePasswordAction.NAME, transportService, ChangePasswordRequest::new, actionFilters);
+        super(ChangePasswordAction.NAME, transportService, actionFilters, ChangePasswordRequest::new);
         this.settings = settings;
         this.nativeUsersStore = nativeUsersStore;
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportDeleteUserAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportDeleteUserAction.java
@@ -29,7 +29,7 @@ public class TransportDeleteUserAction extends HandledTransportAction<DeleteUser
     @Inject
     public TransportDeleteUserAction(Settings settings, ActionFilters actionFilters,
                                      NativeUsersStore usersStore, TransportService transportService) {
-        super(DeleteUserAction.NAME, transportService, DeleteUserRequest::new, actionFilters);
+        super(DeleteUserAction.NAME, transportService, actionFilters, DeleteUserRequest::new);
         this.settings = settings;
         this.usersStore = usersStore;
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportGetUsersAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportGetUsersAction.java
@@ -39,7 +39,7 @@ public class TransportGetUsersAction extends HandledTransportAction<GetUsersRequ
     @Inject
     public TransportGetUsersAction(Settings settings, ActionFilters actionFilters,
                                    NativeUsersStore usersStore, TransportService transportService, ReservedRealm reservedRealm) {
-        super(GetUsersAction.NAME, transportService, GetUsersRequest::new, actionFilters);
+        super(GetUsersAction.NAME, transportService, actionFilters, GetUsersRequest::new);
         this.settings = settings;
         this.usersStore = usersStore;
         this.reservedRealm = reservedRealm;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportHasPrivilegesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportHasPrivilegesAction.java
@@ -41,7 +41,7 @@ public class TransportHasPrivilegesAction extends HandledTransportAction<HasPriv
     public TransportHasPrivilegesAction(ThreadPool threadPool, TransportService transportService,
                                         ActionFilters actionFilters, AuthorizationService authorizationService,
                                         NativePrivilegeStore privilegeStore) {
-        super(HasPrivilegesAction.NAME, transportService, HasPrivilegesRequest::new, actionFilters);
+        super(HasPrivilegesAction.NAME, transportService, actionFilters, HasPrivilegesRequest::new);
         this.threadPool = threadPool;
         this.authorizationService = authorizationService;
         this.privilegeStore = privilegeStore;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportPutUserAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportPutUserAction.java
@@ -36,7 +36,7 @@ public class TransportPutUserAction extends HandledTransportAction<PutUserReques
     @Inject
     public TransportPutUserAction(Settings settings, ActionFilters actionFilters,
                                   NativeUsersStore usersStore, TransportService transportService) {
-        super(PutUserAction.NAME, transportService, PutUserRequest::new, actionFilters);
+        super(PutUserAction.NAME, transportService, actionFilters, PutUserRequest::new);
         this.settings = settings;
         this.usersStore = usersStore;
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportSetEnabledAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportSetEnabledAction.java
@@ -34,7 +34,7 @@ public class TransportSetEnabledAction extends HandledTransportAction<SetEnabled
     @Inject
     public TransportSetEnabledAction(Settings settings, ThreadPool threadPool, TransportService transportService,
                                      ActionFilters actionFilters, NativeUsersStore usersStore) {
-        super(SetEnabledAction.NAME, transportService, SetEnabledRequest::new, actionFilters);
+        super(SetEnabledAction.NAME, transportService, actionFilters, SetEnabledRequest::new);
         this.settings = settings;
         this.threadPool = threadPool;
         this.usersStore = usersStore;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/SamlPrepareAuthenticationRequestTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/SamlPrepareAuthenticationRequestTests.java
@@ -5,12 +5,12 @@
  */
 package org.elasticsearch.xpack.security.action.saml;
 
-import java.io.IOException;
-
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.xpack.core.security.action.saml.SamlPrepareAuthenticationRequest;
 import org.elasticsearch.xpack.security.authc.saml.SamlTestCase;
 import org.hamcrest.Matchers;
+
+import java.io.IOException;
 
 public class SamlPrepareAuthenticationRequestTests extends SamlTestCase {
 
@@ -32,8 +32,7 @@ public class SamlPrepareAuthenticationRequestTests extends SamlTestCase {
         final BytesStreamOutput out = new BytesStreamOutput();
         req1.writeTo(out);
 
-        final SamlPrepareAuthenticationRequest req2 = new SamlPrepareAuthenticationRequest();
-        req2.readFrom(out.bytes().streamInput());
+        final SamlPrepareAuthenticationRequest req2 = new SamlPrepareAuthenticationRequest(out.bytes().streamInput());
 
         assertThat(req2.getRealmName(), Matchers.equalTo(req1.getRealmName()));
         assertThat(req2.getAssertionConsumerServiceURL(), Matchers.equalTo(req1.getAssertionConsumerServiceURL()));

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlClearCursorAction.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlClearCursorAction.java
@@ -5,19 +5,14 @@
  */
 package org.elasticsearch.xpack.sql.action;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class SqlClearCursorAction extends StreamableResponseActionType<SqlClearCursorResponse> {
+public class SqlClearCursorAction extends ActionType<SqlClearCursorResponse> {
 
     public static final SqlClearCursorAction INSTANCE = new SqlClearCursorAction();
     public static final String NAME = "indices:data/read/sql/close_cursor";
 
     private SqlClearCursorAction() {
-        super(NAME);
-    }
-
-    @Override
-    public SqlClearCursorResponse newResponse() {
-        return new SqlClearCursorResponse();
+        super(NAME, SqlClearCursorResponse::new);
     }
 }

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlClearCursorResponse.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlClearCursorResponse.java
@@ -30,7 +30,9 @@ public class SqlClearCursorResponse extends ActionResponse implements StatusToXC
         this.succeeded = succeeded;
     }
 
-    SqlClearCursorResponse() {
+    SqlClearCursorResponse(StreamInput in) throws IOException {
+        super(in);
+        succeeded = in.readBoolean();
     }
 
     /**
@@ -60,8 +62,7 @@ public class SqlClearCursorResponse extends ActionResponse implements StatusToXC
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        succeeded = in.readBoolean();
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlQueryAction.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlQueryAction.java
@@ -5,19 +5,14 @@
  */
 package org.elasticsearch.xpack.sql.action;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class SqlQueryAction extends StreamableResponseActionType<SqlQueryResponse> {
+public class SqlQueryAction extends ActionType<SqlQueryResponse> {
 
     public static final SqlQueryAction INSTANCE = new SqlQueryAction();
     public static final String NAME = "indices:data/read/sql";
 
     private SqlQueryAction() {
-        super(NAME);
-    }
-
-    @Override
-    public SqlQueryResponse newResponse() {
-        return new SqlQueryResponse();
+        super(NAME, SqlQueryResponse::new);
     }
 }

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlQueryResponse.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlQueryResponse.java
@@ -40,7 +40,34 @@ public class SqlQueryResponse extends ActionResponse implements ToXContentObject
     private List<List<Object>> rows;
     private static final String INTERVAL_CLASS_NAME = "Interval";
 
-    public SqlQueryResponse() {
+    public SqlQueryResponse(StreamInput in) throws IOException {
+        super(in);
+        cursor = in.readString();
+        if (in.readBoolean()) {
+            // We might have rows without columns and we might have columns without rows
+            // So we send the column size twice, just to keep the protocol simple
+            int columnCount = in.readVInt();
+            List<ColumnInfo> columns = new ArrayList<>(columnCount);
+            for (int c = 0; c < columnCount; c++) {
+                columns.add(readColumnInfo(in));
+            }
+            this.columns = unmodifiableList(columns);
+        } else {
+            this.columns = null;
+        }
+        int rowCount = in.readVInt();
+        List<List<Object>> rows = new ArrayList<>(rowCount);
+        if (rowCount > 0) {
+            int columnCount = in.readVInt();
+            for (int r = 0; r < rowCount; r++) {
+                List<Object> row = new ArrayList<>(columnCount);
+                for (int c = 0; c < columnCount; c++) {
+                    row.add(in.readGenericValue());
+                }
+                rows.add(unmodifiableList(row));
+            }
+        }
+        this.rows = unmodifiableList(rows);
     }
 
     public SqlQueryResponse(String cursor, Mode mode, boolean columnar, @Nullable List<ColumnInfo> columns, List<List<Object>> rows) {
@@ -92,32 +119,7 @@ public class SqlQueryResponse extends ActionResponse implements ToXContentObject
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        cursor = in.readString();
-        if (in.readBoolean()) {
-            // We might have rows without columns and we might have columns without rows
-            // So we send the column size twice, just to keep the protocol simple
-            int columnCount = in.readVInt();
-            List<ColumnInfo> columns = new ArrayList<>(columnCount);
-            for (int c = 0; c < columnCount; c++) {
-                columns.add(readColumnInfo(in));
-            }
-            this.columns = unmodifiableList(columns);
-        } else {
-            this.columns = null;
-        }
-        int rowCount = in.readVInt();
-        List<List<Object>> rows = new ArrayList<>(rowCount);
-        if (rowCount > 0) {
-            int columnCount = in.readVInt();
-            for (int r = 0; r < rowCount; r++) {
-                List<Object> row = new ArrayList<>(columnCount);
-                for (int c = 0; c < columnCount; c++) {
-                    row.add(in.readGenericValue());
-                }
-                rows.add(unmodifiableList(row));
-            }
-        }
-        this.rows = unmodifiableList(rows);
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlTranslateAction.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlTranslateAction.java
@@ -5,22 +5,17 @@
  */
 package org.elasticsearch.xpack.sql.action;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
 /**
  * Sql action for translating SQL queries into ES requests
  */
-public class SqlTranslateAction extends StreamableResponseActionType<SqlTranslateResponse> {
+public class SqlTranslateAction extends ActionType<SqlTranslateResponse> {
 
     public static final SqlTranslateAction INSTANCE = new SqlTranslateAction();
     public static final String NAME = "indices:data/read/sql/translate";
 
     private SqlTranslateAction() {
-        super(NAME);
-    }
-
-    @Override
-    public SqlTranslateResponse newResponse() {
-        return new SqlTranslateResponse();
+        super(NAME, SqlTranslateResponse::new);
     }
 }

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlTranslateResponse.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlTranslateResponse.java
@@ -21,7 +21,9 @@ import java.util.Objects;
 public class SqlTranslateResponse extends ActionResponse implements ToXContentObject {
     private SearchSourceBuilder source;
 
-    public SqlTranslateResponse() {
+    public SqlTranslateResponse(StreamInput in) throws IOException {
+        super(in);
+        source = new SearchSourceBuilder(in);
     }
 
     public SqlTranslateResponse(SearchSourceBuilder source) {
@@ -34,7 +36,7 @@ public class SqlTranslateResponse extends ActionResponse implements ToXContentOb
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        source = new SearchSourceBuilder(in);
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlClearCursorResponseTests.java
+++ b/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlClearCursorResponseTests.java
@@ -5,10 +5,11 @@
  */
 package org.elasticsearch.xpack.sql.action;
 
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 
-public class SqlClearCursorResponseTests extends AbstractStreamableXContentTestCase<SqlClearCursorResponse> {
+public class SqlClearCursorResponseTests extends AbstractSerializingTestCase<SqlClearCursorResponse> {
 
     @Override
     protected SqlClearCursorResponse createTestInstance() {
@@ -16,8 +17,8 @@ public class SqlClearCursorResponseTests extends AbstractStreamableXContentTestC
     }
 
     @Override
-    protected SqlClearCursorResponse createBlankInstance() {
-        return new SqlClearCursorResponse();
+    protected Writeable.Reader<SqlClearCursorResponse> instanceReader() {
+        return SqlClearCursorResponse::new;
     }
 
     @Override

--- a/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlQueryResponseTests.java
+++ b/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlQueryResponseTests.java
@@ -7,11 +7,12 @@ package org.elasticsearch.xpack.sql.action;
 
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.test.AbstractStreamableXContentTestCase;
+import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.proto.ColumnInfo;
 import org.elasticsearch.xpack.sql.proto.Mode;
@@ -25,10 +26,10 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.common.xcontent.ToXContent.EMPTY_PARAMS;
-import static org.hamcrest.Matchers.hasSize;
 import static org.elasticsearch.xpack.sql.action.AbstractSqlQueryRequest.CURSOR;
+import static org.hamcrest.Matchers.hasSize;
 
-public class SqlQueryResponseTests extends AbstractStreamableXContentTestCase<SqlQueryResponse> {
+public class SqlQueryResponseTests extends AbstractSerializingTestCase<SqlQueryResponse> {
 
     static String randomStringCursor() {
         return randomBoolean() ? "" : randomAlphaOfLength(10);
@@ -37,6 +38,11 @@ public class SqlQueryResponseTests extends AbstractStreamableXContentTestCase<Sq
     @Override
     protected SqlQueryResponse createTestInstance() {
         return createRandomInstance(randomStringCursor(), randomFrom(Mode.values()), randomBoolean());
+    }
+
+    @Override
+    protected Writeable.Reader<SqlQueryResponse> instanceReader() {
+        return SqlQueryResponse::new;
     }
 
     public static SqlQueryResponse createRandomInstance(String cursor, Mode mode, boolean columnar) {
@@ -76,11 +82,6 @@ public class SqlQueryResponseTests extends AbstractStreamableXContentTestCase<Sq
             }
         }
         return new SqlQueryResponse(cursor, mode, false, columns, rows);
-    }
-
-    @Override
-    protected SqlQueryResponse createBlankInstance() {
-        return new SqlQueryResponse();
     }
 
     public void testToXContent() throws IOException {

--- a/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlTranslateResponseTests.java
+++ b/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlTranslateResponseTests.java
@@ -5,13 +5,13 @@
  */
 package org.elasticsearch.xpack.sql.action;
 
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.elasticsearch.test.AbstractStreamableTestCase;
-import org.elasticsearch.xpack.sql.action.SqlTranslateResponse;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.io.IOException;
 
-public class SqlTranslateResponseTests extends AbstractStreamableTestCase<SqlTranslateResponse> {
+public class SqlTranslateResponseTests extends AbstractWireSerializingTestCase<SqlTranslateResponse> {
 
     @Override
     protected SqlTranslateResponse createTestInstance() {
@@ -36,8 +36,8 @@ public class SqlTranslateResponseTests extends AbstractStreamableTestCase<SqlTra
     }
 
     @Override
-    protected SqlTranslateResponse createBlankInstance() {
-        return new SqlTranslateResponse();
+    protected Writeable.Reader<SqlTranslateResponse> instanceReader() {
+        return SqlTranslateResponse::new;
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlClearCursorAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlClearCursorAction.java
@@ -9,7 +9,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.sql.action.SqlClearCursorRequest;
@@ -31,7 +30,7 @@ public class TransportSqlClearCursorAction extends HandledTransportAction<SqlCle
     @Inject
     public TransportSqlClearCursorAction(TransportService transportService, ActionFilters actionFilters, PlanExecutor planExecutor,
                                          SqlLicenseChecker sqlLicenseChecker) {
-        super(NAME, transportService, actionFilters, (Writeable.Reader<SqlClearCursorRequest>) SqlClearCursorRequest::new);
+        super(NAME, transportService, actionFilters, SqlClearCursorRequest::new);
         this.planExecutor = planExecutor;
         this.sqlLicenseChecker = sqlLicenseChecker;
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlQueryAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlQueryAction.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -49,7 +48,7 @@ public class TransportSqlQueryAction extends HandledTransportAction<SqlQueryRequ
     public TransportSqlQueryAction(Settings settings, ClusterService clusterService, TransportService transportService,
                                    ThreadPool threadPool, ActionFilters actionFilters, PlanExecutor planExecutor,
                                    SqlLicenseChecker sqlLicenseChecker) {
-        super(SqlQueryAction.NAME, transportService, actionFilters, (Writeable.Reader<SqlQueryRequest>) SqlQueryRequest::new);
+        super(SqlQueryAction.NAME, transportService, actionFilters, SqlQueryRequest::new);
 
         this.securityContext = XPackSettings.SECURITY_ENABLED.get(settings) ?
                 new SecurityContext(settings, threadPool.getThreadContext()) : null;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlTranslateAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlTranslateAction.java
@@ -10,7 +10,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -40,7 +39,7 @@ public class TransportSqlTranslateAction extends HandledTransportAction<SqlTrans
     public TransportSqlTranslateAction(Settings settings, ClusterService clusterService, TransportService transportService,
                                        ThreadPool threadPool, ActionFilters actionFilters, PlanExecutor planExecutor,
                                        SqlLicenseChecker sqlLicenseChecker) {
-        super(SqlTranslateAction.NAME, transportService, actionFilters, (Writeable.Reader<SqlTranslateRequest>) SqlTranslateRequest::new);
+        super(SqlTranslateAction.NAME, transportService, actionFilters, SqlTranslateRequest::new);
 
         this.securityContext = XPackSettings.SECURITY_ENABLED.get(settings) ?
                 new SecurityContext(settings, threadPool.getThreadContext()) : null;


### PR DESCRIPTION
This commit converts all remaining classes extending ActionRequest
in xpack core to have a StreamInput constructor.

relates #34389