### PR TITLE
Fix types field in JSON Search Slow Logs

### DIFF
--- a/distribution/src/config/log4j2.properties
+++ b/distribution/src/config/log4j2.properties
@@ -104,7 +104,7 @@ appender.index_search_slowlog_rolling.fileName = ${sys:es.logs.base_path}${sys:f
   .cluster_name}_index_search_slowlog.json
 appender.index_search_slowlog_rolling.layout.type = ESJsonLayout
 appender.index_search_slowlog_rolling.layout.type_name = index_search_slowlog
-appender.index_search_slowlog_rolling.layout.esmessagefields=message,took,took_millis,total_hits,stats,search_type,total_shards,source,id
+appender.index_search_slowlog_rolling.layout.esmessagefields=message,took,took_millis,total_hits,types,stats,search_type,total_shards,source,id
 
 appender.index_search_slowlog_rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs\
   .cluster_name}_index_search_slowlog-%i.json.gz

--- a/server/src/main/java/org/elasticsearch/common/logging/ESLogMessage.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ESLogMessage.java
@@ -19,9 +19,11 @@
 
 package org.elasticsearch.common.logging;
 
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.common.SuppressLoggerChecks;
 
+import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -30,6 +32,8 @@ import java.util.stream.Stream;
  * A base class for custom log4j logger messages. Carries additional fields which will populate JSON fields in logs.
  */
 public abstract class ESLogMessage extends ParameterizedMessage {
+    private static final JsonStringEncoder JSON_STRING_ENCODER = JsonStringEncoder.getInstance();
+
     private final Map<String, Object> fields;
 
     /**
@@ -42,19 +46,24 @@ public abstract class ESLogMessage extends ParameterizedMessage {
         this.fields = fields;
     }
 
+    public static String escapeJson(String text) {
+        byte[] sourceEscaped = JSON_STRING_ENCODER.quoteAsUTF8(text);
+        return new String(sourceEscaped, Charset.defaultCharset());
+    }
+
     public String getValueFor(String key) {
         Object value = fields.get(key);
-        return value!=null ? value.toString() : null;
+        return value != null ? value.toString() : null;
     }
 
     public static String inQuotes(String s) {
-        if(s == null)
+        if (s == null)
             return inQuotes("");
         return "\"" + s + "\"";
     }
 
     public static String inQuotes(Object s) {
-        if(s == null)
+        if (s == null)
             return inQuotes("");
         return inQuotes(s.toString());
     }

--- a/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
+++ b/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index;
 
-import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.Strings;
@@ -33,7 +32,6 @@ import org.elasticsearch.index.shard.SearchOperationListener;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.tasks.Task;
 
-import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -172,15 +170,13 @@ public final class SearchSlowLog implements SearchOperationListener {
                 messageFields.put("total_hits", "-1");
             }
             String[] types = context.getQueryShardContext().getTypes();
-            messageFields.put("types", asJsonArray(types != null ? Arrays.stream(types) : Stream.empty()));
+            messageFields.put("types", escapeJson(asJsonArray(types != null ? Arrays.stream(types) : Stream.empty())));
             messageFields.put("stats", asJsonArray(context.groupStats() != null ? context.groupStats().stream() : Stream.empty()));
             messageFields.put("search_type", context.searchType());
             messageFields.put("total_shards", context.numberOfShards());
 
             if (context.request().source() != null) {
-                byte[] sourceEscaped = JsonStringEncoder.getInstance()
-                                                        .quoteAsUTF8(context.request().source().toString(FORMAT_PARAMS));
-                String source = new String(sourceEscaped, Charset.defaultCharset());
+                String source = escapeJson(context.request().source().toString(FORMAT_PARAMS));
 
                 messageFields.put("source", source);
             } else {

--- a/server/src/test/java/org/elasticsearch/index/SearchSlowLogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/SearchSlowLogTests.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.index.shard.ShardId;


### PR DESCRIPTION
The field has to be defined in log4j2.properties and should be an
escaped JSON for now (it is a broken JSON at the moment). This should later be refactored into a JSON array
of strings. 
`  "types": "[\"type1\", \"type2\"]", `
```
{
  "type": "index_search_slowlog",
  "timestamp": "2019-07-22T10:36:07,942+02:00",
  "level": "WARN",
  "component": "i.s.s.query",
  "cluster.name": "distribution_run",
  "node.name": "node-0",
  "message": "[index6][0]",
  "took": "8.9ms",
  "took_millis": "8",
  "total_hits": "0 hits",
  "types": "[\"type1\", \"type2\"]",
  "stats": "[]",
  "search_type": "QUERY_THEN_FETCH",
  "total_shards": "1",
  "source": "{}",
  "id": "ASDF",
  "cluster.uuid": "PkkHdglrTiiWfIE_0V4xWA",
  "node.id": "LFhU0lQaRNmxQPewPk0l7w"
}
```