### PR TITLE
Add missing ZonedDateTime methods for joda compat layer

### DIFF
--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.txt
@@ -127,6 +127,17 @@ class org.elasticsearch.script.JodaCompatibleZonedDateTime {
   ZonedDateTime withZoneSameLocal(ZoneId)
   ZonedDateTime withZoneSameInstant(ZoneId)
 
+  #### ChronoZonedDateTime
+  int compareTo(JodaCompatibleZonedDateTime)
+  Chronology getChronology()
+  String format(DateTimeFormatter)
+  int get(TemporalField)
+  long getLong(TemporalField)
+  ZoneOffset getOffset()
+  boolean isSupported(TemporalField)
+  long toEpochSecond()
+  LocalTime toLocalTime()
+
   #### Joda methods that exist in java time
   boolean equals(Object)
   int hashCode()

--- a/server/src/main/java/org/elasticsearch/script/JodaCompatibleZonedDateTime.java
+++ b/server/src/main/java/org/elasticsearch/script/JodaCompatibleZonedDateTime.java
@@ -32,10 +32,14 @@ import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.Month;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.chrono.Chronology;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAdjuster;
 import java.time.temporal.TemporalAmount;
@@ -94,6 +98,42 @@ public class JodaCompatibleZonedDateTime {
         return DATE_FORMATTER.format(dt);
     }
 
+    public String format(DateTimeFormatter formatter) {
+        return dt.format(formatter);
+    }
+
+    public int get(TemporalField field) {
+        return dt.get(field);
+    }
+
+    public long getLong(TemporalField field) {
+        return dt.getLong(field);
+    }
+
+    public Chronology getChronology() {
+        return dt.getChronology();
+    }
+
+    public int compareTo(JodaCompatibleZonedDateTime o) {
+        return dt.compareTo(o.dt);
+    }
+
+    public ZoneOffset getOffset() {
+        return dt.getOffset();
+    }
+
+    public boolean isSupported(TemporalField field) {
+        return dt.isSupported(field);
+    }
+
+    public long toEpochSecond() {
+        return dt.toEpochSecond();
+    }
+
+    public LocalTime toLocalTime() {
+        return dt.toLocalTime();
+    }
+
     public boolean isAfter(JodaCompatibleZonedDateTime o) {
         return dt.isAfter(o.getZonedDateTime());
     }
@@ -105,6 +145,8 @@ public class JodaCompatibleZonedDateTime {
     public boolean isEqual(JodaCompatibleZonedDateTime o) {
         return dt.isEqual(o.getZonedDateTime());
     }
+
+
 
     public int getDayOfMonth() {
         return dt.getDayOfMonth();


### PR DESCRIPTION
While joda no longer exists in the apis for 7.x, the compatibility layer
still exists with helper methods mimicking the behavior of joda for
ZonedDateTime objects returned for date fields in scripts. This layer
was originally intended to be removed in 7.0, but is now likely to exist
for the lifetime of 7.x.

This commit adds missing methods from ChronoZonedDateTime to the compat
class. These methods were not part of joda, but are needed to act like a
real ZonedDateTime.

relates #44411