### PR TITLE
Mute all GC Disruption Simulating Tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/discovery/MasterDisruptionIT.java
+++ b/server/src/test/java/org/elasticsearch/discovery/MasterDisruptionIT.java
@@ -55,6 +55,7 @@ public class MasterDisruptionIT extends AbstractDisruptionTestCase {
     /**
      * Test that cluster recovers from a long GC on master that causes other nodes to elect a new one
      */
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/43387")
     public void testMasterNodeGCs() throws Exception {
         List<String> nodes = startCluster(3);
 

--- a/server/src/test/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
+++ b/server/src/test/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
@@ -173,6 +173,7 @@ public class StableMasterDisruptionIT extends ESIntegTestCase {
      * Tests that emulates a frozen elected master node that unfreezes and pushes its cluster state to other nodes that already are
      * following another elected master node. These nodes should reject this cluster state and prevent them from following the stale master.
      */
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/43387")
     public void testStaleMasterNotHijackingMajority() throws Exception {
         final List<String> nodes = internalCluster().startNodes(3, Settings.builder()
             .put(LeaderChecker.LEADER_CHECK_TIMEOUT_SETTING.getKey(), "1s")

--- a/test/framework/src/test/java/org/elasticsearch/test/disruption/LongGCDisruptionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/disruption/LongGCDisruptionTests.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.test.disruption;
 
+import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.test.ESTestCase;
 
@@ -36,6 +37,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
+@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/43387")
 public class LongGCDisruptionTests extends ESTestCase {
 
     static class LockedExecutor {


### PR DESCRIPTION
* We suspect these might be causing #43387 so let's mute them on `master` temporarily to find out
