### PR TITLE
Add build hash to global build info

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -24,8 +24,6 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import org.apache.commons.io.IOUtils
-import org.eclipse.jgit.lib.Constants
-import org.eclipse.jgit.lib.RepositoryBuilder
 import org.elasticsearch.gradle.info.GlobalBuildInfoPlugin
 import org.elasticsearch.gradle.info.GlobalInfoExtension
 import org.elasticsearch.gradle.info.JavaHome
@@ -711,26 +709,13 @@ class BuildPlugin implements Plugin<Project> {
                 // after the doFirst added by the info plugin, and we can override attributes
                 JavaVersion compilerJavaVersion = ext.get('compilerJavaVersion') as JavaVersion
                 jarTask.manifest.attributes(
+                        // TODO: remove using the short hash
+                        'Change': ((String)ext.get('gitRevision')).substring(0, 7),
                         'X-Compile-Elasticsearch-Version': VersionProperties.elasticsearch,
                         'X-Compile-Lucene-Version': VersionProperties.lucene,
                         'X-Compile-Elasticsearch-Snapshot': VersionProperties.isElasticsearchSnapshot(),
                         'Build-Date': ZonedDateTime.now(ZoneOffset.UTC),
                         'Build-Java-Version': compilerJavaVersion)
-                if (jarTask.manifest.attributes.containsKey('Change') == false) {
-                    jarTask.logger.warn('Building without git revision id.')
-                    jarTask.manifest.attributes('Change': 'Unknown')
-                } else {
-                    /*
-                     * The info-scm plugin assumes that if GIT_COMMIT is set it was set by Jenkins to the commit hash for this build.
-                     * However, that assumption is wrong as this build could be a sub-build of another Jenkins build for which GIT_COMMIT
-                     * is the commit hash for that build. Therefore, if GIT_COMMIT is set we calculate the commit hash ourselves.
-                     */
-                    if (System.getenv("GIT_COMMIT") != null) {
-                        final String hash = new RepositoryBuilder().findGitDir(project.buildDir).build().resolve(Constants.HEAD).name
-                        final String shortHash = hash?.substring(0, 7)
-                        jarTask.manifest.attributes('Change': shortHash)
-                    }
-                }
             }
 
             // add license/notice files

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GenerateGlobalBuildInfoTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GenerateGlobalBuildInfoTask.java
@@ -38,10 +38,12 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
     private File compilerJavaHome;
     private File runtimeJavaHome;
     private List<JavaHome> javaVersions;
+    private String gitRevision;
     private final RegularFileProperty outputFile;
     private final RegularFileProperty compilerVersionFile;
     private final RegularFileProperty runtimeVersionFile;
     private final RegularFileProperty fipsJvmFile;
+    private final RegularFileProperty gitRevisionFile;
 
     @Inject
     public GenerateGlobalBuildInfoTask(ObjectFactory objectFactory) {
@@ -49,6 +51,7 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
         this.compilerVersionFile = objectFactory.fileProperty();
         this.runtimeVersionFile = objectFactory.fileProperty();
         this.fipsJvmFile = objectFactory.fileProperty();
+        this.gitRevisionFile = objectFactory.fileProperty();
     }
 
     @Input
@@ -98,6 +101,15 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
         this.javaVersions = javaVersions;
     }
 
+    @Input
+    public String gitRevision() {
+        return gitRevision;
+    }
+
+    public void setGitRevision(final String gitRevision) {
+        this.gitRevision = gitRevision;
+    }
+
     @OutputFile
     public RegularFileProperty getOutputFile() {
         return outputFile;
@@ -118,6 +130,11 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
         return fipsJvmFile;
     }
 
