### PR TITLE
[DOCS] Reformat MLT query

### DIFF
--- a/docs/reference/query-dsl/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/mlt-query.asciidoc
@@ -176,9 +176,9 @@ parameter.
 ===== Term selection parameters
 [[mlt-query-analyzer-param]]
 `analyzer`::
-(Optional, string) <<analysis-analyzers,Analyzer>> used to free-form text in the
-<<mlt-query-like-param,`like`>> parameter. Defaults to the analyzer of the first
-field in the <<mlt-query-fields-param,`fields`>> parameter value.
+(Optional, string) <<analysis-analyzers,Analyzer>> used to analyze free-form
+text in the <<mlt-query-like-param,`like`>> parameter. Defaults to the analyzer
+of the first field in the <<mlt-query-fields-param,`fields`>> parameter value.
 
 `max_doc_freq`::
 +

--- a/docs/reference/query-dsl/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/mlt-query.asciidoc
@@ -242,7 +242,7 @@ parameter to explicitly ignore them.
 +
 --
 (Optional, float) Floating point number used to decrease or increase the
-<<query-filter-context, relevance scores>> of returned documents for the MLT
+<<relevance-scores,relevance scores>> of returned documents for the MLT
 query. Defaults to `1.0`.
 
 You can use the `boost` parameter to adjust relevance scores for searches

--- a/docs/reference/query-dsl/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/mlt-query.asciidoc
@@ -243,7 +243,7 @@ parameter to explicitly ignore them.
 --
 (Optional, float) Floating point number used to decrease or increase the
 <<query-filter-context, relevance scores>> of returned documents for the MLT
-query. Defaults to`1.0`.
+query. Defaults to `1.0`.
 
 You can use the `boost` parameter to adjust relevance scores for searches
 containing two or more queries.

--- a/docs/reference/query-dsl/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/mlt-query.asciidoc
@@ -4,19 +4,25 @@
 <titleabbrev>More like this</titleabbrev>
 ++++
 
-The More Like This Query finds documents that are "like" a given
-set of documents. In order to do so, MLT selects a set of representative terms
-of these input documents, forms a query using these terms, executes the query
-and returns the results. The user controls the input documents, how the terms
-should be selected and how the query is formed.
+Returns documents like a provided text or set of documents.
 
-The simplest use case consists of asking for documents that are similar to a
-provided piece of text. Here, we are asking for all movies that have some text
-similar to "Once upon a time" in their "title" and in their "description"
-fields, limiting the number of selected terms to 12.
+The `more_like_this` (MLT) query selects a set of representative terms from a
+provided input text or documents. It then forms a query using these terms,
+executes the query, and returns the results. In addition to the input, you can
+control how these terms are selected and how the query is formed. See
+<<mlt-query-how-works>> for a detailed description of this process.
+
+[[mlt-query-ex-requests]]
+==== Example requests
+
+[[mlt-query-ex-provided-text]]
+===== Find documents like a provided text
+The following search returns documents with values similar to `Once upon a
+time` in the `title` and `description` fields, limiting the number of selected
+terms to `12`.
 
 [source,js]
---------------------------------------------------
+----
 GET /_search
 {
     "query": {
@@ -28,15 +34,19 @@ GET /_search
         }
     }
 }
---------------------------------------------------
+----
 // CONSOLE
 
-A more complicated use case consists of mixing texts with documents already
-existing in the index. In this case, the syntax to specify a document is
-similar to the one used in the <<docs-multi-get,Multi GET API>>.
+[[mlt-query-ex-provided-docs]]
+===== Find documents like other documents
+The following search returns documents similar to a provided text and other
+existing documents.
+
+You can provide input documents using the <<docs-multi-get,Multi GET API>>
+syntax.
 
 [source,js]
---------------------------------------------------
+----
 GET /_search
 {
     "query": {
@@ -58,15 +68,20 @@ GET /_search
         }
     }
 }
