### PR TITLE
SQL: Sessions now hold their state inside a Context

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/PlanExecutor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/PlanExecutor.java
@@ -9,6 +9,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.xpack.sql.analysis.analyzer.Analyzer;
 import org.elasticsearch.xpack.sql.analysis.analyzer.PreAnalyzer;
 import org.elasticsearch.xpack.sql.analysis.analyzer.Verifier;
 import org.elasticsearch.xpack.sql.analysis.index.IndexResolver;
@@ -41,6 +42,7 @@ public class PlanExecutor {
 
     private final IndexResolver indexResolver;
     private final PreAnalyzer preAnalyzer;
+    private final Analyzer analyzer;
     private final Verifier verifier;
     private final Optimizer optimizer;
     private final Planner planner;
@@ -60,10 +62,12 @@ public class PlanExecutor {
         this.verifier = new Verifier(metrics);
         this.optimizer = new Optimizer();
         this.planner = new Planner();
+
+        this.analyzer = new Analyzer(functionRegistry, verifier);
     }
 
     private SqlSession newSession(Configuration cfg) {
-        return new SqlSession(cfg, client, functionRegistry, indexResolver, preAnalyzer, verifier, optimizer, planner, this);
+        return new SqlSession(cfg, client, functionRegistry, indexResolver, preAnalyzer, analyzer, verifier, optimizer, planner, this);
     }
 
     public void searchSource(Configuration cfg, String sql, List<SqlTypedParamValue> params, ActionListener<SearchSourceBuilder> listener) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
@@ -151,7 +151,7 @@ final class QueryTranslator {
             new CountAggs(),
             new DateTimes(),
             new Firsts(),
-            new Lasts(), 
+            new Lasts(),
             new MADs()
             );
 
@@ -270,6 +270,7 @@ final class QueryTranslator {
 
                 // handle functions differently
                 if (exp instanceof Function) {
+
                     // dates are handled differently because of date histograms
                     if (exp instanceof DateTimeHistogramFunction) {
                         DateTimeHistogramFunction dthf = (DateTimeHistogramFunction) exp;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/Context.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/Context.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.sql.session;
+
+import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
+import org.elasticsearch.xpack.sql.analysis.index.IndexResolution;
+
+import java.time.ZoneId;
+
+public class Context {
+
+    private static final ThreadLocal<Context> CURRENT_CONTEXT = new ThreadLocal<>();
+
+    public static Context getCurrentContext() {
+        Context current = CURRENT_CONTEXT.get();
+        if (current == null) {
+            throw new SqlIllegalArgumentException("Cannot determine current SQL context; this is likely a bug");
+        }
+        return current;
+    }
+
+    static void setCurrentContext(Context context) {
+        Context current = CURRENT_CONTEXT.get();
+        if (current != null) {
+            throw new SqlIllegalArgumentException("Current SQL context already set; this is likely a bug");
+        }
+        CURRENT_CONTEXT.set(context);
+    }
+
+    static void cleanCurrentContext() {
+        CURRENT_CONTEXT.remove();
+    }
+
+    /**
+     * Per-request specific settings needed in some of the functions (timezone, username and clustername),
+     * to which they are attached.
+     */
+    private final Configuration configuration;
+
+    /**
+     * Information about the indices against which the SQL is being analyzed.
+     */
+    private final IndexResolution resolution;
+
+    public Context(Configuration configuration, IndexResolution resolution) {
+        this.configuration = configuration;
+        this.resolution = resolution;
+    }
+
+    public Configuration configuration() {
+        return configuration;
+    }
+
+    public IndexResolution indexResolution() {
+        return resolution;
+    }
+
+    public ZoneId zoneId() {
+        return configuration.zoneId();
+    }
+}

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/TestUtils.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/TestUtils.java
@@ -7,12 +7,15 @@
 package org.elasticsearch.xpack.sql;
 
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.xpack.sql.analysis.index.IndexResolution;
 import org.elasticsearch.xpack.sql.proto.Mode;
 import org.elasticsearch.xpack.sql.proto.Protocol;
 import org.elasticsearch.xpack.sql.session.Configuration;
+import org.elasticsearch.xpack.sql.session.ContextTestUtils;
 import org.elasticsearch.xpack.sql.util.DateUtils;
 
 import java.time.ZoneId;
+import java.util.function.Supplier;
 
 import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
 import static org.elasticsearch.test.ESTestCase.randomBoolean;
@@ -58,4 +61,27 @@ public class TestUtils {
                 randomBoolean());
     }
 
+    public static <R> R withContext(Configuration cfg, IndexResolution r, Supplier<R> action) {
+        ContextTestUtils.setContext(cfg, r);
+        try {
+            return action.get();
+        } finally {
+            ContextTestUtils.clearContext();
+        }
+    }
+
+    public static void withContext(Configuration cfg, IndexResolution r, Runnable action) {
+        withContext(cfg, r, () -> {
+            action.run();
+            return null;
+        });
+    }
+
+    public static <R> R withZoneId(ZoneId zoneId, Supplier<R> callback) {
+        return withContext(randomConfiguration(zoneId), null, callback);
+    }
+
+    public static void withZoneId(ZoneId zoneId, Runnable callback) {
+        withContext(randomConfiguration(zoneId), null, callback);
+    }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/FieldAttributeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/FieldAttributeTests.java
@@ -52,11 +52,11 @@ public class FieldAttributeTests extends ESTestCase {
 
         EsIndex test = new EsIndex("test", mapping);
         getIndexResult = IndexResolution.valid(test);
-        analyzer = new Analyzer(TestUtils.TEST_CFG, functionRegistry, getIndexResult, verifier);
+        analyzer = new Analyzer(functionRegistry, verifier);
     }
 
     private LogicalPlan plan(String sql) {
-        return analyzer.analyze(parser.createStatement(sql), true);
+        return TestUtils.withContext(TestUtils.TEST_CFG, getIndexResult, () -> analyzer.analyze(parser.createStatement(sql), true));
     }
 
     private FieldAttribute attribute(String fieldName) {
@@ -171,7 +171,6 @@ public class FieldAttributeTests extends ESTestCase {
 
         EsIndex index = new EsIndex("test", mapping);
         getIndexResult = IndexResolution.valid(index);
-        analyzer = new Analyzer(TestUtils.TEST_CFG, functionRegistry, getIndexResult, verifier);
 
         VerificationException ex = expectThrows(VerificationException.class, () -> plan("SELECT test.bar FROM test"));
         assertEquals(

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
@@ -40,8 +40,9 @@ public class VerifierErrorMessagesTests extends ESTestCase {
     }
 
     private String error(IndexResolution getIndexResult, String sql) {
-        Analyzer analyzer = new Analyzer(TestUtils.TEST_CFG, new FunctionRegistry(), getIndexResult, new Verifier(new Metrics()));
-        VerificationException e = expectThrows(VerificationException.class, () -> analyzer.analyze(parser.createStatement(sql), true));
+        Analyzer analyzer = new Analyzer(new FunctionRegistry(), new Verifier(new Metrics()));
+        VerificationException e = expectThrows(VerificationException.class,
+                () -> TestUtils.withContext(TestUtils.TEST_CFG, getIndexResult, () -> analyzer.analyze(parser.createStatement(sql), true)));
         assertTrue(e.getMessage().startsWith("Found "));
         String header = "Found 1 problem(s)\nline ";
         return e.getMessage().substring(header.length());
@@ -58,8 +59,8 @@ public class VerifierErrorMessagesTests extends ESTestCase {
     }
 
     private LogicalPlan accept(IndexResolution resolution, String sql) {
-        Analyzer analyzer = new Analyzer(TestUtils.TEST_CFG, new FunctionRegistry(), resolution, new Verifier(new Metrics()));
-        return analyzer.analyze(parser.createStatement(sql), true);
+        Analyzer analyzer = new Analyzer(new FunctionRegistry(), new Verifier(new Metrics()));
+        return TestUtils.withContext(TestUtils.TEST_CFG, resolution, () -> analyzer.analyze(parser.createStatement(sql), true));
     }
 
     private IndexResolution incompatible() {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/DatabaseFunctionTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/DatabaseFunctionTests.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.sql.expression.function.scalar;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.sql.TestUtils;
 import org.elasticsearch.xpack.sql.analysis.analyzer.Analyzer;
 import org.elasticsearch.xpack.sql.analysis.analyzer.Verifier;
 import org.elasticsearch.xpack.sql.analysis.index.EsIndex;
@@ -27,17 +28,13 @@ public class DatabaseFunctionTests extends ESTestCase {
         String clusterName = randomAlphaOfLengthBetween(1, 15);
         SqlParser parser = new SqlParser();
         EsIndex test = new EsIndex("test", TypesTests.loadMapping("mapping-basic.json", true));
-        Analyzer analyzer = new Analyzer(
-                new Configuration(DateUtils.UTC, Protocol.FETCH_SIZE, Protocol.REQUEST_TIMEOUT,
-                                  Protocol.PAGE_TIMEOUT, null,
-                                  randomFrom(Mode.values()), randomAlphaOfLength(10),
-                                  null, clusterName, randomBoolean(), randomBoolean()),
-                new FunctionRegistry(),
-                IndexResolution.valid(test),
-                new Verifier(new Metrics())
-        );
+        Analyzer analyzer = new Analyzer(new FunctionRegistry(), new Verifier(new Metrics()));
+
+        Configuration cfg = new Configuration(DateUtils.UTC, Protocol.FETCH_SIZE, Protocol.REQUEST_TIMEOUT, Protocol.PAGE_TIMEOUT, null,
+                randomFrom(Mode.values()), randomAlphaOfLength(10), null, clusterName, randomBoolean(), randomBoolean());
         
-        Project result = (Project) analyzer.analyze(parser.createStatement("SELECT DATABASE()"), true);
+        Project result = (Project) TestUtils.withContext(cfg, IndexResolution.valid(test),
+                () -> analyzer.analyze(parser.createStatement("SELECT DATABASE()"), true));
         assertTrue(result.projections().get(0) instanceof Database);
         assertEquals(clusterName, ((Database) result.projections().get(0)).fold());
     }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/UserFunctionTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/UserFunctionTests.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.sql.expression.function.scalar;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.sql.TestUtils;
 import org.elasticsearch.xpack.sql.analysis.analyzer.Analyzer;
 import org.elasticsearch.xpack.sql.analysis.analyzer.Verifier;
 import org.elasticsearch.xpack.sql.analysis.index.EsIndex;
@@ -26,18 +27,17 @@ public class UserFunctionTests extends ESTestCase {
     public void testNoUsernameFunctionOutput() {
         SqlParser parser = new SqlParser();
         EsIndex test = new EsIndex("test", TypesTests.loadMapping("mapping-basic.json", true));
-        Analyzer analyzer = new Analyzer(
-                new Configuration(DateUtils.UTC, Protocol.FETCH_SIZE, Protocol.REQUEST_TIMEOUT,
-                                  Protocol.PAGE_TIMEOUT, null, 
-                                  randomFrom(Mode.values()), randomAlphaOfLength(10), 
-                                  null, randomAlphaOfLengthBetween(1, 15), 
-                                  randomBoolean(), randomBoolean()),
-                new FunctionRegistry(),
-                IndexResolution.valid(test),
-                new Verifier(new Metrics())
-        );
-        
-        Project result = (Project) analyzer.analyze(parser.createStatement("SELECT USER()"), true);
+        Analyzer analyzer = new Analyzer(new FunctionRegistry(), new Verifier(new Metrics()));
+
+        Configuration cfg = new Configuration(DateUtils.UTC, Protocol.FETCH_SIZE, Protocol.REQUEST_TIMEOUT,
+                Protocol.PAGE_TIMEOUT, null, 
+                randomFrom(Mode.values()), randomAlphaOfLength(10), 
+                null, randomAlphaOfLengthBetween(1, 15), 
+                randomBoolean(), randomBoolean());
+
+        Project result = (Project) TestUtils.withContext(cfg, IndexResolution.valid(test),
+                () -> analyzer.analyze(parser.createStatement("SELECT USER()"), true));
+
         assertTrue(result.projections().get(0) instanceof User);
         assertNull(((User) result.projections().get(0)).fold());
     }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentDateTimeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentDateTimeTests.java
@@ -91,13 +91,15 @@ public class CurrentDateTimeTests extends AbstractNodeTestCase<CurrentDateTime, 
         IndexResolution indexResolution = IndexResolution.valid(new EsIndex("test",
             TypesTests.loadMapping("mapping-multi-field-with-nested.json")));
 
-        Analyzer analyzer = new Analyzer(TestUtils.TEST_CFG, new FunctionRegistry(), indexResolution, new Verifier(new Metrics()));
+        Analyzer analyzer = new Analyzer(new FunctionRegistry(), new Verifier(new Metrics()));
         ParsingException e = expectThrows(ParsingException.class, () ->
-            analyzer.analyze(parser.createStatement("SELECT CURRENT_TIMESTAMP(100000000000000)"), true));
+        TestUtils.withContext(TestUtils.TEST_CFG, indexResolution,
+                () -> analyzer.analyze(parser.createStatement("SELECT CURRENT_TIMESTAMP(100000000000000)"), true)));
         assertEquals("line 1:27: invalid precision; [100000000000000] out of [integer] range", e.getMessage());
 
         e = expectThrows(ParsingException.class, () ->
-            analyzer.analyze(parser.createStatement("SELECT CURRENT_TIMESTAMP(100)"), true));
+        TestUtils.withContext(TestUtils.TEST_CFG, indexResolution,
+                () -> analyzer.analyze(parser.createStatement("SELECT CURRENT_TIMESTAMP(100)"), true)));
         assertEquals("line 1:27: precision needs to be between [0-9], received [100]", e.getMessage());
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentTimeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentTimeTests.java
@@ -92,13 +92,14 @@ public class CurrentTimeTests extends AbstractNodeTestCase<CurrentTime, Expressi
         IndexResolution indexResolution = IndexResolution.valid(new EsIndex("test",
             TypesTests.loadMapping("mapping-multi-field-with-nested.json")));
 
-        Analyzer analyzer = new Analyzer(TestUtils.TEST_CFG, new FunctionRegistry(), indexResolution, new Verifier(new Metrics()));
-        ParsingException e = expectThrows(ParsingException.class, () ->
-            analyzer.analyze(parser.createStatement("SELECT CURRENT_TIME(100000000000000)"), true));
-        assertEquals("line 1:22: invalid precision; [100000000000000] out of [integer] range", e.getMessage());
+        TestUtils.withContext(TestUtils.TEST_CFG, indexResolution, () -> {
+            Analyzer analyzer = new Analyzer(new FunctionRegistry(), new Verifier(new Metrics()));
+            ParsingException e = expectThrows(ParsingException.class,
+                    () -> analyzer.analyze(parser.createStatement("SELECT CURRENT_TIME(100000000000000)"), true));
+            assertEquals("line 1:22: invalid precision; [100000000000000] out of [integer] range", e.getMessage());
 
-        e = expectThrows(ParsingException.class, () ->
-            analyzer.analyze(parser.createStatement("SELECT CURRENT_TIME(100)"), true));
-        assertEquals("line 1:22: precision needs to be between [0-9], received [100]", e.getMessage());
+            e = expectThrows(ParsingException.class, () -> analyzer.analyze(parser.createStatement("SELECT CURRENT_TIME(100)"), true));
+            assertEquals("line 1:22: precision needs to be between [0-9], received [100]", e.getMessage());
+        });
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerRunTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerRunTests.java
@@ -36,12 +36,13 @@ public class OptimizerRunTests extends ESTestCase {
 
         EsIndex test = new EsIndex("test", mapping);
         getIndexResult = IndexResolution.valid(test);
-        analyzer = new Analyzer(TestUtils.TEST_CFG, functionRegistry, getIndexResult, new Verifier(new Metrics()));
+        analyzer = new Analyzer(functionRegistry, new Verifier(new Metrics()));
         optimizer = new Optimizer();
     }
 
     private LogicalPlan plan(String sql) {
-        return optimizer.optimize(analyzer.analyze(parser.createStatement(sql)));
+        return TestUtils.withContext(TestUtils.TEST_CFG, getIndexResult, () ->
+            optimizer.optimize(analyzer.analyze(parser.createStatement(sql))));
     }
 
     public void testWhereClause() {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysColumnsTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysColumnsTests.java
@@ -519,14 +519,14 @@ public class SysColumnsTests extends ESTestCase {
 
     private Tuple<Command, SqlSession> sql(String sql, List<SqlTypedParamValue> params, Map<String, EsField> mapping) {
         EsIndex test = new EsIndex("test", mapping);
-        Analyzer analyzer = new Analyzer(TestUtils.TEST_CFG, new FunctionRegistry(), IndexResolution.valid(test),
-                new Verifier(new Metrics()));
-        Command cmd = (Command) analyzer.analyze(parser.createStatement(sql, params), true);
+        Analyzer analyzer = new Analyzer(new FunctionRegistry(), new Verifier(new Metrics()));
+        Command cmd = (Command) TestUtils.withContext(TestUtils.TEST_CFG, IndexResolution.valid(test),
+                () -> analyzer.analyze(parser.createStatement(sql, params), true));
 
         IndexResolver resolver = mock(IndexResolver.class);
         when(resolver.clusterName()).thenReturn(CLUSTER_NAME);
 
-        SqlSession session = new SqlSession(TestUtils.TEST_CFG, null, null, resolver, null, null, null, null, null);
+        SqlSession session = new SqlSession(TestUtils.TEST_CFG, null, null, resolver, null, analyzer, null, null, null, null);
         return new Tuple<>(cmd, session);
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTablesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTablesTests.java
@@ -350,14 +350,15 @@ public class SysTablesTests extends ESTestCase {
 
     private Tuple<Command, SqlSession> sql(String sql, List<SqlTypedParamValue> params, Configuration cfg) {
         EsIndex test = new EsIndex("test", mapping);
-        Analyzer analyzer = new Analyzer(TestUtils.TEST_CFG, new FunctionRegistry(), IndexResolution.valid(test),
-                                         new Verifier(new Metrics()));
-        Command cmd = (Command) analyzer.analyze(parser.createStatement(sql, params), true);
+        Analyzer analyzer = new Analyzer(new FunctionRegistry(), new Verifier(new Metrics()));
+
+        Command cmd = (Command) TestUtils.withContext(TestUtils.TEST_CFG, IndexResolution.valid(test),
+                () -> analyzer.analyze(parser.createStatement(sql, params), true));
 
         IndexResolver resolver = mock(IndexResolver.class);
         when(resolver.clusterName()).thenReturn(CLUSTER_NAME);
 
-        SqlSession session = new SqlSession(cfg, null, null, resolver, null, null, null, null, null);
+        SqlSession session = new SqlSession(cfg, null, null, resolver, null, analyzer, null, null, null, null);
         return new Tuple<>(cmd, session);
     }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTypesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTypesTests.java
@@ -9,15 +9,12 @@ import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.TestUtils;
 import org.elasticsearch.xpack.sql.analysis.analyzer.Analyzer;
-import org.elasticsearch.xpack.sql.analysis.index.EsIndex;
-import org.elasticsearch.xpack.sql.analysis.index.IndexResolution;
 import org.elasticsearch.xpack.sql.analysis.index.IndexResolver;
 import org.elasticsearch.xpack.sql.expression.function.FunctionRegistry;
 import org.elasticsearch.xpack.sql.parser.SqlParser;
 import org.elasticsearch.xpack.sql.plan.logical.command.Command;
 import org.elasticsearch.xpack.sql.session.SqlSession;
 import org.elasticsearch.xpack.sql.type.DataType;
-import org.elasticsearch.xpack.sql.type.TypesTests;
 
 import java.sql.JDBCType;
 import java.util.List;
@@ -31,12 +28,11 @@ public class SysTypesTests extends ESTestCase {
     private final SqlParser parser = new SqlParser();
 
     private Tuple<Command, SqlSession> sql(String sql) {
-        EsIndex test = new EsIndex("test", TypesTests.loadMapping("mapping-multi-field-with-nested.json", true));
-        Analyzer analyzer = new Analyzer(TestUtils.TEST_CFG, new FunctionRegistry(), IndexResolution.valid(test), null);
-        Command cmd = (Command) analyzer.analyze(parser.createStatement(sql), false);
+        Analyzer analyzer = new Analyzer(new FunctionRegistry(), null);
+        Command cmd = (Command) TestUtils.withContext(TestUtils.TEST_CFG, null, () -> analyzer.analyze(parser.createStatement(sql), false));
 
         IndexResolver resolver = mock(IndexResolver.class);
-        SqlSession session = new SqlSession(TestUtils.TEST_CFG, null, null, resolver, null, null, null, null, null);
+        SqlSession session = new SqlSession(TestUtils.TEST_CFG, null, null, resolver, null, analyzer, null, null, null, null);
         return new Tuple<>(cmd, session);
     }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/session/ContextTestUtils.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/session/ContextTestUtils.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.sql.session;
+
+import org.elasticsearch.xpack.sql.analysis.index.IndexResolution;
+
+public class ContextTestUtils {
+
+    public static void setContext(Configuration cfg, IndexResolution resolution) {
+        Context.setCurrentContext(new Context(cfg, resolution));
+    }
+
+    public static void clearContext() {
+        Context.cleanCurrentContext();
+    }
+}

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/stats/VerifierMetricsTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/stats/VerifierMetricsTests.java
@@ -239,8 +239,8 @@ public class VerifierMetricsTests extends ESTestCase {
             verifier = new Verifier(metrics);
         }
 
-        Analyzer analyzer = new Analyzer(TestUtils.TEST_CFG, new FunctionRegistry(), IndexResolution.valid(test), verifier);
-        analyzer.analyze(parser.createStatement(sql), true);
+        Analyzer analyzer = new Analyzer(new FunctionRegistry(), verifier);
+        TestUtils.withContext(TestUtils.TEST_CFG, IndexResolution.valid(test), () -> analyzer.analyze(parser.createStatement(sql), true));
         
         return metrics == null ? null : metrics.stats();
     }


### PR DESCRIPTION
Store the session state inside a newly introduced Context class which is
used during the bootstrapping initialization of plan execution (creation
or pagination).

The first benefit is the Analyzer doesn't have to have to be created per
session but reused as its scope is now decoupled from the session scope.

NB: The work is done on a separate branch before fully propagating the changes.