### PR TITLE
[7.x][ML] Catch any error thrown while closing data frame analytics p…

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManager.java
@@ -203,7 +203,7 @@ public class AnalyticsProcessManager {
         try {
             processContext.process.close();
             LOGGER.info("[{}] Closed process", configId);
-        } catch (IOException e) {
+        } catch (Exception e) {
             String errorMsg = new ParameterizedMessage("[{}] Error closing data frame analyzer process [{}]"
                 , configId, e.getMessage()).getFormattedMessage();
             processContext.setFailureReason(errorMsg);


### PR DESCRIPTION
…rocess (#44958)

In case closing the process throws an exception we should be catching
it no matter its type. The process may have terminated because of a
fatal error in which case closing the process will throw a server
error, not an `IOException`. If this happens we fail to mark the
persistent task as failed and the task gets in limbo.
