### PR TITLE
Remove assertion in local recovery

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1434,10 +1434,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             assert newSafeCommit.isPresent() : "no safe commit found after local recovery";
             return newSafeCommit.get().localCheckpoint + 1;
         } catch (Exception e) {
-            if (Assertions.ENABLED) {
-                throw new AssertionError(
-                    "failed to find the safe commit after recovering shard locally up to global checkpoint " + globalCheckpoint, e);
-            }
             logger.debug(new ParameterizedMessage(
                 "failed to find the safe commit after recovering shard locally up to global checkpoint {}", globalCheckpoint), e);
             return UNASSIGNED_SEQ_NO;


### PR DESCRIPTION
If the disk becomes broken after we have locally recovered shard up to the global checkpoint, then the assertion won't hold.

CI: https://scans.gradle.com/s/o7xkyphjd4yka