### PR TITLE
[DOCS] Edits 7.3 release highlights

### DIFF
--- a/docs/reference/release-notes/highlights-7.3.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.3.0.asciidoc
@@ -4,8 +4,6 @@
 <titleabbrev>7.3.0</titleabbrev>
 ++++
 
-coming[7.3.0]
-
 //NOTE: The notable-highlights tagged regions are re-used in the
 //Installation and Upgrade Guide
 
@@ -13,8 +11,9 @@ coming[7.3.0]
 [float]
 ==== Voting-only master nodes
 
-A new <<voting-only-node,`node.voting-only`>> role has been introduced that
-allows nodes to participate in elections even though they are not eligible to become the master.
+A new {ref}/modules-node.html#voting-only-node[`node.voting-only`] role has been
+introduced that allows nodes to participate in elections even though they are
+not eligible to become the master.
 The benefit is that these nodes still help with high availability while
 requiring less CPU and heap than master nodes.
 
@@ -27,8 +26,8 @@ distribution of {es}.
 [float]
 ==== Reloading of search-time synonyms
 
-A new <<indices-reload-analyzers,Analyzer reload API>> allows to reload the
-definition of search-time analyzers and their associated resources. A common
+A new {ref}/indices-reload-analyzers.html[Analyzer reload API] allows to reload
+the definition of search-time analyzers and their associated resources. A common
 use-case for this API is the reloading of search-time synonyms. In earlier
 versions of Elasticsearch, users could force synonyms to be reloaded by closing
 the index and then opening it again. With this new API, synonyms can be updated
@@ -43,12 +42,12 @@ of {es}.
 [float]
 ==== New `flattened` field type
 
-A new <<flattened,`flattened`>> field type has been added, which can index
+A new {ref}/flattened.html[`flattened`] field type has been added, which can index
 arbitrary `json` objects into a single field. This helps avoid hitting issues
 due to many fields in mappings, at the cost of more limited search
 functionality.
 
-NOTE: The <<flattened,`flattened`>> field type is only available with the
+NOTE: The `flattened` field type is only available with the
 default distribution of {es}.
 
 // end::notable-highlights[]
@@ -57,9 +56,12 @@ default distribution of {es}.
 [float]
 ==== Functions on vector fields
 
-Painless now support computing the <<vector-functions,cosine similarity>> and
-the <<vector-functions,dot product>> of a query vector and either values of a
-<<sparse-vector,`sparse_vector`>> or <<dense-vector,`dense_vector`>> field.
+Painless now support computing the
+{ref}/query-dsl-script-score-query.html#vector-functions[cosine similarity] and
+the {ref}/query-dsl-script-score-query.html#vector-functions[dot product] of a
+query vector and either values of a
+{ref}/sparse-vector.html[`sparse_vector`] or
+{ref}/dense-vector.html[`dense_vector`] field.
 
 NOTE: These functions are only available with the default distribution of {es}.
 
@@ -69,8 +71,9 @@ NOTE: These functions are only available with the default distribution of {es}.
 [float]
 ==== Prefix and wildcard support for intervals
 
-<<query-dsl-intervals-query,Intervals>> now support querying by
-<<intervals-prefix,prefix>> or <<intervals-wildcard,wildcard>>.
+{ref}/query-dsl-intervals-query.html[Intervals] now support querying by
+{ref}/query-dsl-intervals-query.html#intervals-prefix[prefix] or
+{ref}/query-dsl-intervals-query.html#intervals-wildcard[wildcard].
 
 // end::notable-highlights[]
 
@@ -79,10 +82,10 @@ NOTE: These functions are only available with the default distribution of {es}.
 ==== Rare terms aggregation
 
 A new
-<<search-aggregations-bucket-rare-terms-aggregation,Rare Terms aggregation>>
+{ref}/search-aggregations-bucket-rare-terms-aggregation.html[Rare Terms aggregation]
 allows to find the least frequent values in a field. It is intended to replace
 the `"order" : { "_count" : "asc" }` option of the
