### PR TITLE
Convert several direct uses of Streamable to Writeable (#44586)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksResponse.java
@@ -106,9 +106,7 @@ public class PendingClusterTasksResponse extends ActionResponse implements Itera
         int size = in.readVInt();
         pendingTasks = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
-            PendingClusterTask task = new PendingClusterTask();
-            task.readFrom(in);
-            pendingTasks.add(task);
+            pendingTasks.add(new PendingClusterTask(in));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
@@ -259,7 +259,7 @@ public class CommonStats implements Writeable, ToXContentFragment {
         out.writeOptionalStreamable(warmer);
         out.writeOptionalStreamable(queryCache);
         out.writeOptionalStreamable(fieldData);
-        out.writeOptionalStreamable(completion);
+        out.writeOptionalWriteable(completion);
         out.writeOptionalStreamable(segments);
         out.writeOptionalStreamable(translog);
         out.writeOptionalStreamable(requestCache);

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkItemRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkItemRequest.java
@@ -23,19 +23,23 @@ import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 
 import java.io.IOException;
 import java.util.Objects;
 
-public class BulkItemRequest implements Streamable {
+public class BulkItemRequest implements Writeable {
 
     private int id;
     private DocWriteRequest<?> request;
     private volatile BulkItemResponse primaryResponse;
 
-    BulkItemRequest() {
-
+    BulkItemRequest(StreamInput in) throws IOException {
+        id = in.readVInt();
+        request = DocWriteRequest.readDocumentRequest(in);
+        if (in.readBoolean()) {
+            primaryResponse = new BulkItemResponse(in);
+        }
     }
 
     // NOTE: public for testing only
@@ -89,25 +93,10 @@ public class BulkItemRequest implements Streamable {
         }
     }
 
-    public static BulkItemRequest readBulkItem(StreamInput in) throws IOException {
-        BulkItemRequest item = new BulkItemRequest();
-        item.readFrom(in);
-        return item;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        id = in.readVInt();
-        request = DocWriteRequest.readDocumentRequest(in);
-        if (in.readBoolean()) {
-            primaryResponse = BulkItemResponse.readBulkItem(in);
-        }
-    }
-
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVInt(id);
         DocWriteRequest.writeDocumentRequest(out, request);
-        out.writeOptionalStreamable(primaryResponse);
+        out.writeOptionalWriteable(primaryResponse);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
@@ -32,7 +32,6 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.StatusToXContentObject;
@@ -53,7 +52,7 @@ import static org.elasticsearch.common.xcontent.XContentParserUtils.throwUnknown
  * Represents a single item response for an action executed as part of the bulk API. Holds the index/type/id
  * of the relevant action, and if it has failed or not (with the failure message incase it failed).
  */
-public class BulkItemResponse implements Streamable, StatusToXContentObject {
+public class BulkItemResponse implements Writeable, StatusToXContentObject {
 
     private static final String _INDEX = "_index";
     private static final String _TYPE = "_type";
@@ -361,8 +360,24 @@ public class BulkItemResponse implements Streamable, StatusToXContentObject {
 
     private Failure failure;
 
-    BulkItemResponse() {
+    BulkItemResponse() {}
 
+    BulkItemResponse(StreamInput in) throws IOException {
+        id = in.readVInt();
+        opType = OpType.fromId(in.readByte());
+
+        byte type = in.readByte();
+        if (type == 0) {
+            response = new IndexResponse(in);
+        } else if (type == 1) {
+            response = new DeleteResponse(in);
+        } else if (type == 3) { // make 3 instead of 2, because 2 is already in use for 'no responses'
+            response = new UpdateResponse(in);
+        }
+
+        if (in.readBoolean()) {
+            failure = new Failure(in);
+        }
     }
 
     public BulkItemResponse(int id, OpType opType, DocWriteResponse response) {
@@ -461,31 +476,6 @@ public class BulkItemResponse implements Streamable, StatusToXContentObject {
      */
     public Failure getFailure() {
         return this.failure;
-    }
-
-    public static BulkItemResponse readBulkItem(StreamInput in) throws IOException {
-        BulkItemResponse response = new BulkItemResponse();
-        response.readFrom(in);
-        return response;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        id = in.readVInt();
-        opType = OpType.fromId(in.readByte());
-
-        byte type = in.readByte();
-        if (type == 0) {
-            response = new IndexResponse(in);
-        } else if (type == 1) {
-            response = new DeleteResponse(in);
-        } else if (type == 3) { // make 3 instead of 2, because 2 is already in use for 'no responses'
-            response = new UpdateResponse(in);
-        }
-
-        if (in.readBoolean()) {
-            failure = new Failure(in);
-        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
@@ -62,7 +62,7 @@ public class BulkResponse extends ActionResponse implements Iterable<BulkItemRes
         super(in);
         responses = new BulkItemResponse[in.readVInt()];
         for (int i = 0; i < responses.length; i++) {
-            responses[i] = BulkItemResponse.readBulkItem(in);
+            responses[i] = new BulkItemResponse(in);
         }
         tookInMillis = in.readVLong();
         ingestTookInMillis = in.readZLong();

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkShardRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkShardRequest.java
@@ -38,7 +38,7 @@ public class BulkShardRequest extends ReplicatedWriteRequest<BulkShardRequest> {
         items = new BulkItemRequest[in.readVInt()];
         for (int i = 0; i < items.length; i++) {
             if (in.readBoolean()) {
-                items[i] = BulkItemRequest.readBulkItem(in);
+                items[i] = new BulkItemRequest(in);
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkShardResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkShardResponse.java
@@ -38,7 +38,7 @@ public class BulkShardResponse extends ReplicationResponse implements WriteRespo
         shardId = new ShardId(in);
         responses = new BulkItemResponse[in.readVInt()];
         for (int i = 0; i < responses.length; i++) {
-            responses[i] = BulkItemResponse.readBulkItem(in);
+            responses[i] = new BulkItemResponse(in);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlock.java
+++ b/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlock.java
@@ -23,7 +23,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -35,7 +34,7 @@ import java.util.EnumSet;
 import java.util.Locale;
 import java.util.Objects;
 
-public class ClusterBlock implements Streamable, Writeable, ToXContentFragment {
+public class ClusterBlock implements Writeable, ToXContentFragment {
 
     private int id;
     private @Nullable String uuid;
@@ -145,11 +144,6 @@ public class ClusterBlock implements Streamable, Writeable, ToXContentFragment {
         builder.endArray();
         builder.endObject();
         return builder;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/service/PendingClusterTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/PendingClusterTask.java
@@ -22,13 +22,13 @@ package org.elasticsearch.cluster.service;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.unit.TimeValue;
 
 import java.io.IOException;
 
-public class PendingClusterTask implements Streamable {
+public class PendingClusterTask implements Writeable {
 
     private long insertOrder;
     private Priority priority;
@@ -36,7 +36,12 @@ public class PendingClusterTask implements Streamable {
     private long timeInQueue;
     private boolean executing;
 
-    public PendingClusterTask() {
+    public PendingClusterTask(StreamInput in) throws IOException {
+        insertOrder = in.readVLong();
+        priority = Priority.readFrom(in);
+        source = in.readText();
+        timeInQueue = in.readLong();
+        executing = in.readBoolean();
     }
 
     public PendingClusterTask(long insertOrder, Priority priority, Text source, long timeInQueue, boolean executing) {
@@ -71,15 +76,6 @@ public class PendingClusterTask implements Streamable {
 
     public boolean isExecuting() {
         return executing;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        insertOrder = in.readVLong();
-        priority = Priority.readFrom(in);
-        source = in.readText();
-        timeInQueue = in.readLong();
-        executing = in.readBoolean();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/document/DocumentField.java
+++ b/server/src/main/java/org/elasticsearch/common/document/DocumentField.java
@@ -21,7 +21,7 @@ package org.elasticsearch.common.document;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -44,12 +44,18 @@ import static org.elasticsearch.common.xcontent.XContentParserUtils.parseFieldsV
  * @see SearchHit
  * @see GetResult
  */
-public class DocumentField implements Streamable, ToXContentFragment, Iterable<Object> {
+public class DocumentField implements Writeable, ToXContentFragment, Iterable<Object> {
 
     private String name;
     private List<Object> values;
 
-    private DocumentField() {
+    public DocumentField(StreamInput in) throws IOException {
+        name = in.readString();
+        int size = in.readVInt();
+        values = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            values.add(in.readGenericValue());
+        }
     }
 
     public DocumentField(String name, List<Object> values) {
@@ -91,22 +97,6 @@ public class DocumentField implements Streamable, ToXContentFragment, Iterable<O
     @Override
     public Iterator<Object> iterator() {
         return values.iterator();
-    }
-
-    public static DocumentField readDocumentField(StreamInput in) throws IOException {
-        DocumentField result = new DocumentField();
-        result.readFrom(in);
-        return result;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        name = in.readString();
-        int size = in.readVInt();
-        values = new ArrayList<>(size);
-        for (int i = 0; i < size; i++) {
-            values.add(in.readGenericValue());
-        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/io/stream/Streamable.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/Streamable.java
@@ -38,7 +38,9 @@ public interface Streamable {
     /**
      * Set this object's fields from a {@linkplain StreamInput}.
      */
-    void readFrom(StreamInput in) throws IOException;
+    default void readFrom(StreamInput in) throws IOException {
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
+    }
 
     /**
      * Write this object's fields to a {@linkplain StreamOutput}.

--- a/server/src/main/java/org/elasticsearch/common/transport/BoundTransportAddress.java
+++ b/server/src/main/java/org/elasticsearch/common/transport/BoundTransportAddress.java
@@ -21,7 +21,7 @@ package org.elasticsearch.common.transport;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 
 import java.io.IOException;
 
@@ -32,13 +32,19 @@ import java.io.IOException;
  *
  *
  */
-public class BoundTransportAddress implements Streamable {
+public class BoundTransportAddress implements Writeable {
 
     private TransportAddress[] boundAddresses;
 
     private TransportAddress publishAddress;
 
-    BoundTransportAddress() {
+    public BoundTransportAddress(StreamInput in) throws IOException {
+        int boundAddressLength = in.readInt();
+        boundAddresses = new TransportAddress[boundAddressLength];
+        for (int i = 0; i < boundAddressLength; i++) {
+            boundAddresses[i] = new TransportAddress(in);
+        }
+        publishAddress = new TransportAddress(in);
     }
 
     public BoundTransportAddress(TransportAddress[] boundAddresses, TransportAddress publishAddress) {
@@ -55,22 +61,6 @@ public class BoundTransportAddress implements Streamable {
 
     public TransportAddress publishAddress() {
         return publishAddress;
-    }
-
-    public static BoundTransportAddress readBoundTransportAddress(StreamInput in) throws IOException {
-        BoundTransportAddress addr = new BoundTransportAddress();
-        addr.readFrom(in);
-        return addr;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        int boundAddressLength = in.readInt();
-        boundAddresses = new TransportAddress[boundAddressLength];
-        for (int i = 0; i < boundAddressLength; i++) {
-            boundAddresses[i] = new TransportAddress(in);
-        }
-        publishAddress = new TransportAddress(in);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/http/HttpInfo.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpInfo.java
@@ -48,7 +48,7 @@ public class HttpInfo implements Writeable, ToXContentFragment {
     private final boolean cnameInPublishHost;
 
     public HttpInfo(StreamInput in) throws IOException {
-        this(BoundTransportAddress.readBoundTransportAddress(in), in.readLong(), CNAME_IN_PUBLISH_HOST);
+        this(new BoundTransportAddress(in), in.readLong(), CNAME_IN_PUBLISH_HOST);
     }
 
     public HttpInfo(BoundTransportAddress address, long maxContentLength) {

--- a/server/src/main/java/org/elasticsearch/index/get/GetResult.java
+++ b/server/src/main/java/org/elasticsearch/index/get/GetResult.java
@@ -390,7 +390,7 @@ public class GetResult implements Streamable, Iterable<DocumentField>, ToXConten
         } else {
             fields = new HashMap<>(size);
             for (int i = 0; i < size; i++) {
-                DocumentField field = DocumentField.readDocumentField(in);
+                DocumentField field = new DocumentField(in);
                 fields.put(field.getName(), field);
             }
         }

--- a/server/src/main/java/org/elasticsearch/repositories/VerificationFailure.java
+++ b/server/src/main/java/org/elasticsearch/repositories/VerificationFailure.java
@@ -19,13 +19,7 @@
 
 package org.elasticsearch.repositories;
 
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
-
-import java.io.IOException;
-
-public class VerificationFailure implements Streamable {
+public class VerificationFailure {
 
     private String nodeId;
 
@@ -46,24 +40,6 @@ public class VerificationFailure implements Streamable {
 
     public Throwable cause() {
         return cause;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        nodeId = in.readOptionalString();
-        cause = in.readException();
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        out.writeOptionalString(nodeId);
-        out.writeException(cause);
-    }
-
-    public static VerificationFailure readNode(StreamInput in) throws IOException {
-        VerificationFailure failure = new VerificationFailure();
-        failure.readFrom(in);
-        return failure;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -72,7 +72,6 @@ import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optiona
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureFieldName;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.parseFieldsValue;
-import static org.elasticsearch.search.fetch.subphase.highlight.HighlightField.readHighlightField;
 
 /**
  * A single search hit.
@@ -163,12 +162,12 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
         if (size == 0) {
             fields = emptyMap();
         } else if (size == 1) {
-            DocumentField hitField = DocumentField.readDocumentField(in);
+            DocumentField hitField = new DocumentField(in);
             fields = singletonMap(hitField.getName(), hitField);
         } else {
             Map<String, DocumentField> fields = new HashMap<>();
             for (int i = 0; i < size; i++) {
-                DocumentField hitField = DocumentField.readDocumentField(in);
+                DocumentField hitField = new DocumentField(in);
                 fields.put(hitField.getName(), hitField);
             }
             this.fields = unmodifiableMap(fields);
@@ -178,12 +177,12 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
         if (size == 0) {
             highlightFields = emptyMap();
         } else if (size == 1) {
-            HighlightField field = readHighlightField(in);
+            HighlightField field = new HighlightField(in);
             highlightFields = singletonMap(field.name(), field);
         } else {
             Map<String, HighlightField> highlightFields = new HashMap<>();
             for (int i = 0; i < size; i++) {
-                HighlightField field = readHighlightField(in);
+                HighlightField field = new HighlightField(in);
                 highlightFields.put(field.name(), field);
             }
             this.highlightFields = unmodifiableMap(highlightFields);

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightField.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightField.java
@@ -22,7 +22,7 @@ package org.elasticsearch.search.fetch.subphase.highlight;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -39,13 +39,25 @@ import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpect
 /**
  * A field highlighted with its highlighted fragments.
  */
-public class HighlightField implements ToXContentFragment, Streamable {
+public class HighlightField implements ToXContentFragment, Writeable {
 
     private String name;
 
     private Text[] fragments;
 
-    HighlightField() {
+    public HighlightField(StreamInput in) throws IOException {
+        name = in.readString();
+        if (in.readBoolean()) {
+            int size = in.readVInt();
+            if (size == 0) {
+                fragments = Text.EMPTY_ARRAY;
+            } else {
+                fragments = new Text[size];
+                for (int i = 0; i < size; i++) {
+                    fragments[i] = in.readText();
+                }
+            }
+        }
     }
 
     public HighlightField(String name, Text[] fragments) {
@@ -84,28 +96,6 @@ public class HighlightField implements ToXContentFragment, Streamable {
     @Override
     public String toString() {
         return "[" + name + "], fragments[" + Arrays.toString(fragments) + "]";
-    }
-
-    public static HighlightField readHighlightField(StreamInput in) throws IOException {
-        HighlightField field = new HighlightField();
-        field.readFrom(in);
-        return field;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        name = in.readString();
-        if (in.readBoolean()) {
-            int size = in.readVInt();
-            if (size == 0) {
-                fragments = Text.EMPTY_ARRAY;
-            } else {
-                fragments = new Text[size];
-                for (int i = 0; i < size; i++) {
-                    fragments[i] = in.readText();
-                }
-            }
-        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/query/QuerySearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QuerySearchRequest.java
@@ -34,8 +34,6 @@ import org.elasticsearch.transport.TransportRequest;
 import java.io.IOException;
 import java.util.Map;
 
-import static org.elasticsearch.search.dfs.AggregatedDfs.readAggregatedDfs;
-
 public class QuerySearchRequest extends TransportRequest implements IndicesRequest {
 
     private long id;
@@ -56,7 +54,7 @@ public class QuerySearchRequest extends TransportRequest implements IndicesReque
     public QuerySearchRequest(StreamInput in) throws IOException {
         super(in);
         id = in.readLong();
-        dfs = readAggregatedDfs(in);
+        dfs = new AggregatedDfs(in);
         originalIndices = OriginalIndices.readOriginalIndices(in);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionStats.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionStats.java
@@ -22,7 +22,6 @@ import org.elasticsearch.common.FieldMemoryStats;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
@@ -30,7 +29,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class CompletionStats implements Streamable, Writeable, ToXContentFragment {
+public class CompletionStats implements Writeable, ToXContentFragment {
 
     private static final String COMPLETION = "completion";
     private static final String SIZE_IN_BYTES = "size_in_bytes";
@@ -64,11 +63,6 @@ public class CompletionStats implements Streamable, Writeable, ToXContentFragmen
 
     public FieldMemoryStats getFields() {
         return fields;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreInfo.java
@@ -50,9 +50,7 @@ public class RestoreInfo implements ToXContentObject, Writeable {
 
     private int successfulShards;
 
-    RestoreInfo() {
-
-    }
+    RestoreInfo() {}
 
     public RestoreInfo(String name, List<String> indices, int totalShards, int successfulShards) {
         this.name = name;

--- a/server/src/main/java/org/elasticsearch/transport/TransportInfo.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportInfo.java
@@ -24,7 +24,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.transport.BoundTransportAddress;
-import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -43,13 +42,13 @@ public class TransportInfo implements Writeable, ToXContentFragment {
     }
 
     public TransportInfo(StreamInput in) throws IOException {
-        address = BoundTransportAddress.readBoundTransportAddress(in);
+        address = new BoundTransportAddress(in);
         int size = in.readVInt();
         if (size > 0) {
             profileAddresses = new HashMap<>(size);
             for (int i = 0; i < size; i++) {
                 String key = in.readString();
-                BoundTransportAddress value = BoundTransportAddress.readBoundTransportAddress(in);
+                BoundTransportAddress value = new BoundTransportAddress(in);
                 profileAddresses.put(key, value);
             }
         }

--- a/server/src/test/java/org/elasticsearch/common/transport/BoundTransportAddressTests.java
+++ b/server/src/test/java/org/elasticsearch/common/transport/BoundTransportAddressTests.java
@@ -52,13 +52,7 @@ public class BoundTransportAddressTests extends ESTestCase {
         transportAddress.writeTo(streamOutput);
         StreamInput in = streamOutput.bytes().streamInput();
 
-        BoundTransportAddress serializedAddress;
-        if (randomBoolean()) {
-            serializedAddress = BoundTransportAddress.readBoundTransportAddress(in);
-        } else {
-            serializedAddress = new BoundTransportAddress();
-            serializedAddress.readFrom(in);
-        }
+        BoundTransportAddress serializedAddress = new BoundTransportAddress(in);
 
         assertThat(serializedAddress, not(sameInstance(transportAddress)));
         assertThat(serializedAddress.boundAddresses().length, equalTo(transportAddress.boundAddresses().length));

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightFieldTests.java
@@ -114,7 +114,7 @@ public class HighlightFieldTests extends ESTestCase {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             testField.writeTo(output);
             try (StreamInput in = output.bytes().streamInput()) {
-                HighlightField deserializedCopy = HighlightField.readHighlightField(in);
+                HighlightField deserializedCopy = new HighlightField(in);
                 assertEquals(testField, deserializedCopy);
                 assertEquals(testField.hashCode(), deserializedCopy.hashCode());
                 assertNotSame(testField, deserializedCopy);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportReloadAnalyzersAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportReloadAnalyzersAction.java
@@ -60,9 +60,7 @@ public class TransportReloadAnalyzersAction
 
     @Override
     protected ReloadResult readShardResult(StreamInput in) throws IOException {
-        ReloadResult reloadResult = new ReloadResult();
-        reloadResult.readFrom(in);
-        return reloadResult;
+        return new ReloadResult(in);
     }
 
     @Override
@@ -106,11 +104,7 @@ public class TransportReloadAnalyzersAction
             this.reloadedSearchAnalyzers = reloadedSearchAnalyzers;
         }
 
-        private ReloadResult() {
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
+        private ReloadResult(StreamInput in) throws IOException {
             this.index = in.readString();
             this.nodeId = in.readString();
             this.reloadedSearchAnalyzers = in.readStringList();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/stats/WatcherStatsResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/stats/WatcherStatsResponse.java
@@ -106,7 +106,7 @@ public class WatcherStatsResponse extends BaseNodesResponse<WatcherStatsResponse
                 queuedWatches = in.readList(QueuedWatch::new);
             }
             if (in.readBoolean()) {
-                stats = Counters.read(in);
+                stats = new Counters(in);
             }
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/watch/WatchStatus.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/watch/WatchStatus.java
@@ -10,7 +10,6 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -37,7 +36,7 @@ import static org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils.
 import static org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils.writeDate;
 import static org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils.writeOptionalDate;
 
-public class WatchStatus implements ToXContentObject, Streamable, Writeable {
+public class WatchStatus implements ToXContentObject, Writeable {
 
     public static final String INCLUDE_STATE = "include_state";
 
@@ -237,11 +236,6 @@ public class WatchStatus implements ToXContentObject, Streamable, Writeable {
         if (statusHasHeaders) {
             out.writeMap(headers, StreamOutput::writeString, StreamOutput::writeString);
         }
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/SqlStatsResponse.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/SqlStatsResponse.java
@@ -58,7 +58,7 @@ public class SqlStatsResponse extends BaseNodesResponse<SqlStatsResponse.NodeSta
         public NodeStatsResponse(StreamInput in) throws IOException {
             super(in);
             if (in.readBoolean()) {
-                stats = Counters.read(in);
+                stats = new Counters(in);
             }
         }
 


### PR DESCRIPTION
This commit converts several utility classes that implement Streamable
to have StreamInput constructors. It also adds a default version of
readFrom to Streamable so that overriding to throw UOE is not necessary.

relates #34389
