### PR TITLE
Add null check for ChildAggregationBuilder.joinFieldResolveConfig ParentJoinFieldMapper Issue #42997

### DIFF
--- a/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ChildrenAggregationBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ChildrenAggregationBuilder.java
@@ -112,16 +112,23 @@ public class ChildrenAggregationBuilder
 
     private void joinFieldResolveConfig(SearchContext context, ValuesSourceConfig<WithOrdinals> config) {
         ParentJoinFieldMapper parentJoinFieldMapper = ParentJoinFieldMapper.getMapper(context.mapperService());
-        ParentIdFieldMapper parentIdFieldMapper = parentJoinFieldMapper.getParentIdFieldMapper(childType, false);
-        if (parentIdFieldMapper != null) {
-            parentFilter = parentIdFieldMapper.getParentFilter();
-            childFilter = parentIdFieldMapper.getChildFilter(childType);
-            MappedFieldType fieldType = parentIdFieldMapper.fieldType();
-            final SortedSetDVOrdinalsIndexFieldData fieldData = context.getForField(fieldType);
-            config.fieldContext(new FieldContext(fieldType.name(), fieldData, fieldType));
-        } else {
+        if (parentJoinFieldMapper ==  null) {
             config.unmapped(true);
+            return;
         }
+
+        ParentIdFieldMapper parentIdFieldMapper = parentJoinFieldMapper.getParentIdFieldMapper(childType, false);
+        if (parentIdFieldMapper == null){
+            config.unmapped(true);
+            return;
+        }
+
+
+        parentFilter = parentIdFieldMapper.getParentFilter();
+        childFilter = parentIdFieldMapper.getChildFilter(childType);
+        MappedFieldType fieldType = parentIdFieldMapper.fieldType();
+        final SortedSetDVOrdinalsIndexFieldData fieldData = context.getForField(fieldType);
+        config.fieldContext(new FieldContext(fieldType.name(), fieldData, fieldType));
     }
 
     @Override


### PR DESCRIPTION

I saw that this [PR](https://github.com/elastic/elasticsearch/pull/43360) was never finished, so I thought I'd try it. The code change is pretty straight forward, and I looked at the existing PR for reference, but I'm not sure if my unit test is correct. I made a WIP commit for it.