### PR TITLE
Fix Test Failure in ScalingThreadPoolTests (#44898)

### DIFF
--- a/server/src/test/java/org/elasticsearch/threadpool/ScalingThreadPoolTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ScalingThreadPoolTests.java
@@ -48,13 +48,17 @@ public class ScalingThreadPoolTests extends ESThreadPoolTestCase {
             core = "generic".equals(threadPoolName) ? 4 : 1; // the defaults
         }
 
+        final int availableProcessors = Runtime.getRuntime().availableProcessors();
         final int maxBasedOnNumberOfProcessors;
+        final int processorsUsed;
         if (randomBoolean()) {
             final int processors = randomIntBetween(1, 64);
             maxBasedOnNumberOfProcessors = expectedSize(threadPoolName, processors);
             builder.put("processors", processors);
+            processorsUsed = processors;
         } else {
-            maxBasedOnNumberOfProcessors = expectedSize(threadPoolName, Runtime.getRuntime().availableProcessors());
+            maxBasedOnNumberOfProcessors = expectedSize(threadPoolName, availableProcessors);
+            processorsUsed = availableProcessors;
         }
 
         final int expectedMax;
@@ -93,6 +97,11 @@ public class ScalingThreadPoolTests extends ESThreadPoolTestCase {
             assertThat(info.getMax(), equalTo(expectedMax));
             assertThat(esThreadPoolExecutor.getMaximumPoolSize(), equalTo(expectedMax));
         });
+
+        if (processorsUsed > availableProcessors) {
+            assertWarnings("setting processors to value [" + processorsUsed +
+                "] which is more than available processors [" + availableProcessors + "] is deprecated");
+        }
     }
 
     private int expectedSize(final String threadPoolName, final int numberOfProcessors) {


### PR DESCRIPTION
* Due to #44894 some constellations log a deprecation warning here now
* Fixed by checking for that

back port of #44894 