### PR TITLE
Order ILM actions in policy definition documentation

### DIFF
--- a/docs/reference/ilm/policy-definitions.asciidoc
+++ b/docs/reference/ilm/policy-definitions.asciidoc
@@ -90,20 +90,20 @@ policy definition.
 
 * Hot
   - <<ilm-set-priority-action,Set Priority>>
-  - <<ilm-rollover-action,Rollover>>
   - <<ilm-unfollow-action,Unfollow>>
+  - <<ilm-rollover-action,Rollover>>
 * Warm
   - <<ilm-set-priority-action,Set Priority>>
-  - <<ilm-allocate-action,Allocate>>
-  - <<ilm-readonly-action,Read-Only>>
-  - <<ilm-forcemerge-action,Force Merge>>
-  - <<ilm-shrink-action,Shrink>>
   - <<ilm-unfollow-action,Unfollow>>
+  - <<ilm-readonly-action,Read-Only>>
+  - <<ilm-allocate-action,Allocate>>
+  - <<ilm-shrink-action,Shrink>>
+  - <<ilm-forcemerge-action,Force Merge>>
 * Cold
   - <<ilm-set-priority-action,Set Priority>>
+  - <<ilm-unfollow-action,Unfollow>>
   - <<ilm-allocate-action,Allocate>>
   - <<ilm-freeze-action,Freeze>>
-  - <<ilm-unfollow-action,Unfollow>>
 * Delete
   - <<ilm-delete-action,Delete>>
 


### PR DESCRIPTION
We already have a note that the order of actions is up to ILM for each
phase, this commit puts the actions in the same order as they will be
executed.

Resolves #41729
