### PR TITLE
Fix and rename testFollowStatsApiIncludeShardFollowStatsWithRemovedFollowerIndex

### DIFF
--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/FollowStatsIT.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/FollowStatsIT.java
@@ -30,6 +30,7 @@ import static java.util.Collections.singletonMap;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.xpack.ccr.LocalIndexFollowingIT.getIndexSettings;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 
 /*
@@ -149,10 +150,8 @@ public class FollowStatsIT extends CcrSingleNodeTestCase {
         assertAcked(client().execute(PauseFollowAction.INSTANCE, new PauseFollowAction.Request("follower1")).actionGet());
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/44796")
-    public void testFollowStatsApiIncludeShardFollowStatsWithRemovedFollowerIndex() throws Exception {
-        final String leaderIndexSettings = getIndexSettings(1, 0,
-            singletonMap(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), "true"));
+    public void testFollowStatsApiWithDeletedFollowerIndex() throws Exception {
+        final String leaderIndexSettings = getIndexSettings(1, 0, singletonMap(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), "true"));
         assertAcked(client().admin().indices().prepareCreate("leader1").setSource(leaderIndexSettings, XContentType.JSON));
         ensureGreen("leader1");
 
@@ -172,18 +171,11 @@ public class FollowStatsIT extends CcrSingleNodeTestCase {
 
         assertAcked(client().admin().indices().delete(new DeleteIndexRequest("follower1")).actionGet());
 
-        statsRequest = new FollowStatsAction.StatsRequest();
-        response = client().execute(FollowStatsAction.INSTANCE, statsRequest).actionGet();
-        assertThat(response.getStatsResponses().size(), equalTo(1));
-        assertThat(response.getStatsResponses().get(0).status().followerIndex(), equalTo("follower1"));
-
-        statsRequest = new FollowStatsAction.StatsRequest();
-        statsRequest.setIndices(new String[] {"follower1"});
-        response = client().execute(FollowStatsAction.INSTANCE, statsRequest).actionGet();
-        assertThat(response.getStatsResponses().size(), equalTo(1));
-        assertThat(response.getStatsResponses().get(0).status().followerIndex(), equalTo("follower1"));
-
-        assertAcked(client().execute(PauseFollowAction.INSTANCE, new PauseFollowAction.Request("follower1")).actionGet());
+        assertBusy(() -> {
+            FollowStatsAction.StatsRequest request = new FollowStatsAction.StatsRequest();
+            FollowStatsAction.StatsResponses statsResponse = client().execute(FollowStatsAction.INSTANCE, request).actionGet();
+            assertThat(statsResponse.getStatsResponses(), hasSize(0));
+        });
     }
 
     public void testFollowStatsApiIncludeShardFollowStatsWithClosedFollowerIndex() throws Exception {


### PR DESCRIPTION
This pull request unmutes and renames the test that failed on CI (#44796) after #44702 has been merged.

This test assumes that follow stats still exist after a follower index has been deleted. The follow stats are based on persistent tasks, and since #44702 the persistent tasks of deleted following indices are now automatically cleaned up to avoid to bloat the cluster state.

I don't think we should report any follow stats for deleted indices and I don't think that this test makes much sense now the tasks are cleaned up. This is why the test has been renamed. If we want to show follow stats for deleted indices, we could maybe use something similar to `OldShardsStats` and keep the stats around.

As an additional note, persistent tasks for closed follower indices are not cleaned up. We could maybe remove them and recreate them in case the follower index is reopened.