### PR TITLE
[DOCS] Adds Watcher notification account settings

### DIFF
--- a/docs/reference/settings/notification-settings.asciidoc
+++ b/docs/reference/settings/notification-settings.asciidoc
@@ -229,8 +229,7 @@ via HipChat. You can specify the following HipChat account attributes:
                       `user`, or `v1`. Required.
 
   `auth_token`;;
-  The authentication token to use to access the HipChat API. Required.
-  deprecated[6.6.0]
+  The authentication token to use to access the HipChat API. Required. deprecated[6.6.0]
 
   `secure_auth_token` (<<secure-settings,Secure>>);;
   The authentication token to use to access the HipChat API. Required.
@@ -279,8 +278,7 @@ via Slack. You can specify the following Slack account attributes:
 [[slack-account-attributes]]
 
   `url`;;
-  The Incoming Webhook URL to use to post messages to Slack. Required.
-  deprecated[6.6.0]
+  The Incoming Webhook URL to use to post messages to Slack. Required. deprecated[6.6.0]
                                     
   `secure_url` (<<secure-settings,Secure>>);;
   The Incoming Webhook URL to use to post messages to Slack. Required.
@@ -330,15 +328,13 @@ issues in Jira. You can specify the following Jira account attributes:
   The URL of the Jira Software server. Required.
 
   `user`;;
-  The name of the user to connect to the Jira Software server. Required.
-  deprecated[6.6.0]
+  The name of the user to connect to the Jira Software server. Required. deprecated[6.6.0]
   
   `secure_user` (<<secure-settings,Secure>>);;
   The name of the user to connect to the Jira Software server. Required.
 
   `password`;;
-  The password of the user to connect to the Jira Software server. Required.
-  deprecated[6.6.0]
+  The password of the user to connect to the Jira Software server. Required. deprecated[6.6.0]
   
   `secure_password` (<<secure-settings,Secure>>);;
   The password of the user to connect to the Jira Software server. Required.
@@ -369,8 +365,7 @@ are using to access PagerDuty. Required.
 
 `service_api_key`;;
 The https://developer.pagerduty.com/documentation/rest/authentication[
-PagerDuty API key] to use to access PagerDuty. Required.
-deprecated[6.6.0]
+PagerDuty API key] to use to access PagerDuty. Required. deprecated[6.6.0]
 
 `secure_service_api_key` (<<secure-settings,Secure>>);;
 The https://developer.pagerduty.com/documentation/rest/authentication[

--- a/docs/reference/settings/notification-settings.asciidoc
+++ b/docs/reference/settings/notification-settings.asciidoc
@@ -111,9 +111,9 @@ can specify the following email account attributes:
 
   `smtp.user` (<<cluster-update-settings,Dynamic>>);;
   The user name for SMTP. Required.
-
+  
   `smtp.password` (<<cluster-update-settings,Dynamic>>);;
-  The password for the specified SMTP user. deprecated[6.6]
+  The password for the specified SMTP user. deprecated[6.6.0]
   
   `smtp.secure_password` (<<secure-settings,Secure>>);;
   The password for the specified SMTP user.
@@ -230,7 +230,7 @@ via HipChat. You can specify the following HipChat account attributes:
 
   `auth_token`;;
   The authentication token to use to access the HipChat API. Required.
-  deprecated[6.6]
+  deprecated[6.6.0]
 
   `secure_auth_token` (<<secure-settings,Secure>>);;
   The authentication token to use to access the HipChat API. Required.
@@ -280,7 +280,7 @@ via Slack. You can specify the following Slack account attributes:
 
   `url`;;
   The Incoming Webhook URL to use to post messages to Slack. Required.
-  deprecated[6.6]
+  deprecated[6.6.0]
                                     
   `secure_url` (<<secure-settings,Secure>>);;
   The Incoming Webhook URL to use to post messages to Slack. Required.
@@ -324,21 +324,21 @@ issues in Jira. You can specify the following Jira account attributes:
 [[jira-account-attributes]]
 
   `url`;;
-  The URL of the Jira Software server. Required. deprecated[6.6]
+  The URL of the Jira Software server. Required. deprecated[6.6.0]
 
   `secure_url` (<<secure-settings,Secure>>);;
   The URL of the Jira Software server. Required.
 
   `user`;;
   The name of the user to connect to the Jira Software server. Required.
-  deprecated[6.6]
+  deprecated[6.6.0]
   
   `secure_user` (<<secure-settings,Secure>>);;
   The name of the user to connect to the Jira Software server. Required.
 
   `password`;;
   The password of the user to connect to the Jira Software server. Required.
-  deprecated[6.6]
+  deprecated[6.6.0]
   
   `secure_password` (<<secure-settings,Secure>>);;
   The password of the user to connect to the Jira Software server. Required.
