### PR TITLE
[DOCS] Adds allow no jobs param to the GET, GET stats and Close APIs 7.1-6.5

### DIFF
--- a/docs/reference/ml/apis/close-job.asciidoc
+++ b/docs/reference/ml/apis/close-job.asciidoc
@@ -12,8 +12,8 @@ A job can be opened and closed multiple times throughout its lifecycle.
 A closed job cannot receive data or perform analysis
 operations, but you can still explore and navigate results.
 
-
-==== Request
+[[ml-close-job-request]]
+==== {api-request-title}
 
 `POST _ml/anomaly_detectors/<job_id>/_close` +
 
@@ -21,8 +21,14 @@ operations, but you can still explore and navigate results.
 
 `POST _ml/anomaly_detectors/_all/_close` +
 
+[[ml-close-job-prereqs]]
+==== {api-prereq-title}
 
-==== Description
+You must have `manage_ml`, or `manage` cluster privileges to use this API.
+For more information, see {xpack-ref}/security-privileges.html[Security Privileges].
+
+[[ml-close-job-desc]]
+==== {api-description-title}
 
 You can close multiple jobs in a single API request by using a group name, a
 comma-separated list of jobs, or a wildcard expression. You can close all jobs
@@ -47,15 +53,29 @@ after the close job API returns.  The `force` query parameter should only be use
 situations where the job has already failed, or where you are not interested in
 results the job might have recently produced or might produce in the future.
 
-
-==== Path Parameters
+[[ml-close-job-path-parms]]
+==== {api-path-parms-title}
 
 `job_id`::
   (string) Identifier for the job. It can be a job identifier, a group name, or
   a wildcard expression.
 
+[[ml-close-job-query-parms]]
+==== {api-query-parms-title}
 
-==== Query Parameters
+`allow_no_jobs`::
+  (Optional, boolean) Specifies what to do when the request:
++
+--
+* Contains wildcard expressions and there are no jobs that match.
+* Contains the `_all` string or no identifiers and there are no matches.
+* Contains wildcard expressions and there are only partial matches.
+
+The default value is `true`, which returns an empty `jobs` array 
+when there are no matches and the subset of results when there are partial 
+matches. If this parameter is `false`, the request returns a `404` status code
+when there are no matches or only partial matches.
+--
 
 `force`::
   (boolean) Use to close a failed job, or to forcefully close a job which has not
@@ -65,14 +85,15 @@ results the job might have recently produced or might produce in the future.
   (time units) Controls the time to wait until a job has closed.
   The default value is 30 minutes.
 
+[[ml-close-job-response-codes]]
+==== {api-response-codes-title}
 
-==== Authorization
+`404` (Missing resources)::
+  If `allow_no_jobs` is `false`, this code indicates that there are no 
+  resources that match the request or only partial matches for the request.
 
-You must have `manage_ml`, or `manage` cluster privileges to use this API.
-For more information, see {xpack-ref}/security-privileges.html[Security Privileges].
-
-
-==== Examples
+[[ml-close-job-example]]
+==== {api-examples-title}
 
 The following example closes the `total-requests` job:
 

--- a/docs/reference/ml/apis/get-job-stats.asciidoc
+++ b/docs/reference/ml/apis/get-job-stats.asciidoc
@@ -9,8 +9,8 @@
 Retrieves usage information for jobs.
 
 
-==== Request
-
+[[ml-get-job-stats-request]]
+==== {api-request-title}
 
 
 `GET _ml/anomaly_detectors/<job_id>/_stats`
@@ -21,8 +21,15 @@ Retrieves usage information for jobs.
 
 `GET _ml/anomaly_detectors/_all/_stats` +
 
+[[ml-get-job-stats-prereqs]]
+==== {api-prereq-title}
 
-===== Description
+You must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster
+privileges to use this API. For more information, see
+{xpack-ref}/security-privileges.html[Security Privileges].
+
+[[ml-get-job-stats-desc]]
+==== {api-description-title}
 
 You can get statistics for multiple jobs in a single API request by using a
 group name, a comma-separated list of jobs, or a wildcard expression. You can
@@ -31,16 +38,33 @@ get statistics for all jobs by using `_all`, by specifying `*` as the
 
 IMPORTANT: This API returns a maximum of 10,000 jobs.
 
-
-==== Path Parameters
+[[ml-get-job-stats-path-parms]]
+==== {api-path-parms-title}
 
 `job_id`::
   (string) An identifier for the job. It can be a job identifier, a group name,
   or a wildcard expression. If you do not specify one of these options, the API
   returns statistics for all jobs.
 
+[[ml-get-job-stats-query-parms]]
+==== {api-query-parms-title}
 
-==== Results
+`allow_no_jobs`::
+  (Optional, boolean) Specifies what to do when the request:
++
+--
+* Contains wildcard expressions and there are no jobs that match.
+* Contains the `_all` string or no identifiers and there are no matches.
+* Contains wildcard expressions and there are only partial matches.
+
+The default value is `true`, which returns an empty `jobs` array 
+when there are no matches and the subset of results when there are partial 
+matches. If this parameter is `false`, the request returns a `404` status code
+when there are no matches or only partial matches.
+--
+
+[[ml-get-job-stats-results]]
+==== {api-response-body-title}
 
 The API returns the following information:
 
@@ -48,15 +72,15 @@ The API returns the following information:
   (array) An array of job statistics objects.
   For more information, see <<ml-jobstats,Job Statistics>>.
 
+[[ml-get-job-stats-response-codes]]
+==== {api-response-codes-title}
 
-==== Authorization
+`404` (Missing resources)::
+  If `allow_no_jobs` is `false`, this code indicates that there are no 
+  resources that match the request or only partial matches for the request.
 
-You must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster
-privileges to use this API. For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
-
-
-==== Examples
+[[ml-get-job-stats-example]]
+==== {api-examples-title}
 
 The following example gets usage information for the `farequote` job:
 

--- a/docs/reference/ml/apis/get-job.asciidoc
+++ b/docs/reference/ml/apis/get-job.asciidoc
@@ -8,8 +8,8 @@
 
 Retrieves configuration information for jobs.
 
-
-==== Request
+[[ml-get-job-request]]
+==== {api-request-title}
 
 `GET _ml/anomaly_detectors/<job_id>` +
 
@@ -19,8 +19,15 @@ Retrieves configuration information for jobs.
 
 `GET _ml/anomaly_detectors/_all`
 
+[[ml-get-job-prereqs]]
+==== {api-prereq-title}
 
-===== Description
+You must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster
+privileges to use this API. For more information, see
+{xpack-ref}/security-privileges.html[Security Privileges].
+
+[[ml-get-job-desc]]
+==== {api-description-title}
 
 You can get information for multiple jobs in a single API request by using a
 group name, a comma-separated list of jobs, or a wildcard expression. You can
@@ -29,15 +36,33 @@ get information for all jobs by using `_all`, by specifying `*` as the
 
 IMPORTANT: This API returns a maximum of 10,000 jobs. 
 
-
-==== Path Parameters
+[[ml-get-job-path-parms]]
+==== {api-path-parms-title}
 
 `job_id`::
   (string) Identifier for the job. It can be a job identifier, a group name,
   or a wildcard expression. If you do not specify one of these options, the API
   returns information for all jobs.
 
-==== Results
+[[ml-get-job-query-parms]]
+==== {api-query-parms-title}
+
+`allow_no_jobs`::
+  (Optional, boolean) Specifies what to do when the request:
++
+--
+* Contains wildcard expressions and there are no jobs that match.
+* Contains the `_all` string or no identifiers and there are no matches.
+* Contains wildcard expressions and there are only partial matches.
+
+The default value is `true`, which returns an empty `jobs` array 
+when there are no matches and the subset of results when there are partial 
+matches. If this parameter is `false`, the request returns a `404` status code
+when there are no matches or only partial matches.
+--
+
+[[ml-get-job-results]]
+==== {api-response-body-title}
 
 The API returns the following information:
 
@@ -45,15 +70,15 @@ The API returns the following information:
   (array) An array of job resources.
   For more information, see <<ml-job-resource,Job Resources>>.
 
+[[ml-get-job-response-codes]]
+==== {api-response-codes-title}
 
-==== Authorization
+`404` (Missing resources)::
+  If `allow_no_jobs` is `false`, this code indicates that there are no 
+  resources that match the request or only partial matches for the request.
 
-You must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster
-privileges to use this API. For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
-
-
-==== Examples
+[[ml-get-job-example]]
+==== {api-examples-title}
 
 The following example gets configuration information for the `total-requests` job:
 


### PR DESCRIPTION
This PR adds the allow_no_jobs parameter under the query parameters section to the GET, GET stats, and Close jobs APIs from 7.1 to 6.5.

Related PR (master-7.2): https://github.com/elastic/elasticsearch/pull/44503
Related issue: #44093