### PR TITLE
Whitelist randomUUID in Painless

### DIFF
--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/java.util.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/java.util.txt
@@ -1031,6 +1031,7 @@ class java.util.UUID {
   UUID fromString(String)
   long getLeastSignificantBits()
   long getMostSignificantBits()
+  UUID randomUUID()
   UUID nameUUIDFromBytes(byte[])
   long node()
   long timestamp()

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicAPITests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicAPITests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.painless;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 public class BasicAPITests extends ScriptTestCase {
 
@@ -148,5 +149,21 @@ public class BasicAPITests extends ScriptTestCase {
                 "ZonedDateTime t = d;" +
                 "return ChronoUnit.MILLIS.between(d, t);"
         ));
+    }
+
+    public void testRandomUUID() {
+        assertTrue(
+                Pattern.compile("\\p{XDigit}{8}(-\\p{XDigit}{4}){3}-\\p{XDigit}{12}").matcher(
+                    (String)exec(
+                            "UUID a = UUID.randomUUID();" +
+                            "String s = a.toString(); " +
+                            "UUID b = UUID.fromString(s);" +
+                            "if (a.equals(b) == false) {" +
+                            "   throw new RuntimeException('uuids did not match');" +
+                            "}" +
+                            "return s;"
+                    )
+                ).matches()
+        );
     }
 }


### PR DESCRIPTION
This whitelists randomUUID with the understanding that it's possible for /dev/random to cause blocking on *nix systems. Users that need randomUUID should switch their random generator source to /dev/urandom if this is a concern for them.

Setting /dev/urandom can be done in two ways.
1. Start elasticsearch with the setting ```-Djava.security.egd=file:/dev/urandom```
2. Modify the java.security file to replace the line ```securerandom.source=file:/dev/random``` with ```securerandom.source=file:/dev/urandom```

Addresses:
https://github.com/elastic/elasticsearch/issues/39080