### PR TITLE
Updated slm API spec parameters and URL

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.delete_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.delete_lifecycle.json
@@ -1,13 +1,13 @@
 {
   "slm.delete_lifecycle": {
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api.html",
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-delete.html",
     "stability": "stable",
     "methods": [ "DELETE" ],
     "url": {
       "path": "/_slm/policy/{policy_id}",
       "paths": ["/_slm/policy/{policy_id}"],
       "parts": {
-        "policy": {
+        "policy_id": {
           "type" : "string",
           "description" : "The id of the snapshot lifecycle policy to remove"
         }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.execute_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.execute_lifecycle.json
@@ -1,6 +1,6 @@
 {
   "slm.execute_lifecycle": {
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api.html",
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute.html",
     "stability": "stable",
     "methods": [ "PUT" ],
     "url": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_lifecycle.json
@@ -1,6 +1,6 @@
 {
   "slm.get_lifecycle": {
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api.html",
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-get.html",
     "stability": "stable",
     "methods": [ "GET" ],
     "url": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.put_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.put_lifecycle.json
@@ -1,6 +1,6 @@
 {
   "slm.put_lifecycle": {
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api.html",
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-put.html",
     "stability": "stable",
     "methods": [ "PUT" ],
     "url": {


### PR DESCRIPTION
The doc urls were not correct and `slm.delete_lifecycle.json` had the `policy_id` parameter typed wrong.