### PR TITLE
Change version in serialization code in TimingStats.java to 7.4.0

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/TimingStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/TimingStats.java
@@ -128,7 +128,7 @@ public class TimingStats implements ToXContentObject, Writeable {
         this.maxBucketProcessingTimeMs = in.readOptionalDouble();
         this.avgBucketProcessingTimeMs = in.readOptionalDouble();
         this.exponentialAvgBucketProcessingTimeMs = in.readOptionalDouble();
-        if (in.getVersion().onOrAfter(Version.CURRENT)) {  // TODO: Change to V_7_4_0 after backport
+        if (in.getVersion().onOrAfter(Version.V_7_4_0)) {
             this.exponentialAvgCalculationContext = in.readOptionalWriteable(ExponentialAverageCalculationContext::new);
         } else {
             this.exponentialAvgCalculationContext = new ExponentialAverageCalculationContext();
@@ -223,7 +223,7 @@ public class TimingStats implements ToXContentObject, Writeable {
         out.writeOptionalDouble(maxBucketProcessingTimeMs);
         out.writeOptionalDouble(avgBucketProcessingTimeMs);
         out.writeOptionalDouble(exponentialAvgBucketProcessingTimeMs);
-        if (out.getVersion().onOrAfter(Version.CURRENT)) {  // TODO: Change to V_7_4_0 after backport
+        if (out.getVersion().onOrAfter(Version.V_7_4_0)) {
             out.writeOptionalWriteable(exponentialAvgCalculationContext);
         }
     }


### PR DESCRIPTION
Now, that the backport PR for exponential average (https://github.com/elastic/elasticsearch/pull/44897) is merged in, we can change version used by serialization code in TimingStats.java from CURRENT to 7.4.0 to enable BWC tests.

Related to #29857