### PR TITLE
Remove loop counter from Reserved in Painless AST

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Compiler.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Compiler.java
@@ -208,8 +208,8 @@ final class Compiler {
      */
     Constructor<?> compile(Loader loader, MainMethodReserved reserved, String name, String source, CompilerSettings settings) {
         ScriptClassInfo scriptClassInfo = new ScriptClassInfo(painlessLookup, scriptClass);
-        SSource root = Walker.buildPainlessTree(scriptClassInfo, reserved, name, source, settings, painlessLookup,
-                null);
+        SSource root = Walker.buildPainlessTree(scriptClassInfo, reserved, name, source, settings, painlessLookup, null);
+        root.storeSettings(settings);
         root.analyze(painlessLookup);
         Map<String, Object> statics = root.write();
 
@@ -240,6 +240,7 @@ final class Compiler {
         ScriptClassInfo scriptClassInfo = new ScriptClassInfo(painlessLookup, scriptClass);
         SSource root = Walker.buildPainlessTree(scriptClassInfo, new MainMethodReserved(), name, source, settings, painlessLookup,
                 debugStream);
+        root.storeSettings(settings);
         root.analyze(painlessLookup);
         root.write();
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/Walker.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/Walker.java
@@ -253,7 +253,7 @@ public final class Walker extends PainlessParserBaseVisitor<ANode> {
             statements.add((AStatement)visit(statement));
         }
 
-        return new SSource(scriptClassInfo, settings, sourceName, sourceText, debugStream,
+        return new SSource(scriptClassInfo, sourceName, sourceText, debugStream,
                            (MainMethodReserved)reserved.pop(), location(ctx), functions, statements);
     }
 
@@ -319,8 +319,6 @@ public final class Walker extends PainlessParserBaseVisitor<ANode> {
 
     @Override
     public ANode visitWhile(WhileContext ctx) {
-        reserved.peek().setMaxLoopCounter(settings.getMaxLoopCounter());
-
         AExpression expression = (AExpression)visit(ctx.expression());
 
         if (ctx.trailer() != null) {
@@ -336,8 +334,6 @@ public final class Walker extends PainlessParserBaseVisitor<ANode> {
 
     @Override
     public ANode visitDo(DoContext ctx) {
-        reserved.peek().setMaxLoopCounter(settings.getMaxLoopCounter());
-
         AExpression expression = (AExpression)visit(ctx.expression());
         SBlock block = (SBlock)visit(ctx.block());
 
@@ -346,8 +342,6 @@ public final class Walker extends PainlessParserBaseVisitor<ANode> {
 
     @Override
     public ANode visitFor(ForContext ctx) {
-        reserved.peek().setMaxLoopCounter(settings.getMaxLoopCounter());
-
         ANode initializer = ctx.initializer() == null ? null : visit(ctx.initializer());
         AExpression expression = ctx.expression() == null ? null : (AExpression)visit(ctx.expression());
         AExpression afterthought = ctx.afterthought() == null ? null : (AExpression)visit(ctx.afterthought());
@@ -365,8 +359,6 @@ public final class Walker extends PainlessParserBaseVisitor<ANode> {
 
     @Override
     public ANode visitEach(EachContext ctx) {
-        reserved.peek().setMaxLoopCounter(settings.getMaxLoopCounter());
-
         String type = ctx.decltype().getText();
         String name = ctx.ID().getText();
         AExpression expression = (AExpression)visit(ctx.expression());
@@ -377,8 +369,6 @@ public final class Walker extends PainlessParserBaseVisitor<ANode> {
 
     @Override
     public ANode visitIneach(IneachContext ctx) {
-        reserved.peek().setMaxLoopCounter(settings.getMaxLoopCounter());
-
         String name = ctx.ID().getText();
         AExpression expression = (AExpression)visit(ctx.expression());
         SBlock block = (SBlock)visit(ctx.trailer());

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ANode.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ANode.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -52,6 +53,11 @@ public abstract class ANode {
     ANode(Location location) {
         this.location = Objects.requireNonNull(location);
     }
+
+    /**
+     * Store settings required for future compiler passes.
+     */
+    abstract void storeSettings(CompilerSettings settings);
 
     /**
      * Adds all variable names referenced to the variable set.

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EAssignment.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EAssignment.java
@@ -21,6 +21,7 @@ package org.elasticsearch.painless.node;
 
 
 import org.elasticsearch.painless.AnalyzerCaster;
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.DefBootstrap;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -60,6 +61,15 @@ public final class EAssignment extends AExpression {
         this.pre = pre;
         this.post = post;
         this.operation = operation;
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        lhs.storeSettings(settings);
+
+        if (rhs != null) {
+            rhs.storeSettings(settings);
+        }
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EBinary.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EBinary.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.AnalyzerCaster;
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.DefBootstrap;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -55,6 +56,12 @@ public final class EBinary extends AExpression {
         this.operation = Objects.requireNonNull(operation);
         this.left = Objects.requireNonNull(left);
         this.right = Objects.requireNonNull(right);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        left.storeSettings(settings);
+        right.storeSettings(settings);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EBool.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EBool.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -45,6 +46,12 @@ public final class EBool extends AExpression {
         this.operation = Objects.requireNonNull(operation);
         this.left = Objects.requireNonNull(left);
         this.right = Objects.requireNonNull(right);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        left.storeSettings(settings);
+        right.storeSettings(settings);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EBoolean.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EBoolean.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -35,6 +36,11 @@ public final class EBoolean extends AExpression {
         super(location);
 
         this.constant = constant;
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        // Do nothing.
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ECallLocal.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ECallLocal.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Locals.LocalMethod;
@@ -57,6 +58,13 @@ public final class ECallLocal extends AExpression {
 
         this.name = Objects.requireNonNull(name);
         this.arguments = Objects.requireNonNull(arguments);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        for (AExpression argument : arguments) {
+            argument.storeSettings(settings);
+        }
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ECapturingFunctionRef.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ECapturingFunctionRef.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.DefBootstrap;
 import org.elasticsearch.painless.FunctionRef;
 import org.elasticsearch.painless.Globals;
@@ -50,6 +51,11 @@ public final class ECapturingFunctionRef extends AExpression implements ILambda 
 
         this.variable = Objects.requireNonNull(variable);
         this.call = Objects.requireNonNull(call);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        // Do nothing.
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ECast.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ECast.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -45,8 +46,13 @@ final class ECast extends AExpression {
     }
 
     @Override
+    void storeSettings(CompilerSettings settings) {
+        throw createError(new IllegalStateException("illegal tree structure"));
+    }
+
+    @Override
     void extractVariables(Set<String> variables) {
-        throw new IllegalStateException("Illegal tree structure.");
+        throw createError(new IllegalStateException("Illegal tree structure."));
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EComp.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EComp.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.AnalyzerCaster;
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.DefBootstrap;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -54,6 +55,12 @@ public final class EComp extends AExpression {
         this.operation = Objects.requireNonNull(operation);
         this.left = Objects.requireNonNull(left);
         this.right = Objects.requireNonNull(right);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        left.storeSettings(settings);
+        right.storeSettings(settings);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EConditional.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EConditional.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.AnalyzerCaster;
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -45,6 +46,13 @@ public final class EConditional extends AExpression {
         this.condition = Objects.requireNonNull(condition);
         this.left = Objects.requireNonNull(left);
         this.right = Objects.requireNonNull(right);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        condition.storeSettings(settings);
+        left.storeSettings(settings);
+        right.storeSettings(settings);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EConstant.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EConstant.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -36,6 +37,11 @@ final class EConstant extends AExpression {
         super(location);
 
         this.constant = constant;
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        throw new IllegalStateException("illegal tree structure");
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EDecimal.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EDecimal.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -41,7 +42,14 @@ public final class EDecimal extends AExpression {
     }
 
     @Override
-    void extractVariables(Set<String> variables) {}
+    void storeSettings(CompilerSettings settings) {
+        // Do nothing.
+    }
+
+    @Override
+    void extractVariables(Set<String> variables) {
+        // Do nothing.
+    }
 
     @Override
     void analyze(Locals locals) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EElvis.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EElvis.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.AnalyzerCaster;
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -43,6 +44,12 @@ public class EElvis extends AExpression {
 
         this.lhs = requireNonNull(lhs);
         this.rhs = requireNonNull(rhs);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        lhs.storeSettings(settings);
+        rhs.storeSettings(settings);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EExplicit.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EExplicit.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -40,6 +41,11 @@ public final class EExplicit extends AExpression {
 
         this.type = Objects.requireNonNull(type);
         this.child = Objects.requireNonNull(child);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        child.storeSettings(settings);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EFunctionRef.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EFunctionRef.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.FunctionRef;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -47,7 +48,14 @@ public final class EFunctionRef extends AExpression implements ILambda {
     }
 
     @Override
-    void extractVariables(Set<String> variables) {}
+    void storeSettings(CompilerSettings settings) {
+        // do nothing
+    }
+
+    @Override
+    void extractVariables(Set<String> variables) {
+        // do nothing
+    }
 
     @Override
     void analyze(Locals locals) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EInstanceof.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EInstanceof.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -45,6 +46,11 @@ public final class EInstanceof extends AExpression {
         super(location);
         this.expression = Objects.requireNonNull(expression);
         this.type = Objects.requireNonNull(type);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        expression.storeSettings(settings);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EListInit.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EListInit.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -48,6 +49,13 @@ public final class EListInit extends AExpression {
         super(location);
 
         this.values = values;
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        for (AExpression value : values) {
+            value.storeSettings(settings);
+        }
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EMapInit.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EMapInit.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -50,6 +51,17 @@ public final class EMapInit extends AExpression {
 
         this.keys = keys;
         this.values = values;
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        for (AExpression key : keys) {
+            key.storeSettings(settings);
+        }
+
+        for (AExpression value : values) {
+            value.storeSettings(settings);
+        }
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ENewArray.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ENewArray.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -43,6 +44,13 @@ public final class ENewArray extends AExpression {
         this.type = Objects.requireNonNull(type);
         this.arguments = Objects.requireNonNull(arguments);
         this.initialize = initialize;
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        for (AExpression argument : arguments) {
+            argument.storeSettings(settings);
+        }
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ENewObj.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ENewObj.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -49,6 +50,13 @@ public final class ENewObj extends AExpression {
 
         this.type = Objects.requireNonNull(type);
         this.arguments = Objects.requireNonNull(arguments);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        for (AExpression argument : arguments) {
+            argument.storeSettings(settings);
+        }
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ENull.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ENull.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -35,6 +36,11 @@ public final class ENull extends AExpression {
 
     public ENull(Location location) {
         super(location);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        // do nothing
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ENumeric.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ENumeric.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -40,6 +41,11 @@ public final class ENumeric extends AExpression {
 
         this.value = Objects.requireNonNull(value);
         this.radix = radix;
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        // do nothing
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ERegex.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ERegex.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Constant;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -51,6 +52,11 @@ public final class ERegex extends AExpression {
         }
 
         this.flags = flags;
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        // do nothing
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EStatic.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EStatic.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -38,6 +39,11 @@ public final class EStatic extends AExpression {
         super(location);
 
         this.type = Objects.requireNonNull(type);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        // do nothing
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EString.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EString.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -36,6 +37,11 @@ public final class EString extends AExpression {
         super(location);
 
         this.constant = Objects.requireNonNull(string);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        // do nothing
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EUnary.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EUnary.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.AnalyzerCaster;
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.DefBootstrap;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -51,6 +52,11 @@ public final class EUnary extends AExpression {
 
         this.operation = Objects.requireNonNull(operation);
         this.child = Objects.requireNonNull(child);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        child.storeSettings(settings);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EVariable.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EVariable.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Locals.Variable;
@@ -42,6 +43,11 @@ public final class EVariable extends AStoreable {
         super(location);
 
         this.name = Objects.requireNonNull(name);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        // do nothing
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PBrace.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PBrace.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -44,6 +45,12 @@ public final class PBrace extends AStoreable {
         super(location, prefix);
 
         this.index = Objects.requireNonNull(index);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        prefix.storeSettings(settings);
+        index.storeSettings(settings);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PCallInvoke.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PCallInvoke.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -49,6 +50,15 @@ public final class PCallInvoke extends AExpression {
         this.name = Objects.requireNonNull(name);
         this.nullSafe = nullSafe;
         this.arguments = Objects.requireNonNull(arguments);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        prefix.storeSettings(settings);
+
+        for (AExpression argument : arguments) {
+            argument.storeSettings(settings);
+        }
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PField.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PField.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -50,6 +51,11 @@ public final class PField extends AStoreable {
 
         this.nullSafe = nullSafe;
         this.value = Objects.requireNonNull(value);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        prefix.storeSettings(settings);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubArrayLength.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubArrayLength.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -40,6 +41,11 @@ final class PSubArrayLength extends AStoreable {
 
         this.type = Objects.requireNonNull(type);
         this.value = Objects.requireNonNull(value);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        throw createError(new IllegalStateException("illegal tree structure"));
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubBrace.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubBrace.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -43,8 +44,13 @@ final class PSubBrace extends AStoreable {
     }
 
     @Override
+    void storeSettings(CompilerSettings settings) {
+        throw createError(new IllegalStateException("illegal tree structure"));
+    }
+
+    @Override
     void extractVariables(Set<String> variables) {
-        index.extractVariables(variables);
+        throw createError(new IllegalStateException("illegal tree structure"));
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubCallInvoke.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubCallInvoke.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -44,6 +45,11 @@ final class PSubCallInvoke extends AExpression {
         this.method = Objects.requireNonNull(method);
         this.box = box;
         this.arguments = Objects.requireNonNull(arguments);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        throw createError(new IllegalStateException("illegal tree structure"));
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubDefArray.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubDefArray.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.DefBootstrap;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -41,6 +42,11 @@ final class PSubDefArray extends AStoreable {
         super(location);
 
         this.index = Objects.requireNonNull(index);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        throw createError(new IllegalStateException("illegal tree structure"));
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubDefCall.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubDefCall.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.DefBootstrap;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -50,6 +51,11 @@ final class PSubDefCall extends AExpression {
 
         this.name = Objects.requireNonNull(name);
         this.arguments = Objects.requireNonNull(arguments);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        throw createError(new IllegalStateException("illegal tree structure"));
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubDefField.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubDefField.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.DefBootstrap;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -41,6 +42,11 @@ final class PSubDefField extends AStoreable {
         super(location);
 
         this.value = Objects.requireNonNull(value);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        throw createError(new IllegalStateException("illegal tree structure"));
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubField.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubField.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -42,6 +43,11 @@ final class PSubField extends AStoreable {
         super(location);
 
         this.field = Objects.requireNonNull(field);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        throw createError(new IllegalStateException("illegal tree structure"));
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubListShortcut.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubListShortcut.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -46,6 +47,11 @@ final class PSubListShortcut extends AStoreable {
 
         this.targetClass = Objects.requireNonNull(targetClass);
         this.index = Objects.requireNonNull(index);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        throw createError(new IllegalStateException("illegal tree structure"));
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubMapShortcut.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubMapShortcut.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -45,6 +46,11 @@ final class PSubMapShortcut extends AStoreable {
 
         this.targetClass = Objects.requireNonNull(targetClass);
         this.index = Objects.requireNonNull(index);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        throw createError(new IllegalStateException("illegal tree structure"));
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubNullSafeCallInvoke.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubNullSafeCallInvoke.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -44,8 +45,13 @@ public class PSubNullSafeCallInvoke extends AExpression {
     }
 
     @Override
+    void storeSettings(CompilerSettings settings) {
+        throw createError(new IllegalStateException("illegal tree structure"));
+    }
+
+    @Override
     void extractVariables(Set<String> variables) {
-        guarded.extractVariables(variables);
+        throw createError(new IllegalStateException("illegal tree structure"));
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubNullSafeField.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubNullSafeField.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -39,8 +40,13 @@ public class PSubNullSafeField extends AStoreable {
     }
 
     @Override
+    void storeSettings(CompilerSettings settings) {
+        throw createError(new IllegalStateException("illegal tree structure"));
+    }
+
+    @Override
     void extractVariables(Set<String> variables) {
-        guarded.extractVariables(variables);
+        throw createError(new IllegalStateException("illegal tree structure"));
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubShortcut.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubShortcut.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -44,6 +45,11 @@ final class PSubShortcut extends AStoreable {
         this.type = type;
         this.getter = getter;
         this.setter = setter;
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        throw createError(new IllegalStateException("illegal tree structure"));
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SBlock.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SBlock.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -41,6 +42,13 @@ public final class SBlock extends AStatement {
         super(location);
 
         this.statements = Collections.unmodifiableList(statements);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        for (AStatement statement : statements) {
+            statement.storeSettings(settings);
+        }
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SBreak.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SBreak.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -33,6 +34,11 @@ public final class SBreak extends AStatement {
 
     public SBreak(Location location) {
         super(location);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        // do nothing
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SCatch.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SCatch.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Locals.Variable;
@@ -51,6 +52,11 @@ public final class SCatch extends AStatement {
         this.type = Objects.requireNonNull(type);
         this.name = Objects.requireNonNull(name);
         this.block = block;
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        block.storeSettings(settings);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SContinue.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SContinue.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -33,6 +34,11 @@ public final class SContinue extends AStatement {
 
     public SContinue(Location location) {
         super(location);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        // do nothing
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SDeclBlock.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SDeclBlock.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -41,6 +42,13 @@ public final class SDeclBlock extends AStatement {
         super(location);
 
         this.declarations = Collections.unmodifiableList(declarations);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        for (SDeclaration declaration: declarations) {
+            declaration.storeSettings(settings);
+        }
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SDeclaration.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SDeclaration.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Locals.Variable;
@@ -46,6 +47,13 @@ public final class SDeclaration extends AStatement {
         this.type = Objects.requireNonNull(type);
         this.name = Objects.requireNonNull(name);
         this.expression = expression;
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        if (expression != null) {
+            expression.storeSettings(settings);
+        }
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SDo.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SDo.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -44,6 +45,15 @@ public final class SDo extends AStatement {
 
         this.condition = Objects.requireNonNull(condition);
         this.block = block;
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        condition.storeSettings(settings);
+
+        if (block != null) {
+            block.storeSettings(settings);
+        }
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SEach.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SEach.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Locals.Variable;
@@ -49,6 +50,15 @@ public class SEach extends AStatement {
         this.name = Objects.requireNonNull(name);
         this.expression = Objects.requireNonNull(expression);
         this.block = block;
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        expression.storeSettings(settings);
+
+        if (block != null) {
+            block.storeSettings(settings);
+        }
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SExpression.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SExpression.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -38,6 +39,11 @@ public final class SExpression extends AStatement {
         super(location);
 
         this.expression = Objects.requireNonNull(expression);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        expression.storeSettings(settings);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SFor.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SFor.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -50,6 +51,25 @@ public final class SFor extends AStatement {
         this.condition = condition;
         this.afterthought = afterthought;
         this.block = block;
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        if (initializer != null) {
+            initializer.storeSettings(settings);
+        }
+
+        if (condition != null) {
+            condition.storeSettings(settings);
+        }
+
+        if (afterthought != null) {
+            afterthought.storeSettings(settings);
+        }
+
+        if (block != null) {
+            block.storeSettings(settings);
+        }
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SIf.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SIf.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -42,6 +43,15 @@ public final class SIf extends AStatement {
 
         this.condition = Objects.requireNonNull(condition);
         this.ifblock = ifblock;
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        condition.storeSettings(settings);
+
+        if (ifblock != null) {
+            ifblock.storeSettings(settings);
+        }
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SIfElse.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SIfElse.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -47,6 +48,19 @@ public final class SIfElse extends AStatement {
         this.condition = Objects.requireNonNull(condition);
         this.ifblock = ifblock;
         this.elseblock = elseblock;
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        condition.storeSettings(settings);
+
+        if (ifblock != null) {
+            ifblock.storeSettings(settings);
+        }
+
+        if (elseblock != null) {
+            elseblock.storeSettings(settings);
+        }
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SReturn.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SReturn.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -41,8 +42,17 @@ public final class SReturn extends AStatement {
     }
 
     @Override
+    void storeSettings(CompilerSettings settings) {
+        if (expression != null) {
+            expression.storeSettings(settings);
+        }
+    }
+
+    @Override
     void extractVariables(Set<String> variables) {
-        expression.extractVariables(variables);
+        if (expression != null) {
+            expression.extractVariables(variables);
+        }
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSubEachArray.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSubEachArray.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.AnalyzerCaster;
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Locals.Variable;
@@ -52,6 +53,11 @@ final class SSubEachArray extends AStatement {
         this.variable = Objects.requireNonNull(variable);
         this.expression = Objects.requireNonNull(expression);
         this.block = block;
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        throw createError(new IllegalStateException("illegal tree structure"));
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSubEachIterable.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSubEachIterable.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.AnalyzerCaster;
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.DefBootstrap;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -61,6 +62,11 @@ final class SSubEachIterable extends AStatement {
         this.variable = Objects.requireNonNull(variable);
         this.expression = Objects.requireNonNull(expression);
         this.block = block;
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        throw createError(new IllegalStateException("illegal tree structure"));
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SThrow.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SThrow.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -38,6 +39,11 @@ public final class SThrow extends AStatement {
         super(location);
 
         this.expression = Objects.requireNonNull(expression);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        expression.storeSettings(settings);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/STry.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/STry.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -44,6 +45,17 @@ public final class STry extends AStatement {
 
         this.block = block;
         this.catches = Collections.unmodifiableList(catches);
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        if (block != null) {
+            block.storeSettings(settings);
+        }
+
+        for (SCatch ctch : catches) {
+            ctch.storeSettings(settings);
+        }
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SWhile.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SWhile.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -44,6 +45,15 @@ public final class SWhile extends AStatement {
 
         this.condition = Objects.requireNonNull(condition);
         this.block = block;
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        condition.storeSettings(settings);
+
+        if (block != null) {
+            block.storeSettings(settings);
+        }
     }
 
     @Override


### PR DESCRIPTION
This change adds a compiler pass to give each node the chance to store settings necessary for analysis and writing. This removes the need to pass this in a somewhat convoluted way through an additional class called Reserved, and also removes the need to have the Walker set values for settings on reserved.  This is next step in decoupling the Painless grammar from the Painless AST.

Note the length of this review is long because most nodes require a bit of boilerplate code that cannot be avoided in the current design.  Nodes to pay attention to are ```SSource```, ```SFunction```, ```ELambda```, and ```ENewArrayFunctionRef```.