### PR TITLE
Bump version from 7.3.0 to 7.3.1

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -1,4 +1,4 @@
-elasticsearch     = 7.3.0
+elasticsearch     = 7.3.1
 lucene            = 8.1.0
 
 bundled_jdk       = 12.0.1+12@69cfe15208a647278a19ef0990eea691

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -106,7 +106,8 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_7_2_1 = new Version(7020199, org.apache.lucene.util.Version.LUCENE_8_0_0);
     public static final Version V_7_2_2 = new Version(7020299, org.apache.lucene.util.Version.LUCENE_8_0_0);
     public static final Version V_7_3_0 = new Version(7030099, org.apache.lucene.util.Version.LUCENE_8_1_0);
-    public static final Version CURRENT = V_7_3_0;
+    public static final Version V_7_3_1 = new Version(7030199, org.apache.lucene.util.Version.LUCENE_8_1_0);
+    public static final Version CURRENT = V_7_3_1;
 
     private static final ImmutableOpenIntMap<Version> idToVersion;
 


### PR DESCRIPTION
Prepping for version bump.

Do not merge until green light given to bump versions (CI failures are expected)