### PR TITLE
Remove left-over AwaitsFix in RateClusterStateIT

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/RareClusterStateIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/RareClusterStateIT.java
@@ -183,7 +183,6 @@ public class RareClusterStateIT extends ESIntegTestCase {
         assertHitCount(client().prepareSearch("test").get(), 0);
     }
 
-    @AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/41030")
     public void testDelayedMappingPropagationOnPrimary() throws Exception {
         // Here we want to test that things go well if there is a first request
         // that adds mappings but before mappings are propagated to all nodes
@@ -276,7 +275,6 @@ public class RareClusterStateIT extends ESIntegTestCase {
         });
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/36813")
     public void testDelayedMappingPropagationOnReplica() throws Exception {
         // This is essentially the same thing as testDelayedMappingPropagationOnPrimary
         // but for replicas


### PR DESCRIPTION
Issues are closed and fixes in #42580 and #42430 seem to be merged to 7.x at
least.