### PR TITLE
[TEST] Only test US locale in day/month order test in FIPS JVM

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/filestructurefinder/TimestampFormatFinderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/filestructurefinder/TimestampFormatFinderTests.java
@@ -434,7 +434,13 @@ public class TimestampFormatFinderTests extends FileStructureTestCase {
         TimestampFormatFinder timestampFormatFinder = new TimestampFormatFinder(explanation, true, true, true, NOOP_TIMEOUT_CHECKER);
 
         // Locale fallback is the only way to decide
+
+        // The US locale should work for both FIPS and non-FIPS
         assertFalse(timestampFormatFinder.guessIsDayFirstFromLocale(Locale.US));
+
+        // Non-US locales may not work correctly in a FIPS JVM - see https://github.com/elastic/elasticsearch/issues/45140
+        assumeFalse("Locales not reliable in FIPS JVM", inFipsJvm());
+
         assertTrue(timestampFormatFinder.guessIsDayFirstFromLocale(Locale.UK));
         assertTrue(timestampFormatFinder.guessIsDayFirstFromLocale(Locale.FRANCE));
         assertFalse(timestampFormatFinder.guessIsDayFirstFromLocale(Locale.JAPAN));


### PR DESCRIPTION
In the FIPS JVM the JVM default locale seems to leak into places
where it should be overridden. This change skips assertions
in TimestampFormatFinderTests.testGuessIsDayFirstFromLocale
that may be impacted.

Fixes #45140