### PR TITLE
[DOCS] Reformat info and deprecation APIs to use new API format

### DIFF
--- a/docs/reference/migration/apis/deprecation.asciidoc
+++ b/docs/reference/migration/apis/deprecation.asciidoc
@@ -10,29 +10,23 @@ The deprecation API is to be used to retrieve information about different
 cluster, node, and index level settings that use deprecated features that will
 be removed or changed in the next major version.
 
-[float]
-==== Request
+[[migration-api-request]]
+==== {api-request-title}
 
 `GET /_migration/deprecations` +
 
 `GET /<index_name>/_migration/deprecations`
 
-//=== Description
-
-[float]
-==== Path Parameters
+[[migration-api-path-params]]
+==== {api-path-parms-title}
 
 `index_name`::
-  (string) Identifier for the index. It can be an index name or a wildcard
-  expression. When you specify this parameter, only index-level deprecations for
-  the specified indices are returned.
+  (Optional, string) Identifier for the index. It can be an index name or a
+  wildcard expression. When you specify this parameter, only index-level
+  deprecations for the specified indices are returned.
 
-//=== Query Parameters
-
-//=== Authorization
-
-[float]
-==== Examples
+[[migration-api-example]]
+==== {api-examples-title}
 
 To see the list of offenders in your cluster, submit a GET request to the
 `_migration/deprecations` endpoint:

--- a/docs/reference/rest-api/info.asciidoc
+++ b/docs/reference/rest-api/info.asciidoc
@@ -3,15 +3,17 @@
 [[info-api]]
 == Info API
 
-The info API provides general information about the installed {xpack} features.
+Provides general information about the installed {xpack} features.
 
-[float]
-=== Request
+[discrete]
+[[info-api-request]]
+=== {api-request-title}
 
 `GET /_xpack`
 
-[float]
-=== Description
+[discrete]
+[[info-api-desc]]
+=== {api-description-title}
 
 The information provided by this API includes:
 
@@ -20,24 +22,22 @@ The information provided by this API includes:
 * Features Information - The features that are currently enabled and available
   under the current license.
 
-[float]
-=== Path Parameters
+[discrete]
+[[info-api-path-params]]
+=== {api-path-parms-title}
 
 `categories`::
-  (list) A comma-separated list of the information categories to include in the
-  response. For example, `build,license,features`.
+  (Optional, list) A comma-separated list of the information categories to
+  include in the response. For example, `build,license,features`.
 
 `human`::
-  (boolean) Defines whether additional human-readable information is included in
-  the response. In particular, it adds descriptions and a tag line. The
-  default value is `true`.
+  (Optional, boolean) Defines whether additional human-readable information is
+  included in the response. In particular, it adds descriptions and a tag line.
+  The default value is `true`.
 
-//=== Query Parameters
-
-//=== Authorization
-
-[float]
-=== Examples
+[discrete]
+[[info-api--example]]
+=== {api-examples-title}
 
 The following example queries the info API:
 


### PR DESCRIPTION
With elastic/docs#938, we created a standard template
for Elastic API Reference documentation.

This PR edits the info and deprecation APIs to use that template.

Relates to elastic/docs#937