### PR TITLE
[ML-DataFrame] Adjust data frame stats BWC following backport

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameIndexerTransformStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameIndexerTransformStats.java
@@ -76,7 +76,7 @@ public class DataFrameIndexerTransformStats extends IndexerJobStats {
 
     public DataFrameIndexerTransformStats(StreamInput in) throws IOException {
         super(in);
-        if (in.getVersion().before(Version.V_8_0_0)) { // TODO change to 7.4.0 after backport
+        if (in.getVersion().before(Version.V_7_4_0)) {
             in.readString(); // was transformId
         }
     }
@@ -84,7 +84,7 @@ public class DataFrameIndexerTransformStats extends IndexerJobStats {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (out.getVersion().before(Version.V_8_0_0)) { // TODO change to 7.4.0 after backport
+        if (out.getVersion().before(Version.V_7_4_0)) {
             out.writeString(DEFAULT_TRANSFORM_ID);
         }
     }

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_data_frame_jobs_crud.yml
@@ -1,8 +1,5 @@
 ---
 "Test put batch data frame transforms on mixed cluster":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44768
   - do:
       cluster.health:
         index: "dataframe-transform-airline-data"
@@ -109,9 +106,6 @@
 
 ---
 "Test put continuous data frame transform on mixed cluster":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44768
   - do:
       cluster.health:
         index: "dataframe-transform-airline-data-cont"
@@ -174,9 +168,6 @@
 
 ---
 "Test GET, start, and stop old cluster batch transforms":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44768
   - do:
       cluster.health:
         index: "dataframe-transform-airline-data"
@@ -254,9 +245,6 @@
 
 ---
 "Test GET, stop, start, old continuous transforms":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44768
   - do:
       cluster.health:
         index: "dataframe-transform-airline-data-cont"

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/80_data_frame_jobs_crud.yml
@@ -1,8 +1,5 @@
 ---
 "Test put batch data frame transforms on old cluster":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44768
   - do:
       indices.create:
         index: dataframe-transform-airline-data
@@ -139,9 +136,6 @@
 
 ---
 "Test put continuous data frame transform on old cluster":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44768
   - do:
       indices.create:
         index: dataframe-transform-airline-data-cont

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_data_frame_jobs_crud.yml
@@ -7,9 +7,6 @@ setup:
         timeout: 70s
 ---
 "Get start, stop, and delete old and mixed cluster batch data frame transforms":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44768
   # Simple and complex OLD transforms
   - do:
       data_frame.get_data_frame_transform:
@@ -165,9 +162,6 @@ setup:
 
 ---
 "Test GET, stop, delete, old and mixed continuous transforms":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/44768
   - do:
       data_frame.get_data_frame_transform:
         transform_id: "old-simple-continuous-transform"


### PR DESCRIPTION
This change adjusts the changes of #44768 to account
for the backport to the 7.x branch in #44848.