### PR TITLE
[7.x] [ML][Data Frame] adding dynamic cluster setting for failure retries (#44577)

### DIFF
--- a/docs/reference/settings/data-frames-settings.asciidoc
+++ b/docs/reference/settings/data-frames-settings.asciidoc
@@ -1,0 +1,40 @@
+
+[role="xpack"]
+[[data-frames-settings]]
+=== {dataframe-transforms-cap}  settings in Elasticsearch
+[subs="attributes"]
+++++
+<titleabbrev>{dataframe-transforms-cap} settings</titleabbrev>
+++++
+
+You do not need to configure any settings to use {dataframe-transforms}. It is enabled by default.
+
+All of these settings can be added to the `elasticsearch.yml` configuration file. 
+The dynamic settings can also be updated across a cluster with the 
+<<cluster-update-settings,cluster update settings API>>.
+
+TIP: Dynamic settings take precedence over settings in the `elasticsearch.yml` 
+file.
+
+[float]
+[[general-data-frames-settings]]
+==== General {dataframe-transforms} settings
+
+`xpack.data_frame.enabled`::
+Set to `true` (default) to enable {dataframe-transforms} on the node. +
++
+If set to `false` in `elasticsearch.yml`, the {dataframe-transform} APIs are disabled on the node.
+Therefore the node cannot start or administrate transforms or receive transport (internal)
+communication requests related to {dataframe-transform} APIs.
++
+IMPORTANT: If you want to use {dataframe-transform} features in your cluster, you must have
+`xpack.data_frame.enabled` set to `true` on all master-eligible nodes. This is the
+default behavior.
+
+`xpack.data_frame.num_transform_failure_retries` (<<cluster-update-settings,Dynamic>>)::
+The number of times that a {dataframe-transform} retries when it experiences a
+non-fatal error. Once the number of retries is exhausted, the {dataframe-transform}
+task will be marked as `failed`. The default value is `10` with a valid minimum of `0`
+and maximum of `100`.
+If a {dataframe-transform} is already running, it will have to be restarted
+to use the changed setting.

--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -51,6 +51,8 @@ include::settings/audit-settings.asciidoc[]
 
 include::settings/ccr-settings.asciidoc[]
 
+include::settings/data-frames-settings.asciidoc[]
+
 include::settings/ilm-settings.asciidoc[]
 
 include::settings/license-settings.asciidoc[]

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
@@ -62,7 +62,7 @@ public class XPackSettings {
     /** Setting for enabling or disabling graph. Defaults to true. */
     public static final Setting<Boolean> GRAPH_ENABLED = Setting.boolSetting("xpack.graph.enabled", true, Setting.Property.NodeScope);
 
-    /** Setting for enabling or disabling machine learning. Defaults to false. */
+    /** Setting for enabling or disabling machine learning. Defaults to true. */
     public static final Setting<Boolean> MACHINE_LEARNING_ENABLED = Setting.boolSetting("xpack.ml.enabled", true,
             Setting.Property.NodeScope);
 

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/DataFrame.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/DataFrame.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.common.settings.SettingsModule;
@@ -71,6 +72,7 @@ import org.elasticsearch.xpack.dataframe.rest.action.RestPutDataFrameTransformAc
 import org.elasticsearch.xpack.dataframe.rest.action.RestStartDataFrameTransformAction;
 import org.elasticsearch.xpack.dataframe.rest.action.RestStopDataFrameTransformAction;
 import org.elasticsearch.xpack.dataframe.transforms.DataFrameTransformPersistentTasksExecutor;
+import org.elasticsearch.xpack.dataframe.transforms.DataFrameTransformTask;
 
 import java.io.IOException;
 import java.time.Clock;
@@ -219,6 +221,10 @@ public class DataFrame extends Plugin implements ActionPlugin, PersistentTaskPlu
 
         return Collections.singletonList(new DataFrameTransformPersistentTasksExecutor(client, dataFrameTransformsConfigManager.get(),
                 dataFrameTransformsCheckpointService.get(), schedulerEngine.get(), dataFrameAuditor.get(), threadPool));
+    }
+
+    public List<Setting<?>> getSettings() {
+        return Collections.singletonList(DataFrameTransformTask.NUM_FAILURE_RETRIES_SETTING);
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML][Data Frame] adding dynamic cluster setting for failure retries  (#44577)