### PR TITLE
[DOCS] Reformat span field masking query

### DIFF
--- a/docs/reference/mapping/params/multi-fields.asciidoc
+++ b/docs/reference/mapping/params/multi-fields.asciidoc
@@ -63,6 +63,7 @@ NOTE: Multi-fields do not change the original `_source` field.
 TIP: New multi-fields can be added to existing
 fields using the <<indices-put-mapping,PUT mapping API>>.
 
+[[multi-fields-multiple-analyzers]]
 ==== Multi-fields with multiple analyzers
 
 Another use case of multi-fields is to analyze the same field in different

--- a/docs/reference/query-dsl/span-field-masking-query.asciidoc
+++ b/docs/reference/query-dsl/span-field-masking-query.asciidoc
@@ -7,11 +7,11 @@
 Wraps a <<span-queries,span query>>, letting you use queries like `span_near` or
 `span_or` to search across different fields.
 
-Queries like `span_near` or `span_or` require any nested queries search the same
-field. With the `field_masking_span` query, you can use the `field` parameter to
-meet that requirement but search a different field instead. This is particularly
-useful for searching <<multi-fields-multiple-analyzers,multi-fields with
-multiple analyzers>>.
+Queries like `span_near` or `span_or` require their inner queries to search
+the same field. With the `field_masking_span` query, you can use the `field`
+parameter to meet that requirement but search a different field instead. This is
+particularly useful for searching <<multi-fields-multiple-analyzers,multi-fields
+with multiple analyzers>>.
 
 [[span-mask-query-ex-request]]
 ==== Example request

--- a/docs/reference/query-dsl/span-field-masking-query.asciidoc
+++ b/docs/reference/query-dsl/span-field-masking-query.asciidoc
@@ -4,16 +4,20 @@
 <titleabbrev>Span field masking</titleabbrev>
 ++++
 
-Wrapper to allow span queries to participate in composite single-field span queries by 'lying' about their search field. The span field masking query maps to Lucene's `SpanFieldMaskingQuery`
+Wraps a <<span-queries,span query>>, letting you use queries like `span_near` or
+`span_or` to search across different fields.
 
-This can be used to support queries like `span-near` or `span-or` across different fields, which is not ordinarily permitted.
+Queries like `span_near` or `span_or` require any nested queries search the same
+field. With the `field_masking_span` query, you can use the `field` parameter to
+meet that requirement but search a different field instead. This is particularly
+useful for searching <<multi-fields-multiple-analyzers,multi-fields with
+multiple analyzers>>.
 
-Span field masking query is invaluable in conjunction with *multi-fields* when same content is indexed with multiple analyzers. For instance we could index a field with the standard analyzer which breaks text up into words, and again with the english analyzer which stems words into their root form.
-
-Example:
+[[span-mask-query-ex-request]]
+==== Example request
 
 [source,js]
---------------------------------------------------
+----
 GET /_search
 {
   "query": {
@@ -21,17 +25,17 @@ GET /_search
       "clauses": [
         {
           "span_term": {
-            "text": "quick brown"
+            "message": { "value": "quick brown" }
           }
         },
         {
           "field_masking_span": {
             "query": {
               "span_term": {
-                "text.stems": "fox"
+                "message.stems": { "value": "fox" }
               }
             },
-            "field": "text"
+            "field": "message"
           }
         }
       ],
@@ -40,7 +44,20 @@ GET /_search
     }
   }
 }
---------------------------------------------------
+----
 // CONSOLE
 
-Note: as span field masking query returns the masked field, scoring will be done using the norms of the field name supplied. This may lead to unexpected scoring behaviour.
+[[span-mask-top-level-params]]
+==== Top-level parameters for `field_masking_span`
+`query`::
++
+--
+(Required, query object) Contains a <<span-queries,span query>>.
+
+While returned results are based on this query, the `field_masking_span` query
+calculates <<query-filter-context, relevance scores>> using norms of the field
+in the `field` parameter. This can result in unexpected relevance scoring.
+--
+
+`field`::
+(Required, string) Field used to meet search field requirements.

--- a/docs/reference/query-dsl/span-field-masking-query.asciidoc
+++ b/docs/reference/query-dsl/span-field-masking-query.asciidoc
@@ -55,7 +55,7 @@ GET /_search
 (Required, query object) Contains a <<span-queries,span query>>.
 
 While returned results are based on this query, the `field_masking_span` query
-calculates <<query-filter-context, relevance scores>> using norms of the field
+calculates <<relevance-scores,relevance scores>> using norms of the field
 in the `field` parameter. This can result in unexpected relevance scoring.
 --
 


### PR DESCRIPTION
Rewrites the `field_masking_span` query to use the new query format.

This creates separate sections for the example request and parameters

This is part of #40977, an effort to standardize documentation for query types.

### Preview
http://elasticsearch_44858.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/query-dsl-span-field-masking-query.html