### PR TITLE
Fix issue with Gradle daemons hanging indefinitely on shutdown

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClusterCleanupOnShutdown.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClusterCleanupOnShutdown.java
@@ -19,12 +19,12 @@ public class TestClusterCleanupOnShutdown implements Runnable {
 
     private Set<ElasticsearchCluster> clustersToWatch = new HashSet<>();
 
-    public synchronized void watch(Collection<ElasticsearchCluster> cluster) {
-        clustersToWatch.addAll(cluster);
+    public synchronized void watch(Collection<ElasticsearchCluster> clusters) {
+        clustersToWatch.addAll(clusters);
     }
 
-    public synchronized void unWatch(Collection<ElasticsearchCluster> cluster) {
-        clustersToWatch.removeAll(cluster);
+    public synchronized void unWatch(Collection<ElasticsearchCluster> clusters) {
+        clustersToWatch.removeAll(clusters);
     }
 
     @Override

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClusterCleanupOnShutdown.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClusterCleanupOnShutdown.java
@@ -20,11 +20,11 @@ public class TestClusterCleanupOnShutdown implements Runnable {
     private Set<ElasticsearchCluster> clustersToWatch = new HashSet<>();
 
     public synchronized void watch(Collection<ElasticsearchCluster> cluster) {
-        clustersToWatch.addAll(clustersToWatch);
+        clustersToWatch.addAll(cluster);
     }
 
     public synchronized void unWatch(Collection<ElasticsearchCluster> cluster) {
-        clustersToWatch.removeAll(clustersToWatch);
+        clustersToWatch.removeAll(cluster);
     }
 
     @Override

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClusterCleanupOnShutdown.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClusterCleanupOnShutdown.java
@@ -19,16 +19,12 @@ public class TestClusterCleanupOnShutdown implements Runnable {
 
     private Set<ElasticsearchCluster> clustersToWatch = new HashSet<>();
 
-    public void watch(Collection<ElasticsearchCluster> cluster) {
-        synchronized (clustersToWatch) {
-            clustersToWatch.addAll(clustersToWatch);
-        }
+    public synchronized void watch(Collection<ElasticsearchCluster> cluster) {
+        clustersToWatch.addAll(clustersToWatch);
     }
 
-    public void unWatch(Collection<ElasticsearchCluster> cluster) {
-        synchronized (clustersToWatch) {
-            clustersToWatch.removeAll(clustersToWatch);
-        }
+    public synchronized void unWatch(Collection<ElasticsearchCluster> cluster) {
+        clustersToWatch.removeAll(clustersToWatch);
     }
 
     @Override
@@ -38,21 +34,23 @@ public class TestClusterCleanupOnShutdown implements Runnable {
                 Thread.sleep(Long.MAX_VALUE);
             }
         } catch (InterruptedException interrupted) {
-            synchronized (clustersToWatch) {
-                if (clustersToWatch.isEmpty()) {
-                    return;
-                }
-                logger.info("Cleanup thread was interrupted, shutting down all clusters");
-                Iterator<ElasticsearchCluster> iterator = clustersToWatch.iterator();
-                while (iterator.hasNext()) {
-                    ElasticsearchCluster cluster = iterator.next();
-                    iterator.remove();
-                    try {
-                        cluster.stop(false);
-                    } catch (Exception e) {
-                        logger.warn("Could not shut down {}", cluster, e);
-                    }
-                }
+            shutdownClusters();
+        }
+    }
+
+    public synchronized void shutdownClusters() {
+        if (clustersToWatch.isEmpty()) {
+            return;
+        }
+        logger.info("Cleanup thread was interrupted, shutting down all clusters");
+        Iterator<ElasticsearchCluster> iterator = clustersToWatch.iterator();
+        while (iterator.hasNext()) {
+            ElasticsearchCluster cluster = iterator.next();
+            iterator.remove();
+            try {
+                cluster.stop(false);
+            } catch (Exception e) {
+                logger.warn("Could not shut down {}", cluster, e);
             }
         }
     }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersCleanupExtension.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersCleanupExtension.java
@@ -33,7 +33,6 @@ public class TestClustersCleanupExtension {
         executorService.submit(cleanupThread);
     }
 
-
     public static void createExtension(Project project) {
         if (project.getRootProject().getExtensions().findByType(TestClustersCleanupExtension.class) != null) {
             return;
@@ -43,7 +42,7 @@ public class TestClustersCleanupExtension {
             "__testclusters_rate_limit",
             TestClustersCleanupExtension.class
         );
-        Thread shutdownHook = new Thread(ext.cleanupThread::run);
+        Thread shutdownHook = new Thread(ext.cleanupThread::shutdownClusters);
         Runtime.getRuntime().addShutdownHook(shutdownHook);
         project.getGradle().buildFinished(buildResult -> {
             ext.executorService.shutdownNow();


### PR DESCRIPTION
This PR fixes and issue folks were reporting where Gradle daemons would be hung, such that the processes were still running but commands like `gradle --stop` didn't report them as running. The issue was were were inadvertently registering a shutdown hook that never completes. This caused the daemon on shutdown to unregister itself from the daemon registry (so it would never be reused) but the JVM would never actually exit.