### PR TITLE
Lift build date to global build info

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -714,7 +714,7 @@ class BuildPlugin implements Plugin<Project> {
                         'X-Compile-Elasticsearch-Version': VersionProperties.elasticsearch,
                         'X-Compile-Lucene-Version': VersionProperties.lucene,
                         'X-Compile-Elasticsearch-Snapshot': VersionProperties.isElasticsearchSnapshot(),
-                        'Build-Date': ZonedDateTime.now(ZoneOffset.UTC),
+                        'Build-Date': ext.get('buildDate'),
                         'Build-Java-Version': compilerJavaVersion)
             }
 

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GenerateGlobalBuildInfoTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GenerateGlobalBuildInfoTask.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.nio.file.Files;
-import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 
@@ -40,13 +39,11 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
     private File runtimeJavaHome;
     private List<JavaHome> javaVersions;
     private String gitRevision;
-    private ZonedDateTime buildDate;
     private final RegularFileProperty outputFile;
     private final RegularFileProperty compilerVersionFile;
     private final RegularFileProperty runtimeVersionFile;
     private final RegularFileProperty fipsJvmFile;
     private final RegularFileProperty gitRevisionFile;
-    private final RegularFileProperty buildDateFile;
 
     @Inject
     public GenerateGlobalBuildInfoTask(ObjectFactory objectFactory) {
@@ -55,7 +52,6 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
         this.runtimeVersionFile = objectFactory.fileProperty();
         this.fipsJvmFile = objectFactory.fileProperty();
         this.gitRevisionFile = objectFactory.fileProperty();
-        this.buildDateFile = objectFactory.fileProperty();
     }
 
     @Input
@@ -114,15 +110,6 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
         this.gitRevision = gitRevision;
     }
 
-    @Input
-    public ZonedDateTime getBuildDate() {
-        return buildDate;
-    }
-
-    public void setBuildDate(final ZonedDateTime buildDate) {
-        this.buildDate = buildDate;
-    }
-
     @OutputFile
     public RegularFileProperty getOutputFile() {
         return outputFile;
@@ -146,11 +133,6 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
     @OutputFile
     public RegularFileProperty getGitRevisionFile() {
         return gitRevisionFile;
-    }
-
-    @OutputFile
-    public RegularFileProperty getBuildDateFile() {
-        return buildDateFile;
     }
 
     @TaskAction
@@ -211,8 +193,7 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
                     + " (" + gradleJavaVersionDetails + ")\n");
                 writer.write("  JAVA_HOME             : " + gradleJavaHome + "\n");
             }
-            writer.write("  Git Revision          : " + gitRevision + "\n");
-            writer.write("  Build Date            : " + buildDate);
+            writer.write("  Git Revision          : " + gitRevision);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -254,7 +235,6 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
         writeToFile(runtimeVersionFile.getAsFile().get(), runtimeJavaVersionEnum.name());
         writeToFile(fipsJvmFile.getAsFile().get(), Boolean.toString(inFipsJvm));
         writeToFile(gitRevisionFile.getAsFile().get(), gitRevision);
-        writeToFile(buildDateFile.getAsFile().get(), buildDate.toString());
     }
 
     private void writeToFile(File file, String content) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
@@ -16,6 +16,8 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -43,6 +45,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         File compilerJavaHome = findCompilerJavaHome();
         File runtimeJavaHome = findRuntimeJavaHome(compilerJavaHome);
         final String gitRevision = gitRevision(project);
+        final ZonedDateTime buildDate = ZonedDateTime.now(ZoneOffset.UTC);
 
         final List<JavaHome> javaVersions = new ArrayList<>();
         for (int version = 8; version <= Integer.parseInt(minimumCompilerVersion.getMajorVersion()); version++) {
@@ -59,11 +62,13 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
                 task.setCompilerJavaHome(compilerJavaHome);
                 task.setRuntimeJavaHome(runtimeJavaHome);
                 task.setGitRevision(gitRevision);
+                task.setBuildDate(buildDate);
                 task.getOutputFile().set(new File(project.getBuildDir(), "global-build-info"));
                 task.getCompilerVersionFile().set(new File(project.getBuildDir(), "java-compiler-version"));
                 task.getRuntimeVersionFile().set(new File(project.getBuildDir(), "java-runtime-version"));
                 task.getFipsJvmFile().set(new File(project.getBuildDir(), "in-fips-jvm"));
                 task.getGitRevisionFile().set(new File(project.getBuildDir(), "git-revision"));
+                task.getBuildDateFile().set(new File(project.getBuildDir(), "build-date"));
             });
 
         PrintGlobalBuildInfoTask printTask = project.getTasks().create("printGlobalBuildInfo", PrintGlobalBuildInfoTask.class, task -> {
@@ -72,6 +77,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             task.getRuntimeVersionFile().set(generateTask.getRuntimeVersionFile());
             task.getFipsJvmFile().set(generateTask.getFipsJvmFile());
             task.getGitRevisionFile().set(generateTask.getGitRevisionFile());
+            task.getBuildDateFile().set(generateTask.getBuildDateFile());
             task.setGlobalInfoListeners(extension.listeners);
         });
 
@@ -95,6 +101,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             ext.set("minimumRuntimeVersion", minimumRuntimeVersion);
             ext.set("gradleJavaVersion", Jvm.current().getJavaVersion());
             ext.set("gitRevision", gitRevision);
+            ext.set("buildDate", buildDate);
         });
     }
 

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
@@ -45,7 +45,6 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         File compilerJavaHome = findCompilerJavaHome();
         File runtimeJavaHome = findRuntimeJavaHome(compilerJavaHome);
         final String gitRevision = gitRevision(project);
-        final ZonedDateTime buildDate = ZonedDateTime.now(ZoneOffset.UTC);
 
         final List<JavaHome> javaVersions = new ArrayList<>();
         for (int version = 8; version <= Integer.parseInt(minimumCompilerVersion.getMajorVersion()); version++) {
@@ -62,13 +61,11 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
                 task.setCompilerJavaHome(compilerJavaHome);
                 task.setRuntimeJavaHome(runtimeJavaHome);
                 task.setGitRevision(gitRevision);
-                task.setBuildDate(buildDate);
                 task.getOutputFile().set(new File(project.getBuildDir(), "global-build-info"));
                 task.getCompilerVersionFile().set(new File(project.getBuildDir(), "java-compiler-version"));
                 task.getRuntimeVersionFile().set(new File(project.getBuildDir(), "java-runtime-version"));
                 task.getFipsJvmFile().set(new File(project.getBuildDir(), "in-fips-jvm"));
                 task.getGitRevisionFile().set(new File(project.getBuildDir(), "git-revision"));
-                task.getBuildDateFile().set(new File(project.getBuildDir(), "build-date"));
             });
 
         PrintGlobalBuildInfoTask printTask = project.getTasks().create("printGlobalBuildInfo", PrintGlobalBuildInfoTask.class, task -> {
@@ -77,7 +74,6 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             task.getRuntimeVersionFile().set(generateTask.getRuntimeVersionFile());
             task.getFipsJvmFile().set(generateTask.getFipsJvmFile());
             task.getGitRevisionFile().set(generateTask.getGitRevisionFile());
-            task.getBuildDateFile().set(generateTask.getBuildDateFile());
             task.setGlobalInfoListeners(extension.listeners);
         });
 
@@ -101,7 +97,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             ext.set("minimumRuntimeVersion", minimumRuntimeVersion);
             ext.set("gradleJavaVersion", Jvm.current().getJavaVersion());
             ext.set("gitRevision", gitRevision);
