### PR TITLE
[7.3] Fix issue with Gradle daemons hanging indefinitely on shutdown (#44867)

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersCleanupExtension.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersCleanupExtension.java
@@ -33,7 +33,6 @@ public class TestClustersCleanupExtension {
         executorService.submit(cleanupThread);
     }
 
-
     public static void createExtension(Project project) {
         if (project.getRootProject().getExtensions().findByType(TestClustersCleanupExtension.class) != null) {
             return;
@@ -43,7 +42,7 @@ public class TestClustersCleanupExtension {
             "__testclusters_rate_limit",
             TestClustersCleanupExtension.class
         );
-        Thread shutdownHook = new Thread(ext.cleanupThread::run);
+        Thread shutdownHook = new Thread(ext.cleanupThread::shutdownClusters);
         Runtime.getRuntime().addShutdownHook(shutdownHook);
         project.getGradle().buildFinished(buildResult -> {
             ext.executorService.shutdownNow();


### PR DESCRIPTION
Backports the following commits to 7.3:
 - Fix issue with Gradle daemons hanging indefinitely on shutdown  (#44867)