### PR TITLE
[DOCS] Update parameter format

### DIFF
--- a/docs/reference/query-dsl/boosting-query.asciidoc
+++ b/docs/reference/query-dsl/boosting-query.asciidoc
@@ -40,14 +40,15 @@ GET /_search
 [[boosting-top-level-params]]
 ==== Top-level parameters for `boosting`
 
-`positive` (Required)::
-Query you wish to run. Any returned documents must match this query.
+`positive`::
+(Required, query object) Query you wish to run. Any returned documents must
+match this query.
 
-`negative` (Required)::
+`negative`::
 +
 --
-Query used to decrease the <<query-filter-context, relevance score>> of matching
-documents.
+(Required, query object) Query used to decrease the <<query-filter-context,
+relevance score>> of matching documents.
 
 If a returned document matches the `positive` query and this query, the
 `boosting` query calculates the final <<query-filter-context, relevance score>>
@@ -57,7 +58,7 @@ for the document as follows:
 . Multiply the score by the `negative_boost` value.
 --
 
-`negative_boost` (Required)::
-Floating point number between `0` and `1.0` used to decrease the
-<<query-filter-context, relevance scores>> of documents matching the `negative`
-query.
+`negative_boost`::
+(Required, float) Floating point number between `0` and `1.0` used to decrease
+the <<query-filter-context, relevance scores>> of documents matching the
+`negative` query.

--- a/docs/reference/query-dsl/constant-score-query.asciidoc
+++ b/docs/reference/query-dsl/constant-score-query.asciidoc
@@ -29,14 +29,14 @@ GET /_search
 `filter`::
 +
 --
-<<query-dsl-bool-query, Filter query>> you wish to run. Any returned documents
-must match this query. Required.
+(Required, query object) <<query-dsl-bool-query, Filter query>> you wish to run.
+Any returned documents must match this query.
 
 Filter queries do not calculate <<query-filter-context, relevance scores>>. To
 speed up performance, {es} automatically caches frequently used filter queries.
 --
 
 `boost`::
-Floating point number used as the constant <<query-filter-context, relevance
-score>> for every document matching the `filter` query. Default is `1.0`.
-Optional.
+(Optional, float) Floating point number used as the constant
+<<query-filter-context, relevance score>> for every document matching the
+`filter` query. Defaults to `1.0`.

--- a/docs/reference/query-dsl/dis-max-query.asciidoc
+++ b/docs/reference/query-dsl/dis-max-query.asciidoc
@@ -37,17 +37,18 @@ GET /_search
 [[query-dsl-dis-max-query-top-level-params]]
 ==== Top-level parameters for `dis_max`
 
-`queries` (Required)::
-(array of query objects) Contains one or more query clauses. Returned documents
-**must match one or more** of these queries. If a document matches multiple
-queries, {es} uses the highest <<query-filter-context, relevance score>>.
+`queries`::
+(Required, array of query objects) Contains one or more query clauses. Returned
+documents **must match one or more** of these queries. If a document matches
+multiple queries, {es} uses the highest <<query-filter-context, relevance
+score>>.
 
-`tie_breaker` (Optional)::
+`tie_breaker`::
 +
 --
-(float) Floating point number between `0` and `1.0` used to increase the
-<<query-filter-context, relevance scores>> of documents matching multiple query
-clauses. Defaults to `0.0`.
+(Optional, float) Floating point number between `0` and `1.0` used to increase
+the <<query-filter-context, relevance scores>> of documents matching multiple
+query clauses. Defaults to `0.0`.
 
 You can use the `tie_breaker` value to assign higher relevance scores to
 documents that contain the same term in multiple fields than documents that

--- a/docs/reference/query-dsl/exists-query.asciidoc
+++ b/docs/reference/query-dsl/exists-query.asciidoc
@@ -32,9 +32,10 @@ GET /_search
 [[exists-query-top-level-params]]
 ==== Top-level parameters for `exists`
 `field`::
-Name of the field you wish to search.
+(Required, string) Name of the field you wish to search.
 +
-While a field is deemed non-existant if the JSON value is `null` or `[]`, these values will indicate the field does exist:
+While a field is deemed non-existant if the JSON value is `null` or `[]`, these
+values will indicate the field does exist:
 +
 * Empty strings, such as `""` or `"-"`
 * Arrays containing `null` and another value, such as `[null, "foo"]`

--- a/docs/reference/query-dsl/has-child-query.asciidoc
+++ b/docs/reference/query-dsl/has-child-query.asciidoc
@@ -73,19 +73,19 @@ GET /_search
 ==== Top-level parameters for `has_child`
 
 `type`::
