### PR TITLE
 [DOCS] Reformats cluster stats API and expands common params

### DIFF
--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -24,7 +24,6 @@ memory usage) and information about the current nodes that form the cluster
 [[cluster-stats-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=node-id]
 

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -24,13 +24,21 @@ memory usage) and information about the current nodes that form the cluster
 [[cluster-stats-api-path-params]]
 ==== {api-path-parms-title}
 
+include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+
 include::{docdir}/rest-api/common-parms.asciidoc[tag=node-id]
 
 
 [[cluster-stats-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+
+
+[[cluster-stats-api-example]]
+==== {api-examples-title}
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -1,10 +1,36 @@
 [[cluster-stats]]
 === Cluster Stats
 
-The Cluster Stats API allows to retrieve statistics from a cluster wide perspective.
-The API returns basic index metrics (shard numbers, store size, memory usage) and
-information about the current nodes that form the cluster (number, roles, os, jvm
-versions, memory usage, cpu and installed plugins).
+Returns cluster statistics.
+
+
+[[cluster-stats-api-request]]
+==== {api-request-title}
+
+`GET /_cluster/stats` +
+
+`GET /_cluster/stats/nodes/{node_id}`
+
+
+[[cluster-stats-api-desc]]
+==== {api-description-title}
+
+The Cluster Stats API allows to retrieve statistics from a cluster wide 
+perspective. The API returns basic index metrics (shard numbers, store size, 
+memory usage) and information about the current nodes that form the cluster 
+(number, roles, os, jvm versions, memory usage, cpu and installed plugins).
+
+
+[[cluster-stats-api-path-params]]
+==== {api-path-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=node-id]
+
+
+[[cluster-stats-api-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
 
 [source,js]
 --------------------------------------------------
@@ -13,7 +39,8 @@ GET /_cluster/stats?human&pretty
 // CONSOLE
 // TEST[setup:twitter]
 
-Will return, for example:
+The API returns the following response:
+
 ["source","js",subs="attributes,callouts"]
 --------------------------------------------------
 {

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -9,6 +9,12 @@ tag::cat-h[]
 (Optional, string) Comma-separated list of column names to display.
 end::cat-h[]
 
+tag::flat-settings[]
+`flat_settings`::
+(Optional, boolean) If `true`, returns settings in flat format. Defaults to 
+`false`.
+end::flat-settings[]
+
 tag::help[]
 `help`::
 (Optional, boolean) If `true`, the response returns help information. Defaults


### PR DESCRIPTION
Relates to elastic/docs#937 and https://github.com/elastic/elasticsearch/issues/45197.

This PR updates the cluster stats API to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc) and adds a new param to the common params list (flat_settings).

Resources:
* [Cluster stats API spec](https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.stats.json)
* [Cluster stats doc](https://www.elastic.co/guide/en/elasticsearch/reference/7.3/cluster-stats.html)