+    @OutputFile
+    public RegularFileProperty getGitRevisionFile() {
+        return gitRevisionFile;
+    }
+
     @TaskAction
     public void generate() {
         String javaVendor = System.getProperty("java.vendor");
@@ -131,6 +148,7 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
         JavaVersion runtimeJavaVersionEnum = JavaVersion.current();
         File gradleJavaHome = Jvm.current().getJavaHome();
         boolean inFipsJvm = false;
+        String gitRevsion = gitRevision();
 
         try {
             if (Files.isSameFile(compilerJavaHome.toPath(), gradleJavaHome.toPath()) == false) {
@@ -170,12 +188,13 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
                 writer.write("  Runtime java.home     : " + runtimeJavaHome + "\n");
                 writer.write("  Gradle JDK Version    : " + JavaVersion.toVersion(gradleJavaVersion)
                     + " (" + gradleJavaVersionDetails + ")\n");
-                writer.write("  Gradle java.home      : " + gradleJavaHome);
+                writer.write("  Gradle java.home      : " + gradleJavaHome + "\n");
             } else {
                 writer.write("  JDK Version           : " + JavaVersion.toVersion(gradleJavaVersion)
                     + " (" + gradleJavaVersionDetails + ")\n");
-                writer.write("  JAVA_HOME             : " + gradleJavaHome);
+                writer.write("  JAVA_HOME             : " + gradleJavaHome + "\n");
             }
+            writer.write("  Git Revision          : " + gitRevsion);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -216,6 +235,7 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
         writeToFile(compilerVersionFile.getAsFile().get(), compilerJavaVersionEnum.name());
         writeToFile(runtimeVersionFile.getAsFile().get(), runtimeJavaVersionEnum.name());
         writeToFile(fipsJvmFile.getAsFile().get(), Boolean.toString(inFipsJvm));
+        writeToFile(gitRevisionFile.getAsFile().get(), gitRevsion);
     }
 
     private void writeToFile(File file, String content) {
@@ -273,4 +293,5 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
         }
         return stdout.toString(UTF_8).trim();
     }
+
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GenerateGlobalBuildInfoTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GenerateGlobalBuildInfoTask.java
@@ -148,7 +148,7 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
         JavaVersion runtimeJavaVersionEnum = JavaVersion.current();
         File gradleJavaHome = Jvm.current().getJavaHome();
         boolean inFipsJvm = false;
-        String gitRevsion = gitRevision();
+        final String gitRevision = gitRevision();
 
         try {
             if (Files.isSameFile(compilerJavaHome.toPath(), gradleJavaHome.toPath()) == false) {
@@ -194,7 +194,7 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
                     + " (" + gradleJavaVersionDetails + ")\n");
                 writer.write("  JAVA_HOME             : " + gradleJavaHome + "\n");
             }
-            writer.write("  Git Revision          : " + gitRevsion);
+            writer.write("  Git Revision          : " + gitRevision);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -235,7 +235,7 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
         writeToFile(compilerVersionFile.getAsFile().get(), compilerJavaVersionEnum.name());
         writeToFile(runtimeVersionFile.getAsFile().get(), runtimeJavaVersionEnum.name());
         writeToFile(fipsJvmFile.getAsFile().get(), Boolean.toString(inFipsJvm));
-        writeToFile(gitRevisionFile.getAsFile().get(), gitRevsion);
+        writeToFile(gitRevisionFile.getAsFile().get(), gitRevision);
     }
 
     private void writeToFile(File file, String content) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
@@ -42,7 +42,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
 
         File compilerJavaHome = findCompilerJavaHome();
         File runtimeJavaHome = findRuntimeJavaHome(compilerJavaHome);
