### PR TITLE
[7.3] Fix failed dependency resolution with external build-tools users (#45107)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
@@ -21,6 +21,7 @@ package org.elasticsearch.gradle.test
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.testclusters.ElasticsearchCluster
 import org.elasticsearch.gradle.testclusters.TestClustersPlugin
+import org.elasticsearch.gradle.tool.ClasspathUtils
 import org.gradle.api.DefaultTask
 import org.gradle.api.Task
 import org.gradle.api.execution.TaskExecutionAdapter
@@ -250,7 +251,8 @@ class RestIntegTestTask extends DefaultTask {
             restSpec
         }
         project.dependencies {
-            restSpec project.project(':rest-api-spec')
+            restSpec ClasspathUtils.isElasticsearchProject() ? project.project(':rest-api-spec') :
+                    "org.elasticsearch.rest-api-spec:${VersionProperties.elasticsearch}"
         }
         Task copyRestSpec = project.tasks.findByName('copyRestSpec')
         if (copyRestSpec != null) {


### PR DESCRIPTION
Backports the following commits to 7.3:
 - Fix failed dependency resolution with external build-tools users  (#45107)