### PR TITLE
Publish CI build scans to Gradle Enterprise

### DIFF
--- a/.ci/init.gradle
+++ b/.ci/init.gradle
@@ -70,6 +70,11 @@ projectsLoaded {
             maven configCache()
         }
     }
+    rootProject {
+        project.pluginManager.withPlugin('com.gradle.build-scan') {
+            buildScan.server = 'https://gradle-enterprise.elastic.co'
+        }
+    }
 }
 
 if (System.env.GRADLE_BUILD_CACHE_URL != null) {


### PR DESCRIPTION
Update the CI Gradle init script such that build scans are configured to be published to our internal Gradle Enterprise instance.