### PR TITLE
Fix .security-* indices auto-create

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityIndexManager.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityIndexManager.java
@@ -35,15 +35,9 @@ import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.DeprecationHandler;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -70,8 +64,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.metadata.IndexMetaData.INDEX_FORMAT_SETTING;
-import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureFieldName;
 import static org.elasticsearch.xpack.core.ClientHelper.SECURITY_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
@@ -435,17 +427,7 @@ public class SecurityIndexManager implements ClusterStateListener {
     private static Tuple<String, Settings> parseMappingAndSettingsFromTemplateBytes(byte[] template) throws IOException {
         final PutIndexTemplateRequest request = new PutIndexTemplateRequest("name_is_not_important").source(template, XContentType.JSON);
         final String mappingSource = request.mappings().get(MapperService.SINGLE_MAPPING_NAME);
-        try (XContentParser parser = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY,
-                DeprecationHandler.THROW_UNSUPPORTED_OPERATION, mappingSource)) {
-            // remove the type wrapping to get the mapping
-            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation); // {
-            ensureFieldName(parser, parser.nextToken(), MapperService.SINGLE_MAPPING_NAME); // _doc
-            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation); // {
-
-            XContentBuilder builder = JsonXContent.contentBuilder();
-            builder.generator().copyCurrentStructure(parser);
-            return new Tuple<>(Strings.toString(builder), request.settings());
-        }
+        return new Tuple<>(mappingSource, request.settings());
     }
 
     /**


### PR DESCRIPTION
`.security-7` and `.security-tokens-7` are auto-created when they do not exist, using settings and mappings in the plugin resources. This bug is caused by the way we construct the `create-index` request.

Specifically, when there exists an index template that matches these indices, **the mappings in the template override the mappings of the index** (not vice-versa), even if the mappings in the template are empty. The reasons are entirely tied to the intricacies of mapping merging after the typeless remodeling.

For example:
```
curl -u elastic:password -X PUT "localhost:9200/_template/template_1" -H 'Content-Type: application/json' -d'

{
  "index_patterns": [
    "*"
  ],
  "order": 0,
  "mappings": {
    "_meta": {
      "damn": "man",
      "security-version": "8.0.0"
    },
    "properties": {
      "a": {
        "type": "keyword"
      },
      "doc_type": {
        "type": "boolean"
      }
    }
  }
}
'
```
```
curl -u elastic:password -X POST "localhost:9200/_security/oauth2/token" -H 'Content-Type: application/json' -d'
{
  "grant_type" : "client_credentials"
}
'
```
// `.security-tokens-7` is recreated , but errors...
```
curl -u elastic:password -XGET "localhost:9200/.security-tokens-7?pretty"
{
  ".security-tokens-7" : {
    "aliases" : {
      ".security-tokens" : { }
    },
    "mappings" : {
      "_meta" : {
        "damn" : "man",
        "security-version" : "8.0.0"
      },
      "properties" : {
        "a" : {
          "type" : "keyword"
        },
        "doc_type" : {
          "type" : "boolean" // this is conflicting with "keyword"
        }
      }
    },
    "settings" : {
      "index" : {
        "number_of_shards" : "1",
        "auto_expand_replicas" : "0-1",
        "provided_name" : ".security-tokens-7",
        "format" : "7",
        "creation_date" : "1564162015100",
        "priority" : "1000",
        "number_of_replicas" : "0",
        "uuid" : "b1wluz-jQlqZzg19ioZoeQ",
        "version" : {
          "created" : "8000099"
        }
      }
    }
  }
}
```