### PR TITLE
Wait for pending tasks in TransportSearchFailuresIT

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/basic/TransportSearchFailuresIT.java
+++ b/server/src/test/java/org/elasticsearch/search/basic/TransportSearchFailuresIT.java
@@ -86,7 +86,7 @@ public class TransportSearchFailuresIT extends ESIntegTestCase {
         ClusterHealthResponse clusterHealth = client()
                 .admin()
                 .cluster()
-                .health(clusterHealthRequest("test").waitForYellowStatus().waitForNoRelocatingShards(true)
+                .health(clusterHealthRequest("test").waitForYellowStatus().waitForNoRelocatingShards(true).waitForEvents(Priority.LANGUID)
                         .waitForActiveShards(test.totalNumShards)).actionGet();
         logger.info("Done Cluster Health, status {}", clusterHealth.getStatus());
         assertThat(clusterHealth.isTimedOut(), equalTo(false));


### PR DESCRIPTION
The change in #44433 introduces a state in which the cluster has no relocating
shards but still has a pending reroute task which might start a shard
relocation. `TransportSearchFailuresIT` failed on a PR build seemingly because
it did not wait for this pending task to complete too, reporting more active shards
than expected:

    2> java.lang.AssertionError:
      Expected: <9>
           but: was <10>
          at __randomizedtesting.SeedInfo.seed([4057CA4301FE95FA:207EC88573747235]:0)
          at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
          at org.junit.Assert.assertThat(Assert.java:956)
          at org.junit.Assert.assertThat(Assert.java:923)
          at org.elasticsearch.search.basic.TransportSearchFailuresIT.testFailedSearchWithWrongQuery(TransportSearchFailuresIT.java:97)

This commit addresses this failure by waiting until there are neither pending
tasks nor shard relocations in progress.