### PR TITLE
Incorrect documentation

### DIFF
--- a/docs/reference/settings/notification-settings.asciidoc
+++ b/docs/reference/settings/notification-settings.asciidoc
@@ -113,6 +113,10 @@ can specify the following email account attributes:
   The user name for SMTP. Required.
 
   `smtp.password` (<<cluster-update-settings,Dynamic>>);;
+  deprecated[6.6.0] The password for the specified SMTP user.
+  Use `smtp.secure_password` instead.
+
+  `smtp.secure_password` (<<secure-settings,Secure>>);;
   The password for the specified SMTP user.
 
   `smtp.starttls.enable` (<<cluster-update-settings,Dynamic>>);;


### PR DESCRIPTION
The documentation in 6.6 said that smtp.password is deprecated , but this information is not in the documentation in 6.7 and 6.8
https://www.elastic.co/guide/en/elasticsearch/reference/6.6/notification-settings.html#email-notification-settings
https://www.elastic.co/guide/en/elasticsearch/reference/6.7/notification-settings.html#email-notification-settings
https://www.elastic.co/guide/en/elasticsearch/reference/6.8/notification-settings.html#email-notification-settings

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
