### PR TITLE
[DOCS] Updates terms in machine learning get APIs

### DIFF
--- a/docs/java-rest/high-level/ml/get-buckets.asciidoc
+++ b/docs/java-rest/high-level/ml/get-buckets.asciidoc
@@ -4,14 +4,14 @@
 :response: GetBucketsResponse
 --
 [id="{upid}-{api}"]
-=== Get Buckets API
+=== Get buckets API
 
-The Get Buckets API retrieves one or more bucket results.
+Retrieves one or more bucket results.
 It accepts a +{request}+ object and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Get Buckets Request
+==== Get buckets request
 
 A +{request}+ object gets created with an existing non-null `jobId`.
 
@@ -19,9 +19,9 @@ A +{request}+ object gets created with an existing non-null `jobId`.
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
-<1> Constructing a new request referencing an existing `jobId`
+<1> Constructing a new request referencing an existing `jobId`.
 
-==== Optional Arguments
+==== Optional arguments
 The following arguments are optional:
 
 ["source","java",subs="attributes,callouts,macros"]
@@ -82,7 +82,7 @@ include-tagged::{doc-tests-file}[{api}-start]
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
-==== Get Buckets Response
+==== Get buckets response
 
 The returned +{response}+ contains the requested buckets:
 
@@ -90,5 +90,5 @@ The returned +{response}+ contains the requested buckets:
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
-<1> The count of buckets that were matched
-<2> The buckets retrieved
+<1> The count of buckets that were matched.
+<2> The buckets retrieved.

--- a/docs/java-rest/high-level/ml/get-calendar-events.asciidoc
+++ b/docs/java-rest/high-level/ml/get-calendar-events.asciidoc
@@ -4,13 +4,13 @@
 :response: GetCalendarEventsResponse
 --
 [id="{upid}-{api}"]
-=== Get Calendar Events API
-Retrieves a calendars events.
+=== Get calendar events API
+Retrieves a calendar's events.
 It accepts a +{request}+ and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Get Calendars Request
+==== Get calendars request
 
 A +{request}+ requires a non-null calendar ID.
 Using the literal `_all` returns the events for all calendars.
@@ -19,9 +19,9 @@ Using the literal `_all` returns the events for all calendars.
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
-<1> Constructing a new request for the specified calendarId
+<1> Constructing a new request for the specified calendarId.
 
-==== Optional Arguments
+==== Optional arguments
 The following arguments are optional:
 
 
@@ -48,12 +48,12 @@ include-tagged::{doc-tests-file}[{api}-end]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-jobid]
 --------------------------------------------------
-<1> Get events for the job. When this option is used calendar_id must be `_all`
+<1> Get events for the job. When this option is used calendar_id must be `_all`.
 
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
-==== Get calendars Response
+==== Get calendars response
 
 The returned +{response}+ contains the requested events:
 
@@ -61,5 +61,5 @@ The returned +{response}+ contains the requested events:
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
-<1> The count of events that were matched
-<2> The events retrieved
+<1> The count of events that were matched.
+<2> The events retrieved.

--- a/docs/java-rest/high-level/ml/get-calendars.asciidoc
+++ b/docs/java-rest/high-level/ml/get-calendars.asciidoc
@@ -4,44 +4,45 @@
 :response: GetCalendarsResponse
 --
 [id="{upid}-{api}"]
-=== Get Calendars API
+=== Get calendars API
 Retrieves one or more calendar objects.
 It accepts a +{request}+ and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Get Calendars Request
+==== Get calendars request
 
-By default a +{request}+ with no calendar Id set will return all
+By default, a +{request}+ with no calendar ID set will return all
 calendars. Using the literal `_all` also returns all calendars.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
-<1> Constructing a new request for all calendars
+<1> Constructing a new request for all calendars. 
 
-==== Optional Arguments
+==== Optional arguments
 The following arguments are optional:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-id]
 --------------------------------------------------
-<1> Construct a request for the single calendar `holidays`
+<1> Construct a request for the single calendar `holidays`.
 
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-page]
 --------------------------------------------------
-<1> The page parameters `from` and `size`. `from` specifies the number of calendars to skip.
-`size` specifies the maximum number of calendars to get. Defaults to `0` and `100` respectively.
+<1> The page parameters `from` and `size`. `from` specifies the number of
+calendars to skip. `size` specifies the maximum number of calendars to get.
+Defaults to `0` and `100` respectively.
 
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
-==== Get calendars Response
+==== Get calendars response
 
 The returned +{response}+ contains the requested calendars:
 
@@ -49,5 +50,5 @@ The returned +{response}+ contains the requested calendars:
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
-<1> The count of calendars that were matched
-<2> The calendars retrieved
+<1> The count of calendars that were matched.
+<2> The calendars retrieved.

