### PR TITLE
Fix testFirstListElementsToCommaDelimitedStringReportsFirstElementsIfLong

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationServiceTests.java
@@ -49,8 +49,8 @@ public class AllocationServiceTests extends ESTestCase {
     }
 
     public void testFirstListElementsToCommaDelimitedStringReportsFirstElementsIfLong() {
-        List<String> strings = IntStream.range(0, between(11, 100)).mapToObj(i -> randomAlphaOfLength(10))
-            .distinct().collect(Collectors.toList());
+        List<String> strings = IntStream.range(0, between(0, 100))
+            .mapToObj(i -> randomAlphaOfLength(between(6, 10))).distinct().collect(Collectors.toList());
         final String abbreviated = AllocationService.firstListElementsToCommaDelimitedString(strings, Function.identity(), false);
         for (int i = 0; i < strings.size(); i++) {
             if (i < 10) {
@@ -59,8 +59,13 @@ public class AllocationServiceTests extends ESTestCase {
                 assertThat(abbreviated, not(containsString(strings.get(i))));
             }
         }
-        assertThat(abbreviated, containsString("..."));
-        assertThat(abbreviated, containsString("[" + strings.size() + " items in total]"));
+
+        if (strings.size() > 10) {
+            assertThat(abbreviated, containsString("..."));
+            assertThat(abbreviated, containsString("[" + strings.size() + " items in total]"));
+        } else {
+            assertThat(abbreviated, not(containsString("...")));
+        }
     }
 
     public void testFirstListElementsToCommaDelimitedStringUsesFormatterNotToString() {


### PR DESCRIPTION
This test can fail (super-rarely) if it generates a list of length 11
containing a duplicate, because the `.distinct()` reduces the list length to 10
and then it is not abbreviated any more. This change generalises the test to
cover lists of any random length.

Relates #44419