### PR TITLE
[DOCS] Adds 7.3.0 ml-cpp release notes

### DIFF
--- a/docs/reference/release-notes/7.3.asciidoc
+++ b/docs/reference/release-notes/7.3.asciidoc
@@ -11,9 +11,7 @@ CCR::
 * Do not allow modify aliases on followers {pull}43017[#43017] (issue: {issue}41396[#41396])
 
 Data Frame::
-* [ML][Data Frame] removing format support in date_histogram group_by {pull}43659[#43659]
-
-
+* Removing format support in date_histogram group_by {pull}43659[#43659]
 
 [[breaking-java-7.3.0]]
 [float]
@@ -57,13 +55,13 @@ Audit::
 * Enable console audit logs for docker {pull}42671[#42671] (issue: {issue}42666[#42666])
 
 Data Frame::
-* [ML-DataFrame] add sync api {pull}41800[#41800]
+* Add sync api {pull}41800[#41800]
 
 Infra/Settings::
 * Consistent Secure Settings {pull}40416[#40416]
 
 Machine Learning::
-* [ML] Machine learning data frame analytics {pull}43544[#43544]
+* Machine learning data frame analytics {pull}43544[#43544]
 
 Mapping::
 * Add support for 'flattened object' fields. {pull}42541[#42541] (issues: {issue}25312[#25312], {issue}33003[#33003])
@@ -116,15 +114,15 @@ Cluster Coordination::
 * Log leader and handshake failures by default {pull}42342[#42342] (issue: {issue}42153[#42153])
 
 Data Frame::
-* [ML-DataFrame] Add a frequency option to transform config, default 1m {pull}44120[#44120]
-* [ML][Data Frame] add node attr to GET _stats {pull}43842[#43842] (issue: {issue}43743[#43743])
-* [ML][Data Frame] Add deduced mappings to _preview response payload {pull}43742[#43742] (issue: {issue}39250[#39250])
-* [ML][Data Frame] Add support for allow_no_match for endpoints {pull}43490[#43490] (issue: {issue}42766[#42766])
-* [ML][Data Frame] Add version and create_time to transform config {pull}43384[#43384] (issue: {issue}43037[#43037])
-* [ML][Data Frame] have sum map to a double to prevent overflows {pull}43213[#43213]
-* [ML][Data Frame] adds new pipeline field to dest config {pull}43124[#43124] (issue: {issue}43061[#43061])
-* [ML][Data Frame] write a warning audit on bulk index failures {pull}43106[#43106]
-* [ML] [Data Frame] add support for weighted_avg agg {pull}42646[#42646]
+* Add a frequency option to transform config, default 1m {pull}44120[#44120]
+* Add node attr to GET _stats {pull}43842[#43842] (issue: {issue}43743[#43743])
+* Add deduced mappings to _preview response payload {pull}43742[#43742] (issue: {issue}39250[#39250])
+* Add support for allow_no_match for endpoints {pull}43490[#43490] (issue: {issue}42766[#42766])
+* Add version and create_time to transform config {pull}43384[#43384] (issue: {issue}43037[#43037])
+* Have sum map to a double to prevent overflows {pull}43213[#43213]
+* Add new pipeline field to dest config {pull}43124[#43124] (issue: {issue}43061[#43061])
+* Write a warning audit on bulk index failures {pull}43106[#43106]
+* Add support for weighted_avg agg {pull}42646[#42646]
 
 Distributed::
 * Improve Close Index Response {pull}39687[#39687] (issue: {issue}33888[#33888])
@@ -180,20 +178,22 @@ Infra/Scripting::
 
 Machine Learning::
 * Add version and create_time to data frame analytics config {pull}43683[#43683]
-* [ML] Tag destination index with data frame metadata {pull}43567[#43567]
-* [ML] Improve message when native controller cannot connect {pull}43565[#43565] (issue: {issue}42341[#42341])
-* [ML] Introduce a setting for the process connect timeout {pull}43234[#43234]
+* Tag destination index with data frame metadata {pull}43567[#43567]
+* Improve message when native controller cannot connect {pull}43565[#43565] (issue: {issue}42341[#42341])
+* Introduce a setting for the process connect timeout {pull}43234[#43234]
 * Report exponential_avg_bucket_processing_time which gives more weight to recent buckets {pull}43189[#43189] (issue: {issue}29857[#29857])
-* [ML] Restrict detection of epoch timestamps in find_file_structure {pull}43188[#43188]
-* [ML] Adding support for geo_shape, geo_centroid, geo_point in datafeeds {pull}42969[#42969] (issue: {issue}42820[#42820])
-* [ML] Add earliest and latest timestamps to field stats {pull}42890[#42890]
-* [ML] Change dots in CSV column names to underscores {pull}42839[#42839] (issue: {issue}26800[#26800])
+* Restrict detection of epoch timestamps in find_file_structure {pull}43188[#43188]
+* Adding support for geo_shape, geo_centroid, geo_point in datafeeds {pull}42969[#42969] (issue: {issue}42820[#42820])
+* Add earliest and latest timestamps to field stats {pull}42890[#42890]
+* Change dots in CSV column names to underscores {pull}42839[#42839] (issue: {issue}26800[#26800])
 * Report timing stats as part of the Job stats response {pull}42709[#42709] (issue: {issue}29857[#29857])
-* [ML] Better detection of binary input in find_file_structure {pull}42707[#42707]
-* [ML] Add a limit on line merging in find_file_structure {pull}42501[#42501] (issue: {issue}38086[#38086])
+* Better detection of binary input in find_file_structure {pull}42707[#42707]
+* Add a limit on line merging in find_file_structure {pull}42501[#42501] (issue: {issue}38086[#38086])
 * Implement factory methods for ValidationException {pull}41993[#41993]
-* [ML] Improve file structure finder timestamp format determination {pull}41948[#41948] (issues: {issue}35132[#35132], {issue}35137[#35137], {issue}38086[#38086])
+* Improve file structure finder timestamp format determination {pull}41948[#41948] (issues: {issue}35132[#35132], {issue}35137[#35137], {issue}38086[#38086])
 * Increase maximum forecast interval to 10 years. {pull}41082[#41082] (issue: {issue}41103[#41103])
+* Upgrade to a newer version of the Apache Portable Runtime library. {ml-pull}495[#495]
+* Improve stability of modelling around change points. {ml-pull}496[#496]
 
 Mapping::
 * Add dims parameter to dense_vector mapping {pull}43444[#43444]
@@ -276,19 +276,19 @@ Cluster Coordination::
 * Omit non-masters in ClusterFormationFailureHelper {pull}41344[#41344]
 
 Data Frame::
-* [ML][Data Frame] treat bulk index failures as an indexing failure {pull}44351[#44351] (issue: {issue}44101[#44101])
-* [ML][Data Frame] responding with 409 status code when failing _stop {pull}44231[#44231] (issue: {issue}44103[#44103])
-* [ML][Data Frame] adds index validations to _start data frame transform {pull}44191[#44191] (issue: {issue}44104[#44104])
-* [ML] Data frame task failure do not make a 500 response {pull}44058[#44058] (issue: {issue}44011[#44011])
-* [ML-DataFrame] audit message missing for autostop {pull}43984[#43984] (issue: {issue}43977[#43977])
-* [ML-Data Frame] Add data frame transform cluster privileges to HLRC {pull}43879[#43879]
-* [ML][Data Frame] fix progress measurement for continuous transforms {pull}43838[#43838]
-* [ML][Data Frame] improve pivot nested field validations {pull}43548[#43548]
-* [ML][Data Frame] Adjusting error message {pull}43455[#43455]
-* [Ml Data Frame] Size the GET stats search by number of Ids requested {pull}43206[#43206] (issue: {issue}43203[#43203])
-* [ML-DataFrame] rewrite start and stop to answer with acknowledged {pull}42589[#42589] (issue: {issue}42450[#42450])
-* [ML Data Frame] Set DF task state to stopped when stopping   {pull}42516[#42516] (issue: {issue}42441[#42441])
-* [ML-DataFrame] add support for fixed_interval, calendar_interval, remove interval {pull}42427[#42427] (issues: {issue}33727[#33727], {issue}42297[#42297])
+* Treat bulk index failures as an indexing failure {pull}44351[#44351] (issue: {issue}44101[#44101])
+* Responding with 409 status code when failing _stop {pull}44231[#44231] (issue: {issue}44103[#44103])
+* Adds index validations to _start data frame transform {pull}44191[#44191] (issue: {issue}44104[#44104])
+* Data frame task failure do not make a 500 response {pull}44058[#44058] (issue: {issue}44011[#44011])
+* Audit message missing for autostop {pull}43984[#43984] (issue: {issue}43977[#43977])
+* Add data frame transform cluster privileges to HLRC {pull}43879[#43879]
+* Fix progress measurement for continuous transforms {pull}43838[#43838]
+* Improve pivot nested field validations {pull}43548[#43548]
+* Adjusting error message {pull}43455[#43455]
+* Size the GET stats search by number of Ids requested {pull}43206[#43206] (issue: {issue}43203[#43203])
+* Rewrite start and stop to answer with acknowledged {pull}42589[#42589] (issue: {issue}42450[#42450])
+* Set DF task state to stopped when stopping   {pull}42516[#42516] (issue: {issue}42441[#42441])
+* Add support for fixed_interval, calendar_interval, remove interval {pull}42427[#42427] (issues: {issue}33727[#33727], {issue}42297[#42297])
 
 Distributed::
 * Fix DefaultShardOperationFailedException subclass xcontent serialization {pull}43435[#43435] (issue: {issue}43423[#43423])
@@ -355,10 +355,15 @@ Machine Learning::
 * Fix test for old cluster version >= 7.3.0 {pull}44437[#44437]
 * Use specific version constant for wire bwc check {pull}44316[#44316] (issue: {issue}42501[#42501])
 * Update .ml-config mappings before indexing job, datafeed or df analytics config {pull}44216[#44216] (issue: {issue}44263[#44263])
-* [ML] Wait for .ml-config primary before assigning persistent tasks {pull}44170[#44170] (issue: {issue}44156[#44156])
-* [ML] Fix ML memory tracker lockup when inner step fails {pull}44158[#44158] (issue: {issue}44156[#44156])
-* [ML] Fix datafeed checks when a concrete remote index is present {pull}43923[#43923] (issue: {issue}42113[#42113])
-* [ML] Fix possible race condition when closing an opening job {pull}42506[#42506]
+* Wait for .ml-config primary before assigning persistent tasks {pull}44170[#44170] (issue: {issue}44156[#44156])
+* Fix ML memory tracker lockup when inner step fails {pull}44158[#44158] (issue: {issue}44156[#44156])
+* Fix datafeed checks when a concrete remote index is present {pull}43923[#43923] (issue: {issue}42113[#42113])
+* Fix possible race condition when closing an opening job {pull}42506[#42506]
+* Reduce false positives associated with the multi-bucket feature. {ml-pull}491[#491]
+* Reduce false positives for sum and count functions on sparse data. {ml-pull}492[#492]
+* Fix an edge case causing spurious anomalies (false positives) if the variance
+in the count of events changed significantly throughout the period of a seasonal
+quantity. (See {ml-pull}489[#489].)
 
 Mapping::
 * Ensure field caps doesn't error on rank feature fields. {pull}44370[#44370] (issue: {issue}44330[#44330])

--- a/docs/reference/release-notes/7.3.asciidoc
+++ b/docs/reference/release-notes/7.3.asciidoc
@@ -178,22 +178,19 @@ Infra/Scripting::
 
 Machine Learning::
 * Add version and create_time to data frame analytics config {pull}43683[#43683]
-* Tag destination index with data frame metadata {pull}43567[#43567]
 * Improve message when native controller cannot connect {pull}43565[#43565] (issue: {issue}42341[#42341])
-* Introduce a setting for the process connect timeout {pull}43234[#43234]
 * Report exponential_avg_bucket_processing_time which gives more weight to recent buckets {pull}43189[#43189] (issue: {issue}29857[#29857])
-* Restrict detection of epoch timestamps in find_file_structure {pull}43188[#43188]
 * Adding support for geo_shape, geo_centroid, geo_point in datafeeds {pull}42969[#42969] (issue: {issue}42820[#42820])
-* Add earliest and latest timestamps to field stats {pull}42890[#42890]
-* Change dots in CSV column names to underscores {pull}42839[#42839] (issue: {issue}26800[#26800])
 * Report timing stats as part of the Job stats response {pull}42709[#42709] (issue: {issue}29857[#29857])
-* Better detection of binary input in find_file_structure {pull}42707[#42707]
-* Add a limit on line merging in find_file_structure {pull}42501[#42501] (issue: {issue}38086[#38086])
-* Implement factory methods for ValidationException {pull}41993[#41993]
-* Improve file structure finder timestamp format determination {pull}41948[#41948] (issues: {issue}35132[#35132], {issue}35137[#35137], {issue}38086[#38086])
 * Increase maximum forecast interval to 10 years. {pull}41082[#41082] (issue: {issue}41103[#41103])
 * Upgrade to a newer version of the Apache Portable Runtime library. {ml-pull}495[#495]
 * Improve stability of modelling around change points. {ml-pull}496[#496]
+* Restrict detection of epoch timestamps in find_file_structure {pull}43188[#43188]
+* Better detection of binary input in find_file_structure {pull}42707[#42707]
+* Add a limit on line merging in find_file_structure {pull}42501[#42501] (issue: {issue}38086[#38086])
+* Improve file structure finder timestamp format determination {pull}41948[#41948] (issues: {issue}35132[#35132], {issue}35137[#35137], {issue}38086[#38086])
+* Add earliest and latest timestamps to field stats in find_file_structure response {pull}42890[#42890]
+* Change dots in CSV column names to underscores in find_file_structure response {pull}42839[#42839] (issue: {issue}26800[#26800])
 
 Mapping::
 * Add dims parameter to dense_vector mapping {pull}43444[#43444]
@@ -282,13 +279,11 @@ Data Frame::
 * Data frame task failure do not make a 500 response {pull}44058[#44058] (issue: {issue}44011[#44011])
 * Audit message missing for autostop {pull}43984[#43984] (issue: {issue}43977[#43977])
 * Add data frame transform cluster privileges to HLRC {pull}43879[#43879]
-* Fix progress measurement for continuous transforms {pull}43838[#43838]
 * Improve pivot nested field validations {pull}43548[#43548]
 * Adjusting error message {pull}43455[#43455]
 * Size the GET stats search by number of Ids requested {pull}43206[#43206] (issue: {issue}43203[#43203])
 * Rewrite start and stop to answer with acknowledged {pull}42589[#42589] (issue: {issue}42450[#42450])
-* Set DF task state to stopped when stopping   {pull}42516[#42516] (issue: {issue}42441[#42441])
-* Add support for fixed_interval, calendar_interval, remove interval {pull}42427[#42427] (issues: {issue}33727[#33727], {issue}42297[#42297])
+* Set data frame transform task state to stopped when stopping   {pull}42516[#42516] (issue: {issue}42441[#42441])
 
 Distributed::
 * Fix DefaultShardOperationFailedException subclass xcontent serialization {pull}43435[#43435] (issue: {issue}43423[#43423])
@@ -352,13 +347,9 @@ Infra/Scripting::
 * Allow aggregations using expressions to use _score {pull}42652[#42652]
 
 Machine Learning::
-* Fix test for old cluster version >= 7.3.0 {pull}44437[#44437]
-* Use specific version constant for wire bwc check {pull}44316[#44316] (issue: {issue}42501[#42501])
 * Update .ml-config mappings before indexing job, datafeed or df analytics config {pull}44216[#44216] (issue: {issue}44263[#44263])
 * Wait for .ml-config primary before assigning persistent tasks {pull}44170[#44170] (issue: {issue}44156[#44156])
 * Fix ML memory tracker lockup when inner step fails {pull}44158[#44158] (issue: {issue}44156[#44156])
-* Fix datafeed checks when a concrete remote index is present {pull}43923[#43923] (issue: {issue}42113[#42113])
-* Fix possible race condition when closing an opening job {pull}42506[#42506]
 * Reduce false positives associated with the multi-bucket feature. {ml-pull}491[#491]
 * Reduce false positives for sum and count functions on sparse data. {ml-pull}492[#492]
 * Fix an edge case causing spurious anomalies (false positives) if the variance


### PR DESCRIPTION
This PR adds the PRs fromhttps://raw.githubusercontent.com/elastic/ml-cpp/7.3/docs/CHANGELOG.asciidoc to the Elasticsearch Reference 7.3.0 Release Notes.

It also edits the existing machine learning and data frame transform PRs.