### PR TITLE
Skip update if leader and follower settings identical

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
@@ -185,6 +185,10 @@ public class ShardFollowTasksExecutor extends PersistentTasksExecutor<ShardFollo
                             }
                             return existingSettings.get(s) == null || existingSettings.get(s).equals(settings.get(s)) == false;
                         });
+                        if (updatedSettings.isEmpty()) {
+                            finalHandler.accept(leaderIMD.getSettingsVersion());
+                            return;
+                        }
                         // Figure out whether the updated settings are all dynamic settings and
                         // if so just update the follower index's settings:
                         if (updatedSettings.keySet().stream().allMatch(indexScopedSettings::isDynamicSetting)) {


### PR DESCRIPTION
If the setting on the follower and the leader are identical after filtering out private and internal settings, then we should not call update setting (on the follower) as there's nothing to change. Moreover, this makes the ShardFollowTask abort as it considers ActionRequestValidationException (caused by an empty update setting request) as a fatal error.

Closes #44521
