### PR TITLE
[DOCS] Adds supported time units ref to the frequency and delay params

### DIFF
--- a/docs/reference/data-frames/apis/put-transform.asciidoc
+++ b/docs/reference/data-frames/apis/put-transform.asciidoc
@@ -92,7 +92,7 @@ IMPORTANT:  You must use {kib} or this API to create a {dataframe-transform}.
     (Optional, string) The unique identifier for a <<pipeline,pipeline>>.
 
 `frequency`::
-  (Optional, time units) The interval between checks for changes in the source
+  (Optional, <<time-units, time units>>) The interval between checks for changes in the source
   indices when the {dataframe-transform} is running continuously. Also determines
   the retry interval in the event of transient failures while the {dataframe-transform} is
   searching or indexing. The minimum value is `1s` and the maximum is `1h`. The
@@ -133,7 +133,7 @@ delays.
 
 --
     `delay`::::
-      (Optional, time units) The time delay between the current time and the
+      (Optional, <<time-units, time units>>) The time delay between the current time and the
       latest input data time. The default value is `60s`.
 
 [[put-data-frame-transform-example]]


### PR DESCRIPTION
This PR adds a link to the `frequency` and `delay` params that points to the supported time units table.