### PR TITLE
Reenable Parallel Restore Test on Windows (#45037)

### DIFF
--- a/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.snapshots;
 
-import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
@@ -3691,7 +3690,6 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
     }
 
     public void testParallelRestoreOperationsFromSingleSnapshot() throws Exception {
-        assumeFalse("https://github.com/elastic/elasticsearch/issues/44671", Constants.WINDOWS);
         String indexName1 = "testindex1";
         String indexName2 = "testindex2";
         String repoName = "test-restore-snapshot-repo";


### PR DESCRIPTION
* As a result of #44096 this test shouldn't fail anymore on `master` and `7.4`+ so we should reenable it there
  * For older versions we won't backport that change so the tests should stay disabled there
* Closes #44671

backport of #45037 