### PR TITLE
[Docs] Correct README example snippet

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -156,8 +156,8 @@ Complete control on the index level is allowed. As an example, in the above case
 curl -XPUT http://localhost:9200/another_user?pretty -H 'Content-Type: application/json' -d '
 {
     "settings" : {
-        "number_of_shards" : 2,
-        "number_of_replicas" : 1
+        "index.number_of_shards" : 2,
+        "index.number_of_replicas" : 1
     }
 }'
 </pre>

--- a/README.textile
+++ b/README.textile
@@ -155,7 +155,7 @@ Complete control on the index level is allowed. As an example, in the above case
 <pre>
 curl -XPUT http://localhost:9200/another_user?pretty -H 'Content-Type: application/json' -d '
 {
-    "index" : {
+    "settings" : {
         "number_of_shards" : 2,
         "number_of_replicas" : 1
     }


### PR DESCRIPTION
The example tries to create a new index but the create index API requires the
"settings" parameter to be there.

Closes #45129