-        String gitRevision = gitRevision(project);
+        final String gitRevision = gitRevision(project);
 
         final List<JavaHome> javaVersions = new ArrayList<>();
         for (int version = 8; version <= Integer.parseInt(minimumCompilerVersion.getMajorVersion()); version++) {
@@ -205,9 +205,9 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
     }
 
     private String gitRevision(final Project project) {
-        ByteArrayOutputStream stdout = new ByteArrayOutputStream();
-        ByteArrayOutputStream stderr = new ByteArrayOutputStream();
-        ExecResult result = project.exec(spec -> {
+        final ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+        final ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+        final ExecResult result = project.exec(spec -> {
             spec.setExecutable("git");
             spec.setArgs(Arrays.asList("rev-parse", "HEAD"));
             spec.setStandardOutput(stdout);

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
@@ -7,6 +7,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.gradle.internal.jvm.Jvm;
+import org.gradle.process.ExecResult;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -21,6 +22,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class GlobalBuildInfoPlugin implements Plugin<Project> {
     private static final String GLOBAL_INFO_EXTENSION_NAME = "globalInfo";
@@ -39,6 +42,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
 
         File compilerJavaHome = findCompilerJavaHome();
         File runtimeJavaHome = findRuntimeJavaHome(compilerJavaHome);
+        String gitRevision = gitRevision(project);
 
         final List<JavaHome> javaVersions = new ArrayList<>();
         for (int version = 8; version <= Integer.parseInt(minimumCompilerVersion.getMajorVersion()); version++) {
@@ -54,10 +58,12 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
                 task.setMinimumRuntimeVersion(minimumRuntimeVersion);
                 task.setCompilerJavaHome(compilerJavaHome);
                 task.setRuntimeJavaHome(runtimeJavaHome);
+                task.setGitRevision(gitRevision);
                 task.getOutputFile().set(new File(project.getBuildDir(), "global-build-info"));
                 task.getCompilerVersionFile().set(new File(project.getBuildDir(), "java-compiler-version"));
                 task.getRuntimeVersionFile().set(new File(project.getBuildDir(), "java-runtime-version"));
                 task.getFipsJvmFile().set(new File(project.getBuildDir(), "in-fips-jvm"));
+                task.getGitRevisionFile().set(new File(project.getBuildDir(), "git-revision"));
             });
 
         PrintGlobalBuildInfoTask printTask = project.getTasks().create("printGlobalBuildInfo", PrintGlobalBuildInfoTask.class, task -> {
@@ -65,6 +71,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             task.getCompilerVersionFile().set(generateTask.getCompilerVersionFile());
             task.getRuntimeVersionFile().set(generateTask.getRuntimeVersionFile());
             task.getFipsJvmFile().set(generateTask.getFipsJvmFile());
+            task.getGitRevisionFile().set(generateTask.getGitRevisionFile());
             task.setGlobalInfoListeners(extension.listeners);
         });
 
@@ -87,6 +94,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             ext.set("minimumCompilerVersion", minimumCompilerVersion);
             ext.set("minimumRuntimeVersion", minimumRuntimeVersion);
             ext.set("gradleJavaVersion", Jvm.current().getJavaVersion());
+            ext.set("gitRevision", gitRevision);
         });
     }
 
@@ -195,4 +203,22 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
 
         return _defaultParallel;
     }
+
+    private String gitRevision(final Project project) {
+        ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+        ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+        ExecResult result = project.exec(spec -> {
+            spec.setExecutable("git");
+            spec.setArgs(Arrays.asList("rev-parse", "HEAD"));
+            spec.setStandardOutput(stdout);
+            spec.setErrorOutput(stderr);
+            spec.setIgnoreExitValue(true);
+        });
+
+        if (result.getExitValue() != 0) {
+            return "unknown";
+        }
+        return stdout.toString(UTF_8).trim();
+    }
+
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/PrintGlobalBuildInfoTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/PrintGlobalBuildInfoTask.java
@@ -18,6 +18,7 @@ public class PrintGlobalBuildInfoTask extends DefaultTask {
     private final RegularFileProperty compilerVersionFile;
     private final RegularFileProperty runtimeVersionFile;
     private final RegularFileProperty fipsJvmFile;
+    private final RegularFileProperty gitRevisionFile;
     private List<Runnable> globalInfoListeners = new ArrayList<>();
 
     @Inject
@@ -26,6 +27,7 @@ public class PrintGlobalBuildInfoTask extends DefaultTask {
         this.compilerVersionFile = objectFactory.fileProperty();
         this.runtimeVersionFile = objectFactory.fileProperty();
         this.fipsJvmFile = objectFactory.fileProperty();
+        this.gitRevisionFile = objectFactory.fileProperty();
     }
 
     @InputFile
@@ -46,6 +48,11 @@ public class PrintGlobalBuildInfoTask extends DefaultTask {
     @InputFile
     public RegularFileProperty getFipsJvmFile() {
         return fipsJvmFile;
+    }
+
+    @InputFile
+    public RegularFileProperty getGitRevisionFile() {
+        return gitRevisionFile;
     }
 
     public void setGlobalInfoListeners(List<Runnable> globalInfoListeners) {
@@ -79,6 +86,7 @@ public class PrintGlobalBuildInfoTask extends DefaultTask {
             ext.set("compilerJavaVersion", JavaVersion.valueOf(getFileText(getCompilerVersionFile()).asString()));
             ext.set("runtimeJavaVersion", JavaVersion.valueOf(getFileText(getRuntimeVersionFile()).asString()));
             ext.set("inFipsJvm", Boolean.valueOf(getFileText(getFipsJvmFile()).asString()));
+            ext.set("gitRevision", getFileText(getGitRevisionFile()).asString());
         });
     }
 }


### PR DESCRIPTION
This commit adds the commit hash to the global build info, and adds the git revision as an extension. There are a couple motivations for this change:
 - the current mechanism of getting the build hash does not work with git worktrees (because jgit does not understand them)
 - a follow-up will want to use the git revision when building the Docker images, so we want it available as an extension
 - it allows us to simplify our usage around the build hash as we no longer have to hack around silliness in the info-scm plugin

A follow-up will also stop using the short hash in the product build, so that we use the full hash there. We already know that short hashes in our codebase do collide, so we should move to the full hash to avoid  this problem.
