### PR TITLE
Restore setting up temp dir for windows service (#44541)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -312,7 +312,7 @@ class VagrantTestPlugin implements Plugin<Project> {
                        test_args=( "\$@" )
                      fi
                      
-                     "${-> convertPath(project, linuxGradleJdk.toString()) }"/bin/java -cp "\$PACKAGING_TESTS/*" org.elasticsearch.packaging.VMTestRunner "\${test_args[@]}"
+                     "${-> convertLinuxPath(project, linuxGradleJdk.toString()) }"/bin/java -cp "\$PACKAGING_TESTS/*" org.elasticsearch.packaging.VMTestRunner "\${test_args[@]}"
                      """
         }
         Task createWindowsRunnerScript = project.tasks.create('createWindowsRunnerScript', FileContentsTask) {
@@ -321,13 +321,19 @@ class VagrantTestPlugin implements Plugin<Project> {
             // the use of $args rather than param() here is deliberate because the syntax for array (multivalued) parameters is likely
             // a little trappy for those unfamiliar with powershell
             contents """\
-                     if (\$args.Count -eq 0) {
-                       \$testArgs = @("${-> project.extensions.esvagrant.testClass}")
-                     } else {
-                       \$testArgs = \$args
+                     try {
+                         if (\$args.Count -eq 0) {
+                           \$testArgs = @("${-> project.extensions.esvagrant.testClass}")
+                         } else {
+                           \$testArgs = \$args
+                         }
+                         & "${-> convertWindowsPath(project, windowsGradleJdk.toString()) }/bin/java" -cp "\$Env:PACKAGING_TESTS/*" org.elasticsearch.packaging.VMTestRunner @testArgs
+                         exit \$LASTEXITCODE
+                     } catch {
+                         # catch if we have a failure to even run the script at all above, equivalent to set -e, sort of
+                         echo "\$_.Exception.Message"
+                         exit 1
                      }
-                     & "${-> convertPath(project, windowsGradleJdk.toString()) }"/bin/java -cp "\$Env:PACKAGING_TESTS/*" org.elasticsearch.packaging.VMTestRunner @testArgs
-                     exit \$LASTEXITCODE
                      """
         }
 
@@ -610,7 +616,7 @@ class VagrantTestPlugin implements Plugin<Project> {
                 // https://github.com/hashicorp/vagrant/blob/9c299a2a357fcf87f356bb9d56e18a037a53d138/plugins/communicators/winrm/communicator.rb#L195-L225
                 // https://devops-collective-inc.gitbooks.io/secrets-of-powershell-remoting/content/manuscript/accessing-remote-computers.html
                 javaPackagingTest.command = 'winrm'
-                javaPackagingTest.args = ['--elevated', '--command', 'powershell -File "$Env:PACKAGING_TESTS/run-tests.ps1"']
+                javaPackagingTest.args = ['--elevated', '--command', '& "$Env:PACKAGING_TESTS/run-tests.ps1"; exit $LASTEXITCODE']
             }
 
             TaskExecutionAdapter javaPackagingReproListener = createReproListener(project, javaPackagingTest.path)
@@ -643,7 +649,10 @@ class VagrantTestPlugin implements Plugin<Project> {
     }
 
     // convert the given path from an elasticsearch repo path to a VM path
-    private String convertPath(Project project, String path) {
+    private String convertLinuxPath(Project project, String path) {
         return "/elasticsearch/" + project.rootDir.toPath().relativize(Paths.get(path));
+    }
+    private String convertWindowsPath(Project project, String path) {
+        return "C:\\elasticsearch\\" + project.rootDir.toPath().relativize(Paths.get(path)).toString().replace('/', '\\');
     }
 }

--- a/distribution/src/bin/elasticsearch-service.bat
+++ b/distribution/src/bin/elasticsearch-service.bat
@@ -106,6 +106,10 @@ if exist "%JAVA_HOME%\bin\server\jvm.dll" (
 )
 
 :foundJVM
+if not defined ES_TMPDIR (
+  for /f "tokens=* usebackq" %%a in (`CALL %JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.TempDirectory"`) do set ES_TMPDIR=%%a
+)
+
 set ES_JVM_OPTIONS=%ES_PATH_CONF%\jvm.options
 
 if not "%ES_JAVA_OPTS%" == "" set ES_JAVA_OPTS=%ES_JAVA_OPTS: =;%

--- a/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/WindowsServiceTestCase.java
+++ b/qa/vagrant/src/main/java/org/elasticsearch/packaging/test/WindowsServiceTestCase.java
@@ -92,7 +92,7 @@ public abstract class WindowsServiceTestCase extends PackagingTestCase {
             Result logs = sh.run("$files = Get-ChildItem \"" + installation.logs + "\\elasticsearch.log\"; " +
                 "Write-Output $files; " +
                 "foreach ($file in $files) {" +
-                    "Write-Output \"$file\"; " +    
+                    "Write-Output \"$file\"; " +
                     "Get-Content \"$file\" " +
                 "}");
             logger.error(logs.stdout);


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/41913 setting up the
temp dir for ES was moved from the env script to individual cli scripts.
However, moving it to the windows service cli was missed. This commit
restores setting up the temp dir for the windows service control script.