-(string) Required. Name of the child relationship mapped for the
+(Required, string) Name of the child relationship mapped for the
 <<parent-join,join>> field.
 
 `query`::
-(query object) Required. Query you wish to run on child documents of the `type`
+(Required, query object) Query you wish to run on child documents of the `type`
 field. If a child document matches the search, the query returns the parent
 document.
 
 `ignore_unmapped`::
 +
 --
-(boolean) Optional. Indicates whether to ignore an unmapped `type` and not return
-any documents instead of an error. Defaults to `false`.
+(Optional, boolean) Indicates whether to ignore an unmapped `type` and not
+return any documents instead of an error. Defaults to `false`.
 
 If `false`, {es} returns an error if the `type` is unmapped.
 
@@ -94,19 +94,19 @@ You can use this parameter to query multiple indices that may not contain the
 --
 
 `max_children`::
-(integer) Optional. Maximum number of child documents that match the `query`
+(Optional, integer) Maximum number of child documents that match the `query`
 allowed for a returned parent document. If the parent document exceeds this
 limit, it is excluded from the search results.
 
 `min_children`::
-(integer) Optional. Minimum number of child documents that match the `query`
+(Optional, integer) Minimum number of child documents that match the `query`
 required to match the query for a returned parent document. If the parent
 document does not meet this limit, it is excluded from the search results.
 
 `score_mode`::
 +
 --
-(string) Optional. Indicates how scores for matching child documents affect the
+(Optional, string) Indicates how scores for matching child documents affect the
 root parent document's <<query-filter-context,relevance score>>. Valid values
 are:
 

--- a/docs/reference/query-dsl/ids-query.asciidoc
+++ b/docs/reference/query-dsl/ids-query.asciidoc
@@ -26,4 +26,4 @@ GET /_search
 ==== Top-level parameters for `ids`
 
 `values`::
-An array of <<mapping-id-field, document IDs>>.
+(Required, array of strings) An array of <<mapping-id-field, document IDs>>.

--- a/docs/reference/query-dsl/nested-query.asciidoc
+++ b/docs/reference/query-dsl/nested-query.asciidoc
@@ -64,14 +64,15 @@ GET /my_index/_search
 [[nested-top-level-params]]
 ==== Top-level parameters for `nested`
 
-`path` (Required)::
-(string) Path to the nested object you wish to search.
+`path`::
+(Required, string) Path to the nested object you wish to search.
 
-`query` (Required)::
+`query`::
 +
 --
-(query object) Query you wish to run on nested objects in the `path`. If an
-object matches the search, the `nested` query returns the root parent document.
+(Required, query object) Query you wish to run on nested objects in the `path`.
+If an object matches the search, the `nested` query returns the root parent
+document.
 
 You can search nested fields using dot notation that includes the complete path,
 such as `obj1.name`.
@@ -81,11 +82,12 @@ inner nested query to automatically match the relevant nesting level, rather
 than root, if it exists within another nested query.
 --
 
-`score_mode` (Optional)::
+`score_mode`::
 +
 --
-(string) Indicates how scores for matching child objects affect the root
-parent document's <<query-filter-context,relevance score>>. Valid values are:
+(Optional, string) Indicates how scores for matching child objects affect the
+root parent document's <<query-filter-context,relevance score>>. Valid values
+are:
 
 `avg` (Default)::
 Use the mean relevance score of all matching child objects.
@@ -104,11 +106,11 @@ parent documents a score of `0`.
 Add together the relevance scores of all matching child objects.
 --
 
-`ignore_unmapped` (Optional)::
+`ignore_unmapped`::
 +
 --
-(boolean) Indicates whether to ignore an unmapped `path` and not return any
-documents instead of an error. Defaults to `false`.
+(Optional, boolean) Indicates whether to ignore an unmapped `path` and not
+return any documents instead of an error. Defaults to `false`.
 
 If `false`, {es} returns an error if the `path` is an unmapped field.
 

--- a/docs/reference/query-dsl/range-query.asciidoc
+++ b/docs/reference/query-dsl/range-query.asciidoc
@@ -35,23 +35,23 @@ GET _search
 `<field>`::
 +
 --
-Field you wish to search.
+(Required, object) Field you wish to search.
 --
 
 [[range-query-field-params]]
 ==== Parameters for `<field>`
 
 `gt`::
-Greater than. Optional.
+(Optional) Greater than.
 
 `gte`::
