### PR TITLE
Make 6.8 understand tests.distributions=default

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
@@ -31,6 +31,16 @@ class ClusterConfiguration {
     @Input
     String distribution = 'zip'
 
+    public String getDistribution() {
+        // Never version call this 'default' and 'oss' create an alias so we 
+        // understand those names
+        if (distribution == 'default') {
+            return 'zip'
+        } else {
+            return distribution
+        }
+    }
+
     @Input
     int numNodes = 1
 


### PR DESCRIPTION
This  change removes a lot of complexity from our CI setup by not having
to care about the differences of how distributions are called across
branches.

