### PR TITLE
Deprecate the ability to update datafeed's job_id.

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
@@ -436,9 +436,10 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
     }
 
     public void testUpdateDatafeed() throws Exception {
+        MachineLearningClient machineLearningClient = highLevelClient().machineLearning();
+
         String jobId = randomValidJobId();
         Job job = buildJob(jobId);
-        MachineLearningClient machineLearningClient = highLevelClient().machineLearning();
         execute(new PutJobRequest(job), machineLearningClient::putJob, machineLearningClient::putJobAsync);
 
         String datafeedId = "datafeed-" + jobId;
@@ -460,6 +461,31 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
         assertThat(datafeedUpdate.getId(), equalTo(updatedDatafeed.getId()));
         assertThat(datafeedUpdate.getIndices(), equalTo(updatedDatafeed.getIndices()));
         assertThat(datafeedUpdate.getScrollSize(), equalTo(updatedDatafeed.getScrollSize()));
+    }
+
+    public void testUpdateDatafeed_UpdatingJobIdIsDeprecated() throws Exception {
+        MachineLearningClient machineLearningClient = highLevelClient().machineLearning();
+
+        String jobId = randomValidJobId();
+        Job job = buildJob(jobId);
+        execute(new PutJobRequest(job), machineLearningClient::putJob, machineLearningClient::putJobAsync);
+
+        String anotherJobId = randomValidJobId();
+        Job anotherJob = buildJob(anotherJobId);
+        execute(new PutJobRequest(anotherJob), machineLearningClient::putJob, machineLearningClient::putJobAsync);
+
+        String datafeedId = "datafeed-" + jobId;
+        DatafeedConfig datafeedConfig = DatafeedConfig.builder(datafeedId, jobId).setIndices("some_data_index").build();
+        execute(new PutDatafeedRequest(datafeedConfig), machineLearningClient::putDatafeed, machineLearningClient::putDatafeedAsync);
+
+        DatafeedUpdate datafeedUpdateWithChangedJobId = DatafeedUpdate.builder(datafeedId).setJobId(anotherJobId).build();
+        WarningFailureException exception = expectThrows(
+            WarningFailureException.class,
+            () -> execute(
+                new UpdateDatafeedRequest(datafeedUpdateWithChangedJobId),
+                machineLearningClient::updateDatafeed,
+                machineLearningClient::updateDatafeedAsync));
+        assertThat(exception.getResponse().getWarnings(), contains("The ability to update a datafeed's job_id is deprecated."));
     }
 
     public void testGetDatafeed() throws Exception {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
@@ -32,6 +32,7 @@ import org.elasticsearch.client.MachineLearningIT;
 import org.elasticsearch.client.MlTestStateCleaner;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.WarningFailureException;
 import org.elasticsearch.client.core.PageParams;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.ml.CloseJobRequest;
@@ -718,7 +719,7 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
         DatafeedConfig datafeed = DatafeedConfig.builder(datafeedId, job.getId()).setIndices("foo").build();
         client.machineLearning().putDatafeed(new PutDatafeedRequest(datafeed), RequestOptions.DEFAULT);
 
-        {
+        try {
             AggregatorFactories.Builder aggs = AggregatorFactories.builder();
             List<SearchSourceBuilder.ScriptField> scriptFields = Collections.emptyList();
             // tag::update-datafeed-config
@@ -749,6 +750,10 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
             DatafeedConfig updatedDatafeed = response.getResponse(); // <1>
             // end::update-datafeed-response
             assertThat(updatedDatafeed.getId(), equalTo(datafeedId));
+        } catch (WarningFailureException e) {
+            assertThat(
+                e.getResponse().getWarnings(),
+                equalTo(Collections.singletonList("The ability to update datafeed's job_id is deprecated.")));
         }
         {
             DatafeedUpdate datafeedUpdate = new DatafeedUpdate.Builder(datafeedId).setIndices("index_1", "index_2").build();

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
@@ -32,7 +32,6 @@ import org.elasticsearch.client.MachineLearningIT;
 import org.elasticsearch.client.MlTestStateCleaner;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.client.WarningFailureException;
 import org.elasticsearch.client.core.PageParams;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.ml.CloseJobRequest;
@@ -719,7 +718,7 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
         DatafeedConfig datafeed = DatafeedConfig.builder(datafeedId, job.getId()).setIndices("foo").build();
         client.machineLearning().putDatafeed(new PutDatafeedRequest(datafeed), RequestOptions.DEFAULT);
 
-        try {
+        {
             AggregatorFactories.Builder aggs = AggregatorFactories.builder();
             List<SearchSourceBuilder.ScriptField> scriptFields = Collections.emptyList();
             // tag::update-datafeed-config
@@ -731,8 +730,7 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
                 .setQuery(QueryBuilders.matchAllQuery()) // <6>
                 .setQueryDelay(TimeValue.timeValueMinutes(1)) // <7>
                 .setScriptFields(scriptFields) // <8>
-                .setScrollSize(1000) // <9>
-                .setJobId("update-datafeed-job"); // <10>
+                .setScrollSize(1000); // <9>
             // end::update-datafeed-config
 
             // Clearing aggregation to avoid complex validation rules
@@ -750,10 +748,6 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
             DatafeedConfig updatedDatafeed = response.getResponse(); // <1>
             // end::update-datafeed-response
             assertThat(updatedDatafeed.getId(), equalTo(datafeedId));
-        } catch (WarningFailureException e) {
-            assertThat(
-                e.getResponse().getWarnings(),
-                equalTo(Collections.singletonList("The ability to update datafeed's job_id is deprecated.")));
         }
         {
             DatafeedUpdate datafeedUpdate = new DatafeedUpdate.Builder(datafeedId).setIndices("index_1", "index_2").build();

--- a/docs/java-rest/high-level/ml/update-datafeed.asciidoc
+++ b/docs/java-rest/high-level/ml/update-datafeed.asciidoc
@@ -40,8 +40,6 @@ include-tagged::{doc-tests-file}[{api}-config]
 <7> Optional, the time interval behind real time that data is queried.
 <8> Optional, allows the use of script fields.
 <9> Optional, the `size` parameter used in the searches.
-<10> Optional, the `jobId` that references the job that the datafeed should be associated with
-after the update.
 
 include::../execution.asciidoc[]
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
@@ -5,12 +5,14 @@
  */
 package org.elasticsearch.xpack.core.ml.datafeed;
 
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ObjectParser;
@@ -43,6 +45,9 @@ import java.util.stream.Collectors;
  * fields are nullable.
  */
 public class DatafeedUpdate implements Writeable, ToXContentObject {
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(DatafeedUpdate.class));
+    private static final String DEPRECATION_MESSAGE_ON_JOB_ID_UPDATE = "The ability to update datafeed's job_id is deprecated.";
 
     public static final ObjectParser<Builder, Void> PARSER = new ObjectParser<>("datafeed_update", Builder::new);
 
@@ -105,6 +110,9 @@ public class DatafeedUpdate implements Writeable, ToXContentObject {
         this.scrollSize = scrollSize;
         this.chunkingConfig = chunkingConfig;
         this.delayedDataCheckConfig = delayedDataCheckConfig;
+        if (jobId != null) {
+            deprecationLogger.deprecated(DEPRECATION_MESSAGE_ON_JOB_ID_UPDATE);
+        }
     }
 
     public DatafeedUpdate(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
@@ -47,7 +47,7 @@ import java.util.stream.Collectors;
 public class DatafeedUpdate implements Writeable, ToXContentObject {
 
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(DatafeedUpdate.class));
-    private static final String DEPRECATION_MESSAGE_ON_JOB_ID_UPDATE = "The ability to update datafeed's job_id is deprecated.";
+    private static final String DEPRECATION_MESSAGE_ON_JOB_ID_UPDATE = "The ability to update a datafeed's job_id is deprecated.";
 
     public static final ObjectParser<Builder, Void> PARSER = new ObjectParser<>("datafeed_update", Builder::new);
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/UpdateDatafeedActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/UpdateDatafeedActionRequestTests.java
@@ -30,7 +30,7 @@ public class UpdateDatafeedActionRequestTests extends AbstractSerializingTestCas
 
     @Override
     protected Request createTestInstance() {
-        return new Request(DatafeedUpdateTests.createRandomized(datafeedId));
+        return new Request(DatafeedUpdateTests.createRandomized(datafeedId, null, false));
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdateTests.java
@@ -77,12 +77,12 @@ public class DatafeedUpdateTests extends AbstractSerializingTestCase<DatafeedUpd
     }
 
     public static DatafeedUpdate createRandomized(String datafeedId) {
-        return createRandomized(datafeedId, null);
+        return createRandomized(datafeedId, null, true);
     }
 
-    public static DatafeedUpdate createRandomized(String datafeedId, @Nullable DatafeedConfig datafeed) {
+    public static DatafeedUpdate createRandomized(String datafeedId, @Nullable DatafeedConfig datafeed, boolean canSetJobId) {
         DatafeedUpdate.Builder builder = new DatafeedUpdate.Builder(datafeedId);
-        if (randomBoolean() && datafeed == null) {
+        if (randomBoolean() && datafeed == null && canSetJobId) {
             builder.setJobId(randomAlphaOfLength(10));
         }
         if (randomBoolean()) {
@@ -276,9 +276,9 @@ public class DatafeedUpdateTests extends AbstractSerializingTestCase<DatafeedUpd
                 withoutAggs.setAggProvider(null);
                 datafeed = withoutAggs.build();
             }
-            DatafeedUpdate update = createRandomized(datafeed.getId(), datafeed);
+            DatafeedUpdate update = createRandomized(datafeed.getId(), datafeed, true);
             while (update.isNoop(datafeed)) {
-                update = createRandomized(datafeed.getId(), datafeed);
+                update = createRandomized(datafeed.getId(), datafeed, true);
             }
 
             DatafeedConfig updatedDatafeed = update.apply(datafeed, Collections.emptyMap());

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/datafeeds_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/datafeeds_crud.yml
@@ -203,6 +203,9 @@ setup:
 
 ---
 "Test update datafeed to point to different job":
+  - skip:
+      features: "warnings"
+
   - do:
       ml.put_datafeed:
         datafeed_id: test-datafeed-1
@@ -214,6 +217,8 @@ setup:
           }
 
   - do:
+      warnings:
+        - The ability to update datafeed's job_id is deprecated.
       ml.update_datafeed:
         datafeed_id: test-datafeed-1
         body:  >

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/datafeeds_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/datafeeds_crud.yml
@@ -218,7 +218,7 @@ setup:
 
   - do:
       warnings:
-        - The ability to update datafeed's job_id is deprecated.
+        - The ability to update a datafeed's job_id is deprecated.
       ml.update_datafeed:
         datafeed_id: test-datafeed-1
         body:  >


### PR DESCRIPTION
This PR deprecates the ability to specify job_id in the update datafeed endpoint.

Closes https://github.com/elastic/elasticsearch/issues/44615