### PR TITLE
Convert Transport Request/Response to Writeable (#44636)

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/SyncedFlushResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/SyncedFlushResponseTests.java
@@ -191,7 +191,7 @@ public class SyncedFlushResponseTests extends ESTestCase {
                             );
                         } else {
                             successful++;
-                            shardResponses.put(shardRouting, new SyncedFlushService.ShardSyncedFlushResponse());
+                            shardResponses.put(shardRouting, new SyncedFlushService.ShardSyncedFlushResponse((String) null));
                         }
                     }
                     shardsResults.add(new ShardsSyncedFlushResult(shardId, "_sync_id_" + shard, replicas + 1, shardResponses));

--- a/server/src/main/java/org/elasticsearch/action/ActionRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionRequest.java
@@ -48,11 +48,6 @@ public abstract class ActionRequest extends TransportRequest {
     }
 
     @Override
-    public final void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable " + getClass().getName());
-    }
-
-    @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
     }

--- a/server/src/main/java/org/elasticsearch/action/ActionResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionResponse.java
@@ -35,9 +35,4 @@ public abstract class ActionResponse extends TransportResponse {
     public ActionResponse(StreamInput in) throws IOException {
         super(in);
     }
-
-    @Override
-    public final void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
-    }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -95,7 +95,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         super(in);
         timestamp = in.readVLong();
         if (in.readBoolean()) {
-            indices = NodeIndicesStats.readIndicesStats(in);
+            indices = new NodeIndicesStats(in);
         }
         os = in.readOptionalWriteable(OsStats::new);
         process = in.readOptionalWriteable(ProcessStats::new);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexShardStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexShardStatus.java
@@ -50,7 +50,12 @@ public class SnapshotIndexShardStatus extends BroadcastShardResponse implements 
 
     private String failure;
 
