### PR TITLE
Mute multiple tests on Windows (master)

### DIFF
--- a/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/JvmErgonomicsTests.java
+++ b/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/JvmErgonomicsTests.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.tools.launchers;
 
+import org.junit.Before;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -39,6 +41,13 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class JvmErgonomicsTests extends LaunchersTestCase {
+
+    @Before
+    public void setUp() {
+        assumeFalse("https://github.com/elastic/elasticsearch/issues/44669",
+            System.getProperty("os.name").contains("Win")
+        );
+    }
 
     public void testExtractValidHeapSizeUsingXmx() throws InterruptedException, IOException {
         assertThat(

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -55,6 +55,9 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
 
     @BeforeClass
     public static void loadDatabaseReaders() throws IOException {
+        // there are still problems on windows
+        assumeFalse("https://github.com/elastic/elasticsearch/issues/44552", Constants.WINDOWS);
+
         // Skip setup because Windows cannot cleanup these files properly. The reason is that they are using
         // a MappedByteBuffer which will keep the file mappings active until it is garbage-collected. As a consequence,
         // the corresponding file appears to be still in use and Windows cannot delete it.

--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilSecurityTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilSecurityTests.java
@@ -136,6 +136,7 @@ public class EvilSecurityTests extends ESTestCase {
     }
 
     public void testDuplicateDataPaths() throws IOException {
+        assumeFalse("https://github.com/elastic/elasticsearch/issues/44558", Constants.WINDOWS);
         final Path path = createTempDir();
         final Path home = path.resolve("home");
         final Path data = path.resolve("data");

--- a/qa/logging-config/src/test/java/org/elasticsearch/common/logging/ESJsonLayoutTests.java
+++ b/qa/logging-config/src/test/java/org/elasticsearch/common/logging/ESJsonLayoutTests.java
@@ -50,7 +50,7 @@ public class ESJsonLayoutTests extends ESTestCase {
                 "\"node.name\": \"%node_name\", " +
                 "\"message\": \"%notEmpty{%enc{%marker}{JSON} }%enc{%.-10000m}{JSON}\"" +
                 "%notEmpty{, %node_and_cluster_id }" +
-                "%exceptionAsJson }\n"));
+                "%exceptionAsJson }" + System.lineSeparator()));
     }
 
     public void testLayoutWithAdditionalFields() {
@@ -72,7 +72,7 @@ public class ESJsonLayoutTests extends ESTestCase {
                 "%notEmpty{, \"x-opaque-id\": \"%ESMessageField{x-opaque-id}\"}" +
                 "%notEmpty{, \"someOtherField\": \"%ESMessageField{someOtherField}\"}" +
                 "%notEmpty{, %node_and_cluster_id }" +
-                "%exceptionAsJson }\n"));
+                "%exceptionAsJson }" + System.lineSeparator()));
     }
 
     public void testLayoutWithAdditionalFieldOverride() {
@@ -92,6 +92,6 @@ public class ESJsonLayoutTests extends ESTestCase {
                 "\"node.name\": \"%node_name\"" +
                 "%notEmpty{, \"message\": \"%ESMessageField{message}\"}" +
                 "%notEmpty{, %node_and_cluster_id }" +
-                "%exceptionAsJson }\n"));
+                "%exceptionAsJson }" + System.lineSeparator()));
     }
 }