-            ext.set("buildDate", buildDate);
+            ext.set("buildDate", ZonedDateTime.now(ZoneOffset.UTC));
         });
     }
 

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/PrintGlobalBuildInfoTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/PrintGlobalBuildInfoTask.java
@@ -10,7 +10,6 @@ import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.TaskAction;
 
 import javax.inject.Inject;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,7 +19,6 @@ public class PrintGlobalBuildInfoTask extends DefaultTask {
     private final RegularFileProperty runtimeVersionFile;
     private final RegularFileProperty fipsJvmFile;
     private final RegularFileProperty gitRevisionFile;
-    private final RegularFileProperty buildDateFile;
     private List<Runnable> globalInfoListeners = new ArrayList<>();
 
     @Inject
@@ -30,7 +28,6 @@ public class PrintGlobalBuildInfoTask extends DefaultTask {
         this.runtimeVersionFile = objectFactory.fileProperty();
         this.fipsJvmFile = objectFactory.fileProperty();
         this.gitRevisionFile = objectFactory.fileProperty();
-        this.buildDateFile = objectFactory.fileProperty();
     }
 
     @InputFile
@@ -56,11 +53,6 @@ public class PrintGlobalBuildInfoTask extends DefaultTask {
     @InputFile
     public RegularFileProperty getGitRevisionFile() {
         return gitRevisionFile;
-    }
-
-    @InputFile
-    public RegularFileProperty getBuildDateFile() {
-        return buildDateFile;
     }
 
     public void setGlobalInfoListeners(List<Runnable> globalInfoListeners) {
@@ -95,7 +87,6 @@ public class PrintGlobalBuildInfoTask extends DefaultTask {
             ext.set("runtimeJavaVersion", JavaVersion.valueOf(getFileText(getRuntimeVersionFile()).asString()));
             ext.set("inFipsJvm", Boolean.valueOf(getFileText(getFipsJvmFile()).asString()));
             ext.set("gitRevision", getFileText(getGitRevisionFile()).asString());
-            ext.set("buildDate", ZonedDateTime.parse(getFileText(getBuildDateFile()).asString()));
         });
     }
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/PrintGlobalBuildInfoTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/PrintGlobalBuildInfoTask.java
@@ -10,6 +10,7 @@ import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.TaskAction;
 
 import javax.inject.Inject;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,6 +20,7 @@ public class PrintGlobalBuildInfoTask extends DefaultTask {
     private final RegularFileProperty runtimeVersionFile;
     private final RegularFileProperty fipsJvmFile;
     private final RegularFileProperty gitRevisionFile;
+    private final RegularFileProperty buildDateFile;
     private List<Runnable> globalInfoListeners = new ArrayList<>();
 
     @Inject
@@ -28,6 +30,7 @@ public class PrintGlobalBuildInfoTask extends DefaultTask {
         this.runtimeVersionFile = objectFactory.fileProperty();
         this.fipsJvmFile = objectFactory.fileProperty();
         this.gitRevisionFile = objectFactory.fileProperty();
+        this.buildDateFile = objectFactory.fileProperty();
     }
 
     @InputFile
@@ -53,6 +56,11 @@ public class PrintGlobalBuildInfoTask extends DefaultTask {
     @InputFile
     public RegularFileProperty getGitRevisionFile() {
         return gitRevisionFile;
+    }
+
+    @InputFile
+    public RegularFileProperty getBuildDateFile() {
+        return buildDateFile;
     }
 
     public void setGlobalInfoListeners(List<Runnable> globalInfoListeners) {
@@ -87,6 +95,7 @@ public class PrintGlobalBuildInfoTask extends DefaultTask {
             ext.set("runtimeJavaVersion", JavaVersion.valueOf(getFileText(getRuntimeVersionFile()).asString()));
             ext.set("inFipsJvm", Boolean.valueOf(getFileText(getFipsJvmFile()).asString()));
             ext.set("gitRevision", getFileText(getGitRevisionFile()).asString());
+            ext.set("buildDate", ZonedDateTime.parse(getFileText(getBuildDateFile()).asString()));
         });
     }
 }


### PR DESCRIPTION
This commit adds the build date to global build info mainly so that it is accessible as an extension property.