-Greater than or equal to. Optional.
+(Optional) Greater than or equal to.
 
 `lt`::
-Less than. Optional.
+(Optional) Less than.
 
 `lte`::
-Less than or equal to. Optional.
+(Optional) Less than or equal to.
 
 `format`::
 +
@@ -79,8 +79,8 @@ to `1970-01-10T00:00:00.000Z`.
 `relation`::
 +
 --
-Indicates how the range query matches values for `range` fields. Optional. Valid
-values are:
+(Optional, string) Indicates how the range query matches values for `range`
+fields. Valid values are:
 
 `INTERSECTS` (Default)::
 Matches documents with a range field value that intersects the query's range.
@@ -95,10 +95,11 @@ Matches documents with a range field value entirely within the query's range.
 `time_zone`::
 +
 --
+(Optional, string)
 https://en.wikipedia.org/wiki/List_of_UTC_time_offsets[Coordinated Universal
 Time (UTC) offset] or
 https://en.wikipedia.org/wiki/List_of_tz_database_time_zones[IANA time zone]
-used to convert `date` values in the query to UTC. Optional.
+used to convert `date` values in the query to UTC.
 
 Valid values are ISO 8601 UTC offsets, such as `+01:00` or -`08:00`, and IANA
 time zone IDs, such as `America/Los_Angeles`.
@@ -120,9 +121,8 @@ convert a value of `now/d`.
 `boost`::
 +
 --
-Floating point number used to decrease or increase the
-<<query-filter-context, relevance scores>> of a query. Default is `1.0`.
-Optional.
+(Optional, float) Floating point number used to decrease or increase the
+<<query-filter-context, relevance scores>> of a query. Defaults to `1.0`.
 
 You can use the `boost` parameter to adjust relevance scores for searches
 containing two or more queries.

--- a/docs/reference/query-dsl/range-query.asciidoc
+++ b/docs/reference/query-dsl/range-query.asciidoc
@@ -56,12 +56,12 @@ GET _search
 `format`::
 +
 --
-Date format used to convert `date` values in the query.
+(Optional, string) Date format used to convert `date` values in the query.
 
 By default, {es} uses the <<mapping-date-format,date `format`>> provided in the
 `<field>`'s mapping. This value overrides that mapping format.
 
-For valid syntax, see <<mapping-date-format,`format`>>. Optional.
+For valid syntax, see <<mapping-date-format,`format`>>.
 
 [WARNING]
 ====

--- a/docs/reference/query-dsl/term-query.asciidoc
+++ b/docs/reference/query-dsl/term-query.asciidoc
@@ -43,18 +43,18 @@ GET /_search
 [[term-top-level-params]]
 ==== Top-level parameters for `term`
 `<field>`::
-Field you wish to search.
+(Required, object) Field you wish to search.
 
 [[term-field-params]]
 ==== Parameters for `<field>`
 `value`::
-Term you wish to find in the provided `<field>`. To return a document, the term
-must exactly match the field value, including whitespace and capitalization.
+(Required, string) Term you wish to find in the provided `<field>`. To return a
+document, the term must exactly match the field value, including whitespace and
+capitalization.
 
 `boost`::
-Floating point number used to decrease or increase the
-<<query-filter-context, relevance scores>> of a query. Default is `1.0`.
-Optional.
+(Optional, float) Floating point number used to decrease or increase the
+<<query-filter-context, relevance scores>> of a query. Defaults to `1.0`.
 +
 You can use the `boost` parameter to adjust relevance scores for searches
 containing two or more queries.

--- a/docs/reference/query-dsl/terms-query.asciidoc
+++ b/docs/reference/query-dsl/terms-query.asciidoc
@@ -34,7 +34,7 @@ GET /_search
 `<field>`::
 +
 --
-Field you wish to search.
+(Optional, object) Field you wish to search.
 
 The value of this parameter is an array of terms you wish to find in the
 provided field. To return a document, one or more terms must exactly match a
@@ -52,9 +52,8 @@ To use the field values of an existing document as search terms, use the
 `boost`::
 +
 --
-Floating point number used to decrease or increase the
-<<query-filter-context, relevance scores>> of a query. Default is `1.0`.
-Optional.
+(Optional, float) Floating point number used to decrease or increase the
+<<query-filter-context, relevance scores>> of a query. Defaults to `1.0`.
 
 You can use the `boost` parameter to adjust relevance scores for searches
 containing two or more queries.
@@ -95,15 +94,16 @@ To perform a terms lookup, use the following parameters.
 [[query-dsl-terms-lookup-params]]
 ====== Terms lookup parameters
 `index`::
