### PR TITLE
TaskListener#onFailure to accept Exception instead of Throwable

### DIFF
--- a/server/src/main/java/org/elasticsearch/tasks/LoggingTaskListener.java
+++ b/server/src/main/java/org/elasticsearch/tasks/LoggingTaskListener.java
@@ -49,7 +49,7 @@ public final class LoggingTaskListener<Response> implements TaskListener<Respons
     }
 
     @Override
-    public void onFailure(Task task, Throwable e) {
+    public void onFailure(Task task, Exception e) {
         logger.warn(() -> new ParameterizedMessage("{} failed with exception", task.getId()), e);
     }
 }

--- a/server/src/main/java/org/elasticsearch/tasks/TaskListener.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskListener.java
@@ -44,6 +44,6 @@ public interface TaskListener<Response> {
      * @param e
      *            the failure
      */
-    void onFailure(Task task, Throwable e);
+    void onFailure(Task task, Exception e);
 
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestDeleteJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestDeleteJobAction.java
@@ -79,7 +79,7 @@ public class RestDeleteJobAction extends BaseRestHandler {
             public void onResponse(Task task, T o) {}
 
             @Override
-            public void onFailure(Task task, Throwable e) {}
+            public void onFailure(Task task, Exception e) {}
         };
     }
 }


### PR DESCRIPTION
TaskListener accepts today Throwable in its onFailure method. Though
looking at where it is called (TransportAction), it can never be
notified of a Throwable.

This commit changes the signature of TaskListener#onFailure so that it
accepts an `Exception` rather than a `Throwable` as second argument.