### PR TITLE
[GEO] New ShapeFieldMapper for indexing cartesian geometries

### DIFF
--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -54,6 +54,8 @@ string::         <<text,`text`>> and <<keyword,`keyword`>>
 
 <<flattened>>:: Allows an entire JSON object to be indexed as a single field.
 
+<<shape>>:: `shape` for arbitrary cartesian geometries.
+
 [float]
 [[types-array-handling]]
 === Arrays
@@ -122,3 +124,5 @@ include::types/sparse-vector.asciidoc[]
 include::types/text.asciidoc[]
 
 include::types/token-count.asciidoc[]
+
+include::types/shape.asciidoc[]

--- a/docs/reference/mapping/types/geo-shape.asciidoc
+++ b/docs/reference/mapping/types/geo-shape.asciidoc
@@ -296,7 +296,7 @@ differs from many Geospatial APIs (e.g., Google Maps) that generally
 use the colloquial latitude, longitude (Y, X).
 =============================================
 
-[[geo-point]]
+[[geo-point-type]]
 [float]
 ===== http://geojson.org/geojson-spec.html#id2[Point]
 

--- a/docs/reference/mapping/types/geo-shape.asciidoc
+++ b/docs/reference/mapping/types/geo-shape.asciidoc
@@ -296,7 +296,7 @@ differs from many Geospatial APIs (e.g., Google Maps) that generally
 use the colloquial latitude, longitude (Y, X).
 =============================================
 
-[[point]]
+[[geo-point]]
 [float]
 ===== http://geojson.org/geojson-spec.html#id2[Point]
 
@@ -328,7 +328,7 @@ POST /example/_doc
 // CONSOLE
 
 [float]
-[[linestring]]
+[[geo-linestring]]
 ===== http://geojson.org/geojson-spec.html#id3[LineString]
 
 A `linestring` defined by an array of two or more positions. By
@@ -363,7 +363,7 @@ The above `linestring` would draw a straight line starting at the White
 House to the US Capitol Building.
 
 [float]
-[[polygon]]
+[[geo-polygon]]
 ===== http://www.geojson.org/geojson-spec.html#id4[Polygon]
 
 A polygon is defined by a list of a list of points. The first and last
@@ -480,7 +480,7 @@ POST /example/_doc
 // CONSOLE
 
 [float]
-[[multipoint]]
+[[geo-multipoint]]
 ===== http://www.geojson.org/geojson-spec.html#id5[MultiPoint]
 
 The following is an example of a list of geojson points:
@@ -511,7 +511,7 @@ POST /example/_doc
 // CONSOLE
 
 [float]
-[[multilinestring]]
+[[geo-multilinestring]]
 ===== http://www.geojson.org/geojson-spec.html#id6[MultiLineString]
 
 The following is an example of a list of geojson linestrings:
@@ -544,7 +544,7 @@ POST /example/_doc
 // CONSOLE
 
 [float]
-[[multipolygon]]
+[[geo-multipolygon]]
 ===== http://www.geojson.org/geojson-spec.html#id7[MultiPolygon]
 
 The following is an example of a list of geojson polygons (second polygon contains a hole):
@@ -577,7 +577,7 @@ POST /example/_doc
 // CONSOLE
 
 [float]
-[[geometry_collection]]
+[[geo-geometry_collection]]
 ===== http://geojson.org/geojson-spec.html#geometrycollection[Geometry Collection]
 
 The following is an example of a collection of geojson geometry objects:

