### PR TITLE
[DOCS] Remove X-Pack terminology from installation pages

### DIFF
--- a/docs/reference/setup/install/deb.asciidoc
+++ b/docs/reference/setup/install/deb.asciidoc
@@ -165,10 +165,10 @@ https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-{version}
 endif::[]
 
 ifdef::include-xpack[]
+[role="xpack"]
 [[deb-enable-indices]]
-==== Enable automatic creation of {xpack} indices
+==== Enable automatic creation of system indices
 
-{xpack} will try to automatically create a number of indices within Elasticsearch.
 include::xpack-indices.asciidoc[]
 
 endif::include-xpack[]

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -152,10 +152,10 @@ endif::[]
 include::skip-set-kernel-parameters.asciidoc[]
 
 ifdef::include-xpack[]
+[role="xpack"]
 [[rpm-enable-indices]]
-==== Enable automatic creation of {xpack} indices
+==== Enable automatic creation of system indices
 
-{xpack} will try to automatically create a number of indices within {es}.
 include::xpack-indices.asciidoc[]
 
 endif::include-xpack[]

--- a/docs/reference/setup/install/targz.asciidoc
+++ b/docs/reference/setup/install/targz.asciidoc
@@ -77,10 +77,10 @@ https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-{version}
 endif::[]
 
 ifdef::include-xpack[]
+[role="xpack"]
 [[targz-enable-indices]]
-==== Enable automatic creation of {xpack} indices
+==== Enable automatic creation of system indices
 
-{xpack} will try to automatically create a number of indices within {es}.
 include::xpack-indices.asciidoc[]
 
 endif::include-xpack[]

--- a/docs/reference/setup/install/windows.asciidoc
+++ b/docs/reference/setup/install/windows.asciidoc
@@ -342,11 +342,10 @@ Consult the https://msdn.microsoft.com/en-us/library/windows/desktop/aa367988(v=
 for additional rules related to values containing quotation marks.
 
 ifdef::include-xpack[]
+[role="xpack"]
 [[msi-installer-enable-indices]]
-==== Enable automatic creation of {xpack} indices
+==== Enable automatic creation of system indices
 
-
-The {stack} features try to automatically create a number of indices within {es}.
 include::xpack-indices.asciidoc[]
 
 endif::include-xpack[]

--- a/docs/reference/setup/install/xpack-indices.asciidoc
+++ b/docs/reference/setup/install/xpack-indices.asciidoc
@@ -1,8 +1,9 @@
+Some commercial features automatically create system indices within {es}.
 By default, {es} is configured to allow automatic index creation, and no
 additional steps are required. However, if you have disabled automatic index
 creation in {es}, you must configure
 <<index-creation,`action.auto_create_index`>> in `elasticsearch.yml` to allow
-{xpack} to create the following indices:
+the commercial features to create the following indices:
 
 [source,yaml]
 -----------------------------------------------------------

--- a/docs/reference/setup/install/zip-windows.asciidoc
+++ b/docs/reference/setup/install/zip-windows.asciidoc
@@ -57,10 +57,10 @@ cd c:\elasticsearch-{version}
 endif::[]
 
 ifdef::include-xpack[]
+[role="xpack"]
 [[windows-enable-indices]]
-==== Enable automatic creation of {xpack} indices
+==== Enable automatic creation of system indices
 
-{xpack} will try to automatically create a number of indices within {es}.
 include::xpack-indices.asciidoc[]
 
 endif::include-xpack[]


### PR DESCRIPTION
This PR removes X-Pack terminology from the Elasticsearch Reference's installation pages (e.g. https://www.elastic.co/guide/en/elasticsearch/reference/master/targz.html#targz-enable-indices).

