### PR TITLE
Optimize Netty Frame Decoding (#44664)

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4SizeHeaderFrameDecoder.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4SizeHeaderFrameDecoder.java
@@ -35,20 +35,20 @@ final class Netty4SizeHeaderFrameDecoder extends ByteToMessageDecoder {
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
         try {
-            boolean continueDecode = true;
-            while (continueDecode) {
+            while (in.readableBytes() >= HEADER_SIZE) {
                 int messageLength = TcpTransport.readMessageLength(Netty4Utils.toBytesReference(in));
                 if (messageLength == -1) {
-                    continueDecode = false;
+                    break;
                 } else {
                     int messageLengthWithHeader = messageLength + HEADER_SIZE;
                     // If the message length is greater than the network bytes available, we have not read a complete frame.
                     if (messageLengthWithHeader > in.readableBytes()) {
-                        continueDecode = false;
+                        break;
                     } else {
-                        final ByteBuf message = in.retainedSlice(in.readerIndex() + HEADER_SIZE, messageLength);
+                        final int readerIndex = in.readerIndex();
+                        final ByteBuf message = in.retainedSlice(readerIndex + HEADER_SIZE, messageLength);
                         out.add(message);
-                        in.readerIndex(in.readerIndex() + messageLengthWithHeader);
+                        in.readerIndex(readerIndex + messageLengthWithHeader);
                     }
                 }
             }

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
@@ -26,6 +26,7 @@ import io.netty.util.NettyRuntime;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefIterator;
 import org.elasticsearch.common.Booleans;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 
 import java.io.IOException;
@@ -108,14 +109,10 @@ public class Netty4Utils {
      * Wraps the given ChannelBuffer with a BytesReference
      */
     public static BytesReference toBytesReference(final ByteBuf buffer) {
-        return toBytesReference(buffer, buffer.readableBytes());
+        final int readableBytes = buffer.readableBytes();
+        if (readableBytes == 0) {
+            return BytesArray.EMPTY;
+        }
+        return new ByteBufBytesReference(buffer, buffer.readableBytes());
     }
-
-    /**
-     * Wraps the given ChannelBuffer with a BytesReference of a given size
-     */
-    static BytesReference toBytesReference(final ByteBuf buffer, final int size) {
-        return new ByteBufBytesReference(buffer, size);
-    }
-
 }


### PR DESCRIPTION
* We should not create a new wrapper object if there's no bytes in the `ByteBuf`
* We should not create a new wrapped `ByteBuf` if it can't contain a message anyway because it doesn't even have enough bytes for a header left

back port of #44664 