--- a/docs/reference/mapping/types/shape.asciidoc
+++ b/docs/reference/mapping/types/shape.asciidoc
@@ -1,0 +1,464 @@
+[role="xpack"]
+[testenv="basic"]
+=== Shape datatype
+++++
+<titleabbrev>Shape</titleabbrev>
+++++
+
+The `shape` datatype facilitates the indexing of and searching
+with arbitrary `x, y` cartesian shapes such as rectangles and polygons. It can be
+used to index and query geometries whose coordinates fall in a 2-dimensional planar
+coordinate system.
+
+[[shape-mapping-options]]
+[float]
+==== Mapping Options
+
+Like the <<geo-shape, geo_shape>> field type, the `shape` field mapping maps
+http://www.geojson.org[GeoJSON] or http://docs.opengeospatial.org/is/12-063r5/12-063r5.html[Well-Known Text]
+(WKT) geometry objects to the shape type. To enable it, users must explicitly map
+fields to the shape type.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Option |Description| Default
+
+|`orientation` |Optionally define how to interpret vertex order for
+polygons / multipolygons.  This parameter defines one of two coordinate
+system rules (Right-hand or Left-hand) each of which can be specified in three
+different ways. 1. Right-hand rule: `right`, `ccw`, `counterclockwise`,
+2. Left-hand rule: `left`, `cw`, `clockwise`. The default orientation
+(`counterclockwise`) complies with the OGC standard which defines
+outer ring vertices in counterclockwise order with inner ring(s) vertices (holes)
+in clockwise order. Setting this parameter in the geo_shape mapping explicitly
+sets vertex order for the coordinate list of a geo_shape field but can be
+overridden in each individual GeoJSON or WKT document.
+| `ccw`
+
+|`ignore_malformed` |If true, malformed GeoJSON or WKT shapes are ignored. If
+false (default), malformed GeoJSON and WKT shapes throw an exception and reject the
+entire document.
+| `false`
+
+|`ignore_z_value` |If `true` (default) three dimension points will be accepted (stored in source)
+but only latitude and longitude values will be indexed; the third dimension is ignored. If `false`,
+geo-points containing any more than latitude and longitude (two dimensions) values throw an exception
+and reject the whole document.
+| `true`
+
+|`coerce` |If `true` unclosed linear rings in polygons will be automatically closed.
+| `false`
+
+|=======================================================================
+
+[[geoshape-indexing-approach]]
+[float]
+==== Indexing approach
+Like `geo_shape`, the `shape` field type is indexed by decomposing geometries into
+a triangular mesh and indexing each triangle as a 7 dimension point in a BKD tree.
+The coordinates provided to the indexer are single precision floating point values so
+the field guarantess the same accuracy provided by the java virtual machine (typically
+`1E-38`). For polygons/multi-polygons the performance of the tessellator primarily
+depends on the number of vertices that define the geometry.
+
+*IMPORTANT NOTES*
+
+The following features are not yet supported:
+
+* `shape` query with `MultiPoint` geometry types - Elasticsearch currently prevents searching
+   `shape` fields with a MultiPoint geometry type to avoid a brute force linear search
+   over each individual point. For now, if this is absolutely needed, this can be achieved
+   using a `bool` query with each individual point. (Note: this could be very costly)
+
+* `CONTAINS` relation query - `shape` queries with `relation` defined as `contains` are not
+   yet supported.
+
+[float]
+===== Example
+
+[source,js]
+--------------------------------------------------
+PUT /example
+{
+    "mappings": {
+        "properties": {
+            "geometry": {
+                "type": "shape"
+            }
+        }
+    }
+}
+--------------------------------------------------
+// CONSOLE
+// TESTSETUP
+
+This mapping definition maps the geometry field to the shape type. The indexer uses single
+precision floats for the vertex values so accuracy is guaranteed to the same precision as
+`float` values provided by the java virtual machine approximately (typically 1E-38).
+
+[[input-structure]]
+[float]
+==== Input Structure
+
+Shapes can be represented using either the http://www.geojson.org[GeoJSON]
+or http://docs.opengeospatial.org/is/12-063r5/12-063r5.html[Well-Known Text]
+(WKT) format. The following table provides a mapping of GeoJSON and WKT
+to Elasticsearch types:
+
+[cols="<,<,<,<",options="header",]
+|=======================================================================
+|GeoJSON Type |WKT Type |Elasticsearch Type |Description
+
+|`Point` |`POINT` |`point` |A single `x, y` coordinate.
+|`LineString` |`LINESTRING` |`linestring` |An arbitrary line given two or more points.
+|`Polygon` |`POLYGON` |`polygon` |A _closed_ polygon whose first and last point
+must match, thus requiring `n + 1` vertices to create an `n`-sided
+polygon and a minimum of `4` vertices.
+|`MultiPoint` |`MULTIPOINT` |`multipoint` |An array of unconnected, but likely related
+points.
+|`MultiLineString` |`MULTILINESTRING` |`multilinestring` |An array of separate linestrings.
+|`MultiPolygon` |`MULTIPOLYGON` |`multipolygon` |An array of separate polygons.
+|`GeometryCollection` |`GEOMETRYCOLLECTION` |`geometrycollection` | A shape collection similar to the
+`multi*` shapes except that multiple types can coexist (e.g., a Point and a LineString).
+|`N/A` |`BBOX` |`envelope` |A bounding rectangle, or envelope, specified by
+specifying only the top left and bottom right points.
+|=======================================================================
+
+[NOTE]
+=============================================
+For all types, both the inner `type` and `coordinates` fields are required.
+
+In GeoJSON and WKT, and therefore Elasticsearch, the correct *coordinate order is (X, Y)*
+within coordinate arrays. This differs from many Geospatial APIs (e.g., `geo_shape`) that
+typically use the colloquial latitude, longitude (Y, X) ordering.
+=============================================
+
+[[point]]
+[float]
+===== http://geojson.org/geojson-spec.html#id2[Point]
+
+A point is a single coordinate in cartesian `x, y` space. It may represent the
+location of an item of interest in a virtual world or projected space. The
+following is an example of a point in GeoJSON.
+
+[source,js]
+--------------------------------------------------
+POST /example/_doc
+{
+    "location" : {
+        "type" : "point",
+        "coordinates" : [-377.03653, 389.897676]
+    }
+}
+--------------------------------------------------
+// CONSOLE
+
+The following is an example of a point in WKT:
+
+[source,js]
+--------------------------------------------------
+POST /example/_doc
+{
+    "location" : "POINT (-377.03653 389.897676)"
+}
+--------------------------------------------------
+// CONSOLE
+
+[float]
+[[linestring]]
+===== http://geojson.org/geojson-spec.html#id3[LineString]
+
+A `linestring` defined by an array of two or more positions. By
+specifying only two points, the `linestring` will represent a straight
+line.  Specifying more than two points creates an arbitrary path. The
+following is an example of a LineString in GeoJSON.
+
+[source,js]
+--------------------------------------------------
+POST /example/_doc
+{
+    "location" : {
+        "type" : "linestring",
+        "coordinates" : [[-377.03653, 389.897676], [-377.009051, 389.889939]]
+    }
+}
+--------------------------------------------------
+// CONSOLE
+
+The following is an example of a LineString in WKT:
+
+[source,js]
+--------------------------------------------------
+POST /example/_doc
+{
+    "location" : "LINESTRING (-377.03653 389.897676, -377.009051 389.889939)"
+}
+--------------------------------------------------
+// CONSOLE
+
+[float]
+[[polygon]]
+===== http://www.geojson.org/geojson-spec.html#id4[Polygon]
+
+A polygon is defined by a list of a list of points. The first and last
+points in each (outer) list must be the same (the polygon must be
+closed). The following is an example of a Polygon in GeoJSON.
+
+[source,js]
+--------------------------------------------------
+POST /example/_doc
+{
+    "location" : {
+        "type" : "polygon",
+        "coordinates" : [
+            [ [1000.0, -1001.0], [1001.0, -1001.0], [1001.0, -1000.0], [1000.0, -1000.0], [1000.0, -1001.0] ]
+        ]
+    }
+}
+--------------------------------------------------
+// CONSOLE
+
+The following is an example of a Polygon in WKT:
+
+[source,js]
+--------------------------------------------------
+POST /example/_doc
+{
+    "location" : "POLYGON ((1000.0 -1001.0, 1001.0 -1001.0, 1001.0 -1000.0, 1000.0 -1000.0, 1000.0 -1001.0))"
+}
+--------------------------------------------------
+// CONSOLE
+
+The first array represents the outer boundary of the polygon, the other
+arrays represent the interior shapes ("holes"). The following is a GeoJSON example
+of a polygon with a hole:
+
+[source,js]
+--------------------------------------------------
+POST /example/_doc
+{
+    "location" : {
+        "type" : "polygon",
+        "coordinates" : [
+            [ [1000.0, -1001.0], [1001.0, -1001.0], [1001.0, -1000.0], [1000.0, -1000.0], [1000.0, -1001.0] ],
+            [ [1000.2, -1001.2], [1000.8, -1001.2], [1000.8, -1001.8], [1000.2, -1001.8], [1000.2, -1001.2] ]
+        ]
+    }
+}
+--------------------------------------------------
+// CONSOLE
+
+The following is an example of a Polygon with a hole in WKT:
+
+[source,js]
+--------------------------------------------------
+POST /example/_doc
+{
+    "location" : "POLYGON ((1000.0 1000.0, 1001.0 1000.0, 1001.0 1001.0, 1000.0 1001.0, 1000.0 1000.0), (1000.2 1000.2, 1000.8 1000.2, 1000.8 1000.8, 1000.2 1000.8, 1000.2 1000.2))"
+}
+--------------------------------------------------
+// CONSOLE
+
+*IMPORTANT NOTE:* WKT does not enforce a specific order for vertices.
+https://tools.ietf.org/html/rfc7946#section-3.1.6[GeoJSON] mandates that the
+outer polygon must be counterclockwise and interior shapes must be clockwise,
+which agrees with the Open Geospatial Consortium (OGC)
+http://www.opengeospatial.org/standards/sfa[Simple Feature Access]
+specification for vertex ordering.
+
+By default Elasticsearch expects vertices in counterclockwise (right hand rule)
+order. If data is provided in clockwise order (left hand rule) the user can change
+the `orientation` parameter either in the field mapping, or as a parameter provided
+with the document.
+
+The following is an example of overriding the `orientation` parameters on a document:
+
+[source,js]
+--------------------------------------------------
+POST /example/_doc
+{
+    "location" : {
+        "type" : "polygon",
+        "orientation" : "clockwise",
+        "coordinates" : [
+            [ [1000.0, 1000.0], [1000.0, 1001.0], [1001.0, 1001.0], [1001.0, 1000.0], [1000.0, 1000.0] ]
+        ]
+    }
+}
+--------------------------------------------------
+// CONSOLE
+
+[float]
+[[multipoint]]
+===== http://www.geojson.org/geojson-spec.html#id5[MultiPoint]
+
+The following is an example of a list of geojson points:
+
+[source,js]
+--------------------------------------------------
+POST /example/_doc
+{
+    "location" : {
+        "type" : "multipoint",
+        "coordinates" : [
+            [1002.0, 1002.0], [1003.0, 2000.0]
+        ]
+    }
+}
+--------------------------------------------------
+// CONSOLE
+
+The following is an example of a list of WKT points:
+
+[source,js]
+--------------------------------------------------
+POST /example/_doc
+{
+    "location" : "MULTIPOINT (1002.0 2000.0, 1003.0 2000.0)"
+}
+--------------------------------------------------
+// CONSOLE
+
+[float]
+[[multilinestring]]
+===== http://www.geojson.org/geojson-spec.html#id6[MultiLineString]
+
+The following is an example of a list of geojson linestrings:
+
+[source,js]
+--------------------------------------------------
+POST /example/_doc
+{
+    "location" : {
+        "type" : "multilinestring",
+        "coordinates" : [
+            [ [1002.0, 200.0], [1003.0, 200.0], [1003.0, 300.0], [1002.0, 300.0] ],
+            [ [1000.0, 100.0], [1001.0, 100.0], [1001.0, 100.0], [1000.0, 100.0] ],
+            [ [1000.2, 100.2], [1000.8, 100.2], [1000.8, 100.8], [1000.2, 100.8] ]
+        ]
+    }
+}
+--------------------------------------------------
+// CONSOLE
+
+The following is an example of a list of WKT linestrings:
+
+[source,js]
+--------------------------------------------------
+POST /example/_doc
+{
+    "location" : "MULTILINESTRING ((1002.0 200.0, 1003.0 200.0, 1003.0 300.0, 1002.0 300.0), (1000.0 100.0, 1001.0 100.0, 1001.0 100.0, 1000.0 100.0), (1000.2 0.2, 1000.8 100.2, 1000.8 100.8, 1000.2 100.8))"
+}
+--------------------------------------------------
+// CONSOLE
+
+[float]
+[[multipolygon]]
+===== http://www.geojson.org/geojson-spec.html#id7[MultiPolygon]
+
+The following is an example of a list of geojson polygons (second polygon contains a hole):
+
+[source,js]
+--------------------------------------------------
+POST /example/_doc
+{
+    "location" : {
+        "type" : "multipolygon",
+        "coordinates" : [
+            [ [[1002.0, 200.0], [1003.0, 200.0], [1003.0, 300.0], [1002.0, 300.0], [1002.0, 200.0]] ],
+            [ [[1000.0, 200.0], [1001.0, 100.0], [1001.0, 100.0], [1000.0, 100.0], [1000.0, 100.0]],
+              [[1000.2, 200.2], [1000.8, 100.2], [1000.8, 100.8], [1000.2, 100.8], [1000.2, 100.2]] ]
+        ]
+    }
+}
+--------------------------------------------------
+// CONSOLE
+
+The following is an example of a list of WKT polygons (second polygon contains a hole):
+
+[source,js]
+--------------------------------------------------
+POST /example/_doc
+{
+    "location" : "MULTIPOLYGON (((1002.0 200.0, 1003.0 200.0, 1003.0 300.0, 1002.0 300.0, 102.0 200.0)), ((1000.0 100.0, 1001.0 100.0, 1001.0 100.0, 1000.0 100.0, 1000.0 100.0), (1000.2 100.2, 1000.8 100.2, 1000.8 100.8, 1000.2 100.8, 1000.2 100.2)))"
+}
+--------------------------------------------------
+// CONSOLE
+
+[float]
+[[geometry_collection]]
+===== http://geojson.org/geojson-spec.html#geometrycollection[Geometry Collection]
+
+The following is an example of a collection of geojson geometry objects:
+
+[source,js]
+--------------------------------------------------
+POST /example/_doc
+{
+    "location" : {
+        "type": "geometrycollection",
+        "geometries": [
+            {
+                "type": "point",
+                "coordinates": [1000.0, 100.0]
+            },
+            {
+                "type": "linestring",
+                "coordinates": [ [1001.0, 100.0], [1002.0, 100.0] ]
+            }
+        ]
+    }
+}
+--------------------------------------------------
+// CONSOLE
+
+The following is an example of a collection of WKT geometry objects:
+
+[source,js]
+--------------------------------------------------
+POST /example/_doc
+{
+    "location" : "GEOMETRYCOLLECTION (POINT (1000.0 100.0), LINESTRING (1001.0 100.0, 1002.0 100.0))"
+}
+--------------------------------------------------
+// CONSOLE
+
+[float]
+===== Envelope
+
+Elasticsearch supports an `envelope` type, which consists of coordinates
+for upper left and lower right points of the shape to represent a
+bounding rectangle in the format `[[minX, maxY], [maxX, minY]]`:
+
+[source,js]
+--------------------------------------------------
+POST /example/_doc
+{
+    "location" : {
+        "type" : "envelope",
+        "coordinates" : [ [1000.0, 100.0], [1001.0, 100.0] ]
+    }
+}
+--------------------------------------------------
+// CONSOLE
+
+The following is an example of an envelope using the WKT BBOX format:
+
+*NOTE:* WKT specification expects the following order: minLon, maxLon, maxLat, minLat.
+
+[source,js]
+--------------------------------------------------
+POST /example/_doc
+{
+    "location" : "BBOX (1000.0, 1002.0, 2000.0, 1000.0)"
+}
+--------------------------------------------------
+// CONSOLE
+
+[float]
+==== Sorting and Retrieving index Shapes
+
+Due to the complex input structure and index representation of shapes,
+it is not currently possible to sort shapes or retrieve their fields
+directly. The `shape` value is only retrievable through the `_source`
+field.

