### PR TITLE
Add default CLI JVM options

### DIFF
--- a/distribution/src/bin/elasticsearch-cli
+++ b/distribution/src/bin/elasticsearch-cli
@@ -16,6 +16,10 @@ do
   ES_CLASSPATH="$ES_CLASSPATH:$ES_HOME/$additional_classpath_directory/*"
 done
 
+# use a small heap size for the CLI tools, and thus the serial collector to
+# avoid stealing many CPU cycles; a user can override by setting ES_JAVA_OPTS
+ES_JAVA_OPTS="-Xms4m -Xmx64m -XX:+UseSerialGC ${ES_JAVA_OPTS}"
+
 exec \
   "$JAVA" \
   $ES_JAVA_OPTS \

--- a/distribution/src/bin/elasticsearch-cli.bat
+++ b/distribution/src/bin/elasticsearch-cli.bat
@@ -12,6 +12,10 @@ if defined ES_ADDITIONAL_CLASSPATH_DIRECTORIES (
   )
 )
 
+rem use a small heap size for the CLI tools, and thus the serial collector to
+rem avoid stealing many CPU cycles; a user can override by setting ES_JAVA_OPTS
+set ES_JAVA_OPTS=-Xms4m -Xmx64m -XX:+UseSerialGC %ES_JAVA_OPTS%
+
 %JAVA% ^
   %ES_JAVA_OPTS% ^
   -Des.path.home="%ES_HOME%" ^


### PR DESCRIPTION
This commit adds some default CLI JVM options to control the heap size and the garbage collector used for the CLI tools. We do this because otherwise the JVM will default to large initial and max heap sizes based on the RAM visible to the JVM (which could be all the physical RAM on the machine if not run in a container-aware JVM). This commit therefore sets the initial heap size to 4m, the max heap size to 64m, the garbage collector to the serial collector, and leaves this user-configurable by honoring ES_JAVA_OPTS last.

Closes #42021
Relates elastic/elasticsearch-docker#219