### PR TITLE
Use newIndexSearcher() instead of newSearcher() in BucketScript test

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptAggregatorTests.java
@@ -111,7 +111,7 @@ public class BucketScriptAggregatorTests extends AggregatorTestCase {
             indexWriter.close();
 
             try (IndexReader indexReader = DirectoryReader.open(directory)) {
-                IndexSearcher indexSearcher = newSearcher(indexReader, true, true);
+                IndexSearcher indexSearcher = newIndexSearcher(indexReader);
 
                 InternalFilters filters;
                 filters = searchAndReduce(indexSearcher, query, aggregationBuilder, fieldType);


### PR DESCRIPTION
`newSearcher()` from lucene can randomly choose index readers which are not compatible with our tests, like ParallelCompositeReader. The `newIndexSearcher()` method on AggregatorTestCase is a wrapper similar to newSearcher but compatible with our tests

Just putting up for another round of CI and easy-button merge :)

Closes https://github.com/elastic/elasticsearch/issues/45242