### PR TITLE
[DOCS] Fixes terms in HLRC data frame transform APIs

### DIFF
--- a/docs/java-rest/high-level/dataframe/delete_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/delete_data_frame.asciidoc
@@ -4,10 +4,10 @@
 :response: AcknowledgedResponse
 --
 [id="{upid}-{api}"]
-=== Delete Data Frame Transform API
+=== Delete {dataframe-transform} API
 
 [id="{upid}-{api}-request"]
-==== Delete Data Frame Transform Request
+==== Delete {dataframe-transform} request
 
 A +{request}+ object requires a non-null `id`.
 

--- a/docs/java-rest/high-level/dataframe/get_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/get_data_frame.asciidoc
@@ -4,16 +4,16 @@
 :response: GetDataFrameTransformResponse
 --
 [id="{upid}-{api}"]
-=== Get Data Frame Transform API
+=== Get {dataframe-transform} API
 
-The Get Data Frame Transform API is used get one or more {dataframe-transform}.
+The get {dataframe-transform} API is used get one or more {dataframe-transforms}.
 The API accepts a +{request}+ object and returns a +{response}+.
 
 [id="{upid}-{api}-request"]
-==== Get Data Frame Request
+==== Get {dataframe-transform} request
 
-A +{request}+ requires either a data frame transform id, a comma separated list of ids or
-the special wildcard `_all` to get all {dataframe-transforms}
+A +{request}+ requires either a {dataframe-transform} ID, a comma separated list
+of ids or the special wildcard `_all` to get all {dataframe-transforms}.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
@@ -21,7 +21,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> Constructing a new GET request referencing an existing {dataframe-transform}
 
-==== Optional Arguments
+==== Optional arguments
 
 The following arguments are optional.
 
@@ -40,7 +40,7 @@ include::../execution.asciidoc[]
 [id="{upid}-{api}-response"]
 ==== Response
 
-The returned +{response}+ contains the requested {dataframe-transform}s.
+The returned +{response}+ contains the requested {dataframe-transforms}.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/dataframe/get_data_frame_stats.asciidoc
+++ b/docs/java-rest/high-level/dataframe/get_data_frame_stats.asciidoc
@@ -4,17 +4,17 @@
 :response: GetDataFrameTransformStatsResponse
 --
 [id="{upid}-{api}"]
-=== Get Data Frame Transform Stats API
+=== Get {dataframe-transform} stats API
 
-The Get Data Frame Transform Stats API is used read the operational statistics
-of one or more {dataframe-transform}s.
+The get {dataframe-transform} stats API is used read the operational statistics
+of one or more {dataframe-transforms}.
 The API accepts a +{request}+ object and returns a +{response}+.
 
 [id="{upid}-{api}-request"]
-==== Get Data Frame Transform Stats Request
+==== Get {dataframe-transform} stats request
 
 A +{request}+ requires a data frame transform id or the special wildcard `_all`
-to get the statistics for all {dataframe-transform}s
+to get the statistics for all {dataframe-transforms}.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
@@ -30,8 +30,9 @@ The following arguments are optional.
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request-options]
 --------------------------------------------------
-<1> The page parameters `from` and `size`. `from` specifies the number of data frame transform stats to skip.
-`size` specifies the maximum number of data frame transform stats to get.
+<1> The page parameters `from` and `size`. `from` specifies the number of
+{dataframe-transform} stats to skip.
+`size` specifies the maximum number of {dataframe-transform} stats to get.
 Defaults to `0` and `100` respectively.
 <2> Whether to ignore if a wildcard expression matches no transforms.
 

--- a/docs/java-rest/high-level/dataframe/preview_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/preview_data_frame.asciidoc
@@ -4,17 +4,17 @@
 :response: PreviewDataFrameTransformResponse
 --
 [id="{upid}-{api}"]
-=== Preview Data Frame Transform API
+=== Preview {dataframe-transform} API
 
-The Preview Data Frame Transform API is used to preview the results of
+The preview {dataframe-transform} API is used to preview the results of
 a {dataframe-transform}.
 
 The API accepts a +{request}+ object as a request and returns a +{response}+.
 
 [id="{upid}-{api}-request"]
