### PR TITLE
[DOCS] Reformat match phrase query

### DIFF
--- a/docs/reference/analysis.asciidoc
+++ b/docs/reference/analysis.asciidoc
@@ -32,6 +32,8 @@ to the inverted index:
 ------
 
 [float]
+[[specify-index-time-analyzer]]
+
 === Specifying an index time analyzer
 
 Each <<text,`text`>> field in a mapping can specify its own

--- a/docs/reference/query-dsl/match-phrase-query.asciidoc
+++ b/docs/reference/query-dsl/match-phrase-query.asciidoc
@@ -40,7 +40,7 @@ GET /_search
 `<field>`::
 (Required, object) Field you wish to search.
 
-[[match-field-params]]
+[[match-phrase-field-params]]
 ==== Parameters for `<field>`
 `query`::
 +

--- a/docs/reference/query-dsl/match-phrase-query.asciidoc
+++ b/docs/reference/query-dsl/match-phrase-query.asciidoc
@@ -3,29 +3,21 @@
 ++++
 <titleabbrev>Match phrase</titleabbrev>
 ++++
+Returns documents that contain all words of a provided text, in the **same
+order** as provided.
 
-The `match_phrase` query analyzes the text and creates a `phrase` query
-out of the analyzed text. For example:
+You can use the `match_phrase` query when it's important to find a complete
+phrase or words near each other.
 
-[source,js]
---------------------------------------------------
-GET /_search
-{
-    "query": {
-        "match_phrase" : {
-            "message" : "this is a test"
-        }
-    }
-}
---------------------------------------------------
-// CONSOLE
 
-A phrase query matches terms up to a configurable `slop`
-(which defaults to 0) in any order. Transposed terms have a slop of 2.
+[[match-phrase-query-ex-request]]
+==== Example request
 
-The `analyzer` can be set to control which analyzer will perform the
-analysis process on the text. It defaults to the field explicit mapping
-definition, or the default search analyzer, for example:
+The following `match_phrase` search returns documents containing `brown fox` in
+the `message` field.
+
+This search would match a `message` value of `quick brown fox` but not `the fox
+is brown`.
 
 [source,js]
 --------------------------------------------------
@@ -34,8 +26,7 @@ GET /_search
     "query": {
         "match_phrase" : {
             "message" : {
-                "query" : "this is a test",
-                "analyzer" : "my_analyzer"
+                "query" : "brown fox"
             }
         }
     }
@@ -43,4 +34,43 @@ GET /_search
 --------------------------------------------------
 // CONSOLE
 
-This query also accepts `zero_terms_query`, as explained in <<query-dsl-match-query, `match` query>>.
+
+[[match-phrase-top-level-params]]
+==== Top-level parameters for `match_phrase`
+`<field>`::
+(Required, object) Field you wish to search.
+
+[[match-field-params]]
+==== Parameters for `<field>`
+`query`::
++
+--
+(Required, string) Text you wish to find in the provided `<field>`.
+
+The `match_phrase` query <<analysis,analyzes>> any provided text into tokens
+before performing a search.
+--
+
+`analyzer`::
+(Optional, string) <<analysis,Analyzer>> used to convert text in the `query`
+value into tokens. Defaults to the <<specify-index-time-analyzer,index-time
+analyzer>> mapped for the `<field>`. If no analyzer is mapped, the index's
+default analyzer is used.
+
+`slop`::
+(Optional, integer) Maximum number of positions allowed between matching tokens.
+Defaults to `0`. Transposed terms have a slop of `2`.
+
+`zero_terms_query`::
++
+--
+(Optional, string) Indicates whether no documents are returned if the `analyzer`
+removes all tokens, such as when using a `stop` filter. Valid values are:
+
+ `none` (Default)::
+No documents are returned if the `analyzer` removes all tokens.
+
+ `all`::
+Returns all documents, similar to a <<query-dsl-match-all-query,`match_all`>>
+query.
+--


### PR DESCRIPTION
Updates the `match_phrase` query to use the new query format.

This creates separate sections for the example request, parameters, and notes.

This is part of #40977, an effort to standardize documentation for query types.

### Preview
http://elasticsearch_45204.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/query-dsl-match-query-phrase.html