### PR TITLE
Fix AnalysisMode propagation in NamedAnalyzer

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/analysis/NamedAnalyzer.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/NamedAnalyzer.java
@@ -55,6 +55,8 @@ public class NamedAnalyzer extends DelegatingAnalyzerWrapper {
         this.positionIncrementGap = positionIncrementGap;
         if (analyzer instanceof org.elasticsearch.index.analysis.CustomAnalyzer) {
             this.analysisMode = ((org.elasticsearch.index.analysis.CustomAnalyzer) analyzer).getAnalysisMode();
+        } else if (analyzer instanceof org.elasticsearch.index.analysis.ReloadableCustomAnalyzer) {
+            this.analysisMode = ((org.elasticsearch.index.analysis.ReloadableCustomAnalyzer) analyzer).getAnalysisMode();
         } else {
             this.analysisMode = AnalysisMode.ALL;
         }

--- a/server/src/main/java/org/elasticsearch/index/analysis/NamedAnalyzer.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/NamedAnalyzer.java
@@ -53,10 +53,8 @@ public class NamedAnalyzer extends DelegatingAnalyzerWrapper {
         this.scope = scope;
         this.analyzer = analyzer;
         this.positionIncrementGap = positionIncrementGap;
-        if (analyzer instanceof org.elasticsearch.index.analysis.CustomAnalyzer) {
-            this.analysisMode = ((org.elasticsearch.index.analysis.CustomAnalyzer) analyzer).getAnalysisMode();
-        } else if (analyzer instanceof org.elasticsearch.index.analysis.ReloadableCustomAnalyzer) {
-            this.analysisMode = ((org.elasticsearch.index.analysis.ReloadableCustomAnalyzer) analyzer).getAnalysisMode();
+        if (analyzer instanceof org.elasticsearch.index.analysis.AnalyzerComponentsProvider) {
+            this.analysisMode = ((org.elasticsearch.index.analysis.AnalyzerComponentsProvider) analyzer).getComponents().analysisMode();
         } else {
             this.analysisMode = AnalysisMode.ALL;
         }

--- a/server/src/test/java/org/elasticsearch/index/analysis/NamedAnalyzerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/NamedAnalyzerTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.analysis;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.elasticsearch.index.mapper.MapperException;
+import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.test.ESTestCase;
 
 public class NamedAnalyzerTests extends ESTestCase {
@@ -73,7 +74,13 @@ public class NamedAnalyzerTests extends ESTestCase {
                 return mode;
             }
         };
-        return new CustomAnalyzer(null, new CharFilterFactory[0],
-                new TokenFilterFactory[] { tokenFilter  });
+        TokenFilterFactory[] tokenfilters = new TokenFilterFactory[] { tokenFilter  };
+        CharFilterFactory[] charFilters = new CharFilterFactory[0];
+        if (mode == AnalysisMode.SEARCH_TIME && randomBoolean()) {
+            AnalyzerComponents components = new AnalyzerComponents(null, charFilters, tokenfilters);
+            // sometimes also return reloadable custom analyzer
+            return new ReloadableCustomAnalyzer(components , TextFieldMapper.Defaults.POSITION_INCREMENT_GAP, -1);
+        }
+        return new CustomAnalyzer(null, charFilters, tokenfilters);
     }
 }


### PR DESCRIPTION
NamedAnalyzer should return the same AnalysisMode than any custom analyzer it
wraps, otherwise AnalysisMode.ALL. This used to be only CustomAnalyzer in the
past, but with the introduction of the ReloadableCustomAnalyzer this needs to be
added as an option where the analysis mode gets propagated.

Closes #44625