### PR TITLE
[DOCS] Amends X-Pack APIs TOC

### DIFF
--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -9,7 +9,7 @@ directly to configure and access {xpack} features.
 
 * <<info-api,Info API>>
 * <<ccr-apis,{ccr-cap} APIs>>
-* <<data-frame-apis,{dataframe-cap} APIs>>
+* <<data-frame-apis,{dataframe-transform-cap} APIs>>
 * <<graph-explore-api,Graph Explore API>>
 * <<freeze-index-api>>, <<unfreeze-index-api>>
 * <<index-lifecycle-management-api,Index lifecycle management APIs>>


### PR DESCRIPTION
This PR changes "Data frame APIs" to "Data frame transform APIs" in the X-Pack APIs TOC.

Related to https://github.com/elastic/elasticsearch/pull/44948