### PR TITLE
[7.2][DOCS] Adds allow no datafeeds query param to the GET, GET stats and STOP datafeed APIs

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
@@ -42,6 +42,24 @@ IMPORTANT: This API returns a maximum of 10,000 {dfeeds}.
   wildcard expression. If you do not specify one of these options, the API
   returns statistics for all {dfeeds}.
 
+[[ml-get-datafeed-stats-query-parms]]
+==== {api-query-parms-title}
+
+`allow_no_datafeeds`::
+  (Optional, boolean) Specifies what to do when the request:
++
+--
+* Contains wildcard expressions and there are no {datafeeds} that match.
+* Contains the `_all` string or no identifiers and there are no matches.
+* Contains wildcard expressions and there are only partial matches. 
+
+The default value is `true`, which returns an empty `datafeeds` array when
+there are no matches and the subset of results when there are partial matches.
+If this parameter is `false`, the request returns a `404` status code when there
+are no matches or only partial matches.
+--
+
+
 [[ml-get-datafeed-stats-results]]
 ==== {api-response-body-title}
 
@@ -57,6 +75,13 @@ The API returns the following information:
 You must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster
 privileges to use this API. For more information, see
 {stack-ov}/security-privileges.html[Security Privileges].
+
+[[ml-get-datafeed-stats-response-codes]]
+==== {api-response-codes-title}
+
+`404` (Missing resources)::
+  If `allow_no_datafeeds` is `false`, this code indicates that there are no
+  resources that match the request or only partial matches for the request. 
 
 [[ml-get-datafeed-stats-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
@@ -39,6 +39,23 @@ IMPORTANT: This API returns a maximum of 10,000 {dfeeds}.
   wildcard expression. If you do not specify one of these options, the API
   returns information about all {dfeeds}.
 
+[[ml-get-datafeed-query-parms]]
+==== {api-query-parms-title}
+
+`allow_no_datafeeds`::
+  (Optional, boolean) Specifies what to do when the request:
++
+--
+* Contains wildcard expressions and there are no {datafeeds} that match.
+* Contains the `_all` string or no identifiers and there are no matches.
+* Contains wildcard expressions and there are only partial matches. 
+
+The default value is `true`, which returns an empty `datafeeds` array when
+there are no matches and the subset of results when there are partial matches.
+If this parameter is `false`, the request returns a `404` status code when there
+are no matches or only partial matches.
+--
+
 [[ml-get-datafeed-results]]
 ==== {api-response-body-title}
 
@@ -54,6 +71,13 @@ The API returns the following information:
 You must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster
 privileges to use this API. For more information, see
 {stack-ov}/security-privileges.html[Security Privileges].
+
+[[ml-get-datafeed-response-codes]]
+==== {api-response-codes-title}
+
+`404` (Missing resources)::
+  If `allow_no_datafeeds` is `false`, this code indicates that there are no
+  resources that match the request or only partial matches for the request.
 
 [[ml-get-datafeed-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
@@ -36,6 +36,23 @@ comma-separated list of {dfeeds} or a wildcard expression. You can close all
   (string) Identifier for the {dfeed}. It can be a {dfeed} identifier or a
   wildcard expression.
 
+[[ml-stop-datafeed-query-parms]]
+==== {api-query-parms-title}
+
+`allow_no_datafeeds`::
+  (Optional, boolean) Specifies what to do when the request:
++
+--
+* Contains wildcard expressions and there are no {datafeeds} that match.
+* Contains the `_all` string or no identifiers and there are no matches.
+* Contains wildcard expressions and there are only partial matches. 
+
+The default value is `true`, which returns an empty `datafeeds` array when
+there are no matches and the subset of results when there are partial matches.
+If this parameter is `false`, the request returns a `404` status code when there
+are no matches or only partial matches.
+--
+
 [[ml-stop-datafeed-request-body]]
 ==== {api-request-body-title}
 
@@ -52,6 +69,13 @@ comma-separated list of {dfeeds} or a wildcard expression. You can close all
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
 For more information, see
 {stack-ov}/security-privileges.html[Security privileges].
+
+[[ml-stop-datafeed-response-codes]]
+==== {api-response-codes-title}
+
+`404` (Missing resources)::
+  If `allow_no_datafeeds` is `false`, this code indicates that there are no
+  resources that match the request or only partial matches for the request.
 
 [[ml-stop-datafeed-example]]
 ==== {api-examples-title}


### PR DESCRIPTION
This PR adds the `allow_no_datafeeds` parameter under the query parameters section to the GET, GET stats, and STOP datafeed APIs in 7.2.