### PR TITLE
Remove Needless Synchronization in FollowersChecker

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
@@ -242,11 +242,9 @@ public class FollowersChecker {
     }
 
     private void handleDisconnectedNode(DiscoveryNode discoveryNode) {
-        synchronized (mutex) {
-            FollowerChecker followerChecker = followerCheckers.get(discoveryNode);
-            if (followerChecker != null && followerChecker.running()) {
-                followerChecker.failNode("disconnected");
-            }
+        FollowerChecker followerChecker = followerCheckers.get(discoveryNode);
+        if (followerChecker != null) {
+            followerChecker.failNode("disconnected");
         }
     }
 


### PR DESCRIPTION
* It seems redundant to synchronize here **and** check that the map hasn't checked via the `running` under the mutex
   * The map won't change if under the mutex that locks on all the updates to it
* But, even without the mutex it's very unlikely to change inside the method call relative to the likelihood of changing until the generic pool where we check for `running` again anyway

-> just remove the synchronization (it's on the IO loop) and check since we do check the running state on the generic pool under the mutex anyway when we actually try to fail it
