### PR TITLE
SQL: [Tests] Re-enable testDriverConfigurationWithSSLInURL test with more logging

### DIFF
--- a/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/JdbcConfigurationTests.java
+++ b/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/JdbcConfigurationTests.java
@@ -257,7 +257,7 @@ public class JdbcConfigurationTests extends ESTestCase {
     }
     
     @SuppressForbidden(reason = "JDBC drivers allows logging to Sys.out")
-    public void testDriverConfigurationWithSSLInURL() throws Exception {
+    public void testDriverConfigurationWithSSLInURL() {
         Map<String, String> urlPropMap = sslProperties();
         String sslUrlProps = urlPropMap.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining("&"));
         

--- a/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/JdbcConfigurationTests.java
+++ b/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/JdbcConfigurationTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.sql.jdbc;
 import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.client.SslConfig;
+import org.elasticsearch.xpack.sql.client.SuppressForbidden;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -255,6 +256,7 @@ public class JdbcConfigurationTests extends ESTestCase {
         assertSslConfig(props, JdbcConfiguration.create("jdbc:es://test?" + sslUrlProps.toString(), props, 0).sslConfig());
     }
     
+    @SuppressForbidden(reason = "JDBC drivers allows logging to Sys.out")
     public void testDriverConfigurationWithSSLInURL() throws Exception {
         Map<String, String> urlPropMap = sslProperties();
         String sslUrlProps = urlPropMap.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining("&"));

--- a/x-pack/plugin/sql/jdbc/src/test/resources/plugin-security.policy
+++ b/x-pack/plugin/sql/jdbc/src/test/resources/plugin-security.policy
@@ -1,4 +1,6 @@
 grant {
   // Required for testing the Driver registration
   permission java.sql.SQLPermission "deregisterDriver";
+  // Required for debug logging purposes
+  permission java.sql.SQLPermission "setLog";
 };


### PR DESCRIPTION
Following https://github.com/elastic/elasticsearch/issues/41557, this PR re-enables `JdbcConfigurationTests.testDriverConfigurationWithSSLInURL` with more logging coming from the DriverManager hopefully getting more insight for the next time this test fails.