### PR TITLE
Indicate that some user APIs handle built-in users

### DIFF
--- a/x-pack/docs/en/rest-api/security/change-password.asciidoc
+++ b/x-pack/docs/en/rest-api/security/change-password.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Change passwords</titleabbrev>
 ++++
 
-Changes the passwords of users in the native realm.
+Changes the passwords of users in the native realm and built-in users.
 
 ==== Request
 

--- a/x-pack/docs/en/rest-api/security/get-users.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-users.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Get users</titleabbrev>
 ++++
 
-Retrieves information about users in the native realm. 
+Retrieves information about users in the native realm and built-in users. 
 
 
 ==== Request


### PR DESCRIPTION
The get users API also returns users form the restricted realm or built-in users, as we call them in our docs
