### PR TITLE
[ML][Data Frame] fixing flaky test

### DIFF
--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameRestTestCase.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameRestTestCase.java
@@ -162,7 +162,8 @@ public abstract class DataFrameRestTestCase extends ESRestTestCase {
         String config = "{ \"dest\": {\"index\":\"" + dataFrameIndex + "\"},"
             + " \"source\": {\"index\":\"" + REVIEWS_INDEX_NAME + "\"},"
             //Set frequency high for testing
-            + " \"sync\": {\"time\":{\"field\": \"timestamp\", \"delay\": \"15m\", \"frequency\": \"1s\"}},"
+            + " \"sync\": {\"time\":{\"field\": \"timestamp\", \"delay\": \"15m\"}},"
+            + " \"frequency\": \"1s\","
             + " \"pivot\": {"
             + "   \"group_by\": {"
             + "     \"reviewer\": {"

--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameTaskFailedStateIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameTaskFailedStateIT.java
@@ -29,7 +29,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/44583")
 public class DataFrameTaskFailedStateIT extends DataFrameRestTestCase {
 
     private static final String TRANSFORM_ID = "failure_pivot_1";

--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameTaskFailedStateIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameTaskFailedStateIT.java
@@ -44,7 +44,7 @@ public class DataFrameTaskFailedStateIT extends DataFrameRestTestCase {
         createReviewsIndex();
         String dataFrameIndex = "failure_pivot_reviews";
         createDestinationIndexWithBadMapping(dataFrameIndex);
-        createPivotReviewsTransform(TRANSFORM_ID, dataFrameIndex, null);
+        createContinuousPivotReviewsTransform(TRANSFORM_ID, dataFrameIndex, null);
         startDataframeTransform(TRANSFORM_ID, false);
         awaitState(TRANSFORM_ID, DataFrameTransformTaskState.FAILED);
         Map<?, ?> fullState = getDataFrameState(TRANSFORM_ID);
@@ -77,7 +77,7 @@ public class DataFrameTaskFailedStateIT extends DataFrameRestTestCase {
         createReviewsIndex();
         String dataFrameIndex = "failure_pivot_reviews";
         createDestinationIndexWithBadMapping(dataFrameIndex);
-        createPivotReviewsTransform(TRANSFORM_ID, dataFrameIndex, null);
+        createContinuousPivotReviewsTransform(TRANSFORM_ID, dataFrameIndex, null);
         startDataframeTransform(TRANSFORM_ID, false);
         awaitState(TRANSFORM_ID, DataFrameTransformTaskState.FAILED);
         Map<?, ?> fullState = getDataFrameState(TRANSFORM_ID);

--- a/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameTaskFailedStateIT.java
+++ b/x-pack/plugin/data-frame/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/dataframe/integration/DataFrameTaskFailedStateIT.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.dataframe.integration;
 
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.Strings;


### PR DESCRIPTION
The transforms need to be continuous to ensure state transitions.

Also, blocked by: https://github.com/elastic/elasticsearch/pull/44577 so that timeouts do not occur waiting for the task to fail. 