### PR TITLE
Add destrictive task encapsulating all destructive packaging tasks

### DIFF
--- a/qa/vagrant/build.gradle
+++ b/qa/vagrant/build.gradle
@@ -91,6 +91,9 @@ subprojects { Project platformProject ->
     tasks.register('packagingTest') {
       dependsOn 'distroTest', 'batsTest.oss', 'batsTest.default'
     }
+    tasks.register('destructivePackagingTest') {
+      dependsOn 'destructiveDistroTest', 'destructiveBatsTest.oss', 'destructiveBatsTest.default'
+    }
   }
 
   vagrant {


### PR DESCRIPTION
The tasks run within vagrant for packaging tests are destructive in
nature. Currently these are split between 3 different tasks. In order to
parallelize the packaging tests we will soon run each OS in its own
dedicated cloud VM. This commit adds a task, destructivePackagingTest,
that may be used by the associated CI job running the cloud VM.