### PR TITLE
[DOCS] Reformat rank feature query

### DIFF
--- a/docs/reference/query-dsl/query_filter_context.asciidoc
+++ b/docs/reference/query-dsl/query_filter_context.asciidoc
@@ -1,27 +1,38 @@
 [[query-filter-context]]
 == Query and filter context
 
-The behaviour of a query clause depends on whether it is used in _query context_ or
-in _filter context_:
+[float]
+[[relevance-scores]]
+=== Relevance scores
 
-Query context::
-+
---
-A query clause used in query context answers the question ``__How well does this
+By default, Elasticsearch sorts matching search results by **relevance
+score**, which measures how well each document matches a query.
+
+The relevance score is a positive floating point number, returned in the
+`_score` meta-field of the <<search-request-body,search>> API. The higher the
+`_score`, the more relevant the document. While each query type can calculate
+relevance scores differently, score calculation also depends on whether the
+query clause is run in a **query** or **filter** context.
+
+[float]
+[[query-context]]
+=== Query context
+In the query context, a query clause answers the question ``__How well does this
 document match this query clause?__'' Besides deciding whether or not the
-document matches, the query clause also calculates a `_score` representing how
-well the document matches, relative to other documents.
+document matches, the query clause also calculates a relevance score in the
+`_score` meta-field.
 
-Query context is in effect whenever a query clause is passed to a `query` parameter,
-such as the `query` parameter in the <<request-body-search-query,`search`>> API.
---
+Query context is in effect whenever a query clause is passed to a `query`
+parameter, such as the `query` parameter in the
+<<request-body-search-query,search>> API.
 
-Filter context::
-+
---
-In _filter_ context, a query clause answers the question ``__Does this document
-match this query clause?__''  The answer is a simple Yes or No -- no scores are
-calculated.  Filter context is mostly used for filtering structured data, e.g.
+[float]
+[[filter-context]]
+=== Filter context
+In a filter context, a query clause answers the question ``__Does this
+document match this query clause?__''  The answer is a simple Yes or No -- no
+scores are calculated.  Filter context is mostly used for filtering structured
+data, e.g.
 
 *  __Does this +timestamp+ fall into the range 2015 to 2016?__
 *  __Is the +status+  field set to ++"published"++__?
@@ -34,8 +45,10 @@ parameter, such as the `filter` or `must_not` parameters in the
 <<query-dsl-bool-query,`bool`>> query, the `filter` parameter in the
 <<query-dsl-constant-score-query,`constant_score`>> query, or the
 <<search-aggregations-bucket-filter-aggregation,`filter`>> aggregation.
---
 
+[float]
+[[query-filter-context-ex]]
+=== Example of query and filter contexts
 Below is an example of query clauses being used in query and filter context
 in the `search` API.  This query will match documents where all of the following
 conditions are met:

--- a/docs/reference/query-dsl/rank-feature-query.asciidoc
+++ b/docs/reference/query-dsl/rank-feature-query.asciidoc
@@ -12,6 +12,12 @@ The `rank_feature` query is typically used in the `should` clause of a
 <<query-dsl-bool-query,`bool`>> query so its relevance scores are added to other
 scores from the `bool` query.
 
+Unlike the <<query-dsl-function-score-query,`function_score`>> query or other
+ways to change <<query-filter-context,relevance scores>>, the
+`rank_feature` query efficiently skips non-competitive hits when the
+<<search-uri-request,`track_total_hits`>> parameter is **not** `true`. This can
+dramatically improve query speed.
+
 [[rank-feature-query-functions]]
 ==== Rank feature functions
 
@@ -25,7 +31,6 @@ query supports the following mathematical functions:
 If you don't know where to start, we recommend using the `saturation` function.
 If no function is provided, the `rank_feature` query uses the `saturation`
 function by default.
-
 
 [[rank-feature-query-ex-request]]
 ==== Example request
@@ -319,11 +324,3 @@ GET /test/_search
 }
 --------------------------------------------------
 // CONSOLE
