### PR TITLE
[DOCS] Update relevance score cross-references

### DIFF
--- a/docs/reference/query-dsl/boosting-query.asciidoc
+++ b/docs/reference/query-dsl/boosting-query.asciidoc
@@ -5,7 +5,7 @@
 ++++
 
 Returns documents matching a `positive` query while reducing the
-<<query-filter-context, relevance score>> of documents that also match a
+<<relevance-scores,relevance score>> of documents that also match a
 `negative` query.
 
 You can use the `boosting` query to demote certain documents without
@@ -47,12 +47,12 @@ match this query.
 `negative`::
 +
 --
-(Required, query object) Query used to decrease the <<query-filter-context,
-relevance score>> of matching documents.
+(Required, query object) Query used to decrease the <<relevance-scores,relevance
+score>> of matching documents.
 
 If a returned document matches the `positive` query and this query, the
-`boosting` query calculates the final <<query-filter-context, relevance score>>
-for the document as follows:
+`boosting` query calculates the final <<relevance-scores,relevance score>> for
+the document as follows:
 
 . Take the original relevance score from the `positive` query.
 . Multiply the score by the `negative_boost` value.
@@ -60,5 +60,5 @@ for the document as follows:
 
 `negative_boost`::
 (Required, float) Floating point number between `0` and `1.0` used to decrease
-the <<query-filter-context, relevance scores>> of documents matching the
+the <<relevance-scores,relevance scores>> of documents matching the
 `negative` query.

--- a/docs/reference/query-dsl/constant-score-query.asciidoc
+++ b/docs/reference/query-dsl/constant-score-query.asciidoc
@@ -5,7 +5,7 @@
 ++++
 
 Wraps a <<query-dsl-bool-query, filter query>> and returns every matching
-document with a <<query-filter-context, relevance score>> equal to the `boost`
+document with a <<relevance-scores,relevance score>> equal to the `boost`
 parameter value.
 
 [source,js]
@@ -32,11 +32,11 @@ GET /_search
 (Required, query object) <<query-dsl-bool-query, Filter query>> you wish to run.
 Any returned documents must match this query.
 
-Filter queries do not calculate <<query-filter-context, relevance scores>>. To
+Filter queries do not calculate <<relevance-scores,relevance scores>>. To
 speed up performance, {es} automatically caches frequently used filter queries.
 --
 
 `boost`::
 (Optional, float) Floating point number used as the constant
-<<query-filter-context, relevance score>> for every document matching the
+<<relevance-scores,relevance score>> for every document matching the
 `filter` query. Defaults to `1.0`.

--- a/docs/reference/query-dsl/dis-max-query.asciidoc
+++ b/docs/reference/query-dsl/dis-max-query.asciidoc
@@ -47,7 +47,7 @@ score>>.
 +
 --
 (Optional, float) Floating point number between `0` and `1.0` used to increase
-the <<query-filter-context, relevance scores>> of documents matching multiple
+the <<relevance-scores,relevance scores>> of documents matching multiple
 query clauses. Defaults to `0.0`.
 
 You can use the `tie_breaker` value to assign higher relevance scores to

--- a/docs/reference/query-dsl/distance-feature-query.asciidoc
+++ b/docs/reference/query-dsl/distance-feature-query.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Distance feature</titleabbrev>
 ++++
 
-Boosts the <<query-filter-context, relevance score>> of documents closer to a
+Boosts the <<relevance-scores,relevance score>> of documents closer to a
 provided `origin` date or point. For example, you can use this query to give
 more weight to documents closer to a certain date or location.
 
@@ -196,7 +196,7 @@ must be a <<distance-units,distance unit>>, such as `1km` or `12m`.
 +
 --
 (Optional, float) Floating point number used to multiply the
-<<query-filter-context, relevance score>> of matching documents. This value
+<<relevance-scores,relevance score>> of matching documents. This value
 cannot be negative. Defaults to `1.0`.
 --
 
@@ -208,11 +208,11 @@ cannot be negative. Defaults to `1.0`.
 ===== How the `distance_feature` query calculates relevance scores
 The `distance_feature` query dynamically calculates the distance between the
 `origin` value and a document's field values. It then uses this distance as a
