### PR TITLE
[DOCS] Amends REST API TOC

### DIFF
--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -14,7 +14,7 @@ not be included yet.
 * <<cat, cat APIs>>
 * <<cluster, Cluster APIs>>
 * <<ccr-apis,{ccr-cap} APIs>>
-* <<data-frame-apis,{dataframe-cap} APIs>>
+* <<data-frame-apis,{dataframe-transform-cap} APIs>>
 * <<docs, Document APIs>>
 * <<graph-explore-api,Graph Explore API>>
 * <<indices, Index APIs>>


### PR DESCRIPTION
This PR changes "Data frame APIs" to "Data frame transform APIs" in the REST APIs TOC.

Related to https://github.com/elastic/elasticsearch/pull/44950.