### PR TITLE
Implement exponential average search time per hour statistics.

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/datafeed/DatafeedTimingStats.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/datafeed/DatafeedTimingStats.java
@@ -39,6 +39,7 @@ public class DatafeedTimingStats implements ToXContentObject {
     public static final ParseField BUCKET_COUNT = new ParseField("bucket_count");
     public static final ParseField TOTAL_SEARCH_TIME_MS = new ParseField("total_search_time_ms");
     public static final ParseField AVG_SEARCH_TIME_PER_BUCKET_MS = new ParseField("average_search_time_per_bucket_ms");
+    public static final ParseField EXPONENTIAL_AVG_SEARCH_TIME_PER_HOUR_MS = new ParseField("exponential_average_search_time_per_hour_ms");
 
     public static final ParseField TYPE = new ParseField("datafeed_timing_stats");
 
@@ -55,18 +56,21 @@ public class DatafeedTimingStats implements ToXContentObject {
                     Long bucketCount = (Long) args[2];
                     Double totalSearchTimeMs = (Double) args[3];
                     Double avgSearchTimePerBucketMs = (Double) args[4];
+                    Double exponentialAvgSearchTimePerHourMs = (Double) args[5];
                     return new DatafeedTimingStats(
                         jobId,
                         getOrDefault(searchCount, 0L),
                         getOrDefault(bucketCount, 0L),
                         getOrDefault(totalSearchTimeMs, 0.0),
-                        avgSearchTimePerBucketMs);
+                        avgSearchTimePerBucketMs,
+                        exponentialAvgSearchTimePerHourMs);
                 });
         parser.declareString(constructorArg(), JOB_ID);
         parser.declareLong(optionalConstructorArg(), SEARCH_COUNT);
         parser.declareLong(optionalConstructorArg(), BUCKET_COUNT);
         parser.declareDouble(optionalConstructorArg(), TOTAL_SEARCH_TIME_MS);
         parser.declareDouble(optionalConstructorArg(), AVG_SEARCH_TIME_PER_BUCKET_MS);
+        parser.declareDouble(optionalConstructorArg(), EXPONENTIAL_AVG_SEARCH_TIME_PER_HOUR_MS);
         return parser;
     }
 
