### PR TITLE
[DOCS] Reformat script score query

### DIFF
--- a/docs/reference/query-dsl/script-score-query.asciidoc
+++ b/docs/reference/query-dsl/script-score-query.asciidoc
@@ -4,7 +4,8 @@
 <titleabbrev>Script score</titleabbrev>
 ++++
 
-Uses a <<modules-scripting,script>> to provide a custom <<relevance-scores,relevance score>> for returned documents.
+Uses a <<modules-scripting,script>> to provide a custom score for returned
+documents.
 
 The `script_score` query is useful if, for example, a scoring function is expensive and you only need to calculate the score of a filtered set of documents.
 

--- a/docs/reference/query-dsl/script-score-query.asciidoc
+++ b/docs/reference/query-dsl/script-score-query.asciidoc
@@ -11,9 +11,7 @@ The `script_score` query is useful if, for example, a scoring function is expens
 
 [[script-score-query-ex-request]]
 ==== Example request
-The following `script_score` query assigns each returned document a
-<<relevance-scores,relevance score>> equal to the `likes` field value divided by
-`10`.
+The following `script_score` query assigns each returned document a score equal to the `likes` field value divided by `10`.
 
 [source,js]
 --------------------------------------------------
@@ -42,8 +40,7 @@ GET /_search
 `script`::
 +
 --
-(Required, <<modules-scripting-using,script object>>) Script used to modify
-the <<relevance-scores,relevance score>> of documents returned by the `query`.
+(Required, <<modules-scripting-using,script object>>) Script used to compute the score of documents returned by the `query`.
 
 IMPORTANT: Final relevance scores from the `script_score` query cannot be
 negative. To support certain search optimizations, Lucene requires

--- a/docs/reference/query-dsl/script-score-query.asciidoc
+++ b/docs/reference/query-dsl/script-score-query.asciidoc
@@ -223,7 +223,7 @@ and default time zone. Also calculations with `now` are not supported.
 
 [[script-score-faster-alt]]
 ===== Faster alternatives
-The `script_score` query calculates the <<relevance-scores,relevance score>> for
+The `script_score` query calculates the score for
 every matching document, or hit. There are faster alternative query types that
 can efficiently skip non-competitive hits:
 

--- a/docs/reference/query-dsl/script-score-query.asciidoc
+++ b/docs/reference/query-dsl/script-score-query.asciidoc
@@ -245,7 +245,6 @@ the `script_score` query:
 * <<random-score>>
 * <<field-value-factor>>
 * <<decay-functions>>
-* <<vector-functions>>
 
 [[script-score]]
 ====== `script_score`
@@ -329,6 +328,4 @@ through a script:
 The `script_score` query has equivalent <<decay-functions, decay functions>>
 that can be used in script.
 
-:leveloffset: +1
 include::{es-repo-dir}/vectors/vector-functions.asciidoc[]
-:leveloffset: -1

--- a/docs/reference/query-dsl/script-score-query.asciidoc
+++ b/docs/reference/query-dsl/script-score-query.asciidoc
@@ -4,18 +4,19 @@
 <titleabbrev>Script score</titleabbrev>
 ++++
 
-The `script_score` allows you to modify the score of documents that are
-retrieved by a query. This can be useful if, for example, a score
-function is computationally expensive and it is sufficient to compute
-the score on a filtered set of documents.
+Uses a <<modules-scripting,script>> to modify the <<relevance-scores,relevance
+scores>> of another query.
 
-To use `script_score`, you have to define a query and a script -
-a function to be used to compute a new score for each document returned
-by the query. For more information on scripting see
-<<modules-scripting, scripting documentation>>.
+The `script_score` query is useful if, for example, a scoring function is
+expensive and you only need to calculate the relevance score of a filtered set
+of documents.
 
-Here is an example of using `script_score` to assign each matched document
-a score equal to the number of likes divided by 10:
+
+[[script-score-query-ex-request]]
+==== Example request
+The following `script_score` query assigns each returned document a
+<<relevance-scores,relevance score>> equal to the `likes` field value divided by
+`10`.
 
 [source,js]
 --------------------------------------------------
@@ -35,27 +36,58 @@ GET /_search
 --------------------------------------------------
 // CONSOLE
 
