### PR TITLE
[DOCS] Fixes query default value

### DIFF
--- a/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
@@ -105,4 +105,4 @@ The `source` configuration object has the following properties:
   corresponds to the query object in an {es} search POST body. All the
   options that are supported by {es} can be used, as this object is
   passed verbatim to {es}. By default, this property has the following
-  value: `{"match_all": {"boost": 1}}`.
+  value: `{"match_all": {}}`.


### PR DESCRIPTION
This PR updates the default value for the query property from `{"match_all" : { "boost":1 }}` to `{"match_all" : { }}`, since the boost is not something the machine learning features set explicitly.