### PR TITLE
[DOCS] Clarifies bucket span in overall buckets API

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
@@ -34,8 +34,10 @@ privileges. See {stack-ov}/security-privileges.html[Security privileges] and
 You can summarize the bucket results for all {anomaly-jobs} by using `_all` or
 by specifying `*` as the `<job_id>`.
 
-An overall bucket has a span equal to the largest `bucket_span` value for the
-specified {anomaly-jobs}.
+By default, an overall bucket has a span equal to the largest bucket span of the
+specified {anomaly-jobs}. To override that behavior, use the optional
+`bucket_span` parameter. To learn more about the concept of buckets, see
+{stack-ov}/ml-buckets.html[Buckets].
 
 The `overall_score` is calculated by combining the scores of all the buckets
 within the overall bucket span. First, the maximum `anomaly_score` per
@@ -43,14 +45,12 @@ within the overall bucket span. First, the maximum `anomaly_score` per
 scores are averaged to result in the `overall_score`. This means that you can
 fine-tune the `overall_score` so that it is more or less sensitive to the number
 of jobs that detect an anomaly at the same time. For example, if you set `top_n`
-to `1`, the `overall_score` is the maximum bucket score in the overall bucket. Alternatively, if you set `top_n` to the number of jobs, the `overall_score` is
-high only when all jobs detect anomalies in that overall bucket.
-
-In addition, the optional parameter `bucket_span` may be used in order
-to request overall buckets that span longer than the `bucket_span` of the
-largest {anomaly-job}. When set, the `overall_score` will be the max
-`overall_score` of the corresponding overall buckets with a span equal to the
-`bucket_span` of the largest {anomaly-job}.
+to `1`, the `overall_score` is the maximum bucket score in the overall bucket.
+Alternatively, if you set `top_n` to the number of jobs, the `overall_score` is
+high only when all jobs detect anomalies in that overall bucket.  If you set
+the `bucket_span` parameter (to a value greater than its default), the
+`overall_score` is the maximum `overall_score` of the overall buckets that have
+a span equal to the jobs' largest bucket span.
 
 [[ml-get-overall-buckets-path-parms]]
 ==== {api-path-parms-title}
@@ -69,8 +69,8 @@ largest {anomaly-job}. When set, the `overall_score` will be the max
 
 `bucket_span`::
   (Optional, string) The span of the overall buckets. Must be greater or equal
-  to the `bucket_span` of the largest {anomaly-job}. Defaults to the
-  `bucket_span` of the largest {anomaly-job}. 
+  to the largest bucket span of the specified {anomaly-jobs}, which is the
+  default value.
 
 `end`::
   (Optional, string) Returns overall buckets with timestamps earlier than this


### PR DESCRIPTION
This PR clarifies the usage for the bucket_span parameter in the get overall buckets API (https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-overall-buckets.html), since it differed from the description in the java high-level REST client: https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/java-rest-high-x-pack-ml-get-overall-buckets.html