### PR TITLE
[DOCS] Reformat percolate query

### DIFF
--- a/docs/reference/query-dsl/percolate-query.asciidoc
+++ b/docs/reference/query-dsl/percolate-query.asciidoc
@@ -4,15 +4,28 @@
 <titleabbrev>Percolate</titleabbrev>
 ++++
 
-The `percolate` query can be used to match queries
-stored in an index. The `percolate` query itself
-contains the document that will be used as query
-to match with the stored queries.
+Returns, or percolates, stored queries based on documents those queries would
+match.
 
-[float]
-=== Sample Usage
+The `percolate` query acts as a reverse search. First, you index stored queries
+using a <<percolator,`percolator`>> field. Then you can use a `percolate` query
+to return those stored queries based on documents they would match.
 
-Create an index with two fields:
+
+[[percolate-query-ex-requests]]
+==== Example request
+
+[[percolate-query-index-setup]]
+===== Index setup
+To use the `percolate` query, your index must include a
+<<percolator,`percolator`>> field. To see how you can set up an index for this
+query, try the following example.
+
+Create an index with the following field mapping:
+
+* `stored-query`, a <<percolator,`percolator`>> field used to store queries
+* `message`, a <<text,`text`>> field
+
 
 [source,js]
 --------------------------------------------------
