### PR TITLE
Add types field to JSON slow logs in 7.x

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
+++ b/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
@@ -34,6 +34,7 @@ import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.tasks.Task;
 
 import java.nio.charset.Charset;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -170,6 +171,8 @@ public final class SearchSlowLog implements SearchOperationListener {
             } else {
                 messageFields.put("total_hits", "-1");
             }
+            String[] types = context.getQueryShardContext().getTypes();
+            messageFields.put("types", asJsonArray(types != null ? Arrays.stream(types) : Stream.empty()));
             messageFields.put("stats", asJsonArray(context.groupStats() != null ? context.groupStats().stream() : Stream.empty()));
             messageFields.put("search_type", context.searchType());
             messageFields.put("total_shards", context.numberOfShards());

--- a/server/src/test/java/org/elasticsearch/index/SearchSlowLogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/SearchSlowLogTests.java
@@ -170,6 +170,7 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
         assertThat(p.getValueFor("took"), equalTo("10nanos"));
         assertThat(p.getValueFor("took_millis"), equalTo("0"));
         assertThat(p.getValueFor("total_hits"), equalTo("-1"));
+        assertThat(p.getValueFor("types"), equalTo("[]"));
         assertThat(p.getValueFor("stats"), equalTo("[]"));
         assertThat(p.getValueFor("search_type"), Matchers.nullValue());
         assertThat(p.getValueFor("total_shards"), equalTo("1"));


### PR DESCRIPTION
By mistake in 7.x types field was removed from slow logs. Types are
still present in that version, so this have to be present as a JSON
field
relates #41354
backport that was causing this  #44178