### PR TITLE
Add missing dependency on plugin bundle task

### DIFF
--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -298,7 +298,7 @@ task s3ThirdPartyTests {
 if (useFixture) {
   task integTestECS(type: RestIntegTestTask.class) {
     description = "Runs tests using the ECS repository."
-    dependsOn(project.s3Fixture)
+    dependsOn(project.s3Fixture, 'bundlePlugin')
     runner {
       systemProperty 'tests.rest.blacklist', [
               'repository_s3/10_basic/*',


### PR DESCRIPTION
The S3 integration tests required the plugin bundle be installed into the corresponding test cluster but the required task dependency here is missing causing a [build failure](https://scans.gradle.com/s/meronslnlgobi). This PR makes this dependency explicit.