### PR TITLE
Clarify repository-s3 defaulting to instance role

### DIFF
--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -63,7 +63,7 @@ For more information about creating and updating the {es} keystore, see
 {ref}/secure-settings.html[Secure settings].
 
 For example, if you want to use specific credentials to access S3 then run the
-following commands to add these credentials to the keystore.
+following commands to add these credentials to the keystore:
 
 [source,sh]
 ----

--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -62,13 +62,28 @@ with the exception of the secure settings, which you add to the {es} keystore.
 For more information about creating and updating the {es} keystore, see
 {ref}/secure-settings.html[Secure settings].
 
-For example, before you start the node, run these commands to add AWS access key
-settings to the keystore:
+For example, if you want to use specific credentials to access S3 then run the
+following commands to add these credentials to the keystore.
 
 [source,sh]
 ----
 bin/elasticsearch-keystore add s3.client.default.access_key
 bin/elasticsearch-keystore add s3.client.default.secret_key
+# a session token is optional so the following command may not be necessary
+bin/elasticsearch-keystore add s3.client.default.session_token
+----
+
+If instead you want to use the instance role or container role to access S3
+then you should leave these settings unset. You can switch from using specific
+credentials back to the default of using the instance role or container role by
+removing these settings from the keystore as follows:
+
+[source,sh]
+----
+bin/elasticsearch-keystore remove s3.client.default.access_key
+bin/elasticsearch-keystore remove s3.client.default.secret_key
+# a session token is optional so the following command may not be necessary
+bin/elasticsearch-keystore remove s3.client.default.session_token
 ----
 
 *All* client secure settings of this plugin are
@@ -88,16 +103,17 @@ settings belong in the `elasticsearch.yml` file.
 
 `access_key` ({ref}/secure-settings.html[Secure])::
 
-    An S3 access key. The `secret_key` setting must also be specified.
+    An S3 access key. If set, the `secret_key` setting must also be specified.
+    If unset, the client will use the instance or container role instead.
 
 `secret_key` ({ref}/secure-settings.html[Secure])::
 
-    An S3 secret key. The `access_key` setting must also be specified.
+    An S3 secret key. If set, the `access_key` setting must also be specified.
 
 `session_token` ({ref}/secure-settings.html[Secure])::
 
-    An S3 session token. The `access_key` and `secret_key` settings must also be
-    specified.
+    An S3 session token. If set, the `access_key` and `secret_key` settings
+    must also be specified.
 
 `endpoint`::
 


### PR DESCRIPTION
Specifies more clearly that you can leave the client credential settings unset
if you want to use the instance or container role.