### PR TITLE
[DOCS] Minor edits to HLRC ML APIs

### DIFF
--- a/docs/java-rest/high-level/dataframe/delete_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/delete_data_frame.asciidoc
@@ -6,6 +6,8 @@
 [id="{upid}-{api}"]
 === Delete {dataframe-transform} API
 
+Deletes an existing {dataframe-transform}.
+
 [id="{upid}-{api}-request"]
 ==== Delete {dataframe-transform} request
 

--- a/docs/java-rest/high-level/dataframe/get_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/get_data_frame.asciidoc
@@ -6,7 +6,7 @@
 [id="{upid}-{api}"]
 === Get {dataframe-transform} API
 
-The get {dataframe-transform} API is used get one or more {dataframe-transforms}.
+Retrieves configuration information about one or more {dataframe-transforms}.
 The API accepts a +{request}+ object and returns a +{response}+.
 
 [id="{upid}-{api}-request"]

--- a/docs/java-rest/high-level/dataframe/get_data_frame_stats.asciidoc
+++ b/docs/java-rest/high-level/dataframe/get_data_frame_stats.asciidoc
@@ -6,8 +6,7 @@
 [id="{upid}-{api}"]
 === Get {dataframe-transform} stats API
 
-The get {dataframe-transform} stats API is used read the operational statistics
-of one or more {dataframe-transforms}.
+Retrieves the operational statistics of one or more {dataframe-transforms}.
 The API accepts a +{request}+ object and returns a +{response}+.
 
 [id="{upid}-{api}-request"]
@@ -22,7 +21,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> Constructing a new GET Stats request referencing an existing {dataframe-transform}
 
-==== Optional Arguments
+==== Optional arguments
 
 The following arguments are optional.
 

--- a/docs/java-rest/high-level/dataframe/preview_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/preview_data_frame.asciidoc
@@ -6,8 +6,7 @@
 [id="{upid}-{api}"]
 === Preview {dataframe-transform} API
 
-The preview {dataframe-transform} API is used to preview the results of
-a {dataframe-transform}.
+Previews the results of a {dataframe-transform}.
 
 The API accepts a +{request}+ object as a request and returns a +{response}+.
 

--- a/docs/java-rest/high-level/dataframe/put_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/put_data_frame.asciidoc
@@ -6,7 +6,7 @@
 [id="{upid}-{api}"]
 === Put {dataframe-transform} API
 
-The put {dataframe-transform} API is used to create a new {dataframe-transform}.
+Creates a new {dataframe-transform}.
 
 The API accepts a +{request}+ object as a request and returns a +{response}+.
 

--- a/docs/java-rest/high-level/dataframe/start_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/start_data_frame.asciidoc
@@ -6,7 +6,7 @@
 [id="{upid}-{api}"]
 === Start {dataframe-transform} API
 
-Start a {dataframe-transform}.
+Starts a {dataframe-transform}.
 It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]

--- a/docs/java-rest/high-level/dataframe/stop_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/stop_data_frame.asciidoc
@@ -6,7 +6,7 @@
 [id="{upid}-{api}"]
 === Stop {dataframe-transform} API
 
-Stop a started {dataframe-transform}.
+Stops a started {dataframe-transform}.
 It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]

--- a/docs/java-rest/high-level/ml/delete-job.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-job.asciidoc
@@ -27,9 +27,8 @@ The following arguments are optional:
 ---------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request-force]
 ---------------------------------------------------
-<1> Use to forcefully delete an opened job;
-this method is quicker than closing and deleting the job.
-Defaults to `false`.
+<1> Use to forcefully delete an opened job. This method is quicker than closing
+and deleting the job. Defaults to `false`.
 
 ["source","java",subs="attributes,callouts,macros"]
 ---------------------------------------------------
@@ -50,9 +49,9 @@ for completion:
 ---------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-response]
 ---------------------------------------------------
-<1> whether was job deletion was acknowledged or not; will be `null` when set
-not to wait for completion
-<2> the id of the job deletion task; will be `null` when set to wait for
-completion
+<1> Whether job deletion was acknowledged or not. It will be `null` when set
+to not wait for completion.
+<2> The ID of the job deletion task. It will be `null` when set to wait for
+completion.
 
 include::../execution.asciidoc[]


### PR DESCRIPTION
This PR includes minor edits to the data frame transform APIs and the delete anomaly detection job API in the Java Rest Client documentation.

For example, it addresses the feedback in https://github.com/elastic/elasticsearch/pull/44839#discussion_r307187942