### PR TITLE
Avoid dumping the heap in Painless tests

### DIFF
--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -41,7 +41,8 @@ dependencyLicenses {
 }
 
 test {
-  jvmArgs '-XX:-OmitStackTraceInFastThrow'
+  // in WhenThingsGoWrongTests we intentionally generate an out of memory error, this prevents the heap from being dumped to disk
+  jvmArgs '-XX:-OmitStackTraceInFastThrow', '-XX:-HeapDumpOnOutOfMemoryError'
 }
 
 /* Build Javadoc for the Java classes in Painless's public API that are in the


### PR DESCRIPTION
Well, we have a test here that intentionally causes an OutOfMemoryError, to ensure that Painless handles it (I still strongly disagree with doing this). This causes two things to happen: an OutOfMemoryError to be dumped to the console, and the heap to be dumped to disk. This makes it look like we had an OutOfMemoryError while running tests, and the tests did not fail properly. This commit changes the tests configuration so that we suppress the heap dump, which also causes the OutOfMemoryError to no longer be dumped to the console.