### PR TITLE
Deprecation messages with the same key but different x-opaque-id are allowed (#44587)

### DIFF
--- a/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
+++ b/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
@@ -269,7 +269,7 @@ public class JsonLoggerTests extends ESTestCase {
     }
 
 
-    public void testDuplicates() throws IOException, UserException {
+    public void testDuplicateLogMessages() throws IOException {
         final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger("test"));
 
 

--- a/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
+++ b/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
@@ -349,8 +349,6 @@ public class JsonLoggerTests extends ESTestCase {
         }
     }
 
-
-
     private List<JsonLogLine> collectLines(Stream<JsonLogLine> stream) {
         return stream
             .skip(1)//skip the first line from super class

--- a/qa/logging-config/src/test/resources/org/elasticsearch/common/logging/json_layout/log4j2.properties
+++ b/qa/logging-config/src/test/resources/org/elasticsearch/common/logging/json_layout/log4j2.properties
@@ -13,13 +13,13 @@ appender.deprecated.type = File
 appender.deprecated.name = deprecated
 appender.deprecated.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecated.json
 appender.deprecated.layout.type = ESJsonLayout
-appender.deprecated.layout.type_name = deprecated
+appender.deprecated.layout.type_name = deprecation
 appender.deprecated.layout.esmessagefields = x-opaque-id
 
 appender.deprecatedconsole.type = Console
 appender.deprecatedconsole.name = deprecatedconsole
 appender.deprecatedconsole.layout.type = ESJsonLayout
-appender.deprecatedconsole.layout.type_name = deprecated
+appender.deprecatedconsole.layout.type_name = deprecation
 appender.deprecatedconsole.layout.esmessagefields = x-opaque-id
 
 appender.index_search_slowlog_rolling.type = File
@@ -33,6 +33,14 @@ appender.index_search_slowlog_rolling.layout.esmessagefields=message,took,took_m
 rootLogger.level = info
 rootLogger.appenderRef.console.ref = console
 rootLogger.appenderRef.file.ref = file
+
+logger.deprecation.name = deprecation.test
+logger.deprecation.level = warn
+logger.deprecation.appenderRef.console.ref = console
+logger.deprecation.appenderRef.file.ref = file
+logger.deprecation.appenderRef.deprecation_rolling.ref = deprecated
+logger.deprecation.appenderRef.deprecatedconsole.ref = deprecatedconsole
+logger.deprecation.additivity = false
 
 logger.test.name = test
 logger.test.level = trace

--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -135,7 +135,7 @@ public class DeprecationLogger {
      */
     public void deprecatedAndMaybeLog(final String key, final String msg, final Object... params) {
         String xOpaqueId = getXOpaqueId(THREAD_CONTEXT);
-        boolean log = keys.add(xOpaqueId + key);//todo that will create a lot of string in a pool. should we do this with weakhashmap?
+        boolean log = keys.add(xOpaqueId + key);
         deprecated(THREAD_CONTEXT, msg, log, params);
     }
 
@@ -260,11 +260,11 @@ public class DeprecationLogger {
 
     public String getXOpaqueId(Set<ThreadContext> threadContexts) {
         return threadContexts.stream()
-                                                         .filter(t -> t.isClosed() == false)
-                                                         .filter(t -> t.getHeader(Task.X_OPAQUE_ID) != null)
-                                                         .findFirst()
-                                                         .map(t -> t.getHeader(Task.X_OPAQUE_ID))
-                                                         .orElse("");
+                             .filter(t -> t.isClosed() == false)
+                             .filter(t -> t.getHeader(Task.X_OPAQUE_ID) != null)
+                             .findFirst()
+                             .map(t -> t.getHeader(Task.X_OPAQUE_ID))
+                             .orElse("");
     }
 
     /**


### PR DESCRIPTION
Deprecation logger was filtering log entries by key, that means that if two log messages with the same key are logged from different users, then the second log messages will be filtered.
This change allows to log deprecation message with the same key by different users.


relates #41354