--- a/docs/java-rest/high-level/ml/get-categories.asciidoc
+++ b/docs/java-rest/high-level/ml/get-categories.asciidoc
@@ -4,14 +4,13 @@
 :response: GetCategoriesResponse
 --
 [id="{upid}-{api}"]
-=== Get Categories API
+=== Get categories API
 
-The Get Categories API retrieves one or more category results.
-It accepts a +{request}+ object and responds
-with a +{response}+ object.
+Retrieves one or more category results.
+It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Get Categories Request
+==== Get categories request
 
 A +{request}+ object gets created with an existing non-null `jobId`.
 
@@ -19,28 +18,29 @@ A +{request}+ object gets created with an existing non-null `jobId`.
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
-<1> Constructing a new request referencing an existing `jobId`
+<1> Constructing a new request referencing an existing `jobId`.
 
-==== Optional Arguments
+==== Optional arguments
 The following arguments are optional:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-category-id]
 --------------------------------------------------
-<1> The id of the category to get. Otherwise it will return all categories.
+<1> The ID of the category to get. Otherwise, it will return all categories.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-page]
 --------------------------------------------------
-<1> The page parameters `from` and `size`. `from` specifies the number of categories to skip.
-`size` specifies the maximum number of categories to get. Defaults to `0` and `100` respectively.
+<1> The page parameters `from` and `size`. `from` specifies the number of
+categories to skip. `size` specifies the maximum number of categories to get.
+Defaults to `0` and `100` respectively.
 
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
-==== Get Categories Response
+==== Get categories response
 
 The returned +{response}+ contains the requested categories:
 
@@ -48,5 +48,5 @@ The returned +{response}+ contains the requested categories:
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
-<1> The count of categories that were matched
-<2> The categories retrieved
+<1> The count of categories that were matched.
+<2> The categories retrieved.

--- a/docs/java-rest/high-level/ml/get-datafeed-stats.asciidoc
+++ b/docs/java-rest/high-level/ml/get-datafeed-stats.asciidoc
@@ -4,37 +4,36 @@
 :response: GetDatafeedStatsResponse
 --
 [id="{upid}-{api}"]
-=== Get Datafeed Stats API
+=== Get datafeed stats API
 
-The Get Datafeed Stats API provides the ability to get any number of
- {ml} datafeed's statistics in the cluster.
-It accepts a +{request}+ object and responds
-with a +{response}+ object.
+Retrieves any number of {ml} datafeeds' statistics in the cluster.
+It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Get Datafeed Stats Request
+==== Get datafeed stats request
 
-A +{request}+ object can have any number of `datafeedId`
-entries. However, they all must be non-null. An empty list is the same as
-requesting statistics for all datafeeds.
+A +{request}+ object can have any number of `datafeedId` entries. However, they
+all must be non-null. An empty list is the same as requesting statistics for all
+datafeeds.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
-<1> Constructing a new request referencing existing `datafeedIds`, can contain wildcards
+<1> Constructing a new request referencing existing `datafeedIds`. It can
+contain wildcards.
 <2> Whether to ignore if a wildcard expression matches no datafeeds.
- (This includes `_all` string or when no datafeeds have been specified)
+ (This includes `_all` string or when no datafeeds have been specified).
 
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
-==== Get Datafeed Stats Response
+==== Get datafeed stats response
 The returned +{response}+ contains the requested datafeed statistics:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
-<1> `count()` indicates the number of datafeeds statistics found
-<2> `datafeedStats()` is the collection of {ml} `DatafeedStats` objects found
+<1> `count()` indicates the number of datafeeds statistics found.
+<2> `datafeedStats()` is the collection of {ml} `DatafeedStats` objects found.

--- a/docs/java-rest/high-level/ml/get-datafeed.asciidoc
+++ b/docs/java-rest/high-level/ml/get-datafeed.asciidoc
@@ -4,34 +4,35 @@
 :response: GetDatafeedResponse
 --
 [id="{upid}-{api}"]
-=== Get Datafeed API
+=== Get datafeed API
 
-The Get Datafeed API provides the ability to get {ml} datafeeds in the cluster.
-It accepts a +{request}+ object and responds
-with a +{response}+ object.
+Retrieves configuration information about {ml} datafeeds in the cluster.
+It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Get Datafeed Request
+==== Get datafeed request
 
-A +{request}+ object gets can have any number of `datafeedId` entries.
-However, they all must be non-null. An empty list is the same as requesting for all datafeeds.
+A +{request}+ object gets can have any number of `datafeedId` entries. However,
+they all must be non-null. An empty list is the same as requesting for all
+datafeeds.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
-<1> Constructing a new request referencing existing `datafeedIds`, can contain wildcards
+<1> Constructing a new request referencing existing `datafeedIds`. It can
+contain wildcards.
 <2> Whether to ignore if a wildcard expression matches no datafeeds.
