### PR TITLE
Remove Needless Synchronization in FollowersChecker (#44631)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
@@ -249,11 +249,9 @@ public class FollowersChecker {
     }
 
     private void handleDisconnectedNode(DiscoveryNode discoveryNode) {
-        synchronized (mutex) {
-            FollowerChecker followerChecker = followerCheckers.get(discoveryNode);
-            if (followerChecker != null && followerChecker.running()) {
-                followerChecker.failNode("disconnected");
-            }
+        FollowerChecker followerChecker = followerCheckers.get(discoveryNode);
+        if (followerChecker != null) {
+            followerChecker.failNode("disconnected");
         }
     }
 


### PR DESCRIPTION
* It seems redundant to synchronize here and check that the map hasn't checked via the `isRunning` under the mutex
* The map won't change if under the mutex that locks on all the updates to it
* Without the mutex it's very unlikely to change inside the method call relative to the likelihood of changing until the generic pool where we check for `isRunning` again anyway

-> just remove the synchronization (it's on the IO loop) and check since we do check the running state on the generic pool under the mutex anyway when we actually fail it

backport of #44631 