-NOTE: The values returned from `script_score` cannot be negative. In general,
-Lucene requires the scores produced by queries to be non-negative in order to
-support certain search optimizations.
 
-==== Accessing the score of a document within a script
+[[script-score-top-level-params]]
+==== Top-level parameters for `script_score`
+`query`::
+(Required, query object) Query used to return documents.
+
+`script`::
++
+--
+(Required, <<modules-scripting-using,script object>>) Script used to modify
+the <<relevance-scores,relevance score>> of documents returned by the `query`.
+
+IMPORTANT: Final relevance scores from the `script_score` query cannot be
+negative. To support certain search optimizations, Lucene requires
+scores be positive or `0`.
+--
+
+`min_score`::
+(Optional, float) Documents with a <<relevance-scores,relevance score>> lower
+than this floating point number are excluded from the search results.
+
+
+[[script-score-query-notes]]
+==== Notes
+
+[[script-score-access-scores]]
+===== Use relevance scores in a script
 
 Within a script, you can
 {ref}/modules-scripting-fields.html#scripting-score[access] 
 the `_score` variable which represents the current relevance score of a
 document.
 
+[[script-score-predefined-functions]]
+===== Predefined functions
+You can use any of the available {painless}/painless-contexts.html[painless
+functions] in your `script`. You can also use the following predefined functions
+to customize scoring:
 
-==== Predefined functions within a Painless script
-You can use any of the available
-<<painless-api-reference, painless functions>> in the painless script.
-Besides these functions, there are a number of predefined functions
-that can help you with scoring. We suggest you to use them instead of
-rewriting equivalent functions of your own, as these functions try
-to be the most efficient by using the internal mechanisms.
+* <<script-score-saturation>>
+* <<script-score-sigmoid>>
+* <<random-score-function>>
+* <<decay-functions-numeric-fields>>
+* <<decay-functions-geo-fields>>
+* <<decay-functions-date-fields>>
+* <<script-score-functions-vector-fields>>
 
-===== saturation
+We suggest using these predefined functions instead of writing your own.
+These functions take advantage of efficiencies from {es}' internal mechanisms.
+
+[[script-score-saturation]]
+====== Saturation
 `saturation(value,k) = value/(k + value)`
 
 [source,js]
@@ -66,7 +98,8 @@ to be the most efficient by using the internal mechanisms.
 --------------------------------------------------
 // NOTCONSOLE
 
-===== sigmoid
+[[script-score-sigmoid]]
+====== Sigmoid
 `sigmoid(value, k, a) = value^a/ (k^a + value^a)`
 
 [source,js]
@@ -78,7 +111,7 @@ to be the most efficient by using the internal mechanisms.
 // NOTCONSOLE
 
 [[random-score-function]]
-===== Random score function
+====== Random score function
 `random_score` function generates scores that are uniformly distributed
 from 0 up to but not including 1.
 
@@ -108,7 +141,6 @@ by merges.
 --------------------------------------------------
 // NOTCONSOLE
 
-
 Note that documents that are within the same shard and have the
 same value for field will get the same score, so it is usually desirable
 to use a field that has unique values for all documents across a shard.
@@ -118,7 +150,7 @@ updated since update operations also update the value of the `_seq_no` field.
 
 
 [[decay-functions-numeric-fields]]
-===== Decay functions for numeric fields
+====== Decay functions for numeric fields
 You can read more about decay functions 
 {ref}/query-dsl-function-score-query.html#function-decay[here].
 
@@ -141,8 +173,8 @@ You can read more about decay functions
 // NOTCONSOLE
 <1> Using `params` allows to compile the script only once, even if params change.
 
-
-===== Decay functions for geo fields
+[[decay-functions-geo-fields]]
+====== Decay functions for geo fields
 
 * `double decayGeoLinear(String originStr, String scaleStr, String offsetStr, double decay, GeoPoint docValue)`
 
@@ -164,8 +196,8 @@ You can read more about decay functions
 --------------------------------------------------
 // NOTCONSOLE
 
-
-===== Decay functions for date fields
+[[decay-functions-date-fields]]
+====== Decay functions for date fields
 
 * `double decayDateLinear(String originStr, String scaleStr, String offsetStr, double decay, JodaCompatibleZonedDateTime docValueDate)`
 
