### PR TITLE
Muting tests for backport

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_data_frame_jobs_crud.yml
@@ -1,5 +1,8 @@
 ---
 "Test put batch data frame transforms on mixed cluster":
+  - skip:
+      version: "7.4.0 - "
+      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44590
   - do:
       cluster.health:
         index: "dataframe-transform-airline-data"
@@ -108,6 +111,9 @@
 
 ---
 "Test put continuous data frame transform on mixed cluster":
+  - skip:
+      version: "7.4.0 - "
+      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44590
   - do:
       cluster.health:
         index: "dataframe-transform-airline-data-cont"
@@ -171,6 +177,9 @@
 
 ---
 "Test GET, start, and stop old cluster batch transforms":
+  - skip:
+      version: "7.4.0 - "
+      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44590
   - do:
       cluster.health:
         index: "dataframe-transform-airline-data"
@@ -250,6 +259,9 @@
 
 ---
 "Test GET, stop, start, old continuous transforms":
+  - skip:
+      version: "7.4.0 - "
+      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44590
   - do:
       cluster.health:
         index: "dataframe-transform-airline-data-cont"

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/80_data_frame_jobs_crud.yml
@@ -1,5 +1,8 @@
 ---
 "Test put batch data frame transforms on old cluster":
+  - skip:
+      version: "7.4.0 - "
+      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44590
   - do:
       indices.create:
         index: dataframe-transform-airline-data
@@ -142,6 +145,9 @@
 
 ---
 "Test put continuous data frame transform on old cluster":
+  - skip:
+      version: "7.4.0 - "
+      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44590
   - do:
       indices.create:
         index: dataframe-transform-airline-data-cont

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_data_frame_jobs_crud.yml
@@ -7,6 +7,9 @@ setup:
         timeout: 70s
 ---
 "Get start, stop, and delete old and mixed cluster batch data frame transforms":
+  - skip:
+      version: "7.4.0 - "
+      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44590
   # Simple and complex OLD transforms
   - do:
       data_frame.get_data_frame_transform:
@@ -166,6 +169,9 @@ setup:
 
 ---
 "Test GET, stop, delete, old and mixed continuous transforms":
+  - skip:
+      version: "7.4.0 - "
+      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44590
   - do:
       data_frame.get_data_frame_transform:
         transform_id: "old-simple-continuous-transform"


### PR DESCRIPTION
muting BWC tests for data_frames until https://github.com/elastic/elasticsearch/pull/44590 has been backported.