### PR TITLE
Upgrade to JDK 12.0.2

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -1,7 +1,7 @@
 elasticsearch     = 8.0.0
 lucene            = 8.2.0
 
-bundled_jdk       = 12.0.1+12@69cfe15208a647278a19ef0990eea691
+bundled_jdk       = 12.0.2+10@e482c34c86bd4bf8b56c0b35558996b9
 
 # optional dependencies
 spatial4j         = 0.7


### PR DESCRIPTION
This commit bumps the embedded JDK from 12.0.1 to 12.0.2.