@@ -20,11 +33,11 @@ PUT /my-index
 {
     "mappings": {
         "properties": {
-             "message": {
-                 "type": "text"
-             },
-             "query": {
+             "stored-query": {
                  "type": "percolator"
+             },
+              "message": {
+                 "type": "text"
              }
         }
     }
@@ -32,22 +45,13 @@ PUT /my-index
 --------------------------------------------------
 // CONSOLE
 
-The `message` field is the field used to preprocess the document defined in
-the `percolator` query before it gets indexed into a temporary index.
-
-The `query` field is used for indexing the query documents. It will hold a
-json object that represents an actual Elasticsearch query. The `query` field
-has been configured to use the <<percolator,percolator field type>>. This field
-type understands the query dsl and stores the query in such a way that it can be
-used later on to match documents defined on the `percolate` query.
-
-Register a query in the percolator:
+Index a stored query.
 
 [source,js]
 --------------------------------------------------
 PUT /my-index/_doc/1?refresh
 {
-    "query" : {
+    "stored-query" : {
         "match" : {
             "message" : "bonsai tree"
         }
@@ -57,7 +61,16 @@ PUT /my-index/_doc/1?refresh
 // CONSOLE
 // TEST[continued]
 
-Match a document to the registered percolator queries:
+TIP: This example uses one index, `my-index`, for both stored queries and
+documents. This can work well if your index contains only a few stored queries.
+For heavier usage, we recommend storing queries and documents in separate
+indices. See <<how-it-works>> for more details.
+
+[[percolate-query-ex-query]]
+===== Example query
+
+Run the following `percolate` search to return stored queries that would match
+the provided `document`.
 
 [source,js]
 --------------------------------------------------
@@ -65,7 +78,7 @@ GET /my-index/_search
 {
     "query" : {
         "percolate" : {
-            "field" : "query",
+            "field" : "stored-query",
             "document" : {
                 "message" : "A new bonsai tree in the office"
             }
@@ -76,7 +89,7 @@ GET /my-index/_search
 // CONSOLE
 // TEST[continued]
 
-The above request will yield the following response:
+The search returns the following response.
 
 [source,js]
 --------------------------------------------------
@@ -96,13 +109,13 @@ The above request will yield the following response:
     },
     "max_score": 0.26152915,
     "hits": [
-      { <1>
+      {
         "_index": "my-index",
         "_type": "_doc",
-        "_id": "1",
+        "_id": "1", <1>
         "_score": 0.26152915,
         "_source": {
-          "query": {
+          "stored-query": {
             "match": {
               "message": "bonsai tree"
             }
@@ -120,40 +133,51 @@ The above request will yield the following response:
 
 <1> The query with id `1` matches our document.
 <2> The `_percolator_document_slot` field indicates which document has matched with this query.
-    Useful when percolating multiple document simultaneously.
+    Useful when percolating multiple documents simultaneously.
 
-TIP: To provide a simple example, this documentation uses one index `my-index` for both the percolate queries and documents.
-This set-up can work well when there are just a few percolate queries registered. However, with heavier usage it is recommended
-to store queries and documents in separate indices. Please see <<how-it-works, How it Works Under the Hood>> for more details.
 
-[float]
-==== Parameters
 
-The following parameters are required when percolating a document:
+[[percolate-top-level-params]]
+==== Top-level parameters for `percolate`
+`field`::
+(Required, string) <<percolator,`percolator`>> field used to store queries.
 
-[horizontal]
-`field`:: The field of type `percolator` that holds the indexed queries. This is a required parameter.
-`name`:: The suffix to be used for the `_percolator_document_slot` field in case multiple `percolate` queries have been specified.
-         This is an optional parameter.
-`document`:: The source of the document being percolated.
-`documents`:: Like the `document` parameter, but accepts multiple documents via a json array.
-`document_type`:: The type / mapping of the document being percolated. This parameter is deprecated and will be removed in Elasticsearch 8.0.
+[[percolate-query-document-param]]
+`document`::
++
+--
+(Optional, <<docs-index_,document object>>) Document used to return, or
+percolate, matching queries.
 
-Instead of specifying the source of the document being percolated, the source can also be retrieved from an already
-stored document. The `percolate` query will then internally execute a get request to fetch that document.
+To use multiple documents, use the
+<<percolate-query-documents-param,`documents`>> parameter.
 
-In that case the `document` parameter can be substituted with the following parameters:
+To use an existing document, use <<percolate-document-lookup-params,document
+lookup parameters>>. See <<percolate-query-existing-document>> for an
+example.
+--
 
-[horizontal]
-`index`:: The index the document resides in. This is a required parameter.
-`type`:: The type of the document to fetch. This parameter is deprecated and will be removed in Elasticsearch 8.0.
-`id`:: The id of the document to fetch. This is a required parameter.
-`routing`:: Optionally, routing to be used to fetch document to percolate.
-`preference`:: Optionally, preference to be used to fetch document to percolate.
-`version`:: Optionally, the expected version of the document to be fetched.
+[[percolate-query-documents-param]]
+`documents`::
+(Optional, array of <<docs-index_,document objects>>) Array of documents used to
+find matching stored queries. See <<percolate-query-multi-docs>> for an example.
 
-[float]
-==== Percolating in a filter context
+`name`::
+(Optional, string) Suffix used with the `_percolator_document_slot` meta-field
+if multiple `percolate` queries are used. See <<multiple-percolate-queries>>
+for an example.
+
+`document_type`::
+(Optional, string) <<mapping-type-field,Type>> of the document used to find
+matching queries. This parameter is deprecated and will be removed in 8.0. See
+<<removal-of-types>>.
+
+
+[[percolate-query-notes]]
+==== Notes
+
+[[percolate-query-filter-context]]
+===== Percolate in a filter context
 
 In case you are not interested in the score, better performance can be expected by wrapping
 the percolator query in a `bool` query's filter clause or in a `constant_score` query:
@@ -166,7 +190,7 @@ GET /my-index/_search
         "constant_score": {
             "filter": {
                 "percolate" : {
-                    "field" : "query",
+                    "field" : "stored-query",
                     "document" : {
                         "message" : "A new bonsai tree in the office"
                     }
@@ -188,8 +212,8 @@ should be wrapped in a `constant_score` query or a `bool` query's filter clause.
 
 Note that the `percolate` query never gets cached by the query cache.
 
-[float]
-==== Percolating multiple documents
+[[percolate-query-multi-docs]]
+===== Percolate multiple documents
 
 The `percolate` query can match multiple documents simultaneously with the indexed percolator queries.
 Percolating multiple documents in a single request can improve performance as queries only need to be parsed and
@@ -205,7 +229,7 @@ GET /my-index/_search
 {
     "query" : {
         "percolate" : {
-            "field" : "query",
+            "field" : "stored-query",
             "documents" : [ <1>
                 {
                     "message" : "bonsai tree"
@@ -253,7 +277,7 @@ GET /my-index/_search
         "_id": "1",
         "_score": 0.7093853,
         "_source": {
-          "query": {
+          "stored-query": {
             "match": {
               "message": "bonsai tree"
             }
@@ -272,15 +296,15 @@ GET /my-index/_search
 <1> The `_percolator_document_slot` indicates that the first, second and last documents specified in the `percolate` query
     are matching with this query.
 
-[float]
-==== Percolating an Existing Document
+[[percolate-query-existing-document]]
+===== Percolate an Existing Document
 
 In order to percolate a newly indexed document, the `percolate` query can be used. Based on the response
 from an index request, the `_id` and other meta information can be used to immediately percolate the newly added
 document.
 
-[float]
-===== Example
+[[percolate-query-existing-document-ex]]
+====== Example 
 
 Based on the previous example.
 
@@ -324,7 +348,7 @@ GET /my-index/_search
 {
     "query" : {
         "percolate" : {
-            "field": "query",
+            "field": "stored-query",
             "index" : "my-index",
             "id" : "2",
             "version" : 1 <1>
@@ -341,15 +365,41 @@ case the search request would fail with a version conflict error.
 
 The search response returned is identical as in the previous example.
 
-[float]
-==== Percolate query and highlighting
+[[percolate-document-lookup-params]]
+====== Document lookup parameters
+To fetch an existing document, use the following document lookup parameters
+in place of the <<percolate-query-document-param,`document`>> parameter.
+
+`index`::
+(Required, string) Name of the index from which to fetch a document.
+
+`id`::
+(Required, string) <<mapping-id-field,ID>> of the document to fetch.
+
+`preference`::
+(Optional, string) <<search-request-preference,Preference>> of shard copies from
+which to fetch the document.
+
+`routing`::
+(Optional, string) Custom <<mapping-routing-field, routing value>>
+of the document to fetch.
+
+`type`::
+(Optional, string) <<mapping-type-field,Type>> of the document to fetch. This
+parameter is deprecated and will be removed in 8.0. See <<removal-of-types>>.
+
+`version`::
+(Optional, string) <<search-request-version,Version>> of the document to fetch.
+
+[[percolate-query-highlighting]]
+===== Percolate query and highlighting
 
 The `percolate` query is handled in a special way when it comes to highlighting. The queries hits are used
 to highlight the document that is provided in the `percolate` query. Whereas with regular highlighting the query in
 the search request is used to highlight the hits.
 
-[float]
-===== Example
+[[percolate-query-highlighting-ex]]
+====== Example
 
 This example is based on the mapping of the first example.
 
@@ -359,7 +409,7 @@ Save a query:
 --------------------------------------------------
 PUT /my-index/_doc/3?refresh
 {
-    "query" : {
+    "stored-query" : {
         "match" : {
             "message" : "brown fox"
         }
@@ -375,7 +425,7 @@ Save another query:
 --------------------------------------------------
 PUT /my-index/_doc/4?refresh
 {
-    "query" : {
+    "stored-query" : {
         "match" : {
             "message" : "lazy dog"
         }
@@ -393,7 +443,7 @@ GET /my-index/_search
 {
     "query" : {
         "percolate" : {
-            "field": "query",
+            "field": "stored-query",
             "document" : {
                 "message" : "The quick brown fox jumps over the lazy dog"
             }
@@ -435,7 +485,7 @@ This will yield the following response.
         "_id": "3",
         "_score": 0.26152915,
         "_source": {
-          "query": {
+          "stored-query": {
             "match": {
               "message": "brown fox"
             }
@@ -456,7 +506,7 @@ This will yield the following response.
         "_id": "4",
         "_score": 0.26152915,
         "_source": {
-          "query": {
+          "stored-query": {
             "match": {
               "message": "lazy dog"
             }
@@ -490,7 +540,7 @@ GET /my-index/_search
 {
     "query" : {
         "percolate" : {
-            "field": "query",
+            "field": "stored-query",
             "documents" : [
                 {
                     "message" : "bonsai tree"
@@ -543,7 +593,7 @@ The slightly different response:
         "_id": "1",
         "_score": 0.7093853,
         "_source": {
-          "query": {
+          "stored-query": {
             "match": {
               "message": "bonsai tree"
             }
@@ -573,8 +623,8 @@ The slightly different response:
 <1> The highlight fields have been prefixed with the document slot they belong to,
     in order to know which highlight field belongs to what document.
 
-[float]
-==== Specifying multiple percolate queries
+[[multiple-percolate-queries]]
+===== Use multiple percolate queries
 
 It is possible to specify multiple `percolate` queries in a single search request:
 
@@ -587,7 +637,7 @@ GET /my-index/_search
             "should" : [
                 {
                     "percolate" : {
-                        "field" : "query",
+                        "field" : "stored-query",
                         "document" : {
                             "message" : "bonsai tree"
                         },
@@ -596,7 +646,7 @@ GET /my-index/_search
                 },
                 {
                     "percolate" : {
-                        "field" : "query",
+                        "field" : "stored-query",
                         "document" : {
                             "message" : "tulip flower"
                         },
@@ -642,7 +692,7 @@ The above search request returns a response similar to this:
         "_id": "1",
         "_score": 0.26152915,
         "_source": {
-          "query": {
+          "stored-query": {
             "match": {
               "message": "bonsai tree"
             }
@@ -661,9 +711,8 @@ The above search request returns a response similar to this:
 <1> The `_percolator_document_slot_query1` percolator slot field indicates that these matched slots are from the `percolate`
     query with `_name` parameter set to `query1`.
 
-[float]
 [[how-it-works]]
-==== How it Works Under the Hood
+===== How the `percolate` query works
 
 When indexing a document into an index that has the <<percolator,percolator field type>> mapping configured, the query
 part of the document gets parsed into a Lucene query and is stored into the Lucene index. A binary representation
@@ -697,7 +746,7 @@ GET /_search
 ---------------------------------------------------
 // CONSOLE
 
-NOTE: The above example assumes that there is a `query` field of type
+NOTE: The above example assumes that there is a `stored-query` field of type
 `percolator` in the mappings.
 
 Given the design of percolation, it often makes sense to use separate indices for the percolate queries and documents

--- a/docs/reference/query-dsl/percolate-query.asciidoc
+++ b/docs/reference/query-dsl/percolate-query.asciidoc
@@ -12,7 +12,7 @@ using a <<percolator,`percolator`>> field. Then you can use a `percolate` query
 to return those stored queries based on documents they would match.
 
 
-[[percolate-query-ex-requests]]
+[[percolate-query-ex-request]]
 ==== Example request
 
 [[percolate-query-index-setup]]


### PR DESCRIPTION
Updates the `percolate` query to use the new query format.

This creates separate sections for the example requests, parameters, and notes. Also makes other supporting changes:

- Changes the `percolator` field name from `query` to `stored-query` in examples to reduce confusion with the `query` parameter of the search API
- Renames and adds anchors to several headings

This is part of #40977, an effort to standardize documentation for query types.

### Preview
http://elasticsearch_45055.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/query-dsl-percolate-query.html