### PR TITLE
Fix Snapshot CLI Build Portability

### DIFF
--- a/x-pack/snapshot-tool/src/bin/elasticsearch-snapshot
+++ b/x-pack/snapshot-tool/src/bin/elasticsearch-snapshot
@@ -25,4 +25,11 @@ for J in $(cd "${JARS_PATH}/vendor"; ls *.jar); do
   CLASSPATH=${CLASSPATH}${CLASSPATH:+:}${JARS_PATH}/vendor/${J}
 done
 
-exec java -cp "${CLASSPATH}" org.elasticsearch.snapshots.SnapshotToolCli "$@"
+# Give JAVA_HOME precedence over the `java` on the PATH
+if [ ! -z "$JAVA_HOME" ]; then
+  JAVA="$JAVA_HOME/bin/java"
+else
+  JAVA=java
+fi
+
+exec ${JAVA} -cp "${CLASSPATH}" org.elasticsearch.snapshots.SnapshotToolCli "$@"


### PR DESCRIPTION
The snapshot CLI tool does not use the `java` in `JAVA_HOME` but instead uses it from the `PATH` which will lead to some portability issues with the wrong `java` being used as the ES build itself does allow for having a different `java` than what is in `JAVA_HOME` on the `PATH`.



For the discussion here https://github.com/elastic/elasticsearch/pull/44551#discussion_r307497125