### PR TITLE
Limit processors by available processors

### DIFF
--- a/docs/reference/migration/migrate_8_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/settings.asciidoc
@@ -19,4 +19,5 @@ Previously it was possible to set the number of processors used to set the
 default sizes for the thread pools to be more than the number of available
 processors. As this leads to more context switches and more threads but without
 an increase in the number of physical CPUs on which to schedule these additional
-threads, the `processors` setting is now bounded by the number of available processors.
+threads, the `processors` setting is now bounded by the number of available
+processors.

--- a/docs/reference/migration/migrate_8_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/settings.asciidoc
@@ -11,3 +11,12 @@ provided automatic upgrading of these settings to their `cluster.remote`
 counterparts. In 8.0.0, these settings have been removed. Elasticsearch will
 refuse to start if you have these settings in your configuration or cluster
 state.
+
+[float]
+==== `processors` can no longer exceed the available number of processors
+
+Previously it was possible to set the number of processors used to set the
+default sizes for the thread pools to be more than the number of available
+processors. As this leads to more context switches and more threads but without
+an increase in the number of physical CPUs on which to schedule these additional
+threads, the `processors` setting is now bounded by the number of available processors.

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -48,26 +48,14 @@ import java.util.stream.Collectors;
 
 public class EsExecutors {
 
-    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(EsExecutors.class));
-
     /**
      * Setting to manually set the number of available processors. This setting is used to adjust thread pool sizes per node.
      */
-    public static final Setting<Integer> PROCESSORS_SETTING = new Setting<>(
+    public static final Setting<Integer> PROCESSORS_SETTING = Setting.intSetting(
         "processors",
-        s -> Integer.toString(Runtime.getRuntime().availableProcessors()),
-        s -> {
-            final int value = Setting.parseInt(s, 1, "processors");
-            final int availableProcessors = Runtime.getRuntime().availableProcessors();
-            if (value > availableProcessors) {
-                deprecationLogger.deprecatedAndMaybeLog(
-                    "processors",
-                    "setting processors to value [{}] which is more than available processors [{}] is deprecated",
-                    value,
-                    availableProcessors);
-            }
-            return value;
-        },
+        Runtime.getRuntime().availableProcessors(),
+        1,
+        Runtime.getRuntime().availableProcessors(),
         Property.NodeScope);
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -19,10 +19,8 @@
 
 package org.elasticsearch.common.util.concurrent;
 
-import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.SuppressForbidden;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
@@ -34,8 +34,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.Matchers.matchesPattern;
-import static org.hamcrest.Matchers.matchesRegex;
 
 /**
  * Tests for EsExecutors and its components like EsAbortPolicy.

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
@@ -32,7 +32,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.hamcrest.Matchers.matchesRegex;
 
 /**
  * Tests for EsExecutors and its components like EsAbortPolicy.
@@ -386,6 +389,17 @@ public class EsExecutorsTests extends ESTestCase {
             latch.countDown();
             terminate(executor);
         }
+    }
+
+    public void testProcessorsBound() {
+        final int available = Runtime.getRuntime().availableProcessors();
+        final int processors = randomIntBetween(available + 1, Integer.MAX_VALUE);
+        final Settings settings = Settings.builder().put("processors", processors).build();
+        final IllegalArgumentException e =
+            expectThrows(IllegalArgumentException.class, () -> EsExecutors.PROCESSORS_SETTING.get(settings));
+        assertThat(
+            e,
+            hasToString(containsString("Failed to parse value [" + processors + "] for setting [processors] must be <= " + available)));
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/threadpool/ScalingThreadPoolTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ScalingThreadPoolTests.java
@@ -48,7 +48,7 @@ public class ScalingThreadPoolTests extends ESThreadPoolTestCase {
             core = "generic".equals(threadPoolName) ? 4 : 1; // the defaults
         }
 
-        final int processors = randomIntBetween(1, 1 + Runtime.getRuntime().availableProcessors());
+        final int processors = randomIntBetween(1, Runtime.getRuntime().availableProcessors());
         final int maxBasedOnNumberOfProcessors = expectedSize(threadPoolName, processors);
 
         final int expectedMax;

--- a/server/src/test/java/org/elasticsearch/threadpool/ScalingThreadPoolTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ScalingThreadPoolTests.java
@@ -48,18 +48,8 @@ public class ScalingThreadPoolTests extends ESThreadPoolTestCase {
             core = "generic".equals(threadPoolName) ? 4 : 1; // the defaults
         }
 
-        final int availableProcessors = Runtime.getRuntime().availableProcessors();
-        final int maxBasedOnNumberOfProcessors;
-        final int processorsUsed;
-        if (randomBoolean()) {
-            final int processors = randomIntBetween(1, 64);
-            maxBasedOnNumberOfProcessors = expectedSize(threadPoolName, processors);
-            builder.put("processors", processors);
-            processorsUsed = processors;
-        } else {
-            maxBasedOnNumberOfProcessors = expectedSize(threadPoolName, availableProcessors);
-            processorsUsed = availableProcessors;
-        }
+        final int processors = randomIntBetween(1, 1 + Runtime.getRuntime().availableProcessors());
+        final int maxBasedOnNumberOfProcessors = expectedSize(threadPoolName, processors);
 
         final int expectedMax;
         if (maxBasedOnNumberOfProcessors < core || randomBoolean()) {
@@ -98,10 +88,6 @@ public class ScalingThreadPoolTests extends ESThreadPoolTestCase {
             assertThat(esThreadPoolExecutor.getMaximumPoolSize(), equalTo(expectedMax));
         });
 
-        if (processorsUsed > availableProcessors) {
-            assertWarnings("setting processors to value [" + processorsUsed +
-                "] which is more than available processors [" + availableProcessors + "] is deprecated");
-        }
     }
 
     private int expectedSize(final String threadPoolName, final int numberOfProcessors) {


### PR DESCRIPTION
This commit limits the processors setting to be more than the number of available processors.

Relates #44889