- (This includes `_all` string or when no datafeeds have been specified)
+ (This includes `_all` string or when no datafeeds have been specified).
 
 [id="{upid}-{api}-response"]
-==== Get Datafeed Response
+==== Get datafeed response
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
-<1> The count of retrieved datafeeds
-<2> The retrieved datafeeds
+<1> The count of retrieved datafeeds.
+<2> The retrieved datafeeds.
 
 include::../execution.asciidoc[]

--- a/docs/java-rest/high-level/ml/get-filters.asciidoc
+++ b/docs/java-rest/high-level/ml/get-filters.asciidoc
@@ -4,14 +4,13 @@
 :response: GetFiltersResponse
 --
 [id="{upid}-{api}"]
-=== Get Filters API
+=== Get filters API
 
-The Get Filters API retrieves one or more filter results.
-It accepts a +{request}+ object and responds
-with a +{response}+ object.
+Retrieves one or more filter results.
+It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Get Filters Request
+==== Get filters request
 
 A +{request}+ object gets created.
 
@@ -19,16 +18,16 @@ A +{request}+ object gets created.
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
-<1> Constructing a new request
+<1> Constructing a new request.
 
-==== Optional Arguments
+==== Optional arguments
 The following arguments are optional:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-filter-id]
 --------------------------------------------------
-<1> The id of the filter to get. Otherwise it will return all filters.
+<1> The ID of the filter to get. Otherwise, it will return all filters.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
@@ -40,7 +39,7 @@ include-tagged::{doc-tests-file}[{api}-page-params]
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
-==== Get Filters Response
+==== Get filters response
 
 The returned +{response}+ contains the requested filters:
 
@@ -48,5 +47,5 @@ The returned +{response}+ contains the requested filters:
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
-<1> The count of filters that were matched
-<2> The filters retrieved
+<1> The count of filters that were matched.
+<2> The filters retrieved.

--- a/docs/java-rest/high-level/ml/get-influencers.asciidoc
+++ b/docs/java-rest/high-level/ml/get-influencers.asciidoc
@@ -4,14 +4,13 @@
 :response: GetInfluencersResponse
 --
 [id="{upid}-{api}"]
-=== Get Influencers API
+=== Get influencers API
 
-The Get Influencers API retrieves one or more influencer results.
-It accepts a +{request}+ object and responds
-with a +{response}+ object.
+Retrieves one or more influencer results.
+It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Get Influencers Request
+==== Get influencers request
 
 A +{request}+ object gets created with an existing non-null `jobId`.
 
@@ -19,9 +18,9 @@ A +{request}+ object gets created with an existing non-null `jobId`.
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
-<1> Constructing a new request referencing an existing `jobId`
+<1> Constructing a new request referencing an existing `jobId`.
 
-==== Optional Arguments
+==== Optional arguments
 The following arguments are optional:
 
 ["source","java",subs="attributes,callouts,macros"]
@@ -46,14 +45,16 @@ include-tagged::{doc-tests-file}[{api}-exclude-interim]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-influencer-score]
 --------------------------------------------------
-<1> Influencers with influencer_score greater or equal than this value will be returned.
+<1> Influencers with `influencer_score` greater than or equal to this value will
+be returned.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-page]
 --------------------------------------------------
-<1> The page parameters `from` and `size`. `from` specifies the number of influencers to skip.
-`size` specifies the maximum number of influencers to get. Defaults to `0` and `100` respectively.
+<1> The page parameters `from` and `size`. `from` specifies the number of
+influencers to skip. `size` specifies the maximum number of influencers to get.
+Defaults to `0` and `100` respectively.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
@@ -70,7 +71,7 @@ include-tagged::{doc-tests-file}[{api}-start]
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
-==== Get Influencers Response
+==== Get influencers response
 
 The returned +{response}+ contains the requested influencers:
 
@@ -78,5 +79,5 @@ The returned +{response}+ contains the requested influencers:
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
-<1> The count of influencers that were matched
-<2> The influencers retrieved
+<1> The count of influencers that were matched.
+<2> The influencers retrieved.

--- a/docs/java-rest/high-level/ml/get-info.asciidoc
+++ b/docs/java-rest/high-level/ml/get-info.asciidoc
@@ -4,30 +4,31 @@
 :response: MlInfoResponse
 --
 [id="{upid}-{api}"]
-=== ML Get Info API
+=== ML get info API
 
-The ML Get API provides defaults and limits used internally by {ml}.
+Provides defaults and limits used internally by {ml}.
 These may be useful to a user interface that needs to interpret machine learning
-configurations where certain fields are missing because the end user was happy with the default value.
+configurations where certain fields are missing because the end user was happy
+with the default value.
 
 It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Get Info Request
