### PR TITLE
Backport: Add stream serialization to ReloadAnalyzersResponse (#44420)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/ReloadAnalyzersResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/ReloadAnalyzersResponse.java
@@ -8,6 +8,9 @@ package org.elasticsearch.xpack.core.action;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -15,12 +18,12 @@ import org.elasticsearch.xpack.core.action.TransportReloadAnalyzersAction.Reload
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
@@ -31,14 +34,14 @@ import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constru
 public class ReloadAnalyzersResponse extends BroadcastResponse  {
 
     private final Map<String, ReloadDetails> reloadDetails;
+
     private static final ParseField RELOAD_DETAILS_FIELD = new ParseField("reload_details");
     private static final ParseField INDEX_FIELD = new ParseField("index");
     private static final ParseField RELOADED_ANALYZERS_FIELD = new ParseField("reloaded_analyzers");
     private static final ParseField RELOADED_NODE_IDS_FIELD = new ParseField("reloaded_node_ids");
 
-
     public ReloadAnalyzersResponse() {
-        reloadDetails = Collections.emptyMap();
+        reloadDetails = new HashMap<>();
     }
 
     public ReloadAnalyzersResponse(int totalShards, int successfulShards, int failedShards,
@@ -99,7 +102,36 @@ public class ReloadAnalyzersResponse extends BroadcastResponse  {
         return PARSER.apply(parser, null);
     }
 
-    public static class ReloadDetails {
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeMap(reloadDetails, StreamOutput::writeString, (stream, details) -> details.writeTo(stream));
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        this.reloadDetails.putAll(in.readMap(StreamInput::readString, ReloadDetails::new));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ReloadAnalyzersResponse that = (ReloadAnalyzersResponse) o;
+        return Objects.equals(reloadDetails, that.reloadDetails);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(reloadDetails);
+    }
+
+    public static class ReloadDetails implements Writeable {
 
         private final String indexName;
         private final Set<String> reloadedIndicesNodes;
@@ -109,6 +141,19 @@ public class ReloadAnalyzersResponse extends BroadcastResponse  {
             this.indexName = name;
             this.reloadedIndicesNodes = reloadedIndicesNodes;
             this.reloadedAnalyzers = reloadedAnalyzers;
+        }
+
+        ReloadDetails(StreamInput in) throws IOException {
+            this.indexName = in.readString();
+            this.reloadedIndicesNodes = new HashSet<>(in.readList(StreamInput::readString));
+            this.reloadedAnalyzers = new HashSet<>(in.readList(StreamInput::readString));
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(indexName);
+            out.writeStringCollection(reloadedIndicesNodes);
+            out.writeStringCollection(reloadedAnalyzers);
         }
 
         public String getIndexName() {
@@ -127,6 +172,25 @@ public class ReloadAnalyzersResponse extends BroadcastResponse  {
             assert this.indexName == other.index;
             this.reloadedAnalyzers.addAll(other.reloadedSearchAnalyzers);
             this.reloadedIndicesNodes.add(other.nodeId);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ReloadDetails that = (ReloadDetails) o;
+            return Objects.equals(indexName, that.indexName)
+                    && Objects.equals(reloadedIndicesNodes, that.reloadedIndicesNodes)
+                    && Objects.equals(reloadedAnalyzers, that.reloadedAnalyzers);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(indexName, reloadedIndicesNodes, reloadedAnalyzers);
         }
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/action/ReloadAnalyzersResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/action/ReloadAnalyzersResponseTests.java
@@ -9,6 +9,7 @@ import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractBroadcastResponseTestCase;
+import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.xpack.core.action.ReloadAnalyzersResponse.ReloadDetails;
 
 import java.io.IOException;
@@ -53,4 +54,12 @@ public class ReloadAnalyzersResponseTests extends AbstractBroadcastResponseTestC
                 + "}",
                 output);
     }
+
+    public void testSerialization() throws IOException {
+        ReloadAnalyzersResponse response = createTestInstance();
+        ReloadAnalyzersResponse copy = copyStreamable(response, writableRegistry(), ReloadAnalyzersResponse::new,
+                VersionUtils.randomVersion(random()));
+        assertEquals(response.getReloadDetails(), copy.getReloadDetails());
+    }
+
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/action/ReloadDetailsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/action/ReloadDetailsTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.action;
+
+import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.core.action.ReloadAnalyzersResponse.ReloadDetails;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ReloadDetailsTests extends AbstractWireSerializingTestCase<ReloadDetails> {
+
+    @Override
+    protected ReloadDetails createTestInstance() {
+        return new ReloadDetails(randomAlphaOfLengthBetween(5, 10), 
+                new HashSet<>(Arrays.asList(generateRandomStringArray(5, 5, false))),
+                new HashSet<>(Arrays.asList(generateRandomStringArray(5, 5, false))));
+    }
+
+    @Override
+    protected Reader<ReloadDetails> instanceReader() {
+        return ReloadDetails::new;
+    }
+
+    @Override
+    protected ReloadDetails mutateInstance(ReloadDetails instance) throws IOException {
+        String indexName = instance.getIndexName();
+        Set<String> reloadedAnalyzers = new HashSet<>(instance.getReloadedAnalyzers());
+        Set<String> reloadedIndicesNodes = new HashSet<>(instance.getReloadedIndicesNodes());
+        int mutate = randomIntBetween(0, 2);
+        switch (mutate) {
+        case 0:
+            indexName = indexName + randomAlphaOfLength(2);
+            break;
+        case 1:
+            reloadedAnalyzers.add(randomAlphaOfLength(10));
+            break;
+        case 2:
+            reloadedIndicesNodes.add(randomAlphaOfLength(10));
+            break;
+        default:
+            throw new IllegalStateException("Requested to modify more than available parameters.");
+        }
+        return new ReloadDetails(indexName, reloadedIndicesNodes, reloadedAnalyzers);
+    }
+
+}


### PR DESCRIPTION
This change adds Writeable support to ReloadAnalyzersResponse that
is required when using the transport client in 7.x.

Closes #44383