-
-[[rank-feature-skip-hits]]
-===== Skip non-competitive hits
-Unlike the <<query-dsl-function-score-query,`function_score`>> query or other
-ways to change <<query-filter-context,relevance scores>>, the
-`rank_feature` query efficiently skips non-competitive hits when the
-<<search-uri-request,`track_total_hits`>> parameter is **not** `true`. This can
-dramatically improve query speed.

--- a/docs/reference/query-dsl/rank-feature-query.asciidoc
+++ b/docs/reference/query-dsl/rank-feature-query.asciidoc
@@ -126,7 +126,6 @@ The following query searches for `2016` and boosts relevance scores based or
 
 [source,js]
 ----
-
 GET /test/_search 
 {
   "query": {

--- a/docs/reference/query-dsl/rank-feature-query.asciidoc
+++ b/docs/reference/query-dsl/rank-feature-query.asciidoc
@@ -43,7 +43,7 @@ To use the `rank_feature` query, your index must include a
 mapping. To see how you can set up an index for the `rank_feature` query, try
 the following example.
 
-. Create a `test` index with the following field mappings:
+Create a `test` index with the following field mappings:
 +
 --
 - `pagerank`, a <<rank-feature,`rank_feature`>> field which measures the
@@ -78,7 +78,7 @@ PUT /test
 // TESTSETUP
 --
 
-. Index several documents to the `test` index.
+Index several documents to the `test` index.
 +
 --
 [source,js]

--- a/docs/reference/query-dsl/rank-feature-query.asciidoc
+++ b/docs/reference/query-dsl/rank-feature-query.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Rank feature</titleabbrev>
 ++++
 
-Boosts the <<query-filter-context,relevance score>> of documents based on the
+Boosts the <<relevance-scores,relevance score>> of documents based on the
 numeric value of a <<rank-feature,`rank_feature`>> or
 <<rank-features,`rank_features`>> field.
 
@@ -13,7 +13,7 @@ The `rank_feature` query is typically used in the `should` clause of a
 scores from the `bool` query.
 
 Unlike the <<query-dsl-function-score-query,`function_score`>> query or other
-ways to change <<query-filter-context,relevance scores>>, the
+ways to change <<relevance-scores,relevance scores>>, the
 `rank_feature` query efficiently skips non-competitive hits when the
 <<search-uri-request,`track_total_hits`>> parameter is **not** `true`. This can
 dramatically improve query speed.
@@ -174,13 +174,13 @@ GET /test/_search
 `field`::
 (Required, string) <<rank-feature,`rank_feature`>> or
 <<rank-features,`rank_features`>> field used to boost
-<<query-filter-context,relevance scores>>.
+<<relevance-scores,relevance scores>>.
 
 `boost`::
 +
 --
 (Optional, float) Floating point number used to decrease or increase
-<<query-filter-context,relevance scores>>. Defaults to `1.0`.
+<<relevance-scores,relevance scores>>. Defaults to `1.0`.
 
 Boost values are relative to the default value of `1.0`. A boost value between
 `0` and `1.0` decreases the relevance score. A value greater than `1.0`
@@ -191,7 +191,7 @@ increases the relevance score.
 +
 --
 (Optional, <<rank-feature-query-saturation,function object>>) Saturation
-function used to boost <<query-filter-context,relevance scores>> based on the
+function used to boost <<relevance-scores,relevance scores>> based on the
 value of the rank feature `field`. If no function is provided, the `rank_feature`
 query defaults to the `saturation` function. See
 <<rank-feature-query-saturation,Saturation>> for more information.
@@ -203,7 +203,7 @@ Only one function `saturation`, `log`, or `sigmoid` can be provided.
 +
 --
 (Optional, <<rank-feature-query-logarithm,function object>>) Logarithmic
-function used to boost <<query-filter-context,relevance scores>> based on the
+function used to boost <<relevance-scores,relevance scores>> based on the
 value of the rank feature `field`. See
 <<rank-feature-query-logarithm,Logarithm>> for more information.
 
@@ -214,7 +214,7 @@ Only one function `saturation`, `log`, or `sigmoid` can be provided.
 +
 --
 (Optional, <<rank-feature-query-sigmoid,function object>>) Sigmoid function used
-to boost <<query-filter-context,relevance scores>> based on the value of the
+to boost <<relevance-scores,relevance scores>> based on the value of the
 rank feature `field`. See <<rank-feature-query-sigmoid,Sigmoid>> for more
 information.
 

--- a/docs/reference/query-dsl/rank-feature-query.asciidoc
+++ b/docs/reference/query-dsl/rank-feature-query.asciidoc
@@ -44,8 +44,7 @@ mapping. To see how you can set up an index for the `rank_feature` query, try
 the following example.
 
 Create a `test` index with the following field mappings:
-+
---
+
 - `pagerank`, a <<rank-feature,`rank_feature`>> field which measures the
 importance of a website
 - `url_length`, a <<rank-feature,`rank_feature`>> field which contains the
@@ -76,11 +75,10 @@ PUT /test
 ----
 // CONSOLE
 // TESTSETUP
---
+
 
 Index several documents to the `test` index.
-+
---
+
 [source,js]
 ----
 PUT /test/_doc/1?refresh
@@ -121,7 +119,6 @@ PUT /test/_doc/3?refresh
 }
 ----
 // CONSOLE
---
 
 [[rank-feature-query-ex-query]]
 ===== Example query

--- a/docs/reference/query-dsl/rank-feature-query.asciidoc
+++ b/docs/reference/query-dsl/rank-feature-query.asciidoc
@@ -233,7 +233,7 @@ parameters.
 The `saturation` function gives a score equal to `S / (S + pivot)`, where `S` is
 the value of the rank feature field and `pivot` is a configurable pivot value so
 that the result will be less than `0.5` if `S` is less than pivot and greater
-than `0.5` otherwise. Scores are always between `0` and `1`.
+than `0.5` otherwise. Scores are always `(0,1)`.
 
 If the rank feature has a negative score impact then the function will be
 computed as `pivot / (S + pivot)`, which decreases when `S` increases.
@@ -302,9 +302,9 @@ GET /test/_search
 The `sigmoid` function is an extension of `saturation` which adds a configurable
 exponent. Scores are computed as `S^exp^ / (S^exp^ + pivot^exp^)`. Like for the
 `saturation` function, `pivot` is the value of `S` that gives a score of `0.5`
-and scores are between `0` and `1`.
+and scores are `(0,1)`.
 
-The `exponent` must be positive and is typically in between `0.5` and `1`. A
+The `exponent` must be positive and is typically in `[0.5, 1]`. A
 good value should be computed via training. If you don't have the opportunity to
 do so, we recommend you use the `saturation` function instead.
 

--- a/docs/reference/query-dsl/rank-feature-query.asciidoc
+++ b/docs/reference/query-dsl/rank-feature-query.asciidoc
@@ -196,8 +196,7 @@ value of the rank feature `field`. If no function is provided, the `rank_feature
 query defaults to the `saturation` function. See
 <<rank-feature-query-saturation,Saturation>> for more information.
 
-You cannot use the `saturation` parameter with the `log` or `sigmoid`
-parameters.
+Only one function `saturation`, `log`, or `sigmoid` can be provided.
 --
 
 `log`::
@@ -208,8 +207,7 @@ function used to boost <<query-filter-context,relevance scores>> based on the
 value of the rank feature `field`. See
 <<rank-feature-query-logarithm,Logarithm>> for more information.
 
-You cannot use the `log` parameter with the `saturation` or `sigmoid`
-parameters.
+Only one function `saturation`, `log`, or `sigmoid` can be provided.
 --
 
 `sigmoid`::
@@ -220,8 +218,7 @@ to boost <<query-filter-context,relevance scores>> based on the value of the
 rank feature `field`. See <<rank-feature-query-sigmoid,Sigmoid>> for more
 information.
 
-You cannot use the `sigmoid` parameter with the `saturation` or `log`
-parameters.
+Only one function `saturation`, `log`, or `sigmoid` can be provided.
 --
 
 

--- a/docs/reference/query-dsl/rank-feature-query.asciidoc
+++ b/docs/reference/query-dsl/rank-feature-query.asciidoc
@@ -4,33 +4,54 @@
 <titleabbrev>Rank feature</titleabbrev>
 ++++
 
-The `rank_feature` query is a specialized query that only works on
-<<rank-feature,`rank_feature`>> fields and <<rank-features,`rank_features`>> fields.
-Its goal is to boost the score of documents based on the values of numeric
-features. It is typically put in a `should` clause of a
-<<query-dsl-bool-query,`bool`>> query so that its score is added to the score
-of the query.
+Boosts the <<query-filter-context,relevance score>> of documents based on the
+numeric value of a <<rank-feature,`rank_feature`>> or
+<<rank-features,`rank_features`>> field.
 
-Compared to using <<query-dsl-function-score-query,`function_score`>> or other
-ways to modify the score, this query has the benefit of being able to
-efficiently skip non-competitive hits when
-<<search-uri-request,`track_total_hits`>> is not set to `true`. Speedups may be
-spectacular.
+The `rank_feature` query is typically used in the `should` clause of a
+<<query-dsl-bool-query,`bool`>> query so its relevance scores are added to other
+scores from the `bool` query.
 
-Here is an example that indexes various features:
- - https://en.wikipedia.org/wiki/PageRank[`pagerank`], a measure of the
-   importance of a website,
- - `url_length`, the length of the url, which typically correlates negatively
-   with relevance,
- - `topics`, which associates a list of topics with every document alongside a
-   measure of how well the document is connected to this topic.
+[[rank-feature-query-functions]]
+==== Rank feature functions
 
-Then the example includes an example query that searches for `"2016"` and boosts
-based or `pagerank`, `url_length` and the `sports` topic.
+To calculate relevance scores based on rank feature fields, the `rank_feature`
+query supports the following mathematical functions:
+
+* <<rank-feature-query-saturation,Saturation>>
+* <<rank-feature-query-logarithm,Logarithm>>
+* <<rank-feature-query-sigmoid,Sigmoid>>
+
+If you don't know where to start, we recommend using the `saturation` function.
+If no function is provided, the `rank_feature` query uses the `saturation`
+function by default.
+
+
+[[rank-feature-query-ex-request]]
+==== Example request
+
+[[rank-feature-query-index-setup]]
+===== Index setup
+
+To use the `rank_feature` query, your index must include a
+<<rank-feature,`rank_feature`>> or <<rank-features,`rank_features`>> field
+mapping. To see how you can set up an index for the `rank_feature` query, try
+the following example.
+
+. Create a `test` index with the following field mappings:
++
+--
+- `pagerank`, a <<rank-feature,`rank_feature`>> field which measures the
+importance of a website
+- `url_length`, a <<rank-feature,`rank_feature`>> field which contains the
+length of the website's URL. For this example, a long URL correlates negatively
+to relevance, indicated by a `positive_score_impact` value of `false`.
+- `topics`, a <<rank-features,`rank_features`>> field which contains a list of
+topics and a measure of how well each document is connected to this topic
 
 [source,js]
---------------------------------------------------
-PUT test
+----
+PUT /test
 {
   "mappings": {
     "properties": {
@@ -47,8 +68,17 @@ PUT test
     }
   }
 }
+----
+// CONSOLE
+// TESTSETUP
+--
 
-PUT test/_doc/1
+. Index several documents to the `test` index.
++
+--
+[source,js]
+----
+PUT /test/_doc/1?refresh
 {
   "url": "http://en.wikipedia.org/wiki/2016_Summer_Olympics",
   "content": "Rio 2016",
@@ -60,10 +90,10 @@ PUT test/_doc/1
   }
 }
 
-PUT test/_doc/2
+PUT /test/_doc/2?refresh
 {
   "url": "http://en.wikipedia.org/wiki/2016_Brazilian_Grand_Prix",
-  "content": "Formula One motor race held on 13 November 2016 at the Autódromo José Carlos Pace in São Paulo, Brazil",
+  "content": "Formula One motor race held on 13 November 2016",
   "pagerank": 50.3,
   "url_length": 47,
   "topics": {
@@ -73,7 +103,7 @@ PUT test/_doc/2
   }
 }
 
-PUT test/_doc/3
+PUT /test/_doc/3?refresh
 {
   "url": "http://en.wikipedia.org/wiki/Deadpool_(film)",
   "content": "Deadpool is a 2016 American superhero film",
@@ -84,10 +114,20 @@ PUT test/_doc/3
     "super hero": 65
   }
 }
+----
+// CONSOLE
+--
 
-POST test/_refresh
+[[rank-feature-query-ex-query]]
+===== Example query
 
-GET test/_search 
+The following query searches for `2016` and boosts relevance scores based or
+`pagerank`, `url_length`, and the `sports` topic.
+
+[source,js]
+----
+
+GET /test/_search 
 {
   "query": {
     "bool": {
@@ -120,31 +160,83 @@ GET test/_search
     }
   }
 }
---------------------------------------------------
+----
 // CONSOLE
 
-[float]
-=== Supported functions
 
-The `rank_feature` query supports 3 functions in order to boost scores using the
-values of rank features. If you do not know where to start, we recommend that you
-start with the `saturation` function, which is the default when no function is
-provided.
+[[rank-feature-top-level-params]]
+==== Top-level parameters for `rank_feature`
 
-[float]
-==== Saturation
+`field`::
+(Required, string) <<rank-feature,`rank_feature`>> or
+<<rank-features,`rank_features`>> field used to boost
+<<query-filter-context,relevance scores>>.
 
-This function gives a score that is equal to `S / (S + pivot)` where `S` is the
-value of the rank feature and `pivot` is a configurable pivot value so that the
-result will be less than +0.5+ if `S` is less than pivot and greater than +0.5+
-otherwise. Scores are always is +(0, 1)+.
+`boost`::
++
+--
+(Optional, float) Floating point number used to decrease or increase
+<<query-filter-context,relevance scores>>. Defaults to `1.0`.
 
-If the rank feature has a negative score impact then the function will be computed as
-`pivot / (S + pivot)`, which decreases when `S` increases.
+Boost values are relative to the default value of `1.0`. A boost value between
+`0` and `1.0` decreases the relevance score. A value greater than `1.0`
+increases the relevance score.
+--
+
+`saturation`::
++
+--
+(Optional, <<rank-feature-query-saturation,function object>>) Saturation
+function used to boost <<query-filter-context,relevance scores>> based on the
+value of the rank feature `field`. If no function is provided, the `rank_feature`
+query defaults to the `saturation` function. See
+<<rank-feature-query-saturation,Saturation>> for more information.
+
+You cannot use the `saturation` parameter with the `log` or `sigmoid`
+parameters.
+--
+
+`log`::
++
+--
+(Optional, <<rank-feature-query-logarithm,function object>>) Logarithmic
+function used to boost <<query-filter-context,relevance scores>> based on the
+value of the rank feature `field`. See
+<<rank-feature-query-logarithm,Logarithm>> for more information.
+
+You cannot use the `log` parameter with the `saturation` or `sigmoid`
+parameters.
+--
+
+`sigmoid`::
++
+--
+(Optional, <<rank-feature-query-sigmoid,function object>>) Sigmoid function used
+to boost <<query-filter-context,relevance scores>> based on the value of the
+rank feature `field`. See <<rank-feature-query-sigmoid,Sigmoid>> for more
+information.
+
+You cannot use the `sigmoid` parameter with the `saturation` or `log`
+parameters.
+--
+
+
+[[rank-feature-query-notes]]
+==== Notes
+
+[[rank-feature-query-saturation]]
+===== Saturation
+The `saturation` function gives a score equal to `S / (S + pivot)`, where `S` is
+the value of the rank feature field and `pivot` is a configurable pivot value so
+that the result will be less than `0.5` if `S` is less than pivot and greater
+than `0.5` otherwise. Scores are always between `0` and `1`.
+
+If the rank feature has a negative score impact then the function will be
+computed as `pivot / (S + pivot)`, which decreases when `S` increases.
 
 [source,js]
 --------------------------------------------------
-GET test/_search
+GET /test/_search
 {
   "query": {
     "rank_feature": {
@@ -157,16 +249,15 @@ GET test/_search
 }
 --------------------------------------------------
 // CONSOLE
-// TEST[continued]
 
-If +pivot+ is not supplied then Elasticsearch will compute a default value that
-will be approximately equal to the geometric mean of all feature values that
-exist in the index. We recommend this if you haven't had the opportunity to
-train a good pivot value.
+If a `pivot` value is not provided, {es} computes a default value equal to the
+approximate geometric mean of all rank feature values in the index. We recommend
+using this default value if you haven't had the opportunity to train a good
+pivot value.
 
 [source,js]
 --------------------------------------------------
-GET test/_search
+GET /test/_search
 {
   "query": {
     "rank_feature": {
@@ -177,20 +268,18 @@ GET test/_search
 }
 --------------------------------------------------
 // CONSOLE
-// TEST[continued]
 
-[float]
-==== Logarithm
-
-This function gives a score that is equal to `log(scaling_factor + S)` where
-`S` is the value of the rank feature and `scaling_factor` is a configurable scaling
-factor. Scores are unbounded.
+[[rank-feature-query-logarithm]]
+===== Logarithm
+The `log` function gives a score equal to `log(scaling_factor + S)`, where `S`
+is the value of the rank feature field and `scaling_factor` is a configurable
+scaling factor. Scores are unbounded.
 
 This function only supports rank features that have a positive score impact.
 
 [source,js]
 --------------------------------------------------
-GET test/_search
+GET /test/_search
 {
   "query": {
     "rank_feature": {
@@ -203,23 +292,21 @@ GET test/_search
 }
 --------------------------------------------------
 // CONSOLE
-// TEST[continued]
 
-[float]
-==== Sigmoid
-
-This function is an extension of `saturation` which adds a configurable
+[[rank-feature-query-sigmoid]]
+===== Sigmoid
+The `sigmoid` function is an extension of `saturation` which adds a configurable
 exponent. Scores are computed as `S^exp^ / (S^exp^ + pivot^exp^)`. Like for the
-`saturation` function, `pivot` is the value of `S` that gives a score of +0.5+
-and scores are in +(0, 1)+.
+`saturation` function, `pivot` is the value of `S` that gives a score of `0.5`
+and scores are between `0` and `1`.
 
-`exponent` must be positive, but is typically in +[0.5, 1]+. A good value should
-be computed via training. If you don't have the opportunity to do so, we recommend
-that you stick to the `saturation` function instead.
+The `exponent` must be positive and is typically in between `0.5` and `1`. A
+good value should be computed via training. If you don't have the opportunity to
+do so, we recommend you use the `saturation` function instead.
 
 [source,js]
 --------------------------------------------------
-GET test/_search
+GET /test/_search
 {
   "query": {
     "rank_feature": {
@@ -233,4 +320,11 @@ GET test/_search
 }
 --------------------------------------------------
 // CONSOLE
-// TEST[continued]
+
+[[rank-feature-skip-hits]]
+===== Skip non-competitive hits
+Unlike the <<query-dsl-function-score-query,`function_score`>> query or other
+ways to change <<query-filter-context,relevance scores>>, the
+`rank_feature` query efficiently skips non-competitive hits when the
+<<search-uri-request,`track_total_hits`>> parameter is **not** `true`. This can
+dramatically improve query speed.


### PR DESCRIPTION
Updates the `rank_feature` query to use the new query format.

This creates separate sections for the example requests, parameters, and notes.

This is part of #40977, an effort to standardize documentation for query types.

### Preview
http://elasticsearch_44975.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/query-dsl-rank-feature-query.html

http://elasticsearch_44975.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/query-filter-context.html