+==== Get info request
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
-<1> Constructing a new request
+<1> Constructing a new request.
 
 [id="{upid}-{api}-response"]
-==== ML Get Info Response
+==== ML get info response
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
-<1> `info` from the +{response}+ contains ml info details
+<1> `info` from the +{response}+ contains {ml} info details.
 
 include::../execution.asciidoc[]

--- a/docs/java-rest/high-level/ml/get-job-stats.asciidoc
+++ b/docs/java-rest/high-level/ml/get-job-stats.asciidoc
@@ -4,37 +4,36 @@
 :response: GetJobStatsResponse
 --
 [id="{upid}-{api}"]
-=== Get Job Stats API
+=== Get {anomaly-job} stats API
 
-The Get Job Stats API provides the ability to get any number of
- {ml} job's statistics in the cluster.
-It accepts a +{request}+ object and responds
-with a +{response}+ object.
+Retrieves statistics for any number of {anomaly-jobs} in the cluster.
+It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Get Job Stats Request
+==== Get job stats request
 
 A `GetJobsStatsRequest` object can have any number of `jobId`
 entries. However, they all must be non-null. An empty list is the same as
-requesting statistics for all jobs.
+requesting statistics for all {anomaly-jobs}.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
-<1> Constructing a new request referencing existing `jobIds`, can contain wildcards
-<2> Whether to ignore if a wildcard expression matches no jobs.
- (This includes `_all` string or when no jobs have been specified)
+<1> Constructing a new request referencing existing `jobIds`. It can contain
+wildcards.
+<2> Whether to ignore if a wildcard expression matches no {anomaly-jobs}.
+ (This includes `_all` string or when no jobs have been specified).
 
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
-==== Get Job Stats Response
+==== Get job stats response
 The returned +{response}+ contains the requested job statistics:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
-<1> `getCount()` indicates the number of jobs statistics found
-<2> `getJobStats()` is the collection of {ml} `JobStats` objects found
+<1> `getCount()` indicates the number of jobs statistics found.
+<2> `getJobStats()` is the collection of {ml} `JobStats` objects found.

--- a/docs/java-rest/high-level/ml/get-job.asciidoc
+++ b/docs/java-rest/high-level/ml/get-job.asciidoc
@@ -4,35 +4,35 @@
 :response: GetJobResponse
 --
 [id="{upid}-{api}"]
-=== Get Job API
+=== Get {anomaly-jobs} API
 
-The Get Job API provides the ability to get {ml} jobs in the cluster.
-It accepts a +{request}+ object and responds
-with a +{response}+ object.
+Retrieves configuration information for {anomaly-jobs} in the cluster.
+It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Get Job Request
+==== Get {anomaly-jobs} request
 
 A +{request}+ object gets can have any number of `jobId` or `groupName`
 entries. However, they all must be non-null. An empty list is the same as
-requesting for all jobs.
+requesting for all {anomaly-jobs}.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
-<1> Constructing a new request referencing existing `jobIds`, can contain wildcards
-<2> Whether to ignore if a wildcard expression matches no jobs.
- (This includes `_all` string or when no jobs have been specified)
+<1> Constructing a new request referencing existing `jobIds`. It can contain
+wildcards.
+<2> Whether to ignore if a wildcard expression matches no {anomaly-jobs}.
+ (This includes `_all` string or when no jobs have been specified).
 
 [id="{upid}-{api}-response"]
-==== Get Job Response
+==== Get {anomaly-jobs} response
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
-<1> `getCount()` from the +{response}+ indicates the number of jobs found
-<2> `getJobs()` is the collection of {ml} `Job` objects found
+<1> `getCount()` from the +{response}+ indicates the number of jobs found.
+<2> `getJobs()` is the collection of {ml} `Job` objects found.
 
 include::../execution.asciidoc[]

--- a/docs/java-rest/high-level/ml/get-model-snapshots.asciidoc
+++ b/docs/java-rest/high-level/ml/get-model-snapshots.asciidoc
@@ -4,14 +4,13 @@
 :response: GetModelSnapshotsResponse
 --
 [id="{upid}-{api}"]
-=== Get Model Snapshots API
+=== Get model snapshots API
 
-The Get Model Snapshots API retrieves one or more model snapshot results.
-It accepts a +{request}+ object and responds
-with a +{response}+ object.
+Retrieves one or more model snapshot results.
+It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Get Model Snapshots Request
+==== Get model snapshots request
 
 A +{request}+ object gets created with an existing non-null `jobId`.
 
@@ -19,16 +18,16 @@ A +{request}+ object gets created with an existing non-null `jobId`.
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
-<1> Constructing a new request referencing an existing `jobId`
+<1> Constructing a new request referencing an existing `jobId`.
 