@@ -75,14 +79,21 @@ public class DatafeedTimingStats implements ToXContentObject {
     private long bucketCount;
     private double totalSearchTimeMs;
     private Double avgSearchTimePerBucketMs;
+    private Double exponentialAvgSearchTimePerHourMs;
 
     public DatafeedTimingStats(
-            String jobId, long searchCount, long bucketCount, double totalSearchTimeMs, @Nullable Double avgSearchTimePerBucketMs) {
+            String jobId,
+            long searchCount,
+            long bucketCount,
+            double totalSearchTimeMs,
+            @Nullable Double avgSearchTimePerBucketMs,
+            @Nullable Double exponentialAvgSearchTimePerHourMs) {
         this.jobId = Objects.requireNonNull(jobId);
         this.searchCount = searchCount;
         this.bucketCount = bucketCount;
         this.totalSearchTimeMs = totalSearchTimeMs;
         this.avgSearchTimePerBucketMs = avgSearchTimePerBucketMs;
+        this.exponentialAvgSearchTimePerHourMs = exponentialAvgSearchTimePerHourMs;
     }
 
     public String getJobId() {
@@ -105,6 +116,10 @@ public class DatafeedTimingStats implements ToXContentObject {
         return avgSearchTimePerBucketMs;
     }
 
+    public Double getExponentialAvgSearchTimePerHourMs() {
+        return exponentialAvgSearchTimePerHourMs;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
         builder.startObject();
@@ -114,6 +129,9 @@ public class DatafeedTimingStats implements ToXContentObject {
         builder.field(TOTAL_SEARCH_TIME_MS.getPreferredName(), totalSearchTimeMs);
         if (avgSearchTimePerBucketMs != null) {
             builder.field(AVG_SEARCH_TIME_PER_BUCKET_MS.getPreferredName(), avgSearchTimePerBucketMs);
+        }
+        if (exponentialAvgSearchTimePerHourMs != null) {
+            builder.field(EXPONENTIAL_AVG_SEARCH_TIME_PER_HOUR_MS.getPreferredName(), exponentialAvgSearchTimePerHourMs);
         }
         builder.endObject();
         return builder;
@@ -133,12 +151,19 @@ public class DatafeedTimingStats implements ToXContentObject {
             && this.searchCount == other.searchCount
             && this.bucketCount == other.bucketCount
             && this.totalSearchTimeMs == other.totalSearchTimeMs
-            && Objects.equals(this.avgSearchTimePerBucketMs, other.avgSearchTimePerBucketMs);
+            && Objects.equals(this.avgSearchTimePerBucketMs, other.avgSearchTimePerBucketMs)
+            && Objects.equals(this.exponentialAvgSearchTimePerHourMs, other.exponentialAvgSearchTimePerHourMs);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(jobId, searchCount, bucketCount, totalSearchTimeMs, avgSearchTimePerBucketMs);
+        return Objects.hash(
+            jobId,
+            searchCount,
+            bucketCount,
+            totalSearchTimeMs,
+            avgSearchTimePerBucketMs,
+            exponentialAvgSearchTimePerHourMs);
     }
 
     @Override

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/process/TimingStats.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/process/TimingStats.java
@@ -45,6 +45,8 @@ public class TimingStats implements ToXContentObject {
     public static final ParseField AVG_BUCKET_PROCESSING_TIME_MS = new ParseField("average_bucket_processing_time_ms");
     public static final ParseField EXPONENTIAL_AVG_BUCKET_PROCESSING_TIME_MS =
         new ParseField("exponential_average_bucket_processing_time_ms");
+    public static final ParseField EXPONENTIAL_AVG_BUCKET_PROCESSING_TIME_PER_HOUR_MS =
+        new ParseField("exponential_average_bucket_processing_time_per_hour_ms");
 
     public static final ConstructingObjectParser<TimingStats, Void> PARSER =
         new ConstructingObjectParser<>(
@@ -58,6 +60,7 @@ public class TimingStats implements ToXContentObject {
                 Double maxBucketProcessingTimeMs = (Double) args[4];
                 Double avgBucketProcessingTimeMs = (Double) args[5];
                 Double exponentialAvgBucketProcessingTimeMs = (Double) args[6];
+                Double exponentialAvgBucketProcessingTimePerHourMs = (Double) args[7];
                 return new TimingStats(
                     jobId,
                     getOrDefault(bucketCount, 0L),
@@ -65,7 +68,8 @@ public class TimingStats implements ToXContentObject {
                     minBucketProcessingTimeMs,
                     maxBucketProcessingTimeMs,
                     avgBucketProcessingTimeMs,
-                    exponentialAvgBucketProcessingTimeMs);
+                    exponentialAvgBucketProcessingTimeMs,
+                    exponentialAvgBucketProcessingTimePerHourMs);
             });
 
     static {
@@ -76,6 +80,7 @@ public class TimingStats implements ToXContentObject {
         PARSER.declareDouble(optionalConstructorArg(), MAX_BUCKET_PROCESSING_TIME_MS);
         PARSER.declareDouble(optionalConstructorArg(), AVG_BUCKET_PROCESSING_TIME_MS);
         PARSER.declareDouble(optionalConstructorArg(), EXPONENTIAL_AVG_BUCKET_PROCESSING_TIME_MS);
+        PARSER.declareDouble(optionalConstructorArg(), EXPONENTIAL_AVG_BUCKET_PROCESSING_TIME_PER_HOUR_MS);
     }
 
     private final String jobId;
@@ -85,6 +90,7 @@ public class TimingStats implements ToXContentObject {
     private Double maxBucketProcessingTimeMs;
     private Double avgBucketProcessingTimeMs;
     private Double exponentialAvgBucketProcessingTimeMs;
+    private Double exponentialAvgBucketProcessingTimePerHourMs;
 
     public TimingStats(
             String jobId,
@@ -93,7 +99,8 @@ public class TimingStats implements ToXContentObject {
             @Nullable Double minBucketProcessingTimeMs,
             @Nullable Double maxBucketProcessingTimeMs,
             @Nullable Double avgBucketProcessingTimeMs,
-            @Nullable Double exponentialAvgBucketProcessingTimeMs) {
+            @Nullable Double exponentialAvgBucketProcessingTimeMs,
+            @Nullable Double exponentialAvgBucketProcessingTimePerHourMs) {
         this.jobId = jobId;
         this.bucketCount = bucketCount;
         this.totalBucketProcessingTimeMs = totalBucketProcessingTimeMs;
@@ -101,6 +108,7 @@ public class TimingStats implements ToXContentObject {
         this.maxBucketProcessingTimeMs = maxBucketProcessingTimeMs;
         this.avgBucketProcessingTimeMs = avgBucketProcessingTimeMs;
         this.exponentialAvgBucketProcessingTimeMs = exponentialAvgBucketProcessingTimeMs;
+        this.exponentialAvgBucketProcessingTimePerHourMs = exponentialAvgBucketProcessingTimePerHourMs;
     }
 
     public String getJobId() {
@@ -131,6 +139,10 @@ public class TimingStats implements ToXContentObject {
         return exponentialAvgBucketProcessingTimeMs;
     }
 
+    public Double getExponentialAvgBucketProcessingTimePerHourMs() {
+        return exponentialAvgBucketProcessingTimePerHourMs;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
         builder.startObject();
@@ -149,6 +161,10 @@ public class TimingStats implements ToXContentObject {
         if (exponentialAvgBucketProcessingTimeMs != null) {
             builder.field(EXPONENTIAL_AVG_BUCKET_PROCESSING_TIME_MS.getPreferredName(), exponentialAvgBucketProcessingTimeMs);
         }
+        if (exponentialAvgBucketProcessingTimePerHourMs != null) {
+            builder.field(
+                EXPONENTIAL_AVG_BUCKET_PROCESSING_TIME_PER_HOUR_MS.getPreferredName(), exponentialAvgBucketProcessingTimePerHourMs);
+        }
         builder.endObject();
         return builder;
     }
@@ -164,7 +180,8 @@ public class TimingStats implements ToXContentObject {
             && Objects.equals(this.minBucketProcessingTimeMs, that.minBucketProcessingTimeMs)
             && Objects.equals(this.maxBucketProcessingTimeMs, that.maxBucketProcessingTimeMs)
             && Objects.equals(this.avgBucketProcessingTimeMs, that.avgBucketProcessingTimeMs)
-            && Objects.equals(this.exponentialAvgBucketProcessingTimeMs, that.exponentialAvgBucketProcessingTimeMs);
+            && Objects.equals(this.exponentialAvgBucketProcessingTimeMs, that.exponentialAvgBucketProcessingTimeMs)
+            && Objects.equals(this.exponentialAvgBucketProcessingTimePerHourMs, that.exponentialAvgBucketProcessingTimePerHourMs);
     }
 
     @Override
@@ -176,7 +193,8 @@ public class TimingStats implements ToXContentObject {
             minBucketProcessingTimeMs,
             maxBucketProcessingTimeMs,
             avgBucketProcessingTimeMs,
-            exponentialAvgBucketProcessingTimeMs);
+            exponentialAvgBucketProcessingTimeMs,
+            exponentialAvgBucketProcessingTimePerHourMs);
     }
 
     @Override

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/datafeed/DatafeedTimingStatsTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/datafeed/DatafeedTimingStatsTests.java
@@ -35,7 +35,12 @@ public class DatafeedTimingStatsTests extends AbstractXContentTestCase<DatafeedT
 
     public static DatafeedTimingStats createRandomInstance() {
         return new DatafeedTimingStats(
-            randomAlphaOfLength(10), randomLong(), randomLong(), randomDouble(), randomBoolean() ? null : randomDouble());
+            randomAlphaOfLength(10),
+            randomLong(),
+            randomLong(),
+            randomDouble(),
+            randomBoolean() ? null : randomDouble(),
+            randomBoolean() ? null : randomDouble());
     }
 
     @Override
@@ -64,35 +69,17 @@ public class DatafeedTimingStatsTests extends AbstractXContentTestCase<DatafeedT
             assertThat(stats.getBucketCount(), equalTo(0L));
             assertThat(stats.getTotalSearchTimeMs(), equalTo(0.0));
             assertThat(stats.getAvgSearchTimePerBucketMs(), nullValue());
+            assertThat(stats.getExponentialAvgSearchTimePerHourMs(), nullValue());
         }
     }
 
-    public void testEquals() {
-        DatafeedTimingStats stats1 = new DatafeedTimingStats(JOB_ID, 5, 10, 100.0, 20.0);
-        DatafeedTimingStats stats2 = new DatafeedTimingStats(JOB_ID, 5, 10, 100.0, 20.0);
-        DatafeedTimingStats stats3 = new DatafeedTimingStats(JOB_ID, 5, 10, 200.0, 20.0);
-
-        assertTrue(stats1.equals(stats1));
-        assertTrue(stats1.equals(stats2));
-        assertFalse(stats2.equals(stats3));
-    }
-
-    public void testHashCode() {
-        DatafeedTimingStats stats1 = new DatafeedTimingStats(JOB_ID, 5, 10, 100.0, 20.0);
-        DatafeedTimingStats stats2 = new DatafeedTimingStats(JOB_ID, 5, 10, 100.0, 20.0);
-        DatafeedTimingStats stats3 = new DatafeedTimingStats(JOB_ID, 5, 10, 200.0, 20.0);
-
-        assertEquals(stats1.hashCode(), stats1.hashCode());
-        assertEquals(stats1.hashCode(), stats2.hashCode());
-        assertNotEquals(stats2.hashCode(), stats3.hashCode());
-    }
-
     public void testConstructorAndGetters() {
-        DatafeedTimingStats stats = new DatafeedTimingStats(JOB_ID, 5, 10, 123.456, 78.9);
+        DatafeedTimingStats stats = new DatafeedTimingStats(JOB_ID, 5, 10, 123.456, 78.9, 98.7);
         assertThat(stats.getJobId(), equalTo(JOB_ID));
         assertThat(stats.getSearchCount(), equalTo(5L));
         assertThat(stats.getBucketCount(), equalTo(10L));
         assertThat(stats.getTotalSearchTimeMs(), equalTo(123.456));
         assertThat(stats.getAvgSearchTimePerBucketMs(), equalTo(78.9));
+        assertThat(stats.getExponentialAvgSearchTimePerHourMs(), equalTo(98.7));
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/job/process/TimingStatsTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/job/process/TimingStatsTests.java
@@ -41,6 +41,7 @@ public class TimingStatsTests extends AbstractXContentTestCase<TimingStats> {
             randomBoolean() ? null : randomDouble(),
             randomBoolean() ? null : randomDouble(),
             randomBoolean() ? null : randomDouble(),
+            randomBoolean() ? null : randomDouble(),
             randomBoolean() ? null : randomDouble());
     }
 
@@ -60,7 +61,7 @@ public class TimingStatsTests extends AbstractXContentTestCase<TimingStats> {
     }
 
     public void testConstructor() {
-        TimingStats stats = new TimingStats(JOB_ID, 7, 8.61, 1.0, 2.0, 1.23, 7.89);
+        TimingStats stats = new TimingStats(JOB_ID, 7, 8.61, 1.0, 2.0, 1.23, 7.89, 4.56);
 
         assertThat(stats.getJobId(), equalTo(JOB_ID));
         assertThat(stats.getBucketCount(), equalTo(7L));
@@ -69,10 +70,11 @@ public class TimingStatsTests extends AbstractXContentTestCase<TimingStats> {
         assertThat(stats.getMaxBucketProcessingTimeMs(), equalTo(2.0));
         assertThat(stats.getAvgBucketProcessingTimeMs(), equalTo(1.23));
         assertThat(stats.getExponentialAvgBucketProcessingTimeMs(), equalTo(7.89));
+        assertThat(stats.getExponentialAvgBucketProcessingTimePerHourMs(), equalTo(4.56));
     }
 
     public void testConstructor_NullValues() {
-        TimingStats stats = new TimingStats(JOB_ID, 7, 8.61, null, null, null, null);
+        TimingStats stats = new TimingStats(JOB_ID, 7, 8.61, null, null, null, null, null);
 
         assertThat(stats.getJobId(), equalTo(JOB_ID));
         assertThat(stats.getBucketCount(), equalTo(7L));
@@ -81,6 +83,7 @@ public class TimingStatsTests extends AbstractXContentTestCase<TimingStats> {
         assertThat(stats.getMaxBucketProcessingTimeMs(), nullValue());
         assertThat(stats.getAvgBucketProcessingTimeMs(), nullValue());
         assertThat(stats.getExponentialAvgBucketProcessingTimeMs(), nullValue());
+        assertThat(stats.getExponentialAvgBucketProcessingTimePerHourMs(), nullValue());
     }
 
     public void testParse_OptionalFieldsAbsent() throws IOException {
@@ -96,26 +99,7 @@ public class TimingStatsTests extends AbstractXContentTestCase<TimingStats> {
             assertThat(stats.getMaxBucketProcessingTimeMs(), nullValue());
             assertThat(stats.getAvgBucketProcessingTimeMs(), nullValue());
             assertThat(stats.getExponentialAvgBucketProcessingTimeMs(), nullValue());
+            assertThat(stats.getExponentialAvgBucketProcessingTimePerHourMs(), nullValue());
         }
-    }
-
-    public void testEquals() {
-        TimingStats stats1 = new TimingStats(JOB_ID, 7, 8.61, 1.0, 2.0, 1.23, 7.89);
-        TimingStats stats2 = new TimingStats(JOB_ID, 7, 8.61, 1.0, 2.0, 1.23, 7.89);
-        TimingStats stats3 = new TimingStats(JOB_ID, 7, 8.61, 1.0, 3.0, 1.23, 7.89);
-
-        assertTrue(stats1.equals(stats1));
-        assertTrue(stats1.equals(stats2));
-        assertFalse(stats2.equals(stats3));
-    }
-
-    public void testHashCode() {
-        TimingStats stats1 = new TimingStats(JOB_ID, 7, 8.61, 1.0, 2.0, 1.23, 7.89);
-        TimingStats stats2 = new TimingStats(JOB_ID, 7, 8.61, 1.0, 2.0, 1.23, 7.89);
-        TimingStats stats3 = new TimingStats(JOB_ID, 7, 8.61, 1.0, 3.0, 1.23, 7.89);
-
-        assertEquals(stats1.hashCode(), stats1.hashCode());
-        assertEquals(stats1.hashCode(), stats2.hashCode());
-        assertNotEquals(stats2.hashCode(), stats3.hashCode());
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedTimingStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedTimingStats.java
@@ -16,9 +16,11 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.ml.job.results.Result;
+import org.elasticsearch.xpack.core.ml.utils.ExponentialAverageCalculationContext;
 import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Objects;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
@@ -31,6 +33,8 @@ public class DatafeedTimingStats implements ToXContentObject, Writeable {
     public static final ParseField BUCKET_COUNT = new ParseField("bucket_count");
     public static final ParseField TOTAL_SEARCH_TIME_MS = new ParseField("total_search_time_ms");
     public static final ParseField AVG_SEARCH_TIME_PER_BUCKET_MS = new ParseField("average_search_time_per_bucket_ms");
+    public static final ParseField EXPONENTIAL_AVG_CALCULATION_CONTEXT = new ParseField("exponential_average_calculation_context");
+    public static final ParseField EXPONENTIAL_AVG_SEARCH_TIME_PER_HOUR_MS = new ParseField("exponential_average_search_time_per_hour_ms");
 
     public static final ParseField TYPE = new ParseField("datafeed_timing_stats");
 
@@ -46,13 +50,19 @@ public class DatafeedTimingStats implements ToXContentObject, Writeable {
                     Long searchCount = (Long) args[1];
                     Long bucketCount = (Long) args[2];
                     Double totalSearchTimeMs = (Double) args[3];
+                    ExponentialAverageCalculationContext exponentialAvgCalculationContext = (ExponentialAverageCalculationContext) args[4];
                     return new DatafeedTimingStats(
-                        jobId, getOrDefault(searchCount, 0L), getOrDefault(bucketCount, 0L), getOrDefault(totalSearchTimeMs, 0.0));
+                        jobId,
+                        getOrDefault(searchCount, 0L),
+                        getOrDefault(bucketCount, 0L),
+                        getOrDefault(totalSearchTimeMs, 0.0),
+                        getOrDefault(exponentialAvgCalculationContext, new ExponentialAverageCalculationContext()));
                 });
         parser.declareString(constructorArg(), JOB_ID);
         parser.declareLong(optionalConstructorArg(), SEARCH_COUNT);
         parser.declareLong(optionalConstructorArg(), BUCKET_COUNT);
         parser.declareDouble(optionalConstructorArg(), TOTAL_SEARCH_TIME_MS);
+        parser.declareObject(optionalConstructorArg(), ExponentialAverageCalculationContext.PARSER, EXPONENTIAL_AVG_CALCULATION_CONTEXT);
         return parser;
     }
 
@@ -64,27 +74,40 @@ public class DatafeedTimingStats implements ToXContentObject, Writeable {
     private long searchCount;
     private long bucketCount;
     private double totalSearchTimeMs;
+    private final ExponentialAverageCalculationContext exponentialAvgCalculationContext;
 
-    public DatafeedTimingStats(String jobId, long searchCount, long bucketCount, double totalSearchTimeMs) {
+    public DatafeedTimingStats(
+            String jobId,
+            long searchCount,
+            long bucketCount,
+            double totalSearchTimeMs,
+            ExponentialAverageCalculationContext exponentialAvgCalculationContext) {
         this.jobId = Objects.requireNonNull(jobId);
         this.searchCount = searchCount;
         this.bucketCount = bucketCount;
         this.totalSearchTimeMs = totalSearchTimeMs;
+        this.exponentialAvgCalculationContext = Objects.requireNonNull(exponentialAvgCalculationContext);
     }
 
     public DatafeedTimingStats(String jobId) {
-        this(jobId, 0, 0, 0.0);
+        this(jobId, 0, 0, 0.0, new ExponentialAverageCalculationContext());
     }
 
     public DatafeedTimingStats(StreamInput in) throws IOException {
-        jobId = in.readString();
-        searchCount = in.readLong();
-        bucketCount = in.readLong();
-        totalSearchTimeMs = in.readDouble();
+        this.jobId = in.readString();
+        this.searchCount = in.readLong();
+        this.bucketCount = in.readLong();
+        this.totalSearchTimeMs = in.readDouble();
+        this.exponentialAvgCalculationContext = in.readOptionalWriteable(ExponentialAverageCalculationContext::new);
     }
 
     public DatafeedTimingStats(DatafeedTimingStats other) {
-        this(other.jobId, other.searchCount, other.bucketCount, other.totalSearchTimeMs);
+        this(
+            other.jobId,
+            other.searchCount,
+            other.bucketCount,
+            other.totalSearchTimeMs,
+            new ExponentialAverageCalculationContext(other.exponentialAvgCalculationContext));
     }
 
     public String getJobId() {
@@ -104,18 +127,31 @@ public class DatafeedTimingStats implements ToXContentObject, Writeable {
     }
 
     public Double getAvgSearchTimePerBucketMs() {
-        return bucketCount > 0
-            ? totalSearchTimeMs / bucketCount
-            : null;
+        if (bucketCount == 0) return null;
+        return totalSearchTimeMs / bucketCount;
     }
 
-    public void incrementTotalSearchTimeMs(double searchTimeMs) {
+    public Double getExponentialAvgSearchTimePerHourMs() {
+        return exponentialAvgCalculationContext.getCurrentExponentialAverageMs();
+    }
+
+    // Visible for testing
+    ExponentialAverageCalculationContext getExponentialAvgCalculationContext() {
+        return exponentialAvgCalculationContext;
+    }
+
+    public void incrementSearchTimeMs(double searchTimeMs) {
         this.searchCount++;
         this.totalSearchTimeMs += searchTimeMs;
+        this.exponentialAvgCalculationContext.increment(searchTimeMs);
     }
 
     public void incrementBucketCount(long bucketCount) {
         this.bucketCount += bucketCount;
+    }
+
+    public void setLatestRecordTimestamp(Instant latestRecordTimestamp) {
+        this.exponentialAvgCalculationContext.setLatestTimestamp(latestRecordTimestamp);
     }
 
     @Override
@@ -124,6 +160,7 @@ public class DatafeedTimingStats implements ToXContentObject, Writeable {
         out.writeLong(searchCount);
         out.writeLong(bucketCount);
         out.writeDouble(totalSearchTimeMs);
+        out.writeOptionalWriteable(exponentialAvgCalculationContext);
     }
 
     @Override
@@ -137,10 +174,17 @@ public class DatafeedTimingStats implements ToXContentObject, Writeable {
         builder.field(BUCKET_COUNT.getPreferredName(), bucketCount);
         builder.field(TOTAL_SEARCH_TIME_MS.getPreferredName(), totalSearchTimeMs);
         if (params.paramAsBoolean(ToXContentParams.INCLUDE_CALCULATED_FIELDS, false)) {
-            Double avgSearchTimePerBucket = getAvgSearchTimePerBucketMs();
-            if (avgSearchTimePerBucket != null) {
-                builder.field(AVG_SEARCH_TIME_PER_BUCKET_MS.getPreferredName(), getAvgSearchTimePerBucketMs());
+            Double avgSearchTimePerBucketMs = getAvgSearchTimePerBucketMs();
+            if (avgSearchTimePerBucketMs != null) {
+                builder.field(AVG_SEARCH_TIME_PER_BUCKET_MS.getPreferredName(), avgSearchTimePerBucketMs);
             }
+            Double expAvgSearchTimePerHourMs = getExponentialAvgSearchTimePerHourMs();
+            if (expAvgSearchTimePerHourMs != null) {
+                builder.field(EXPONENTIAL_AVG_SEARCH_TIME_PER_HOUR_MS.getPreferredName(), expAvgSearchTimePerHourMs);
+            }
+        }
+        if (params.paramAsBoolean(ToXContentParams.FOR_INTERNAL_STORAGE, false)) {
+            builder.field(EXPONENTIAL_AVG_CALCULATION_CONTEXT.getPreferredName(), exponentialAvgCalculationContext);
         }
         builder.endObject();
         return builder;
@@ -159,12 +203,18 @@ public class DatafeedTimingStats implements ToXContentObject, Writeable {
         return Objects.equals(this.jobId, other.jobId)
             && this.searchCount == other.searchCount
             && this.bucketCount == other.bucketCount
-            && this.totalSearchTimeMs == other.totalSearchTimeMs;
+            && this.totalSearchTimeMs == other.totalSearchTimeMs
+            && Objects.equals(this.exponentialAvgCalculationContext, other.exponentialAvgCalculationContext);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(jobId, searchCount, bucketCount, totalSearchTimeMs);
+        return Objects.hash(
+            jobId,
+            searchCount,
+            bucketCount,
+            totalSearchTimeMs,
+            exponentialAvgCalculationContext);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
@@ -58,6 +58,7 @@ import org.elasticsearch.xpack.core.ml.job.results.ModelPlot;
 import org.elasticsearch.xpack.core.ml.job.results.ReservedFieldNames;
 import org.elasticsearch.xpack.core.ml.job.results.Result;
 import org.elasticsearch.xpack.core.ml.notifications.AuditMessage;
+import org.elasticsearch.xpack.core.ml.utils.ExponentialAverageCalculationContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -931,12 +932,27 @@ public class ElasticsearchMappings {
             .endObject()
             .startObject(TimingStats.EXPONENTIAL_AVG_BUCKET_PROCESSING_TIME_MS.getPreferredName())
                 .field(TYPE, DOUBLE)
+            .endObject()
+            .startObject(TimingStats.EXPONENTIAL_AVG_CALCULATION_CONTEXT.getPreferredName())
+                .startObject(PROPERTIES)
+                    .startObject(ExponentialAverageCalculationContext.INCREMENTAL_TIME_METRIC_MS.getPreferredName())
+                        .field(TYPE, DOUBLE)
+                    .endObject()
+                    .startObject(ExponentialAverageCalculationContext.LATEST_TIMESTAMP.getPreferredName())
+                        .field(TYPE, DATE)
+                    .endObject()
+                    .startObject(ExponentialAverageCalculationContext.PREVIOUS_EXPONENTIAL_AVERAGE_MS.getPreferredName())
+                        .field(TYPE, DOUBLE)
+                    .endObject()
+                .endObject()
             .endObject();
     }
 
     /**
      * {@link DatafeedTimingStats} mapping.
      * Does not include mapping for BUCKET_COUNT as this mapping is added by {@link #addDataCountsMapping} method.
+     * Does not include mapping for EXPONENTIAL_AVG_CALCULATION_CONTEXT as this mapping is added by
+     *     {@link #addTimingStatsExceptBucketCountMapping} method.
      *
      * @throws IOException On builder write error
      */
@@ -948,6 +964,7 @@ public class ElasticsearchMappings {
             // re-used: BUCKET_COUNT
             .startObject(DatafeedTimingStats.TOTAL_SEARCH_TIME_MS.getPreferredName())
                 .field(TYPE, DOUBLE)
+            // re-used: EXPONENTIAL_AVG_CALCULATION_CONTEXT
             .endObject();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
@@ -935,7 +935,7 @@ public class ElasticsearchMappings {
             .endObject()
             .startObject(TimingStats.EXPONENTIAL_AVG_CALCULATION_CONTEXT.getPreferredName())
                 .startObject(PROPERTIES)
-                    .startObject(ExponentialAverageCalculationContext.INCREMENTAL_TIME_METRIC_MS.getPreferredName())
+                    .startObject(ExponentialAverageCalculationContext.INCREMENTAL_METRIC_VALUE_MS.getPreferredName())
                         .field(TYPE, DOUBLE)
                     .endObject()
                     .startObject(ExponentialAverageCalculationContext.LATEST_TIMESTAMP.getPreferredName())

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/TimingStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/TimingStats.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.core.ml.job.process.autodetect.state;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
@@ -16,9 +17,11 @@ import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.results.Result;
+import org.elasticsearch.xpack.core.ml.utils.ExponentialAverageCalculationContext;
 import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Objects;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
@@ -36,6 +39,9 @@ public class TimingStats implements ToXContentObject, Writeable {
     public static final ParseField AVG_BUCKET_PROCESSING_TIME_MS = new ParseField("average_bucket_processing_time_ms");
     public static final ParseField EXPONENTIAL_AVG_BUCKET_PROCESSING_TIME_MS =
         new ParseField("exponential_average_bucket_processing_time_ms");
+    public static final ParseField EXPONENTIAL_AVG_CALCULATION_CONTEXT = new ParseField("exponential_average_calculation_context");
+    public static final ParseField EXPONENTIAL_AVG_BUCKET_PROCESSING_TIME_PER_HOUR_MS =
+        new ParseField("exponential_average_bucket_processing_time_per_hour_ms");
 
     public static final ParseField TYPE = new ParseField("timing_stats");
 
@@ -50,13 +56,15 @@ public class TimingStats implements ToXContentObject, Writeable {
                 Double maxBucketProcessingTimeMs = (Double) args[3];
                 Double avgBucketProcessingTimeMs = (Double) args[4];
                 Double exponentialAvgBucketProcessingTimeMs = (Double) args[5];
+                ExponentialAverageCalculationContext exponentialAvgCalculationContext = (ExponentialAverageCalculationContext) args[6];
                 return new TimingStats(
                     jobId,
                     bucketCount,
                     minBucketProcessingTimeMs,
                     maxBucketProcessingTimeMs,
                     avgBucketProcessingTimeMs,
-                    exponentialAvgBucketProcessingTimeMs);
+                    exponentialAvgBucketProcessingTimeMs,
+                    getOrDefault(exponentialAvgCalculationContext, new ExponentialAverageCalculationContext()));
             });
 
     static {
@@ -66,6 +74,7 @@ public class TimingStats implements ToXContentObject, Writeable {
         PARSER.declareDouble(optionalConstructorArg(), MAX_BUCKET_PROCESSING_TIME_MS);
         PARSER.declareDouble(optionalConstructorArg(), AVG_BUCKET_PROCESSING_TIME_MS);
         PARSER.declareDouble(optionalConstructorArg(), EXPONENTIAL_AVG_BUCKET_PROCESSING_TIME_MS);
+        PARSER.declareObject(optionalConstructorArg(), ExponentialAverageCalculationContext.PARSER, EXPONENTIAL_AVG_CALCULATION_CONTEXT);
     }
 
     public static String documentId(String jobId) {
@@ -78,6 +87,7 @@ public class TimingStats implements ToXContentObject, Writeable {
     private Double maxBucketProcessingTimeMs;
     private Double avgBucketProcessingTimeMs;
     private Double exponentialAvgBucketProcessingTimeMs;
+    private final ExponentialAverageCalculationContext exponentialAvgCalculationContext;
 
     public TimingStats(
             String jobId,
@@ -85,17 +95,19 @@ public class TimingStats implements ToXContentObject, Writeable {
             @Nullable Double minBucketProcessingTimeMs,
             @Nullable Double maxBucketProcessingTimeMs,
             @Nullable Double avgBucketProcessingTimeMs,
-            @Nullable Double exponentialAvgBucketProcessingTimeMs) {
-        this.jobId = jobId;
+            @Nullable Double exponentialAvgBucketProcessingTimeMs,
+            ExponentialAverageCalculationContext exponentialAvgCalculationContext) {
+        this.jobId = Objects.requireNonNull(jobId);
         this.bucketCount = bucketCount;
         this.minBucketProcessingTimeMs = minBucketProcessingTimeMs;
         this.maxBucketProcessingTimeMs = maxBucketProcessingTimeMs;
         this.avgBucketProcessingTimeMs = avgBucketProcessingTimeMs;
         this.exponentialAvgBucketProcessingTimeMs = exponentialAvgBucketProcessingTimeMs;
+        this.exponentialAvgCalculationContext = Objects.requireNonNull(exponentialAvgCalculationContext);
     }
 
     public TimingStats(String jobId) {
-        this(jobId, 0, null, null, null, null);
+        this(jobId, 0, null, null, null, null, new ExponentialAverageCalculationContext());
     }
 
     public TimingStats(TimingStats lhs) {
@@ -105,7 +117,8 @@ public class TimingStats implements ToXContentObject, Writeable {
             lhs.minBucketProcessingTimeMs,
             lhs.maxBucketProcessingTimeMs,
             lhs.avgBucketProcessingTimeMs,
-            lhs.exponentialAvgBucketProcessingTimeMs);
+            lhs.exponentialAvgBucketProcessingTimeMs,
+            new ExponentialAverageCalculationContext(lhs.exponentialAvgCalculationContext));
     }
 
     public TimingStats(StreamInput in) throws IOException {
@@ -115,6 +128,11 @@ public class TimingStats implements ToXContentObject, Writeable {
         this.maxBucketProcessingTimeMs = in.readOptionalDouble();
         this.avgBucketProcessingTimeMs = in.readOptionalDouble();
         this.exponentialAvgBucketProcessingTimeMs = in.readOptionalDouble();
+        if (in.getVersion().onOrAfter(Version.V_7_4_0)) {
+            this.exponentialAvgCalculationContext = in.readOptionalWriteable(ExponentialAverageCalculationContext::new);
+        } else {
+            this.exponentialAvgCalculationContext = new ExponentialAverageCalculationContext();
+        }
     }
 
     public String getJobId() {
@@ -148,6 +166,15 @@ public class TimingStats implements ToXContentObject, Writeable {
         return exponentialAvgBucketProcessingTimeMs;
     }
 
+    public Double getExponentialAvgBucketProcessingTimePerHourMs() {
+        return exponentialAvgCalculationContext.getCurrentExponentialAverageMs();
+    }
+
+    // Visible for testing
+    ExponentialAverageCalculationContext getExponentialAvgCalculationContext() {
+        return exponentialAvgCalculationContext;
+    }
+
     /**
      * Updates the statistics (min, max, avg, exponential avg) for the given data point (bucket processing time).
      */
@@ -176,6 +203,11 @@ public class TimingStats implements ToXContentObject, Writeable {
             exponentialAvgBucketProcessingTimeMs = (1 - ALPHA) * exponentialAvgBucketProcessingTimeMs + ALPHA * bucketProcessingTimeMs;
         }
         bucketCount++;
+        exponentialAvgCalculationContext.increment(bucketProcessingTimeMs);
+    }
+
+    public void setLatestRecordTimestamp(Instant latestRecordTimestamp) {
+        exponentialAvgCalculationContext.setLatestTimestamp(latestRecordTimestamp);
     }
 
     /**
@@ -191,6 +223,9 @@ public class TimingStats implements ToXContentObject, Writeable {
         out.writeOptionalDouble(maxBucketProcessingTimeMs);
         out.writeOptionalDouble(avgBucketProcessingTimeMs);
         out.writeOptionalDouble(exponentialAvgBucketProcessingTimeMs);
+        if (out.getVersion().onOrAfter(Version.V_7_4_0)) {
+            out.writeOptionalWriteable(exponentialAvgCalculationContext);
+        }
     }
 
     @Override
@@ -216,6 +251,15 @@ public class TimingStats implements ToXContentObject, Writeable {
         if (exponentialAvgBucketProcessingTimeMs != null) {
             builder.field(EXPONENTIAL_AVG_BUCKET_PROCESSING_TIME_MS.getPreferredName(), exponentialAvgBucketProcessingTimeMs);
         }
+        if (params.paramAsBoolean(ToXContentParams.INCLUDE_CALCULATED_FIELDS, false)) {
+            Double expAvgBucketProcessingTimePerHourMs = getExponentialAvgBucketProcessingTimePerHourMs();
+            if (expAvgBucketProcessingTimePerHourMs != null) {
+                builder.field(EXPONENTIAL_AVG_BUCKET_PROCESSING_TIME_PER_HOUR_MS.getPreferredName(), expAvgBucketProcessingTimePerHourMs);
+            }
+        }
+        if (params.paramAsBoolean(ToXContentParams.FOR_INTERNAL_STORAGE, false)) {
+            builder.field(EXPONENTIAL_AVG_CALCULATION_CONTEXT.getPreferredName(), exponentialAvgCalculationContext);
+        }
         builder.endObject();
         return builder;
     }
@@ -230,7 +274,8 @@ public class TimingStats implements ToXContentObject, Writeable {
             && Objects.equals(this.minBucketProcessingTimeMs, that.minBucketProcessingTimeMs)
             && Objects.equals(this.maxBucketProcessingTimeMs, that.maxBucketProcessingTimeMs)
             && Objects.equals(this.avgBucketProcessingTimeMs, that.avgBucketProcessingTimeMs)
-            && Objects.equals(this.exponentialAvgBucketProcessingTimeMs, that.exponentialAvgBucketProcessingTimeMs);
+            && Objects.equals(this.exponentialAvgBucketProcessingTimeMs, that.exponentialAvgBucketProcessingTimeMs)
+            && Objects.equals(this.exponentialAvgCalculationContext, that.exponentialAvgCalculationContext);
     }
 
     @Override
@@ -241,11 +286,16 @@ public class TimingStats implements ToXContentObject, Writeable {
             minBucketProcessingTimeMs,
             maxBucketProcessingTimeMs,
             avgBucketProcessingTimeMs,
-            exponentialAvgBucketProcessingTimeMs);
+            exponentialAvgBucketProcessingTimeMs,
+            exponentialAvgCalculationContext);
     }
 
     @Override
     public String toString() {
         return Strings.toString(this);
+    }
+
+    private static <T> T getOrDefault(@Nullable T value, T defaultValue) {
+        return value != null ? value : defaultValue;
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/TimingStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/TimingStats.java
@@ -128,7 +128,7 @@ public class TimingStats implements ToXContentObject, Writeable {
         this.maxBucketProcessingTimeMs = in.readOptionalDouble();
         this.avgBucketProcessingTimeMs = in.readOptionalDouble();
         this.exponentialAvgBucketProcessingTimeMs = in.readOptionalDouble();
-        if (in.getVersion().onOrAfter(Version.V_7_4_0)) {
+        if (in.getVersion().onOrAfter(Version.CURRENT)) {  // TODO: Change to V_7_4_0 after backport
             this.exponentialAvgCalculationContext = in.readOptionalWriteable(ExponentialAverageCalculationContext::new);
         } else {
             this.exponentialAvgCalculationContext = new ExponentialAverageCalculationContext();
@@ -223,7 +223,7 @@ public class TimingStats implements ToXContentObject, Writeable {
         out.writeOptionalDouble(maxBucketProcessingTimeMs);
         out.writeOptionalDouble(avgBucketProcessingTimeMs);
         out.writeOptionalDouble(exponentialAvgBucketProcessingTimeMs);
-        if (out.getVersion().onOrAfter(Version.V_7_4_0)) {
+        if (out.getVersion().onOrAfter(Version.CURRENT)) {  // TODO: Change to V_7_4_0 after backport
             out.writeOptionalWriteable(exponentialAvgCalculationContext);
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ReservedFieldNames.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ReservedFieldNames.java
@@ -29,6 +29,7 @@ import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSizeSta
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshotField;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.TimingStats;
+import org.elasticsearch.xpack.core.ml.utils.ExponentialAverageCalculationContext;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -185,10 +186,16 @@ public final class ReservedFieldNames {
             TimingStats.MAX_BUCKET_PROCESSING_TIME_MS.getPreferredName(),
             TimingStats.AVG_BUCKET_PROCESSING_TIME_MS.getPreferredName(),
             TimingStats.EXPONENTIAL_AVG_BUCKET_PROCESSING_TIME_MS.getPreferredName(),
+            TimingStats.EXPONENTIAL_AVG_CALCULATION_CONTEXT.getPreferredName(),
 
             DatafeedTimingStats.SEARCH_COUNT.getPreferredName(),
             DatafeedTimingStats.BUCKET_COUNT.getPreferredName(),
             DatafeedTimingStats.TOTAL_SEARCH_TIME_MS.getPreferredName(),
+            DatafeedTimingStats.EXPONENTIAL_AVG_CALCULATION_CONTEXT.getPreferredName(),
+
+            ExponentialAverageCalculationContext.INCREMENTAL_TIME_METRIC_MS.getPreferredName(),
+            ExponentialAverageCalculationContext.LATEST_TIMESTAMP.getPreferredName(),
+            ExponentialAverageCalculationContext.PREVIOUS_EXPONENTIAL_AVERAGE_MS.getPreferredName(),
 
             GetResult._ID,
             GetResult._INDEX,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ReservedFieldNames.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ReservedFieldNames.java
@@ -193,7 +193,7 @@ public final class ReservedFieldNames {
             DatafeedTimingStats.TOTAL_SEARCH_TIME_MS.getPreferredName(),
             DatafeedTimingStats.EXPONENTIAL_AVG_CALCULATION_CONTEXT.getPreferredName(),
 
-            ExponentialAverageCalculationContext.INCREMENTAL_TIME_METRIC_MS.getPreferredName(),
+            ExponentialAverageCalculationContext.INCREMENTAL_METRIC_VALUE_MS.getPreferredName(),
             ExponentialAverageCalculationContext.LATEST_TIMESTAMP.getPreferredName(),
             ExponentialAverageCalculationContext.PREVIOUS_EXPONENTIAL_AVERAGE_MS.getPreferredName(),
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ExponentialAverageCalculationContext.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ExponentialAverageCalculationContext.java
@@ -51,7 +51,7 @@ import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optiona
  */
 public class ExponentialAverageCalculationContext implements Writeable, ToXContentObject {
 
-    public static final ParseField INCREMENTAL_TIME_METRIC_MS = new ParseField("incremental_time_metric_ms");
+    public static final ParseField INCREMENTAL_METRIC_VALUE_MS = new ParseField("incremental_metric_value_ms");
     public static final ParseField LATEST_TIMESTAMP = new ParseField("latest_timestamp");
     public static final ParseField PREVIOUS_EXPONENTIAL_AVERAGE_MS = new ParseField("previous_exponential_average_ms");
 
@@ -70,7 +70,7 @@ public class ExponentialAverageCalculationContext implements Writeable, ToXConte
             });
 
     static {
-        PARSER.declareDouble(optionalConstructorArg(), INCREMENTAL_TIME_METRIC_MS);
+        PARSER.declareDouble(optionalConstructorArg(), INCREMENTAL_METRIC_VALUE_MS);
         PARSER.declareField(
             optionalConstructorArg(),
             p -> TimeUtils.parseTimeFieldToInstant(p, LATEST_TIMESTAMP.getPreferredName()),
@@ -171,7 +171,7 @@ public class ExponentialAverageCalculationContext implements Writeable, ToXConte
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(INCREMENTAL_TIME_METRIC_MS.getPreferredName(), incrementalMetricValueMs);
+        builder.field(INCREMENTAL_METRIC_VALUE_MS.getPreferredName(), incrementalMetricValueMs);
         if (latestTimestamp != null) {
             builder.timeField(
                 LATEST_TIMESTAMP.getPreferredName(),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ExponentialAverageCalculationContext.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ExponentialAverageCalculationContext.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ml.utils;
+
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.common.time.TimeUtils;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+import java.util.Objects;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+/**
+ * Utility for calculating current value of exponentially-weighted moving average per fixed-sized time window.
+ *
+ * The formula for the current value of the exponentially-weighted moving average is:
+ *
+ *   currentExponentialAverageMs = alpha * previousExponentialAverageMs + (1 - alpha) * incrementalMetricValueMs
+ *
+ * where alpha depends on what fraction of the current time window we've already seen:
+ *
+ *   alpha = e^(-time_elapsed_since_window_start/window_size)
+ *   time_elapsed_since_window_start = latestTimestamp - window_start
+ *
+ * The class holds 3 values based on which it performs the calculation:
+ *  - incrementalMetricValueMs - accumulated value of the metric in the current time window
+ *  - latestTimestamp - timestamp updated as the time passes through the current time window
+ *  - previousExponentialAverageMs - exponential average for previous time windows
+ *
+ * incrementalMetricValueMs should be updated using {@link #increment}.
+ * latestTimestamp should be updated using {@link #setLatestTimestamp}.
+ * Because it can happen that the timestamp is not available while incrementing the metric value, it is the responsibility of the user
+ * of this class to always call {@link #setLatestTimestamp} *after* all the relevant (i.e. referring to the points in time before the
+ * latest timestamp mentioned) {@link #increment} calls are made.
+ */
+public class ExponentialAverageCalculationContext implements Writeable, ToXContentObject {
+
+    public static final ParseField INCREMENTAL_TIME_METRIC_MS = new ParseField("incremental_time_metric_ms");
+    public static final ParseField LATEST_TIMESTAMP = new ParseField("latest_timestamp");
+    public static final ParseField PREVIOUS_EXPONENTIAL_AVERAGE_MS = new ParseField("previous_exponential_average_ms");
+
+    public static final ConstructingObjectParser<ExponentialAverageCalculationContext, Void> PARSER =
+        new ConstructingObjectParser<>(
+            "exponential_average_calculation_context",
+            true,
+            args -> {
+                Double incrementalMetricValueMs = (Double) args[0];
+                Instant latestTimestamp = (Instant) args[1];
+                Double previousExponentialAverageMs = (Double) args[2];
+                return new ExponentialAverageCalculationContext(
+                    getOrDefault(incrementalMetricValueMs, 0.0),
+                    latestTimestamp,
+                    previousExponentialAverageMs);
+            });
+
+    static {
+        PARSER.declareDouble(optionalConstructorArg(), INCREMENTAL_TIME_METRIC_MS);
+        PARSER.declareField(
+            optionalConstructorArg(),
+            p -> TimeUtils.parseTimeFieldToInstant(p, LATEST_TIMESTAMP.getPreferredName()),
+            LATEST_TIMESTAMP,
+            ObjectParser.ValueType.VALUE);
+        PARSER.declareDouble(optionalConstructorArg(), PREVIOUS_EXPONENTIAL_AVERAGE_MS);
+    }
+
+    private static final TemporalUnit WINDOW_UNIT = ChronoUnit.HOURS;
+    private static final Duration WINDOW_SIZE = WINDOW_UNIT.getDuration();
+
+    private double incrementalMetricValueMs;
+    private Instant latestTimestamp;
+    private Double previousExponentialAverageMs;
+
+    public ExponentialAverageCalculationContext() {
+        this(0.0, null, null);
+    }
+
+    public ExponentialAverageCalculationContext(
+            double incrementalMetricValueMs,
+            @Nullable Instant latestTimestamp,
+            @Nullable Double previousExponentialAverageMs) {
+        this.incrementalMetricValueMs = incrementalMetricValueMs;
+        this.latestTimestamp = latestTimestamp != null ? Instant.ofEpochMilli(latestTimestamp.toEpochMilli()) : null;
+        this.previousExponentialAverageMs = previousExponentialAverageMs;
+    }
+
+    public ExponentialAverageCalculationContext(ExponentialAverageCalculationContext lhs) {
+        this(lhs.incrementalMetricValueMs, lhs.latestTimestamp, lhs.previousExponentialAverageMs);
+    }
+
+    public ExponentialAverageCalculationContext(StreamInput in) throws IOException {
+        this.incrementalMetricValueMs = in.readDouble();
+        this.latestTimestamp = in.readOptionalInstant();
+        this.previousExponentialAverageMs = in.readOptionalDouble();
+    }
+
+    // Visible for testing
+    public double getIncrementalMetricValueMs() {
+        return incrementalMetricValueMs;
+    }
+
+    // Visible for testing
+    public Instant getLatestTimestamp() {
+        return latestTimestamp;
+    }
+
+    // Visible for testing
+    public Double getPreviousExponentialAverageMs() {
+        return previousExponentialAverageMs;
+    }
+
+    public Double getCurrentExponentialAverageMs() {
+        if (previousExponentialAverageMs == null || latestTimestamp == null) return incrementalMetricValueMs;
+        Instant currentWindowStartTimestamp = latestTimestamp.truncatedTo(WINDOW_UNIT);
+        double alpha = Math.exp(
+            - (double) Duration.between(currentWindowStartTimestamp, latestTimestamp).toMillis() / WINDOW_SIZE.toMillis());
+        return alpha * previousExponentialAverageMs + (1 - alpha) * incrementalMetricValueMs;
+    }
+
+    /**
+     * Increments the current accumulated metric value by the given delta.
+     */
+    public void increment(double metricValueDeltaMs) {
+        incrementalMetricValueMs += metricValueDeltaMs;
+    }
+
+    /**
+     * Sets the latest timestamp that serves as an indication of the current point in time.
+     * Before calling this method make sure all the associated calls to {@link #increment} were already made.
+     */
+    public void setLatestTimestamp(Instant newLatestTimestamp) {
+        Objects.requireNonNull(newLatestTimestamp);
+        if (this.latestTimestamp != null) {
+            Instant nextWindowStartTimestamp = this.latestTimestamp.truncatedTo(WINDOW_UNIT).plus(WINDOW_SIZE);
+            if (newLatestTimestamp.compareTo(nextWindowStartTimestamp) >= 0) {
+                // When we cross the boundary between windows, we update the exponential average with metric values accumulated so far in
+                // incrementalMetricValueMs variable.
+                this.previousExponentialAverageMs = getCurrentExponentialAverageMs();
+                this.incrementalMetricValueMs = 0.0;
+            }
+        } else {
+            // This is the first time {@link #setLatestRecordTimestamp} is called on this object.
+        }
+        if (this.latestTimestamp == null || newLatestTimestamp.isAfter(this.latestTimestamp)) {
+            this.latestTimestamp = newLatestTimestamp;
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeDouble(incrementalMetricValueMs);
+        out.writeOptionalInstant(latestTimestamp);
+        out.writeOptionalDouble(previousExponentialAverageMs);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(INCREMENTAL_TIME_METRIC_MS.getPreferredName(), incrementalMetricValueMs);
+        if (latestTimestamp != null) {
+            builder.timeField(
+                LATEST_TIMESTAMP.getPreferredName(),
+                LATEST_TIMESTAMP.getPreferredName() + "_string",
+                latestTimestamp.toEpochMilli());
+        }
+        if (previousExponentialAverageMs != null) {
+            builder.field(PREVIOUS_EXPONENTIAL_AVERAGE_MS.getPreferredName(), previousExponentialAverageMs);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ExponentialAverageCalculationContext that = (ExponentialAverageCalculationContext) o;
+        return this.incrementalMetricValueMs == that.incrementalMetricValueMs
+            && Objects.equals(this.latestTimestamp, that.latestTimestamp)
+            && Objects.equals(this.previousExponentialAverageMs, that.previousExponentialAverageMs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(incrementalMetricValueMs, latestTimestamp, previousExponentialAverageMs);
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T getOrDefault(@Nullable T value, T defaultValue) {
+        return value != null ? value : defaultValue;
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedStatsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedStatsActionResponseTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStatsTests;
+import org.elasticsearch.xpack.core.ml.utils.ExponentialAverageCalculationContext;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -78,7 +79,8 @@ public class GetDatafeedStatsActionResponseTests extends AbstractWireSerializing
                 Set.of(),
                 Version.CURRENT);
 
-        DatafeedTimingStats timingStats = new DatafeedTimingStats("my-job-id", 5, 10, 100.0);
+        DatafeedTimingStats timingStats =
+            new DatafeedTimingStats("my-job-id", 5, 10, 100.0, new ExponentialAverageCalculationContext(50.0, null, null));
 
         Response.DatafeedStats stats = new Response.DatafeedStats("df-id", DatafeedState.STARTED, node, null, timingStats);
 
@@ -110,11 +112,12 @@ public class GetDatafeedStatsActionResponseTests extends AbstractWireSerializing
         assertThat(nodeAttributes, hasEntry("ml.max_open_jobs", "5"));
 
         Map<String, Object> timingStatsMap = (Map<String, Object>) dfStatsMap.get("timing_stats");
-        assertThat(timingStatsMap.size(), is(equalTo(5)));
+        assertThat(timingStatsMap.size(), is(equalTo(6)));
         assertThat(timingStatsMap, hasEntry("job_id", "my-job-id"));
         assertThat(timingStatsMap, hasEntry("search_count", 5));
         assertThat(timingStatsMap, hasEntry("bucket_count", 10));
         assertThat(timingStatsMap, hasEntry("total_search_time_ms", 100.0));
         assertThat(timingStatsMap, hasEntry("average_search_time_per_bucket_ms", 10.0));
+        assertThat(timingStatsMap, hasEntry("exponential_average_search_time_per_hour_ms", 50.0));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/TimingStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/TimingStatsTests.java
@@ -6,10 +6,17 @@
 package org.elasticsearch.xpack.core.ml.job.process.autodetect.state;
 
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractSerializingTestCase;
+import org.elasticsearch.xpack.core.ml.utils.ExponentialAverageCalculationContext;
+import org.elasticsearch.xpack.core.ml.utils.ExponentialAverageCalculationContextTests;
+import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
 import org.hamcrest.CustomTypeSafeMatcher;
 import org.hamcrest.Matcher;
+
+import java.time.Instant;
+import java.util.Collections;
 
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
@@ -26,7 +33,8 @@ public class TimingStatsTests extends AbstractSerializingTestCase<TimingStats> {
             randomBoolean() ? null : randomDouble(),
             randomBoolean() ? null : randomDouble(),
             randomBoolean() ? null : randomDouble(),
-            randomBoolean() ? null : randomDouble());
+            randomBoolean() ? null : randomDouble(),
+            ExponentialAverageCalculationContextTests.createRandom());
     }
 
     @Override
@@ -44,24 +52,9 @@ public class TimingStatsTests extends AbstractSerializingTestCase<TimingStats> {
         return TimingStats.PARSER.apply(parser, null);
     }
 
-    public void testEquals() {
-        TimingStats stats1 = new TimingStats(JOB_ID, 7, 1.0, 2.0, 1.23, 7.89);
-        TimingStats stats2 = new TimingStats(JOB_ID, 7, 1.0, 2.0, 1.23, 7.89);
-        TimingStats stats3 = new TimingStats(JOB_ID, 7, 1.0, 3.0, 1.23, 7.89);
-
-        assertTrue(stats1.equals(stats1));
-        assertTrue(stats1.equals(stats2));
-        assertFalse(stats2.equals(stats3));
-    }
-
-    public void testHashCode() {
-        TimingStats stats1 = new TimingStats(JOB_ID, 7, 1.0, 2.0, 1.23, 7.89);
-        TimingStats stats2 = new TimingStats(JOB_ID, 7, 1.0, 2.0, 1.23, 7.89);
-        TimingStats stats3 = new TimingStats(JOB_ID, 7, 1.0, 3.0, 1.23, 7.89);
-
-        assertEquals(stats1.hashCode(), stats1.hashCode());
-        assertEquals(stats1.hashCode(), stats2.hashCode());
-        assertNotEquals(stats2.hashCode(), stats3.hashCode());
+    @Override
+    protected ToXContent.Params getToXContentParams() {
+        return new ToXContent.MapParams(Collections.singletonMap(ToXContentParams.FOR_INTERNAL_STORAGE, "true"));
     }
 
     public void testDefaultConstructor() {
@@ -74,10 +67,13 @@ public class TimingStatsTests extends AbstractSerializingTestCase<TimingStats> {
         assertThat(stats.getMaxBucketProcessingTimeMs(), nullValue());
         assertThat(stats.getAvgBucketProcessingTimeMs(), nullValue());
         assertThat(stats.getExponentialAvgBucketProcessingTimeMs(), nullValue());
+        assertThat(stats.getExponentialAvgCalculationContext(), equalTo(new ExponentialAverageCalculationContext()));
     }
 
     public void testConstructor() {
-        TimingStats stats = new TimingStats(JOB_ID, 7, 1.0, 2.0, 1.23, 7.89);
+        ExponentialAverageCalculationContext context =
+            new ExponentialAverageCalculationContext(78.9, Instant.ofEpochMilli(123456789), 987.0);
+        TimingStats stats = new TimingStats(JOB_ID, 7, 1.0, 2.0, 1.23, 7.89, context);
 
         assertThat(stats.getJobId(), equalTo(JOB_ID));
         assertThat(stats.getBucketCount(), equalTo(7L));
@@ -86,10 +82,13 @@ public class TimingStatsTests extends AbstractSerializingTestCase<TimingStats> {
         assertThat(stats.getMaxBucketProcessingTimeMs(), equalTo(2.0));
         assertThat(stats.getAvgBucketProcessingTimeMs(), equalTo(1.23));
         assertThat(stats.getExponentialAvgBucketProcessingTimeMs(), equalTo(7.89));
+        assertThat(stats.getExponentialAvgCalculationContext(), equalTo(context));
     }
 
     public void testCopyConstructor() {
-        TimingStats stats1 = new TimingStats(JOB_ID, 7, 1.0, 2.0, 1.23, 7.89);
+        ExponentialAverageCalculationContext context =
+            new ExponentialAverageCalculationContext(78.9, Instant.ofEpochMilli(123456789), 987.0);
+        TimingStats stats1 = new TimingStats(JOB_ID, 7, 1.0, 2.0, 1.23, 7.89, context);
         TimingStats stats2 = new TimingStats(stats1);
 
         assertThat(stats2.getJobId(), equalTo(JOB_ID));
@@ -99,27 +98,30 @@ public class TimingStatsTests extends AbstractSerializingTestCase<TimingStats> {
         assertThat(stats2.getMaxBucketProcessingTimeMs(), equalTo(2.0));
         assertThat(stats2.getAvgBucketProcessingTimeMs(), equalTo(1.23));
         assertThat(stats2.getExponentialAvgBucketProcessingTimeMs(), equalTo(7.89));
-        assertEquals(stats1, stats2);
-        assertEquals(stats1.hashCode(), stats2.hashCode());
+        assertThat(stats2.getExponentialAvgCalculationContext(), equalTo(context));
     }
 
     public void testUpdateStats() {
         TimingStats stats = new TimingStats(JOB_ID);
 
         stats.updateStats(3);
-        assertThat(stats, areCloseTo(new TimingStats(JOB_ID, 1, 3.0, 3.0, 3.0, 3.0), 1e-9));
+        assertThat(stats, areCloseTo(new TimingStats(JOB_ID, 1, 3.0, 3.0, 3.0, 3.0, createContext(3.0)), 1e-9));
 
         stats.updateStats(2);
-        assertThat(stats, areCloseTo(new TimingStats(JOB_ID, 2, 2.0, 3.0, 2.5, 2.99), 1e-9));
+        assertThat(stats, areCloseTo(new TimingStats(JOB_ID, 2, 2.0, 3.0, 2.5, 2.99, createContext(5.0)), 1e-9));
 
         stats.updateStats(4);
-        assertThat(stats, areCloseTo(new TimingStats(JOB_ID, 3, 2.0, 4.0, 3.0, 3.0001), 1e-9));
+        assertThat(stats, areCloseTo(new TimingStats(JOB_ID, 3, 2.0, 4.0, 3.0, 3.0001, createContext(9.0)), 1e-9));
 
         stats.updateStats(1);
-        assertThat(stats, areCloseTo(new TimingStats(JOB_ID, 4, 1.0, 4.0, 2.5, 2.980099), 1e-9));
+        assertThat(stats, areCloseTo(new TimingStats(JOB_ID, 4, 1.0, 4.0, 2.5, 2.980099, createContext(10.0)), 1e-9));
 
         stats.updateStats(5);
-        assertThat(stats, areCloseTo(new TimingStats(JOB_ID, 5, 1.0, 5.0, 3.0, 3.00029801), 1e-9));
+        assertThat(stats, areCloseTo(new TimingStats(JOB_ID, 5, 1.0, 5.0, 3.0, 3.00029801, createContext(15.0)), 1e-9));
+    }
+
+    private static ExponentialAverageCalculationContext createContext(double incrementalSearchTimeMs) {
+        return new ExponentialAverageCalculationContext(incrementalSearchTimeMs, null, null);
     }
 
     public void testTotalBucketProcessingTimeIsCalculatedProperlyAfterUpdates() {
@@ -166,7 +168,9 @@ public class TimingStatsTests extends AbstractSerializingTestCase<TimingStats> {
                     && closeTo(operand.getMaxBucketProcessingTimeMs(), error).matches(item.getMaxBucketProcessingTimeMs())
                     && closeTo(operand.getAvgBucketProcessingTimeMs(), error).matches(item.getAvgBucketProcessingTimeMs())
                     && closeTo(operand.getExponentialAvgBucketProcessingTimeMs(), error)
-                        .matches(item.getExponentialAvgBucketProcessingTimeMs());
+                        .matches(item.getExponentialAvgBucketProcessingTimeMs())
+                    && closeTo(operand.getExponentialAvgBucketProcessingTimePerHourMs(), error)
+                        .matches(item.getExponentialAvgBucketProcessingTimePerHourMs());
             }
         };
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/ExponentialAverageCalculationContextTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/ExponentialAverageCalculationContextTests.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ml.utils;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+
+import java.time.Instant;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+public class ExponentialAverageCalculationContextTests extends AbstractSerializingTestCase<ExponentialAverageCalculationContext> {
+
+    public static ExponentialAverageCalculationContext createRandom() {
+        return new ExponentialAverageCalculationContext(
+            randomDouble(),
+            randomBoolean() ? Instant.now() : null,
+            randomBoolean() ? randomDouble() : null);
+    }
+
+    @Override
+    public ExponentialAverageCalculationContext createTestInstance() {
+        return createRandom();
+    }
+
+    @Override
+    protected Writeable.Reader<ExponentialAverageCalculationContext> instanceReader() {
+        return ExponentialAverageCalculationContext::new;
+    }
+
+    @Override
+    protected ExponentialAverageCalculationContext doParseInstance(XContentParser parser) {
+        return ExponentialAverageCalculationContext.PARSER.apply(parser, null);
+    }
+
+    public void testDefaultConstructor() {
+        ExponentialAverageCalculationContext context = new ExponentialAverageCalculationContext();
+
+        assertThat(context.getIncrementalMetricValueMs(), equalTo(0.0));
+        assertThat(context.getLatestTimestamp(), nullValue());
+        assertThat(context.getPreviousExponentialAverageMs(), nullValue());
+    }
+
+    public void testConstructor() {
+        ExponentialAverageCalculationContext context =
+            new ExponentialAverageCalculationContext(1.23, Instant.ofEpochMilli(123456789), 4.56);
+
+        assertThat(context.getIncrementalMetricValueMs(), equalTo(1.23));
+        assertThat(context.getLatestTimestamp(), equalTo(Instant.ofEpochMilli(123456789)));
+        assertThat(context.getPreviousExponentialAverageMs(), equalTo(4.56));
+    }
+
+    public void testCopyConstructor() {
+        ExponentialAverageCalculationContext context1 =
+            new ExponentialAverageCalculationContext(1.23, Instant.ofEpochMilli(123456789), 4.56);
+        ExponentialAverageCalculationContext context2 = new ExponentialAverageCalculationContext(context1);
+
+        assertThat(context2.getIncrementalMetricValueMs(), equalTo(1.23));
+        assertThat(context2.getLatestTimestamp(), equalTo(Instant.ofEpochMilli(123456789)));
+        assertThat(context2.getPreviousExponentialAverageMs(), equalTo(4.56));
+        assertThat(context2.getCurrentExponentialAverageMs(), equalTo(context1.getCurrentExponentialAverageMs()));
+    }
+
+    public void testExponentialAverageCalculation() {
+        ExponentialAverageCalculationContext context = new ExponentialAverageCalculationContext(0.0, null, null);
+        assertThat(context.getIncrementalMetricValueMs(), equalTo(0.0));
+        assertThat(context.getLatestTimestamp(), nullValue());
+        assertThat(context.getPreviousExponentialAverageMs(), nullValue());
+        assertThat(context.getCurrentExponentialAverageMs(), equalTo(0.0));
+
+        context.increment(100.0);
+        context.increment(100.0);
+        context.increment(100.0);
+        assertThat(context.getIncrementalMetricValueMs(), equalTo(300.0));
+        assertThat(context.getLatestTimestamp(), nullValue());
+        assertThat(context.getPreviousExponentialAverageMs(), nullValue());
+        assertThat(context.getCurrentExponentialAverageMs(), equalTo(300.0));
+
+        context.setLatestTimestamp(Instant.parse("2019-07-19T03:30:00.00Z"));
+        assertThat(context.getIncrementalMetricValueMs(), equalTo(300.0));
+        assertThat(context.getLatestTimestamp(), equalTo(Instant.parse("2019-07-19T03:30:00.00Z")));
+        assertThat(context.getPreviousExponentialAverageMs(), nullValue());
+        assertThat(context.getCurrentExponentialAverageMs(), equalTo(300.0));
+
+        context.increment(200.0);
+        assertThat(context.getIncrementalMetricValueMs(), equalTo(500.0));
+        assertThat(context.getLatestTimestamp(), equalTo(Instant.parse("2019-07-19T03:30:00.00Z")));
+        assertThat(context.getPreviousExponentialAverageMs(), nullValue());
+        assertThat(context.getCurrentExponentialAverageMs(), equalTo(500.0));
+
+        context.setLatestTimestamp(Instant.parse("2019-07-19T04:00:01.00Z"));
+        assertThat(context.getIncrementalMetricValueMs(), equalTo(0.0));
+        assertThat(context.getLatestTimestamp(), equalTo(Instant.parse("2019-07-19T04:00:01.00Z")));
+        assertThat(context.getPreviousExponentialAverageMs(), equalTo(500.0));
+        assertThat(context.getCurrentExponentialAverageMs(), closeTo(499.8, 0.1));
+
+        context.increment(1000.0);
+        context.setLatestTimestamp(Instant.parse("2019-07-19T04:30:00.00Z"));
+        assertThat(context.getIncrementalMetricValueMs(), equalTo(1000.0));
+        assertThat(context.getLatestTimestamp(), equalTo(Instant.parse("2019-07-19T04:30:00.00Z")));
+        assertThat(context.getPreviousExponentialAverageMs(), equalTo(500.0));
+        assertThat(context.getCurrentExponentialAverageMs(), closeTo(696.7, 0.1));
+    }
+
+    public void testExponentialAverageCalculationOnWindowBoundary() {
+        ExponentialAverageCalculationContext context =
+            new ExponentialAverageCalculationContext(500.0, Instant.parse("2019-07-19T04:25:06.00Z"), 200.0);
+        assertThat(context.getIncrementalMetricValueMs(), equalTo(500.0));
+        assertThat(context.getLatestTimestamp(), equalTo(Instant.parse("2019-07-19T04:25:06.00Z")));
+        assertThat(context.getPreviousExponentialAverageMs(), equalTo(200.0));
+        assertThat(context.getCurrentExponentialAverageMs(), closeTo(302.5, 0.1));
+
+        context.setLatestTimestamp(Instant.parse("2019-07-19T05:00:00.00Z"));
+        assertThat(context.getIncrementalMetricValueMs(), equalTo(0.0));
+        assertThat(context.getLatestTimestamp(), equalTo(Instant.parse("2019-07-19T05:00:00.00Z")));
+        assertThat(context.getPreviousExponentialAverageMs(), closeTo(302.5, 0.1));
+        assertThat(context.getCurrentExponentialAverageMs(), equalTo(context.getPreviousExponentialAverageMs()));
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporter.java
@@ -46,7 +46,7 @@ public class DatafeedTimingStatsReporter {
         if (searchDuration == null) {
             return;
         }
-        currentTimingStats.incrementTotalSearchTimeMs(searchDuration.millis());
+        currentTimingStats.incrementSearchTimeMs(searchDuration.millis());
         flushIfDifferSignificantly();
     }
 
@@ -58,6 +58,9 @@ public class DatafeedTimingStatsReporter {
             return;
         }
         currentTimingStats.incrementBucketCount(dataCounts.getBucketCount());
+        if (dataCounts.getLatestRecordTimeStamp() != null) {
+            currentTimingStats.setLatestRecordTimestamp(dataCounts.getLatestRecordTimeStamp().toInstant());
+        }
         flushIfDifferSignificantly();
     }
 
@@ -79,7 +82,8 @@ public class DatafeedTimingStatsReporter {
     public static boolean differSignificantly(DatafeedTimingStats stats1, DatafeedTimingStats stats2) {
         return countsDifferSignificantly(stats1.getSearchCount(), stats2.getSearchCount())
             || differSignificantly(stats1.getTotalSearchTimeMs(), stats2.getTotalSearchTimeMs())
-            || differSignificantly(stats1.getAvgSearchTimePerBucketMs(), stats2.getAvgSearchTimePerBucketMs());
+            || differSignificantly(stats1.getAvgSearchTimePerBucketMs(), stats2.getAvgSearchTimePerBucketMs())
+            || differSignificantly(stats1.getExponentialAvgSearchTimePerHourMs(), stats2.getExponentialAvgSearchTimePerHourMs());
     }
 
     /**

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/TimingStatsReporter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/TimingStatsReporter.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.ml.job.persistence;
 
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.TimingStats;
+import org.elasticsearch.xpack.core.ml.job.results.Bucket;
 
 import java.util.Objects;
 
@@ -35,8 +36,9 @@ public class TimingStatsReporter {
         return new TimingStats(currentTimingStats);
     }
 
-    public void reportBucketProcessingTime(long bucketProcessingTimeMs) {
-        currentTimingStats.updateStats(bucketProcessingTimeMs);
+    public void reportBucket(Bucket bucket) {
+        currentTimingStats.updateStats(bucket.getProcessingTimeMs());
+        currentTimingStats.setLatestRecordTimestamp(bucket.getTimestamp().toInstant().plusSeconds(bucket.getBucketSpan()));
         if (differSignificantly(currentTimingStats, persistedTimingStats)) {
             flush();
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
@@ -213,7 +213,7 @@ public class AutodetectResultProcessor {
 
             // persist after deleting interim results in case the new
             // results are also interim
-            timingStatsReporter.reportBucketProcessingTime(bucket.getProcessingTimeMs());
+            timingStatsReporter.reportBucket(bucket);
             bulkResultsPersister.persistBucket(bucket).executeRequest();
 
             ++bucketCount;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
@@ -25,9 +25,11 @@ import org.elasticsearch.xpack.core.ml.job.results.Bucket;
 import org.elasticsearch.xpack.core.ml.job.results.BucketInfluencer;
 import org.elasticsearch.xpack.core.ml.job.results.Influencer;
 import org.elasticsearch.xpack.core.ml.job.results.ModelPlot;
+import org.elasticsearch.xpack.core.ml.utils.ExponentialAverageCalculationContext;
 import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -208,7 +210,9 @@ public class JobResultsPersisterTests extends ESTestCase {
         Client client = mockClient(bulkRequestCaptor);
 
         JobResultsPersister persister = new JobResultsPersister(client);
-        TimingStats timingStats = new TimingStats("foo", 7, 1.0, 2.0, 1.23, 7.89);
+        TimingStats timingStats =
+            new TimingStats(
+                "foo", 7, 1.0, 2.0, 1.23, 7.89, new ExponentialAverageCalculationContext(600.0, Instant.ofEpochMilli(123456789), 60.0));
         persister.bulkPersisterBuilder(JOB_ID).persistTimingStats(timingStats).executeRequest();
 
         verify(client, times(1)).bulk(bulkRequestCaptor.capture());
@@ -227,7 +231,11 @@ public class JobResultsPersisterTests extends ESTestCase {
                     "minimum_bucket_processing_time_ms", 1.0,
                     "maximum_bucket_processing_time_ms", 2.0,
                     "average_bucket_processing_time_ms", 1.23,
-                    "exponential_average_bucket_processing_time_ms", 7.89)));
+                    "exponential_average_bucket_processing_time_ms", 7.89,
+                    "exponential_average_calculation_context", Map.of(
+                        "incremental_time_metric_ms", 600.0,
+                        "previous_exponential_average_ms", 60.0,
+                        "latest_timestamp", 123456789))));
 
         verify(client, times(1)).threadPool();
         verifyNoMoreInteractions(client);
@@ -247,7 +255,9 @@ public class JobResultsPersisterTests extends ESTestCase {
             .when(client).index(any(), any(ActionListener.class));
 
         JobResultsPersister persister = new JobResultsPersister(client);
-        DatafeedTimingStats timingStats = new DatafeedTimingStats("foo", 6, 66, 666.0);
+        DatafeedTimingStats timingStats =
+            new DatafeedTimingStats(
+                "foo", 6, 66, 666.0, new ExponentialAverageCalculationContext(600.0, Instant.ofEpochMilli(123456789), 60.0));
         persister.persistDatafeedTimingStats(timingStats, WriteRequest.RefreshPolicy.IMMEDIATE);
 
         ArgumentCaptor<IndexRequest> indexRequestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
@@ -264,7 +274,11 @@ public class JobResultsPersisterTests extends ESTestCase {
                     "job_id", "foo",
                     "search_count", 6,
                     "bucket_count", 66,
-                    "total_search_time_ms", 666.0)));
+                    "total_search_time_ms", 666.0,
+                    "exponential_average_calculation_context", Map.of(
+                        "incremental_time_metric_ms", 600.0,
+                        "previous_exponential_average_ms", 60.0,
+                        "latest_timestamp", 123456789))));
 
         verify(client, times(1)).threadPool();
         verifyNoMoreInteractions(client);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
@@ -233,7 +233,7 @@ public class JobResultsPersisterTests extends ESTestCase {
                     "average_bucket_processing_time_ms", 1.23,
                     "exponential_average_bucket_processing_time_ms", 7.89,
                     "exponential_average_calculation_context", Map.of(
-                        "incremental_time_metric_ms", 600.0,
+                        "incremental_metric_value_ms", 600.0,
                         "previous_exponential_average_ms", 60.0,
                         "latest_timestamp", 123456789))));
 
@@ -276,7 +276,7 @@ public class JobResultsPersisterTests extends ESTestCase {
                     "bucket_count", 66,
                     "total_search_time_ms", 666.0,
                     "exponential_average_calculation_context", Map.of(
-                        "incremental_time_metric_ms", 600.0,
+                        "incremental_metric_value_ms", 600.0,
                         "previous_exponential_average_ms", 60.0,
                         "latest_timestamp", 123456789))));
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
@@ -849,7 +849,7 @@ public class JobResultsProviderTests extends ESTestCase {
                     TimingStats.AVG_BUCKET_PROCESSING_TIME_MS.getPreferredName(), 666.0,
                     TimingStats.EXPONENTIAL_AVG_BUCKET_PROCESSING_TIME_MS.getPreferredName(), 777.0,
                     TimingStats.EXPONENTIAL_AVG_CALCULATION_CONTEXT.getPreferredName(), Map.of(
-                        ExponentialAverageCalculationContext.INCREMENTAL_TIME_METRIC_MS.getPreferredName(), 100.0,
+                        ExponentialAverageCalculationContext.INCREMENTAL_METRIC_VALUE_MS.getPreferredName(), 100.0,
                         ExponentialAverageCalculationContext.LATEST_TIMESTAMP.getPreferredName(), Instant.ofEpochMilli(1000_000_000),
                         ExponentialAverageCalculationContext.PREVIOUS_EXPONENTIAL_AVERAGE_MS.getPreferredName(), 200.0)));
         SearchResponse response = createSearchResponse(source);
@@ -914,7 +914,7 @@ public class JobResultsProviderTests extends ESTestCase {
                     DatafeedTimingStats.BUCKET_COUNT.getPreferredName(), 66,
                     DatafeedTimingStats.TOTAL_SEARCH_TIME_MS.getPreferredName(), 666.0,
                     DatafeedTimingStats.EXPONENTIAL_AVG_CALCULATION_CONTEXT.getPreferredName(), Map.of(
-                        ExponentialAverageCalculationContext.INCREMENTAL_TIME_METRIC_MS.getPreferredName(), 600.0,
+                        ExponentialAverageCalculationContext.INCREMENTAL_METRIC_VALUE_MS.getPreferredName(), 600.0,
                         ExponentialAverageCalculationContext.LATEST_TIMESTAMP.getPreferredName(), Instant.ofEpochMilli(100000600),
                         ExponentialAverageCalculationContext.PREVIOUS_EXPONENTIAL_AVERAGE_MS.getPreferredName(), 60.0)));
         List<Map<String, Object>> sourceBar =
@@ -925,7 +925,7 @@ public class JobResultsProviderTests extends ESTestCase {
                     DatafeedTimingStats.BUCKET_COUNT.getPreferredName(), 77,
                     DatafeedTimingStats.TOTAL_SEARCH_TIME_MS.getPreferredName(), 777.0,
                     DatafeedTimingStats.EXPONENTIAL_AVG_CALCULATION_CONTEXT.getPreferredName(), Map.of(
-                        ExponentialAverageCalculationContext.INCREMENTAL_TIME_METRIC_MS.getPreferredName(), 700.0,
+                        ExponentialAverageCalculationContext.INCREMENTAL_METRIC_VALUE_MS.getPreferredName(), 700.0,
                         ExponentialAverageCalculationContext.LATEST_TIMESTAMP.getPreferredName(), Instant.ofEpochMilli(100000700),
                         ExponentialAverageCalculationContext.PREVIOUS_EXPONENTIAL_AVERAGE_MS.getPreferredName(), 70.0)));
         SearchResponse responseFoo = createSearchResponse(sourceFoo);
@@ -989,7 +989,7 @@ public class JobResultsProviderTests extends ESTestCase {
                     DatafeedTimingStats.BUCKET_COUNT.getPreferredName(), 66,
                     DatafeedTimingStats.TOTAL_SEARCH_TIME_MS.getPreferredName(), 666.0,
                     DatafeedTimingStats.EXPONENTIAL_AVG_CALCULATION_CONTEXT.getPreferredName(), Map.of(
-                        ExponentialAverageCalculationContext.INCREMENTAL_TIME_METRIC_MS.getPreferredName(), 600.0,
+                        ExponentialAverageCalculationContext.INCREMENTAL_METRIC_VALUE_MS.getPreferredName(), 600.0,
                         ExponentialAverageCalculationContext.LATEST_TIMESTAMP.getPreferredName(), Instant.ofEpochMilli(100000600),
                         ExponentialAverageCalculationContext.PREVIOUS_EXPONENTIAL_AVERAGE_MS.getPreferredName(), 60.0)));
         SearchResponse response = createSearchResponse(source);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/TimingStatsReporterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/TimingStatsReporterTests.java
@@ -5,10 +5,17 @@
  */
 package org.elasticsearch.xpack.ml.job.persistence;
 
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.TimingStats;
+import org.elasticsearch.xpack.core.ml.job.results.Bucket;
+import org.elasticsearch.xpack.core.ml.utils.ExponentialAverageCalculationContext;
 import org.junit.Before;
 import org.mockito.InOrder;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -20,6 +27,8 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 public class TimingStatsReporterTests extends ESTestCase {
 
     private static final String JOB_ID = "my-job-id";
+    private static final Instant TIMESTAMP = Instant.ofEpochMilli(1000000000);
+    private static final Duration BUCKET_SPAN = Duration.ofMinutes(1);
 
     private JobResultsPersister.Builder bulkResultsPersister;
 
@@ -29,56 +38,56 @@ public class TimingStatsReporterTests extends ESTestCase {
     }
 
     public void testGetCurrentTimingStats() {
-        TimingStats stats = new TimingStats(JOB_ID, 7, 1.0, 2.0, 1.23, 7.89);
-        TimingStatsReporter reporter = new TimingStatsReporter(stats, bulkResultsPersister);
+        TimingStats stats = createTimingStats(JOB_ID, 7, 1.0, 2.0, 1.23, 7.89);
+        TimingStatsReporter reporter = createReporter(stats);
         assertThat(reporter.getCurrentTimingStats(), equalTo(stats));
 
         verifyZeroInteractions(bulkResultsPersister);
     }
 
     public void testReporting() {
-        TimingStatsReporter reporter = new TimingStatsReporter(new TimingStats(JOB_ID), bulkResultsPersister);
+        TimingStatsReporter reporter = createReporter(new TimingStats(JOB_ID));
         assertThat(reporter.getCurrentTimingStats(), equalTo(new TimingStats(JOB_ID)));
 
-        reporter.reportBucketProcessingTime(10);
-        assertThat(reporter.getCurrentTimingStats(), equalTo(new TimingStats(JOB_ID, 1, 10.0, 10.0, 10.0, 10.0)));
+        reporter.reportBucket(createBucket(10));
+        assertThat(reporter.getCurrentTimingStats(), equalTo(createTimingStats(JOB_ID, 1, 10.0, 10.0, 10.0, 10.0, 10.0)));
 
-        reporter.reportBucketProcessingTime(20);
-        assertThat(reporter.getCurrentTimingStats(), equalTo(new TimingStats(JOB_ID, 2, 10.0, 20.0, 15.0, 10.1)));
+        reporter.reportBucket(createBucket(20));
+        assertThat(reporter.getCurrentTimingStats(), equalTo(createTimingStats(JOB_ID, 2, 10.0, 20.0, 15.0, 10.1, 30.0)));
 
-        reporter.reportBucketProcessingTime(15);
-        assertThat(reporter.getCurrentTimingStats(), equalTo(new TimingStats(JOB_ID, 3, 10.0, 20.0, 15.0, 10.149)));
+        reporter.reportBucket(createBucket(15));
+        assertThat(reporter.getCurrentTimingStats(), equalTo(createTimingStats(JOB_ID, 3, 10.0, 20.0, 15.0, 10.149, 45.0)));
 
         InOrder inOrder = inOrder(bulkResultsPersister);
-        inOrder.verify(bulkResultsPersister).persistTimingStats(new TimingStats(JOB_ID, 1, 10.0, 10.0, 10.0, 10.0));
-        inOrder.verify(bulkResultsPersister).persistTimingStats(new TimingStats(JOB_ID, 2, 10.0, 20.0, 15.0, 10.1));
+        inOrder.verify(bulkResultsPersister).persistTimingStats(createTimingStats(JOB_ID, 1, 10.0, 10.0, 10.0, 10.0, 10.0));
+        inOrder.verify(bulkResultsPersister).persistTimingStats(createTimingStats(JOB_ID, 2, 10.0, 20.0, 15.0, 10.1, 30.0));
         inOrder.verifyNoMoreInteractions();
     }
 
     public void testFinishReporting() {
-        TimingStatsReporter reporter = new TimingStatsReporter(new TimingStats(JOB_ID), bulkResultsPersister);
+        TimingStatsReporter reporter = createReporter(new TimingStats(JOB_ID));
         assertThat(reporter.getCurrentTimingStats(), equalTo(new TimingStats(JOB_ID)));
 
-        reporter.reportBucketProcessingTime(10);
-        assertThat(reporter.getCurrentTimingStats(), equalTo(new TimingStats(JOB_ID, 1, 10.0, 10.0, 10.0, 10.0)));
+        reporter.reportBucket(createBucket(10));
+        assertThat(reporter.getCurrentTimingStats(), equalTo(createTimingStats(JOB_ID, 1, 10.0, 10.0, 10.0, 10.0, 10.0)));
 
-        reporter.reportBucketProcessingTime(10);
-        assertThat(reporter.getCurrentTimingStats(), equalTo(new TimingStats(JOB_ID, 2, 10.0, 10.0, 10.0, 10.0)));
+        reporter.reportBucket(createBucket(10));
+        assertThat(reporter.getCurrentTimingStats(), equalTo(createTimingStats(JOB_ID, 2, 10.0, 10.0, 10.0, 10.0, 20.0)));
 
-        reporter.reportBucketProcessingTime(10);
-        assertThat(reporter.getCurrentTimingStats(), equalTo(new TimingStats(JOB_ID, 3, 10.0, 10.0, 10.0, 10.0)));
+        reporter.reportBucket(createBucket(10));
+        assertThat(reporter.getCurrentTimingStats(), equalTo(createTimingStats(JOB_ID, 3, 10.0, 10.0, 10.0, 10.0, 30.0)));
 
         reporter.finishReporting();
-        assertThat(reporter.getCurrentTimingStats(), equalTo(new TimingStats(JOB_ID, 3, 10.0, 10.0, 10.0, 10.0)));
+        assertThat(reporter.getCurrentTimingStats(), equalTo(createTimingStats(JOB_ID, 3, 10.0, 10.0, 10.0, 10.0, 30.0)));
 
         InOrder inOrder = inOrder(bulkResultsPersister);
-        inOrder.verify(bulkResultsPersister).persistTimingStats(new TimingStats(JOB_ID, 1, 10.0, 10.0, 10.0, 10.0));
-        inOrder.verify(bulkResultsPersister).persistTimingStats(new TimingStats(JOB_ID, 3, 10.0, 10.0, 10.0, 10.0));
+        inOrder.verify(bulkResultsPersister).persistTimingStats(createTimingStats(JOB_ID, 1, 10.0, 10.0, 10.0, 10.0, 10.0));
+        inOrder.verify(bulkResultsPersister).persistTimingStats(createTimingStats(JOB_ID, 3, 10.0, 10.0, 10.0, 10.0, 30.0));
         inOrder.verifyNoMoreInteractions();
     }
 
     public void testFinishReportingNoChange() {
-        TimingStatsReporter reporter = new TimingStatsReporter(new TimingStats(JOB_ID), bulkResultsPersister);
+        TimingStatsReporter reporter = createReporter(new TimingStats(JOB_ID));
 
         reporter.finishReporting();
 
@@ -86,27 +95,27 @@ public class TimingStatsReporterTests extends ESTestCase {
     }
 
     public void testFinishReportingWithChange() {
-        TimingStatsReporter reporter = new TimingStatsReporter(new TimingStats(JOB_ID), bulkResultsPersister);
+        TimingStatsReporter reporter = createReporter(new TimingStats(JOB_ID));
 
-        reporter.reportBucketProcessingTime(10);
+        reporter.reportBucket(createBucket(10));
 
         reporter.finishReporting();
 
-        verify(bulkResultsPersister).persistTimingStats(new TimingStats(JOB_ID, 1, 10.0, 10.0, 10.0, 10.0));
+        verify(bulkResultsPersister).persistTimingStats(createTimingStats(JOB_ID, 1, 10.0, 10.0, 10.0, 10.0, 10.0));
     }
 
     public void testTimingStatsDifferSignificantly() {
         assertThat(
             TimingStatsReporter.differSignificantly(
-                new TimingStats(JOB_ID, 10, 10.0, 10.0, 1.0, 10.0), new TimingStats(JOB_ID, 10, 10.0, 10.0, 1.0, 10.0)),
+                createTimingStats(JOB_ID, 10, 10.0, 10.0, 1.0, 10.0), createTimingStats(JOB_ID, 10, 10.0, 10.0, 1.0, 10.0)),
             is(false));
         assertThat(
             TimingStatsReporter.differSignificantly(
-                new TimingStats(JOB_ID, 10, 10.0, 10.0, 1.0, 10.0), new TimingStats(JOB_ID, 10, 10.0, 11.0, 1.0, 10.0)),
+                createTimingStats(JOB_ID, 10, 10.0, 10.0, 1.0, 10.0), createTimingStats(JOB_ID, 10, 10.0, 11.0, 1.0, 10.0)),
             is(false));
         assertThat(
             TimingStatsReporter.differSignificantly(
-                new TimingStats(JOB_ID, 10, 10.0, 10.0, 1.0, 10.0), new TimingStats(JOB_ID, 10, 10.0, 12.0, 1.0, 10.0)),
+                createTimingStats(JOB_ID, 10, 10.0, 10.0, 1.0, 10.0), createTimingStats(JOB_ID, 10, 10.0, 12.0, 1.0, 10.0)),
             is(true));
     }
 
@@ -120,5 +129,52 @@ public class TimingStatsReporterTests extends ESTestCase {
         assertThat(TimingStatsReporter.differSignificantly(1.0, 0.899999), is(true));
         assertThat(TimingStatsReporter.differSignificantly(0.0, 1.0), is(true));
         assertThat(TimingStatsReporter.differSignificantly(1.0, 0.0), is(true));
+    }
+
+    private TimingStatsReporter createReporter(TimingStats timingStats) {
+        return new TimingStatsReporter(timingStats, bulkResultsPersister);
+    }
+
+    private static TimingStats createTimingStats(
+        String jobId,
+        long bucketCount,
+        @Nullable Double minBucketProcessingTimeMs,
+        @Nullable Double maxBucketProcessingTimeMs,
+        @Nullable Double avgBucketProcessingTimeMs,
+        @Nullable Double exponentialAvgBucketProcessingTimeMs) {
+        return createTimingStats(
+            jobId,
+            bucketCount,
+            minBucketProcessingTimeMs,
+            maxBucketProcessingTimeMs,
+            avgBucketProcessingTimeMs,
+            exponentialAvgBucketProcessingTimeMs,
+            0.0);
+    }
+
+    private static TimingStats createTimingStats(
+            String jobId,
+            long bucketCount,
+            @Nullable Double minBucketProcessingTimeMs,
+            @Nullable Double maxBucketProcessingTimeMs,
+            @Nullable Double avgBucketProcessingTimeMs,
+            @Nullable Double exponentialAvgBucketProcessingTimeMs,
+            double incrementalBucketProcessingTimeMs) {
+        ExponentialAverageCalculationContext context =
+            new ExponentialAverageCalculationContext(incrementalBucketProcessingTimeMs, TIMESTAMP.plus(BUCKET_SPAN), null);
+        return new TimingStats(
+            jobId,
+            bucketCount,
+            minBucketProcessingTimeMs,
+            maxBucketProcessingTimeMs,
+            avgBucketProcessingTimeMs,
+            exponentialAvgBucketProcessingTimeMs,
+            context);
+    }
+
+    private static Bucket createBucket(long processingTimeMs) {
+        Bucket bucket = new Bucket(JOB_ID, Date.from(TIMESTAMP), BUCKET_SPAN.getSeconds());
+        bucket.setProcessingTimeMs(processingTimeMs);
+        return bucket;
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessorTests.java
@@ -134,7 +134,7 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         when(bulkBuilder.persistTimingStats(any(TimingStats.class))).thenReturn(bulkBuilder);
         when(bulkBuilder.persistBucket(any(Bucket.class))).thenReturn(bulkBuilder);
         AutodetectResult result = mock(AutodetectResult.class);
-        Bucket bucket = mock(Bucket.class);
+        Bucket bucket = new Bucket(JOB_ID, new Date(), BUCKET_SPAN_MS);
         when(result.getBucket()).thenReturn(bucket);
 
         processorUnderTest.setDeleteInterimRequired(false);
@@ -151,7 +151,7 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         when(bulkBuilder.persistTimingStats(any(TimingStats.class))).thenReturn(bulkBuilder);
         when(bulkBuilder.persistBucket(any(Bucket.class))).thenReturn(bulkBuilder);
         AutodetectResult result = mock(AutodetectResult.class);
-        Bucket bucket = mock(Bucket.class);
+        Bucket bucket = new Bucket(JOB_ID, new Date(), BUCKET_SPAN_MS);
         when(result.getBucket()).thenReturn(bucket);
 
         processorUnderTest.processResult(result);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/params/AutodetectParamsTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/params/AutodetectParamsTests.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.ml.job.process.autodetect.params;
 
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.TimingStats;
+import org.elasticsearch.xpack.core.ml.utils.ExponentialAverageCalculationContext;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -15,13 +16,17 @@ public class AutodetectParamsTests extends ESTestCase {
     private static final String JOB_ID = "my-job";
 
     public void testBuilder_WithTimingStats() {
-        TimingStats timingStats = new TimingStats(JOB_ID, 7, 1.0, 1000.0, 666.0, 1000.0);
+        TimingStats timingStats = new TimingStats(JOB_ID, 7, 1.0, 1000.0, 666.0, 1000.0, new ExponentialAverageCalculationContext());
         AutodetectParams params = new AutodetectParams.Builder(JOB_ID).setTimingStats(timingStats).build();
         assertThat(params.timingStats(), equalTo(timingStats));
 
         timingStats.updateStats(2000.0);
-        assertThat(timingStats, equalTo(new TimingStats(JOB_ID, 8, 1.0, 2000.0, 832.75, 1010.0)));
-        assertThat(params.timingStats(), equalTo(new TimingStats(JOB_ID, 7, 1.0, 1000.0, 666.0, 1000.0)));
+        assertThat(
+            timingStats,
+            equalTo(new TimingStats(JOB_ID, 8, 1.0, 2000.0, 832.75, 1010.0, new ExponentialAverageCalculationContext(2000.0, null, null))));
+        assertThat(
+            params.timingStats(),
+            equalTo(new TimingStats(JOB_ID, 7, 1.0, 1000.0, 666.0, 1000.0, new ExponentialAverageCalculationContext())));
     }
 
     public void testBuilder_WithoutTimingStats() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/results/BucketTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/results/BucketTests.java
@@ -27,13 +27,15 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class BucketTests extends AbstractSerializingTestCase<Bucket> {
 
+    private static final long MAX_BUCKET_SPAN_SEC = 100_000_000_000L;  // bucket span of > 3000 years should be enough for everyone
+
     @Override
     public Bucket createTestInstance() {
         return createTestInstance("foo");
     }
 
     public Bucket createTestInstance(String jobId) {
-        Bucket bucket = new Bucket(jobId, randomDate(), randomNonNegativeLong());
+        Bucket bucket = new Bucket(jobId, randomDate(), randomLongBetween(1, MAX_BUCKET_SPAN_SEC));
         if (randomBoolean()) {
             bucket.setAnomalyScore(randomDouble());
         }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/ml/JobStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/ml/JobStatsMonitoringDocTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSizeStats;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.TimingStats;
 import org.elasticsearch.xpack.core.ml.stats.ForecastStats;
+import org.elasticsearch.xpack.core.ml.utils.ExponentialAverageCalculationContext;
 import org.elasticsearch.xpack.core.monitoring.MonitoredSystem;
 import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringDoc;
 import org.elasticsearch.xpack.monitoring.exporter.BaseMonitoringDocTestCase;
@@ -103,7 +104,8 @@ public class JobStatsMonitoringDocTests extends BaseMonitoringDocTestCase<JobSta
 
         final DataCounts dataCounts = new DataCounts("_job_id", 0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, date3, date4, date5, date6, date7);
         final ForecastStats forecastStats = new ForecastStats();
-        final TimingStats timingStats = new TimingStats("_job_id", 100, 10.0, 30.0, 20.0, 25.0);
+        final TimingStats timingStats = new TimingStats(
+            "_job_id", 100, 10.0, 30.0, 20.0, 25.0, new ExponentialAverageCalculationContext(50.0, null, null));
         final JobStats jobStats = new JobStats(
             "_job", dataCounts, modelStats, forecastStats, JobState.OPENED, discoveryNode, "_explanation", time, timingStats);
         final MonitoringDoc.Node node = new MonitoringDoc.Node("_uuid", "_host", "_addr", "_ip", "_name", 1504169190855L);
@@ -179,7 +181,8 @@ public class JobStatsMonitoringDocTests extends BaseMonitoringDocTestCase<JobSta
                         + "\"minimum_bucket_processing_time_ms\":10.0,"
                         + "\"maximum_bucket_processing_time_ms\":30.0,"
                         + "\"average_bucket_processing_time_ms\":20.0,"
-                        + "\"exponential_average_bucket_processing_time_ms\":25.0"
+                        + "\"exponential_average_bucket_processing_time_ms\":25.0,"
+                        + "\"exponential_average_bucket_processing_time_per_hour_ms\":50.0"
                        + "}"
                      + "}"
                     + "}", xContent.utf8ToString());


### PR DESCRIPTION
This PR introduces two new fields:
- JobStats.TimingStats.exponential_average_bucket_processing_time_per_hour_ms
- DatafeedStats.TimingStats.exponential_average_search_time_per_hour_ms

These fields implement exponential moving average calculation. They are directly comparable to each other giving the user the idea whether the job spends more time searching or performing end-of-bucket processing.

Related to https://github.com/elastic/elasticsearch/issues/29857