### PR TITLE
Create snapshot-tool:testArtifacts configuration for qa submodules

### DIFF
--- a/x-pack/snapshot-tool/build.gradle
+++ b/x-pack/snapshot-tool/build.gradle
@@ -88,7 +88,7 @@ configurations {
 }
 
 task jarTest (type: Jar) {
-  from sourceSets.test.output
+  from sourceSets.test.output, sourceSets.main.output
 }
 
 artifacts {

--- a/x-pack/snapshot-tool/build.gradle
+++ b/x-pack/snapshot-tool/build.gradle
@@ -82,6 +82,19 @@ dependencyLicenses {
 test.enabled = false
 testingConventions.enabled = false
 
+// We make AbstractCleanupTests class available to qa submodules by creating testArtifacts configuration
+configurations {
+  testArtifacts
+}
+
+task jarTest (type: Jar) {
+  from sourceSets.test.output
+}
+
+artifacts {
+  testArtifacts jarTest
+}
+
 task unpackArchive(dependsOn: tasks.assemble, type: Copy) {
   from tarTree("${project.buildDir}/snapshot-tool-${project.version}.tgz")
   into "${project.buildDir}"

--- a/x-pack/snapshot-tool/qa/google-cloud-storage/build.gradle
+++ b/x-pack/snapshot-tool/qa/google-cloud-storage/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     compile project(":plugins:repository-gcs")
     testCompile project(":test:framework")
     testCompile project(':x-pack:snapshot-tool')
-    testCompile files(project(':x-pack:snapshot-tool').sourceSets.test.output)
+    testCompile project(path: ':x-pack:snapshot-tool', configuration: 'testArtifacts')
 }
 
 test.enabled = false

--- a/x-pack/snapshot-tool/qa/google-cloud-storage/build.gradle
+++ b/x-pack/snapshot-tool/qa/google-cloud-storage/build.gradle
@@ -10,7 +10,6 @@ apply plugin: 'elasticsearch.build'
 dependencies {
     compile project(":plugins:repository-gcs")
     testCompile project(":test:framework")
-    testCompile project(':x-pack:snapshot-tool')
     testCompile project(path: ':x-pack:snapshot-tool', configuration: 'testArtifacts')
 }
 

--- a/x-pack/snapshot-tool/qa/s3/build.gradle
+++ b/x-pack/snapshot-tool/qa/s3/build.gradle
@@ -8,7 +8,6 @@ apply plugin: 'elasticsearch.build'
 dependencies {
     compile project(":plugins:repository-s3")
     testCompile project(":test:framework")
-    testCompile project(':x-pack:snapshot-tool')
     testCompile project(path: ':x-pack:snapshot-tool', configuration: 'testArtifacts')
 }
 

--- a/x-pack/snapshot-tool/qa/s3/build.gradle
+++ b/x-pack/snapshot-tool/qa/s3/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile project(":plugins:repository-s3")
     testCompile project(":test:framework")
     testCompile project(':x-pack:snapshot-tool')
-    testCompile files(project(':x-pack:snapshot-tool').sourceSets.test.output)
+    testCompile project(path: ':x-pack:snapshot-tool', configuration: 'testArtifacts')
 }
 
 test.enabled = false


### PR DESCRIPTION
`:x-pack:snapshot-tool:qa:{s3|google-cloud-storage}` depend on
`AbstractCleanupTests` file, which belongs to `:x-pack:snapshot-tool`
test sourceSet.
Instead of directly reaching out to another project test sourceSet, we
can create `testArtifacts` configuration in `x-pack:snapshot-tool`
project and make qa projects depend on this configuration.