### PR TITLE
Stop Suspending Threads in NIO Syscalls in Tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/disruption/LongGCDisruption.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/disruption/LongGCDisruption.java
@@ -47,7 +47,9 @@ public class LongGCDisruption extends SingleNodeDisruption {
         // security manager is shared across all nodes and it uses synchronized maps internally
         Pattern.compile("java\\.lang\\.SecurityManager"),
         // SecureRandom instance from SecureRandomHolder class is shared by all nodes
-        Pattern.compile("java\\.security\\.SecureRandom")
+        Pattern.compile("java\\.security\\.SecureRandom"),
+        // Don't suspend in nio system calls to avoid potential build portability issues
+        Pattern.compile("sun\\.nio")
     };
 
     private static final ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();


### PR DESCRIPTION
* We suspected suspending threads to be at fault when it comes to #43387
* I can't see a direct connection between suspending threads in one test and another test failing but maybe we are breaking some per JVM state/lock accidentally here
   * I think we should just not suspend in nio syscalls to rule out this possibility

@ywelsch this one is pure paranoia to some degree. **But**, I have never been able to reproduce #43387 by just running in a loop. Maybe we're braking some e-poll internal state by suspending without noticing and you were right all along. Just because we don't suspend the threads that block, doesn't mean we didn't break some global state.
Even ignoring just #43387 we probably shouldn't be suspending in `sun.nio` in the first place anyway, that seems needlessly dangerous. WDYT?