### PR TITLE
Mute testParallelRestoreOperations in 6.8 (#44962)

### DIFF
--- a/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -3615,6 +3615,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
     }
 
     public void testParallelRestoreOperations() {
+        assumeFalse("https://github.com/elastic/elasticsearch/issues/44630", Constants.WINDOWS);
         String indexName1 = "testindex1";
         String indexName2 = "testindex2";
         String repoName = "test-restore-snapshot-repo";


### PR DESCRIPTION
* Mute testParallelRestoreOperations on 6.8

* For https://github.com/elastic/elasticsearch/issues/44630, this is already fixed in 7.4+ via https://github.com/elastic/elasticsearch/pull/44096 so I'd just mute it in 7.3 and 7.2, 6.8
* The failure in in #44630 is an exclusive result of of concurrently trying to create the `incompatible-snapshots` snapshots blob whihc isn't an issue in production because the blob would exist there anyway
