### PR TITLE
Avoid building docker images when running precommit task

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -128,15 +128,15 @@ processTestResources {
   from project(':x-pack:plugin:core')
           .file('src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.jks')
   dependsOn configurations.restSpec
-  // don't add the tasks to build the docker images if we have no way of testing them
-  if (TestFixturesPlugin.dockerComposeSupported()) {
-    dependsOn assemble
-  }
 }
 
 task integTest(type: Test) {
   maxParallelForks = '1'
   include '**/*IT.class'
+  // don't add the tasks to build the docker images if we have no way of testing them
+  if (TestFixturesPlugin.dockerComposeSupported()) {
+    dependsOn assemble
+  }
 }
 
 check.dependsOn integTest


### PR DESCRIPTION
This PR avoid incidentally triggering the assembly of Docker images when running `precommit`. The dependency exists because Docker distribution tests require the images. This brings the question @atorok if we should simply fail the build if you attempt to run the Docker distribution integration tests w/o Docker compose. Wouldn't the tests themselves fail otherwise?