### PR TITLE
Assert Not Escaping byte[] from Pooled ByteBuf

### DIFF
--- a/plugins/transport-nio/src/main/java/org/elasticsearch/http/nio/ByteBufUtils.java
+++ b/plugins/transport-nio/src/main/java/org/elasticsearch/http/nio/ByteBufUtils.java
@@ -21,6 +21,7 @@ package org.elasticsearch.http.nio;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefIterator;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -133,6 +134,7 @@ class ByteBufUtils {
         @Override
         public BytesRef toBytesRef() {
             if (buffer.hasArray()) {
+                assert isBufferHierarchyUnpooled(buffer);
                 return new BytesRef(buffer.array(), buffer.arrayOffset() + offset, length);
             }
             final byte[] copy = new byte[length];
@@ -145,6 +147,29 @@ class ByteBufUtils {
             return buffer.capacity();
         }
 
+    }
+
+    /**
+     * Checks if a {@link ByteBuf} is an unpooled buffer or if derived from other buffers is only derived from unpooled buffers.
+     *
+     * @param buffer A byte buffer instance. Must not be null.
+     * @return <code>true</code> iff this byte buffer and all its components have been allocated outside of Netty's buffer pool.
+     */
+    private static boolean isBufferHierarchyUnpooled(ByteBuf buffer) {
+        if (buffer.alloc() instanceof UnpooledByteBufAllocator) {
+            if (buffer instanceof CompositeByteBuf) {
+                CompositeByteBuf compositeBuffer = (CompositeByteBuf) buffer;
+                for(int i = 0; i < compositeBuffer.numComponents(); i++) {
+                    // access the internal component to avoid duplicating the buffer (see CompositeByteBuf#component(int))
+                    if (isBufferHierarchyUnpooled(compositeBuffer.internalComponent(i)) == false) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        } else {
+            return false;
+        }
     }
 
     private static class ByteBufStreamInput extends StreamInput {


### PR DESCRIPTION
* We shouldn't just be using the byte array from poole buffers here. Doing so relies on the fact that we will never use the `BytesRef` after releasing the wrapped `ByteBuf`
* Related to the investigation in #44568 
  * If we're afraid of not copying the `ByteBuf` there because the derived `BytesRef` from it would contain garbage if they were to live beyond releasing the `ByteBuf`, shouldn't we then prevent this (using the array from a pooled buffer to back a `BytesRef` from ever happening?  
  * This PR adds the necessary assertion for that (shamelessly stolen from #32228. I didn't want to actually prevent this (escaping the array from a pooled buffer) from happening yet (technically it would be fine unless we release the buffer too early) because it could have very serious performance implications in production in some cases but figured we should get some visibility on this 