### PR TITLE
Remove left-over AwaitsFix in DedicatedClusterSnapshotRestoreIT

### DIFF
--- a/server/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -21,6 +21,7 @@ package org.elasticsearch.snapshots;
 
 import com.carrotsearch.hppc.IntHashSet;
 import com.carrotsearch.hppc.IntSet;
+
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
@@ -998,7 +999,6 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
      * can be restored when the node the shrunken index was created on is no longer part of
      * the cluster.
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/38845")
     public void testRestoreShrinkIndex() throws Exception {
         logger.info("-->  starting a master node and a data node");
         internalCluster().startMasterOnlyNode();


### PR DESCRIPTION
The issue mentioned (#38845) seems to have been closed with #38891 so the test
can be re-activated.