### PR TITLE
do not expire smb_fixture pws

### DIFF
--- a/x-pack/test/smb-fixture/src/main/resources/provision/installsmb.sh
+++ b/x-pack/test/smb-fixture/src/main/resources/provision/installsmb.sh
@@ -23,6 +23,8 @@ mv /etc/samba/smb.conf /etc/samba/smb.conf.orig
 
 samba-tool domain provision --server-role=dc --use-rfc2307 --dns-backend=SAMBA_INTERNAL --realm=AD.TEST.ELASTICSEARCH.COM --domain=ADES --adminpass=Passw0rd --use-ntvfs
 
+samba-tool domain passwordsettings set --max-pwd-age=0
+
 cp /var/lib/samba/private/krb5.conf /etc/krb5.conf
 
 service samba-ad-dc restart


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

We are using the docker image produced by the `smb_fixture` package in our cloud tests.  We built the image for consumption on our docker hub.  Now that the image has been hanging out for ~month the passwords for the users has expired.  To prevent this we can ask samba to not expire any passwords.  I thumbed through the integration tests which rely on this fixture and it does not seem any tests rely on password expiration workflows.