### PR TITLE
[DOCS] Add intro blurb to ES Ref TOC page

### DIFF
--- a/docs/reference/index-docinfo.xml
+++ b/docs/reference/index-docinfo.xml
@@ -1,0 +1,13 @@
+<legalnotice>
+    <simpara>
+      Welcome to the official documentation for Elasticsearch:
+      the search and analytics engine that powers the Elastic Stack.
+      If you want to learn how to use Elasticsearch to search and analyze your
+      data, you've come to the right place. This guide shows you how to:
+    </simpara>
+    <itemizedlist>
+      <listitem><simpara>Install, configure, and administer an Elasticsearch cluster.</simpara></listitem>
+      <listitem><simpara>Index your data, optimize your indices, and search with the Elasticsearch query language.</simpara></listitem>
+      <listitem><simpara>Discover trends, patterns, and anomalies with aggregations and the machine learning APIs.</simpara></listitem>
+    </itemizedlist>
+</legalnotice>


### PR DESCRIPTION
Provides context for folks who land on the TOC page and also helps discoverability through search. 