-<<search-aggregations-bucket-terms-aggregation,terms aggregations>>.
+{ref}/search-aggregations-bucket-terms-aggregation.html[terms aggregations].
 
 // end::notable-highlights[]
 
@@ -90,8 +93,8 @@ the `"order" : { "_count" : "asc" }` option of the
 [float]
 ==== Aliases are replicated via {ccr}
 
-Read aliases are now replicated via <<ccr-put-follow,{ccr}>>. Note that write
-aliases are still not replicated since they only make sense for indices that
+Read aliases are now replicated via {ref}/ccr-put-follow.html[{ccr}]. Note that
+write aliases are still not replicated since they only make sense for indices that
 are being written to while follower indices do not receive direct writes.
 
 // end::notable-highlights[]
@@ -100,8 +103,8 @@ are being written to while follower indices do not receive direct writes.
 [float]
 ==== SQL supports frozen indices
 
-{es-sql} now supports querying <<frozen-indices, frozen indices>> via the new
-<<sql-index-frozen,`FROZEN`>> keyword.
+{es-sql} now supports querying {ref}/frozen-indices.html[frozen indices] via the
+new {ref}/sql-index-frozen.html[`FROZEN`] keyword.
 
 // end::notable-highlights[]
 
@@ -109,7 +112,7 @@ are being written to while follower indices do not receive direct writes.
 [float]
 ==== Fixed memory leak when using templates in document-level security
 
-{xpack-ref}/document-level-security.html[Document-level security] was using an
+{stack-ov}/document-level-security.html[Document-level security] was using an
 unbounded cache for the set of visible documents. This could lead to a memory
 leak when using a templated query as a role query. The cache has been fixed to
 evict based on memory usage and has a limit of 50MB.
@@ -120,9 +123,9 @@ evict based on memory usage and has a limit of 50MB.
 [float]
 ==== More memory-efficient aggregations on `keyword` fields
 
-<<search-aggregations-bucket-terms-aggregation,Terms aggregations>> generally
-need to build
-<<search-aggregations-bucket-terms-aggregation-execution-hint,global ordinals>>
+{ref}/search-aggregations-bucket-terms-aggregation.html[Terms aggregations]
+generally need to build
+{ref}/search-aggregations-bucket-terms-aggregation.html#search-aggregations-bucket-terms-aggregation-execution-hint[global ordinals]
 in order to run. Unfortunately this operation became more memory-intensive in
 6.0 due to the move to doc-value iterators in order to improve handling of
 sparse fields. Memory pressure of global ordinals now goes back to a more
@@ -170,7 +173,8 @@ bulk of the data in the index. We assign to each analysed data point an
 index.
  
 In addition to new {oldetection} functionality, we are introducing the 
-{ref}/evaluate-dfanalytics.html[evaluate {dfanalytics} API], which enables you to compute a range of performance metrics such 
+{ref}/evaluate-dfanalytics.html[evaluate {dfanalytics} API], which enables you
+to compute a range of performance metrics such 
 as confusion matrices, precision, recall, the 
 https://en.wikipedia.org/wiki/Receiver_operating_characteristic[receiver-operating characteristics (ROC) curve] 
 and the area under the ROC curve. If you are running {oldetection} on a source 

--- a/docs/reference/sql/index.asciidoc
+++ b/docs/reference/sql/index.asciidoc
@@ -7,7 +7,6 @@
 :sql-specs: {sql-tests}/src/main/resources/
 :jdbc-tests: {sql-tests}/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc
 :security-tests: {sql-tests}/security/src/test/java/org/elasticsearch/xpack/sql/qa/security
-:es-sql: Elasticsearch SQL
 
 [partintro]
 --


### PR DESCRIPTION
This PR updates the Elasticsearch 7.3.0 Release Highlights so that they can be successfully re-used in the Installation and Upgrade Guide (https://www.elastic.co/guide/en/elastic-stack/current/elasticsearch-highlights.html).  In particular, it:

- removes the coming[7.3.0] tag,
- moves the es-sql attribute to the shared attributes in https://github.com/elastic/docs/blob/master/shared/attributes.asciidoc
- change all inline links to external links, so they'll work in both places