### PR TITLE
[DOCS] Adds allow no datafeeds query param to the GET, GET stats and STOP datafeed APIs (7.1-6.3)

### DIFF
--- a/docs/reference/ml/apis/get-datafeed-stats.asciidoc
+++ b/docs/reference/ml/apis/get-datafeed-stats.asciidoc
@@ -43,6 +43,22 @@ IMPORTANT: This API returns a maximum of 10,000 {dfeeds}.
   wildcard expression. If you do not specify one of these options, the API
   returns statistics for all {dfeeds}.
 
+[[ml-get-datafeed-stats-query-parms]]
+==== {api-query-parms-title}
+
+`allow_no_datafeeds`::
+  (Optional, boolean) Specifies what to do when the request:
++
+--
+* Contains wildcard expressions and there are no {datafeeds} that match.
+* Contains the `_all` string or no identifiers and there are no matches.
+* Contains wildcard expressions and there are only partial matches. 
+
+The default value is `true`, which returns an empty `datafeeds` array when
+there are no matches and the subset of results when there are partial matches.
+If this parameter is `false`, the request returns a `404` status code when there
+are no matches or only partial matches.
+--
 
 ==== Results
 
@@ -52,6 +68,12 @@ The API returns the following information:
   (array) An array of {dfeed} count objects.
   For more information, see <<ml-datafeed-counts>>.
 
+[[ml-get-datafeed-stats-response-codes]]
+==== {api-response-codes-title}
+
+`404` (Missing resources)::
+  If `allow_no_datafeeds` is `false`, this code indicates that there are no
+  resources that match the request or only partial matches for the request.
 
 ==== Authorization
 

--- a/docs/reference/ml/apis/get-datafeed.asciidoc
+++ b/docs/reference/ml/apis/get-datafeed.asciidoc
@@ -38,6 +38,22 @@ IMPORTANT: This API returns a maximum of 10,000 {dfeeds}.
   wildcard expression. If you do not specify one of these options, the API
   returns information about all {dfeeds}.
 
+[[ml-get-datafeed-query-parms]]
+==== {api-query-parms-title}
+
+`allow_no_datafeeds`::
+  (Optional, boolean) Specifies what to do when the request:
++
+--
+* Contains wildcard expressions and there are no {datafeeds} that match.
+* Contains the `_all` string or no identifiers and there are no matches.
+* Contains wildcard expressions and there are only partial matches. 
+
+The default value is `true`, which returns an empty `datafeeds` array when
+there are no matches and the subset of results when there are partial matches.
+If this parameter is `false`, the request returns a `404` status code when there
+are no matches or only partial matches.
+--
 
 ==== Results
 
@@ -47,6 +63,12 @@ The API returns the following information:
   (array) An array of {dfeed} objects.
   For more information, see <<ml-datafeed-resource>>.
 
+[[ml-get-datafeed-response-codes]]
+==== {api-response-codes-title}
+
+`404` (Missing resources)::
+  If `allow_no_datafeeds` is `false`, this code indicates that there are no
+  resources that match the request or only partial matches for the request.
 
 ==== Authorization
 

--- a/docs/reference/ml/apis/stop-datafeed.asciidoc
+++ b/docs/reference/ml/apis/stop-datafeed.asciidoc
@@ -35,6 +35,22 @@ comma-separated list of {dfeeds} or a wildcard expression. You can close all
   (string) Identifier for the {dfeed}. It can be a {dfeed} identifier or a
   wildcard expression.
 
+[[ml-stop-datafeed-query-parms]]
+==== {api-query-parms-title}
+
+`allow_no_datafeeds`::
+  (Optional, boolean) Specifies what to do when the request:
++
+--
+* Contains wildcard expressions and there are no {datafeeds} that match.
+* Contains the `_all` string or no identifiers and there are no matches.
+* Contains wildcard expressions and there are only partial matches. 
+
+The default value is `true`, which returns an empty `datafeeds` array when
+there are no matches and the subset of results when there are partial matches.
+If this parameter is `false`, the request returns a `404` status code when there
+are no matches or only partial matches.
+--
 
 ==== Request Body
 
@@ -45,6 +61,12 @@ comma-separated list of {dfeeds} or a wildcard expression. You can close all
   (time) Controls the amount of time to wait until a {dfeed} stops.
   The default value is 20 seconds.
 
+[[ml-stop-datafeed-response-codes]]
+==== {api-response-codes-title}
+
+`404` (Missing resources)::
+  If `allow_no_datafeeds` is `false`, this code indicates that there are no
+  resources that match the request or only partial matches for the request.
 
 ==== Authorization
 


### PR DESCRIPTION
This PR applies the same changes as https://github.com/elastic/elasticsearch/pull/44499. As the folder structure has been changed after 7.1, it is necessary to apply the same changes again in the old structure and backport them down to 6.3.