### PR TITLE
Fix clock used in update requests

### DIFF
--- a/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/25_script_upsert.yml
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/25_script_upsert.yml
@@ -82,7 +82,7 @@
         body:
           script:
             # assume _now is an absolute clock if it's in the range [now - 1m, now]; this tolerance might need adjustment after CI cycles
-            source: "long now = System.currentTimeMillis();ctx._source.within_ten_minutes = ctx._now <= now && ctx._now => now - 1000 * 60 * 1"
+            source: "long now = System.currentTimeMillis();ctx._source.within_ten_minutes = ctx._now <= now && ctx._now >= now - 1000 * 60 * 1"
             lang: "painless"
           upsert: { within_ten_minutes: false }
           scripted_upsert: true

--- a/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/25_script_upsert.yml
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/25_script_upsert.yml
@@ -82,9 +82,9 @@
         body:
           script:
             # assume _now is an absolute clock if it's in the range [now - 1m, now]; this tolerance might need adjustment after CI cycles
-            source: "long now = System.currentTimeMillis();ctx._source.within_ten_minutes = ctx._now <= now && ctx._now >= now - 1000 * 60 * 1"
+            source: "long now = System.currentTimeMillis();ctx._source.within_one_minute = ctx._now <= now && ctx._now >= now - 1000 * 60 * 1"
             lang: "painless"
-          upsert: { within_ten_minutes: false }
+          upsert: { within_one_minute: false }
           scripted_upsert: true
 
   - do:
@@ -92,4 +92,4 @@
         index: test_1
         id: 4
 
-  - match: { _source.within_ten_minutes: true }
+  - match: { _source.within_one_minute: true }

--- a/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/25_script_upsert.yml
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/25_script_upsert.yml
@@ -74,3 +74,22 @@
           id:     3
 
   - match:  { _source.has_now: true }
+
+  - do:
+      update:
+        index: test_1
+        id: 4
+        body:
+          script:
+            # assume _now is an absolute clock if it's in the range [now - 1m, now]; this tolerance might need adjustment after CI cycles
+            source: "long now = System.currentTimeMillis();ctx._source.within_ten_minutes = ctx._now <= now && ctx._now => now - 1000 * 60 * 1"
+            lang: "painless"
+          upsert: { within_ten_minutes: false }
+          scripted_upsert: true
+
+  - do:
+      get:
+        index: test_1
+        id: 4
+
+  - match: { _source.within_ten_minutes: true }

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -117,7 +117,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
     protected void shardOperationOnPrimary(BulkShardRequest request, IndexShard primary,
             ActionListener<PrimaryResult<BulkShardRequest, BulkShardResponse>> listener) {
         ClusterStateObserver observer = new ClusterStateObserver(clusterService, request.timeout(), logger, threadPool.getThreadContext());
-        performOnPrimary(request, primary, updateHelper, threadPool::relativeTimeInMillis,
+        performOnPrimary(request, primary, updateHelper, threadPool::absoluteTimeInMillis,
             (update, shardId, type, mappingListener) -> {
                 assert update != null;
                 assert shardId != null;

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
@@ -305,7 +305,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
         BulkPrimaryExecutionContext context = new BulkPrimaryExecutionContext(bulkShardRequest, shard);
         final CountDownLatch latch = new CountDownLatch(1);
         TransportShardBulkAction.executeBulkItemRequest(
-            context, null, threadPool::relativeTimeInMillis,
+            context, null, threadPool::absoluteTimeInMillis,
             errorOnWait == false ? new ThrowingMappingUpdatePerformer(err) : new NoopMappingUpdatePerformer(),
             errorOnWait ? listener -> listener.onFailure(err) : listener -> listener.onResponse(null),
             new LatchedActionListener<>(new ActionListener<Void>() {


### PR DESCRIPTION
We accidentally switched to using the relative time provider here. This commit fixes this by switching to the appropriate absolute clock.

Closes #45254