### PR TITLE
Adds pagination support to cat APIs and X-Total-Count header on response

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/cat/AbstractCatAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/AbstractCatAction.java
@@ -73,7 +73,7 @@ public abstract class AbstractCatAction extends BaseRestHandler {
         }
     }
 
-    static Set<String> RESPONSE_PARAMS = Set.of("format", "h", "v", "ts", "pri", "bytes", "size", "time", "s");
+    static Set<String> RESPONSE_PARAMS = Set.of("format", "h", "v", "ts", "pri", "bytes", "size", "time", "s", "from", "limit");
 
     @Override
     protected Set<String> responseParams() {


### PR DESCRIPTION
This adds pagination support to _cat APIs along with X-Total-Count header.

Ideally I would of used from/size instead of from/limit, but size is already used by one of the _cat APIs.

Looking into the other APIs that support pagination, there seems to be a convention of allowing -1 as values to mean _no pagination_ (equivalent of not providing parameters), so this follows the same pattern. And similarly throws an IllegalArgumentException if it's -2 or less.

```
curl "localhost:9200/_cat/indices"
yellow open test_4 Mw4ss8WST8i3Ip9GYd4cDQ 1 1 0 0 283b 283b
yellow open test_3 r9nybkLLRAy9BOnSHY5haQ 1 1 0 0 283b 283b
yellow open test_2 oGaLXFiKQfi70cr1_JTFPA 1 1 0 0 283b 283b
yellow open test_1 poun91pISi2hcRvd5jSJsA 1 1 0 0 283b 283b
yellow open test_0 xFWp8cW5TcSB1TLI6Fd7pw 1 1 0 0 283b 283b
yellow open test_9 nExns3QRQh60MAzUDlPg9w 1 1 0 0 283b 283b
yellow open test_8 VvW51vHGTrqlii1EldUvKA 1 1 0 0 283b 283b
yellow open test_7 2De4AM40SauLU7FNjAEsfw 1 1 0 0 283b 283b
yellow open test_6 es2DStS6TZu4dboZT6783Q 1 1 0 0 283b 283b
yellow open test_5 Q8vDTS9iRF2klRm1VJFy1w 1 1 0 0 283b 283b

curl "localhost:9200/_cat/indices?from=3"
yellow open test_1 poun91pISi2hcRvd5jSJsA 1 1 0 0 283b 283b
yellow open test_0 xFWp8cW5TcSB1TLI6Fd7pw 1 1 0 0 283b 283b
yellow open test_9 nExns3QRQh60MAzUDlPg9w 1 1 0 0 283b 283b
yellow open test_8 VvW51vHGTrqlii1EldUvKA 1 1 0 0 283b 283b
yellow open test_7 2De4AM40SauLU7FNjAEsfw 1 1 0 0 283b 283b
yellow open test_6 es2DStS6TZu4dboZT6783Q 1 1 0 0 283b 283b
yellow open test_5 Q8vDTS9iRF2klRm1VJFy1w 1 1 0 0 283b 283b

curl "localhost:9200/_cat/indices?from=3&limit=2"
yellow open test_1 poun91pISi2hcRvd5jSJsA 1 1 0 0 283b 283b
yellow open test_0 xFWp8cW5TcSB1TLI6Fd7pw 1 1 0 0 283b 283b

curl "localhost:9200/_cat/indices?s=index"
yellow open test_0 xFWp8cW5TcSB1TLI6Fd7pw 1 1 0 0 283b 283b
yellow open test_1 poun91pISi2hcRvd5jSJsA 1 1 0 0 283b 283b
yellow open test_2 oGaLXFiKQfi70cr1_JTFPA 1 1 0 0 283b 283b
yellow open test_3 r9nybkLLRAy9BOnSHY5haQ 1 1 0 0 283b 283b
yellow open test_4 Mw4ss8WST8i3Ip9GYd4cDQ 1 1 0 0 283b 283b
yellow open test_5 Q8vDTS9iRF2klRm1VJFy1w 1 1 0 0 283b 283b
yellow open test_6 es2DStS6TZu4dboZT6783Q 1 1 0 0 283b 283b
yellow open test_7 2De4AM40SauLU7FNjAEsfw 1 1 0 0 283b 283b
yellow open test_8 VvW51vHGTrqlii1EldUvKA 1 1 0 0 283b 283b
yellow open test_9 nExns3QRQh60MAzUDlPg9w 1 1 0 0 283b 283b

curl "localhost:9200/_cat/indices?s=index&from=2"
yellow open test_2 oGaLXFiKQfi70cr1_JTFPA 1 1 0 0 283b 283b
yellow open test_3 r9nybkLLRAy9BOnSHY5haQ 1 1 0 0 283b 283b
yellow open test_4 Mw4ss8WST8i3Ip9GYd4cDQ 1 1 0 0 283b 283b
yellow open test_5 Q8vDTS9iRF2klRm1VJFy1w 1 1 0 0 283b 283b
yellow open test_6 es2DStS6TZu4dboZT6783Q 1 1 0 0 283b 283b
yellow open test_7 2De4AM40SauLU7FNjAEsfw 1 1 0 0 283b 283b
yellow open test_8 VvW51vHGTrqlii1EldUvKA 1 1 0 0 283b 283b
yellow open test_9 nExns3QRQh60MAzUDlPg9w 1 1 0 0 283b 283b

curl "localhost:9200/_cat/indices?s=index&from=2&limit=4"
yellow open test_2 oGaLXFiKQfi70cr1_JTFPA 1 1 0 0 283b 283b
yellow open test_3 r9nybkLLRAy9BOnSHY5haQ 1 1 0 0 283b 283b
yellow open test_4 Mw4ss8WST8i3Ip9GYd4cDQ 1 1 0 0 283b 283b
yellow open test_5 Q8vDTS9iRF2klRm1VJFy1w 1 1 0 0 283b 283b

curl "localhost:9200/_cat/indices?s=index&from=0"
yellow open test_0 xFWp8cW5TcSB1TLI6Fd7pw 1 1 0 0 283b 283b
yellow open test_1 poun91pISi2hcRvd5jSJsA 1 1 0 0 283b 283b
yellow open test_2 oGaLXFiKQfi70cr1_JTFPA 1 1 0 0 283b 283b
yellow open test_3 r9nybkLLRAy9BOnSHY5haQ 1 1 0 0 283b 283b
yellow open test_4 Mw4ss8WST8i3Ip9GYd4cDQ 1 1 0 0 283b 283b
yellow open test_5 Q8vDTS9iRF2klRm1VJFy1w 1 1 0 0 283b 283b
yellow open test_6 es2DStS6TZu4dboZT6783Q 1 1 0 0 283b 283b
yellow open test_7 2De4AM40SauLU7FNjAEsfw 1 1 0 0 283b 283b
yellow open test_8 VvW51vHGTrqlii1EldUvKA 1 1 0 0 283b 283b
yellow open test_9 nExns3QRQh60MAzUDlPg9w 1 1 0 0 283b 283b

curl "localhost:9200/_cat/indices?s=index&from=-1"
yellow open test_0 xFWp8cW5TcSB1TLI6Fd7pw 1 1 0 0 283b 283b
yellow open test_1 poun91pISi2hcRvd5jSJsA 1 1 0 0 283b 283b
yellow open test_2 oGaLXFiKQfi70cr1_JTFPA 1 1 0 0 283b 283b
yellow open test_3 r9nybkLLRAy9BOnSHY5haQ 1 1 0 0 283b 283b
yellow open test_4 Mw4ss8WST8i3Ip9GYd4cDQ 1 1 0 0 283b 283b
yellow open test_5 Q8vDTS9iRF2klRm1VJFy1w 1 1 0 0 283b 283b
yellow open test_6 es2DStS6TZu4dboZT6783Q 1 1 0 0 283b 283b
yellow open test_7 2De4AM40SauLU7FNjAEsfw 1 1 0 0 283b 283b
yellow open test_8 VvW51vHGTrqlii1EldUvKA 1 1 0 0 283b 283b
yellow open test_9 nExns3QRQh60MAzUDlPg9w 1 1 0 0 283b 283b

curl "localhost:9200/_cat/indices?s=index&from=-2"
{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"[from] parameter cannot be negative, found [-2]"}],"type":"illegal_argument_exception","reason":"[from] parameter cannot be negative, found [-2]"},"status":400}

curl "localhost:9200/_cat/indices?s=index&limit=-2"
{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"[limit] parameter cannot be negative, found [-2]"}],"type":"illegal_argument_exception","reason":"[limit] parameter cannot be negative, found [-2]"},"status":400}

curl "localhost:9200/_cat/indices?s=index&from=2&limit=4&format=yaml"
---
- health: "yellow"
  status: "open"
  index: "test_2"
  uuid: "oGaLXFiKQfi70cr1_JTFPA"
  pri: "1"
  rep: "1"
  docs.count: "0"
  docs.deleted: "0"
  store.size: "283b"
  pri.store.size: "283b"
- health: "yellow"
  status: "open"
  index: "test_3"
  uuid: "r9nybkLLRAy9BOnSHY5haQ"
  pri: "1"
  rep: "1"
  docs.count: "0"
  docs.deleted: "0"
  store.size: "283b"
  pri.store.size: "283b"
- health: "yellow"
  status: "open"
  index: "test_4"
  uuid: "Mw4ss8WST8i3Ip9GYd4cDQ"
  pri: "1"
  rep: "1"
  docs.count: "0"
  docs.deleted: "0"
  store.size: "283b"
  pri.store.size: "283b"
- health: "yellow"
  status: "open"
  index: "test_5"
  uuid: "Q8vDTS9iRF2klRm1VJFy1w"
  pri: "1"
  rep: "1"
  docs.count: "0"
  docs.deleted: "0"
  store.size: "283b"
  pri.store.size: "283b"

curl -i "localhost:9200/_cat/indices?s=index&from=2&limit=4"
HTTP/1.1 200 OK
X-Total-Count: 10
content-type: text/plain; charset=UTF-8
content-length: 240

yellow open test_2 oGaLXFiKQfi70cr1_JTFPA 1 1 0 0 283b 283b
yellow open test_3 r9nybkLLRAy9BOnSHY5haQ 1 1 0 0 283b 283b
yellow open test_4 Mw4ss8WST8i3Ip9GYd4cDQ 1 1 0 0 283b 283b
yellow open test_5 Q8vDTS9iRF2klRm1VJFy1w 1 1 0 0 283b 283b
```