### PR TITLE
Fix testRetentionLeasesClearedOnRestore (#44754)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexStateService.java
@@ -442,7 +442,7 @@ public class MetaDataIndexStateService {
             final boolean acknowledged = result.getValue().hasFailures() == false;
             try {
                 if (acknowledged == false) {
-                    logger.debug("verification of shards before closing {} failed", index);
+                    logger.debug("verification of shards before closing {} failed [{}]", index, result);
                     continue;
                 }
                 final IndexMetaData indexMetaData = metadata.getSafe(index);

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
@@ -311,6 +311,8 @@ public abstract class ESBlobStoreRepositoryIntegTestCase extends ESIntegTestCase
             addRandomDocuments(indexName, extraDocCount);
         }
 
+        // Wait for green so the close does not fail in the edge case of coinciding with a shard recovery that hasn't fully synced yet
+        ensureGreen();
         logger.info("-->  close index {}", indexName);
         assertAcked(client().admin().indices().prepareClose(indexName));
 


### PR DESCRIPTION
* Fix this test randomly failing when running into async translog persistence edge case and failing to successfully close index
* Also, slightly improve debug logging on close failure
* Closes #44681

back port of #44754 