@@ -370,7 +370,7 @@ are using to access PagerDuty. Required.
 `service_api_key`;;
 The https://developer.pagerduty.com/documentation/rest/authentication[
 PagerDuty API key] to use to access PagerDuty. Required.
-deprecated[6.6]
+deprecated[6.6.0]
 
 `secure_service_api_key` (<<secure-settings,Secure>>);;
 The https://developer.pagerduty.com/documentation/rest/authentication[

--- a/docs/reference/settings/notification-settings.asciidoc
+++ b/docs/reference/settings/notification-settings.asciidoc
@@ -113,6 +113,9 @@ can specify the following email account attributes:
   The user name for SMTP. Required.
 
   `smtp.password` (<<cluster-update-settings,Dynamic>>);;
+  The password for the specified SMTP user. deprecated[6.6]
+  
+  `smtp.secure_password` (<<secure-settings,Secure>>);;
   The password for the specified SMTP user.
 
   `smtp.starttls.enable` (<<cluster-update-settings,Dynamic>>);;
@@ -226,8 +229,11 @@ via HipChat. You can specify the following HipChat account attributes:
                       `user`, or `v1`. Required.
 
   `auth_token`;;
-  The authentication token to use to access
-                      the HipChat API. Required.
+  The authentication token to use to access the HipChat API. Required.
+  deprecated[6.6]
+
+  `secure_auth_token` (<<secure-settings,Secure>>);;
+  The authentication token to use to access the HipChat API. Required.
 
   `host`;;
   The HipChat server hostname. Defaults to `api.hipchat.com`.
@@ -273,8 +279,11 @@ via Slack. You can specify the following Slack account attributes:
 [[slack-account-attributes]]
 
   `url`;;
-  The Incoming Webhook URL to use to post
-                                    messages to Slack. Required.
+  The Incoming Webhook URL to use to post messages to Slack. Required.
+  deprecated[6.6]
+                                    
+  `secure_url` (<<secure-settings,Secure>>);;
+  The Incoming Webhook URL to use to post messages to Slack. Required.
 
   `message_defaults.from`;;
   The sender name to display in the
@@ -315,12 +324,23 @@ issues in Jira. You can specify the following Jira account attributes:
 [[jira-account-attributes]]
 
   `url`;;
+  The URL of the Jira Software server. Required. deprecated[6.6]
+
+  `secure_url` (<<secure-settings,Secure>>);;
   The URL of the Jira Software server. Required.
 
   `user`;;
   The name of the user to connect to the Jira Software server. Required.
+  deprecated[6.6]
+  
+  `secure_user` (<<secure-settings,Secure>>);;
+  The name of the user to connect to the Jira Software server. Required.
 
   `password`;;
+  The password of the user to connect to the Jira Software server. Required.
+  deprecated[6.6]
+  
+  `secure_password` (<<secure-settings,Secure>>);;
   The password of the user to connect to the Jira Software server. Required.
 
   `issue_defaults`;;
@@ -348,6 +368,11 @@ A name for the PagerDuty account associated with the API key you
 are using to access PagerDuty. Required.
 
 `service_api_key`;;
+The https://developer.pagerduty.com/documentation/rest/authentication[
+PagerDuty API key] to use to access PagerDuty. Required.
+deprecated[6.6]
+
+`secure_service_api_key` (<<secure-settings,Secure>>);;
 The https://developer.pagerduty.com/documentation/rest/authentication[
 PagerDuty API key] to use to access PagerDuty. Required.
 --


### PR DESCRIPTION
Per https://www.elastic.co/guide/en/elasticsearch/reference/6.6/breaking-changes-6.6.html#watcher-notifications-account-settings

> The following settings have been deprecated and the secure variants should be used instead...
> xpack.notification.email.account.<id>.smtp.password, instead use xpack.notification.email.account.<id>.smtp.secure_password
xpack.notification.hipchat.account.<id>.auth_token, instead use xpack.notification.hipchat.account.<id>.secure_auth_token
xpack.notification.jira.account.<id>.url, instead use xpack.notification.jira.account.<id>.secure_url
xpack.notification.jira.account.<id>.user, instead use xpack.notification.jira.account.<id>.secure_user
xpack.notification.jira.account.<id>.password, instead use xpack.notification.jira.account.<id>.secure_password
xpack.notification.pagerduty.account.<id>.service_api_key, instead use xpack.notification.pagerduty.account.<id>.secure_service_api_key
xpack.notification.slack.account.<id>.url, instead use xpack.notification.slack.account.<id>.secure_url

However, the new settings are missing from the 6.6, 6.7,  and 6.8 documentation (https://www.elastic.co/guide/en/elasticsearch/reference/6.6/notification-settings.html)

Related to https://github.com/elastic/elasticsearch/pull/35610