### PR TITLE
Remove unnecessary plugin application and project configuration

### DIFF
--- a/x-pack/plugin/ilm/qa/build.gradle
+++ b/x-pack/plugin/ilm/qa/build.gradle
@@ -1,12 +1,5 @@
 import org.elasticsearch.gradle.test.RestIntegTestTask
 
-apply plugin: 'elasticsearch.build'
-test.enabled = false
-
-dependencies {
-    compile project(':test:framework')
-}
-
 subprojects {
     project.tasks.withType(RestIntegTestTask) {
         final File xPackResources = new File(xpackProject('plugin').projectDir, 'src/test/resources')

--- a/x-pack/plugin/security/qa/build.gradle
+++ b/x-pack/plugin/security/qa/build.gradle
@@ -1,12 +1,5 @@
 import org.elasticsearch.gradle.test.RestIntegTestTask
 
-apply plugin: 'elasticsearch.build'
-test.enabled = false
-
-dependencies {
-    compile project(':test:framework')
-}
-
 subprojects {
     project.tasks.withType(RestIntegTestTask) {
         final File xPackResources = new File(xpackProject('plugin').projectDir, 'src/test/resources')


### PR DESCRIPTION
In scenarios where we have a Gradle project which is just meant as a logical container for subprojects there's no need to apply and plugins to them. This just does unnecessary work and creates tasks that end up getting skipped during execution.