### PR TITLE
[DOCS] Reformat cat master API

### DIFF
--- a/docs/reference/cat/master.asciidoc
+++ b/docs/reference/cat/master.asciidoc
@@ -1,8 +1,36 @@
 [[cat-master]]
 === cat master
 
-`master` doesn't have any extra options. It simply displays the
-master's node ID, bound IP address, and node name. For example:
+Returns information about the master node, including the ID, bound IP address,
+and name.
+
+
+[[cat-master-api-request]]
+==== {api-request-title}
+
+`GET /_cat/master`
+
+
+[[cat-master-api-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+
+
+[[cat-master-api-example]]
+==== {api-examples-title}
 
 [source,js]
 --------------------------------------------------
@@ -10,7 +38,7 @@ GET /_cat/master?v
 --------------------------------------------------
 // CONSOLE
 
-might respond:
+The API returns the following response:
 
 [source,txt]
 --------------------------------------------------


### PR DESCRIPTION
Relates to elastic/docs#937.

This PR updates the cat master API to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc).