### PR TITLE
Make PathTrieIterator a Little more Memory Efficient (#44951)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/path/PathTrie.java
+++ b/server/src/main/java/org/elasticsearch/common/path/PathTrie.java
@@ -57,7 +57,7 @@ public class PathTrie<T> {
         WILDCARD_NODES_ALLOWED
     }
 
-    static EnumSet<TrieMatchingMode> EXPLICIT_OR_ROOT_WILDCARD =
+    private static final EnumSet<TrieMatchingMode> EXPLICIT_OR_ROOT_WILDCARD =
             EnumSet.of(TrieMatchingMode.EXPLICIT_NODES_ONLY, TrieMatchingMode.WILDCARD_ROOT_NODES_ALLOWED);
 
     public interface Decoder {
@@ -79,17 +79,15 @@ public class PathTrie<T> {
     public class TrieNode {
         private transient String key;
         private transient T value;
-        private boolean isWildcard;
         private final String wildcard;
 
         private transient String namedWildcard;
 
         private Map<String, TrieNode> children;
 
-        public TrieNode(String key, T value, String wildcard) {
+        private TrieNode(String key, T value, String wildcard) {
             this.key = key;
             this.wildcard = wildcard;
-            this.isWildcard = (key.equals(wildcard));
             this.value = value;
             this.children = emptyMap();
             if (isNamedWildcard(key)) {
@@ -99,7 +97,7 @@ public class PathTrie<T> {
             }
         }
 
-        public void updateKeyWithNamedWildcard(String key) {
+        private void updateKeyWithNamedWildcard(String key) {
             this.key = key;
             namedWildcard = key.substring(key.indexOf('{') + 1, key.indexOf('}'));
         }
@@ -110,7 +108,7 @@ public class PathTrie<T> {
             children = unmodifiableMap(newChildren);
         }
 
-        public synchronized void insert(String[] path, int index, T value) {
+        private synchronized void insert(String[] path, int index, T value) {
             if (index >= path.length)
                 return;
 
@@ -145,7 +143,7 @@ public class PathTrie<T> {
             node.insert(path, index + 1, value);
         }
 
-        public synchronized void insertOrUpdate(String[] path, int index, T value, BiFunction<T, T, T> updater) {
+        private synchronized void insertOrUpdate(String[] path, int index, T value, BiFunction<T, T, T> updater) {
             if (index >= path.length)
                 return;
 
@@ -357,14 +355,14 @@ public class PathTrie<T> {
         return new PathTrieIterator<>(this, path, paramSupplier);
     }
 
-    class PathTrieIterator<T> implements Iterator<T> {
+    private static class PathTrieIterator<T> implements Iterator<T> {
 
         private final List<TrieMatchingMode> modes;
         private final Supplier<Map<String, String>> paramSupplier;
         private final PathTrie<T> trie;
         private final String path;
 
-        PathTrieIterator(PathTrie trie, String path, Supplier<Map<String, String>> paramSupplier) {
+        PathTrieIterator(PathTrie<T> trie, String path, Supplier<Map<String, String>> paramSupplier) {
             this.path = path;
             this.trie = trie;
             this.paramSupplier = paramSupplier;

--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -363,11 +363,12 @@ public class RestController implements HttpServerTransport.Dispatcher {
         // Between retrieving the correct path, we need to reset the parameters,
         // otherwise parameters are parsed out of the URI that aren't actually handled.
         final Map<String, String> originalParams = new HashMap<>(request.params());
+        final Map<String, String> requestParamsRef = request.params();
         return handlers.retrieveAll(getPath(request), () -> {
             // PathTrie modifies the request, so reset the params between each iteration
-            request.params().clear();
-            request.params().putAll(originalParams);
-            return request.params();
+            requestParamsRef.clear();
+            requestParamsRef.putAll(originalParams);
+            return requestParamsRef;
         });
     }
 


### PR DESCRIPTION
* There's no need to have the trie iterator hold another reference to the request object (which could be huge, see #44564)
* Also removed unused boolean field from trie node

backport of #44951 