### PR TITLE
[DOCS] Adds more validation details for data frame transforms

### DIFF
--- a/docs/reference/data-frames/apis/put-transform.asciidoc
+++ b/docs/reference/data-frames/apis/put-transform.asciidoc
@@ -31,6 +31,12 @@ information, see {stack-ov}/security-privileges.html[Security privileges] and
 [[put-data-frame-transform-desc]]
 ==== {api-description-title}
 
+When the {dataframe-transform} is created, a series of validations occur to
+ensure its success. For example, there is a check for the existence of the
+source indices and a check that the destination index is not part of the source
+index pattern. You can use the `defer_validation` parameter to skip these
+checks.
+
 IMPORTANT:  You must use {kib} or this API to create a {dataframe-transform}.
             Do not put a {dataframe-transform} directly into any
             `.data-frame-internal*` indices using the Elasticsearch index API.
@@ -49,13 +55,13 @@ IMPORTANT:  You must use {kib} or this API to create a {dataframe-transform}.
 ==== {api-query-parms-title}
 
 `defer_validation`::
- (Optional, boolean) When `true`, deferrable validations are not run. This
- behavior may be desired if the source index does not exist until after the
-{dataframe-transform} is created. Deferred validations are always run when the
-{dataframe-transform} is started, with the exception of privilege checks. If the
-user who created the transform does not have the required privileges on the
-source and destination indices, the transform starts but then fails when it
-attempts the unauthorized operation. The default value is `false`.
+  (Optional, boolean) When `true`, deferrable validations are not run. This
+  behavior may be desired if the source index does not exist until after the
+  {dataframe-transform} is created. Deferred validations are always run when the
+  {dataframe-transform} is started, with the exception of privilege checks. If
+  the user who created the transform does not have the required privileges on
+  the source and destination indices, the transform starts but then fails when
+  it attempts the unauthorized operation. The default value is `false`.
 
 [[put-data-frame-transform-request-body]]
 ==== {api-request-body-title}

--- a/docs/reference/data-frames/apis/start-transform.asciidoc
+++ b/docs/reference/data-frames/apis/start-transform.asciidoc
@@ -27,6 +27,16 @@ have `view_index_metadata` privileges on the source index for the
 {stack-ov}/security-privileges.html[Security privileges] and
 {stack-ov}/built-in-roles.html[Built-in roles].
 
+[[start-data-frame-transform-desc]]
+==== {api-description-title}
+
+When a {dataframe-transform} starts, a series of validations occur to ensure its
+success. If you deferred validation when you created the {dataframe-transform},
+they occur when you start the transform--with the exception of privilege checks.
+If the user who created the transform does not have the required privileges on
+the source and destination indices, the transform starts but then fails when
+it attempts the unauthorized operation.
+
 [[start-data-frame-transform-path-parms]]
 ==== {api-path-parms-title}
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/44455

This PR updates the create data frame transform API and start data frame transform API to include more information about validation in their description.