### PR TITLE
Add OCI annotations and adjust existing annotations

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -24,8 +24,10 @@ ext.expansions = { oss, local ->
   final String classifier = 'linux-x86_64'            
   final String elasticsearch = oss ? "elasticsearch-oss-${VersionProperties.elasticsearch}-${classifier}.tar.gz" : "elasticsearch-${VersionProperties.elasticsearch}-${classifier}.tar.gz"
   return [
+    'build_date'          : project.ext.buildDate,
     'elasticsearch'       : elasticsearch,
-    'license'             : oss ? 'Apache-2.0' : 'Elastic License',
+    'git_revision'        : project.ext.gitRevision,
+    'license'             : oss ? 'Apache-2.0' : 'Elastic-License',
     'source_elasticsearch': local ? "COPY $elasticsearch /opt/" : "RUN cd /opt && curl --retry 8 -s -L -O https://artifacts.elastic.co/downloads/elasticsearch/${elasticsearch} && cd -",
     'version'             : VersionProperties.elasticsearch
   ]

--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -69,13 +69,25 @@ RUN chgrp 0 /usr/local/bin/docker-entrypoint.sh && \
 
 EXPOSE 9200 9300
 
-LABEL org.label-schema.schema-version="1.0" \
-  org.label-schema.vendor="Elastic" \
-  org.label-schema.name="elasticsearch" \
-  org.label-schema.version="${version}" \
+LABEL org.label-schema.build-date=${build_date} \
+  org.label-schema.license="${license}" \
+  org.label-schema.name="Elasticsearch" \
+  org.label-schema.schema-version="1.0" \
   org.label-schema.url="https://www.elastic.co/products/elasticsearch" \
+  org.label-schema.usage="https://www.elastic.co/guide/en/elasticsearch/reference/index.html" \
+  org.label-schema.vcs-ref="${git_revision}" \
   org.label-schema.vcs-url="https://github.com/elastic/elasticsearch" \
-  license="${license}"
+  org.label-schema.vendor="Elastic" \
+  org.label-schema.version="${version}" \
+  org.opencontainers.image.created=${build_date} \
+  org.opencontainers.image.documentation="https://www.elastic.co/guide/en/elasticsearch/reference/index.html" \
+  org.opencontainers.image.licenses="${license}" \
+  org.opencontainers.image.revision="${git_revision}" \
+  org.opencontainers.image.source="https://github.com/elastic/elasticsearch" \
+  org.opencontainers.image.title="Elasticsearch" \
+  org.opencontainers.image.url="https://www.elastic.co/products/elasticsearch" \
+  org.opencontainers.image.vendor="Elastic"
+  org.opencontainers.image.version="${version}" \
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 # Dummy overridable parameter parsed by entrypoint

--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -69,7 +69,7 @@ RUN chgrp 0 /usr/local/bin/docker-entrypoint.sh && \
 
 EXPOSE 9200 9300
 
-LABEL org.label-schema.build-date=${build_date} \
+LABEL org.label-schema.build-date="${build_date}" \
   org.label-schema.license="${license}" \
   org.label-schema.name="Elasticsearch" \
   org.label-schema.schema-version="1.0" \
@@ -79,7 +79,7 @@ LABEL org.label-schema.build-date=${build_date} \
   org.label-schema.vcs-url="https://github.com/elastic/elasticsearch" \
   org.label-schema.vendor="Elastic" \
   org.label-schema.version="${version}" \
-  org.opencontainers.image.created=${build_date} \
+  org.opencontainers.image.created="${build_date}" \
   org.opencontainers.image.documentation="https://www.elastic.co/guide/en/elasticsearch/reference/index.html" \
   org.opencontainers.image.licenses="${license}" \
   org.opencontainers.image.revision="${git_revision}" \

--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -86,8 +86,8 @@ LABEL org.label-schema.build-date=${build_date} \
   org.opencontainers.image.source="https://github.com/elastic/elasticsearch" \
   org.opencontainers.image.title="Elasticsearch" \
   org.opencontainers.image.url="https://www.elastic.co/products/elasticsearch" \
-  org.opencontainers.image.vendor="Elastic"
-  org.opencontainers.image.version="${version}" \
+  org.opencontainers.image.vendor="Elastic" \
+  org.opencontainers.image.version="${version}"
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 # Dummy overridable parameter parsed by entrypoint


### PR DESCRIPTION
The org.label-schema labels on Docker images have been superseded by pre-defined OCI annotations. However, there is still a lot of tooling in use that relies on the org.label-schema, so we do not want to drop them. This commit adds values for the org.opencontainers.image pre-defined annotation keys. Additionally, we correct an issue with the label used to represent the license, to use the org.label-schema.license label. While this label was never accepted into the org.label-schema specfication (because this specification was superseded, it's not that it was explicitly rejected) there are containers out there using this label. In particular, our base image is and so we need to override otherwise we inherit, and end up mis-reporting the license.

Relates #45162
Relates #45166
