### PR TITLE
[DOCS] Reformat span or query

### DIFF
--- a/docs/reference/query-dsl/span-or-query.asciidoc
+++ b/docs/reference/query-dsl/span-or-query.asciidoc
@@ -30,7 +30,7 @@ GET /_search
 
 
 [[span-or-top-level-params]]
-==== Top-level parameters for `span_near`
+==== Top-level parameters for `span_or`
 `clauses`::
 (Required, array of query objects) Array of one or more other
 <<span-queries,span query>> clauses. Returned documents must one or more of

--- a/docs/reference/query-dsl/span-or-query.asciidoc
+++ b/docs/reference/query-dsl/span-or-query.asciidoc
@@ -4,24 +4,34 @@
 <titleabbrev>Span or</titleabbrev>
 ++++
 
-Matches the union of its span clauses. The span or query maps to Lucene
-`SpanOrQuery`. Here is an example:
+Wraps one or more <<span-queries,span queries>>, called query clauses or
+clauses. Returned documents must match **one or more** of these queries.
+
+
+[[span-or-query-ex-request]]
+==== Example request
 
 [source,js]
---------------------------------------------------
+----
 GET /_search
 {
     "query": {
         "span_or" : {
             "clauses" : [
-                { "span_term" : { "field" : "value1" } },
-                { "span_term" : { "field" : "value2" } },
-                { "span_term" : { "field" : "value3" } }
+                { "span_term" : { "message" : { "value" : "value1" } } },
+                { "span_term" : { "message" : { "value" : "value2" } } },
+                { "span_term" : { "message" : { "value" : "value3" } } }
             ]
         }
     }
 }
---------------------------------------------------
+----
 // CONSOLE
 
-The `clauses` element is a list of one or more other span type queries.
+
+[[span-or-top-level-params]]
+==== Top-level parameters for `span_near`
+`clauses`::
+(Required, array of query objects) Array of one or more other
+<<span-queries,span query>> clauses. Returned documents must one or more of
+these queries.


### PR DESCRIPTION
Rewrites the `span_or` query to use the new query format.

This creates separate sections for the example request and parameters

This is part of #40977, an effort to standardize documentation for query types.

### Preview
http://elasticsearch_44827.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/query-dsl-span-or-query.html