### PR TITLE
[DOCS] Reformat span queries overview

### DIFF
--- a/docs/reference/query-dsl/span-queries.asciidoc
+++ b/docs/reference/query-dsl/span-queries.asciidoc
@@ -56,7 +56,7 @@ Returns documents matching an `include` span query while removing overlapping
 matches from an `exclude` span query.
 
 <<query-dsl-span-or-query,`span_or` query>>::
-Returns documents with spans that match one or more of wrapped span queries.
+Returns documents with spans that match one or more wrapped span queries.
 
 <<query-dsl-span-term-query,`span_term` query>>::
 Matches spans that contain an exact term in a provided field.

--- a/docs/reference/query-dsl/span-queries.asciidoc
+++ b/docs/reference/query-dsl/span-queries.asciidoc
@@ -21,7 +21,7 @@ For nested span queries, you can only set the `boost` parameter on the outermost
 span query.
 
 Compound span queries, like `span_near`, only use matching spans from inner
-queries to find their own spans. <<query-filter-context, Relevance scores>> are
+queries to find their own spans. <<relevance-scores,Relevance scores>> are
 not calculated for inner span queries, which is why the `boost` parameter is not
 allowed.
 

--- a/docs/reference/query-dsl/span-queries.asciidoc
+++ b/docs/reference/query-dsl/span-queries.asciidoc
@@ -28,7 +28,7 @@ allowed.
 
 [float]
 [[span-query-types]]
-=== Types of span queries
+=== Span query types
 
 <<query-dsl-span-containing-query,`span_containing` query>>::
 Returns matching spans from a `big` span query that also match

--- a/docs/reference/query-dsl/span-queries.asciidoc
+++ b/docs/reference/query-dsl/span-queries.asciidoc
@@ -1,53 +1,69 @@
 [[span-queries]]
 == Span queries
 
-Span queries are low-level positional queries which provide expert control
-over the order and proximity of the specified terms. These are typically used
-to implement very specific queries on legal documents or patents.
+Span queries are low-level positional queries that provide precise control over the
+order and proximity of matching terms. Span queries are typically used to
+perform very specific searches on legal documents or patents.
 
-It is only allowed to set boost on an outer span query. Compound span queries,
-like span_near, only use the list of matching spans of inner span queries in
-order to find their own spans, which they then use to produce a score. Scores
-are never computed on inner span queries, which is the reason why boosts are not
-allowed: they only influence the way scores are computed, not spans.
 
-Span queries cannot be mixed with non-span queries (with the exception of the `span_multi` query).
+[float]
+[[span-query-mixes]]
+=== Mixing span queries with other query types
+Except for the `span_multi` query, you cannot use span queries with other query
+types.
 
-The queries in this group are:
+
+[float]
+[[span-query-boosts]]
+=== `boost` for nested span queries
+
+For nested span queries, you can only set the `boost` parameter on the outermost
+span query.
+
+Compound span queries, like `span_near`, only use matching spans from inner
+queries to find their own spans. <<query-filter-context, Relevance scores>> are
+not calculated for inner span queries, which is why the `boost` parameter is not
+allowed.
+
+
+[float]
+[[span-query-types]]
+=== Types of span queries
 
 <<query-dsl-span-containing-query,`span_containing` query>>::
-Accepts a list of span queries, but only returns those spans which also match a second span query.
+Returns matching spans from a `big` span query that also match
+a `little` span query.
 
 <<query-dsl-span-field-masking-query,`field_masking_span` query>>::
-Allows queries like `span-near` or `span-or` across different fields.
+Wraps another span query, letting you use queries like `span_near` or `span_or`
+to search across different fields.
 
 <<query-dsl-span-first-query,`span_first` query>>::
-Accepts another span query whose matches must appear within the first N
-positions of the field.
+Wraps another span query whose returned documents must contain
+matches within the first `N` positions of the field.
 
 <<query-dsl-span-multi-term-query,`span_multi` query>>::
-Wraps a <<query-dsl-term-query,`term`>>, <<query-dsl-range-query,`range`>>,
-<<query-dsl-prefix-query,`prefix`>>, <<query-dsl-wildcard-query,`wildcard`>>,
-<<query-dsl-regexp-query,`regexp`>>, or <<query-dsl-fuzzy-query,`fuzzy`>> query.
+Wraps a <<query-dsl-fuzzy-query, `fuzzy`>>,
+<<query-dsl-prefix-query, `prefix`>>, <<query-dsl-regexp-query, `regexp`>>, or
+<<query-dsl-wildcard-query, `wildcard`>> query, which is run as a span query.
 
 <<query-dsl-span-near-query,`span_near` query>>::
-Accepts multiple span queries whose matches must be within the specified distance of each other, and possibly in the same order.
+Wraps one or more span queries whose matches must be within the specified
+distance of each other, and possibly in the same order.
 
 <<query-dsl-span-not-query,`span_not` query>>::
-Wraps another span query, and excludes any documents which match that query.
+Returns documents matching an `include` span query while removing overlapping
+matches from an `exclude` span query.
 
 <<query-dsl-span-or-query,`span_or` query>>::
-Combines multiple span queries -- returns documents which match any of the
-specified queries.
+Returns documents with spans that match one or more of wrapped span queries.
 
 <<query-dsl-span-term-query,`span_term` query>>::
-
-The equivalent of the <<query-dsl-term-query,`term` query>> but for use with
-other span queries.
+Matches spans that contain an exact term in a provided field.
 
 <<query-dsl-span-within-query,`span_within` query>>::
-The result from a single span query is returned as long is its span falls
-within the spans returned by a list of other span queries.
+Returns spans from a `little` span query that are enclosed in spans matching a
+`big` span query.
 
 
 include::span-containing-query.asciidoc[]


### PR DESCRIPTION
### Changes
* Updates introductory section
* Adds headings for boost and query type mixing
* Rewrites short descriptions for each span query

This is part of #40977, an effort to standardize documentation for query types.

### Preview
http://elasticsearch_44868.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/span-queries.html