### PR TITLE
Rename "indices APIs" to "index APIs"

### DIFF
--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -83,12 +83,12 @@ include::miscellaneous/ping.asciidoc[]
 include::miscellaneous/x-pack-info.asciidoc[]
 include::miscellaneous/x-pack-usage.asciidoc[]
 
-== Indices APIs
+== Index APIs
 
 :upid: {mainid}
 :doc-tests-file: {doc-tests}/IndicesClientDocumentationIT.java
 
-The Java High Level REST Client supports the following Indices APIs:
+The Java High Level REST Client supports the following Index APIs:
 
 Index Management::
 * <<{upid}-analyze>>

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -19,7 +19,7 @@ using simple `test1,test2,test3` notation (or `_all` for all indices). It also
 supports wildcards, for example: `test*` or `*test` or `te*t` or `*test*`, and the
 ability to "exclude" (`-`), for example: `test*,-test3`.
 
-All multi indices APIs support the following url query string parameters:
+All multi index APIs support the following url query string parameters:
 
 [horizontal]
 `ignore_unavailable`::

--- a/docs/reference/mapping/removal_of_types.asciidoc
+++ b/docs/reference/mapping/removal_of_types.asciidoc
@@ -438,7 +438,7 @@ documents to it using typeless `index` calls, and load documents with typeless
 `get` calls.
 
 [float]
-==== Indices APIs
+==== Index APIs
 
 Index creation, index template, and mapping APIs support a new `include_type_name`
 URL parameter that specifies whether mapping definitions in requests and responses
@@ -718,7 +718,7 @@ indices.
 ==== Mixed-version clusters
 
 In a cluster composed of both 6.8 and 7.0 nodes, the parameter
-`include_type_name` should be specified in indices APIs like index
+`include_type_name` should be specified in index APIs like index
 creation. This is because the parameter has a different default between
 6.8 and 7.0, so the same mapping definition will not be valid for both
 node versions.

--- a/docs/reference/ml/anomaly-detection/transforms.asciidoc
+++ b/docs/reference/ml/anomaly-detection/transforms.asciidoc
@@ -21,7 +21,7 @@ more detectors.
 * <<ml-configuring-transform8>>
 * <<ml-configuring-transform9>>
 
-The following indices APIs create and add content to an index that is used in
+The following index APIs create and add content to an index that is used in
 subsequent examples:
 
 [source,js]


### PR DESCRIPTION
#44568 changed the 'Indices APIs' heading to 'Index APIs.'

This updates a few references missed during that change.