### PR TITLE
Introduce 7.3.1 version number on 7.x

### DIFF
--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -106,6 +106,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_7_2_1 = new Version(7020199, org.apache.lucene.util.Version.LUCENE_8_0_0);
     public static final Version V_7_2_2 = new Version(7020299, org.apache.lucene.util.Version.LUCENE_8_0_0);
     public static final Version V_7_3_0 = new Version(7030099, org.apache.lucene.util.Version.LUCENE_8_1_0);
+    public static final Version V_7_3_1 = new Version(7030199, org.apache.lucene.util.Version.LUCENE_8_1_0);
     public static final Version V_7_4_0 = new Version(7040099, org.apache.lucene.util.Version.LUCENE_8_2_0);
     public static final Version CURRENT = V_7_4_0;
 


### PR DESCRIPTION
Prepping for version bump.

Do not merge until green light given to bump versions (CI failures are expected)