### PR TITLE
Fail TestingConventionTasks if there are no enabled test tasks

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/TestingConventionsTasks.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/TestingConventionsTasks.java
@@ -130,6 +130,10 @@ public class TestingConventionsTasks extends DefaultTask {
 
     @TaskAction
     public void doCheck() throws IOException {
+        if (getProject().getTasks().withType(Test.class).stream().filter(Task::getEnabled).findAny().isEmpty()) {
+            throw new IllegalArgumentException("There are no enabled test tasks. Did you forget testingConventions.enabled = false?");
+        }
+
         final String problems;
 
         try (URLClassLoader isolatedClassLoader = new URLClassLoader(


### PR DESCRIPTION
While working on https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+7.2+multijob-windows-compatibility/os=windows-2016/16/console test failure, I've noticed that if there are no enabled test tasks in the project testConvention task fails with an incorrect error message, like this:
```
Test classes are not included in any enabled task ():
07:09:41 
07:09:41   * org.elasticsearch.wildfly.WildflyIT
```
I think we need to explicitly check if there are no enabled test tasks and fail-fast.
