### PR TITLE
[GEO] Refactor DeprecatedParameters in AbstractGeometryFieldMapper

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
@@ -192,7 +192,7 @@ public abstract class AbstractGeometryFieldMapper<Parsed, Processed> extends Fie
         }
     }
 
-    protected final static String DEPRECATED_PARAMETERS_KEY = "deprecated_parameters";
+    protected static final String DEPRECATED_PARAMETERS_KEY = "deprecated_parameters";
 
     public static class TypeParser implements Mapper.TypeParser {
         protected boolean parseXContentParameters(String name, Map.Entry<String, Object> entry, Map<String, Object> params)

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
@@ -42,6 +42,7 @@ import org.elasticsearch.index.query.QueryShardException;
 
 import java.io.IOException;
 import java.text.ParseException;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -191,61 +192,73 @@ public abstract class AbstractGeometryFieldMapper<Parsed, Processed> extends Fie
         }
     }
 
+    protected final static String DEPRECATED_PARAMETERS_KEY = "deprecated_parameters";
+
     public static class TypeParser implements Mapper.TypeParser {
+        protected boolean parseXContentParameters(String name, Map.Entry<String, Object> entry, Map<String, Object> params)
+                throws MapperParsingException {
+            if (DeprecatedParameters.parse(name, entry.getKey(), entry.getValue(),
+                (DeprecatedParameters)params.get(DEPRECATED_PARAMETERS_KEY))) {
+                return true;
+            }
+            return false;
+        }
+
+        protected Builder newBuilder(String name, Map<String, Object> params) {
+            if (params.containsKey(DEPRECATED_PARAMETERS_KEY)) {
+                return new LegacyGeoShapeFieldMapper.Builder(name, (DeprecatedParameters)params.get(DEPRECATED_PARAMETERS_KEY));
+            }
+            return new GeoShapeFieldMapper.Builder(name);
+        }
 
         @Override
         public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
-            Boolean coerce = null;
-            Boolean ignoreZ = null;
-            Boolean ignoreMalformed = null;
-            Orientation orientation = null;
-            DeprecatedParameters deprecatedParameters = new DeprecatedParameters();
-            boolean parsedDeprecatedParams = false;
+            Map<String, Object> params = new HashMap<>();
+            boolean parsedDeprecatedParameters = false;
+            params.put(DEPRECATED_PARAMETERS_KEY, new DeprecatedParameters());
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
                 Map.Entry<String, Object> entry = iterator.next();
                 String fieldName = entry.getKey();
                 Object fieldNode = entry.getValue();
-                if (DeprecatedParameters.parse(name, fieldName, fieldNode, deprecatedParameters)) {
-                    parsedDeprecatedParams = true;
+                if (parseXContentParameters(name, entry, params)) {
+                    parsedDeprecatedParameters = true;
                     iterator.remove();
                 } else if (Names.ORIENTATION.match(fieldName, LoggingDeprecationHandler.INSTANCE)) {
-                    orientation = ShapeBuilder.Orientation.fromString(fieldNode.toString());
+                    params.put(Names.ORIENTATION.getPreferredName(), ShapeBuilder.Orientation.fromString(fieldNode.toString()));
                     iterator.remove();
                 } else if (IGNORE_MALFORMED.equals(fieldName)) {
-                    ignoreMalformed = XContentMapValues.nodeBooleanValue(fieldNode, name + ".ignore_malformed");
+                    params.put(IGNORE_MALFORMED, XContentMapValues.nodeBooleanValue(fieldNode, name + ".ignore_malformed"));
                     iterator.remove();
                 } else if (Names.COERCE.match(fieldName, LoggingDeprecationHandler.INSTANCE)) {
-                    coerce = XContentMapValues.nodeBooleanValue(fieldNode, name + "." + Names.COERCE.getPreferredName());
+                    params.put(Names.COERCE.getPreferredName(),
+                        XContentMapValues.nodeBooleanValue(fieldNode, name + "." + Names.COERCE.getPreferredName()));
                     iterator.remove();
                 } else if (GeoPointFieldMapper.Names.IGNORE_Z_VALUE.getPreferredName().equals(fieldName)) {
-                    ignoreZ = XContentMapValues.nodeBooleanValue(fieldNode,
-                        name + "." + GeoPointFieldMapper.Names.IGNORE_Z_VALUE.getPreferredName());
+                    params.put(GeoPointFieldMapper.Names.IGNORE_Z_VALUE.getPreferredName(),
+                        XContentMapValues.nodeBooleanValue(fieldNode,
+                            name + "." + GeoPointFieldMapper.Names.IGNORE_Z_VALUE.getPreferredName()));
                     iterator.remove();
                 }
             }
-            final Builder builder;
-            if (parsedDeprecatedParams) {
-                // Legacy index-based shape
-                builder = new LegacyGeoShapeFieldMapper.Builder(name, deprecatedParameters);
-            } else {
-                // BKD-based shape
-                builder = new GeoShapeFieldMapper.Builder(name);
+            if (parsedDeprecatedParameters == false) {
+                params.remove(DEPRECATED_PARAMETERS_KEY);
+            }
+            Builder builder = newBuilder(name, params);
+
+            if (params.containsKey(Names.COERCE.getPreferredName())) {
+                builder.coerce((Boolean)params.get(Names.COERCE.getPreferredName()));
             }
 
-            if (coerce != null) {
-                builder.coerce(coerce);
+            if (params.containsKey(GeoPointFieldMapper.Names.IGNORE_Z_VALUE.getPreferredName())) {
+                builder.ignoreZValue((Boolean)params.get(GeoPointFieldMapper.Names.IGNORE_Z_VALUE.getPreferredName()));
             }
 
-            if (ignoreZ != null) {
-                builder.ignoreZValue(ignoreZ);
+            if (params.containsKey(IGNORE_MALFORMED)) {
+                builder.ignoreMalformed((Boolean)params.get(IGNORE_MALFORMED));
             }
 
-            if (ignoreMalformed != null) {
-                builder.ignoreMalformed(ignoreMalformed);
-            }
-
-            if (orientation != null) {
-                builder.orientation(orientation);
+            if (params.containsKey(Names.ORIENTATION.getPreferredName())) {
+                builder.orientation((Orientation)params.get(Names.ORIENTATION.getPreferredName()));
             }
 
             return builder;
@@ -300,7 +313,8 @@ public abstract class AbstractGeometryFieldMapper<Parsed, Processed> extends Fie
 
         @Override
         public Query termQuery(Object value, QueryShardContext context) {
-            throw new QueryShardException(context, "Geo fields do not support exact searching, use dedicated geo queries instead");
+            throw new QueryShardException(context,
+                "Geometry fields do not support exact searching, use dedicated geometry queries instead");
         }
 
         public void setGeometryIndexer(Indexer<Parsed, Processed> geometryIndexer) {
@@ -359,6 +373,7 @@ public abstract class AbstractGeometryFieldMapper<Parsed, Processed> extends Fie
 
     @Override
     protected void parseCreateField(ParseContext context, List<IndexableField> fields) throws IOException {
+        throw new UnsupportedOperationException("Parsing is implemented in parse(), this method should NEVER be called");
     }
 
     @Override


### PR DESCRIPTION
Refactors `DeprecatedParameters` (which are specific to legacy `geo_shape` prefix trees) out of `AbstractGeometryFieldMapper.TypeParser#parse`