--- a/docs/reference/mapping/types/shape.asciidoc
+++ b/docs/reference/mapping/types/shape.asciidoc
@@ -1,3 +1,4 @@
+[[shape]]
 [role="xpack"]
 [testenv="basic"]
 === Shape datatype

--- a/docs/reference/mapping/types/shape.asciidoc
+++ b/docs/reference/mapping/types/shape.asciidoc
@@ -52,7 +52,7 @@ and reject the whole document.
 
 |=======================================================================
 
-[[geoshape-indexing-approach]]
+[[shape-indexing-approach]]
 [float]
 ==== Indexing approach
 Like `geo_shape`, the `shape` field type is indexed by decomposing geometries into
@@ -97,7 +97,7 @@ This mapping definition maps the geometry field to the shape type. The indexer u
 precision floats for the vertex values so accuracy is guaranteed to the same precision as
 `float` values provided by the java virtual machine approximately (typically 1E-38).
 
-[[input-structure]]
+[[shape-input-structure]]
 [float]
 ==== Input Structure
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
@@ -93,8 +93,13 @@ public abstract class AbstractGeometryFieldMapper<Parsed, Processed> extends Fie
      * interface representing a query builder that generates a query from the given shape
      */
     public interface QueryProcessor {
+        Query process(Geometry shape, String fieldName, ShapeRelation relation, QueryShardContext context);
 
-        Query process(Geometry shape, String fieldName, SpatialStrategy strategy, ShapeRelation relation, QueryShardContext context);
+        @Deprecated
+        default Query process(Geometry shape, String fieldName, SpatialStrategy strategy, ShapeRelation relation,
+                              QueryShardContext context) {
+            return process(shape, fieldName, relation, context);
+        }
     }
 
     public abstract static class Builder<T extends Builder, Y extends AbstractGeometryFieldMapper>
@@ -377,7 +382,7 @@ public abstract class AbstractGeometryFieldMapper<Parsed, Processed> extends Fie
     }
 
     @Override
-    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
+    public void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
         builder.field("type", contentType());
         AbstractGeometryFieldType ft = (AbstractGeometryFieldType)fieldType();
         if (includeDefaults || ft.orientation() != Defaults.ORIENTATION.value()) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
@@ -516,7 +516,7 @@ public class LegacyGeoShapeFieldMapper extends AbstractGeometryFieldMapper<Shape
     }
 
     @Override
-    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
+    public void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
         super.doXContentBody(builder, includeDefaults, params);
 
         if (includeDefaults

--- a/server/src/main/java/org/elasticsearch/index/query/LegacyGeoShapeQueryProcessor.java
+++ b/server/src/main/java/org/elasticsearch/index/query/LegacyGeoShapeQueryProcessor.java
@@ -64,6 +64,11 @@ public class LegacyGeoShapeQueryProcessor implements AbstractGeometryFieldMapper
     }
 
     @Override
