### PR TITLE
Do not use scroll when finding duplicate API key

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -211,7 +211,6 @@ public class ApiKeyService {
         boolQuery.filter(expiredQuery);
 
         final SearchRequest searchRequest = client.prepareSearch(SECURITY_MAIN_ALIAS)
-            .setScroll(DEFAULT_KEEPALIVE_SETTING.get(settings))
             .setQuery(boolQuery)
             .setVersion(false)
             .setSize(1)


### PR DESCRIPTION
When we create API key we check if the API key with the name
already exists. It searches with scroll enabled and this causes
the request to fail when creating a large number of API keys in
parallel as it hits the number of open scroll limit (default 500).
We do not need the search context to be created so this commit
removes the scroll parameter from the search request done for 
a duplicate API key check.
Manual testing is done by creating 100K API keys (100 threads running in parallel)