### PR TITLE
Don't Swallow Interrupt in TransportService#onRequestReceived

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -915,7 +915,8 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
         try {
             blockIncomingRequestsLatch.await();
         } catch (InterruptedException e) {
-            logger.trace("interrupted while waiting for incoming requests block to be removed");
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("interrupted while waiting for incoming requests block to be removed");
         }
         if (tracerLog.isTraceEnabled() && shouldTraceAction(action)) {
             tracerLog.trace("[{}][{}] received request", requestId, action);


### PR DESCRIPTION
* We shouldn't just swallow the interrupt here quietly and keep going on the IO thread
   * Currently interrupt continues here just the same way an invocation of `acceptIncomingRequests` woudl have made things continue
* Relates #44610 ... it seems to me what might happen here is that the first message arrives, waits on the latch, latch is never counted down, gets interrupted processes the message in some way and just hangs on the next message in the pipeline forever explaining the blocked threads in the failures in #44610
* Also relates #41745 which gets stuck indefinitely on that same latch too