+    public Query process(Geometry shape, String fieldName, ShapeRelation relation, QueryShardContext context) {
+        return process(shape, fieldName, LegacyGeoShapeFieldMapper.DeprecatedParameters.Defaults.STRATEGY, relation, context);
+    }
+
+    @Override
     public Query process(Geometry shape, String fieldName, SpatialStrategy strategy, ShapeRelation relation, QueryShardContext context) {
         LegacyGeoShapeFieldMapper.GeoShapeFieldType shapeFieldType = (LegacyGeoShapeFieldMapper.GeoShapeFieldType) ft;
         SpatialStrategy spatialStrategy = shapeFieldType.strategy();

--- a/server/src/main/java/org/elasticsearch/index/query/LegacyGeoShapeQueryProcessor.java
+++ b/server/src/main/java/org/elasticsearch/index/query/LegacyGeoShapeQueryProcessor.java
@@ -65,7 +65,7 @@ public class LegacyGeoShapeQueryProcessor implements AbstractGeometryFieldMapper
 
     @Override
     public Query process(Geometry shape, String fieldName, ShapeRelation relation, QueryShardContext context) {
-        return process(shape, fieldName, LegacyGeoShapeFieldMapper.DeprecatedParameters.Defaults.STRATEGY, relation, context);
+        throw new UnsupportedOperationException("process method should not be called for PrefixTree based geo_shapes");
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
@@ -121,9 +121,6 @@ public class XPackSettings {
     /** Setting for enabling or disabling vectors. Defaults to true. */
     public static final Setting<Boolean> VECTORS_ENABLED = Setting.boolSetting("xpack.vectors.enabled", true, Setting.Property.NodeScope);
 
-    /** Setting for enabling or disabling geo. Defaults to true. */
-    public static final Setting<Boolean> SPATIAL_ENABLED = Setting.boolSetting("xpack.spatial.enabled", true, Setting.Property.NodeScope);
-
     /*
      * SSL settings. These are the settings that are specifically registered for SSL. Many are private as we do not explicitly use them
      * but instead parse based on a prefix (eg *.ssl.*)
@@ -216,7 +213,6 @@ public class XPackSettings {
         settings.add(DATA_FRAME_ENABLED);
         settings.add(FLATTENED_ENABLED);
         settings.add(VECTORS_ENABLED);
-        settings.add(SPATIAL_ENABLED);
         return Collections.unmodifiableList(settings);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
@@ -121,6 +121,9 @@ public class XPackSettings {
     /** Setting for enabling or disabling vectors. Defaults to true. */
     public static final Setting<Boolean> VECTORS_ENABLED = Setting.boolSetting("xpack.vectors.enabled", true, Setting.Property.NodeScope);
 
+    /** Setting for enabling or disabling geo. Defaults to true. */
+    public static final Setting<Boolean> SPATIAL_ENABLED = Setting.boolSetting("xpack.spatial.enabled", true, Setting.Property.NodeScope);
+
     /*
      * SSL settings. These are the settings that are specifically registered for SSL. Many are private as we do not explicitly use them
      * but instead parse based on a prefix (eg *.ssl.*)
@@ -213,6 +216,7 @@ public class XPackSettings {
         settings.add(DATA_FRAME_ENABLED);
         settings.add(FLATTENED_ENABLED);
         settings.add(VECTORS_ENABLED);
+        settings.add(SPATIAL_ENABLED);
         return Collections.unmodifiableList(settings);
     }
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialPlugin.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialPlugin.java
@@ -12,7 +12,6 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.action.XPackInfoFeatureAction;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
 import org.elasticsearch.xpack.spatial.index.mapper.ShapeFieldMapper;
@@ -23,13 +22,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Collections.emptyMap;
-
 public class SpatialPlugin extends Plugin implements ActionPlugin, MapperPlugin {
-    protected final boolean enabled;
 
     public SpatialPlugin(Settings settings) {
-        this.enabled = XPackSettings.SPATIAL_ENABLED.get(settings);
     }
 
     @Override
@@ -41,9 +36,6 @@ public class SpatialPlugin extends Plugin implements ActionPlugin, MapperPlugin 
 
     @Override
     public Map<String, Mapper.TypeParser> getMappers() {
-        if (enabled == false) {
-            return emptyMap();
-        }
         Map<String, Mapper.TypeParser> mappers = new LinkedHashMap<>();
         mappers.put(ShapeFieldMapper.CONTENT_TYPE, new ShapeFieldMapper.TypeParser());
         return Collections.unmodifiableMap(mappers);

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialPlugin.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialPlugin.java
@@ -8,17 +8,28 @@ package org.elasticsearch.xpack.spatial;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.plugins.ActionPlugin;
+import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.action.XPackInfoFeatureAction;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
+import org.elasticsearch.xpack.spatial.index.mapper.ShapeFieldMapper;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
-public class SpatialPlugin extends Plugin implements ActionPlugin {
+import static java.util.Collections.emptyMap;
+
+public class SpatialPlugin extends Plugin implements ActionPlugin, MapperPlugin {
+    protected final boolean enabled;
 
     public SpatialPlugin(Settings settings) {
+        this.enabled = XPackSettings.SPATIAL_ENABLED.get(settings);
     }
 
     @Override
@@ -26,5 +37,15 @@ public class SpatialPlugin extends Plugin implements ActionPlugin {
         return Arrays.asList(
             new ActionPlugin.ActionHandler<>(XPackUsageFeatureAction.SPATIAL, SpatialUsageTransportAction.class),
             new ActionPlugin.ActionHandler<>(XPackInfoFeatureAction.SPATIAL, SpatialInfoTransportAction.class));
+    }
+
+    @Override
+    public Map<String, Mapper.TypeParser> getMappers() {
+        if (enabled == false) {
+            return emptyMap();
+        }
+        Map<String, Mapper.TypeParser> mappers = new LinkedHashMap<>();
+        mappers.put(ShapeFieldMapper.CONTENT_TYPE, new ShapeFieldMapper.TypeParser());
+        return Collections.unmodifiableMap(mappers);
     }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialUsageTransportAction.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialUsageTransportAction.java
@@ -17,7 +17,6 @@ import org.elasticsearch.protocol.xpack.XPackUsageRequest;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureTransportAction;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialUsageTransportAction.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialUsageTransportAction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.protocol.xpack.XPackUsageRequest;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureTransportAction;
@@ -40,7 +41,8 @@ public class SpatialUsageTransportAction extends XPackUsageFeatureTransportActio
     @Override
     protected void masterOperation(Task task, XPackUsageRequest request, ClusterState state,
                                    ActionListener<XPackUsageFeatureResponse> listener) {
-        SpatialFeatureSetUsage usage = new SpatialFeatureSetUsage(licenseState.isSpatialAllowed(), true);
+        SpatialFeatureSetUsage usage =
+            new SpatialFeatureSetUsage(licenseState.isSpatialAllowed(), XPackSettings.SPATIAL_ENABLED.get(settings));
         listener.onResponse(new XPackUsageFeatureResponse(usage));
     }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialUsageTransportAction.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialUsageTransportAction.java
@@ -42,7 +42,7 @@ public class SpatialUsageTransportAction extends XPackUsageFeatureTransportActio
     protected void masterOperation(Task task, XPackUsageRequest request, ClusterState state,
                                    ActionListener<XPackUsageFeatureResponse> listener) {
         SpatialFeatureSetUsage usage =
-            new SpatialFeatureSetUsage(licenseState.isSpatialAllowed(), XPackSettings.SPATIAL_ENABLED.get(settings));
+            new SpatialFeatureSetUsage(licenseState.isSpatialAllowed(), true);
         listener.onResponse(new XPackUsageFeatureResponse(usage));
     }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
@@ -5,32 +5,17 @@
  */
 package org.elasticsearch.xpack.spatial.index.mapper;
 
-import org.apache.lucene.document.Field;
 import org.apache.lucene.document.XYShape;
-import org.apache.lucene.geo.XYLine;
-import org.apache.lucene.geo.XYPolygon;
-import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.geo.GeometryParser;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.geo.geometry.Circle;
 import org.elasticsearch.geo.geometry.Geometry;
-import org.elasticsearch.geo.geometry.GeometryCollection;
-import org.elasticsearch.geo.geometry.GeometryVisitor;
-import org.elasticsearch.geo.geometry.LinearRing;
-import org.elasticsearch.geo.geometry.MultiLine;
-import org.elasticsearch.geo.geometry.MultiPoint;
-import org.elasticsearch.geo.geometry.MultiPolygon;
-import org.elasticsearch.geo.geometry.Point;
 import org.elasticsearch.index.mapper.AbstractGeometryFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperParsingException;
-import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.xpack.spatial.index.query.ShapeQueryProcessor;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Map;
 
 /**
@@ -84,7 +69,7 @@ public class ShapeFieldMapper extends AbstractGeometryFieldMapper<Geometry, Geom
             GeometryParser geometryParser = new GeometryParser(orientation == ShapeBuilder.Orientation.RIGHT,
                 coerce(context).value(), ignoreZValue().value());
 
-            fieldType().setGeometryIndexer(new ShapeIndexer());
+            fieldType().setGeometryIndexer(new ShapeIndexer(fieldType().name()));
             fieldType().setGeometryParser((parser, mapper) -> geometryParser.parse(parser));
             fieldType().setGeometryQueryBuilder(new ShapeQueryProcessor());
         }
@@ -145,125 +130,5 @@ public class ShapeFieldMapper extends AbstractGeometryFieldMapper<Geometry, Geom
     @Override
     public ShapeFieldType fieldType() {
         return (ShapeFieldType) super.fieldType();
-    }
-
-    @Override
-    protected void indexShape(ParseContext context, Geometry shape) {
-        shape.visit(new LuceneGeometryIndexer(context));
-    }
-
-    /** @todo move to {@link ShapeIndexer} after refactor is complete */
-    private class LuceneGeometryIndexer implements GeometryVisitor<Void, RuntimeException> {
-        private ParseContext context;
-
-        private LuceneGeometryIndexer(ParseContext context) {
-            this.context = context;
-        }
-
-        @Override
-        public Void visit(Circle circle) {
-            throw new IllegalArgumentException("invalid shape type found [Circle] while indexing shape");
-        }
-
-        @Override
-        public Void visit(GeometryCollection<?> collection) {
-            for (Geometry geometry : collection) {
-                geometry.visit(this);
-            }
-            return null;
-        }
-
-        @Override
-        public Void visit(org.elasticsearch.geo.geometry.Line line) {
-            float[] x = new float[line.length()];
-            float[] y = new float[x.length];
-            for (int i = 0; i < x.length; ++i) {
-                x[i] = (float)line.getLon(i);
-                y[i] = (float)line.getLat(i);
-            }
-            indexFields(context, XYShape.createIndexableFields(name(), new XYLine(x, y)));
-            return null;
-        }
-
-        @Override
-        public Void visit(LinearRing ring) {
-            throw new IllegalArgumentException("invalid shape type found [LinearRing] while indexing shape");
-        }
-
-        @Override
-        public Void visit(MultiLine multiLine) {
-            for (org.elasticsearch.geo.geometry.Line line : multiLine) {
-                visit(line);
-            }
-            return null;
-        }
-
-        @Override
-        public Void visit(MultiPoint multiPoint) {
-            for(Point point : multiPoint) {
-                visit(point);
-            }
-            return null;
-        }
-
-        @Override
-        public Void visit(MultiPolygon multiPolygon) {
-            for(org.elasticsearch.geo.geometry.Polygon polygon : multiPolygon) {
-                visit(polygon);
-            }
-            return null;
-        }
-
-        @Override
-        public Void visit(Point point) {
-            indexFields(context, XYShape.createIndexableFields(name(), (float)point.getLon(), (float)point.getLat()));
-            return null;
-        }
-
-        @Override
-        public Void visit(org.elasticsearch.geo.geometry.Polygon polygon) {
-            indexFields(context, XYShape.createIndexableFields(name(), toLucenePolygon(polygon)));
-            return null;
-        }
-
-        @Override
-        public Void visit(org.elasticsearch.geo.geometry.Rectangle r) {
-            XYPolygon p = new XYPolygon(
-                new float[]{(float)r.getMinLon(), (float)r.getMaxLon(), (float)r.getMaxLon(), (float)r.getMinLon(), (float)r.getMinLon()},
-                new float[]{(float)r.getMinLat(), (float)r.getMinLat(), (float)r.getMaxLat(), (float)r.getMaxLat(), (float)r.getMinLat()});
-            indexFields(context, XYShape.createIndexableFields(name(), p));
-            return null;
-        }
-
-        private void indexFields(ParseContext context, Field[] fields) {
-            ArrayList<IndexableField> flist = new ArrayList<>(Arrays.asList(fields));
-            createFieldNamesField(context, flist);
-            for (IndexableField f : flist) {
-                context.doc().add(f);
-            }
-        }
-    }
-
-    public static XYPolygon toLucenePolygon(org.elasticsearch.geo.geometry.Polygon polygon) {
-        XYPolygon[] holes = new XYPolygon[polygon.getNumberOfHoles()];
-        LinearRing ring;
-        for(int i = 0; i<holes.length; i++) {
-            ring = polygon.getHole(i);
-            float[] x = new float[ring.length()];
-            float[] y = new float[x.length];
-            for (int j = 0; j < x.length; ++j) {
-                x[j] = (float)ring.getLon(j);
-                y[j] = (float)ring.getLat(j);
-            }
-            holes[i] = new XYPolygon(x, y);
-        }
-        ring = polygon.getPolygon();
-        float[] x = new float[ring.length()];
-        float[] y = new float[x.length];
-        for (int i = 0; i < x.length; ++i) {
-            x[i] = (float)ring.getLon(i);
-            y[i] = (float)ring.getLat(i);
-        }
-        return new XYPolygon(x, y, holes);
     }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.spatial.index.mapper;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.XYShape;
+import org.apache.lucene.geo.XYLine;
+import org.apache.lucene.geo.XYPolygon;
+import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.geo.GeometryParser;
+import org.elasticsearch.common.geo.builders.ShapeBuilder;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.geo.geometry.Circle;
+import org.elasticsearch.geo.geometry.Geometry;
+import org.elasticsearch.geo.geometry.GeometryCollection;
+import org.elasticsearch.geo.geometry.GeometryVisitor;
+import org.elasticsearch.geo.geometry.LinearRing;
+import org.elasticsearch.geo.geometry.MultiLine;
+import org.elasticsearch.geo.geometry.MultiPoint;
+import org.elasticsearch.geo.geometry.MultiPolygon;
+import org.elasticsearch.geo.geometry.Point;
+import org.elasticsearch.index.mapper.AbstractGeometryFieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.xpack.spatial.index.query.ShapeQueryProcessor;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+
+/**
+ * FieldMapper for indexing cartesian {@link XYShape}s.
+ * <p>
+ * Format supported:
+ * <p>
+ * "field" : {
+ * "type" : "polygon",
+ * "coordinates" : [
+ * [ [1050.0, -1000.0], [1051.0, -1000.0], [1051.0, -1001.0], [1050.0, -1001.0], [1050.0, -1000.0] ]
+ * ]
+ * }
+ * <p>
+ * or:
+ * <p>
+ * "field" : "POLYGON ((1050.0 -1000.0, 1051.0 -1000.0, 1051.0 -1001.0, 1050.0 -1001.0, 1050.0 -1000.0))
+ */
+public class ShapeFieldMapper extends AbstractGeometryFieldMapper<Geometry, Geometry> {
+    public static final String CONTENT_TYPE = "shape";
+
+    public static class Defaults extends AbstractGeometryFieldMapper.Defaults {
+        public static final ShapeFieldType FIELD_TYPE = new ShapeFieldType();
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static class Builder extends AbstractGeometryFieldMapper.Builder<AbstractGeometryFieldMapper.Builder, ShapeFieldMapper> {
+
+        public Builder(String name) {
+            super(name, Defaults.FIELD_TYPE, Defaults.FIELD_TYPE);
+            builder = this;
+        }
+
+        @Override
+        public ShapeFieldMapper build(BuilderContext context) {
+            setupFieldType(context);
+            return new ShapeFieldMapper(name, fieldType, defaultFieldType, ignoreMalformed(context), coerce(context),
+                ignoreZValue(), context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
+        }
+
+        @Override
+        public ShapeFieldType fieldType() {
+            return (ShapeFieldType)fieldType;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        protected void setupFieldType(BuilderContext context) {
+            super.setupFieldType(context);
+
+            GeometryParser geometryParser = new GeometryParser(orientation == ShapeBuilder.Orientation.RIGHT,
+                coerce(context).value(), ignoreZValue().value());
+
+            fieldType().setGeometryIndexer(new ShapeIndexer());
+            fieldType().setGeometryParser((parser, mapper) -> geometryParser.parse(parser));
+            fieldType().setGeometryQueryBuilder(new ShapeQueryProcessor());
+        }
+    }
+
+    public static class TypeParser extends AbstractGeometryFieldMapper.TypeParser {
+        @Override
+        protected boolean parseXContentParameters(String name, Map.Entry<String, Object> entry,
+                                                  Map<String, Object> params) throws MapperParsingException {
+            return false;
+        }
+
+        @Override
+        public Builder newBuilder(String name, Map<String, Object> params) {
+            return new Builder(name);
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static final class ShapeFieldType extends AbstractGeometryFieldType {
+        public ShapeFieldType() {
+            super();
+        }
+
+        public ShapeFieldType(ShapeFieldType ref) {
+            super(ref);
+        }
+
+        @Override
+        public ShapeFieldType clone() {
+            return new ShapeFieldType(this);
+        }
+
+        @Override
+        public String typeName() {
+            return CONTENT_TYPE;
+        }
+
+        @Override
+        protected Indexer<Geometry, Geometry> geometryIndexer() {
+            return geometryIndexer;
+        }
+    }
+
+    public ShapeFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType,
+                            Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
+                            Explicit<Boolean> ignoreZValue, Settings indexSettings,
+                            MultiFields multiFields, CopyTo copyTo) {
+        super(simpleName, fieldType, defaultFieldType, ignoreMalformed, coerce, ignoreZValue, indexSettings,
+            multiFields, copyTo);
+    }
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    @Override
+    public ShapeFieldType fieldType() {
+        return (ShapeFieldType) super.fieldType();
+    }
+
+    @Override
+    protected void indexShape(ParseContext context, Geometry shape) {
+        shape.visit(new LuceneGeometryIndexer(context));
+    }
+
+    /** @todo move to {@link ShapeIndexer} after refactor is complete */
+    private class LuceneGeometryIndexer implements GeometryVisitor<Void, RuntimeException> {
+        private ParseContext context;
+
+        private LuceneGeometryIndexer(ParseContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public Void visit(Circle circle) {
+            throw new IllegalArgumentException("invalid shape type found [Circle] while indexing shape");
+        }
+
+        @Override
+        public Void visit(GeometryCollection<?> collection) {
+            for (Geometry geometry : collection) {
+                geometry.visit(this);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visit(org.elasticsearch.geo.geometry.Line line) {
+            float[] x = new float[line.length()];
+            float[] y = new float[x.length];
+            for (int i = 0; i < x.length; ++i) {
+                x[i] = (float)line.getLon(i);
+                y[i] = (float)line.getLat(i);
+            }
+            indexFields(context, XYShape.createIndexableFields(name(), new XYLine(x, y)));
+            return null;
+        }
+
+        @Override
+        public Void visit(LinearRing ring) {
+            throw new IllegalArgumentException("invalid shape type found [LinearRing] while indexing shape");
+        }
+
+        @Override
+        public Void visit(MultiLine multiLine) {
+            for (org.elasticsearch.geo.geometry.Line line : multiLine) {
+                visit(line);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visit(MultiPoint multiPoint) {
+            for(Point point : multiPoint) {
+                visit(point);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visit(MultiPolygon multiPolygon) {
+            for(org.elasticsearch.geo.geometry.Polygon polygon : multiPolygon) {
+                visit(polygon);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visit(Point point) {
+            indexFields(context, XYShape.createIndexableFields(name(), (float)point.getLon(), (float)point.getLat()));
+            return null;
+        }
+
+        @Override
+        public Void visit(org.elasticsearch.geo.geometry.Polygon polygon) {
+            indexFields(context, XYShape.createIndexableFields(name(), toLucenePolygon(polygon)));
+            return null;
+        }
+
+        @Override
+        public Void visit(org.elasticsearch.geo.geometry.Rectangle r) {
+            XYPolygon p = new XYPolygon(
+                new float[]{(float)r.getMinLon(), (float)r.getMaxLon(), (float)r.getMaxLon(), (float)r.getMinLon(), (float)r.getMinLon()},
+                new float[]{(float)r.getMinLat(), (float)r.getMinLat(), (float)r.getMaxLat(), (float)r.getMaxLat(), (float)r.getMinLat()});
+            indexFields(context, XYShape.createIndexableFields(name(), p));
+            return null;
+        }
+
+        private void indexFields(ParseContext context, Field[] fields) {
+            ArrayList<IndexableField> flist = new ArrayList<>(Arrays.asList(fields));
+            createFieldNamesField(context, flist);
+            for (IndexableField f : flist) {
+                context.doc().add(f);
+            }
+        }
+    }
+
+    public static XYPolygon toLucenePolygon(org.elasticsearch.geo.geometry.Polygon polygon) {
+        XYPolygon[] holes = new XYPolygon[polygon.getNumberOfHoles()];
+        LinearRing ring;
+        for(int i = 0; i<holes.length; i++) {
+            ring = polygon.getHole(i);
+            float[] x = new float[ring.length()];
+            float[] y = new float[x.length];
+            for (int j = 0; j < x.length; ++j) {
+                x[j] = (float)ring.getLon(j);
+                y[j] = (float)ring.getLat(j);
+            }
+            holes[i] = new XYPolygon(x, y);
+        }
+        ring = polygon.getPolygon();
+        float[] x = new float[ring.length()];
+        float[] y = new float[x.length];
+        for (int i = 0; i < x.length; ++i) {
+            x[i] = (float)ring.getLon(i);
+            y[i] = (float)ring.getLat(i);
+        }
+        return new XYPolygon(x, y, holes);
+    }
+}

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeIndexer.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeIndexer.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.spatial.index.mapper;
+
+import org.elasticsearch.geo.geometry.Geometry;
+import org.elasticsearch.index.mapper.AbstractGeometryFieldMapper;
+
+public class ShapeIndexer implements AbstractGeometryFieldMapper.Indexer<Geometry, Geometry> {
+
+    @Override
+    public Geometry prepareForIndexing(Geometry geometry) {
+        return geometry;
+    }
+
+    @Override
+    public Class<Geometry> processedClass() {
+        return Geometry.class;
+    }
+}

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeIndexer.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeIndexer.java
@@ -5,10 +5,32 @@
  */
 package org.elasticsearch.xpack.spatial.index.mapper;
 
+import org.apache.lucene.document.XYShape;
+import org.apache.lucene.geo.XYLine;
+import org.apache.lucene.geo.XYPolygon;
+import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.geo.geometry.Circle;
 import org.elasticsearch.geo.geometry.Geometry;
+import org.elasticsearch.geo.geometry.GeometryCollection;
+import org.elasticsearch.geo.geometry.GeometryVisitor;
+import org.elasticsearch.geo.geometry.LinearRing;
+import org.elasticsearch.geo.geometry.MultiLine;
+import org.elasticsearch.geo.geometry.MultiPoint;
+import org.elasticsearch.geo.geometry.MultiPolygon;
+import org.elasticsearch.geo.geometry.Point;
 import org.elasticsearch.index.mapper.AbstractGeometryFieldMapper;
+import org.elasticsearch.index.mapper.ParseContext;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class ShapeIndexer implements AbstractGeometryFieldMapper.Indexer<Geometry, Geometry> {
+    private final String name;
+
+    public ShapeIndexer(String name) {
+        this.name = name;
+    }
 
     @Override
     public Geometry prepareForIndexing(Geometry geometry) {
@@ -18,5 +40,123 @@ public class ShapeIndexer implements AbstractGeometryFieldMapper.Indexer<Geometr
     @Override
     public Class<Geometry> processedClass() {
         return Geometry.class;
+    }
+
+    @Override
+    public List<IndexableField> indexShape(ParseContext context, Geometry shape) {
+        LuceneGeometryVisitor visitor = new LuceneGeometryVisitor(name);
+        shape.visit(visitor);
+        return visitor.fields;
+    }
+
+    private class LuceneGeometryVisitor implements GeometryVisitor<Void, RuntimeException> {
+        private List<IndexableField> fields = new ArrayList<>();
+        private String name;
+
+        private LuceneGeometryVisitor(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public Void visit(Circle circle) {
+            throw new IllegalArgumentException("invalid shape type found [Circle] while indexing shape");
+        }
+
+        @Override
+        public Void visit(GeometryCollection<?> collection) {
+            for (Geometry geometry : collection) {
+                geometry.visit(this);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visit(org.elasticsearch.geo.geometry.Line line) {
+            float[] x = new float[line.length()];
+            float[] y = new float[x.length];
+            for (int i = 0; i < x.length; ++i) {
+                x[i] = (float)line.getLon(i);
+                y[i] = (float)line.getLat(i);
+            }
+            addFields(XYShape.createIndexableFields(name, new XYLine(x, y)));
+            return null;
+        }
+
+        @Override
+        public Void visit(LinearRing ring) {
+            throw new IllegalArgumentException("invalid shape type found [LinearRing] while indexing shape");
+        }
+
+        @Override
+        public Void visit(MultiLine multiLine) {
+            for (org.elasticsearch.geo.geometry.Line line : multiLine) {
+                visit(line);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visit(MultiPoint multiPoint) {
+            for(Point point : multiPoint) {
+                visit(point);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visit(MultiPolygon multiPolygon) {
+            for(org.elasticsearch.geo.geometry.Polygon polygon : multiPolygon) {
+                visit(polygon);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visit(Point point) {
+            addFields(XYShape.createIndexableFields(name, (float)point.getLon(), (float)point.getLat()));
+            return null;
+        }
+
+        @Override
+        public Void visit(org.elasticsearch.geo.geometry.Polygon polygon) {
+            addFields(XYShape.createIndexableFields(name, toLucenePolygon(polygon)));
+            return null;
+        }
+
+        @Override
+        public Void visit(org.elasticsearch.geo.geometry.Rectangle r) {
+            XYPolygon p = new XYPolygon(
+                new float[]{(float)r.getMinLon(), (float)r.getMaxLon(), (float)r.getMaxLon(), (float)r.getMinLon(), (float)r.getMinLon()},
+                new float[]{(float)r.getMinLat(), (float)r.getMinLat(), (float)r.getMaxLat(), (float)r.getMaxLat(), (float)r.getMinLat()});
+            addFields(XYShape.createIndexableFields(name, p));
+            return null;
+        }
+
+        private void addFields(IndexableField[] fields) {
+            this.fields.addAll(Arrays.asList(fields));
+        }
+    }
+
+    public static XYPolygon toLucenePolygon(org.elasticsearch.geo.geometry.Polygon polygon) {
+        XYPolygon[] holes = new XYPolygon[polygon.getNumberOfHoles()];
+        LinearRing ring;
+        for(int i = 0; i<holes.length; i++) {
+            ring = polygon.getHole(i);
+            float[] x = new float[ring.length()];
+            float[] y = new float[x.length];
+            for (int j = 0; j < x.length; ++j) {
+                x[j] = (float)ring.getLon(j);
+                y[j] = (float)ring.getLat(j);
+            }
+            holes[i] = new XYPolygon(x, y);
+        }
+        ring = polygon.getPolygon();
+        float[] x = new float[ring.length()];
+        float[] y = new float[x.length];
+        for (int i = 0; i < x.length; ++i) {
+            x[i] = (float)ring.getLon(i);
+            y[i] = (float)ring.getLat(i);
+        }
+        return new XYPolygon(x, y, holes);
     }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryProcessor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryProcessor.java
@@ -1,29 +1,16 @@
 /*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
  */
+package org.elasticsearch.xpack.spatial.index.query;
 
-package org.elasticsearch.index.query;
-
-import org.apache.lucene.document.LatLonShape;
-import org.apache.lucene.geo.Line;
-import org.apache.lucene.geo.Polygon;
+import org.apache.lucene.document.XYShape;
+import org.apache.lucene.geo.XYLine;
+import org.apache.lucene.geo.XYPolygon;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.geo.GeoShapeType;
@@ -38,13 +25,13 @@ import org.elasticsearch.geo.geometry.MultiPoint;
 import org.elasticsearch.geo.geometry.MultiPolygon;
 import org.elasticsearch.geo.geometry.Point;
 import org.elasticsearch.index.mapper.AbstractGeometryFieldMapper;
-import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
-import org.elasticsearch.index.mapper.GeoShapeIndexer;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.QueryShardException;
 
-import static org.elasticsearch.index.mapper.GeoShapeFieldMapper.toLucenePolygon;
+import static org.elasticsearch.xpack.spatial.index.mapper.ShapeFieldMapper.toLucenePolygon;
 
-public class VectorGeoShapeQueryProcessor implements AbstractGeometryFieldMapper.QueryProcessor {
+public class ShapeQueryProcessor implements AbstractGeometryFieldMapper.QueryProcessor {
 
     @Override
     public Query process(Geometry shape, String fieldName, ShapeRelation relation, QueryShardContext context) {
@@ -53,19 +40,11 @@ public class VectorGeoShapeQueryProcessor implements AbstractGeometryFieldMapper
             throw new QueryShardException(context,
                 ShapeRelation.CONTAINS + " query relation not supported for Field [" + fieldName + "]");
         }
-        // wrap geoQuery as a ConstantScoreQuery
-        return getVectorQueryFromShape(shape, fieldName, relation, context);
-    }
-
-    protected Query getVectorQueryFromShape(Geometry queryShape, String fieldName, ShapeRelation relation, QueryShardContext context) {
-        GeoShapeIndexer geometryIndexer = new GeoShapeIndexer(true);
-
-        Geometry processedShape = geometryIndexer.prepareForIndexing(queryShape);
-
-        if (processedShape == null) {
+        if (shape == null) {
             return new MatchNoDocsQuery();
         }
-        return processedShape.visit(new ShapeVisitor(context, fieldName, relation));
+        // wrap geometry Query as a ConstantScoreQuery
+        return new ConstantScoreQuery(shape.visit(new ShapeVisitor(context, fieldName, relation)));
     }
 
     private class ShapeVisitor implements GeometryVisitor<Query, RuntimeException> {
@@ -106,8 +85,8 @@ public class VectorGeoShapeQueryProcessor implements AbstractGeometryFieldMapper
 
         @Override
         public Query visit(org.elasticsearch.geo.geometry.Line line) {
-            validateIsGeoShapeFieldType();
-            return LatLonShape.newLineQuery(fieldName, relation.getLuceneRelation(), new Line(line.getLats(), line.getLons()));
+            return XYShape.newLineQuery(fieldName, relation.getLuceneRelation(),
+                new XYLine(doubleArrayToFloatArray(line.getLons()), doubleArrayToFloatArray(line.getLats())));
         }
 
         @Override
@@ -117,12 +96,12 @@ public class VectorGeoShapeQueryProcessor implements AbstractGeometryFieldMapper
 
         @Override
         public Query visit(MultiLine multiLine) {
-            validateIsGeoShapeFieldType();
-            Line[] lines = new Line[multiLine.size()];
-            for (int i = 0; i < multiLine.size(); i++) {
-                lines[i] = new Line(multiLine.get(i).getLats(), multiLine.get(i).getLons());
+            XYLine[] lines = new XYLine[multiLine.size()];
+            for (int i=0; i<multiLine.size(); i++) {
+                lines[i] = new XYLine(doubleArrayToFloatArray(multiLine.get(i).getLons()),
+                    doubleArrayToFloatArray(multiLine.get(i).getLats()));
             }
-            return LatLonShape.newLineQuery(fieldName, relation.getLuceneRelation(), lines);
+            return XYShape.newLineQuery(fieldName, relation.getLuceneRelation(), lines);
         }
 
         @Override
@@ -133,38 +112,40 @@ public class VectorGeoShapeQueryProcessor implements AbstractGeometryFieldMapper
 
         @Override
         public Query visit(MultiPolygon multiPolygon) {
-            Polygon[] polygons = new Polygon[multiPolygon.size()];
-            for (int i = 0; i < multiPolygon.size(); i++) {
+            XYPolygon[] polygons = new XYPolygon[multiPolygon.size()];
+            for (int i=0; i<multiPolygon.size(); i++) {
                 polygons[i] = toLucenePolygon(multiPolygon.get(i));
             }
-            return LatLonShape.newPolygonQuery(fieldName, relation.getLuceneRelation(), polygons);
+            return visitMultiPolygon(polygons);
+        }
+
+        private Query visitMultiPolygon(XYPolygon... polygons) {
+            return XYShape.newPolygonQuery(fieldName, relation.getLuceneRelation(), polygons);
         }
 
         @Override
         public Query visit(Point point) {
-            validateIsGeoShapeFieldType();
-            return LatLonShape.newBoxQuery(fieldName, relation.getLuceneRelation(),
-                point.getLat(), point.getLat(), point.getLon(), point.getLon());
+            return XYShape.newBoxQuery(fieldName, relation.getLuceneRelation(),
+                (float)point.getLon(), (float)point.getLon(), (float)point.getLat(), (float)point.getLat());
         }
 
         @Override
         public Query visit(org.elasticsearch.geo.geometry.Polygon polygon) {
-            return LatLonShape.newPolygonQuery(fieldName, relation.getLuceneRelation(), toLucenePolygon(polygon));
+            return XYShape.newPolygonQuery(fieldName, relation.getLuceneRelation(), toLucenePolygon(polygon));
         }
 
         @Override
         public Query visit(org.elasticsearch.geo.geometry.Rectangle r) {
-            return LatLonShape.newBoxQuery(fieldName, relation.getLuceneRelation(),
-                r.getMinLat(), r.getMaxLat(), r.getMinLon(), r.getMaxLon());
-        }
-
-        private void validateIsGeoShapeFieldType() {
-            if (fieldType instanceof GeoShapeFieldMapper.GeoShapeFieldType == false) {
-                throw new QueryShardException(context, "Expected " + GeoShapeFieldMapper.CONTENT_TYPE
-                    + " field type for Field [" + fieldName + "] but found " + fieldType.typeName());
-            }
+            return XYShape.newBoxQuery(fieldName, relation.getLuceneRelation(),
+                (float)r.getMinLon(), (float)r.getMaxLon(), (float)r.getMinLat(), (float)r.getMaxLat());
         }
     }
 
+    private static float[] doubleArrayToFloatArray(double[] array) {
+        float[] result = new float[array.length];
+        for (int i = 0; i < array.length; ++i) {
+            result[i] = (float) array[i];
+        }
+        return result;
+    }
 }
-

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryProcessor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryProcessor.java
@@ -29,7 +29,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.QueryShardException;
 
-import static org.elasticsearch.xpack.spatial.index.mapper.ShapeFieldMapper.toLucenePolygon;
+import static org.elasticsearch.xpack.spatial.index.mapper.ShapeIndexer.toLucenePolygon;
 
 public class ShapeQueryProcessor implements AbstractGeometryFieldMapper.QueryProcessor {
 

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapperTests.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.spatial.index.mapper;
+
+import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.geo.builders.ShapeBuilder;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.mapper.AbstractGeometryFieldMapper;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.DocumentMapperParser;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
+import org.elasticsearch.xpack.core.XPackPlugin;
+import org.elasticsearch.xpack.spatial.SpatialPlugin;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.elasticsearch.index.mapper.GeoPointFieldMapper.Names.IGNORE_Z_VALUE;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+/** testing for {@link org.elasticsearch.xpack.spatial.index.mapper.ShapeFieldMapper} */
+public class ShapeFieldMapperTests extends ESSingleNodeTestCase {
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(InternalSettingsPlugin.class, SpatialPlugin.class, XPackPlugin.class);
+    }
+
+    public void testDefaultConfiguration() throws IOException {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location")
+            .field("type", "shape")
+            .endObject().endObject()
+            .endObject().endObject());
+
+        DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(mapping));
+        Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(ShapeFieldMapper.class));
+
+        ShapeFieldMapper shapeFieldMapper = (ShapeFieldMapper) fieldMapper;
+        assertThat(shapeFieldMapper.fieldType().orientation(),
+            equalTo(ShapeFieldMapper.Defaults.ORIENTATION.value()));
+    }
+
+    /**
+     * Test that orientation parameter correctly parses
+     */
+    public void testOrientationParsing() throws IOException {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location")
+            .field("type", "shape")
+            .field("orientation", "left")
+            .endObject().endObject()
+            .endObject().endObject());
+
+        DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(mapping));
+        Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(ShapeFieldMapper.class));
+
+        ShapeBuilder.Orientation orientation = ((ShapeFieldMapper)fieldMapper).fieldType().orientation();
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.CLOCKWISE));
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.LEFT));
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.CW));
+
+        // explicit right orientation test
+        mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location")
+            .field("type", "shape")
+            .field("orientation", "right")
+            .endObject().endObject()
+            .endObject().endObject());
+
+        defaultMapper = createIndex("test2").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(mapping));
+        fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(ShapeFieldMapper.class));
+
+        orientation = ((ShapeFieldMapper)fieldMapper).fieldType().orientation();
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.COUNTER_CLOCKWISE));
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.RIGHT));
+        assertThat(orientation, equalTo(ShapeBuilder.Orientation.CCW));
+    }
+
+    /**
+     * Test that coerce parameter correctly parses
+     */
+    public void testCoerceParsing() throws IOException {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location")
+            .field("type", "shape")
+            .field("coerce", "true")
+            .endObject().endObject()
+            .endObject().endObject());
+
+        DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(mapping));
+        Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(ShapeFieldMapper.class));
+
+        boolean coerce = ((ShapeFieldMapper)fieldMapper).coerce().value();
+        assertThat(coerce, equalTo(true));
+
+        // explicit false coerce test
+        mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location")
+            .field("type", "shape")
+            .field("coerce", "false")
+            .endObject().endObject()
+            .endObject().endObject());
+
+        defaultMapper = createIndex("test2").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(mapping));
+        fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(ShapeFieldMapper.class));
+
+        coerce = ((ShapeFieldMapper)fieldMapper).coerce().value();
+        assertThat(coerce, equalTo(false));
+        assertFieldWarnings("tree");
+    }
+
+
+    /**
+     * Test that accept_z_value parameter correctly parses
+     */
+    public void testIgnoreZValue() throws IOException {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location")
+            .field("type", "shape")
+            .field(IGNORE_Z_VALUE.getPreferredName(), "true")
+            .endObject().endObject()
+            .endObject().endObject());
+
+        DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(mapping));
+        Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(ShapeFieldMapper.class));
+
+        boolean ignoreZValue = ((ShapeFieldMapper)fieldMapper).ignoreZValue().value();
+        assertThat(ignoreZValue, equalTo(true));
+
+        // explicit false accept_z_value test
+        mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location")
+            .field("type", "shape")
+            .field(IGNORE_Z_VALUE.getPreferredName(), "false")
+            .endObject().endObject()
+            .endObject().endObject());
+
+        defaultMapper = createIndex("test2").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(mapping));
+        fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(ShapeFieldMapper.class));
+
+        ignoreZValue = ((ShapeFieldMapper)fieldMapper).ignoreZValue().value();
+        assertThat(ignoreZValue, equalTo(false));
+    }
+
+    /**
+     * Test that ignore_malformed parameter correctly parses
+     */
+    public void testIgnoreMalformedParsing() throws IOException {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location")
+            .field("type", "shape")
+            .field("ignore_malformed", "true")
+            .endObject().endObject()
+            .endObject().endObject());
+
+        DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(mapping));
+        Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(ShapeFieldMapper.class));
+
+        Explicit<Boolean> ignoreMalformed = ((ShapeFieldMapper)fieldMapper).ignoreMalformed();
+        assertThat(ignoreMalformed.value(), equalTo(true));
+
+        // explicit false ignore_malformed test
+        mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location")
+            .field("type", "shape")
+            .field("ignore_malformed", "false")
+            .endObject().endObject()
+            .endObject().endObject());
+
+        defaultMapper = createIndex("test2").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(mapping));
+        fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(ShapeFieldMapper.class));
+
+        ignoreMalformed = ((ShapeFieldMapper)fieldMapper).ignoreMalformed();
+        assertThat(ignoreMalformed.explicit(), equalTo(true));
+        assertThat(ignoreMalformed.value(), equalTo(false));
+    }
+
+
+    private void assertFieldWarnings(String... fieldNames) {
+        String[] warnings = new String[fieldNames.length];
+        for (int i = 0; i < fieldNames.length; ++i) {
+            warnings[i] = "Field parameter [" + fieldNames[i] + "] "
+                + "is deprecated and will be removed in a future version.";
+        }
+    }
+
+    public void testShapeMapperMerge() throws Exception {
+        String stage1Mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type").startObject("properties")
+            .startObject("shape").field("type", "shape")
+            .field("orientation", "ccw")
+            .endObject().endObject().endObject().endObject());
+        MapperService mapperService = createIndex("test").mapperService();
+        DocumentMapper docMapper = mapperService.merge("type", new CompressedXContent(stage1Mapping),
+            MapperService.MergeReason.MAPPING_UPDATE);
+        String stage2Mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
+            .startObject("properties").startObject("shape").field("type", "shape")
+            .field("orientation", "cw").endObject().endObject().endObject().endObject());
+        mapperService.merge("type", new CompressedXContent(stage2Mapping), MapperService.MergeReason.MAPPING_UPDATE);
+
+        // verify nothing changed
+        Mapper fieldMapper = docMapper.mappers().getMapper("shape");
+        assertThat(fieldMapper, instanceOf(ShapeFieldMapper.class));
+
+        ShapeFieldMapper ShapeFieldMapper = (ShapeFieldMapper) fieldMapper;
+        assertThat(ShapeFieldMapper.fieldType().orientation(), equalTo(ShapeBuilder.Orientation.CCW));
+
+        // change mapping; orientation
+        stage2Mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
+            .startObject("properties").startObject("shape").field("type", "shape")
+            .field("orientation", "cw").endObject().endObject().endObject().endObject());
+        docMapper = mapperService.merge("type", new CompressedXContent(stage2Mapping), MapperService.MergeReason.MAPPING_UPDATE);
+
+        fieldMapper = docMapper.mappers().getMapper("shape");
+        assertThat(fieldMapper, instanceOf(ShapeFieldMapper.class));
+
+        ShapeFieldMapper shapeFieldMapper = (ShapeFieldMapper) fieldMapper;
+        assertThat(shapeFieldMapper.fieldType().orientation(), equalTo(ShapeBuilder.Orientation.CW));
+    }
+
+    public void testEmptyName() throws Exception {
+        // after 5.x
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("")
+            .field("type", "shape")
+            .endObject().endObject()
+            .endObject().endObject());
+        DocumentMapperParser parser = createIndex("test").mapperService().documentMapperParser();
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            () -> parser.parse("type1", new CompressedXContent(mapping))
+        );
+        assertThat(e.getMessage(), containsString("name cannot be empty string"));
+    }
+
+    public void testSerializeDefaults() throws Exception {
+        DocumentMapperParser parser = createIndex("test").mapperService().documentMapperParser();
+        {
+            String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+                .startObject("properties").startObject("location")
+                .field("type", "shape")
+                .endObject().endObject()
+                .endObject().endObject());
+            DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
+            String serialized = toXContentString((ShapeFieldMapper) defaultMapper.mappers().getMapper("location"));
+            assertTrue(serialized, serialized.contains("\"orientation\":\"" +
+                AbstractGeometryFieldMapper.Defaults.ORIENTATION.value() + "\""));
+        }
+    }
+
+    public String toXContentString(ShapeFieldMapper mapper, boolean includeDefaults) throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        ToXContent.Params params;
+        if (includeDefaults) {
+            params = new ToXContent.MapParams(Collections.singletonMap("include_defaults", "true"));
+        } else {
+            params = ToXContent.EMPTY_PARAMS;
+        }
+        mapper.doXContentBody(builder, includeDefaults, params);
+        return Strings.toString(builder.endObject());
+    }
+
+    public String toXContentString(ShapeFieldMapper mapper) throws IOException {
+        return toXContentString(mapper, true);
+    }
+}


### PR DESCRIPTION
This PR adds a new `ShapeFieldMapper` to the xpack spatial module for indexing arbitrary cartesian geometries using a new field type called `shape`.

The indexing approach leverages lucene's new `XYShape` field type which is backed by BKD in the same manner as `LatLonShape` but without the WGS84 latitude longitude restrictions. The new field mapper builds on and extends the refactoring effort in `AbstractGeometryFieldMapper` and accepts shapes in either GeoJSON or WKT format (both of which support non geospatial geometries).

Tests are provided in the `ShapeFieldMapperTests` class in the same manner as `GeoShapeFieldMapperTests` and `LegacyGeoShapeFieldMapperTests`.

Documentation for how to use the new field type and what parameters are accepted is also provided. QueryBuilder is provided in a separate PR.