### PR TITLE
Use the full hash in build info

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -709,8 +709,7 @@ class BuildPlugin implements Plugin<Project> {
                 // after the doFirst added by the info plugin, and we can override attributes
                 JavaVersion compilerJavaVersion = ext.get('compilerJavaVersion') as JavaVersion
                 jarTask.manifest.attributes(
-                        // TODO: remove using the short hash
-                        'Change': ((String)ext.get('gitRevision')).substring(0, 7),
+                        'Change': ext.get('gitRevision'),
                         'X-Compile-Elasticsearch-Version': VersionProperties.elasticsearch,
                         'X-Compile-Lucene-Version': VersionProperties.lucene,
                         'X-Compile-Elasticsearch-Snapshot': VersionProperties.isElasticsearchSnapshot(),

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/core/MainResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/core/MainResponseTests.java
@@ -58,7 +58,7 @@ public class MainResponseTests extends AbstractResponseTestCase<org.elasticsearc
         assertThat(serverTestInstance.getNodeName(), equalTo(clientInstance.getNodeName()));
         assertThat("You Know, for Search", equalTo(clientInstance.getTagline()));
 
-        assertThat(serverTestInstance.getBuild().shortHash(), equalTo(clientInstance.getVersion().getBuildHash()));
+        assertThat(serverTestInstance.getBuild().hash(), equalTo(clientInstance.getVersion().getBuildHash()));
         assertThat(serverTestInstance.getVersion().toString(), equalTo(clientInstance.getVersion().getNumber()));
         assertThat(serverTestInstance.getBuild().date(), equalTo(clientInstance.getVersion().getBuildDate()));
         assertThat(serverTestInstance.getBuild().flavor().displayName(), equalTo(clientInstance.getVersion().getBuildFlavor()));

--- a/client/rest/src/main/java/org/elasticsearch/client/Response.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/Response.java
@@ -102,7 +102,7 @@ public class Response {
 
     private static final Pattern WARNING_HEADER_PATTERN = Pattern.compile(
             "299 " + // warn code
-            "Elasticsearch-\\d+\\.\\d+\\.\\d+(?:-(?:alpha|beta|rc)\\d+)?(?:-SNAPSHOT)?-(?:[a-f0-9]{7}|Unknown) " + // warn agent
+            "Elasticsearch-\\d+\\.\\d+\\.\\d+(?:-(?:alpha|beta|rc)\\d+)?(?:-SNAPSHOT)?-(?:[a-f0-9]{40}|unknown) " + // warn agent
             "\"((?:\t| |!|[\\x23-\\x5B]|[\\x5D-\\x7E]|[\\x80-\\xFF]|\\\\|\\\\\")*)\"( " + // quoted warning value, captured
             // quoted RFC 1123 date format
             "\"" + // opening quote

--- a/client/rest/src/main/java/org/elasticsearch/client/Response.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/Response.java
@@ -102,7 +102,9 @@ public class Response {
 
     private static final Pattern WARNING_HEADER_PATTERN = Pattern.compile(
             "299 " + // warn code
-            "Elasticsearch-\\d+\\.\\d+\\.\\d+(?:-(?:alpha|beta|rc)\\d+)?(?:-SNAPSHOT)?-(?:[a-f0-9]{40}|unknown) " + // warn agent
+            "Elasticsearch-" + // warn agent
+            "\\d+\\.\\d+\\.\\d+(?:-(?:alpha|beta|rc)\\d+)?(?:-SNAPSHOT)?-" + // warn agent
+            "(?:[a-f0-9]{7}(?:[a-f0-9]{33})?|unknown) " + // warn agent
             "\"((?:\t| |!|[\\x23-\\x5B]|[\\x5D-\\x7E]|[\\x80-\\xFF]|\\\\|\\\\\")*)\"( " + // quoted warning value, captured
             // quoted RFC 1123 date format
             "\"" + // opening quote

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostTests.java
@@ -526,7 +526,7 @@ public class RestClientSingleHostTests extends RestClientTestCase {
      * cases. We don't have that available because we're testing against 1.7.
      */
     private static String formatWarning(String warningBody) {
-        return "299 Elasticsearch-1.2.2-SNAPSHOT-eeeeeee \"" + warningBody + "\" \"Mon, 01 Jan 2001 00:00:00 GMT\"";
+        return "299 Elasticsearch-1.2.2-SNAPSHOT-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee \"" + warningBody + "\" \"Mon, 01 Jan 2001 00:00:00 GMT\"";
     }
 
     private HttpUriRequest performRandomRequest(String method) throws Exception {

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostTests.java
@@ -526,7 +526,8 @@ public class RestClientSingleHostTests extends RestClientTestCase {
      * cases. We don't have that available because we're testing against 1.7.
      */
     private static String formatWarning(String warningBody) {
-        return "299 Elasticsearch-1.2.2-SNAPSHOT-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee \"" + warningBody + "\" \"Mon, 01 Jan 2001 00:00:00 GMT\"";
+        final String hash = new String(new byte[40]).replace('\0', 'e');
+        return "299 Elasticsearch-1.2.2-SNAPSHOT-" + hash + " \"" + warningBody + "\" \"Mon, 01 Jan 2001 00:00:00 GMT\"";
     }
 
     private HttpUriRequest performRandomRequest(String method) throws Exception {

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostTests.java
@@ -62,6 +62,7 @@ import java.io.StringWriter;
 import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -526,7 +527,7 @@ public class RestClientSingleHostTests extends RestClientTestCase {
      * cases. We don't have that available because we're testing against 1.7.
      */
     private static String formatWarning(String warningBody) {
-        final String hash = new String(new byte[40]).replace('\0', 'e');
+        final String hash = new String(new byte[40], StandardCharsets.UTF_8).replace('\0', 'e');
         return "299 Elasticsearch-1.2.2-SNAPSHOT-" + hash + " \"" + warningBody + "\" \"Mon, 01 Jan 2001 00:00:00 GMT\"";
     }
 

--- a/server/src/main/java/org/elasticsearch/Build.java
+++ b/server/src/main/java/org/elasticsearch/Build.java
@@ -124,7 +124,7 @@ public class Build {
     static {
         final Flavor flavor;
         final Type type;
-        final String shortHash;
+        final String hash;
         final String date;
         final boolean isSnapshot;
         final String version;
@@ -142,7 +142,7 @@ public class Build {
         )) {
             try (JarInputStream jar = new JarInputStream(FileSystemUtils.openFileURLStream(url))) {
                 Manifest manifest = jar.getManifest();
-                shortHash = manifest.getMainAttributes().getValue("Change");
+                hash = manifest.getMainAttributes().getValue("Change");
                 date = manifest.getMainAttributes().getValue("Build-Date");
                 isSnapshot = "true".equals(manifest.getMainAttributes().getValue("X-Compile-Elasticsearch-Snapshot"));
                 version = manifest.getMainAttributes().getValue("X-Compile-Elasticsearch-Version");
@@ -151,8 +151,8 @@ public class Build {
             }
         } else {
             // not running from the official elasticsearch jar file (unit tests, IDE, uber client jar, shadiness)
-            shortHash = "Unknown";
-            date = "Unknown";
+            hash = "unknown";
+            date = "unknown";
             version = Version.CURRENT.toString();
             final String buildSnapshot = System.getProperty("build.snapshot");
             if (buildSnapshot != null) {
@@ -167,8 +167,8 @@ public class Build {
                 isSnapshot = true;
             }
         }
-        if (shortHash == null) {
-            throw new IllegalStateException("Error finding the build shortHash. " +
+        if (hash == null) {
+            throw new IllegalStateException("Error finding the build hash. " +
                     "Stopping Elasticsearch now so it doesn't run in subtly broken ways. This is likely a build bug.");
         }
         if (date == null) {
@@ -180,7 +180,7 @@ public class Build {
                 "Stopping Elasticsearch now so it doesn't run in subtly broken ways. This is likely a build bug.");
         }
 
-        CURRENT = new Build(flavor, type, shortHash, date, isSnapshot, version);
+        CURRENT = new Build(flavor, type, hash, date, isSnapshot, version);
     }
 
     private final boolean isSnapshot;
@@ -197,24 +197,24 @@ public class Build {
 
     private final Flavor flavor;
     private final Type type;
-    private final String shortHash;
+    private final String hash;
     private final String date;
     private final String version;
 
     public Build(
-        final Flavor flavor, final Type type, final String shortHash, final String date, boolean isSnapshot,
+        final Flavor flavor, final Type type, final String hash, final String date, boolean isSnapshot,
         String version
     ) {
         this.flavor = flavor;
         this.type = type;
-        this.shortHash = shortHash;
+        this.hash = hash;
         this.date = date;
         this.isSnapshot = isSnapshot;
         this.version = version;
     }
 
-    public String shortHash() {
-        return shortHash;
+    public String hash() {
+        return hash;
     }
 
     public String date() {
@@ -240,7 +240,7 @@ public class Build {
     public static void writeBuild(Build build, StreamOutput out) throws IOException {
         out.writeString(build.flavor().displayName());
         out.writeString(build.type().displayName());
-        out.writeString(build.shortHash());
+        out.writeString(build.hash());
         out.writeString(build.date());
         out.writeBoolean(build.isSnapshot());
         out.writeString(build.getQualifiedVersion());
@@ -282,7 +282,7 @@ public class Build {
 
     @Override
     public String toString() {
-        return "[" + flavor.displayName() + "][" + type.displayName + "][" + shortHash + "][" + date + "][" + version +"]";
+        return "[" + flavor.displayName() + "][" + type.displayName + "][" + hash + "][" + date + "][" + version +"]";
     }
 
     @Override
@@ -307,7 +307,7 @@ public class Build {
         if (isSnapshot != build.isSnapshot) {
             return false;
         }
-        if (!shortHash.equals(build.shortHash)) {
+        if (hash.equals(build.hash) == false) {
             return false;
         }
         if (version.equals(build.version) == false) {
@@ -318,7 +318,7 @@ public class Build {
 
     @Override
     public int hashCode() {
-        return Objects.hash(flavor, type, isSnapshot, shortHash, date, version);
+        return Objects.hash(flavor, type, isSnapshot, hash, date, version);
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -338,7 +338,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
             Build.CURRENT.getQualifiedVersion(),
                 Build.CURRENT.flavor().displayName(),
                 Build.CURRENT.type().displayName(),
-                Build.CURRENT.shortHash(),
+                Build.CURRENT.hash(),
                 Build.CURRENT.date(),
                 JvmInfo.jvmInfo().version());
         System.out.println(versionOutput);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
@@ -69,7 +69,7 @@ public class NodesInfoResponse extends BaseNodesResponse<NodeInfo> implements To
             builder.field("version", nodeInfo.getVersion());
             builder.field("build_flavor", nodeInfo.getBuild().flavor().displayName());
             builder.field("build_type", nodeInfo.getBuild().type().displayName());
-            builder.field("build_hash", nodeInfo.getBuild().shortHash());
+            builder.field("build_hash", nodeInfo.getBuild().hash());
             if (nodeInfo.getTotalIndexingBuffer() != null) {
                 builder.humanReadableField("total_indexing_buffer", "total_indexing_buffer_in_bytes", nodeInfo.getTotalIndexingBuffer());
             }

--- a/server/src/main/java/org/elasticsearch/action/main/MainResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/main/MainResponse.java
@@ -101,7 +101,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
             .field("number", build.getQualifiedVersion())
             .field("build_flavor", build.flavor().displayName())
             .field("build_type", build.type().displayName())
-            .field("build_hash", build.shortHash())
+            .field("build_hash", build.hash())
             .field("build_date", build.date())
             .field("build_snapshot", build.isSnapshot())
             .field("lucene_version", version.luceneVersion.toString())

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -127,7 +127,7 @@ class Elasticsearch extends EnvironmentAwareCommand {
                 Build.CURRENT.getQualifiedVersion(),
                 Build.CURRENT.flavor().displayName(),
                 Build.CURRENT.type().displayName(),
-                Build.CURRENT.shortHash(),
+                Build.CURRENT.hash(),
                 Build.CURRENT.date(),
                 JvmInfo.jvmInfo().version()
             );

--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -160,7 +160,7 @@ public class DeprecationLogger {
      */
     public static final Pattern WARNING_HEADER_PATTERN = Pattern.compile(
             "299 " + // warn code
-                    "Elasticsearch-\\d+\\.\\d+\\.\\d+(?:-(?:alpha|beta|rc)\\d+)?(?:-SNAPSHOT)?-(?:[a-f0-9]{40}|unknown) " + // warn agent
+                    "Elasticsearch-\\d+\\.\\d+\\.\\d+(?:-(?:alpha|beta|rc)\\d+)?(?:-SNAPSHOT)?-(?:[a-f0-9]{7}|[a-f0-9]{40}|unknown) " + // warn agent
                     "\"((?:\t| |!|[\\x23-\\x5B]|[\\x5D-\\x7E]|[\\x80-\\xFF]|\\\\|\\\\\")*)\"( " + // quoted warning value, captured
                     // quoted RFC 1123 date format
                     "\"" + // opening quote

--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -160,7 +160,7 @@ public class DeprecationLogger {
      */
     public static final Pattern WARNING_HEADER_PATTERN = Pattern.compile(
             "299 " + // warn code
-                    "Elasticsearch-\\d+\\.\\d+\\.\\d+(?:-(?:alpha|beta|rc)\\d+)?(?:-SNAPSHOT)?-(?:[a-f0-9]{7}|Unknown) " + // warn agent
+                    "Elasticsearch-\\d+\\.\\d+\\.\\d+(?:-(?:alpha|beta|rc)\\d+)?(?:-SNAPSHOT)?-(?:[a-f0-9]{40}|unknown) " + // warn agent
                     "\"((?:\t| |!|[\\x23-\\x5B]|[\\x5D-\\x7E]|[\\x80-\\xFF]|\\\\|\\\\\")*)\"( " + // quoted warning value, captured
                     // quoted RFC 1123 date format
                     "\"" + // opening quote

--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -152,7 +152,7 @@ public class DeprecationLogger {
                     "299 Elasticsearch-%s%s-%s",
                     Version.CURRENT.toString(),
                     Build.CURRENT.isSnapshot() ? "-SNAPSHOT" : "",
-                    Build.CURRENT.shortHash());
+                    Build.CURRENT.hash());
 
     /**
      * Regular expression to test if a string matches the RFC7234 specification for warning headers. This pattern assumes that the warn code

--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -162,7 +162,7 @@ public class DeprecationLogger {
             "299 " + // warn code
                     "Elasticsearch-" + // warn agent
                     "\\d+\\.\\d+\\.\\d+(?:-(?:alpha|beta|rc)\\d+)?(?:-SNAPSHOT)?-" + // warn agent
-                    "(?:[a-f0-9]{7}([a-f0-9]{33})?|unknown) " + // warn agent
+                    "(?:[a-f0-9]{7}[a-f0-9]{33}?|unknown) " + // warn agent
                     "\"((?:\t| |!|[\\x23-\\x5B]|[\\x5D-\\x7E]|[\\x80-\\xFF]|\\\\|\\\\\")*)\"( " + // quoted warning value, captured
                     // quoted RFC 1123 date format
                     "\"" + // opening quote

--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -162,7 +162,7 @@ public class DeprecationLogger {
             "299 " + // warn code
                     "Elasticsearch-" + // warn agent
                     "\\d+\\.\\d+\\.\\d+(?:-(?:alpha|beta|rc)\\d+)?(?:-SNAPSHOT)?-" + // warn agent
-                    "(?:[a-f0-9]{7}[a-f0-9]{33}?|unknown) " + // warn agent
+                    "(?:[a-f0-9]{7}(?:[a-f0-9]{33})?|unknown) " + // warn agent
                     "\"((?:\t| |!|[\\x23-\\x5B]|[\\x5D-\\x7E]|[\\x80-\\xFF]|\\\\|\\\\\")*)\"( " + // quoted warning value, captured
                     // quoted RFC 1123 date format
                     "\"" + // opening quote

--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -160,7 +160,9 @@ public class DeprecationLogger {
      */
     public static final Pattern WARNING_HEADER_PATTERN = Pattern.compile(
             "299 " + // warn code
-                    "Elasticsearch-\\d+\\.\\d+\\.\\d+(?:-(?:alpha|beta|rc)\\d+)?(?:-SNAPSHOT)?-(?:[a-f0-9]{7}|[a-f0-9]{40}|unknown) " + // warn agent
+                    "Elasticsearch-" + // warn agent
+                    "\\d+\\.\\d+\\.\\d+(?:-(?:alpha|beta|rc)\\d+)?(?:-SNAPSHOT)?-" + // warn agent
+                    "(?:[a-f0-9]{7}([a-f0-9]{33})?|unknown) " + // warn agent
                     "\"((?:\t| |!|[\\x23-\\x5B]|[\\x5D-\\x7E]|[\\x80-\\xFF]|\\\\|\\\\\")*)\"( " + // quoted warning value, captured
                     // quoted RFC 1123 date format
                     "\"" + // opening quote

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -285,7 +285,7 @@ public class Node implements Closeable {
                 jvmInfo.pid(),
                 Build.CURRENT.flavor().displayName(),
                 Build.CURRENT.type().displayName(),
-                Build.CURRENT.shortHash(),
+                Build.CURRENT.hash(),
                 Build.CURRENT.date(),
                 Constants.OS_NAME,
                 Constants.OS_VERSION,

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -279,7 +279,7 @@ public class RestNodesAction extends AbstractCatAction {
             table.addCell(node.getVersion().toString());
             table.addCell(info == null ? null : info.getBuild().flavor().displayName());
             table.addCell(info == null ? null : info.getBuild().type().displayName());
-            table.addCell(info == null ? null : info.getBuild().shortHash());
+            table.addCell(info == null ? null : info.getBuild().hash());
             table.addCell(jvmInfo == null ? null : jvmInfo.version());
 
 
@@ -299,7 +299,7 @@ public class RestNodesAction extends AbstractCatAction {
             table.addCell(diskUsed);
             table.addCell(diskAvailable);
             table.addCell(diskUsedPercent);
-            
+
             table.addCell(jvmStats == null ? null : jvmStats.getMem().getHeapUsed());
             table.addCell(jvmStats == null ? null : jvmStats.getMem().getHeapUsedPercent());
             table.addCell(jvmInfo == null ? null : jvmInfo.getMem().getHeapMax());

--- a/server/src/test/java/org/elasticsearch/BuildTests.java
+++ b/server/src/test/java/org/elasticsearch/BuildTests.java
@@ -48,23 +48,23 @@ public class BuildTests extends ESTestCase {
         try (InputStream ignored = FileSystemUtils.openFileURLStream(url)) {}
         // these should never be null
         assertNotNull(Build.CURRENT.date());
-        assertNotNull(Build.CURRENT.shortHash());
+        assertNotNull(Build.CURRENT.hash());
     }
 
     public void testIsProduction() {
         Build build = new Build(
-            Build.CURRENT.flavor(), Build.CURRENT.type(), Build.CURRENT.shortHash(), Build.CURRENT.date(),
+            Build.CURRENT.flavor(), Build.CURRENT.type(), Build.CURRENT.hash(), Build.CURRENT.date(),
             Build.CURRENT.isSnapshot(), Math.abs(randomInt()) + "." + Math.abs(randomInt()) + "." + Math.abs(randomInt())
         );
         assertTrue(build.getQualifiedVersion(), build.isProductionRelease());
 
         assertFalse(new Build(
-            Build.CURRENT.flavor(), Build.CURRENT.type(), Build.CURRENT.shortHash(), Build.CURRENT.date(),
+            Build.CURRENT.flavor(), Build.CURRENT.type(), Build.CURRENT.hash(), Build.CURRENT.date(),
             Build.CURRENT.isSnapshot(), "7.0.0-SNAPSHOT"
         ).isProductionRelease());
 
         assertFalse(new Build(
-            Build.CURRENT.flavor(), Build.CURRENT.type(), Build.CURRENT.shortHash(), Build.CURRENT.date(),
+            Build.CURRENT.flavor(), Build.CURRENT.type(), Build.CURRENT.hash(), Build.CURRENT.date(),
             Build.CURRENT.isSnapshot(), "Unknown"
         ).isProductionRelease());
     }
@@ -73,7 +73,7 @@ public class BuildTests extends ESTestCase {
         Build build = Build.CURRENT;
 
         Build another = new Build(
-            build.flavor(), build.type(), build.shortHash(), build.date(), build.isSnapshot(), build.getQualifiedVersion()
+            build.flavor(), build.type(), build.hash(), build.date(), build.isSnapshot(), build.getQualifiedVersion()
         );
         assertEquals(build, another);
         assertEquals(build.hashCode(), another.hashCode());
@@ -82,7 +82,7 @@ public class BuildTests extends ESTestCase {
                 Arrays.stream(Build.Flavor.values()).filter(f -> !f.equals(build.flavor())).collect(Collectors.toSet());
         final Build.Flavor otherFlavor = randomFrom(otherFlavors);
         Build differentFlavor = new Build(
-            otherFlavor, build.type(), build.shortHash(), build.date(), build.isSnapshot(), build.getQualifiedVersion()
+            otherFlavor, build.type(), build.hash(), build.date(), build.isSnapshot(), build.getQualifiedVersion()
         );
         assertNotEquals(build, differentFlavor);
 
@@ -90,7 +90,7 @@ public class BuildTests extends ESTestCase {
                 Arrays.stream(Build.Type.values()).filter(f -> !f.equals(build.type())).collect(Collectors.toSet());
         final Build.Type otherType = randomFrom(otherTypes);
         Build differentType = new Build(
-            build.flavor(), otherType, build.shortHash(), build.date(), build.isSnapshot(), build.getQualifiedVersion()
+            build.flavor(), otherType, build.hash(), build.date(), build.isSnapshot(), build.getQualifiedVersion()
         );
         assertNotEquals(build, differentType);
 
@@ -101,17 +101,17 @@ public class BuildTests extends ESTestCase {
         assertNotEquals(build, differentHash);
 
         Build differentDate = new Build(
-            build.flavor(), build.type(), build.shortHash(), "1970-01-01", build.isSnapshot(), build.getQualifiedVersion()
+            build.flavor(), build.type(), build.hash(), "1970-01-01", build.isSnapshot(), build.getQualifiedVersion()
         );
         assertNotEquals(build, differentDate);
 
         Build differentSnapshot = new Build(
-            build.flavor(), build.type(), build.shortHash(), build.date(), !build.isSnapshot(), build.getQualifiedVersion()
+            build.flavor(), build.type(), build.hash(), build.date(), !build.isSnapshot(), build.getQualifiedVersion()
         );
         assertNotEquals(build, differentSnapshot);
 
         Build differentVersion = new Build(
-            build.flavor(), build.type(), build.shortHash(), build.date(), build.isSnapshot(), "1.2.3"
+            build.flavor(), build.type(), build.hash(), build.date(), build.isSnapshot(), "1.2.3"
         );
         assertNotEquals(build, differentVersion);
     }
@@ -161,23 +161,23 @@ public class BuildTests extends ESTestCase {
                     case 1:
                         return new WriteableBuild(new Build(
                             randomValueOtherThan(b.build.flavor(), () -> randomFrom(Build.Flavor.values())), b.build.type(),
-                            b.build.shortHash(), b.build.date(), b.build.isSnapshot(), b.build.getQualifiedVersion()));
+                            b.build.hash(), b.build.date(), b.build.isSnapshot(), b.build.getQualifiedVersion()));
                     case 2:
                         return new WriteableBuild(new Build(b.build.flavor(),
                             randomValueOtherThan(b.build.type(), () -> randomFrom(Build.Type.values())),
-                            b.build.shortHash(), b.build.date(), b.build.isSnapshot(), b.build.getQualifiedVersion()));
+                            b.build.hash(), b.build.date(), b.build.isSnapshot(), b.build.getQualifiedVersion()));
                     case 3:
                         return new WriteableBuild(new Build(b.build.flavor(), b.build.type(),
-                            randomStringExcept(b.build.shortHash()), b.build.date(), b.build.isSnapshot(), b.build.getQualifiedVersion()));
+                            randomStringExcept(b.build.hash()), b.build.date(), b.build.isSnapshot(), b.build.getQualifiedVersion()));
                     case 4:
                         return new WriteableBuild(new Build(b.build.flavor(), b.build.type(),
-                            b.build.shortHash(), randomStringExcept(b.build.date()), b.build.isSnapshot(), b.build.getQualifiedVersion()));
+                            b.build.hash(), randomStringExcept(b.build.date()), b.build.isSnapshot(), b.build.getQualifiedVersion()));
                     case 5:
                         return new WriteableBuild(new Build(b.build.flavor(), b.build.type(),
-                            b.build.shortHash(), b.build.date(), b.build.isSnapshot() == false, b.build.getQualifiedVersion()));
+                            b.build.hash(), b.build.date(), b.build.isSnapshot() == false, b.build.getQualifiedVersion()));
                     case 6:
                         return new WriteableBuild(new Build(b.build.flavor(), b.build.type(),
-                            b.build.shortHash(), b.build.date(), b.build.isSnapshot(), randomStringExcept(b.build.getQualifiedVersion())));
+                            b.build.hash(), b.build.date(), b.build.isSnapshot(), randomStringExcept(b.build.getQualifiedVersion())));
                 }
                 throw new AssertionError();
             });

--- a/server/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
@@ -64,7 +64,7 @@ public class MainResponseTests extends AbstractSerializingTestCase<MainResponse>
         String clusterUUID = randomAlphaOfLengthBetween(10, 20);
         final Build current = Build.CURRENT;
         Build build = new Build(
-            current.flavor(), current.type(), current.shortHash(), current.date(), current.isSnapshot(),
+            current.flavor(), current.type(), current.hash(), current.date(), current.isSnapshot(),
             current.getQualifiedVersion()
         );
         Version version = Version.CURRENT;
@@ -79,7 +79,7 @@ public class MainResponseTests extends AbstractSerializingTestCase<MainResponse>
                     + "\"number\":\"" + build.getQualifiedVersion() + "\","
                     + "\"build_flavor\":\"" + current.flavor().displayName() + "\","
                     + "\"build_type\":\"" + current.type().displayName() + "\","
-                    + "\"build_hash\":\"" + current.shortHash() + "\","
+                    + "\"build_hash\":\"" + current.hash() + "\","
                     + "\"build_date\":\"" + current.date() + "\","
                     + "\"build_snapshot\":" + current.isSnapshot() + ","
                     + "\"lucene_version\":\"" + version.luceneVersion.toString() + "\","
@@ -106,7 +106,7 @@ public class MainResponseTests extends AbstractSerializingTestCase<MainResponse>
             case 2:
                 // toggle the snapshot flag of the original Build parameter
                 build = new Build(
-                    Build.Flavor.UNKNOWN, Build.Type.UNKNOWN, build.shortHash(), build.date(), !build.isSnapshot(),
+                    Build.Flavor.UNKNOWN, Build.Type.UNKNOWN, build.hash(), build.date(), !build.isSnapshot(),
                     build.getQualifiedVersion()
                 );
                 break;

--- a/server/src/test/java/org/elasticsearch/bootstrap/ElasticsearchCliTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/ElasticsearchCliTests.java
@@ -68,7 +68,7 @@ public class ElasticsearchCliTests extends ESElasticsearchCliTestCase {
                     "Build: %s/%s/%s/%s",
                     Build.CURRENT.flavor().displayName(),
                     Build.CURRENT.type().displayName(),
-                    Build.CURRENT.shortHash(),
+                    Build.CURRENT.hash(),
                     Build.CURRENT.date());
             assertThat(output, containsString(expectedBuildOutput));
             assertThat(output, containsString("JVM: " + JvmInfo.jvmInfo().version()));


### PR DESCRIPTION
This commit switches to using the full hash to build into the JAR manifest, which is used in node startup and the REST main action to display the build hash.

Relates #45162