--- a/qa/unconfigured-node-name/build.gradle
+++ b/qa/unconfigured-node-name/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.OS
+
 /*
  * Licensed to Elasticsearch under one or more contributor
  * license agreements. See the NOTICE file distributed with
@@ -28,4 +30,6 @@ testClusters.integTest {
 integTest.runner {
   nonInputProperties.systemProperty 'tests.logfile',
     "${ -> testClusters.integTest.singleNode().getServerLog() }"
+  // https://github.com/elastic/elasticsearch/issues/44656
+  onlyIf { OS.WINDOWS.equals(OS.current()) == false }
 }

--- a/server/src/test/java/org/elasticsearch/node/NodeTests.java
+++ b/server/src/test/java/org/elasticsearch/node/NodeTests.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.node;
 
+import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.bootstrap.BootstrapCheck;
 import org.elasticsearch.bootstrap.BootstrapContext;
@@ -149,6 +150,7 @@ public class NodeTests extends ESTestCase {
     }
 
     public void testCloseOnOutstandingTask() throws Exception {
+        assumeFalse("https://github.com/elastic/elasticsearch/issues/44256", Constants.WINDOWS);
         Node node = new MockNode(baseSettings().build(), basePlugins());
         node.start();
         ThreadPool threadpool = node.injector().getInstance(ThreadPool.class);

--- a/server/src/test/java/org/elasticsearch/persistent/TestPersistentTasksPlugin.java
+++ b/server/src/test/java/org/elasticsearch/persistent/TestPersistentTasksPlugin.java
@@ -337,7 +337,7 @@ public class TestPersistentTasksPlugin extends Plugin implements ActionPlugin, P
                     assertTrue(awaitBusy(() -> testTask.isCancelled() ||
                                     testTask.getOperation() != null ||
                                     clusterService.lifecycleState() != Lifecycle.State.STARTED,   // speedup finishing on closed nodes
-                            30, TimeUnit.SECONDS)); // This can take a while during large cluster restart
+                            45, TimeUnit.SECONDS)); // This can take a while during large cluster restart
                     if (clusterService.lifecycleState() != Lifecycle.State.STARTED) {
                         return;
                     }

--- a/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.snapshots;
 
+import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
@@ -3513,6 +3514,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
     }
 
     public void testSnapshotStatusOnFailedIndex() throws Exception {
+        assumeFalse("https://github.com/elastic/elasticsearch/issues/44671", Constants.WINDOWS);
         logger.info("--> creating repository");
         final Path repoPath = randomRepoPath();
         final Client client = client();

--- a/x-pack/plugin/ccr/build.gradle
+++ b/x-pack/plugin/ccr/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.OS
+
 evaluationDependsOn(xpackModule('core'))
 
 apply plugin: 'elasticsearch.esplugin'
@@ -22,6 +24,8 @@ task internalClusterTestNoSecurityManager(type: Test) {
     include noSecurityManagerITClasses
     systemProperty 'es.set.netty.runtime.available.processors', 'false'
     systemProperty 'tests.security.manager', 'false'
+    // Disable tests on windows https://github.com/elastic/elasticsearch/issues/44610
+    onlyIf { OS.WINDOWS.equals(OS.current()) == false }
 }
 
 // Instead we create a separate task to run the
@@ -34,6 +38,8 @@ task internalClusterTest(type: Test) {
     include '**/*IT.class'
     exclude noSecurityManagerITClasses
     systemProperty 'es.set.netty.runtime.available.processors', 'false'
+    // Disable tests on windows https://github.com/elastic/elasticsearch/issues/44610
+    onlyIf { OS.WINDOWS.equals(OS.current()) == false }
 }
 
 check.dependsOn internalClusterTest

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.xpack.ccr;
 
-import org.apache.lucene.util.Constants;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
@@ -307,7 +306,6 @@ public class AutoFollowIT extends CcrIntegTestCase {
     }
 
     public void testConflictingPatterns() throws Exception {
-        assumeFalse("https://github.com/elastic/elasticsearch/issues/44610", Constants.WINDOWS);
         Settings leaderIndexSettings = Settings.builder()
             .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
             .put(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.ccr;
 
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
@@ -306,6 +307,7 @@ public class AutoFollowIT extends CcrIntegTestCase {
     }
 
     public void testConflictingPatterns() throws Exception {
+        assumeFalse("https://github.com/elastic/elasticsearch/issues/44610", Constants.WINDOWS);
         Settings leaderIndexSettings = Settings.builder()
             .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
             .put(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/BasicRenormalizationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/BasicRenormalizationIT.java
@@ -33,7 +33,7 @@ public class BasicRenormalizationIT extends MlNativeAutodetectIntegTestCase {
     }
 
     public void testDefaultRenormalization() throws Exception {
-        assertFalse("https://github.com/elastic/elasticsearch/issues/44613", Constants.WINDOWS);
+        assumeFalse("https://github.com/elastic/elasticsearch/issues/44613", Constants.WINDOWS);
         String jobId = "basic-renormalization-it-test-default-renormalization-job";
         createAndRunJob(jobId, null);
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/BasicRenormalizationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/BasicRenormalizationIT.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.ml.integration;
 
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.xpack.core.ml.action.GetRecordsAction;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
@@ -32,6 +33,7 @@ public class BasicRenormalizationIT extends MlNativeAutodetectIntegTestCase {
     }
 
     public void testDefaultRenormalization() throws Exception {
+        assertFalse("https://github.com/elastic/elasticsearch/issues/44613", Constants.WINDOWS);
         String jobId = "basic-renormalization-it-test-default-renormalization-job";
         createAndRunJob(jobId, null);
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ForecastIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ForecastIT.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.ml.integration;
 
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
@@ -211,6 +212,7 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
     }
 
     public void testOverflowToDisk() throws Exception {
+        assumeFalse("https://github.com/elastic/elasticsearch/issues/44609", Constants.WINDOWS);
         Detector.Builder detector = new Detector.Builder("mean", "value");
         detector.setByFieldName("clientIP");
 


### PR DESCRIPTION
This PR mutes multiple tests on windows.
It does this aggressively to be able to have these passing and make sure we don't cause further breakage on windows. 
These were found on a local CI setup running with `./gradlew.bat --continue` 