### PR TITLE
move geo-encoding of points to GeometryTree

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/geo/GeometryTreeWriter.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeometryTreeWriter.java
@@ -160,14 +160,22 @@ public class GeometryTreeWriter implements Writeable {
 
         @Override
         public Void visit(Point point) {
-            Point2DWriter writer = new Point2DWriter(point);
+            int x = GeoEncodingUtils.encodeLongitude(point.getLon());
+            int y = GeoEncodingUtils.encodeLatitude(point.getLat());
+            Point2DWriter writer = new Point2DWriter(x, y);
             addWriter(writer);
             return null;
         }
 
         @Override
         public Void visit(MultiPoint multiPoint) {
-            Point2DWriter writer = new Point2DWriter(multiPoint);
+            int[] x = new int[multiPoint.size()];
+            int[] y = new int[x.length];
+            for (int i = 0; i < multiPoint.size(); i++) {
+                x[i] = GeoEncodingUtils.encodeLongitude(multiPoint.get(i).getLon());
+                y[i] = GeoEncodingUtils.encodeLatitude(multiPoint.get(i).getLat());
+            }
+            Point2DWriter writer = new Point2DWriter(x, y);
             addWriter(writer);
             return null;
         }

--- a/server/src/main/java/org/elasticsearch/common/geo/Point2DWriter.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/Point2DWriter.java
@@ -18,10 +18,7 @@
  */
 package org.elasticsearch.common.geo;
 
-import org.apache.lucene.geo.GeoEncodingUtils;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.geo.geometry.MultiPoint;
-import org.elasticsearch.geo.geometry.Point;
 import org.elasticsearch.geo.geometry.ShapeType;
 
 import java.io.IOException;
@@ -39,32 +36,28 @@ public class Point2DWriter extends ShapeTreeWriter {
     // size of a leaf node where searches are done sequentially.
     static final int LEAF_SIZE = 64;
 
-    Point2DWriter(MultiPoint multiPoint) {
-        int numPoints = multiPoint.size();
+    Point2DWriter(int[] x, int[] y) {
+        assert x.length == y.length;
         int minX = Integer.MAX_VALUE;
         int minY = Integer.MAX_VALUE;
         int maxX = Integer.MIN_VALUE;
         int maxY = Integer.MIN_VALUE;
-        coords = new int[numPoints * K];
-        int i = 0;
-        for (Point point : multiPoint) {
-            int x = GeoEncodingUtils.encodeLongitude(point.getLon());
-            int y = GeoEncodingUtils.encodeLatitude(point.getLat());
-            minX = Math.min(minX, x);
-            minY = Math.min(minY, y);
-            maxX = Math.max(maxX, x);
-            maxY = Math.max(maxY, y);
-            coords[2 * i] = x;
-            coords[2 * i + 1] = y;
-            i++;
+        coords = new int[x.length * K];
+        for (int i = 0; i < x.length; i++) {
+            int xi = x[i];
+            int yi = y[i];
+            minX = Math.min(minX, xi);
+            minY = Math.min(minY, yi);
+            maxX = Math.max(maxX, xi);
+            maxY = Math.max(maxY, yi);
+            coords[2 * i] = xi;
+            coords[2 * i + 1] = yi;
         }
-        sort(0, numPoints - 1, 0);
+        sort(0, x.length - 1, 0);
         this.extent = new Extent(minX, minY, maxX, maxY);
     }
 
-    Point2DWriter(Point point) {
-        int x = GeoEncodingUtils.encodeLongitude(point.getLon());
-        int y = GeoEncodingUtils.encodeLatitude(point.getLat());
+    Point2DWriter(int x, int y) {
         coords = new int[] {x, y};
         this.extent = new Extent(x, y, x, y);
     }

--- a/server/src/test/java/org/elasticsearch/common/geo/Point2DTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/Point2DTests.java
@@ -22,15 +22,12 @@ import org.apache.lucene.geo.GeoEncodingUtils;
 import org.elasticsearch.common.geo.builders.PointBuilder;
 import org.elasticsearch.common.io.stream.ByteBufferStreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.geo.geometry.MultiPoint;
 import org.elasticsearch.geo.geometry.Point;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.geo.RandomShapeGenerator;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -41,7 +38,7 @@ public class Point2DTests extends ESTestCase {
         Point point = gen.buildGeometry();
         int x = GeoEncodingUtils.encodeLongitude(point.getLon());
         int y = GeoEncodingUtils.encodeLatitude(point.getLat());
-        Point2DWriter writer = new Point2DWriter(point);
+        Point2DWriter writer = new Point2DWriter(x, y);
 
         BytesStreamOutput output = new BytesStreamOutput();
         writer.writeTo(output);
@@ -63,15 +60,16 @@ public class Point2DTests extends ESTestCase {
             int maxX = randomIntBetween(minX + 10, 180);
             int minY = randomIntBetween(-90, 80);
             int maxY = randomIntBetween(minY + 10, 90);
-            Extent extent = new Extent(GeoEncodingUtils.encodeLongitude(minX), GeoEncodingUtils.encodeLatitude(minY),
-                GeoEncodingUtils.encodeLongitude(maxX), GeoEncodingUtils.encodeLatitude(maxY));
+            Extent extent = new Extent(minX, minY, maxX, maxY);
             int numPoints = randomIntBetween(2, 1000);
 
-            List<Point> points = new ArrayList<>(numPoints);
+            int[] x = new int[numPoints];
+            int[] y = new int[numPoints];
             for (int j = 0; j < numPoints; j++) {
-                points.add(new Point(randomDoubleBetween(minY, maxY, true), randomDoubleBetween(minX, maxX, true)));
+                x[j] = randomIntBetween(minX, maxX);
+                y[j] = randomIntBetween(minY, maxY);
             }
-            Point2DWriter writer = new Point2DWriter(new MultiPoint(points));
+            Point2DWriter writer = new Point2DWriter(x, y);
 
             BytesStreamOutput output = new BytesStreamOutput();
             writer.writeTo(output);


### PR DESCRIPTION
moves the encoding of lat/lon from Point2D to GeometryTree

Point2D and EdgeTree should be agnostic to lat/lon geometries