-Name of the index from which to fetch field values.
+(Optional, string) Name of the index from which to fetch field values.
 
 `id`::
-<<mapping-id-field,ID>> of the document from which to fetch field values.
+(Optional, string) <<mapping-id-field,ID>> of the document from which to fetch
+field values.
 
 `path`::
 +
 --
-Name of the field from which to fetch field values. {es} uses
+(Optional, string) Name of the field from which to fetch field values. {es} uses
 these values as search terms for the query.
 
 If the field values include an array of nested inner objects, you can access
@@ -111,9 +111,9 @@ those objects using dot notation syntax.
 --
 
 `routing`::
-Custom <<mapping-routing-field, routing value>> of the document from which to
-fetch term values. If a custom routing value was provided when the document was
-indexed, this parameter is required.
+(Optional, string) Custom <<mapping-routing-field, routing value>> of the
+document from which to fetch term values. If a custom routing value was provided
+when the document was indexed, this parameter is required.
 
 [[query-dsl-terms-lookup-example]]
 ====== Terms lookup example

--- a/docs/reference/query-dsl/terms-set-query.asciidoc
+++ b/docs/reference/query-dsl/terms-set-query.asciidoc
@@ -155,7 +155,7 @@ GET /job-candidates/_search
 ==== Top-level parameters for `terms_set`
 
 `<field>`::
-Field you wish to search.
+(Required, object) Field you wish to search.
 
 [[terms-set-field-params]]
 ==== Parameters for `<field>`
@@ -163,23 +163,23 @@ Field you wish to search.
 `terms`::
 +
 --
-Array of terms you wish to find in the provided `<field>`. To return a document,
-a required number of terms must exactly match the field values, including
-whitespace and capitalization.
+(Required, array of strings) Array of terms you wish to find in the provided
+`<field>`. To return a document, a required number of terms must exactly match
+the field values, including whitespace and capitalization.
 
 The required number of matching terms is defined in the
 `minimum_should_match_field` or `minimum_should_match_script` parameter.
 --
 
 `minimum_should_match_field`::
-<<number, Numeric>> field containing the number of matching terms
-required to return a document.
+(Optional, string) <<number, Numeric>> field containing the number of matching
+terms required to return a document.
 
 `minimum_should_match_script`::
 +
 --
-Custom script containing the number of matching terms required to return a
-document.
+(Optional, string) Custom script containing the number of matching terms
+required to return a document.
 
 For parameters and valid values, see <<modules-scripting, Scripting>>.
 

--- a/docs/reference/query-dsl/wildcard-query.asciidoc
+++ b/docs/reference/query-dsl/wildcard-query.asciidoc
@@ -37,12 +37,13 @@ GET /_search
 [[wildcard-top-level-params]]
 ==== Top-level parameters for `wildcard`
 `<field>`::
-Field you wish to search.
+(Required, object) Field you wish to search.
 
 [[wildcard-query-field-params]]
 ==== Parameters for `<field>`
 `value`::
-Wildcard pattern for terms you wish to find in the provided `<field>`.
+(Required, string) Wildcard pattern for terms you wish to find in the provided
+`<field>`.
 +
 --
 This parameter supports two wildcard operators:
@@ -55,9 +56,8 @@ the iterations needed to find matching terms and slow search performance.
 -- 
 
 `boost`::
-Floating point number used to decrease or increase the
-<<query-filter-context, relevance scores>> of a query. Default is `1.0`.
-Optional.
+(Optional, float) Floating point number used to decrease or increase the
+<<query-filter-context, relevance scores>> of a query. Defaults to `1.0`.
 +
 You can use the `boost` parameter to adjust relevance scores for searches
 containing two or more queries.
@@ -66,6 +66,6 @@ Boost values are relative to the default value of `1.0`. A boost value between
 `0` and `1.0` decreases the relevance score. A value greater than `1.0`
 increases the relevance score.
 
-`rewrite` (Expert)::
-Method used to rewrite the query. For valid values and more information, see the
-<<query-dsl-multi-term-rewrite, `rewrite` parameter>>. Optional.
+`rewrite`::
+(Optional, string) Method used to rewrite the query. For valid values and more information, see the
+<<query-dsl-multi-term-rewrite, `rewrite` parameter>>.


### PR DESCRIPTION
elastic/docs#982 updated the API reference template to change the location of the Required/Optional parameter qualifier.

This updates the parameter format for any query documentation updated as part of #40977 to match the template. This PR includes no other substantive changes.