### PR TITLE
[DOCS] Update release state for 7.3 release.

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -17,7 +17,7 @@ bare_version never includes -alpha or -beta
 release-state can be: released | prerelease | unreleased
 //////////
 
-:release-state:   unreleased
+:release-state:   released
 
 :issue:           https://github.com/elastic/elasticsearch/issues/
 :ml-issue:        https://github.com/elastic/ml-cpp/issues/


### PR DESCRIPTION
Sets release-state to _released_ for 7.3.

Will merge on release day.

