### PR TITLE
[ML][Data Frame] enable bwc tests again, adjusting after backport

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/action/DeleteDataFrameTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/action/DeleteDataFrameTransformAction.java
@@ -39,7 +39,7 @@ public class DeleteDataFrameTransformAction extends ActionType<AcknowledgedRespo
         public Request(StreamInput in) throws IOException {
             super(in);
             id = in.readString();
-            if (in.getVersion().onOrAfter(Version.CURRENT)) {
+            if (in.getVersion().onOrAfter(Version.V_7_4_0)) {
                 force = in.readBoolean();
             } else {
                 force = false;
@@ -58,7 +58,7 @@ public class DeleteDataFrameTransformAction extends ActionType<AcknowledgedRespo
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeString(id);
-            if (out.getVersion().onOrAfter(Version.CURRENT)) {
+            if (out.getVersion().onOrAfter(Version.V_7_4_0)) {
                 out.writeBoolean(force);
             }
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/action/PutDataFrameTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/action/PutDataFrameTransformAction.java
@@ -53,7 +53,7 @@ public class PutDataFrameTransformAction extends ActionType<AcknowledgedResponse
         public Request(StreamInput in) throws IOException {
             super(in);
             this.config = new DataFrameTransformConfig(in);
-            if (in.getVersion().onOrAfter(Version.CURRENT)) {
+            if (in.getVersion().onOrAfter(Version.V_7_4_0)) {
                 this.deferValidation = in.readBoolean();
             } else {
                 this.deferValidation = false;
@@ -129,7 +129,7 @@ public class PutDataFrameTransformAction extends ActionType<AcknowledgedResponse
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             this.config.writeTo(out);
-            if (out.getVersion().onOrAfter(Version.CURRENT)) {
+            if (out.getVersion().onOrAfter(Version.V_7_4_0)) {
                 out.writeBoolean(this.deferValidation);
             }
         }

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_data_frame_jobs_crud.yml
@@ -1,8 +1,5 @@
 ---
 "Test put batch data frame transforms on mixed cluster":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44590
   - do:
       cluster.health:
         index: "dataframe-transform-airline-data"
@@ -111,9 +108,6 @@
 
 ---
 "Test put continuous data frame transform on mixed cluster":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44590
   - do:
       cluster.health:
         index: "dataframe-transform-airline-data-cont"
@@ -177,9 +171,6 @@
 
 ---
 "Test GET, start, and stop old cluster batch transforms":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44590
   - do:
       cluster.health:
         index: "dataframe-transform-airline-data"
@@ -259,9 +250,6 @@
 
 ---
 "Test GET, stop, start, old continuous transforms":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44590
   - do:
       cluster.health:
         index: "dataframe-transform-airline-data-cont"

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/80_data_frame_jobs_crud.yml
@@ -1,8 +1,5 @@
 ---
 "Test put batch data frame transforms on old cluster":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44590
   - do:
       indices.create:
         index: dataframe-transform-airline-data
@@ -145,9 +142,6 @@
 
 ---
 "Test put continuous data frame transform on old cluster":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44590
   - do:
       indices.create:
         index: dataframe-transform-airline-data-cont

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_data_frame_jobs_crud.yml
@@ -7,9 +7,6 @@ setup:
         timeout: 70s
 ---
 "Get start, stop, and delete old and mixed cluster batch data frame transforms":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44590
   # Simple and complex OLD transforms
   - do:
       data_frame.get_data_frame_transform:
@@ -169,9 +166,6 @@ setup:
 
 ---
 "Test GET, stop, delete, old and mixed continuous transforms":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44590
   - do:
       data_frame.get_data_frame_transform:
         transform_id: "old-simple-continuous-transform"


### PR DESCRIPTION
Adjusts BWC version for both backported prs:
* https://github.com/elastic/elasticsearch/pull/44697
* https://github.com/elastic/elasticsearch/pull/44696

Turns BWC tests for data frames back on