### PR TITLE
Simplify handling of git revision

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GenerateGlobalBuildInfoTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GenerateGlobalBuildInfoTask.java
@@ -38,12 +38,10 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
     private File compilerJavaHome;
     private File runtimeJavaHome;
     private List<JavaHome> javaVersions;
-    private String gitRevision;
     private final RegularFileProperty outputFile;
     private final RegularFileProperty compilerVersionFile;
     private final RegularFileProperty runtimeVersionFile;
     private final RegularFileProperty fipsJvmFile;
-    private final RegularFileProperty gitRevisionFile;
 
     @Inject
     public GenerateGlobalBuildInfoTask(ObjectFactory objectFactory) {
@@ -51,7 +49,6 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
         this.compilerVersionFile = objectFactory.fileProperty();
         this.runtimeVersionFile = objectFactory.fileProperty();
         this.fipsJvmFile = objectFactory.fileProperty();
-        this.gitRevisionFile = objectFactory.fileProperty();
     }
 
     @Input
@@ -101,15 +98,6 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
         this.javaVersions = javaVersions;
     }
 
-    @Input
-    public String getGitRevision() {
-        return gitRevision;
-    }
-
-    public void setGitRevision(final String gitRevision) {
-        this.gitRevision = gitRevision;
-    }
-
     @OutputFile
     public RegularFileProperty getOutputFile() {
         return outputFile;
@@ -128,11 +116,6 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
     @OutputFile
     public RegularFileProperty getFipsJvmFile() {
         return fipsJvmFile;
-    }
-
-    @OutputFile
-    public RegularFileProperty getGitRevisionFile() {
-        return gitRevisionFile;
     }
 
     @TaskAction
@@ -187,13 +170,12 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
                 writer.write("  Runtime java.home     : " + runtimeJavaHome + "\n");
                 writer.write("  Gradle JDK Version    : " + JavaVersion.toVersion(gradleJavaVersion)
                     + " (" + gradleJavaVersionDetails + ")\n");
-                writer.write("  Gradle java.home      : " + gradleJavaHome + "\n");
+                writer.write("  Gradle java.home      : " + gradleJavaHome);
             } else {
                 writer.write("  JDK Version           : " + JavaVersion.toVersion(gradleJavaVersion)
                     + " (" + gradleJavaVersionDetails + ")\n");
-                writer.write("  JAVA_HOME             : " + gradleJavaHome + "\n");
+                writer.write("  JAVA_HOME             : " + gradleJavaHome);
             }
-            writer.write("  Git Revision          : " + gitRevision);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -234,7 +216,6 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
         writeToFile(compilerVersionFile.getAsFile().get(), compilerJavaVersionEnum.name());
         writeToFile(runtimeVersionFile.getAsFile().get(), runtimeJavaVersionEnum.name());
         writeToFile(fipsJvmFile.getAsFile().get(), Boolean.toString(inFipsJvm));
-        writeToFile(gitRevisionFile.getAsFile().get(), gitRevision);
     }
 
     private void writeToFile(File file, String content) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
@@ -44,7 +44,6 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
 
         File compilerJavaHome = findCompilerJavaHome();
         File runtimeJavaHome = findRuntimeJavaHome(compilerJavaHome);
-        final String gitRevision = gitRevision(project);
 
         final List<JavaHome> javaVersions = new ArrayList<>();
         for (int version = 8; version <= Integer.parseInt(minimumCompilerVersion.getMajorVersion()); version++) {
@@ -60,12 +59,10 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
                 task.setMinimumRuntimeVersion(minimumRuntimeVersion);
                 task.setCompilerJavaHome(compilerJavaHome);
                 task.setRuntimeJavaHome(runtimeJavaHome);
-                task.setGitRevision(gitRevision);
                 task.getOutputFile().set(new File(project.getBuildDir(), "global-build-info"));
                 task.getCompilerVersionFile().set(new File(project.getBuildDir(), "java-compiler-version"));
                 task.getRuntimeVersionFile().set(new File(project.getBuildDir(), "java-runtime-version"));
                 task.getFipsJvmFile().set(new File(project.getBuildDir(), "in-fips-jvm"));
-                task.getGitRevisionFile().set(new File(project.getBuildDir(), "git-revision"));
             });
 
         PrintGlobalBuildInfoTask printTask = project.getTasks().create("printGlobalBuildInfo", PrintGlobalBuildInfoTask.class, task -> {
@@ -73,7 +70,6 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             task.getCompilerVersionFile().set(generateTask.getCompilerVersionFile());
             task.getRuntimeVersionFile().set(generateTask.getRuntimeVersionFile());
             task.getFipsJvmFile().set(generateTask.getFipsJvmFile());
-            task.getGitRevisionFile().set(generateTask.getGitRevisionFile());
             task.setGlobalInfoListeners(extension.listeners);
         });
 
@@ -96,7 +92,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             ext.set("minimumCompilerVersion", minimumCompilerVersion);
             ext.set("minimumRuntimeVersion", minimumRuntimeVersion);
             ext.set("gradleJavaVersion", Jvm.current().getJavaVersion());
-            ext.set("gitRevision", gitRevision);
+            ext.set("gitRevision", gitRevision(project));
             ext.set("buildDate", ZonedDateTime.now(ZoneOffset.UTC));
         });
     }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/PrintGlobalBuildInfoTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/PrintGlobalBuildInfoTask.java
@@ -18,7 +18,6 @@ public class PrintGlobalBuildInfoTask extends DefaultTask {
     private final RegularFileProperty compilerVersionFile;
     private final RegularFileProperty runtimeVersionFile;
     private final RegularFileProperty fipsJvmFile;
-    private final RegularFileProperty gitRevisionFile;
     private List<Runnable> globalInfoListeners = new ArrayList<>();
 
     @Inject
@@ -27,7 +26,6 @@ public class PrintGlobalBuildInfoTask extends DefaultTask {
         this.compilerVersionFile = objectFactory.fileProperty();
         this.runtimeVersionFile = objectFactory.fileProperty();
         this.fipsJvmFile = objectFactory.fileProperty();
-        this.gitRevisionFile = objectFactory.fileProperty();
     }
 
     @InputFile
@@ -48,11 +46,6 @@ public class PrintGlobalBuildInfoTask extends DefaultTask {
     @InputFile
     public RegularFileProperty getFipsJvmFile() {
         return fipsJvmFile;
-    }
-
-    @InputFile
-    public RegularFileProperty getGitRevisionFile() {
-        return gitRevisionFile;
     }
 
     public void setGlobalInfoListeners(List<Runnable> globalInfoListeners) {
@@ -86,7 +79,6 @@ public class PrintGlobalBuildInfoTask extends DefaultTask {
             ext.set("compilerJavaVersion", JavaVersion.valueOf(getFileText(getCompilerVersionFile()).asString()));
             ext.set("runtimeJavaVersion", JavaVersion.valueOf(getFileText(getRuntimeVersionFile()).asString()));
             ext.set("inFipsJvm", Boolean.valueOf(getFileText(getFipsJvmFile()).asString()));
-            ext.set("gitRevision", getFileText(getGitRevisionFile()).asString());
         });
     }
 }


### PR DESCRIPTION
This commit simplifies the handling of git revision in the build. In particular we remove pushing git revision through the generate build info and print build info tasks as the git revision does not need to be cached.

Relates #45162