### PR TITLE
[DOCS] Reformat script query

### DIFF
--- a/docs/reference/query-dsl/script-query.asciidoc
+++ b/docs/reference/query-dsl/script-query.asciidoc
@@ -4,12 +4,16 @@
 <titleabbrev>Script</titleabbrev>
 ++++
 
-A query allowing to define
-<<modules-scripting,scripts>> as queries. They are typically used in a filter
-context, for example:
+
+Accepts another query as a <<modules-scripting-using,script>>. `script` queries
+are typically used in a <<query-filter-context,filter context>>.
+
+
+[[script-query-ex-request]]
+==== Example request
 
 [source,js]
-----------------------------------------------
+----
 GET /_search
 {
     "query": {
@@ -25,18 +29,29 @@ GET /_search
         }
     }
 }
-----------------------------------------------
+----
 // CONSOLE
 
-[float]
-==== Custom Parameters
 
-Scripts are compiled and cached for faster execution. If the same script
-can be used, just with different parameters provider, it is preferable
-to use the ability to pass parameters to the script itself, for example:
+[[script-top-level-params]]
+==== Top-level parameters for `script`
+
+`script`::
+(Required, <<modules-scripting-using, script object>>) Contains a script to run
+as a query.
+
+[[script-query-notes]]
+==== Notes
+
+[[script-query-custom-params]]
+===== Custom Parameters
+
+Like <<query-filter-context,filters>>, scripts are cached for faster execution.
+If you frequently change the arguments of a script, we recommend you store them
+in the script's `params` parameter. For example:
 
 [source,js]
-----------------------------------------------
+----
 GET /_search
 {
     "query": {
@@ -55,6 +70,5 @@ GET /_search
         }
     }
 }
-----------------------------------------------
+----
 // CONSOLE
-

--- a/docs/reference/query-dsl/script-query.asciidoc
+++ b/docs/reference/query-dsl/script-query.asciidoc
@@ -37,7 +37,7 @@ GET /_search
 
 `script`::
 (Required, <<modules-scripting-using, script object>>) Contains a script to run
-as a query.
+as a query. This script must return a boolean value, `true` or `false`.
 
 [[script-query-notes]]
 ==== Notes

--- a/docs/reference/query-dsl/script-query.asciidoc
+++ b/docs/reference/query-dsl/script-query.asciidoc
@@ -4,9 +4,8 @@
 <titleabbrev>Script</titleabbrev>
 ++++
 
-
-Accepts another query as a <<modules-scripting-using,script>>. `script` queries
-are typically used in a <<query-filter-context,filter context>>.
+Filter documents based on a provided <<modules-scripting-using,script>>. The
+`script` query is typically used in a <<query-filter-context,filter context>>.
 
 
 [[script-query-ex-request]]

--- a/docs/reference/query-dsl/script-query.asciidoc
+++ b/docs/reference/query-dsl/script-query.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Script</titleabbrev>
 ++++
 
-Filter documents based on a provided <<modules-scripting-using,script>>. The
+Filters documents based on a provided <<modules-scripting-using,script>>. The
 `script` query is typically used in a <<query-filter-context,filter context>>.
 
 


### PR DESCRIPTION
Rewrites the `script` query to use the new query format.

This creates separate sections for the example request and parameters

This is part of #40977, an effort to standardize documentation for query types.

### Preview
http://elasticsearch_44882.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/query-dsl-script-query.html