-==== Preview Data Frame Request
+==== Preview {dataframe-transform} request
 
-A +{request}+ takes a single argument: a valid data frame transform config.
+A +{request}+ takes a single argument: a valid {dataframe-transform} config.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
@@ -22,7 +22,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> The source config from which the data should be gathered
 <2> The pivot config used to transform the data
-<3> The configuration of the {dataframe-job} to preview
+<3> The configuration of the {dataframe-transform} to preview
 
 include::../execution.asciidoc[]
 

--- a/docs/java-rest/high-level/dataframe/put_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/put_data_frame.asciidoc
@@ -4,14 +4,14 @@
 :response: AcknowledgedResponse
 --
 [id="{upid}-{api}"]
-=== Put Data Frame Transform API
+=== Put {dataframe-transform} API
 
-The Put Data Frame Transform API is used to create a new {dataframe-transform}.
+The put {dataframe-transform} API is used to create a new {dataframe-transform}.
 
 The API accepts a +{request}+ object as a request and returns a +{response}+.
 
 [id="{upid}-{api}-request"]
-==== Put Data Frame Request
+==== Put {dataframe-transform} request
 
 A +{request}+ requires the following argument:
 
@@ -26,10 +26,10 @@ with the privileges of the user creating it. Meaning, if they do not have privil
 such an error will not be visible until `_start` is called.
 
 [id="{upid}-{api}-config"]
-==== Data Frame Transform Configuration
+==== {dataframe-transform-cap} configuration
 
-The `DataFrameTransformConfig` object contains all the details about the {dataframe-transform}
-configuration and contains the following arguments:
+The `DataFrameTransformConfig` object contains all the details about the
+{dataframe-transform} configuration and contains the following arguments:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/dataframe/start_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/start_data_frame.asciidoc
@@ -4,13 +4,13 @@
 :response: StartDataFrameTransformResponse
 --
 [id="{upid}-{api}"]
-=== Start Data Frame Transform API
+=== Start {dataframe-transform} API
 
-Start a {dataframe-job}.
+Start a {dataframe-transform}.
 It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Start Data Frame Request
+==== Start {dataframe-transform} request
 
 A +{request}+ object requires a non-null `id`.
 
@@ -18,9 +18,10 @@ A +{request}+ object requires a non-null `id`.
 ---------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 ---------------------------------------------------
-<1> Constructing a new start request referencing an existing {dataframe-job}
+<1> Constructing a new start request referencing an existing
+{dataframe-transform}
 
-==== Optional Arguments
+==== Optional arguments
 
 The following arguments are optional.
 
@@ -28,10 +29,11 @@ The following arguments are optional.
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request-options]
 --------------------------------------------------
-<1> Controls the amount of time to wait until the {dataframe-job} starts.
+<1> Controls the amount of time to wait until the {dataframe-transform} starts.
 
 include::../execution.asciidoc[]
 
 ==== Response
 
-The returned +{response}+ object acknowledges the {dataframe-job} has started.
+The returned +{response}+ object acknowledges the {dataframe-transform} has
+started.

--- a/docs/java-rest/high-level/dataframe/stop_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/stop_data_frame.asciidoc
@@ -4,25 +4,25 @@
 :response: StopDataFrameTransformResponse
 --
 [id="{upid}-{api}"]
-=== Stop Data Frame Transform API
+=== Stop {dataframe-transform} API
 
-Stop a started {dataframe-job}.
+Stop a started {dataframe-transform}.
 It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Stop Data Frame Request
+==== Stop {dataframe-transform} request
 
-A +{request}+ object requires a non-null `id`. `id` can be a comma separated list of Ids
-or a single Id. Wildcards, `*` and `_all` are also accepted.
+A +{request}+ object requires a non-null `id`. `id` can be a comma separated
+list of IDs or a single ID. Wildcards, `*` and `_all` are also accepted.
 
 
 ["source","java",subs="attributes,callouts,macros"]
 ---------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 ---------------------------------------------------
-<1> Constructing a new stop request referencing an existing {dataframe-job}
+<1> Constructing a new stop request referencing an existing {dataframe-transform}
 