-    private SnapshotIndexShardStatus() {
+    public SnapshotIndexShardStatus(StreamInput in) throws IOException {
+        super(in);
+        stage = SnapshotIndexShardStage.fromValue(in.readByte());
+        stats = new SnapshotStats(in);
+        nodeId = in.readOptionalString();
+        failure = in.readOptionalString();
     }
 
     SnapshotIndexShardStatus(ShardId shardId, SnapshotIndexShardStage stage) {
@@ -127,13 +132,6 @@ public class SnapshotIndexShardStatus extends BroadcastShardResponse implements 
         return failure;
     }
 
-
-    public static SnapshotIndexShardStatus readShardSnapshotStatus(StreamInput in) throws IOException {
-        SnapshotIndexShardStatus shardStatus = new SnapshotIndexShardStatus();
-        shardStatus.readFrom(in);
-        return shardStatus;
-    }
-
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
@@ -141,15 +139,6 @@ public class SnapshotIndexShardStatus extends BroadcastShardResponse implements 
         stats.writeTo(out);
         out.writeOptionalString(nodeId);
         out.writeOptionalString(failure);
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        stage = SnapshotIndexShardStage.fromValue(in.readByte());
-        stats = new SnapshotStats(in);
-        nodeId = in.readOptionalString();
-        failure = in.readOptionalString();
     }
 
     static final class Fields {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
@@ -78,7 +78,7 @@ public class SnapshotStatus implements ToXContentObject, Writeable {
         int size = in.readVInt();
         List<SnapshotIndexShardStatus> builder = new ArrayList<>();
         for (int i = 0; i < size; i++) {
-            builder.add(SnapshotIndexShardStatus.readShardSnapshotStatus(in));
+            builder.add(new SnapshotIndexShardStatus(in));
         }
         shards = Collections.unmodifiableList(builder);
         if (in.getVersion().onOrAfter(Version.V_6_2_0)) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
@@ -198,7 +198,7 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<Transpor
                 Map<ShardId, SnapshotIndexShardStatus> shardMapBuilder = new HashMap<>(numberOfShards);
                 for (int j = 0; j < numberOfShards; j++) {
                     ShardId shardId =  new ShardId(in);
-                    SnapshotIndexShardStatus status = SnapshotIndexShardStatus.readShardSnapshotStatus(in);
+                    SnapshotIndexShardStatus status = new SnapshotIndexShardStatus(in);
                     shardMapBuilder.put(shardId, status);
                 }
                 snapshotMapBuilder.put(snapshot, unmodifiableMap(shardMapBuilder));

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/flush/SyncedFlushResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/flush/SyncedFlushResponse.java
@@ -65,7 +65,7 @@ public class SyncedFlushResponse extends ActionResponse implements ToXContentFra
             List<ShardsSyncedFlushResult> shardsSyncedFlushResults = new ArrayList<>();
             int numShards = in.readInt();
             for (int j =0; j< numShards; j++) {
-                shardsSyncedFlushResults.add(ShardsSyncedFlushResult.readShardsSyncedFlushResult(in));
+                shardsSyncedFlushResults.add(new ShardsSyncedFlushResult(in));
             }
             tmpShardsResultPerIndex.put(index, shardsSyncedFlushResults);
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/segments/ShardSegments.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/segments/ShardSegments.java
@@ -50,7 +50,7 @@ public class ShardSegments implements Writeable, Iterable<Segment> {
         } else {
             segments = new ArrayList<>(size);
             for (int i = 0; i < size; i++) {
-                segments.add(Segment.readSegment(in));
+                segments.add(new Segment(in));
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/upgrade/get/ShardUpgradeStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/upgrade/get/ShardUpgradeStatus.java
@@ -36,7 +36,12 @@ public class ShardUpgradeStatus extends BroadcastShardResponse {
 
     private long toUpgradeBytesAncient;
 
-    ShardUpgradeStatus() {
+    public ShardUpgradeStatus(StreamInput in) throws IOException {
+        super(in);
+        shardRouting = new ShardRouting(in);
+        totalBytes = in.readLong();
+        toUpgradeBytes = in.readLong();
+        toUpgradeBytesAncient = in.readLong();
     }
 
     ShardUpgradeStatus(ShardRouting shardRouting, long totalBytes, long toUpgradeBytes, long upgradeBytesAncient) {
@@ -62,21 +67,6 @@ public class ShardUpgradeStatus extends BroadcastShardResponse {
 
     public long getToUpgradeBytesAncient() {
         return toUpgradeBytesAncient;
-    }
-
-    public static ShardUpgradeStatus readShardUpgradeStatus(StreamInput in) throws IOException {
-        ShardUpgradeStatus shard = new ShardUpgradeStatus();
-        shard.readFrom(in);
-        return shard;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        shardRouting = new ShardRouting(in);
-        totalBytes = in.readLong();
-        toUpgradeBytes = in.readLong();
-        toUpgradeBytesAncient = in.readLong();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/upgrade/get/TransportUpgradeStatusAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/upgrade/get/TransportUpgradeStatusAction.java
@@ -76,7 +76,7 @@ public class TransportUpgradeStatusAction
 
     @Override
     protected ShardUpgradeStatus readShardResult(StreamInput in) throws IOException {
-        return ShardUpgradeStatus.readShardUpgradeStatus(in);
+        return new ShardUpgradeStatus(in);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/upgrade/get/UpgradeStatusResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/upgrade/get/UpgradeStatusResponse.java
@@ -43,7 +43,7 @@ public class UpgradeStatusResponse extends BroadcastResponse {
         super(in);
         shards = new ShardUpgradeStatus[in.readVInt()];
         for (int i = 0; i < shards.length; i++) {
-            shards[i] = ShardUpgradeStatus.readShardUpgradeStatus(in);
+            shards[i] = new ShardUpgradeStatus(in);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/ShardUpgradeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/upgrade/post/ShardUpgradeRequest.java
@@ -29,20 +29,16 @@ import java.io.IOException;
 
 public final class ShardUpgradeRequest extends BroadcastShardRequest {
 
-    private UpgradeRequest request = new UpgradeRequest();
+    private UpgradeRequest request;
 
-    public ShardUpgradeRequest() {
+    public ShardUpgradeRequest(StreamInput in) throws IOException {
+        super(in);
+        request = new UpgradeRequest(in);
     }
 
     ShardUpgradeRequest(ShardId shardId, UpgradeRequest request) {
         super(shardId, request);
         this.request = request;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        request.readFrom(in);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryResponse.java
@@ -39,8 +39,11 @@ class ShardValidateQueryResponse extends BroadcastShardResponse {
 
     private String error;
     
-    ShardValidateQueryResponse() {
-
+    ShardValidateQueryResponse(StreamInput in) throws IOException {
+        super(in);
+        valid = in.readBoolean();
+        explanation = in.readOptionalString();
+        error = in.readOptionalString();
     }
 
     ShardValidateQueryResponse(ShardId shardId, boolean valid, String explanation, String error) {
@@ -60,14 +63,6 @@ class ShardValidateQueryResponse extends BroadcastShardResponse {
     
     public String getError() {
         return error;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        valid = in.readBoolean();
-        explanation = in.readOptionalString();
-        error = in.readOptionalString();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
@@ -36,6 +36,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.query.ParsedQuery;
@@ -122,8 +123,8 @@ public class TransportValidateQueryAction extends TransportBroadcastAction<
     }
 
     @Override
-    protected ShardValidateQueryResponse newShardResponse() {
-        return new ShardValidateQueryResponse();
+    protected ShardValidateQueryResponse readShardResponse(StreamInput in) throws IOException {
+        return new ShardValidateQueryResponse(in);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/explain/ExplainResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/explain/ExplainResponse.java
@@ -91,7 +91,7 @@ public class ExplainResponse extends ActionResponse implements StatusToXContentO
             explanation = readExplanation(in);
         }
         if (in.readBoolean()) {
-            getResult = GetResult.readGetResult(in);
+            getResult = new GetResult(in);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/get/GetResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/get/GetResponse.java
@@ -50,7 +50,7 @@ public class GetResponse extends ActionResponse implements Iterable<DocumentFiel
 
     GetResponse(StreamInput in) throws IOException {
         super(in);
-        getResult = GetResult.readGetResult(in);
+        getResult = new GetResult(in);
     }
 
     public GetResponse(GetResult getResult) {

--- a/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
@@ -266,9 +266,6 @@ public class SearchTransportService {
 
         private boolean freed;
 
-        SearchFreeContextResponse() {
-        }
-
         SearchFreeContextResponse(StreamInput in) throws IOException {
             freed = in.readBoolean();
         }
@@ -279,12 +276,6 @@ public class SearchTransportService {
 
         public boolean isFreed() {
             return freed;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            freed = in.readBoolean();
         }
 
         @Override
@@ -306,8 +297,9 @@ public class SearchTransportService {
                 channel.sendResponse(new SearchFreeContextResponse(freed));
         });
         TransportActionProxy.registerProxyAction(transportService, FREE_CONTEXT_ACTION_NAME, SearchFreeContextResponse::new);
-        transportService.registerRequestHandler(CLEAR_SCROLL_CONTEXTS_ACTION_NAME, () -> TransportRequest.Empty.INSTANCE,
-            ThreadPool.Names.SAME, (request, channel, task) -> {
+        transportService.registerRequestHandler(CLEAR_SCROLL_CONTEXTS_ACTION_NAME, ThreadPool.Names.SAME,
+            TransportRequest.Empty::new,
+            (request, channel, task) -> {
                 searchService.freeAllScrollContexts();
                 channel.sendResponse(TransportResponse.Empty.INSTANCE);
         });

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardResponse.java
@@ -30,8 +30,9 @@ public abstract class BroadcastShardResponse extends TransportResponse {
 
     ShardId shardId;
 
-    protected BroadcastShardResponse() {
-
+    protected BroadcastShardResponse(StreamInput in) throws IOException {
+        super(in);
+        shardId = new ShardId(in);
     }
 
     protected BroadcastShardResponse(ShardId shardId) {
@@ -44,12 +45,6 @@ public abstract class BroadcastShardResponse extends TransportResponse {
 
     public ShardId getShardId() {
         return this.shardId;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        shardId = new ShardId(in);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/TransportBroadcastAction.java
@@ -87,7 +87,7 @@ public abstract class TransportBroadcastAction<
 
     protected abstract ShardRequest newShardRequest(int numShards, ShardRouting shard, Request request);
 
-    protected abstract ShardResponse newShardResponse();
+    protected abstract ShardResponse readShardResponse(StreamInput in) throws IOException;
 
     protected abstract ShardResponse shardOperation(ShardRequest request, Task task) throws IOException;
 
@@ -180,9 +180,7 @@ public abstract class TransportBroadcastAction<
                             new TransportResponseHandler<ShardResponse>() {
                                 @Override
                                 public ShardResponse read(StreamInput in) throws IOException {
-                                    ShardResponse response = newShardResponse();
-                                    response.readFrom(in);
-                                    return response;
+                                    return readShardResponse(in);
                                 }
 
                                 @Override

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
@@ -111,7 +111,7 @@ public abstract class TransportBroadcastByNodeAction<Request extends BroadcastRe
 
         transportNodeBroadcastAction = actionName + "[n]";
 
-        transportService.registerRequestHandler(transportNodeBroadcastAction, NodeRequest::new, executor, false, canTripCircuitBreaker,
+        transportService.registerRequestHandler(transportNodeBroadcastAction, executor, false, canTripCircuitBreaker, NodeRequest::new,
             new BroadcastByNodeTransportRequestHandler());
     }
 
@@ -452,7 +452,11 @@ public abstract class TransportBroadcastByNodeAction<Request extends BroadcastRe
 
         protected Request indicesLevelRequest;
 
-        public NodeRequest() {
+        public NodeRequest(StreamInput in) throws IOException {
+            super(in);
+            indicesLevelRequest = readRequestFrom(in);
+            shards = in.readList(ShardRouting::new);
+            nodeId = in.readString();
         }
 
         public NodeRequest(String nodeId, Request request, List<ShardRouting> shards) {
@@ -477,14 +481,6 @@ public abstract class TransportBroadcastByNodeAction<Request extends BroadcastRe
         @Override
         public IndicesOptions indicesOptions() {
             return indicesLevelRequest.indicesOptions();
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            indicesLevelRequest = readRequestFrom(in);
-            shards = in.readList(ShardRouting::new);
-            nodeId = in.readString();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodeRequest.java
@@ -39,11 +39,6 @@ public abstract class BaseNodeRequest extends TransportRequest {
     }
 
     @Override
-    public final void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
-    }
-
-    @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         if (out.getVersion().before(Version.V_7_3_0)) {

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodeResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodeResponse.java
@@ -51,11 +51,6 @@ public abstract class BaseNodeResponse extends TransportResponse {
     }
 
     @Override
-    public final void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
-    }
-
-    @Override
     public void writeTo(StreamOutput out) throws IOException {
         node.writeTo(out);
     }

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -1102,11 +1102,6 @@ public abstract class TransportReplicationAction<
         }
 
         @Override
-        public void readFrom(StreamInput in) {
-            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
-        }
-
-        @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeString(targetAllocationID);
             out.writeVLong(primaryTerm);
@@ -1157,11 +1152,6 @@ public abstract class TransportReplicationAction<
             super(request, targetAllocationID, primaryTerm);
             this.globalCheckpoint = globalCheckpoint;
             this.maxSeqNoOfUpdatesOrDeletes = maxSeqNoOfUpdatesOrDeletes;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) {
-            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
@@ -265,9 +265,7 @@ public abstract class TransportTasksAction<
                                 new TransportResponseHandler<NodeTasksResponse>() {
                                     @Override
                                     public NodeTasksResponse read(StreamInput in) throws IOException {
-                                        NodeTasksResponse response = new NodeTasksResponse();
-                                        response.readFrom(in);
-                                        return response;
+                                        return new NodeTasksResponse(in);
                                     }
 
                                     @Override
@@ -368,28 +366,8 @@ public abstract class TransportTasksAction<
         protected List<TaskOperationFailure> exceptions;
         protected List<TaskResponse> results;
 
-        NodeTasksResponse() {
-        }
-
-        NodeTasksResponse(String nodeId,
-                                 List<TaskResponse> results,
-                                 List<TaskOperationFailure> exceptions) {
-            this.nodeId = nodeId;
-            this.results = results;
-            this.exceptions = exceptions;
-        }
-
-        public String getNodeId() {
-            return nodeId;
-        }
-
-        public List<TaskOperationFailure> getExceptions() {
-            return exceptions;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
+        NodeTasksResponse(StreamInput in) throws IOException {
+            super(in);
             nodeId = in.readString();
             int resultsSize = in.readVInt();
             results = new ArrayList<>(resultsSize);
@@ -406,6 +384,22 @@ public abstract class TransportTasksAction<
             } else {
                 exceptions = null;
             }
+        }
+
+        NodeTasksResponse(String nodeId,
+                                 List<TaskResponse> results,
+                                 List<TaskOperationFailure> exceptions) {
+            this.nodeId = nodeId;
+            this.results = results;
+            this.exceptions = exceptions;
+        }
+
+        public String getNodeId() {
+            return nodeId;
+        }
+
+        public List<TaskOperationFailure> getExceptions() {
+            return exceptions;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -312,12 +311,12 @@ public class UpdateHelper {
 
     public static class Result {
 
-        private final Streamable action;
+        private final Writeable action;
         private final DocWriteResponse.Result result;
         private final Map<String, Object> updatedSourceAsMap;
         private final XContentType updateSourceContentType;
 
-        public Result(Streamable action, DocWriteResponse.Result result, Map<String, Object> updatedSourceAsMap,
+        public Result(Writeable action, DocWriteResponse.Result result, Map<String, Object> updatedSourceAsMap,
                       XContentType updateSourceContentType) {
             this.action = action;
             this.result = result;

--- a/server/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
@@ -42,7 +42,7 @@ public class UpdateResponse extends DocWriteResponse {
     public UpdateResponse(StreamInput in) throws IOException {
         super(in);
         if (in.readBoolean()) {
-            getResult = GetResult.readGetResult(in);
+            getResult = new GetResult(in);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/action/index/NodeMappingRefreshAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/action/index/NodeMappingRefreshAction.java
@@ -54,7 +54,7 @@ public class NodeMappingRefreshAction {
         this.transportService = transportService;
         this.metaDataMappingService = metaDataMappingService;
         transportService.registerRequestHandler(ACTION_NAME,
-            NodeMappingRefreshRequest::new, ThreadPool.Names.SAME, new NodeMappingRefreshTransportHandler());
+           ThreadPool.Names.SAME,  NodeMappingRefreshRequest::new, new NodeMappingRefreshTransportHandler());
     }
 
     public void nodeMappingRefresh(final DiscoveryNode masterNode, final NodeMappingRefreshRequest request) {
@@ -80,7 +80,11 @@ public class NodeMappingRefreshAction {
         private String indexUUID = IndexMetaData.INDEX_UUID_NA_VALUE;
         private String nodeId;
 
-        public NodeMappingRefreshRequest() {
+        public NodeMappingRefreshRequest(StreamInput in) throws IOException {
+            super(in);
+            index = in.readString();
+            nodeId = in.readString();
+            indexUUID = in.readString();
         }
 
         public NodeMappingRefreshRequest(String index, String indexUUID, String nodeId) {
@@ -117,14 +121,6 @@ public class NodeMappingRefreshAction {
             out.writeString(index);
             out.writeString(nodeId);
             out.writeString(indexUUID);
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            index = in.readString();
-            nodeId = in.readString();
-            indexUUID = in.readString();
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
@@ -115,7 +115,7 @@ public class FollowersChecker {
         transportService.registerRequestHandler(FOLLOWER_CHECK_ACTION_NAME, Names.SAME, false, false, FollowerCheckRequest::new,
             (request, transportChannel, task) -> handleFollowerCheck(request, transportChannel));
         transportService.registerRequestHandler(
-            NodesFaultDetection.PING_ACTION_NAME, NodesFaultDetection.PingRequest::new, Names.SAME, false, false,
+            NodesFaultDetection.PING_ACTION_NAME, Names.SAME, false, false, NodesFaultDetection.PingRequest::new,
             (request, channel, task) -> // TODO: check that we're a follower of the requesting node?
                 channel.sendResponse(new NodesFaultDetection.PingResponse()));
         transportService.addConnectionListener(new TransportConnectionListener() {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -124,8 +124,8 @@ public class JoinHelper {
         transportService.registerRequestHandler(JOIN_ACTION_NAME, ThreadPool.Names.GENERIC, false, false, JoinRequest::new,
             (request, channel, task) -> joinHandler.accept(request, transportJoinCallback(request, channel)));
 
-        transportService.registerRequestHandler(MembershipAction.DISCOVERY_JOIN_ACTION_NAME, MembershipAction.JoinRequest::new,
-            ThreadPool.Names.GENERIC, false, false,
+        transportService.registerRequestHandler(MembershipAction.DISCOVERY_JOIN_ACTION_NAME,
+            ThreadPool.Names.GENERIC, false, false, MembershipAction.JoinRequest::new,
             (request, channel, task) -> joinHandler.accept(new JoinRequest(request.getNode(), Optional.empty()), // treat as non-voting join
                 transportJoinCallback(request, channel)));
 
@@ -138,7 +138,7 @@ public class JoinHelper {
             });
 
         transportService.registerRequestHandler(VALIDATE_JOIN_ACTION_NAME,
-            ValidateJoinRequest::new, ThreadPool.Names.GENERIC,
+            ThreadPool.Names.GENERIC, ValidateJoinRequest::new,
             (request, channel, task) -> {
                 final ClusterState localState = currentStateSupplier.get();
                 if (localState.metaData().clusterUUIDCommitted() &&
@@ -152,7 +152,7 @@ public class JoinHelper {
             });
 
         transportService.registerRequestHandler(MembershipAction.DISCOVERY_JOIN_VALIDATE_ACTION_NAME,
-            ValidateJoinRequest::new, ThreadPool.Names.GENERIC,
+            ThreadPool.Names.GENERIC, ValidateJoinRequest::new,
             (request, channel, task) -> {
                 final ClusterState localState = currentStateSupplier.get();
                 if (localState.metaData().clusterUUIDCommitted() &&
@@ -167,11 +167,11 @@ public class JoinHelper {
             });
 
         transportService.registerRequestHandler(
-            ZenDiscovery.DISCOVERY_REJOIN_ACTION_NAME, ZenDiscovery.RejoinClusterRequest::new, ThreadPool.Names.SAME,
+            ZenDiscovery.DISCOVERY_REJOIN_ACTION_NAME, ThreadPool.Names.SAME, ZenDiscovery.RejoinClusterRequest::new,
             (request, channel, task) -> channel.sendResponse(Empty.INSTANCE)); // TODO: do we need to implement anything here?
 
         transportService.registerRequestHandler(
-            MembershipAction.DISCOVERY_LEAVE_ACTION_NAME, MembershipAction.LeaveRequest::new, ThreadPool.Names.SAME,
+            MembershipAction.DISCOVERY_LEAVE_ACTION_NAME, ThreadPool.Names.SAME, MembershipAction.LeaveRequest::new,
             (request, channel, task) -> channel.sendResponse(Empty.INSTANCE)); // TODO: do we need to implement anything here?
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
@@ -106,8 +106,8 @@ public class LeaderChecker {
                 channel.sendResponse(Empty.INSTANCE);
             });
 
-        transportService.registerRequestHandler(MasterFaultDetection.MASTER_PING_ACTION_NAME, MasterFaultDetection.MasterPingRequest::new,
-            Names.SAME, false, false, (request, channel, task) -> {
+        transportService.registerRequestHandler(MasterFaultDetection.MASTER_PING_ACTION_NAME,
+            Names.SAME, false, false, MasterFaultDetection.MasterPingRequest::new, (request, channel, task) -> {
                 try {
                     handleLeaderCheck(new LeaderCheckRequest(request.sourceNode));
                 } catch (CoordinationStateRejectedException e) {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
@@ -96,12 +96,11 @@ public class PublicationTransportHandler {
         this.namedWriteableRegistry = namedWriteableRegistry;
         this.handlePublishRequest = handlePublishRequest;
 
-        transportService.registerRequestHandler(PUBLISH_STATE_ACTION_NAME, BytesTransportRequest::new, ThreadPool.Names.GENERIC,
-            false, false, (request, channel, task) -> channel.sendResponse(handleIncomingPublishRequest(request)));
+        transportService.registerRequestHandler(PUBLISH_STATE_ACTION_NAME, ThreadPool.Names.GENERIC, false, false,
+            BytesTransportRequest::new, (request, channel, task) -> channel.sendResponse(handleIncomingPublishRequest(request)));
 
-        transportService.registerRequestHandler(PublishClusterStateAction.SEND_ACTION_NAME, BytesTransportRequest::new,
-            ThreadPool.Names.GENERIC,
-            false, false, (request, channel, task) -> {
+        transportService.registerRequestHandler(PublishClusterStateAction.SEND_ACTION_NAME, ThreadPool.Names.GENERIC,
+            false, false, BytesTransportRequest::new, (request, channel, task) -> {
                 handleIncomingPublishRequest(request);
                 channel.sendResponse(TransportResponse.Empty.INSTANCE);
             });
@@ -111,8 +110,7 @@ public class PublicationTransportHandler {
             (request, channel, task) -> handleApplyCommit.accept(request, transportCommitCallback(channel)));
 
         transportService.registerRequestHandler(PublishClusterStateAction.COMMIT_ACTION_NAME,
-            PublishClusterStateAction.CommitClusterStateRequest::new,
-            ThreadPool.Names.GENERIC, false, false,
+            ThreadPool.Names.GENERIC, false, false, PublishClusterStateAction.CommitClusterStateRequest::new,
             (request, channel, task) -> {
                 final Optional<ClusterState> matchingClusterState = Optional.ofNullable(lastSeenClusterState.get()).filter(
                     cs -> cs.stateUUID().equals(request.stateUUID));

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ValidateJoinRequest.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ValidateJoinRequest.java
@@ -28,16 +28,13 @@ import java.io.IOException;
 public class ValidateJoinRequest extends TransportRequest {
     private ClusterState state;
 
-    public ValidateJoinRequest() {}
+    public ValidateJoinRequest(StreamInput in) throws IOException {
+        super(in);
+        this.state = ClusterState.readFrom(in, null);
+    }
 
     public ValidateJoinRequest(ClusterState state) {
         this.state = state;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        this.state = ClusterState.readFrom(in, null);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/discovery/zen/MasterFaultDetection.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/MasterFaultDetection.java
@@ -93,7 +93,7 @@ public class MasterFaultDetection extends FaultDetection {
             pingRetryCount);
 
         transportService.registerRequestHandler(
-            MASTER_PING_ACTION_NAME, MasterPingRequest::new, ThreadPool.Names.SAME, false, false, new MasterPingRequestHandler());
+            MASTER_PING_ACTION_NAME, ThreadPool.Names.SAME, false, false, MasterPingRequest::new, new MasterPingRequestHandler());
     }
 
     public DiscoveryNode masterNode() {
@@ -406,21 +406,17 @@ public class MasterFaultDetection extends FaultDetection {
         private DiscoveryNode masterNode;
         private ClusterName clusterName;
 
-        public MasterPingRequest() {
+        public MasterPingRequest(StreamInput in) throws IOException {
+            super(in);
+            sourceNode = new DiscoveryNode(in);
+            masterNode = new DiscoveryNode(in);
+            clusterName = new ClusterName(in);
         }
 
         public MasterPingRequest(DiscoveryNode sourceNode, DiscoveryNode masterNode, ClusterName clusterName) {
             this.sourceNode = sourceNode;
             this.masterNode = masterNode;
             this.clusterName = clusterName;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            sourceNode = new DiscoveryNode(in);
-            masterNode = new DiscoveryNode(in);
-            clusterName = new ClusterName(in);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/discovery/zen/MembershipAction.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/MembershipAction.java
@@ -72,13 +72,13 @@ public class MembershipAction {
         this.listener = listener;
 
 
-        transportService.registerRequestHandler(DISCOVERY_JOIN_ACTION_NAME, JoinRequest::new,
-            ThreadPool.Names.GENERIC, new JoinRequestRequestHandler());
+        transportService.registerRequestHandler(DISCOVERY_JOIN_ACTION_NAME,
+            ThreadPool.Names.GENERIC, JoinRequest::new, new JoinRequestRequestHandler());
         transportService.registerRequestHandler(DISCOVERY_JOIN_VALIDATE_ACTION_NAME,
-            () -> new ValidateJoinRequest(), ThreadPool.Names.GENERIC,
+            ThreadPool.Names.GENERIC, ValidateJoinRequest::new,
             new ValidateJoinRequestRequestHandler(transportService::getLocalNode, joinValidators));
-        transportService.registerRequestHandler(DISCOVERY_LEAVE_ACTION_NAME, LeaveRequest::new,
-            ThreadPool.Names.GENERIC, new LeaveRequestRequestHandler());
+        transportService.registerRequestHandler(DISCOVERY_LEAVE_ACTION_NAME,
+            ThreadPool.Names.GENERIC, LeaveRequest::new, new LeaveRequestRequestHandler());
     }
 
     public void sendLeaveRequest(DiscoveryNode masterNode, DiscoveryNode node) {
@@ -112,17 +112,13 @@ public class MembershipAction {
             return node;
         }
 
-        public JoinRequest() {
+        public JoinRequest(StreamInput in) throws IOException {
+            super(in);
+            node = new DiscoveryNode(in);
         }
 
         public JoinRequest(DiscoveryNode node) {
             this.node = node;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            node = new DiscoveryNode(in);
         }
 
         @Override
@@ -183,17 +179,13 @@ public class MembershipAction {
 
         private DiscoveryNode node;
 
-        public LeaveRequest() {
+        public LeaveRequest(StreamInput in) throws IOException {
+            super(in);
+            node = new DiscoveryNode(in);
         }
 
         private LeaveRequest(DiscoveryNode node) {
             this.node = node;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            node = new DiscoveryNode(in);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/discovery/zen/NodesFaultDetection.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/NodesFaultDetection.java
@@ -86,7 +86,7 @@ public class NodesFaultDetection extends FaultDetection {
             pingRetryCount);
 
         transportService.registerRequestHandler(
-            PING_ACTION_NAME, PingRequest::new, ThreadPool.Names.SAME, false, false, new PingRequestHandler());
+            PING_ACTION_NAME, ThreadPool.Names.SAME, false, false, PingRequest::new, new PingRequestHandler());
     }
 
     public void setLocalNode(DiscoveryNode localNode) {
@@ -313,7 +313,12 @@ public class NodesFaultDetection extends FaultDetection {
 
         private long clusterStateVersion = ClusterState.UNKNOWN_VERSION;
 
-        public PingRequest() {
+        public PingRequest(StreamInput in) throws IOException {
+            super(in);
+            targetNode = new DiscoveryNode(in);
+            clusterName = new ClusterName(in);
+            masterNode = new DiscoveryNode(in);
+            clusterStateVersion = in.readLong();
         }
 
         public PingRequest(DiscoveryNode targetNode, ClusterName clusterName, DiscoveryNode masterNode, long clusterStateVersion) {
@@ -337,15 +342,6 @@ public class NodesFaultDetection extends FaultDetection {
 
         public long clusterStateVersion() {
             return clusterStateVersion;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            targetNode = new DiscoveryNode(in);
-            clusterName = new ClusterName(in);
-            masterNode = new DiscoveryNode(in);
-            clusterStateVersion = in.readLong();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/discovery/zen/PublishClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/PublishClusterStateAction.java
@@ -113,9 +113,9 @@ public class PublishClusterStateAction {
         this.namedWriteableRegistry = namedWriteableRegistry;
         this.incomingClusterStateListener = incomingClusterStateListener;
         this.discoverySettings = discoverySettings;
-        transportService.registerRequestHandler(SEND_ACTION_NAME, BytesTransportRequest::new, ThreadPool.Names.SAME, false, false,
+        transportService.registerRequestHandler(SEND_ACTION_NAME, ThreadPool.Names.SAME, false, false, BytesTransportRequest::new,
             new SendClusterStateRequestHandler());
-        transportService.registerRequestHandler(COMMIT_ACTION_NAME, CommitClusterStateRequest::new, ThreadPool.Names.SAME, false, false,
+        transportService.registerRequestHandler(COMMIT_ACTION_NAME, ThreadPool.Names.SAME, false, false, CommitClusterStateRequest::new,
             new CommitClusterStateRequestHandler());
     }
 
@@ -462,17 +462,13 @@ public class PublishClusterStateAction {
 
         public String stateUUID;
 
-        public CommitClusterStateRequest() {
+        public CommitClusterStateRequest(StreamInput in) throws IOException {
+            super(in);
+            stateUUID = in.readString();
         }
 
         public CommitClusterStateRequest(String stateUUID) {
             this.stateUUID = stateUUID;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            stateUUID = in.readString();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/discovery/zen/UnicastZenPing.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/UnicastZenPing.java
@@ -534,11 +534,6 @@ public class UnicastZenPing implements ZenPing {
         }
 
         @Override
-        public void readFrom(StreamInput in) throws IOException {
-            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
-        }
-
-        @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeInt(id);
@@ -569,11 +564,6 @@ public class UnicastZenPing implements ZenPing {
             for (int i = 0; i < pingResponses.length; i++) {
                 pingResponses[i] = new PingResponse(in);
             }
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -233,7 +233,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
         masterService.setClusterStateSupplier(this::clusterState);
 
         transportService.registerRequestHandler(
-            DISCOVERY_REJOIN_ACTION_NAME, RejoinClusterRequest::new, ThreadPool.Names.SAME, new RejoinClusterRequestHandler());
+            DISCOVERY_REJOIN_ACTION_NAME, ThreadPool.Names.SAME, RejoinClusterRequest::new, new RejoinClusterRequestHandler());
 
         if (clusterApplier instanceof ClusterApplierService) {
             ((ClusterApplierService) clusterApplier).addLowPriorityApplier(gatewayMetaState);
@@ -1097,13 +1097,10 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
             this.fromNodeId = fromNodeId;
         }
 
-        public RejoinClusterRequest() {
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
+        public RejoinClusterRequest(StreamInput in) throws IOException {
+            super(in);
             fromNodeId = in.readOptionalString();
+
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
+++ b/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
@@ -73,7 +73,7 @@ public class LocalAllocateDangledIndices {
         this.clusterService = clusterService;
         this.allocationService = allocationService;
         this.metaDataIndexUpgradeService = metaDataIndexUpgradeService;
-        transportService.registerRequestHandler(ACTION_NAME, AllocateDangledRequest::new, ThreadPool.Names.SAME,
+        transportService.registerRequestHandler(ACTION_NAME, ThreadPool.Names.SAME, AllocateDangledRequest::new,
             new AllocateDangledRequestHandler());
     }
 
@@ -89,9 +89,7 @@ public class LocalAllocateDangledIndices {
         transportService.sendRequest(masterNode, ACTION_NAME, request, new TransportResponseHandler<AllocateDangledResponse>() {
             @Override
             public AllocateDangledResponse read(StreamInput in) throws IOException {
-                final AllocateDangledResponse response = new AllocateDangledResponse();
-                response.readFrom(in);
-                return response;
+                return new AllocateDangledResponse(in);
             }
 
             @Override
@@ -212,22 +210,18 @@ public class LocalAllocateDangledIndices {
         DiscoveryNode fromNode;
         IndexMetaData[] indices;
 
-        public AllocateDangledRequest() {
-        }
-
-        AllocateDangledRequest(DiscoveryNode fromNode, IndexMetaData[] indices) {
-            this.fromNode = fromNode;
-            this.indices = indices;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
+        public AllocateDangledRequest(StreamInput in) throws IOException {
+            super(in);
             fromNode = new DiscoveryNode(in);
             indices = new IndexMetaData[in.readVInt()];
             for (int i = 0; i < indices.length; i++) {
                 indices[i] = IndexMetaData.readFrom(in);
             }
+        }
+
+        AllocateDangledRequest(DiscoveryNode fromNode, IndexMetaData[] indices) {
+            this.fromNode = fromNode;
+            this.indices = indices;
         }
 
         @Override
@@ -245,17 +239,13 @@ public class LocalAllocateDangledIndices {
 
         private boolean ack;
 
-        AllocateDangledResponse() {
+        public AllocateDangledResponse(StreamInput in) throws IOException {
+            super(in);
+            ack = in.readBoolean();
         }
 
         AllocateDangledResponse(boolean ack) {
             this.ack = ack;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            ack = in.readBoolean();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/cache/query/QueryCacheStats.java
+++ b/server/src/main/java/org/elasticsearch/index/cache/query/QueryCacheStats.java
@@ -22,7 +22,6 @@ package org.elasticsearch.index.cache.query;
 import org.apache.lucene.search.DocIdSet;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -31,7 +30,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class QueryCacheStats implements Streamable, Writeable, ToXContentFragment {
+public class QueryCacheStats implements Writeable, ToXContentFragment {
 
     private long ramBytesUsed;
     private long hitCount;
@@ -114,11 +113,6 @@ public class QueryCacheStats implements Streamable, Writeable, ToXContentFragmen
      */
     public long getEvictions() {
         return cacheCount - cacheSize;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/cache/request/RequestCacheStats.java
+++ b/server/src/main/java/org/elasticsearch/index/cache/request/RequestCacheStats.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.cache.request;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
@@ -29,7 +28,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class RequestCacheStats implements Streamable, Writeable, ToXContentFragment {
+public class RequestCacheStats implements Writeable, ToXContentFragment {
 
     private long memorySize;
     private long evictions;
@@ -78,11 +77,6 @@ public class RequestCacheStats implements Streamable, Writeable, ToXContentFragm
 
     public long getMissCount() {
         return this.missCount;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/engine/Segment.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Segment.java
@@ -31,7 +31,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.unit.ByteSizeValue;
 
@@ -42,7 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-public class Segment implements Streamable {
+public class Segment implements Writeable {
 
     private String name;
     private long generation;
@@ -59,7 +59,32 @@ public class Segment implements Streamable {
     public Accountable ramTree = null;
     public Map<String, String> attributes;
 
-    Segment() {
+    public Segment(StreamInput in) throws IOException {
+        name = in.readString();
+        generation = Long.parseLong(name.substring(1), Character.MAX_RADIX);
+        committed = in.readBoolean();
+        search = in.readBoolean();
+        docCount = in.readInt();
+        delDocCount = in.readInt();
+        sizeInBytes = in.readLong();
+        version = Lucene.parseVersionLenient(in.readOptionalString(), null);
+        compound = in.readOptionalBoolean();
+        mergeId = in.readOptionalString();
+        memoryInBytes = in.readLong();
+        if (in.readBoolean()) {
+            // verbose mode
+            ramTree = readRamTree(in);
+        }
+        if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
+            segmentSort = readSegmentSort(in);
+        } else {
+            segmentSort = null;
+        }
+        if (in.getVersion().onOrAfter(Version.V_6_1_0) && in.readBoolean()) {
+            attributes = in.readMap(StreamInput::readString, StreamInput::readString);
+        } else {
+            attributes = null;
+        }
     }
 
     public Segment(String name) {
@@ -149,41 +174,6 @@ public class Segment implements Streamable {
     @Override
     public int hashCode() {
         return name != null ? name.hashCode() : 0;
-    }
-
-    public static Segment readSegment(StreamInput in) throws IOException {
-        Segment segment = new Segment();
-        segment.readFrom(in);
-        return segment;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        name = in.readString();
-        generation = Long.parseLong(name.substring(1), Character.MAX_RADIX);
-        committed = in.readBoolean();
-        search = in.readBoolean();
-        docCount = in.readInt();
-        delDocCount = in.readInt();
-        sizeInBytes = in.readLong();
-        version = Lucene.parseVersionLenient(in.readOptionalString(), null);
-        compound = in.readOptionalBoolean();
-        mergeId = in.readOptionalString();
-        memoryInBytes = in.readLong();
-        if (in.readBoolean()) {
-            // verbose mode
-            ramTree = readRamTree(in);
-        }
-        if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
-            segmentSort = readSegmentSort(in);
-        } else {
-            segmentSort = null;
-        }
-        if (in.getVersion().onOrAfter(Version.V_6_1_0) && in.readBoolean()) {
-            attributes = in.readMap(StreamInput::readString, StreamInput::readString);
-        } else {
-            attributes = null;
-        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/engine/SegmentsStats.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/SegmentsStats.java
@@ -23,7 +23,6 @@ import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
@@ -31,7 +30,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class SegmentsStats implements Streamable, Writeable, ToXContentFragment {
+public class SegmentsStats implements Writeable, ToXContentFragment {
 
     private long count;
     private long memoryInBytes;
@@ -363,11 +362,6 @@ public class SegmentsStats implements Streamable, Writeable, ToXContentFragment 
         static final String SIZE = "size";
         static final String SIZE_IN_BYTES = "size_in_bytes";
         static final String DESCRIPTION = "description";
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/FieldDataStats.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/FieldDataStats.java
@@ -23,7 +23,6 @@ import org.elasticsearch.common.FieldMemoryStats;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
@@ -32,7 +31,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.Objects;
 
-public class FieldDataStats implements Streamable, Writeable, ToXContentFragment {
+public class FieldDataStats implements Writeable, ToXContentFragment {
 
     private static final String FIELDDATA = "fielddata";
     private static final String MEMORY_SIZE = "memory_size";
@@ -87,11 +86,6 @@ public class FieldDataStats implements Streamable, Writeable, ToXContentFragment
     @Nullable
     public FieldMemoryStats getFields() {
         return fields;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/flush/FlushStats.java
+++ b/server/src/main/java/org/elasticsearch/index/flush/FlushStats.java
@@ -22,7 +22,6 @@ package org.elasticsearch.index.flush;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
@@ -30,7 +29,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class FlushStats implements Streamable, Writeable, ToXContentFragment {
+public class FlushStats implements Writeable, ToXContentFragment {
 
     private long total;
     private long periodic;
@@ -117,11 +116,6 @@ public class FlushStats implements Streamable, Writeable, ToXContentFragment {
         static final String PERIODIC = "periodic";
         static final String TOTAL_TIME = "total_time";
         static final String TOTAL_TIME_IN_MILLIS = "total_time_in_millis";
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/get/GetResult.java
+++ b/server/src/main/java/org/elasticsearch/index/get/GetResult.java
@@ -27,7 +27,7 @@ import org.elasticsearch.common.compress.CompressorFactory;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -48,7 +48,7 @@ import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpect
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 
-public class GetResult implements Streamable, Iterable<DocumentField>, ToXContentObject {
+public class GetResult implements Writeable, Iterable<DocumentField>, ToXContentObject {
 
     public static final String _INDEX = "_index";
     public static final String _TYPE = "_type";
@@ -72,7 +72,34 @@ public class GetResult implements Streamable, Iterable<DocumentField>, ToXConten
     private BytesReference source;
     private byte[] sourceAsBytes;
 
-    GetResult() {
+    public GetResult(StreamInput in) throws IOException {
+        index = in.readString();
+        type = in.readOptionalString();
+        id = in.readString();
+        if (in.getVersion().onOrAfter(Version.V_6_6_0)) {
+            seqNo = in.readZLong();
+            primaryTerm = in.readVLong();
+        } else {
+            seqNo = UNASSIGNED_SEQ_NO;
+            primaryTerm = UNASSIGNED_PRIMARY_TERM;
+        }
+        version = in.readLong();
+        exists = in.readBoolean();
+        if (exists) {
+            source = in.readBytesReference();
+            if (source.length() == 0) {
+                source = null;
+            }
+            if (in.getVersion().onOrAfter(Version.V_7_3_0)) {
+                documentFields = readFields(in);
+                metaFields = readFields(in);
+            } else {
+                Map<String, DocumentField> fields = readFields(in);
+                documentFields = new HashMap<>();
+                metaFields = new HashMap<>();
+                splitFieldsByMetadata(fields, documentFields, metaFields);
+            }
+        }
     }
 
     public GetResult(String index, String type, String id, long seqNo, long primaryTerm, long version, boolean exists,
@@ -376,12 +403,6 @@ public class GetResult implements Streamable, Iterable<DocumentField>, ToXConten
         return fromXContentEmbedded(parser);
     }
 
-    public static GetResult readGetResult(StreamInput in) throws IOException {
-        GetResult result = new GetResult();
-        result.readFrom(in);
-        return result;
-    }
-
     private Map<String, DocumentField> readFields(StreamInput in) throws IOException {
         Map<String, DocumentField> fields = null;
         int size = in.readVInt();
@@ -407,37 +428,6 @@ public class GetResult implements Streamable, Iterable<DocumentField>, ToXConten
                 outMetadata.put(fieldEntry.getKey(), fieldEntry.getValue());
             } else {
                 outOther.put(fieldEntry.getKey(), fieldEntry.getValue());                
-            }
-        }
-    }
-    
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        index = in.readString();
-        type = in.readOptionalString();
-        id = in.readString();
-        if (in.getVersion().onOrAfter(Version.V_6_6_0)) {
-            seqNo = in.readZLong();
-            primaryTerm = in.readVLong();
-        } else {
-            seqNo = UNASSIGNED_SEQ_NO;
-            primaryTerm = UNASSIGNED_PRIMARY_TERM;
-        }
-        version = in.readLong();
-        exists = in.readBoolean();
-        if (exists) {
-            source = in.readBytesReference();
-            if (source.length() == 0) {
-                source = null;
-            }
-            if (in.getVersion().onOrAfter(Version.V_7_3_0)) {
-                documentFields = readFields(in);
-                metaFields = readFields(in);            
-            } else {
-                Map<String, DocumentField> fields = readFields(in);
-                documentFields = new HashMap<>();
-                metaFields = new HashMap<>();
-                splitFieldsByMetadata(fields, documentFields, metaFields);
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/get/GetStats.java
+++ b/server/src/main/java/org/elasticsearch/index/get/GetStats.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.get;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
@@ -29,7 +28,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class GetStats implements Streamable, Writeable, ToXContentFragment {
+public class GetStats implements Writeable, ToXContentFragment {
 
     private long existsCount;
     private long existsTimeInMillis;
@@ -141,11 +140,6 @@ public class GetStats implements Streamable, Writeable, ToXContentFragment {
         static final String MISSING_TIME = "missing_time";
         static final String MISSING_TIME_IN_MILLIS = "missing_time_in_millis";
         static final String CURRENT = "current";
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/merge/MergeStats.java
+++ b/server/src/main/java/org/elasticsearch/index/merge/MergeStats.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.merge;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
@@ -30,7 +29,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class MergeStats implements Streamable, Writeable, ToXContentFragment {
+public class MergeStats implements Writeable, ToXContentFragment {
 
     private long total;
     private long totalTimeInMillis;
@@ -236,11 +235,6 @@ public class MergeStats implements Streamable, Writeable, ToXContentFragment {
         static final String TOTAL_SIZE_IN_BYTES = "total_size_in_bytes";
         static final String TOTAL_THROTTLE_BYTES_PER_SEC_IN_BYTES = "total_auto_throttle_in_bytes";
         static final String TOTAL_THROTTLE_BYTES_PER_SEC = "total_auto_throttle";
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/recovery/RecoveryStats.java
+++ b/server/src/main/java/org/elasticsearch/index/recovery/RecoveryStats.java
@@ -20,7 +20,6 @@ package org.elasticsearch.index.recovery;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
@@ -34,7 +33,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * Recovery related statistics, starting at the shard level and allowing aggregation to
  * indices and node level
  */
-public class RecoveryStats implements ToXContentFragment, Writeable, Streamable {
+public class RecoveryStats implements ToXContentFragment, Writeable {
 
     private final AtomicInteger currentAsSource = new AtomicInteger();
     private final AtomicInteger currentAsTarget = new AtomicInteger();
@@ -120,11 +119,6 @@ public class RecoveryStats implements ToXContentFragment, Writeable, Streamable 
         static final String CURRENT_AS_TARGET = "current_as_target";
         static final String THROTTLE_TIME = "throttle_time";
         static final String THROTTLE_TIME_IN_MILLIS = "throttle_time_in_millis";
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/refresh/RefreshStats.java
+++ b/server/src/main/java/org/elasticsearch/index/refresh/RefreshStats.java
@@ -22,7 +22,6 @@ package org.elasticsearch.index.refresh;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
@@ -31,7 +30,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.Objects;
 
-public class RefreshStats implements Streamable, Writeable, ToXContentFragment {
+public class RefreshStats implements Writeable, ToXContentFragment {
 
     private long total;
 
@@ -149,11 +148,6 @@ public class RefreshStats implements Streamable, Writeable, ToXContentFragment {
         builder.field("listeners", listeners);
         builder.endObject();
         return builder;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/shard/DocsStats.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/DocsStats.java
@@ -22,7 +22,6 @@ package org.elasticsearch.index.shard;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -30,7 +29,7 @@ import org.elasticsearch.index.store.StoreStats;
 
 import java.io.IOException;
 
-public class DocsStats implements Streamable, Writeable, ToXContentFragment {
+public class DocsStats implements Writeable, ToXContentFragment {
 
     private long count = 0;
     private long deleted = 0;
@@ -91,11 +90,6 @@ public class DocsStats implements Streamable, Writeable, ToXContentFragment {
     public long getAverageSizeInBytes() {
         long totalDocs = count + deleted;
         return totalDocs == 0 ? 0 : totalSizeInBytes / totalDocs;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexingStats.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexingStats.java
@@ -22,7 +22,6 @@ package org.elasticsearch.index.shard;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -33,9 +32,9 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-public class IndexingStats implements Streamable, Writeable, ToXContentFragment {
+public class IndexingStats implements Writeable, ToXContentFragment {
 
-    public static class Stats implements Streamable, Writeable, ToXContentFragment {
+    public static class Stats implements Writeable, ToXContentFragment {
 
         private long indexCount;
         private long indexTimeInMillis;
@@ -145,11 +144,6 @@ public class IndexingStats implements Streamable, Writeable, ToXContentFragment 
 
         public long getNoopUpdateCount() {
             return noopUpdateCount;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -280,11 +274,6 @@ public class IndexingStats implements Streamable, Writeable, ToXContentFragment 
         static final String IS_THROTTLED = "is_throttled";
         static final String THROTTLED_TIME_IN_MILLIS = "throttle_time_in_millis";
         static final String THROTTLED_TIME = "throttle_time";
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/store/StoreStats.java
+++ b/server/src/main/java/org/elasticsearch/index/store/StoreStats.java
@@ -22,7 +22,6 @@ package org.elasticsearch.index.store;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
@@ -30,7 +29,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class StoreStats implements Streamable, Writeable, ToXContentFragment {
+public class StoreStats implements Writeable, ToXContentFragment {
 
     private long sizeInBytes;
 
@@ -71,11 +70,6 @@ public class StoreStats implements Streamable, Writeable, ToXContentFragment {
 
     public ByteSizeValue getSize() {
         return size();
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogStats.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogStats.java
@@ -22,7 +22,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
@@ -30,7 +29,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class TranslogStats implements Streamable, Writeable, ToXContentFragment {
+public class TranslogStats implements Writeable, ToXContentFragment {
 
     private long translogSizeInBytes;
     private int numberOfOperations;
@@ -128,11 +127,6 @@ public class TranslogStats implements Streamable, Writeable, ToXContentFragment 
     @Override
     public String toString() {
         return Strings.toString(this, true, true);
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/warmer/WarmerStats.java
+++ b/server/src/main/java/org/elasticsearch/index/warmer/WarmerStats.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.warmer;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
@@ -29,7 +28,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class WarmerStats implements Streamable, Writeable, ToXContentFragment {
+public class WarmerStats implements Writeable, ToXContentFragment {
 
     private long current;
 
@@ -109,11 +108,6 @@ public class WarmerStats implements Streamable, Writeable, ToXContentFragment {
         static final String TOTAL = "total";
         static final String TOTAL_TIME = "total_time";
         static final String TOTAL_TIME_IN_MILLIS = "total_time_in_millis";
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
+++ b/server/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
@@ -25,7 +25,7 @@ import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.Index;
@@ -55,12 +55,26 @@ import java.util.Map;
 /**
  * Global information on indices stats running on a specific node.
  */
-public class NodeIndicesStats implements Streamable, ToXContentFragment {
+public class NodeIndicesStats implements Writeable, ToXContentFragment {
 
     private CommonStats stats;
     private Map<Index, List<IndexShardStats>> statsByShard;
 
-    NodeIndicesStats() {
+    public NodeIndicesStats(StreamInput in) throws IOException {
+        stats = new CommonStats(in);
+        if (in.readBoolean()) {
+            int entries = in.readVInt();
+            statsByShard = new HashMap<>();
+            for (int i = 0; i < entries; i++) {
+                Index index = new Index(in);
+                int indexShardListSize = in.readVInt();
+                List<IndexShardStats> indexShardStats = new ArrayList<>(indexShardListSize);
+                for (int j = 0; j < indexShardListSize; j++) {
+                    indexShardStats.add(new IndexShardStats(in));
+                }
+                statsByShard.put(index, indexShardStats);
+            }
+        }
     }
 
     public NodeIndicesStats(CommonStats oldStats, Map<Index, List<IndexShardStats>> statsByShard) {
@@ -156,30 +170,6 @@ public class NodeIndicesStats implements Streamable, ToXContentFragment {
     @Nullable
     public RecoveryStats getRecoveryStats() {
         return stats.getRecoveryStats();
-    }
-
-    public static NodeIndicesStats readIndicesStats(StreamInput in) throws IOException {
-        NodeIndicesStats stats = new NodeIndicesStats();
-        stats.readFrom(in);
-        return stats;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        stats = new CommonStats(in);
-        if (in.readBoolean()) {
-            int entries = in.readVInt();
-            statsByShard = new HashMap<>();
-            for (int i = 0; i < entries; i++) {
-                Index index = new Index(in);
-                int indexShardListSize = in.readVInt();
-                List<IndexShardStats> indexShardStats = new ArrayList<>(indexShardListSize);
-                for (int j = 0; j < indexShardListSize; j++) {
-                    indexShardStats.add(new IndexShardStats(in));
-                }
-                statsByShard.put(index, indexShardStats);
-            }
-        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/indices/flush/ShardsSyncedFlushResult.java
+++ b/server/src/main/java/org/elasticsearch/indices/flush/ShardsSyncedFlushResult.java
@@ -21,7 +21,7 @@ package org.elasticsearch.indices.flush;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
@@ -34,7 +34,7 @@ import static java.util.Collections.unmodifiableMap;
 /**
  * Result for all copies of a shard
  */
-public class ShardsSyncedFlushResult implements Streamable {
+public class ShardsSyncedFlushResult implements Writeable {
     private String failureReason;
     private Map<ShardRouting, SyncedFlushService.ShardSyncedFlushResponse> shardResponses;
     private String syncId;
@@ -42,7 +42,18 @@ public class ShardsSyncedFlushResult implements Streamable {
     // some shards may be unassigned, so we need this as state
     private int totalShards;
 
-    private ShardsSyncedFlushResult() {
+    public ShardsSyncedFlushResult(StreamInput in) throws IOException {
+        failureReason = in.readOptionalString();
+        int numResponses = in.readInt();
+        shardResponses = new HashMap<>();
+        for (int i = 0; i < numResponses; i++) {
+            ShardRouting shardRouting = new ShardRouting(in);
+            SyncedFlushService.ShardSyncedFlushResponse response = SyncedFlushService.ShardSyncedFlushResponse.readSyncedFlushResponse(in);
+            shardResponses.put(shardRouting, response);
+        }
+        syncId = in.readOptionalString();
+        shardId = new ShardId(in);
+        totalShards = in.readInt();
     }
 
     public ShardId getShardId() {
@@ -139,21 +150,6 @@ public class ShardsSyncedFlushResult implements Streamable {
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
-        failureReason = in.readOptionalString();
-        int numResponses = in.readInt();
-        shardResponses = new HashMap<>();
-        for (int i = 0; i < numResponses; i++) {
-            ShardRouting shardRouting = new ShardRouting(in);
-            SyncedFlushService.ShardSyncedFlushResponse response = SyncedFlushService.ShardSyncedFlushResponse.readSyncedFlushResponse(in);
-            shardResponses.put(shardRouting, response);
-        }
-        syncId = in.readOptionalString();
-        shardId = new ShardId(in);
-        totalShards = in.readInt();
-    }
-
-    @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalString(failureReason);
         out.writeInt(shardResponses.size());
@@ -164,11 +160,5 @@ public class ShardsSyncedFlushResult implements Streamable {
         out.writeOptionalString(syncId);
         shardId.writeTo(out);
         out.writeInt(totalShards);
-    }
-
-    public static ShardsSyncedFlushResult readShardsSyncedFlushResult(StreamInput in) throws IOException {
-        ShardsSyncedFlushResult shardsSyncedFlushResult = new ShardsSyncedFlushResult();
-        shardsSyncedFlushResult.readFrom(in);
-        return shardsSyncedFlushResult;
     }
 }

--- a/server/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
+++ b/server/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
@@ -94,11 +94,11 @@ public class SyncedFlushService implements IndexEventListener {
         this.clusterService = clusterService;
         this.transportService = transportService;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
-        transportService.registerRequestHandler(PRE_SYNCED_FLUSH_ACTION_NAME, PreShardSyncedFlushRequest::new, ThreadPool.Names.FLUSH,
+        transportService.registerRequestHandler(PRE_SYNCED_FLUSH_ACTION_NAME, ThreadPool.Names.FLUSH, PreShardSyncedFlushRequest::new,
             new PreSyncedFlushTransportHandler());
-        transportService.registerRequestHandler(SYNCED_FLUSH_ACTION_NAME, ShardSyncedFlushRequest::new, ThreadPool.Names.FLUSH,
+        transportService.registerRequestHandler(SYNCED_FLUSH_ACTION_NAME, ThreadPool.Names.FLUSH, ShardSyncedFlushRequest::new,
             new SyncedFlushTransportHandler());
-        transportService.registerRequestHandler(IN_FLIGHT_OPS_ACTION_NAME, InFlightOpsRequest::new, ThreadPool.Names.SAME,
+        transportService.registerRequestHandler(IN_FLIGHT_OPS_ACTION_NAME, ThreadPool.Names.SAME, InFlightOpsRequest::new,
             new InFlightOpCountTransportHandler());
     }
 
@@ -283,7 +283,7 @@ public class SyncedFlushService implements IndexEventListener {
         final Map<ShardRouting, ShardSyncedFlushResponse> results = new HashMap<>();
         for (final ShardRouting shard : shards) {
             if (preSyncResponses.containsKey(shard.currentNodeId())) {
-                results.put(shard, new ShardSyncedFlushResponse());
+                results.put(shard, new ShardSyncedFlushResponse((String) null));
             }
         }
         listener.onResponse(new ShardsSyncedFlushResult(shardId, existingSyncId, totalShards, results));
@@ -323,9 +323,7 @@ public class SyncedFlushService implements IndexEventListener {
                     new TransportResponseHandler<InFlightOpsResponse>() {
                         @Override
                         public InFlightOpsResponse read(StreamInput in) throws IOException {
-                            InFlightOpsResponse response = new InFlightOpsResponse();
-                            response.readFrom(in);
-                            return response;
+                            return new InFlightOpsResponse(in);
                         }
 
                         @Override
@@ -403,9 +401,7 @@ public class SyncedFlushService implements IndexEventListener {
                     new TransportResponseHandler<ShardSyncedFlushResponse>() {
                         @Override
                         public ShardSyncedFlushResponse read(StreamInput in) throws IOException {
-                            ShardSyncedFlushResponse response = new ShardSyncedFlushResponse();
-                            response.readFrom(in);
-                            return response;
+                            return new ShardSyncedFlushResponse(in);
                         }
 
                         @Override
@@ -469,9 +465,7 @@ public class SyncedFlushService implements IndexEventListener {
                 new TransportResponseHandler<PreSyncedFlushResponse>() {
                 @Override
                 public PreSyncedFlushResponse read(StreamInput in) throws IOException {
-                    PreSyncedFlushResponse response = new PreSyncedFlushResponse();
-                    response.readFrom(in);
-                    return response;
+                    return new PreSyncedFlushResponse(in);
                 }
 
                 @Override
@@ -521,7 +515,7 @@ public class SyncedFlushService implements IndexEventListener {
         logger.trace("{} sync flush done. sync id [{}], result [{}]", request.shardId(), request.syncId(), result);
         switch (result) {
             case SUCCESS:
-                return new ShardSyncedFlushResponse();
+                return new ShardSyncedFlushResponse((String) null);
             case COMMIT_MISMATCH:
                 return new ShardSyncedFlushResponse("commit has changed");
             case PENDING_OPERATIONS:
@@ -544,7 +538,9 @@ public class SyncedFlushService implements IndexEventListener {
     public static final class PreShardSyncedFlushRequest extends TransportRequest {
         private ShardId shardId;
 
-        public PreShardSyncedFlushRequest() {
+        public PreShardSyncedFlushRequest(StreamInput in) throws IOException {
+            super(in);
+            this.shardId = new ShardId(in);
         }
 
         public PreShardSyncedFlushRequest(ShardId shardId) {
@@ -564,12 +560,6 @@ public class SyncedFlushService implements IndexEventListener {
             shardId.writeTo(out);
         }
 
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            this.shardId = new ShardId(in);
-        }
-
         public ShardId shardId() {
             return shardId;
         }
@@ -585,7 +575,17 @@ public class SyncedFlushService implements IndexEventListener {
         int numDocs;
         @Nullable String existingSyncId = null;
 
-        PreSyncedFlushResponse() {
+        PreSyncedFlushResponse(StreamInput in) throws IOException {
+            super(in);
+            commitId = new Engine.CommitId(in);
+            if (includeNumDocs(in.getVersion())) {
+                numDocs = in.readInt();
+            } else {
+                numDocs = UNKNOWN_NUM_DOCS;
+            }
+            if (includeExistingSyncId(in.getVersion())) {
+                existingSyncId = in.readOptionalString();
+            }
         }
 
         PreSyncedFlushResponse(Engine.CommitId commitId, int numDocs, String existingSyncId) {
@@ -600,20 +600,6 @@ public class SyncedFlushService implements IndexEventListener {
 
         boolean includeExistingSyncId(Version version) {
             return version.onOrAfter(Version.V_6_3_0);
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            commitId = new Engine.CommitId(in);
-            if (includeNumDocs(in.getVersion())) {
-                numDocs = in.readInt();
-            } else {
-                numDocs = UNKNOWN_NUM_DOCS;
-            }
-            if (includeExistingSyncId(in.getVersion())) {
-                existingSyncId = in.readOptionalString();
-            }
         }
 
         @Override
@@ -634,21 +620,17 @@ public class SyncedFlushService implements IndexEventListener {
         private Engine.CommitId expectedCommitId;
         private ShardId shardId;
 
-        public ShardSyncedFlushRequest() {
+        public ShardSyncedFlushRequest(StreamInput in) throws IOException {
+            super(in);
+            shardId = new ShardId(in);
+            expectedCommitId = new Engine.CommitId(in);
+            syncId = in.readString();
         }
 
         public ShardSyncedFlushRequest(ShardId shardId, String syncId, Engine.CommitId expectedCommitId) {
             this.expectedCommitId = expectedCommitId;
             this.shardId = shardId;
             this.syncId = syncId;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            shardId = new ShardId(in);
-            expectedCommitId = new Engine.CommitId(in);
-            syncId = in.readString();
         }
 
         @Override
@@ -690,18 +672,13 @@ public class SyncedFlushService implements IndexEventListener {
          */
         String failureReason;
 
-        public ShardSyncedFlushResponse() {
-            failureReason = null;
+        public ShardSyncedFlushResponse(StreamInput in) throws IOException {
+            super(in);
+            failureReason = in.readOptionalString();
         }
 
         public ShardSyncedFlushResponse(String failureReason) {
             this.failureReason = failureReason;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            failureReason = in.readOptionalString();
         }
 
         @Override
@@ -726,9 +703,7 @@ public class SyncedFlushService implements IndexEventListener {
         }
 
         public static ShardSyncedFlushResponse readSyncedFlushResponse(StreamInput in) throws IOException {
-            ShardSyncedFlushResponse shardSyncedFlushResponse = new ShardSyncedFlushResponse();
-            shardSyncedFlushResponse.readFrom(in);
-            return shardSyncedFlushResponse;
+            return new ShardSyncedFlushResponse(in);
         }
     }
 
@@ -737,17 +712,13 @@ public class SyncedFlushService implements IndexEventListener {
 
         private ShardId shardId;
 
-        public InFlightOpsRequest() {
+        public InFlightOpsRequest(StreamInput in) throws IOException {
+            super(in);
+            shardId = new ShardId(in);
         }
 
         public InFlightOpsRequest(ShardId shardId) {
             this.shardId = shardId;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            shardId = new ShardId(in);
         }
 
         @Override
@@ -775,18 +746,14 @@ public class SyncedFlushService implements IndexEventListener {
 
         int opCount;
 
-        InFlightOpsResponse() {
+        InFlightOpsResponse(StreamInput in) throws IOException {
+            super(in);
+            opCount = in.readVInt();
         }
 
         InFlightOpsResponse(int opCount) {
             assert opCount >= 0 : opCount;
             this.opCount = opCount;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            opCount = in.readVInt();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
@@ -71,7 +71,7 @@ public class PeerRecoverySourceService implements IndexEventListener {
         this.transportService = transportService;
         this.indicesService = indicesService;
         this.recoverySettings = recoverySettings;
-        transportService.registerRequestHandler(Actions.START_RECOVERY, StartRecoveryRequest::new, ThreadPool.Names.GENERIC,
+        transportService.registerRequestHandler(Actions.START_RECOVERY, ThreadPool.Names.GENERIC, StartRecoveryRequest::new,
             new StartRecoveryTransportRequestHandler());
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -112,22 +112,22 @@ public class PeerRecoveryTargetService implements IndexEventListener {
         this.clusterService = clusterService;
         this.onGoingRecoveries = new RecoveriesCollection(logger, threadPool);
 
-        transportService.registerRequestHandler(Actions.FILES_INFO, RecoveryFilesInfoRequest::new, ThreadPool.Names.GENERIC, new
-                FilesInfoRequestHandler());
-        transportService.registerRequestHandler(Actions.FILE_CHUNK, RecoveryFileChunkRequest::new, ThreadPool.Names.GENERIC, new
-                FileChunkTransportRequestHandler());
+        transportService.registerRequestHandler(Actions.FILES_INFO, ThreadPool.Names.GENERIC, RecoveryFilesInfoRequest::new,
+            new FilesInfoRequestHandler());
+        transportService.registerRequestHandler(Actions.FILE_CHUNK, ThreadPool.Names.GENERIC, RecoveryFileChunkRequest::new,
+            new FileChunkTransportRequestHandler());
         transportService.registerRequestHandler(Actions.CLEAN_FILES, ThreadPool.Names.GENERIC,
             RecoveryCleanFilesRequest::new, new CleanFilesRequestHandler());
         transportService.registerRequestHandler(Actions.PREPARE_TRANSLOG, ThreadPool.Names.GENERIC,
                 RecoveryPrepareForTranslogOperationsRequest::new, new PrepareForTranslogOperationsRequestHandler());
         transportService.registerRequestHandler(Actions.TRANSLOG_OPS, ThreadPool.Names.GENERIC, RecoveryTranslogOperationsRequest::new,
             new TranslogOperationsRequestHandler());
-        transportService.registerRequestHandler(Actions.FINALIZE, RecoveryFinalizeRecoveryRequest::new, ThreadPool.Names.GENERIC, new
-                FinalizeRecoveryRequestHandler());
+        transportService.registerRequestHandler(Actions.FINALIZE, ThreadPool.Names.GENERIC, RecoveryFinalizeRecoveryRequest::new,
+            new FinalizeRecoveryRequestHandler());
         transportService.registerRequestHandler(
                 Actions.HANDOFF_PRIMARY_CONTEXT,
-                RecoveryHandoffPrimaryContextRequest::new,
                 ThreadPool.Names.GENERIC,
+                RecoveryHandoffPrimaryContextRequest::new,
                 new HandoffPrimaryContextRequestHandler());
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFileChunkRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFileChunkRequest.java
@@ -41,7 +41,21 @@ public final class RecoveryFileChunkRequest extends TransportRequest {
 
     private int totalTranslogOps;
 
-    public RecoveryFileChunkRequest() {
+    public RecoveryFileChunkRequest(StreamInput in) throws IOException {
+        super(in);
+        recoveryId = in.readLong();
+        shardId = new ShardId(in);
+        String name = in.readString();
+        position = in.readVLong();
+        long length = in.readVLong();
+        String checksum = in.readString();
+        content = in.readBytesReference();
+        Version writtenBy = Lucene.parseVersionLenient(in.readString(), null);
+        assert writtenBy != null;
+        metaData = new StoreFileMetaData(name, length, checksum, writtenBy);
+        lastChunk = in.readBoolean();
+        totalTranslogOps = in.readVInt();
+        sourceThrottleTimeInNanos = in.readLong();
     }
 
     public RecoveryFileChunkRequest(long recoveryId, ShardId shardId, StoreFileMetaData metaData, long position, BytesReference content,
@@ -90,24 +104,6 @@ public final class RecoveryFileChunkRequest extends TransportRequest {
 
     public long sourceThrottleTimeInNanos() {
         return sourceThrottleTimeInNanos;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        recoveryId = in.readLong();
-        shardId = new ShardId(in);
-        String name = in.readString();
-        position = in.readVLong();
-        long length = in.readVLong();
-        String checksum = in.readString();
-        content = in.readBytesReference();
-        Version writtenBy = Lucene.parseVersionLenient(in.readString(), null);
-        assert writtenBy != null;
-        metaData = new StoreFileMetaData(name, length, checksum, writtenBy);
-        lastChunk = in.readBoolean();
-        totalTranslogOps = in.readVInt();
-        sourceThrottleTimeInNanos = in.readLong();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFilesInfoRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFilesInfoRequest.java
@@ -40,31 +40,8 @@ public class RecoveryFilesInfoRequest extends TransportRequest {
 
     int totalTranslogOps;
 
-    public RecoveryFilesInfoRequest() {
-    }
-
-    RecoveryFilesInfoRequest(long recoveryId, ShardId shardId, List<String> phase1FileNames, List<Long> phase1FileSizes,
-                             List<String> phase1ExistingFileNames, List<Long> phase1ExistingFileSizes, int totalTranslogOps) {
-        this.recoveryId = recoveryId;
-        this.shardId = shardId;
-        this.phase1FileNames = phase1FileNames;
-        this.phase1FileSizes = phase1FileSizes;
-        this.phase1ExistingFileNames = phase1ExistingFileNames;
-        this.phase1ExistingFileSizes = phase1ExistingFileSizes;
-        this.totalTranslogOps = totalTranslogOps;
-    }
-
-    public long recoveryId() {
-        return this.recoveryId;
-    }
-
-    public ShardId shardId() {
-        return shardId;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
+    public RecoveryFilesInfoRequest(StreamInput in) throws IOException {
+        super(in);
         recoveryId = in.readLong();
         shardId = new ShardId(in);
         int size = in.readVInt();
@@ -91,6 +68,25 @@ public class RecoveryFilesInfoRequest extends TransportRequest {
             phase1ExistingFileSizes.add(in.readVLong());
         }
         totalTranslogOps = in.readVInt();
+    }
+
+    RecoveryFilesInfoRequest(long recoveryId, ShardId shardId, List<String> phase1FileNames, List<Long> phase1FileSizes,
+                             List<String> phase1ExistingFileNames, List<Long> phase1ExistingFileSizes, int totalTranslogOps) {
+        this.recoveryId = recoveryId;
+        this.shardId = shardId;
+        this.phase1FileNames = phase1FileNames;
+        this.phase1FileSizes = phase1FileSizes;
+        this.phase1ExistingFileNames = phase1ExistingFileNames;
+        this.phase1ExistingFileSizes = phase1ExistingFileSizes;
+        this.totalTranslogOps = totalTranslogOps;
+    }
+
+    public long recoveryId() {
+        return this.recoveryId;
+    }
+
+    public ShardId shardId() {
+        return shardId;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFinalizeRecoveryRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFinalizeRecoveryRequest.java
@@ -34,7 +34,15 @@ public class RecoveryFinalizeRecoveryRequest extends TransportRequest {
     private ShardId shardId;
     private long globalCheckpoint;
 
-    public RecoveryFinalizeRecoveryRequest() {
+    public RecoveryFinalizeRecoveryRequest(StreamInput in) throws IOException {
+        super(in);
+        recoveryId = in.readLong();
+        shardId = new ShardId(in);
+        if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
+            globalCheckpoint = in.readZLong();
+        } else {
+            globalCheckpoint = SequenceNumbers.UNASSIGNED_SEQ_NO;
+        }
     }
 
     RecoveryFinalizeRecoveryRequest(final long recoveryId, final ShardId shardId, final long globalCheckpoint) {
@@ -53,18 +61,6 @@ public class RecoveryFinalizeRecoveryRequest extends TransportRequest {
 
     public long globalCheckpoint() {
         return globalCheckpoint;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        recoveryId = in.readLong();
-            shardId = new ShardId(in);
-        if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
-            globalCheckpoint = in.readZLong();
-        } else {
-            globalCheckpoint = SequenceNumbers.UNASSIGNED_SEQ_NO;
-        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryHandoffPrimaryContextRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryHandoffPrimaryContextRequest.java
@@ -39,7 +39,11 @@ class RecoveryHandoffPrimaryContextRequest extends TransportRequest {
     /**
      * Initialize an empty request (used to serialize into when reading from a stream).
      */
-    RecoveryHandoffPrimaryContextRequest() {
+    RecoveryHandoffPrimaryContextRequest(StreamInput in) throws IOException {
+        super(in);
+        recoveryId = in.readLong();
+        shardId = new ShardId(in);
+        primaryContext = new ReplicationTracker.PrimaryContext(in);
     }
 
     /**
@@ -66,14 +70,6 @@ class RecoveryHandoffPrimaryContextRequest extends TransportRequest {
 
     ReplicationTracker.PrimaryContext primaryContext() {
         return primaryContext;
-    }
-
-    @Override
-    public void readFrom(final StreamInput in) throws IOException {
-        super.readFrom(in);
-        recoveryId = in.readLong();
-        shardId = new ShardId(in);
-        primaryContext = new ReplicationTracker.PrimaryContext(in);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryPrepareForTranslogOperationsRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryPrepareForTranslogOperationsRequest.java
@@ -43,7 +43,7 @@ class RecoveryPrepareForTranslogOperationsRequest extends TransportRequest {
     }
 
     RecoveryPrepareForTranslogOperationsRequest(StreamInput in) throws IOException {
-        super.readFrom(in);
+        super(in);
         recoveryId = in.readLong();
         shardId = new ShardId(in);
         totalTranslogOps = in.readVInt();

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -26,7 +26,6 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
@@ -47,7 +46,7 @@ import java.util.Map;
 /**
  * Keeps track of state related to shard recovery.
  */
-public class RecoveryState implements ToXContentFragment, Streamable, Writeable {
+public class RecoveryState implements ToXContentFragment, Writeable {
 
     public enum Stage {
         INIT((byte) 0),
@@ -253,11 +252,6 @@ public class RecoveryState implements ToXContentFragment, Streamable, Writeable 
 
     public static RecoveryState readRecoveryState(StreamInput in) throws IOException {
         return new RecoveryState(in);
-    }
-
-    @Override
-    public synchronized void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTranslogOperationsRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTranslogOperationsRequest.java
@@ -100,7 +100,7 @@ public class RecoveryTranslogOperationsRequest extends TransportRequest {
     }
 
     RecoveryTranslogOperationsRequest(StreamInput in) throws IOException {
-        super.readFrom(in);
+        super(in);
         recoveryId = in.readLong();
         shardId = new ShardId(in);
         operations = Translog.readOperations(in, "recovery");

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryWaitForClusterStateRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryWaitForClusterStateRequest.java
@@ -31,7 +31,11 @@ public class RecoveryWaitForClusterStateRequest extends TransportRequest {
     private ShardId shardId;
     private long clusterStateVersion;
 
-    public RecoveryWaitForClusterStateRequest() {
+    public RecoveryWaitForClusterStateRequest(StreamInput in) throws IOException {
+        super(in);
+        recoveryId = in.readLong();
+        shardId = new ShardId(in);
+        clusterStateVersion = in.readVLong();
     }
 
     RecoveryWaitForClusterStateRequest(long recoveryId, ShardId shardId, long clusterStateVersion) {
@@ -50,14 +54,6 @@ public class RecoveryWaitForClusterStateRequest extends TransportRequest {
 
     public long clusterStateVersion() {
         return clusterStateVersion;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        recoveryId = in.readLong();
-        shardId = new ShardId(in);
-        clusterStateVersion = in.readVLong();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
@@ -44,7 +44,20 @@ public class StartRecoveryRequest extends TransportRequest {
     private boolean primaryRelocation;
     private long startingSeqNo;
 
-    public StartRecoveryRequest() {
+    public StartRecoveryRequest(StreamInput in) throws IOException {
+        super(in);
+        recoveryId = in.readLong();
+        shardId = new ShardId(in);
+        targetAllocationId = in.readString();
+        sourceNode = new DiscoveryNode(in);
+        targetNode = new DiscoveryNode(in);
+        metadataSnapshot = new Store.MetadataSnapshot(in);
+        primaryRelocation = in.readBoolean();
+        if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
+            startingSeqNo = in.readLong();
+        } else {
+            startingSeqNo = SequenceNumbers.UNASSIGNED_SEQ_NO;
+        }
     }
 
     /**
@@ -109,23 +122,6 @@ public class StartRecoveryRequest extends TransportRequest {
 
     public long startingSeqNo() {
         return startingSeqNo;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        recoveryId = in.readLong();
-        shardId = new ShardId(in);
-        targetAllocationId = in.readString();
-        sourceNode = new DiscoveryNode(in);
-        targetNode = new DiscoveryNode(in);
-        metadataSnapshot = new Store.MetadataSnapshot(in);
-        primaryRelocation = in.readBoolean();
-        if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
-            startingSeqNo = in.readLong();
-        } else {
-            startingSeqNo = SequenceNumbers.UNASSIGNED_SEQ_NO;
-        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
@@ -37,7 +37,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -174,11 +174,13 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
         }
     }
 
-    public static class StoreFilesMetaData implements Iterable<StoreFileMetaData>, Streamable {
+    public static class StoreFilesMetaData implements Iterable<StoreFileMetaData>, Writeable {
         private ShardId shardId;
         Store.MetadataSnapshot metadataSnapshot;
 
-        StoreFilesMetaData() {
+        public StoreFilesMetaData(StreamInput in) throws IOException {
+            this.shardId = new ShardId(in);
+            this.metadataSnapshot = new Store.MetadataSnapshot(in);
         }
 
         public StoreFilesMetaData(ShardId shardId, Store.MetadataSnapshot metadataSnapshot) {
@@ -205,18 +207,6 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
 
         public StoreFileMetaData file(String name) {
             return metadataSnapshot.asMap().get(name);
-        }
-
-        public static StoreFilesMetaData readStoreFilesMetaData(StreamInput in) throws IOException {
-            StoreFilesMetaData md = new StoreFilesMetaData();
-            md.readFrom(in);
-            return md;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            shardId = new ShardId(in);
-            this.metadataSnapshot = new Store.MetadataSnapshot(in);
         }
 
         @Override
@@ -311,7 +301,7 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
 
         public NodeStoreFilesMetaData(StreamInput in) throws IOException {
             super(in);
-            storeFilesMetaData = StoreFilesMetaData.readStoreFilesMetaData(in);
+            storeFilesMetaData = new StoreFilesMetaData(in);
         }
 
         public NodeStoreFilesMetaData(DiscoveryNode node, StoreFilesMetaData storeFilesMetaData) {

--- a/server/src/main/java/org/elasticsearch/repositories/VerifyNodeRepositoryAction.java
+++ b/server/src/main/java/org/elasticsearch/repositories/VerifyNodeRepositoryAction.java
@@ -63,7 +63,7 @@ public class VerifyNodeRepositoryAction {
         this.transportService = transportService;
         this.clusterService = clusterService;
         this.repositoriesService = repositoriesService;
-        transportService.registerRequestHandler(ACTION_NAME, VerifyNodeRepositoryRequest::new, ThreadPool.Names.SNAPSHOT,
+        transportService.registerRequestHandler(ACTION_NAME, ThreadPool.Names.SNAPSHOT, VerifyNodeRepositoryRequest::new,
             new VerifyNodeRepositoryRequestHandler());
     }
 
@@ -131,19 +131,15 @@ public class VerifyNodeRepositoryAction {
         private String repository;
         private String verificationToken;
 
-        public VerifyNodeRepositoryRequest() {
+        public VerifyNodeRepositoryRequest(StreamInput in) throws IOException {
+            super(in);
+            repository = in.readString();
+            verificationToken = in.readString();
         }
 
         VerifyNodeRepositoryRequest(String repository, String verificationToken) {
             this.repository = repository;
             this.verificationToken = verificationToken;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            repository = in.readString();
-            verificationToken = in.readString();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/SearchPhaseResult.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchPhaseResult.java
@@ -91,11 +91,6 @@ public abstract class SearchPhaseResult extends TransportResponse {
     public FetchSearchResult fetchResult() { return null; }
 
     @Override
-    public final void readFrom(StreamInput in) {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
-    }
-
-    @Override
     public void writeTo(StreamOutput out) throws IOException {
         // TODO: this seems wrong, SearchPhaseResult should have a writeTo?
     }

--- a/server/src/main/java/org/elasticsearch/transport/BytesTransportRequest.java
+++ b/server/src/main/java/org/elasticsearch/transport/BytesTransportRequest.java
@@ -35,8 +35,10 @@ public class BytesTransportRequest extends TransportRequest {
     BytesReference bytes;
     Version version;
 
-    public BytesTransportRequest() {
-
+    public BytesTransportRequest(StreamInput in) throws IOException {
+        super(in);
+        bytes = in.readBytesReference();
+        version = in.getVersion();
     }
 
     public BytesTransportRequest(BytesReference bytes, Version version) {
@@ -50,13 +52,6 @@ public class BytesTransportRequest extends TransportRequest {
 
     public BytesReference bytes() {
         return this.bytes;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        bytes = in.readBytesReference();
-        version = in.getVersion();
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
@@ -171,7 +171,7 @@ final class TransportHandshaker {
         }
 
         HandshakeRequest(StreamInput streamInput) throws IOException {
-            super.readFrom(streamInput);
+            super(streamInput);
             BytesReference remainingMessage;
             try {
                 remainingMessage = streamInput.readBytesReference();
@@ -185,11 +185,6 @@ final class TransportHandshaker {
                     this.version = Version.readVersion(messageStreamInput);
                 }
             }
-        }
-
-        @Override
-        public void readFrom(StreamInput in) {
-            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -215,11 +210,6 @@ final class TransportHandshaker {
         private HandshakeResponse(StreamInput in) throws IOException {
             super(in);
             responseVersion = Version.readVersion(in);
-        }
-
-        @Override
-        public void readFrom(StreamInput in) {
-            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/transport/TransportInterceptor.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportInterceptor.java
@@ -20,8 +20,7 @@
 package org.elasticsearch.transport;
 
 import org.elasticsearch.cluster.node.DiscoveryNode;
-
-import java.util.function.Supplier;
+import org.elasticsearch.common.io.stream.Writeable.Reader;
 
 /**
  * This interface allows plugins to intercept requests on both the sender and the receiver side.
@@ -29,8 +28,8 @@ import java.util.function.Supplier;
 public interface TransportInterceptor {
     /**
      * This is called for each handler that is registered via
-     * {@link TransportService#registerRequestHandler(String, Supplier, String, boolean, boolean, TransportRequestHandler)} or
-     * {@link TransportService#registerRequestHandler(String, Supplier, String, TransportRequestHandler)}. The returned handler is
+     * {@link TransportService#registerRequestHandler(String, String, boolean, boolean, Reader, TransportRequestHandler)} or
+     * {@link TransportService#registerRequestHandler(String, String, Reader, TransportRequestHandler)}. The returned handler is
      * used instead of the passed in handler. By default the provided handler is returned.
      */
     default <T extends TransportRequest> TransportRequestHandler<T> interceptHandler(String action, String executor,

--- a/server/src/main/java/org/elasticsearch/transport/TransportMessage.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportMessage.java
@@ -52,7 +52,7 @@ public abstract class TransportMessage implements Streamable, Writeable {
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
-
+    public final void readFrom(StreamInput in) throws IOException {
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/TransportRequest.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportRequest.java
@@ -66,12 +66,6 @@ public abstract class TransportRequest extends TransportMessage implements TaskA
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        parentTaskId = TaskId.readFromStream(in);
-    }
-
-    @Override
     public void writeTo(StreamOutput out) throws IOException {
         parentTaskId.writeTo(out);
     }

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -35,7 +35,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.regex.Regex;
@@ -184,9 +183,9 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
         }
         registerRequestHandler(
             HANDSHAKE_ACTION_NAME,
-            () -> HandshakeRequest.INSTANCE,
             ThreadPool.Names.SAME,
             false, false,
+            HandshakeRequest::new,
             (request, channel, task) -> channel.sendResponse(
                 new HandshakeResponse(localNode, clusterName, localNode.getVersion())));
     }
@@ -484,6 +483,10 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
     static class HandshakeRequest extends TransportRequest {
 
         public static final HandshakeRequest INSTANCE = new HandshakeRequest();
+
+        HandshakeRequest(StreamInput in) throws IOException {
+            super(in);
+        }
 
         private HandshakeRequest() {
         }
@@ -842,23 +845,6 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
      * Registers a new request handler
      *
      * @param action         The action the request handler is associated with
-     * @param requestFactory a callable to be used construct new instances for streaming
-     * @param executor       The executor the request handling will be executed on
-     * @param handler        The handler itself that implements the request handling
-     */
-    public <Request extends TransportRequest> void registerRequestHandler(String action, Supplier<Request> requestFactory,
-                                                    String executor, TransportRequestHandler<Request> handler) {
-        validateActionName(action);
-        handler = interceptor.interceptHandler(action, executor, false, handler);
-        RequestHandlerRegistry<Request> reg = new RequestHandlerRegistry<>(
-            action, Streamable.newWriteableReader(requestFactory), taskManager, handler, executor, false, true);
-        transport.registerRequestHandler(reg);
-    }
-
-    /**
-     * Registers a new request handler
-     *
-     * @param action         The action the request handler is associated with
      * @param requestReader  a callable to be used construct new instances for streaming
      * @param executor       The executor the request handling will be executed on
      * @param handler        The handler itself that implements the request handling
@@ -870,27 +856,6 @@ public class TransportService extends AbstractLifecycleComponent implements Tran
         handler = interceptor.interceptHandler(action, executor, false, handler);
         RequestHandlerRegistry<Request> reg = new RequestHandlerRegistry<>(
             action, requestReader, taskManager, handler, executor, false, true);
-        transport.registerRequestHandler(reg);
-    }
-
-    /**
-     * Registers a new request handler
-     *
-     * @param action                The action the request handler is associated with
-     * @param request               The request class that will be used to construct new instances for streaming
-     * @param executor              The executor the request handling will be executed on
-     * @param forceExecution        Force execution on the executor queue and never reject it
-     * @param canTripCircuitBreaker Check the request size and raise an exception in case the limit is breached.
-     * @param handler               The handler itself that implements the request handling
-     */
-    public <Request extends TransportRequest> void registerRequestHandler(String action, Supplier<Request> request,
-                                                                          String executor, boolean forceExecution,
-                                                                          boolean canTripCircuitBreaker,
-                                                                          TransportRequestHandler<Request> handler) {
-        validateActionName(action);
-        handler = interceptor.interceptHandler(action, executor, forceExecution, handler);
-        RequestHandlerRegistry<Request> reg = new RequestHandlerRegistry<>(
-            action, Streamable.newWriteableReader(request), taskManager, handler, executor, forceExecution, canTripCircuitBreaker);
         transport.registerRequestHandler(reg);
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/flush/SyncedFlushUnitTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/flush/SyncedFlushUnitTests.java
@@ -168,7 +168,7 @@ public class SyncedFlushUnitTests extends ESTestCase {
                             shardResponses.put(shardRouting, new SyncedFlushService.ShardSyncedFlushResponse("copy failure " + shardId));
                         } else {
                             successful++;
-                            shardResponses.put(shardRouting, new SyncedFlushService.ShardSyncedFlushResponse());
+                            shardResponses.put(shardRouting, new SyncedFlushService.ShardSyncedFlushResponse((String) null));
                         }
                     }
                     shardsResults.add(new ShardsSyncedFlushResult(shardId, "_sync_id_" + shard, replicas + 1, shardResponses));

--- a/server/src/test/java/org/elasticsearch/index/engine/SegmentTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/SegmentTests.java
@@ -95,8 +95,7 @@ public class SegmentTests extends ESTestCase {
             segment.writeTo(output);
             output.flush();
             StreamInput input = output.bytes().streamInput();
-            Segment deserialized = new Segment();
-            deserialized.readFrom(input);
+            Segment deserialized = new Segment(input);
             assertTrue(isSegmentEquals(deserialized, segment));
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
@@ -872,7 +872,7 @@ public class StoreTests extends ESTestCase {
         InputStreamStreamInput in = new InputStreamStreamInput(inBuffer);
         in.setVersion(targetNodeVersion);
         TransportNodesListShardStoreMetaData.StoreFilesMetaData inStoreFileMetaData =
-            TransportNodesListShardStoreMetaData.StoreFilesMetaData.readStoreFilesMetaData(in);
+            new TransportNodesListShardStoreMetaData.StoreFilesMetaData(in);
         Iterator<StoreFileMetaData> outFiles = outStoreFileMetaData.iterator();
         for (StoreFileMetaData inFile : inStoreFileMetaData) {
             assertThat(inFile.name(), equalTo(outFiles.next().name()));

--- a/server/src/test/java/org/elasticsearch/indices/NodeIndicesStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/NodeIndicesStatsTests.java
@@ -30,7 +30,7 @@ import static org.hamcrest.object.HasToString.hasToString;
 public class NodeIndicesStatsTests extends ESTestCase {
 
     public void testInvalidLevel() {
-        final NodeIndicesStats stats = new NodeIndicesStats();
+        final NodeIndicesStats stats = new NodeIndicesStats(null, Collections.emptyMap());
         final String level = randomAlphaOfLength(16);
         final ToXContent.Params params = new ToXContent.MapParams(Collections.singletonMap("level", level));
         final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> stats.toXContent(null, params));

--- a/server/src/test/java/org/elasticsearch/indices/recovery/StartRecoveryRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/StartRecoveryRequestTests.java
@@ -65,8 +65,7 @@ public class StartRecoveryRequestTests extends ESTestCase {
         final ByteArrayInputStream inBuffer = new ByteArrayInputStream(outBuffer.toByteArray());
         InputStreamStreamInput in = new InputStreamStreamInput(inBuffer);
         in.setVersion(targetNodeVersion);
-        final StartRecoveryRequest inRequest = new StartRecoveryRequest();
-        inRequest.readFrom(in);
+        final StartRecoveryRequest inRequest = new StartRecoveryRequest(in);
 
         assertThat(outRequest.shardId(), equalTo(inRequest.shardId()));
         assertThat(outRequest.targetAllocationId(), equalTo(inRequest.targetAllocationId()));

--- a/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
@@ -171,11 +171,6 @@ public class InboundHandlerTests extends ESTestCase {
         }
 
         @Override
-        public void readFrom(StreamInput in) throws IOException {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeString(value);
@@ -193,11 +188,6 @@ public class InboundHandlerTests extends ESTestCase {
         private TestResponse(StreamInput in) throws IOException {
             super(in);
             this.value = in.readString();
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/transport/InboundMessageTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundMessageTests.java
@@ -224,20 +224,12 @@ public class InboundMessageTests extends ESTestCase {
 
         public String value;
 
-        private Message() {
-        }
-
         private Message(StreamInput in) throws IOException {
-            readFrom(in);
+            value = in.readString();
         }
 
         private Message(String value) {
             this.value = value;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            value = in.readString();
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
@@ -158,8 +158,7 @@ public class OutboundHandlerTests extends ESTestCase {
             InboundMessage.Request inboundRequest = (InboundMessage.Request) inboundMessage;
             assertThat(inboundRequest.getFeatures(), contains(feature1, feature2));
 
-            Request readMessage = new Request();
-            readMessage.readFrom(inboundMessage.getStreamInput());
+            Request readMessage = new Request(inboundMessage.getStreamInput());
             assertEquals(value, readMessage.value);
 
             try (ThreadContext.StoredContext existing = threadContext.stashContext()) {
@@ -226,8 +225,7 @@ public class OutboundHandlerTests extends ESTestCase {
             InboundMessage.Response inboundResponse = (InboundMessage.Response) inboundMessage;
             assertFalse(inboundResponse.isError());
 
-            Response readMessage = new Response();
-            readMessage.readFrom(inboundMessage.getStreamInput());
+            Response readMessage = new Response(inboundMessage.getStreamInput());
             assertEquals(value, readMessage.value);
 
             try (ThreadContext.StoredContext existing = threadContext.stashContext()) {
@@ -302,16 +300,12 @@ public class OutboundHandlerTests extends ESTestCase {
 
         public String value;
 
-        private Request() {
+        private Request(StreamInput in) throws IOException {
+            value = in.readString();
         }
 
         private Request(String value) {
             this.value = value;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            value = in.readString();
         }
 
         @Override
@@ -324,16 +318,13 @@ public class OutboundHandlerTests extends ESTestCase {
 
         public String value;
 
-        private Response() {
+        private Response(StreamInput in) throws IOException {
+            super(in);
+            value = in.readString();
         }
 
         private Response(String value) {
             this.value = value;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            value = in.readString();
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
@@ -215,11 +215,6 @@ public class TransportActionProxyTests extends ESTestCase {
         }
 
         @Override
-        public void readFrom(StreamInput in) throws IOException {
-            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
-        }
-
-        @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeString(sourceNode);

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -1149,11 +1149,6 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         }
 
         @Override
-        public void readFrom(StreamInput in) throws IOException {
-            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
-        }
-
-        @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeString(message);
@@ -1173,8 +1168,6 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             this.message = in.readString();
         }
 
-
-
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeString(message);
@@ -1191,11 +1184,6 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         Version0Request(StreamInput in) throws IOException {
             super(in);
             value1 = in.readInt();
-        }
-
-        @Override
-        public final void readFrom(StreamInput in) throws IOException {
-            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -1658,11 +1646,6 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         }
 
         @Override
-        public void readFrom(StreamInput in) throws IOException {
-            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
-        }
-
-        @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeOptionalString(info);
@@ -1682,16 +1665,12 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         final String info;
 
         TestResponse(StreamInput in) throws IOException {
+            super(in);
             this.info = in.readOptionalString();
         }
 
         TestResponse(String info) {
             this.info = info;
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override


### PR DESCRIPTION
This commit converts all remaining TransportRequest and
TransportResponse classes to implement Writeable, and disallows
Streamable implementations.

relates #34389