-==== Optional Arguments
+==== Optional arguments
 The following arguments are optional:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-snapshot-id]
 --------------------------------------------------
-<1> The id of the snapshot to get. Otherwise it will return all snapshots.
+<1> The ID of the snapshot to get. Otherwise, it will return all snapshots.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
@@ -58,13 +57,14 @@ include-tagged::{doc-tests-file}[{api}-start]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-page]
 --------------------------------------------------
-<1> The page parameters `from` and `size`. `from` specifies the number of snapshots to skip.
-`size` specifies the maximum number of snapshots to retrieve. Defaults to `0` and `100` respectively.
+<1> The page parameters `from` and `size`. `from` specifies the number of
+snapshots to skip. `size` specifies the maximum number of snapshots to retrieve.
+Defaults to `0` and `100` respectively.
 
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
-==== Get Model Snapshots Response
+==== Get model snapshots response
 
 The returned +{response}+ contains the requested snapshots:
 
@@ -72,5 +72,5 @@ The returned +{response}+ contains the requested snapshots:
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
-<1> The count of snapshots that were matched
-<2> The snapshots retrieved
+<1> The count of snapshots that were matched.
+<2> The snapshots retrieved.

--- a/docs/java-rest/high-level/ml/get-overall-buckets.asciidoc
+++ b/docs/java-rest/high-level/ml/get-overall-buckets.asciidoc
@@ -4,15 +4,15 @@
 :response: GetOverallBucketsResponse
 --
 [id="{upid}-{api}"]
-=== Get Overall Buckets API
+=== Get overall buckets API
 
-The Get Overall Buckets API retrieves overall bucket results that
-summarize the bucket results of multiple jobs.
+Retrieves overall bucket results that summarize the bucket results of multiple
+{anomaly-jobs}.
 It accepts a +{request}+ object and responds
 with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Get Overall Buckets Request
+==== Get overall buckets request
 
 A +{request}+ object gets created with one or more `jobId`.
 
@@ -22,14 +22,15 @@ include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
 <1> Constructing a new request referencing job IDs `jobId1` and `jobId2`.
 
-==== Optional Arguments
+==== Optional arguments
 The following arguments are optional:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-bucket-span]
 --------------------------------------------------
-<1> The span of the overall buckets. Must be greater or equal to the jobs' largest `bucket_span`.
+<1> The span of the overall buckets. Must be greater or equal to the jobs'
+largest `bucket_span`.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
@@ -41,14 +42,16 @@ include-tagged::{doc-tests-file}[{api}-end]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-exclude-interim]
 --------------------------------------------------
-<1> If `true`, interim results will be excluded. Overall buckets are interim if any of the job buckets
-within the overall bucket interval are interim. Defaults to `false`.
+<1> If `true`, interim results will be excluded. Overall buckets are interim if
+any of the job buckets within the overall bucket interval are interim. Defaults
+to `false`.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-overall-score]
 --------------------------------------------------
-<1> Overall buckets with overall scores greater or equal than this value will be returned.
+<1> Overall buckets with overall scores greater or equal than this value will be
+returned.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
@@ -60,12 +63,13 @@ include-tagged::{doc-tests-file}[{api}-start]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-top-n]
 --------------------------------------------------
-<1> The number of top job bucket scores to be used in the `overall_score` calculation. Defaults to `1`.
+<1> The number of top job bucket scores to be used in the `overall_score`
+calculation. Defaults to `1`.
 
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
-==== Get Overall Buckets Response
+==== Get overall buckets response
 
 The returned +{response}+ contains the requested buckets:
 
@@ -73,5 +77,5 @@ The returned +{response}+ contains the requested buckets:
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
-<1> The count of overall buckets that were matched
-<2> The overall buckets retrieved
+<1> The count of overall buckets that were matched.
+<2> The overall buckets retrieved.

--- a/docs/java-rest/high-level/ml/get-records.asciidoc
+++ b/docs/java-rest/high-level/ml/get-records.asciidoc
@@ -4,14 +4,13 @@
 :response: GetRecordsResponse
 --
 [id="{upid}-{api}"]
-=== Get Records API
+=== Get records API
 
-The Get Records API retrieves one or more record results.
-It accepts a +{request}+ object and responds
-with a +{response}+ object.
+Retrieves one or more record results.
+It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Get Records Request
+==== Get records request
 
 A +{request}+ object gets created with an existing non-null `jobId`.
 
@@ -19,9 +18,9 @@ A +{request}+ object gets created with an existing non-null `jobId`.
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
-<1> Constructing a new request referencing an existing `jobId`
+<1> Constructing a new request referencing an existing `jobId`.
 
-==== Optional Arguments
+==== Optional arguments
 The following arguments are optional:
 
 ["source","java",subs="attributes,callouts,macros"]