@@ -190,33 +222,44 @@ You can read more about decay functions
 NOTE: Decay functions on dates are limited to dates in the default format
 and default time zone. Also calculations with `now` are not supported.
 
-===== Functions for vector fields
+[[script-score-functions-vector-fields]]
+====== Functions for vector fields
 <<vector-functions, Functions for vector fields>> are accessible through
 `script_score` query.
 
-==== Faster alternatives
-Script Score Query calculates the score for every hit (matching document).
-There are faster alternative query types that can efficiently skip
-non-competitive hits:
+[[script-score-faster-alt]]
+===== Faster alternatives
+The `script_score` query calculates the <<relevance-scores,relevance score>> for
+every matching document, or hit. There are faster alternative query types that
+can efficiently skip non-competitive hits:
 
-* If you want to boost documents on some static fields, use
- <<query-dsl-rank-feature-query, Rank Feature Query>>.
+* If you want to boost documents on some static fields, use the 
+ <<query-dsl-rank-feature-query, `rank_feature`>> query.
+ * If you want to boost documents closer to a date or geographic point, use the
+ <<query-dsl-distance-feature-query, `distance_feature`>> query.
 
+[[script-score-function-score-transition]]
+===== Transition from the function score query
+We are deprecating the <<query-dsl-function-score-query, `function_score`>>
+query. We recommend using the `script_score` query instead.
 
-==== Transition from Function Score Query
-We are deprecating <<query-dsl-function-score-query, Function Score>>, and
-Script Score Query will be a substitute for it.
+You can implement the following functions from the `function_score` query using
+the `script_score` query:
 
-Here we describe how Function Score Query's functions can be
-equivalently implemented in Script Score Query:
+* <<script-score>>
+* <<weight>>
+* <<random-score>>
+* <<field-value-factor>>
+* <<decay-functions>>
+* <<vector-functions>>
 
 [[script-score]]
-===== `script_score`
+====== `script_score`
 What you used in `script_score` of the Function Score query, you
 can copy into the Script Score query. No changes here.
 
 [[weight]]
-===== `weight`
+====== `weight`
 `weight` function can be implemented in the Script Score query through
 the following script:
 
@@ -232,13 +275,13 @@ the following script:
 // NOTCONSOLE
 
 [[random-score]]
-===== `random_score`
+====== `random_score`
 
 Use `randomScore` function
 as described in <<random-score-function, random score function>>.
 
 [[field-value-factor]]
-===== `field_value_factor`
+====== `field_value_factor`
 `field_value_factor` function can be easily implemented through script:
 
 [source,js]
@@ -288,8 +331,10 @@ through a script:
 |=======================================================================
 
 [[decay-functions]]
-===== `decay functions`
-Script Score query has equivalent <<decay-functions, decay functions>>
+====== `decay` functions
+The `script_score` query has equivalent <<decay-functions, decay functions>>
 that can be used in script.
 
+:leveloffset: +1
 include::{es-repo-dir}/vectors/vector-functions.asciidoc[]
+:leveloffset: -1

--- a/docs/reference/query-dsl/script-score-query.asciidoc
+++ b/docs/reference/query-dsl/script-score-query.asciidoc
@@ -4,12 +4,9 @@
 <titleabbrev>Script score</titleabbrev>
 ++++
 
-Uses a <<modules-scripting,script>> to modify the <<relevance-scores,relevance
-scores>> of another query.
+Uses a <<modules-scripting,script>> to provide a custom <<relevance-scores,relevance score>> for returned documents.
 
-The `script_score` query is useful if, for example, a scoring function is
-expensive and you only need to calculate the relevance score of a filtered set
-of documents.
+The `script_score` query is useful if, for example, a scoring function is expensive and you only need to calculate the score of a filtered set of documents.
 
 
 [[script-score-query-ex-request]]


### PR DESCRIPTION
Updates the `script_score` query to use the new query format.

This creates separate sections for the example requests, parameters, and notes.

This is part of #40977, an effort to standardize documentation for query types.

### Preview
http://elasticsearch_45087.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/query-dsl-script-score-query.html