### PR TITLE
[ML-DataFrame] Adjust data frame stats BWC following backport

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformCheckpointStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformCheckpointStats.java
@@ -73,7 +73,7 @@ public class DataFrameTransformCheckpointStats implements Writeable, ToXContentO
     }
 
     public DataFrameTransformCheckpointStats(StreamInput in) throws IOException {
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) { // TODO change to V_7_4_0 after backport
+        if (in.getVersion().onOrAfter(Version.V_7_4_0)) {
             this.checkpoint = in.readVLong();
             if (in.readBoolean()) {
                 this.indexerState = in.readEnum(IndexerState.class);
@@ -151,7 +151,7 @@ public class DataFrameTransformCheckpointStats implements Writeable, ToXContentO
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) { // TODO change to V_7_4_0 after backport
+        if (out.getVersion().onOrAfter(Version.V_7_4_0)) {
             out.writeVLong(checkpoint);
             if (indexerState != null) {
                 out.writeBoolean(true);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformStats.java
@@ -100,7 +100,7 @@ public class DataFrameTransformStats implements Writeable, ToXContentObject {
     }
 
     public DataFrameTransformStats(StreamInput in) throws IOException {
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) { // TODO change to V_7_4_0 after backport
+        if (in.getVersion().onOrAfter(Version.V_7_4_0)) {
             this.id = in.readString();
             this.taskState = in.readEnum(DataFrameTransformTaskState.class);
             this.reason = in.readOptionalString();
@@ -145,7 +145,7 @@ public class DataFrameTransformStats implements Writeable, ToXContentObject {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) { // TODO change to V_7_4_0 after backport
+        if (out.getVersion().onOrAfter(Version.V_7_4_0)) {
             out.writeString(id);
             out.writeEnum(taskState);
             out.writeOptionalString(reason);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformStoredDoc.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformStoredDoc.java
@@ -70,7 +70,7 @@ public class DataFrameTransformStoredDoc implements Writeable, ToXContentObject 
         this.id = in.readString();
         this.transformState = new DataFrameTransformState(in);
         this.transformStats = new DataFrameIndexerTransformStats(in);
-        if (in.getVersion().before(Version.V_8_0_0)) { // TODO change to V_7_4_0 after backport
+        if (in.getVersion().before(Version.V_7_4_0)) {
             new DataFrameTransformCheckpointingInfo(in);
         }
     }
@@ -91,7 +91,7 @@ public class DataFrameTransformStoredDoc implements Writeable, ToXContentObject 
         out.writeString(id);
         transformState.writeTo(out);
         transformStats.writeTo(out);
-        if (out.getVersion().before(Version.V_8_0_0)) { // TODO change to V_7_4_0 after backport
+        if (out.getVersion().before(Version.V_7_4_0)) {
             DataFrameTransformCheckpointingInfo.EMPTY.writeTo(out);
         }
     }

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_data_frame_jobs_crud.yml
@@ -29,10 +29,7 @@
         transform_id: "mixed-simple-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-simple-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we
-  # cannot assert on task_state in the mixed cluster as it could be at the top level or under state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.task_state: "/started|stopped/" }
+  - match: { transforms.0.task_state: "/started|stopped/" }
 
   - do:
       data_frame.stop_data_frame_transform:
@@ -45,10 +42,7 @@
         transform_id: "mixed-simple-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-simple-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we
-  # cannot assert on task_state in the mixed cluster as it could be at the top level or under state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.task_state: "stopped" }
+  - match: { transforms.0.task_state: "stopped" }
 
   - do:
       data_frame.put_data_frame_transform:
@@ -95,10 +89,7 @@
         transform_id: "mixed-complex-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-complex-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we
-  # cannot assert on task_state in the mixed cluster as it could be at the top level or under state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.task_state: "/started|stopped/" }
+  - match: { transforms.0.task_state: "/started|stopped/" }
 
   - do:
       data_frame.stop_data_frame_transform:
@@ -111,10 +102,7 @@
         transform_id: "mixed-complex-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-complex-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we
-  # cannot assert on task_state in the mixed cluster as it could be at the top level or under state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.task_state: "stopped" }
+  - match: { transforms.0.task_state: "stopped" }
 
 ---
 "Test put continuous data frame transform on mixed cluster":
@@ -163,10 +151,7 @@
         transform_id: "mixed-simple-continuous-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-simple-continuous-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we
-  # cannot assert on task_state in the mixed cluster as it could be at the top level or under state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.task_state: "started" }
+  - match: { transforms.0.task_state: "started" }
 
   - do:
       data_frame.stop_data_frame_transform:
@@ -179,10 +164,7 @@
         transform_id: "mixed-simple-continuous-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-simple-continuous-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we
-  # cannot assert on task_state in the mixed cluster as it could be at the top level or under state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.task_state: "stopped" }
+  - match: { transforms.0.task_state: "stopped" }
 
 ---
 "Test GET, start, and stop old cluster batch transforms":
@@ -211,10 +193,7 @@
         transform_id: "old-simple-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we
-  # cannot assert on task_state in the mixed cluster as it could be at the top level or under state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.task_state: "/started|stopped/" }
+  - match: { transforms.0.task_state: "/started|stopped/" }
 
   - do:
       data_frame.stop_data_frame_transform:
@@ -226,10 +205,7 @@
         transform_id: "old-simple-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we
-  # cannot assert on task_state in the mixed cluster as it could be at the top level or under state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.task_state: "stopped" }
+  - match: { transforms.0.task_state: "stopped" }
 
   - do:
       data_frame.get_data_frame_transform:
@@ -253,10 +229,7 @@
         transform_id: "old-complex-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-complex-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we
-  # cannot assert on task_state in the mixed cluster as it could be at the top level or under state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.task_state: "/started|stopped/" }
+  - match: { transforms.0.task_state: "/started|stopped/" }
 
   - do:
       data_frame.stop_data_frame_transform:
@@ -268,10 +241,7 @@
         transform_id: "old-complex-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-complex-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we
-  # cannot assert on task_state in the mixed cluster as it could be at the top level or under state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.state.task_state: "stopped" }
+  - match: { transforms.0.state.task_state: "stopped" }
 
 ---
 "Test GET, stop, start, old continuous transforms":
@@ -300,10 +270,7 @@
         transform_id: "old-simple-continuous-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-continuous-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we
-  # cannot assert on task_state in the mixed cluster as it could be at the top level or under state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.task_state: "started" }
+  - match: { transforms.0.task_state: "started" }
 
   - do:
       data_frame.stop_data_frame_transform:
@@ -316,7 +283,4 @@
         transform_id: "old-simple-continuous-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-continuous-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we
-  # cannot assert on task_state in the mixed cluster as it could be at the top level or under state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.task_state: "stopped" }
+  - match: { transforms.0.task_state: "stopped" }

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_data_frame_jobs_crud.yml
@@ -1,8 +1,5 @@
 ---
 "Test put batch data frame transforms on mixed cluster":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44350
   - do:
       cluster.health:
         index: "dataframe-transform-airline-data"
@@ -121,9 +118,6 @@
 
 ---
 "Test put continuous data frame transform on mixed cluster":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44350
   - do:
       cluster.health:
         index: "dataframe-transform-airline-data-cont"
@@ -192,9 +186,6 @@
 
 ---
 "Test GET, start, and stop old cluster batch transforms":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44350
   - do:
       cluster.health:
         index: "dataframe-transform-airline-data"
@@ -284,9 +275,6 @@
 
 ---
 "Test GET, stop, start, old continuous transforms":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44350
   - do:
       cluster.health:
         index: "dataframe-transform-airline-data-cont"

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_data_frame_jobs_crud.yml
@@ -241,7 +241,7 @@
         transform_id: "old-complex-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-complex-transform" }
-  - match: { transforms.0.state.task_state: "stopped" }
+  - match: { transforms.0.task_state: "stopped" }
 
 ---
 "Test GET, stop, start, old continuous transforms":

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/80_data_frame_jobs_crud.yml
@@ -1,8 +1,5 @@
 ---
 "Test put batch data frame transforms on old cluster":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44350
   - do:
       indices.create:
         index: dataframe-transform-airline-data
@@ -139,9 +136,6 @@
 
 ---
 "Test put continuous data frame transform on old cluster":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44350
   - do:
       indices.create:
         index: dataframe-transform-airline-data-cont

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_data_frame_jobs_crud.yml
@@ -7,9 +7,6 @@ setup:
         timeout: 70s
 ---
 "Get start, stop, and delete old and mixed cluster batch data frame transforms":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44350
   # Simple and complex OLD transforms
   - do:
       data_frame.get_data_frame_transform:
@@ -165,9 +162,6 @@ setup:
 
 ---
 "Test GET, stop, delete, old and mixed continuous transforms":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44350
   - do:
       data_frame.get_data_frame_transform:
         transform_id: "old-simple-continuous-transform"


### PR DESCRIPTION
This change adjusts the changes of #44350 to account
for the backport to the 7.x branch in #44743.