@@ -46,8 +45,9 @@ include-tagged::{doc-tests-file}[{api}-exclude-interim]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-page]
 --------------------------------------------------
-<1> The page parameters `from` and `size`. `from` specifies the number of records to skip.
-`size` specifies the maximum number of records to get. Defaults to `0` and `100` respectively.
+<1> The page parameters `from` and `size`. `from` specifies the number of
+records to skip. `size` specifies the maximum number of records to get. Defaults
+to `0` and `100` respectively.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
@@ -70,7 +70,7 @@ include-tagged::{doc-tests-file}[{api}-start]
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
-==== Get Records Response
+==== Get records response
 
 The returned +{response}+ contains the requested records:
 
@@ -78,5 +78,5 @@ The returned +{response}+ contains the requested records:
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
-<1> The count of records that were matched
-<2> The records retrieved
+<1> The count of records that were matched.
+<2> The records retrieved.

--- a/docs/reference/ml/anomaly-detection/apis/get-bucket.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-bucket.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Get buckets</titleabbrev>
 ++++
 
-Retrieves job results for one or more buckets.
+Retrieves {anomaly-job} results for one or more buckets.
 
 [[ml-get-bucket-request]]
 ==== {api-request-title}
@@ -36,7 +36,7 @@ bucket.
 ==== {api-path-parms-title}
 
 `<job_id>`::
-  (Required, string) Identifier for the job
+  (Required, string) Identifier for the {anomaly-job}.
 
 `<timestamp>`::
   (Optional, string) The timestamp of a single bucket result. If you do not

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
@@ -59,7 +59,8 @@ The API returns the following information:
     (string) A numerical character string that uniquely identifies the calendar.
 
   `job_ids`:::
