### PR TITLE
Add predicate wrapper so implies checks can be performed correctly

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/permission/ClusterPermissionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/permission/ClusterPermissionTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.security.authz.privilege.ClusterPrivilege;
 import org.elasticsearch.xpack.core.security.authz.privilege.ClusterPrivilegeResolver;
 import org.elasticsearch.xpack.core.security.authz.privilege.ConfigurableClusterPrivilege;
+import org.elasticsearch.xpack.core.security.authz.privilege.ConfigurableClusterPrivileges;
 import org.elasticsearch.xpack.core.security.support.Automatons;
 import org.junit.Before;
 import org.mockito.Mockito;
@@ -48,10 +49,10 @@ public class ClusterPermissionTests extends ESTestCase {
 
         builder = ClusterPrivilegeResolver.MANAGE_SECURITY.buildPermission(builder);
         builder = ClusterPrivilegeResolver.MANAGE_ILM.buildPermission(builder);
-        final MockConfigurableClusterPrivilege mockConfigurableClusterPrivilege1 =
-            new MockConfigurableClusterPrivilege(r -> r == mockTransportRequest);
-        final MockConfigurableClusterPrivilege mockConfigurableClusterPrivilege2 =
-            new MockConfigurableClusterPrivilege(r -> false);
+        final ConfigurableClusterPrivileges.ManageApplicationPrivileges mockConfigurableClusterPrivilege1 =
+            new ConfigurableClusterPrivileges.ManageApplicationPrivileges(Set.of("application-1"));
+        final ConfigurableClusterPrivileges.ManageApplicationPrivileges mockConfigurableClusterPrivilege2 =
+            new ConfigurableClusterPrivileges.ManageApplicationPrivileges(Set.of("application-1", "application-2"));
         builder = mockConfigurableClusterPrivilege1.buildPermission(builder);
         builder = mockConfigurableClusterPrivilege2.buildPermission(builder);
         final ClusterPermission clusterPermission = builder.build();
@@ -70,10 +71,10 @@ public class ClusterPermissionTests extends ESTestCase {
         builder = ClusterPrivilegeResolver.MANAGE_SECURITY.buildPermission(builder);
         builder = ClusterPrivilegeResolver.MANAGE_ILM.buildPermission(builder);
 
-        final MockConfigurableClusterPrivilege mockConfigurableClusterPrivilege1 =
-            new MockConfigurableClusterPrivilege(r -> r == mockTransportRequest);
-        final MockConfigurableClusterPrivilege mockConfigurableClusterPrivilege2 =
-            new MockConfigurableClusterPrivilege(r -> false);
+        final ConfigurableClusterPrivileges.ManageApplicationPrivileges mockConfigurableClusterPrivilege1 =
+            new ConfigurableClusterPrivileges.ManageApplicationPrivileges(Set.of("application-1"));
+        final ConfigurableClusterPrivileges.ManageApplicationPrivileges mockConfigurableClusterPrivilege2 =
+            new ConfigurableClusterPrivileges.ManageApplicationPrivileges(Set.of("application-1", "application-2"));
         builder = mockConfigurableClusterPrivilege1.buildPermission(builder);
         builder = mockConfigurableClusterPrivilege2.buildPermission(builder);
         final ClusterPermission clusterPermission = builder.build();
@@ -128,10 +129,10 @@ public class ClusterPermissionTests extends ESTestCase {
         ClusterPermission.Builder builder = ClusterPermission.builder();
         builder = ClusterPrivilegeResolver.MANAGE_SECURITY.buildPermission(builder);
         builder = ClusterPrivilegeResolver.MANAGE_ILM.buildPermission(builder);
-        final MockConfigurableClusterPrivilege mockConfigurableClusterPrivilege1 =
-            new MockConfigurableClusterPrivilege(r -> r == mockTransportRequest);
-        final MockConfigurableClusterPrivilege mockConfigurableClusterPrivilege2 =
-            new MockConfigurableClusterPrivilege(r -> false);
+        final ConfigurableClusterPrivileges.ManageApplicationPrivileges mockConfigurableClusterPrivilege1 =
+            new ConfigurableClusterPrivileges.ManageApplicationPrivileges(Set.of("application-1"));
+        final ConfigurableClusterPrivileges.ManageApplicationPrivileges mockConfigurableClusterPrivilege2 =
+            new ConfigurableClusterPrivileges.ManageApplicationPrivileges(Set.of("application-1", "application-2"));
         builder = mockConfigurableClusterPrivilege1.buildPermission(builder);
         builder = mockConfigurableClusterPrivilege2.buildPermission(builder);
         final ClusterPermission clusterPermission = builder.build();
@@ -143,8 +144,8 @@ public class ClusterPermissionTests extends ESTestCase {
         ClusterPermission.Builder builder = ClusterPermission.builder();
         builder = ClusterPrivilegeResolver.MANAGE_ML.buildPermission(builder);
         builder = ClusterPrivilegeResolver.MANAGE_ILM.buildPermission(builder);
-        final MockConfigurableClusterPrivilege mockConfigurableClusterPrivilege1 =
-            new MockConfigurableClusterPrivilege(r -> r == mockTransportRequest);
+        final ConfigurableClusterPrivileges.ManageApplicationPrivileges mockConfigurableClusterPrivilege1 =
+            new ConfigurableClusterPrivileges.ManageApplicationPrivileges(Set.of("application-1"));
         builder = mockConfigurableClusterPrivilege1.buildPermission(builder);
         final ClusterPermission clusterPermission = builder.build();
 
@@ -160,16 +161,16 @@ public class ClusterPermissionTests extends ESTestCase {
         ClusterPermission.Builder builder = ClusterPermission.builder();
         builder = ClusterPrivilegeResolver.MANAGE_ML.buildPermission(builder);
         builder = ClusterPrivilegeResolver.MANAGE_ILM.buildPermission(builder);
-        final MockConfigurableClusterPrivilege mockConfigurableClusterPrivilege1 =
-            new MockConfigurableClusterPrivilege(r -> r == mockTransportRequest);
+        final ConfigurableClusterPrivileges.ManageApplicationPrivileges mockConfigurableClusterPrivilege1 =
+            new ConfigurableClusterPrivileges.ManageApplicationPrivileges(Set.of("application-1"));
         builder = mockConfigurableClusterPrivilege1.buildPermission(builder);
         final ClusterPermission clusterPermission = builder.build();
 
         ClusterPermission.Builder builder1 = ClusterPermission.builder();
         builder1 = ClusterPrivilegeResolver.MANAGE_ML.buildPermission(builder1);
         builder1 = mockConfigurableClusterPrivilege1.buildPermission(builder1);
-        final MockConfigurableClusterPrivilege mockConfigurableClusterPrivilege2 =
-            new MockConfigurableClusterPrivilege(r -> false);
+        final ConfigurableClusterPrivileges.ManageApplicationPrivileges mockConfigurableClusterPrivilege2 =
+            new ConfigurableClusterPrivileges.ManageApplicationPrivileges(Set.of("application-1", "application-2"));
         builder1 = mockConfigurableClusterPrivilege2.buildPermission(builder1);
         final ClusterPermission otherClusterPermission = builder1.build();
 
@@ -206,8 +207,8 @@ public class ClusterPermissionTests extends ESTestCase {
         ClusterPermission.Builder builder = ClusterPermission.builder();
         builder = ClusterPrivilegeResolver.MANAGE_ML.buildPermission(builder);
         builder = ClusterPrivilegeResolver.MANAGE_ILM.buildPermission(builder);
-        final MockConfigurableClusterPrivilege mockConfigurableClusterPrivilege1 =
-            new MockConfigurableClusterPrivilege(r -> r == mockTransportRequest);
+        final ConfigurableClusterPrivileges.ManageApplicationPrivileges mockConfigurableClusterPrivilege1 =
+            new ConfigurableClusterPrivileges.ManageApplicationPrivileges(Set.of("application-1"));
         builder = mockConfigurableClusterPrivilege1.buildPermission(builder);
         final ClusterPermission clusterPermission = builder.build();
 
@@ -220,62 +221,5 @@ public class ClusterPermissionTests extends ESTestCase {
             ClusterPrivilegeResolver.MANAGE_ILM.buildPermission(ClusterPermission.builder()).build();
 
         assertThat(allClusterPermission.implies(otherClusterPermission), is(true));
-    }
-
-    private static class MockConfigurableClusterPrivilege implements ConfigurableClusterPrivilege {
-        static final Predicate<String> ACTION_PREDICATE = Automatons.predicate("cluster:admin/xpack/security/privilege/*");
-        private Predicate<TransportRequest> requestPredicate;
-
-        MockConfigurableClusterPrivilege(Predicate<TransportRequest> requestPredicate) {
-            this.requestPredicate = requestPredicate;
-        }
-
-        @Override
-        public Category getCategory() {
-            return Category.APPLICATION;
-        }
-
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            return builder;
-        }
-
-        @Override
-        public String getWriteableName() {
-            return "mock-ccp";
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            final MockConfigurableClusterPrivilege that = (MockConfigurableClusterPrivilege) o;
-            return requestPredicate.equals(that.requestPredicate);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(requestPredicate);
-        }
-
-        @Override
-        public String toString() {
-            return "MockConfigurableClusterPrivilege{" +
-                "requestPredicate=" + requestPredicate +
-                '}';
-        }
-
-        @Override
-        public ClusterPermission.Builder buildPermission(ClusterPermission.Builder builder) {
-            return builder.add(this, ACTION_PREDICATE, requestPredicate);
-        }
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/permission/ClusterPermissionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/permission/ClusterPermissionTests.java
@@ -8,22 +8,15 @@
 
 package org.elasticsearch.xpack.core.security.authz.permission;
 
-import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.security.authz.privilege.ClusterPrivilege;
 import org.elasticsearch.xpack.core.security.authz.privilege.ClusterPrivilegeResolver;
-import org.elasticsearch.xpack.core.security.authz.privilege.ConfigurableClusterPrivilege;
 import org.elasticsearch.xpack.core.security.authz.privilege.ConfigurableClusterPrivileges;
-import org.elasticsearch.xpack.core.security.support.Automatons;
 import org.junit.Before;
 import org.mockito.Mockito;
 
-import java.io.IOException;
-import java.util.Objects;
 import java.util.Set;
-import java.util.function.Predicate;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -364,7 +364,7 @@ public class AuthorizationServiceTests extends ESTestCase {
 
                         @Override
                         public Predicate<TransportRequest> predicate() {
-                            return r -> r == request;
+                            return r -> false;
                         }
                     });
                 return builder;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -51,7 +51,6 @@ import org.elasticsearch.xpack.core.security.authz.privilege.IndexPrivilege;
 import org.elasticsearch.xpack.core.security.authz.store.ReservedRolesStore;
 import org.elasticsearch.xpack.core.security.authz.store.RoleRetrievalResult;
 import org.elasticsearch.xpack.core.security.index.RestrictedIndicesNames;
-import org.elasticsearch.xpack.core.security.support.Automatons;
 import org.elasticsearch.xpack.core.security.user.AnonymousUser;
 import org.elasticsearch.xpack.core.security.user.SystemUser;
 import org.elasticsearch.xpack.core.security.user.User;
@@ -550,9 +549,19 @@ public class CompositeRolesStoreTests extends ESTestCase {
         ConfigurableClusterPrivilege ccp1 = new MockConfigurableClusterPrivilege() {
             @Override
             public ClusterPermission.Builder buildPermission(ClusterPermission.Builder builder) {
-                Predicate<String> predicate1 =
-                    Automatons.predicate(((ActionClusterPrivilege) ClusterPrivilegeResolver.MANAGE_SECURITY).getAllowedActionPatterns());
-                builder.add(this, predicate1, req -> req == request1);
+                builder.add(this, ((ActionClusterPrivilege) ClusterPrivilegeResolver.MANAGE_SECURITY).getAllowedActionPatterns(),
+                    Set.of(), new ClusterPermission.PermissionCheckPredicate<TransportRequest>() {
+
+                        @Override
+                        public boolean implies(ClusterPermission.PermissionCheckPredicate<TransportRequest> permissionCheckPredicate) {
+                            return this.predicate() == permissionCheckPredicate.predicate();
+                        }
+
+                        @Override
+                        public Predicate<TransportRequest> predicate() {
+                            return r -> r == request1;
+                        }
+                    });
                 return builder;
             }
         };
@@ -582,9 +591,19 @@ public class CompositeRolesStoreTests extends ESTestCase {
         ConfigurableClusterPrivilege ccp2 = new MockConfigurableClusterPrivilege() {
             @Override
             public ClusterPermission.Builder buildPermission(ClusterPermission.Builder builder) {
-                Predicate<String> predicate2 =
-                    Automatons.predicate(((ActionClusterPrivilege) ClusterPrivilegeResolver.MANAGE_SECURITY).getAllowedActionPatterns());
-                builder.add(this, predicate2, req -> req == request2);
+                builder.add(this, ((ActionClusterPrivilege) ClusterPrivilegeResolver.MANAGE_SECURITY).getAllowedActionPatterns(),
+                    Set.of(), new ClusterPermission.PermissionCheckPredicate<TransportRequest>() {
+
+                        @Override
+                        public boolean implies(ClusterPermission.PermissionCheckPredicate<TransportRequest> permissionCheckPredicate) {
+                            return this.predicate() == permissionCheckPredicate.predicate();
+                        }
+
+                        @Override
+                        public Predicate<TransportRequest> predicate() {
+                            return r -> r == request2;
+                        }
+                    });
                 return builder;
             }
         };


### PR DESCRIPTION
This commit adds `PermissionCheckPredicate` a wrapper class which the `ClusterPrivilege`s can use to define the predicates for cluster permission. This allows us to enforce the implementers to implement `implies`.
Currently, when we perform `implies` check on `ClusterPermissionCheck` we check equality of the `ClusterPrivilege` which I think it should be proper implies check. The equals check is something that the implementers have to think about when adding `ClusterPrivilege`.

I am not sure if `predicate implies otherPredicate` makes sense or not, so I would like to hear your opinions on this. Thank you.