### PR TITLE
[DOCS] Updates terms in machine learning calendar APIs

### DIFF
--- a/docs/java-rest/high-level/ml/delete-calendar-event.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-calendar-event.asciidoc
@@ -4,13 +4,13 @@
 :response: AcknowledgedResponse
 --
 [id="{upid}-{api}"]
-=== Delete Calendar Event API
+=== Delete calendar event API
 Removes a scheduled event from an existing {ml} calendar.
 The API accepts a +{request}+ and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Delete Calendar Event Request
+==== Delete calendar event request
 
 A +{request}+ is constructed referencing a non-null
 calendar ID, and eventId which to remove from the calendar
@@ -23,7 +23,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 <2> The eventId to remove from the calendar
 
 [id="{upid}-{api}-response"]
-====  Delete Calendar Event Response
+====  Delete calendar event response
 
 The returned +{response}+ acknowledges the success of the request:
 

--- a/docs/java-rest/high-level/ml/delete-calendar-job.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-calendar-job.asciidoc
@@ -4,13 +4,13 @@
 :response: PutCalendarResponse
 --
 [id="{upid}-{api}"]
-=== Delete Calendar Job API
-Removes {ml} jobs from an existing {ml} calendar.
+=== Delete {anomaly-jobs} from calendar API
+Removes {anomaly-jobs} from an existing {ml} calendar.
 The API accepts a +{request}+ and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Delete Calendar Job Request
+==== Delete {anomaly-jobs} from calendar request
 
 A +{request}+ is constructed referencing a non-null
 calendar ID, and JobIDs which to remove from the calendar
@@ -23,7 +23,7 @@ include-tagged::{doc-tests-file}[{api}-request]
 <2> The JobIds to remove from the calendar
 
 [id="{upid}-{api}-response"]
-====  Delete Calendar Job Response
+====  Delete {anomaly-jobs} from calendar response
 
 The returned +{response}+ contains the updated Calendar:
 
@@ -31,6 +31,6 @@ The returned +{response}+ contains the updated Calendar:
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
-<1> The updated Calendar with the jobs removed
+<1> The updated calendar with the jobs removed
 
 include::../execution.asciidoc[]

--- a/docs/java-rest/high-level/ml/delete-calendar.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-calendar.asciidoc
@@ -4,13 +4,13 @@
 :response: AcknowledgedResponse
 --
 [id="{upid}-{api}"]
-=== Delete Calendar API
+=== Delete calendar API
 Delete a {ml} calendar.
 The API accepts a +{request}+ and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Delete Calendar Request
+==== Delete calendar request
 
 A `DeleteCalendar` object requires a non-null `calendarId`.
 
@@ -18,10 +18,10 @@ A `DeleteCalendar` object requires a non-null `calendarId`.
 ---------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 ---------------------------------------------------
-<1> Constructing a new request referencing an existing Calendar
+<1> Constructing a new request referencing an existing calendar
 
 [id="{upid}-{api}-response"]
-==== Delete Calendar Response
+==== Delete calendar response
 
 The returned +{response}+ object indicates the acknowledgement of the request:
 ["source","java",subs="attributes,callouts,macros"]

--- a/docs/java-rest/high-level/ml/put-calendar-job.asciidoc
+++ b/docs/java-rest/high-level/ml/put-calendar-job.asciidoc
@@ -4,13 +4,13 @@
 :response: PutCalendarResponse
 --
 [id="{upid}-{api}"]
-=== Put Calendar Job API
-Adds {ml} jobs to an existing {ml} calendar.
+=== Put {anomaly-jobs} in calendar API
+Adds {anomaly-jobs} jobs to an existing {ml} calendar.
 The API accepts a +{request}+ and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Put Calendar Job Request
+==== Put {anomaly-jobs} in calendar request
 
 A +{request}+ is constructed referencing a non-null
 calendar ID, and JobIDs to which to add to the calendar
@@ -23,14 +23,14 @@ include-tagged::{doc-tests-file}[{api}-request]
 <2> The JobIds to add to the calendar
 
 [id="{upid}-{api}-response"]
-==== Put Calendar Response
+==== Put {anomaly-jobs} in calendar response
 
-The returned +{response}+ contains the updated Calendar:
+The returned +{response}+ contains the updated calendar:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
-<1> The updated Calendar
+<1> The updated calendar
 
 include::../execution.asciidoc[]

--- a/docs/java-rest/high-level/ml/put-calendar.asciidoc
+++ b/docs/java-rest/high-level/ml/put-calendar.asciidoc
@@ -4,32 +4,32 @@
 :response: PutCalendarResponse
 --
 [id="{upid}-{api}"]
-=== Put Calendar API
+=== Put calendar API
 Creates a new {ml} calendar.
 The API accepts a +{request}+ and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Put Calendar Request
+==== Put calendar request
 
-A +{request}+ is constructed with a Calendar object
+A +{request}+ is constructed with a calendar object
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
-<1> Create a request with the given Calendar
+<1> Create a request with the given calendar.
 
 
 [id="{upid}-{api}-response"]
 ==== Put Calendar Response
 
-The returned +{response}+ contains the created Calendar:
+The returned +{response}+ contains the created calendar:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
-<1> The created Calendar
+<1> The created calendar.
 
 include::../execution.asciidoc[]

--- a/docs/reference/ml/anomaly-detection/apis/delete-calendar-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-calendar-job.asciidoc
@@ -1,12 +1,12 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-delete-calendar-job]]
-=== Delete jobs from calendar API
+=== Delete {anomaly-jobs} from calendar API
 ++++
 <titleabbrev>Delete jobs from calendar</titleabbrev>
 ++++
 
-Deletes jobs from a calendar.
+Deletes {anomaly-jobs} from a calendar.
 
 [[ml-delete-calendar-job-request]]
 ==== {api-request-title}
@@ -27,8 +27,8 @@ Deletes jobs from a calendar.
   (Required, string) Identifier for the calendar.
 
 `<job_id>`::
-  (Required, string) An identifier for the job. It can be a job identifier, a
-  group name, or a comma-separated list of jobs or groups.
+  (Required, string) An identifier for the {anomaly-jobs}. It can be a job
+  identifier, a group name, or a comma-separated list of jobs or groups.
 
 [[ml-delete-calendar-job-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-calendar-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-calendar-job.asciidoc
@@ -1,12 +1,12 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-put-calendar-job]]
-=== Add jobs to calendar API
+=== Add {anomaly-jobs} to calendar API
 ++++
 <titleabbrev>Add jobs to calendar</titleabbrev>
 ++++
 
-Adds a job to a calendar.
+Adds an {anomaly-job} to a calendar.
 
 [[ml-put-calendar-job-request]]
 ==== {api-request-title}
@@ -27,8 +27,8 @@ Adds a job to a calendar.
   (Required, string) Identifier for the calendar.
 
 `<job_id>`::
-  (Required, string) An identifier for the job. It can be a job identifier, a
-  group name, or a comma-separated list of jobs or groups.
+  (Required, string) An identifier for the {anomaly-jobs}. It can be a job
+  identifier, a group name, or a comma-separated list of jobs or groups.
 
 [[ml-put-calendar-job-example]]
 ==== {api-examples-title}


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/issues/237

This PR updates the terminology in the Java REST Client and Elasticsearch Reference documentation such that it uses appropriate "anomaly detection job" terminology in the machine learning calendar-related APIs.

It also fixes minor style issues related to the capitalization of titles.