### PR TITLE
Close connection manager on current thread in RemoteClusterConnection

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
@@ -332,8 +332,7 @@ final class RemoteClusterConnection implements TransportConnectionListener, Clos
     @Override
     public void close() throws IOException {
         IOUtils.close(connectHandler);
-        // In the ConnectionManager we wait on connections being closed.
-        threadPool.generic().execute(connectionManager::close);
+        connectionManager.closeNoBlock();
     }
 
     public boolean isClosed() {

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
@@ -114,13 +114,6 @@ public class RemoteClusterConnectionTests extends ESTestCase {
         ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
     }
 
-    @Override
-    @Before
-    public void setUp() throws Exception {
-        super.setUp();
-        assumeFalse("https://github.com/elastic/elasticsearch/issues/44339", System.getProperty("os.name").contains("Win"));
-    }
-
     private MockTransportService startTransport(String id, List<DiscoveryNode> knownNodes, Version version) {
         return startTransport(id, knownNodes, version, threadPool);
     }

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
@@ -64,7 +64,6 @@ import org.elasticsearch.test.transport.StubbableConnectionManager;
 import org.elasticsearch.test.transport.StubbableTransport;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.junit.Before;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -94,6 +93,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.iterableWithSize;
@@ -101,7 +101,6 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.Matchers.startsWith;
-import static org.hamcrest.Matchers.endsWith;
 
 public class RemoteClusterConnectionTests extends ESTestCase {
 

--- a/x-pack/plugin/ccr/build.gradle
+++ b/x-pack/plugin/ccr/build.gradle
@@ -1,5 +1,3 @@
-import org.elasticsearch.gradle.OS
-
 evaluationDependsOn(xpackModule('core'))
 
 apply plugin: 'elasticsearch.esplugin'
@@ -24,8 +22,6 @@ task internalClusterTestNoSecurityManager(type: Test) {
     include noSecurityManagerITClasses
     systemProperty 'es.set.netty.runtime.available.processors', 'false'
     systemProperty 'tests.security.manager', 'false'
-    // Disable tests on windows https://github.com/elastic/elasticsearch/issues/44610
-    onlyIf { OS.WINDOWS.equals(OS.current()) == false }
 }
 
 // Instead we create a separate task to run the
@@ -38,8 +34,6 @@ task internalClusterTest(type: Test) {
     include '**/*IT.class'
     exclude noSecurityManagerITClasses
     systemProperty 'es.set.netty.runtime.available.processors', 'false'
-    // Disable tests on windows https://github.com/elastic/elasticsearch/issues/44610
-    onlyIf { OS.WINDOWS.equals(OS.current()) == false }
 }
 
 check.dependsOn internalClusterTest


### PR DESCRIPTION
We have seen test failures on Windows (#44339) in RemoteClusterConnectionTests with the following stack trace:

```
com.carrotsearch.randomizedtesting.UncaughtExceptionError: Captured an uncaught exception in thread: Thread[id=1051, name=elasticsearch[org.elasticsearch.transport.RemoteClusterConnectionTests][generic][T#1], state=RUNNABLE, group=TGRP-RemoteClusterConnectionTests]
	at __randomizedtesting.SeedInfo.seed([D538288F42486FCF:F1425459462DF885]:0)
Caused by: java.lang.IllegalStateException: java.lang.InterruptedException
	at __randomizedtesting.SeedInfo.seed([D538288F42486FCF]:0)
	at org.elasticsearch.transport.ConnectionManager.close(ConnectionManager.java:259)
	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:699)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.InterruptedException
	at java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1040)
	at java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1345)
	at java.base/java.util.concurrent.CountDownLatch.await(CountDownLatch.java:232)
	at org.elasticsearch.transport.ConnectionManager.close(ConnectionManager.java:256)
	... 4 more
```

Even though I don't have Windows to reproduce the issue, I think it's not specific to Windows but rather a timing-related issue. The problem is that RemoteClusterConnection closes the connection manager asynchronously, which races with the threadpool being shutdown at the end of the test.

Closes #44339, #44610