---------------------------------------------------
+----
 // CONSOLE
 
-Finally, users can mix some texts, a chosen set of documents but also provide
-documents not necessarily present in the index. To provide documents not
-present in the index, the syntax is similar to <<docs-termvectors-artificial-doc,artificial documents>>.
+[[mlt-query-ex-artificial-docs]]
+===== Find documents like an artificial document
+The following query returns documents similar to documents in another index and
+an <<docs-termvectors-artificial-doc,artificial document>> not present in that
+index.
+
+You can provide artificial documents using the
+<<docs-termvectors-artificial-doc,artificial documents>> syntax.
 
 [source,js]
---------------------------------------------------
+----
 GET /_search
 {
     "query": {
@@ -93,11 +108,195 @@ GET /_search
         }
     }
 }
---------------------------------------------------
+----
 // CONSOLE
 
-==== How it Works
+[[mlt-top-level-params]]
+==== Top-level parameters for `more_like_this`
+The MLT query has the following parameter types:
 
+* <<mlt-query-document-input-params,Document input parameters>>
+* <<mlt-query-term-selection,Term selection parameters>>
+* <<mlt-query-formation-params,Query formation parameters>>
+
+Only the <<mlt-query-like-param,`like`>> parameter is required. All other
+parameters have sensible defaults.
+
+[[mlt-query-document-input-params]]
+===== Document input parameters
+[[mlt-query-like-param]]
+`like`::
++
+--
+(Required, string or array of <<docs-multi-get,document objects>> and strings)
+Free-form text or array of documents and text used to find similar documents.
+
+Free-form text is analyzed using the <<mlt-query-fields-param,`fields`>>
+analyzer. To override the analyzer, use a syntax similar to the
+`per_field_analyzer` parameter of the <<docs-termvectors-per-field-analyzer,Term
+vectors API>>.
+
+To provide a document, use the <<docs-multi-get,Multi GET API>> syntax. When
+specifying documents, values are fetched from the
+<<mlt-query-fields-param,`fields`>> parameter unless overridden in each document
+request.
+
+Documents provided in this parameter must meet one of the following field
+mapping requirements:
+
+* The <<mapping-source-field,`_source`>> field is enabled.
+* The <<mapping-store,`store`>> mapping parameter value is `true`.
+* The <<term-vector,`term_vector`>> mapping parameter value is **not** `no`.
+
+To provide artificial documents not present in an index, use the 
+<<docs-termvectors-artificial-doc,artificial documents>> syntax. See
+<<mlt-query-ex-artificial-docs>> for an example.
+
+
+--
+
+[[mlt-query-fields-param]]
+`fields`::
+(Optional, array of strings) <<keyword,`keyword`>> or <<text,`text`>> fields
+from which to fetch and analyze text.
+
+`unlike`::
++
+--
+(Optional, string or array of <<docs-multi-get,document objects>> and strings)
+Free-form text or array of documents and text used with the
+<<mlt-query-like-param,`like`>> parameter to exclude select terms.
+
+For example, you can search for documents `like: "apple"` but `unlike: "cake
+crumble tree"`. The syntax is the same as the <<mlt-query-like-param,`like`>>
+parameter.
+--
+
+[[mlt-query-term-selection]]
+===== Term selection parameters
+[[mlt-query-analyzer-param]]
+`analyzer`::
+(Optional, string) <<analysis-analyzers,Analyzer>> used to free-form text in the
+<<mlt-query-like-param,`like`>> parameter. Defaults to the analyzer of the first
+field in the <<mlt-query-fields-param,`fields`>> parameter value.
+
+`max_doc_freq`::
++
+--
+(Optional, integer) Maximum document frequency above which terms are ignored
+from the <<mlt-query-like-param,`like`>>  parameter value. Defaults to `0`
+(unbounded).
+
+You can use this parameter to ignore highly frequent words, such as stop words.
+--
+
+`max_query_terms`::
++
+--
+(Optional, integer) Maximum number of query terms selected from the
+<<mlt-query-like-param,`like`>> parameter value. Defaults to `25`.
+
+Increasing this value provides greater accuracy but decreases query execution
+speed.
+--
+
+`max_word_length`::
++
+--
+(Optional, integer) Maximum word length above which terms are
+ignored. Defaults to `0` (unbounded).
+
+This parameter replaces the `max_word_len` parameter, which is deprecated.
+--
+
+`min_doc_freq`::
+(Optional, integer) Minimum document frequency below which terms are ignored
+from the <<mlt-query-like-param,`like`>>  parameter value. Defaults to `5`.
+
+`min_term_freq`::
+(Optional, integer) Minimum term frequency below which terms are ignored from
+the `like` parameter value. Defaults to `2`.
+
+`min_word_length`::
++
+--
+(Optional, integer) Minimum word length below which terms are ignored from the
+<<mlt-query-like-param,`like`>> parameter value. Defaults to `0`.
+
+This parameter replaces the `min_word_len` parameter, which is deprecated.
+--
+
+`stop_words`::
++
+--
+(Optional, array of strings) Set of stop words. Any word in this array is
+ignored.
+
+If the <<mlt-query-analyzer-param,analyzer>> allows stop words, you can use this
+parameter to explicitly ignore them.
+--
+
+[[mlt-query-formation-params]]
+===== Query formation parameters
+`boost`::
++
+--
+(Optional, float) Floating point number used to decrease or increase the
+<<query-filter-context, relevance scores>> of returned documents for the MLT
+query. Defaults to`1.0`.
+
+You can use the `boost` parameter to adjust relevance scores for searches
+containing two or more queries.
+
+Boost values are relative to the default value of `1.0`. A boost value between
+`0` and `1.0` decreases the relevance score. A value greater than `1.0`
+increases the relevance score.
+--
+
+`boost_terms`::
++
+--
+(Optional, float) Each term in the formed query could be further boosted by
+their https://en.wikipedia.org/wiki/Tf%E2%80%93idf[tf-idf] score. This floating
+point number sets the boost factor to use for this feature. Defaults to
+`0` (deactivated).
+
+Any other positive value boosts terms using the provided boost factor.
+--
+
+`fail_on_unsupported_field`::
++
+--
+(Optional, boolean) Indicates whether {es} returns an error if the
+<<mlt-query-fields-param,`fields`>> parameter contains a field type other than
+`keyword` or `text`. Defaults to `true`.
+
+If `false`, {es} ignores unsupported field types in the
+<<mlt-query-fields-param,`fields`>> parameter instead of returning an error.
+This means {es} could return no documents.
+--
+
+`include`::
+(Optional, boolean)
+Specifies whether the input documents should also be included in the search
+results returned. Defaults to `false`.
+
+`minimum_should_match`::
++
+--
+(Optional, string) Number of terms that must match the query after the
+final query is formed. Defaults to `30%`.
+
+See <<query-dsl-minimum-should-match,`minimum_should_match` parameter>> for
+syntax and more information.
+--
+
+
+[[mlt-query-notes]]
+==== Notes
+
+[[mlt-query-how-works]]
+===== How the MLT query works
 Suppose we wanted to find all documents similar to a given input document.
 Obviously, the input document itself should be its best match for that type of
 query. And the reason would be mostly, according to