-==== Optional Arguments
+==== Optional arguments
 
 The following arguments are optional.
 
@@ -31,11 +31,11 @@ The following arguments are optional.
 include-tagged::{doc-tests-file}[{api}-request-options]
 --------------------------------------------------
 <1> If true wait for the data frame task to stop before responding
-<2> Controls the amount of time to wait until the {dataframe-job} stops.
+<2> Controls the amount of time to wait until the {dataframe-transform} stops.
 <3> Whether to ignore if a wildcard expression matches no transforms.
 
 include::../execution.asciidoc[]
 
 ==== Response
 
-The returned +{response}+ object acknowledges the {dataframe-job} has stopped.
+The returned +{response}+ object acknowledges the {dataframe-transform} has stopped.

--- a/docs/java-rest/high-level/execution-no-req.asciidoc
+++ b/docs/java-rest/high-level/execution-no-req.asciidoc
@@ -5,7 +5,7 @@ For methods with requests, see execution.asciidoc
 ////
 
 [id="{upid}-{api}-sync"]
-==== Synchronous Execution
+==== Synchronous execution
 
 When executing the +{api}+ API in the following manner, the client waits
 for the +{response}+ to be returned before continuing with code execution:
@@ -25,7 +25,7 @@ a generic `ElasticsearchException` and adds the original `ResponseException` as 
 suppressed exception to it.
 
 [id="{upid}-{api}-async"]
-==== Asynchronous Execution
+==== Asynchronous execution
 
 The +{api}+ API can also be called in an asynchronous fashion so that
 the client can return directly. Users need to specify how the response or

--- a/docs/java-rest/high-level/execution.asciidoc
+++ b/docs/java-rest/high-level/execution.asciidoc
@@ -8,7 +8,7 @@ test.
 ////
 
 [id="{upid}-{api}-sync"]
-==== Synchronous Execution
+==== Synchronous execution
 
 When executing a +{request}+ in the following manner, the client waits
 for the +{response}+ to be returned before continuing with code execution:
@@ -28,7 +28,7 @@ a generic `ElasticsearchException` and adds the original `ResponseException` as 
 suppressed exception to it.
 
 [id="{upid}-{api}-async"]
-==== Asynchronous Execution
+==== Asynchronous execution
 
 Executing a +{request}+ can also be done in an asynchronous fashion so that
 the client can return directly. Users need to specify how the response or

--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -564,12 +564,13 @@ include::ilm/lifecycle_management_status.asciidoc[]
 include::ilm/retry_lifecycle_policy.asciidoc[]
 include::ilm/remove_lifecycle_policy_from_index.asciidoc[]
 
-== Data Frame APIs
+== Data Frame Transform APIs
 
 :upid: {mainid}-dataframe
 :doc-tests-file: {doc-tests}/DataFrameTransformDocumentationIT.java
 
-The Java High Level REST Client supports the following Data Frame APIs:
+The Java High Level REST Client supports the following {dataframe-transform}
+APIs:
 
 * <<{upid}-get-data-frame-transform>>
 * <<{upid}-get-data-frame-transform-stats>>

--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -564,6 +564,7 @@ include::ilm/lifecycle_management_status.asciidoc[]
 include::ilm/retry_lifecycle_policy.asciidoc[]
 include::ilm/remove_lifecycle_policy_from_index.asciidoc[]
 
+[[_data_frame_transform_apis]]
 == {dataframe-transform-cap} APIs
 
 :upid: {mainid}-dataframe

--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -564,7 +564,7 @@ include::ilm/lifecycle_management_status.asciidoc[]
 include::ilm/retry_lifecycle_policy.asciidoc[]
 include::ilm/remove_lifecycle_policy_from_index.asciidoc[]
 
-== Data Frame Transform APIs
+== {dataframe-transform-cap} APIs
 
 :upid: {mainid}-dataframe
 :doc-tests-file: {doc-tests}/DataFrameTransformDocumentationIT.java


### PR DESCRIPTION
This PR updates the content in the Java REST Client > Java High Level REST Client > Data Frame APIs documentation (https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/_data_frame_apis.html) such that it uses appropriate attributes for the terminology.

It also fixes the titles to follow sentence style capitalization.