### PR TITLE
Correct a code snippet in removal_of_types.

### DIFF
--- a/docs/reference/mapping/removal_of_types.asciidoc
+++ b/docs/reference/mapping/removal_of_types.asciidoc
@@ -352,7 +352,8 @@ POST _reindex
     "type": "user"
   },
   "dest": {
-    "index": "users"
+    "index": "users",
+    "type": "_doc"
   }
 }
 
@@ -363,7 +364,8 @@ POST _reindex
     "type": "tweet"
   },
   "dest": {
-    "index": "tweets"
+    "index": "tweets",
+    "type": "_doc"
   }
 }
 ----


### PR DESCRIPTION
Previously, the reindex examples did not include `_doc` as the destination
type. On 6.x this would result in the reindex failing with the error "Rejecting
mapping update to [users] as the final mapping would have more than 1 type:
[_doc, user]".

Relates to #43100.