@@ -121,7 +320,7 @@ perform MLT on the "description" and "tags" fields, as `_source` is enabled by
 default, but there will be no speed up on analysis for these fields.
 
 [source,js]
---------------------------------------------------
+----
 PUT /imdb
 {
     "mappings": {
@@ -146,107 +345,5 @@ PUT /imdb
         }
     }
 }
---------------------------------------------------
+----
 // CONSOLE
-
-==== Parameters
-
-The only required parameter is `like`, all other parameters have sensible
-defaults. There are three types of parameters: one to specify the document
-input, the other one for term selection and for query formation.
-
-[float]
-==== Document Input Parameters
-
-[horizontal]
-`like`::
-The only *required* parameter of the MLT query is `like` and follows a
-versatile syntax, in which the user can specify free form text and/or a single
-or multiple documents (see examples above). The syntax to specify documents is
-similar to the one used by the <<docs-multi-get,Multi GET API>>. When
-specifying documents, the text is fetched from `fields` unless overridden in
-each document request. The text is analyzed by the analyzer at the field, but
-could also be overridden. The syntax to override the analyzer at the field
-follows a similar syntax to the `per_field_analyzer` parameter of the
-<<docs-termvectors-per-field-analyzer,Term Vectors API>>.
-Additionally, to provide documents not necessarily present in the index,
-<<docs-termvectors-artificial-doc,artificial documents>> are also supported.
-
-`unlike`::
-The `unlike` parameter is used in conjunction with `like` in order not to
-select terms found in a chosen set of documents. In other words, we could ask
-for documents `like: "Apple"`, but `unlike: "cake crumble tree"`. The syntax
-is the same as `like`.
-
-`fields`::
-A list of fields to fetch and analyze the text from.
-
-[float]
-[[mlt-query-term-selection]]
-==== Term Selection Parameters
-
-[horizontal]
-`max_query_terms`::
-The maximum number of query terms that will be selected. Increasing this value
-gives greater accuracy at the expense of query execution speed. Defaults to
-`25`.
-
-`min_term_freq`::
-The minimum term frequency below which the terms will be ignored from the
-input document. Defaults to `2`.
-
-`min_doc_freq`::
-The minimum document frequency below which the terms will be ignored from the
-input document. Defaults to `5`.
-
-`max_doc_freq`::
-The maximum document frequency above which the terms will be ignored from the
-input document. This could be useful in order to ignore highly frequent words
-such as stop words. Defaults to unbounded (`0`).
-
-`min_word_length`::
-The minimum word length below which the terms will be ignored. The old name
-`min_word_len` is deprecated. Defaults to `0`.
-
-`max_word_length`::
-The maximum word length above which the terms will be ignored. The old name
-`max_word_len` is deprecated. Defaults to unbounded (`0`).
-
-`stop_words`::
-An array of stop words. Any word in this set is considered "uninteresting" and
-ignored. If the analyzer allows for stop words, you might want to tell MLT to
-explicitly ignore them, as for the purposes of document similarity it seems
-reasonable to assume that "a stop word is never interesting".
-
-`analyzer`::
-The analyzer that is used to analyze the free form text. Defaults to the
-analyzer associated with the first field in `fields`.
-
-[float]
-==== Query Formation Parameters
-
-[horizontal]
-`minimum_should_match`::
-After the disjunctive query has been formed, this parameter controls the
-number of terms that must match.
-The syntax is the same as the <<query-dsl-minimum-should-match,minimum should match>>.
-(Defaults to `"30%"`).
-
-`fail_on_unsupported_field`::
-Controls whether the query should fail (throw an exception) if any of the 
-specified fields are not of the supported types
-(`text` or `keyword`). Set this to `false` to ignore the field and continue
-processing. Defaults to `true`.
-
-`boost_terms`::
-Each term in the formed query could be further boosted by their tf-idf score.
-This sets the boost factor to use when using this feature. Defaults to
-deactivated (`0`). Any other positive value activates terms boosting with the
-given boost factor.
-
-`include`::
-Specifies whether the input documents should also be included in the search
-results returned. Defaults to `false`.
-
-`boost`::
-Sets the boost value of the whole query. Defaults to `1.0`.


### PR DESCRIPTION
Updates the `more_like_this` query to use the new query format.

This creates separate sections for the example requests, parameters, and notes.

This is part of #40977, an effort to standardize documentation for query types.

### Preview
http://elasticsearch_45017.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/query-dsl-mlt-query.html