-    (array) An array of job identifiers. For example: `["total-requests"]`.
+    (array) An array of {anomaly-job} identifiers. For example:
+    `["total-requests"]`.
 
 [[ml-get-calendar-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Get categories</titleabbrev>
 ++++
 
-Retrieves job results for one or more categories.
+Retrieves {anomaly-job} results for one or more categories.
 
 [[ml-get-category-request]]
 ==== {api-request-title}
@@ -35,11 +35,12 @@ For more information about categories, see
 ==== {api-path-parms-title}
 
 `<job_id>`::
-  (Required, string) Identifier for the job.
+  (Required, string) Identifier for the {anomaly-job}.
 
 `<category_id>`::
   (Optional, long) Identifier for the category. If you do not specify this
-  parameter, the API returns information about all categories in the job.
+  parameter, the API returns information about all categories in the
+  {anomaly-job}.
 
 [[ml-get-category-request-body]]
 ==== {api-request-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Get influencers</titleabbrev>
 ++++
 
-Retrieves job results for one or more influencers.
+Retrieves {anomaly-job} results for one or more influencers.
 
 [[ml-get-influencer-request]]
 ==== {api-request-title}
@@ -27,7 +27,7 @@ privileges. See {stack-ov}/security-privileges.html[Security privileges] and
 ==== {api-path-parms-title}
 
 `<job_id>`::
-  (Required, string) Identifier for the job.
+  (Required, string) Identifier for the {anomaly-job}.
 
 [[ml-get-influencer-request-body]]
 ==== {api-request-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
@@ -1,12 +1,12 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-get-job-stats]]
-=== Get job statistics API
+=== Get {anomaly-job} statistics API
 ++++
 <titleabbrev>Get job statistics</titleabbrev>
 ++++
 
-Retrieves usage information for jobs.
+Retrieves usage information for {anomaly-jobs}.
 
 [[ml-get-job-stats-request]]
 ==== {api-request-title}
@@ -29,10 +29,10 @@ Retrieves usage information for jobs.
 [[ml-get-job-stats-desc]]
 ==== {api-description-title}
 
-You can get statistics for multiple jobs in a single API request by using a
-group name, a comma-separated list of jobs, or a wildcard expression. You can
-get statistics for all jobs by using `_all`, by specifying `*` as the
-`<job_id>`, or by omitting the `<job_id>`.
+You can get statistics for multiple {anomaly-jobs} in a single API request by
+using a group name, a comma-separated list of jobs, or a wildcard expression.
+You can get statistics for all {anomaly-jobs} by using `_all`, by specifying `*`
+as the `<job_id>`, or by omitting the `<job_id>`.
 
 IMPORTANT: This API returns a maximum of 10,000 jobs.
 
@@ -40,9 +40,9 @@ IMPORTANT: This API returns a maximum of 10,000 jobs.
 ==== {api-path-parms-title}
 
 `<job_id>`::
-  (Optional, string) An identifier for the job. It can be a job identifier, a
-  group name, or a wildcard expression. If you do not specify one of these
-  options, the API returns statistics for all jobs.
+  (Optional, string) An identifier for the {anomaly-job}. It can be a
+  job identifier, a group name, or a wildcard expression. If you do not specify
+  one of these options, the API returns statistics for all {anomaly-jobs}.
 
 [[ml-get-job-stats-results]]
 ==== {api-response-body-title}
@@ -50,8 +50,8 @@ IMPORTANT: This API returns a maximum of 10,000 jobs.
 The API returns the following information:
 
 `jobs`::
-  (array) An array of job statistics objects.
-  For more information, see <<ml-jobstats,Job Statistics>>.
+  (array) An array of {anomaly-job} statistics objects.
+  For more information, see <<ml-jobstats>>.
 
 [[ml-get-job-stats-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
@@ -1,12 +1,12 @@
 [role="xpack"]
 [testenv="platinum"]
 [[ml-get-job]]
-=== Get jobs API
+=== Get {anomaly-jobs} API
 ++++
 <titleabbrev>Get jobs</titleabbrev>
 ++++
 
-Retrieves configuration information for jobs.
+Retrieves configuration information for {anomaly-jobs}.
 
 [[ml-get-job-request]]
 ==== {api-request-title}
@@ -29,10 +29,10 @@ Retrieves configuration information for jobs.
 [[ml-get-job-desc]]
 ==== {api-description-title}
 
-You can get information for multiple jobs in a single API request by using a
-group name, a comma-separated list of jobs, or a wildcard expression. You can
-get information for all jobs by using `_all`, by specifying `*` as the
-`<job_id>`, or by omitting the `<job_id>`.
+You can get information for multiple {anomaly-jobs} in a single API request by
+using a group name, a comma-separated list of jobs, or a wildcard expression.
+You can get information for all {anomaly-jobs} by using `_all`, by specifying
+`*` as the `<job_id>`, or by omitting the `<job_id>`.
 
 IMPORTANT: This API returns a maximum of 10,000 jobs. 
 
@@ -40,9 +40,9 @@ IMPORTANT: This API returns a maximum of 10,000 jobs.
 ==== {api-path-parms-title}
 
 `<job_id>`::
-  (Optional, string) Identifier for the job. It can be a job identifier, a group
-  name, or a wildcard expression. If you do not specify one of these options,
-  the API returns information for all jobs.
+  (Optional, string) Identifier for the {anomaly-job}. It can be a job
+  identifier, a group name, or a wildcard expression. If you do not specify one
+  of these options, the API returns information for all {anomaly-jobs}.
 
 [[ml-get-job-results]]
 ==== {api-response-body-title}
@@ -50,8 +50,8 @@ IMPORTANT: This API returns a maximum of 10,000 jobs.
 The API returns the following information:
 
 `jobs`::
-  (array) An array of job resources.
-  For more information, see <<ml-job-resource,Job Resources>>.
+  (array) An array of {anomaly-job} resources.
+  For more information, see <<ml-job-resource>>.
 
 [[ml-get-job-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
@@ -6,8 +6,8 @@
 <titleabbrev>Get overall buckets</titleabbrev>
 ++++
 
-Retrieves overall bucket results that summarize the
-bucket results of multiple jobs.
+Retrieves overall bucket results that summarize the bucket results of multiple
+{anomaly-jobs}.
 
 [[ml-get-overall-buckets-request]]
 ==== {api-request-title}
@@ -31,45 +31,46 @@ privileges. See {stack-ov}/security-privileges.html[Security privileges] and
 [[ml-get-overall-buckets-desc]]
 ==== {api-description-title}
 
-You can summarize the bucket results for all jobs by using `_all` or by
-specifying `*` as the `<job_id>`.
+You can summarize the bucket results for all {anomaly-jobs} by using `_all` or
+by specifying `*` as the `<job_id>`.
 
 An overall bucket has a span equal to the largest `bucket_span` value for the
-specified jobs.
+specified {anomaly-jobs}.
 
-The `overall_score` is calculated by combining the scores of all
-the buckets within the overall bucket span. First, the maximum `anomaly_score` per
-job in the overall bucket is calculated. Then the `top_n` of those scores are
-averaged to result in the `overall_score`. This means that you can fine-tune
-the `overall_score` so that it is more or less sensitive to the number
+The `overall_score` is calculated by combining the scores of all the buckets
+within the overall bucket span. First, the maximum `anomaly_score` per
+{anomaly-job} in the overall bucket is calculated. Then the `top_n` of those
+scores are averaged to result in the `overall_score`. This means that you can
+fine-tune the `overall_score` so that it is more or less sensitive to the number
 of jobs that detect an anomaly at the same time. For example, if you set `top_n`
-to `1`, the `overall_score` is the maximum bucket
-score in the overall bucket. Alternatively, if you set `top_n` to the number of
-jobs, the `overall_score` is high only when all jobs detect anomalies in that
-overall bucket.
+to `1`, the `overall_score` is the maximum bucket score in the overall bucket. Alternatively, if you set `top_n` to the number of jobs, the `overall_score` is
+high only when all jobs detect anomalies in that overall bucket.
 
 In addition, the optional parameter `bucket_span` may be used in order
-to request overall buckets that span longer than the largest job's `bucket_span`.
-When set, the `overall_score` will be the max `overall_score` of the corresponding
-overall buckets with a span equal to the largest job's `bucket_span`.
+to request overall buckets that span longer than the `bucket_span` of the
+largest {anomaly-job}. When set, the `overall_score` will be the max
+`overall_score` of the corresponding overall buckets with a span equal to the
+`bucket_span` of the largest {anomaly-job}.
 
 [[ml-get-overall-buckets-path-parms]]
 ==== {api-path-parms-title}
 
 `<job_id>`::
-  (Required, string) Identifier for the job. It can be a job identifier, a group
-  name, a comma-separated list of jobs or groups, or a wildcard expression.
+  (Required, string) Identifier for the {anomaly-job}. It can be a job
+  identifier, a group name, a comma-separated list of jobs or groups, or a
+  wildcard expression.
 
 [[ml-get-overall-buckets-request-body]]
 ==== {api-request-body-title}
 
 `allow_no_jobs`::
-  (Optional, boolean) If `false` and the `job_id` does not match any job, an
-  error occurs. The default value is `true`.
+  (Optional, boolean) If `false` and the `job_id` does not match any
+  {anomaly-jobs}, an error occurs. The default value is `true`.
 
 `bucket_span`::
   (Optional, string) The span of the overall buckets. Must be greater or equal
-  to the largest job's `bucket_span`. Defaults to the largest job's `bucket_span`.
+  to the `bucket_span` of the largest {anomaly-job}. Defaults to the
+  `bucket_span` of the largest {anomaly-job}. 
 
 `end`::
   (Optional, string) Returns overall buckets with timestamps earlier than this
@@ -88,8 +89,8 @@ overall buckets with a span equal to the largest job's `bucket_span`.
   (Optional, string) Returns overall buckets with timestamps after this time.
 
 `top_n`::
-  (Optional, integer) The number of top job bucket scores to be used in the
-  `overall_score` calculation. The default value is `1`.
+  (Optional, integer) The number of top {anomaly-job} bucket scores to be used
+  in the `overall_score` calculation. The default value is `1`.
 
 [[ml-get-overall-buckets-results]]
 ==== {api-response-body-title}
@@ -103,7 +104,8 @@ The API returns the following information:
 [[ml-get-overall-buckets-example]]
 ==== {api-examples-title}
 
-The following example gets overall buckets for jobs with IDs matching `job-*`:
+The following example gets overall buckets for {anomaly-jobs} with IDs matching
+`job-*`:
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Get records</titleabbrev>
 ++++
 
-Retrieves anomaly records for a job.
+Retrieves anomaly records for an {anomaly-job}.
 
 [[ml-get-record-request]]
 ==== {api-request-title}
@@ -27,7 +27,7 @@ privileges. See {stack-ov}/security-privileges.html[Security privileges] and
 ==== {api-path-parms-title}
 
 `<job_id>`::
-  (Required, string) Identifier for the job.
+  (Required, string) Identifier for the {anomaly-job}.
 
 [[ml-get-record-request-body]]
 ==== {api-request-body-title}
@@ -66,7 +66,7 @@ The API returns the following information:
 
 `records`::
   (array) An array of record objects. For more information, see
-  <<ml-results-records,Records>>.
+  <<ml-results-records>>.
 
 [[ml-get-record-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
@@ -26,7 +26,7 @@ Retrieves information about model snapshots.
 ==== {api-path-parms-title}
 
 `<job_id>`::
-  (Required, string) Identifier for the job.
+  (Required, string) Identifier for the {anomaly-job}.
 
 `<snapshot_id>`::
   (Optional, string) Identifier for the model snapshot. If you do not specify
@@ -61,7 +61,7 @@ The API returns the following information:
 
 `model_snapshots`::
   (array) An array of model snapshot objects. For more information, see
-  <<ml-snapshot-resource,Model Snapshots>>.
+  <<ml-snapshot-resource>>.
 
 [[ml-get-snapshot-example]]
 ==== {api-examples-title}


### PR DESCRIPTION
Related to elastic/stack-docs#237

This PR updates the terminology in the Java REST Client and Elasticsearch Reference documentation such that it uses appropriate "anomaly detection job" terminology in the machine learning get APIs.

It also fixes minor style issues related to the capitalization of titles.