-feature to boost the <<query-filter-context, relevance score>> of closer
+feature to boost the <<relevance-scores,relevance score>> of closer
 documents.
 
-The `distance_feature` query calculates a document's <<query-filter-context,
-relevance score>> as follows:
+The `distance_feature` query calculates a document's
+<<relevance-scores,relevance score>> as follows:
 
 ```
 relevance score = boost * pivot / (pivot + distance)
@@ -224,6 +224,6 @@ document's field value.
 [[distance-feature-skip-hits]]
 ===== Skip non-competitive hits
 Unlike the <<query-dsl-function-score-query,`function_score`>> query or other
-ways to change <<query-filter-context, relevance scores>>, the
+ways to change <<relevance-scores,relevance scores>>, the
 `distance_feature` query efficiently skips non-competitive hits when the
 <<search-uri-request,`track_total_hits`>> parameter is **not** `true`.

--- a/docs/reference/query-dsl/has-child-query.asciidoc
+++ b/docs/reference/query-dsl/has-child-query.asciidoc
@@ -107,7 +107,7 @@ document does not meet this limit, it is excluded from the search results.
 +
 --
 (Optional, string) Indicates how scores for matching child documents affect the
-root parent document's <<query-filter-context,relevance score>>. Valid values
+root parent document's <<relevance-scores,relevance score>>. Valid values
 are:
 
 `none` (Default)::

--- a/docs/reference/query-dsl/nested-query.asciidoc
+++ b/docs/reference/query-dsl/nested-query.asciidoc
@@ -86,7 +86,7 @@ than root, if it exists within another nested query.
 +
 --
 (Optional, string) Indicates how scores for matching child objects affect the
-root parent document's <<query-filter-context,relevance score>>. Valid values
+root parent document's <<relevance-scores,relevance score>>. Valid values
 are:
 
 `avg` (Default)::

--- a/docs/reference/query-dsl/range-query.asciidoc
+++ b/docs/reference/query-dsl/range-query.asciidoc
@@ -122,7 +122,7 @@ convert a value of `now/d`.
 +
 --
 (Optional, float) Floating point number used to decrease or increase the
-<<query-filter-context, relevance scores>> of a query. Defaults to `1.0`.
+<<relevance-scores,relevance scores>> of a query. Defaults to `1.0`.
 
 You can use the `boost` parameter to adjust relevance scores for searches
 containing two or more queries.

--- a/docs/reference/query-dsl/term-query.asciidoc
+++ b/docs/reference/query-dsl/term-query.asciidoc
@@ -54,7 +54,7 @@ capitalization.
 
 `boost`::
 (Optional, float) Floating point number used to decrease or increase the
-<<query-filter-context, relevance scores>> of a query. Defaults to `1.0`.
+<<relevance-scores,relevance scores>> of a query. Defaults to `1.0`.
 +
 You can use the `boost` parameter to adjust relevance scores for searches
 containing two or more queries.

--- a/docs/reference/query-dsl/terms-query.asciidoc
+++ b/docs/reference/query-dsl/terms-query.asciidoc
@@ -53,7 +53,7 @@ To use the field values of an existing document as search terms, use the
 +
 --
 (Optional, float) Floating point number used to decrease or increase the
-<<query-filter-context, relevance scores>> of a query. Defaults to `1.0`.
+<<relevance-scores,relevance scores>> of a query. Defaults to `1.0`.
 
 You can use the `boost` parameter to adjust relevance scores for searches
 containing two or more queries.

--- a/docs/reference/query-dsl/wildcard-query.asciidoc
+++ b/docs/reference/query-dsl/wildcard-query.asciidoc
@@ -57,7 +57,7 @@ the iterations needed to find matching terms and slow search performance.
 
 `boost`::
 (Optional, float) Floating point number used to decrease or increase the
-<<query-filter-context, relevance scores>> of a query. Defaults to `1.0`.
+<<relevance-scores,relevance scores>> of a query. Defaults to `1.0`.
 +
 You can use the `boost` parameter to adjust relevance scores for searches
 containing two or more queries.


### PR DESCRIPTION
#44975 Added a new [Relevance scores](https://www.elastic.co/guide/en/elasticsearch/reference/master/query-filter-context.html#relevance-scores) section to the Elasticsearch Reference.

This updates any existing relevance score cross-references to link to that new section.