### PR TITLE
Fix stats in slow logs to be a escaped JSON backport(#44642)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/ESLogMessage.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ESLogMessage.java
@@ -19,9 +19,11 @@
 
 package org.elasticsearch.common.logging;
 
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.common.SuppressLoggerChecks;
 
+import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -30,6 +32,7 @@ import java.util.stream.Stream;
  * A base class for custom log4j logger messages. Carries additional fields which will populate JSON fields in logs.
  */
 public abstract class ESLogMessage extends ParameterizedMessage {
+    private static final JsonStringEncoder JSON_STRING_ENCODER = JsonStringEncoder.getInstance();
     private final Map<String, Object> fields;
 
     /**
@@ -40,6 +43,11 @@ public abstract class ESLogMessage extends ParameterizedMessage {
     public ESLogMessage(Map<String, Object> fields, String messagePattern, Object... args) {
         super(messagePattern, args);
         this.fields = fields;
+    }
+
+    public static String escapeJson(String text) {
+        byte[] sourceEscaped = JSON_STRING_ENCODER.quoteAsUTF8(text);
+        return new String(sourceEscaped, Charset.defaultCharset());
     }
 
     public String getValueFor(String key) {

--- a/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
+++ b/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index;
 
-import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.Strings;
@@ -33,7 +32,6 @@ import org.elasticsearch.index.shard.SearchOperationListener;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.tasks.Task;
 
-import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -173,14 +171,13 @@ public final class SearchSlowLog implements SearchOperationListener {
             }
             String[] types = context.getQueryShardContext().getTypes();
             messageFields.put("types", asJsonArray(types != null ? Arrays.stream(types) : Stream.empty()));
-            messageFields.put("stats", asJsonArray(context.groupStats() != null ? context.groupStats().stream() : Stream.empty()));
+            messageFields.put("stats", escapeJson(asJsonArray(
+                context.groupStats() != null ? context.groupStats().stream() : Stream.empty())));
             messageFields.put("search_type", context.searchType());
             messageFields.put("total_shards", context.numberOfShards());
 
             if (context.request().source() != null) {
-                byte[] sourceEscaped = JsonStringEncoder.getInstance()
-                                                        .quoteAsUTF8(context.request().source().toString(FORMAT_PARAMS));
-                String source = new String(sourceEscaped, Charset.defaultCharset());
+                String source = escapeJson(context.request().source().toString(FORMAT_PARAMS));
 
                 messageFields.put("source", source);
             } else {

--- a/server/src/test/java/org/elasticsearch/index/SearchSlowLogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/SearchSlowLogTests.java
@@ -42,7 +42,9 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
@@ -55,6 +57,9 @@ import static org.hamcrest.Matchers.startsWith;
 public class SearchSlowLogTests extends ESSingleNodeTestCase {
     @Override
     protected SearchContext createSearchContext(IndexService indexService) {
+       return createSearchContext(indexService, new String[]{});
+    }
+    protected SearchContext createSearchContext(IndexService indexService, String ... groupStats) {
         BigArrays bigArrays = indexService.getBigArrays();
         ThreadPool threadPool = indexService.getThreadPool();
         return new TestSearchContext(bigArrays, indexService) {
@@ -150,6 +155,12 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
                     return null;
                 }
             };
+
+            @Override
+            public List<String> groupStats() {
+                return Arrays.asList(groupStats);
+            }
+
             @Override
             public ShardSearchRequest request() {
                 return request;
@@ -175,6 +186,26 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
         assertThat(p.getValueFor("search_type"), Matchers.nullValue());
         assertThat(p.getValueFor("total_shards"), equalTo("1"));
         assertThat(p.getValueFor("source"), equalTo("{\\\"query\\\":{\\\"match_all\\\":{\\\"boost\\\":1.0}}}"));
+    }
+
+    public void testSlowLogsWithStats() throws IOException {
+        IndexService index = createIndex("foo");
+        SearchContext searchContext = createSearchContext(index,"group1");
+        SearchSourceBuilder source = SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery());
+        searchContext.request().source(source);
+        searchContext.setTask(new SearchTask(0, "n/a", "n/a", "test", null,
+            Collections.singletonMap(Task.X_OPAQUE_ID, "my_id")));
+
+        SearchSlowLog.SearchSlowLogMessage p = new SearchSlowLog.SearchSlowLogMessage(searchContext, 10);
+        assertThat(p.getValueFor("stats"), equalTo("[\\\"group1\\\"]"));
+
+        searchContext = createSearchContext(index, "group1", "group2");
+        source = SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery());
+        searchContext.request().source(source);
+        searchContext.setTask(new SearchTask(0, "n/a", "n/a", "test", null,
+            Collections.singletonMap(Task.X_OPAQUE_ID, "my_id")));
+        p = new SearchSlowLog.SearchSlowLogMessage(searchContext, 10);
+        assertThat(p.getValueFor("stats"), equalTo("[\\\"group1\\\", \\\"group2\\\"]"));
     }
 
     public void testSlowLogSearchContextPrinterToLog() throws IOException {


### PR DESCRIPTION
Fields in JSON logs should be an escaped JSON fields. It is a broken json value at the moment
"stats": "["group1", "group2"]", -> "stats": "[\"group1\", \"group2\"]",
This should later be refactored into a JSON array of strings (the same as types in 7.x)
backport(#44642)