### PR TITLE
[ML-DataFrame] do not assert on indexer state

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
@@ -393,7 +393,6 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
             indexer.start();
             assertThat(indexer.getState(), equalTo(IndexerState.STARTED));
             assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
-            assertThat(indexer.getState(), equalTo(IndexerState.INDEXING));
             assertTrue(awaitBusy(() -> isFinished.get()));
             indexer.assertCounters();
         } finally {


### PR DESCRIPTION
remove the unreliable check for the state change

fixes #44813

What happened in the test failure:

There are 2 threads involved, A the managing thread(the test code), B the indexer thread. A triggers B to change the state to `INDEXING` and start the work. In this test B is supposed to do 5 iterations and then finish. What happened in the failure is that B changed state to `INDEXING`, ran 5 times and by design switched back to `STARTED` before A checked the state (the offending line). In other tests we do the same but sync B using a latch, so it does not finish before the latch is counted down.

Checking the indexer state is not the main purpose of this test, additionally we cover this case already in other tests, therefore removing the offending line is proper way to fix, we do not loose coverage.

The test in question has been added in 7.4, so no further backport than 7.4 required.