### PR TITLE
[ML][Data Frame] deregister scheduler on transform failure

### DIFF
--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameTaskFailedStateIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameTaskFailedStateIT.java
@@ -6,69 +6,109 @@
 
 package org.elasticsearch.xpack.dataframe.integration;
 
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.elasticsearch.client.Request;
 import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformTaskState;
+import org.junit.After;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 
 public class DataFrameTaskFailedStateIT extends DataFrameRestTestCase {
 
-    public void testDummy() {
-        // remove once the awaits fix below is resolved
+    private static final String TRANSFORM_ID = "failure_pivot_1";
+
+    @After
+    public void cleanUpPotentiallyFailedTransform() throws Exception {
+        // If the tests failed in the middle, we should force stop it. This prevents other transform tests from failing due
+        // to this left over transform
+        stopDataFrameTransform(TRANSFORM_ID, true);
+        deleteDataFrameTransform(TRANSFORM_ID);
     }
 
-    @AwaitsFix( bugUrl = "https://github.com/elastic/elasticsearch/issues/40543")
-    public void testFailureStateInteraction() throws Exception {
+    public void testForceStopFailedTransform() throws Exception {
         createReviewsIndex();
-        String transformId = "failure_pivot_1";
         String dataFrameIndex = "failure_pivot_reviews";
-        createPivotReviewsTransform(transformId, dataFrameIndex, null);
-        deleteIndex(REVIEWS_INDEX_NAME); // trigger start failure due to index missing
-        startDataframeTransform(transformId, false);
-        awaitState(transformId, DataFrameTransformTaskState.FAILED);
-        Map<?, ?> fullState = getDataFrameState(transformId);
-
+        createDestinationIndexWithBadMapping(dataFrameIndex);
+        createPivotReviewsTransform(TRANSFORM_ID, dataFrameIndex, null);
+        startDataframeTransform(TRANSFORM_ID, false);
+        awaitState(TRANSFORM_ID, DataFrameTransformTaskState.FAILED);
+        Map<?, ?> fullState = getDataFrameState(TRANSFORM_ID);
+        final String failureReason = "task encountered more than 10 failures; latest failure: " +
+            "Bulk index experienced failures. See the logs of the node running the transform for details.";
         // Verify we have failed for the expected reason
         assertThat(XContentMapValues.extractValue("state.reason", fullState),
-            equalTo("task encountered irrecoverable failure: no such index [reviews]"));
-        assertThat(XContentMapValues.extractValue("state.indexer_state", fullState), equalTo("started"));
+            equalTo(failureReason));
 
-        // Verify that we cannot stop or start the transform when the task is in a failed state
-        ResponseException ex = expectThrows(ResponseException.class, () -> stopDataFrameTransform(transformId, false));
+        // verify that we cannot stop a failed transform
+        ResponseException ex = expectThrows(ResponseException.class, () -> stopDataFrameTransform(TRANSFORM_ID, false));
         assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(RestStatus.CONFLICT.getStatus()));
         assertThat(XContentMapValues.extractValue("error.reason", entityAsMap(ex.getResponse())),
-            equalTo("Unable to stop data frame transform [failure_pivot_1] as it is in a failed state with reason: [" +
-                "task encountered irrecoverable failure: no such index [reviews]]. Use force stop to stop the data frame transform."));
+            equalTo("Unable to stop data frame transform [failure_pivot_1] as it is in a failed state with reason [" +
+                failureReason +
+                "]. Use force stop to stop the data frame transform."));
 
-        ex = expectThrows(ResponseException.class, () -> startDataframeTransform(transformId, false));
+        // Verify that we can force stop a failed transform
+        stopDataFrameTransform(TRANSFORM_ID, true);
+
+        awaitState(TRANSFORM_ID, DataFrameTransformTaskState.STOPPED);
+        fullState = getDataFrameState(TRANSFORM_ID);
+        // Verify we have failed for the expected reason
+        assertThat(XContentMapValues.extractValue("state.reason", fullState),
+            is(nullValue()));
+    }
+
+
+    public void testForceStartFailedTransform() throws Exception {
+        createReviewsIndex();
+        String dataFrameIndex = "failure_pivot_reviews";
+        createDestinationIndexWithBadMapping(dataFrameIndex);
+        createPivotReviewsTransform(TRANSFORM_ID, dataFrameIndex, null);
+        startDataframeTransform(TRANSFORM_ID, false);
+        awaitState(TRANSFORM_ID, DataFrameTransformTaskState.FAILED);
+        Map<?, ?> fullState = getDataFrameState(TRANSFORM_ID);
+        final String failureReason = "task encountered more than 10 failures; latest failure: " +
+            "Bulk index experienced failures. See the logs of the node running the transform for details.";
+        // Verify we have failed for the expected reason
+        assertThat(XContentMapValues.extractValue("state.reason", fullState),
+            equalTo(failureReason));
+
+        // Verify that we cannot start the transform when the task is in a failed state
+        ResponseException ex = expectThrows(ResponseException.class, () -> startDataframeTransform(TRANSFORM_ID, false));
         assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(RestStatus.CONFLICT.getStatus()));
         assertThat(XContentMapValues.extractValue("error.reason", entityAsMap(ex.getResponse())),
             equalTo("Unable to start data frame transform [failure_pivot_1] as it is in a failed state with failure: [" +
-                "task encountered irrecoverable failure: no such index [reviews]]. " +
-                "Use force start to restart data frame transform once error is resolved."));
+                failureReason +
+                "]. Use force start to restart data frame transform once error is resolved."));
 
