### PR TITLE
[DOCS] Adds notable 7.3 breaking changes

### DIFF
--- a/docs/reference/migration/migrate_7_3.asciidoc
+++ b/docs/reference/migration/migrate_7_3.asciidoc
@@ -9,21 +9,17 @@ your application to Elasticsearch 7.3.
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
-coming[7.3.0]
-
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
-
-// end::notable-breaking-changes[]
-
+[discrete]
 [[breaking_73_mapping_changes]]
 === Mapping changes
 `dense_vector` field now requires `dims` parameter, specifying the number of
 dimensions for document and query vectors for this field.
 
-[float]
+[discrete]
 ==== Defining multi-fields within multi-fields
 
 Previously, it was possible to define a multi-field within a multi-field.
@@ -33,39 +29,41 @@ in 8.0. To resolve the issue, all instances of `fields` that occur within a
 chained `fields` blocks into a single level, or by switching to `copy_to` if
 appropriate.
 
+[discrete]
 [[breaking_73_plugin_changes]]
 === Plugins changes
 
-[float]
+[discrete]
 ==== IndexStorePlugin changes
 
 IndexStore and DirectoryService have been replaced by a stateless and simple
 DirectoryFactory interface to create custom Lucene directory instances per shard.
 
 
-[float]
+[discrete]
 [[breaking_73_search_changes]]
-=== Search Changes
+=== Search changes
 
-[float]
+[discrete]
 ==== Deprecation of queries
 
 The `common` query has been deprecated. The same functionality can be achieved
 by the `match` query if the total number of hits is not tracked.
 
-[float]
+[discrete]
 ===== Deprecation of query parameters
 
 The `cutoff_frequency` parameter has been deprecated for `match` and `multi_match`
 queries. The same functionality can be achieved without any configuration provided
 that the total number of hits is not tracked.
 
-[float]
+[discrete]
 [[breaking_73_ccr_changes]]
-=== CCR Changes
+=== CCR changes
 
-[float]
+[discrete]
 ==== Directly modifying aliases of follower indices is no longer allowed
 
 Aliases are now replicated to a follower from its leader, so directly modifying
 aliases on follower indices is no longer allowed.
+// end::notable-breaking-changes[]


### PR DESCRIPTION
This PR updates the tagged section in the Elasticsearch 7.3 breaking changes, such that all of the breaking changes are considered "notable" and propagated to the Installation and Upgrade Guide (https://www.elastic.co/guide/en/elastic-stack/current/elasticsearch-breaking-changes.html). It also fixes some sections that needed float/discrete attributes.