### PR TITLE
Ensure index is green in SimpleClusterStateIT.testIndicesOptions()

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
@@ -257,6 +257,7 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
         ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().clear().setMetaData(true).setIndices("f*")
                 .get();
         assertThat(clusterStateResponse.getState().metaData().indices().size(), is(2));
+        ensureGreen("fuu");
 
         // close one index
         assertAcked(client().admin().indices().close(Requests.closeIndexRequest("fuu")).get());


### PR DESCRIPTION
SimpleClusterStateIT testIndicesOptions failed in #44817 because it tries to close an index at the beginning of the test. With random index settings, it is possible that the index has a high number of shards (10) and replicas (1), which means that on CI this index can take time to be fully allocated.

The close index request can fail in the case where replicas are still recovering operations. This pull request adds a simple ensureGreen() at the beginning of the test to be sure that all replicas are started before trying to close the index.