-        // Correct the failure by creating the reviews index again
-        createReviewsIndex();
+        // Correct the failure by deleting the destination index
+        deleteIndex(dataFrameIndex);
         // Force start the data frame to indicate failure correction
-        startDataframeTransform(transformId, true);
+        startDataframeTransform(TRANSFORM_ID, true);
         // Wait for data to be indexed appropriately and refresh for search
-        waitForDataFrameCheckpoint(transformId);
+        waitForDataFrameCheckpoint(TRANSFORM_ID);
         refreshIndex(dataFrameIndex);
 
         // Verify that we have started and that our reason is cleared
-        fullState = getDataFrameState(transformId);
+        fullState = getDataFrameState(TRANSFORM_ID);
         assertThat(XContentMapValues.extractValue("state.reason", fullState), is(nullValue()));
         assertThat(XContentMapValues.extractValue("state.task_state", fullState), equalTo("started"));
         assertThat(XContentMapValues.extractValue("state.indexer_state", fullState), equalTo("started"));
-        assertThat(XContentMapValues.extractValue("stats.search_failures", fullState), equalTo(1));
+        assertThat((int)XContentMapValues.extractValue("stats.index_failures", fullState), greaterThan(0));
 
         // get and check some users to verify we restarted
         assertOnePivotValue(dataFrameIndex + "/_search?q=reviewer:user_0", 3.776978417);
@@ -76,17 +116,13 @@ public class DataFrameTaskFailedStateIT extends DataFrameRestTestCase {
         assertOnePivotValue(dataFrameIndex + "/_search?q=reviewer:user_11", 3.846153846);
         assertOnePivotValue(dataFrameIndex + "/_search?q=reviewer:user_20", 3.769230769);
         assertOnePivotValue(dataFrameIndex + "/_search?q=reviewer:user_26", 3.918918918);
-
-
-        stopDataFrameTransform(transformId, true);
-        deleteDataFrameTransform(transformId);
     }
 
     private void awaitState(String transformId, DataFrameTransformTaskState state) throws Exception {
         assertBusy(() -> {
             String currentState = getDataFrameTaskState(transformId);
-            assertThat(state.value(), equalTo(currentState));
-        });
+            assertThat(currentState, equalTo(state.value()));
+        }, 180, TimeUnit.SECONDS); // It should not take this long, but if the scheduler gets deferred, it could
     }
 
     private void assertOnePivotValue(String query, double expected) throws IOException {
@@ -95,5 +131,26 @@ public class DataFrameTaskFailedStateIT extends DataFrameRestTestCase {
         assertEquals(1, XContentMapValues.extractValue("hits.total.value", searchResult));
         double actual = (Double) ((List<?>) XContentMapValues.extractValue("hits.hits._source.avg_rating", searchResult)).get(0);
         assertEquals(expected, actual, 0.000001);
+    }
+
+    private void createDestinationIndexWithBadMapping(String indexName) throws IOException {
+        // create mapping
+        try (XContentBuilder builder = jsonBuilder()) {
+            builder.startObject();
+            {
+                builder.startObject("mappings")
+                    .startObject("properties")
+                    .startObject("reviewer")
+                    .field("type", "long")
+                    .endObject()
+                    .endObject()
+                    .endObject();
+            }
+            builder.endObject();
+            final StringEntity entity = new StringEntity(Strings.toString(builder), ContentType.APPLICATION_JSON);
+            Request req = new Request("PUT", indexName);
+            req.setEntity(entity);
+            client().performRequest(req);
+        }
     }
 }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
@@ -253,6 +253,7 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
         }
 
         IndexerState state = getIndexer().stop();
+        stateReason.set(null);
         if (state == IndexerState.STOPPED) {
             getIndexer().onStop();
             getIndexer().doSaveState(state, getIndexer().getPosition(), () -> {});
@@ -322,6 +323,9 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
         taskState.set(DataFrameTransformTaskState.FAILED);
         stateReason.set(reason);
         auditor.error(transform.getId(), reason);
+        // We should not keep retrying. Either the task will be stopped, or started
+        // If it is started again, it is registered again.
+        deregisterSchedulerJob();
         // Even though the indexer information is persisted to an index, we still need DataFrameTransformTaskState in the clusterstate
         // This keeps track of STARTED, FAILED, STOPPED
         // This is because a FAILED state can occur because we cannot read the config from the internal index, which would imply that


### PR DESCRIPTION
If a transform task fails, we should not continually attempt to run it. Currently, since it stays scheduled, it will attempt to run again at every configured interval. A better alternative, is to remove itself from the scheduling engine when it fails. We still get to keep the persistent task in the cluster, but we don't have to worry about the indexer getting scheduled to run again.

Additionally, I fixed the failed state interaction tests since now we have a good way to force task failures (bulk indexing failures). 

Closes #40543