### PR TITLE
Fix wrong comment

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -66,7 +66,7 @@ A type used to be a logical category/partition of your index to allow you to sto
 
 A document is a basic unit of information that can be indexed. For example, you can have a document for a single customer, another document for a single product, and yet another for a single order. This document is expressed in http://json.org/[JSON] (JavaScript Object Notation) which is a ubiquitous internet data interchange format.
 
-Within an index/type, you can store as many documents as you want. Note that although a document physically resides in an index, a document actually must be indexed/assigned to a type inside an index.
+There is maximum number of documents you can have in an index/type(refer to note in Shards & Replicas). Note that although a document physically resides in an index, a document actually must be indexed/assigned to a type inside an index.
 
 [[getting-started-shards-and-replicas]]
 [float]


### PR DESCRIPTION
With note in `Shards & Replicas`, the docs in an index has max number rather that limitless.

Signed-off-by: Xiang Dai <764524258@qq.com>
