### PR TITLE
[DOCS] typo: SQL JDBC Plugin Example Typo.

### DIFF
--- a/docs/reference/sql/endpoints/jdbc.asciidoc
+++ b/docs/reference/sql/endpoints/jdbc.asciidoc
@@ -151,7 +151,7 @@ To put all of it together, the following URL:
 
 ["source","text"]
 ----
-jdbc:es://http://server:3456/?timezone=UTC&page.size=250
+jdbc:es://http://server:3456?timezone=UTC&page.size=250
 ----
 
 Opens up a {es-sql} connection to `server` on port `3456`, setting the JDBC connection timezone to `UTC` and its pagesize to `250` entries.


### PR DESCRIPTION
Related to: https://github.com/elastic/stack-docs/issues/147