### PR TITLE
Enable reloading of synonym_graph filters

### DIFF
--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymGraphTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymGraphTokenFilterFactory.java
@@ -26,6 +26,7 @@ import org.apache.lucene.analysis.synonym.SynonymMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.analysis.AnalysisMode;
 import org.elasticsearch.index.analysis.CharFilterFactory;
 import org.elasticsearch.index.analysis.TokenFilterFactory;
 import org.elasticsearch.index.analysis.TokenizerFactory;
@@ -61,6 +62,11 @@ public class SynonymGraphTokenFilterFactory extends SynonymTokenFilterFactory {
             @Override
             public TokenStream create(TokenStream tokenStream) {
                 return synonyms.fst == null ? tokenStream : new SynonymGraphFilter(tokenStream, synonyms, false);
+            }
+
+            @Override
+            public AnalysisMode getAnalysisMode() {
+                return analysisMode;
             }
         };
     }

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
@@ -51,7 +51,7 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
     private final boolean lenient;
     protected final Settings settings;
     protected final Environment environment;
-    private final boolean updateable;
+    protected final AnalysisMode analysisMode;
 
     SynonymTokenFilterFactory(IndexSettings indexSettings, Environment env,
                                       String name, Settings settings) {
@@ -67,13 +67,14 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
         this.expand = settings.getAsBoolean("expand", true);
         this.lenient = settings.getAsBoolean("lenient", false);
         this.format = settings.get("format", "");
-        this.updateable = settings.getAsBoolean("updateable", false);
+        boolean updateable = settings.getAsBoolean("updateable", false);
+        this.analysisMode = updateable ? AnalysisMode.SEARCH_TIME : AnalysisMode.ALL;
         this.environment = env;
     }
 
     @Override
     public AnalysisMode getAnalysisMode() {
-        return this.updateable ? AnalysisMode.SEARCH_TIME : AnalysisMode.ALL;
+        return this.analysisMode;
     }
 
     @Override
@@ -109,7 +110,7 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
 
             @Override
             public AnalysisMode getAnalysisMode() {
-                return updateable ? AnalysisMode.SEARCH_TIME : AnalysisMode.ALL;
+                return analysisMode;
             }
         };
     }


### PR DESCRIPTION
Reloading of `synonym_graph` filter doesn't work currently because the search time
AnalysisMode doesn't get propagated to the TokenFilterFactory emitted by the
graph filters getChainAwareTokenFilterFactory() method. This change fixes that.

Closes #45127