### PR TITLE
[DOCS] Adds supported time units ref to the ML and DF API params

### DIFF
--- a/docs/reference/data-frames/apis/update-transform.asciidoc
+++ b/docs/reference/data-frames/apis/update-transform.asciidoc
@@ -78,11 +78,11 @@ IMPORTANT:  You must use {kib} or this API to update a {dataframe-transform}.
     (Optional, string) The unique identifier for a <<pipeline,pipeline>>.
 
 `frequency`::
-  (Optional, time units) The interval between checks for changes in the source
-  indices when the {dataframe-transform} is running continuously. Also determines
-  the retry interval in the event of transient failures while the {dataframe-transform} is
-  searching or indexing. The minimum value is `1s` and the maximum is `1h`. The
-  default value is `1m`.
+  (Optional, <<time-units, time units>>) The interval between checks for changes 
+  in the source indices when the {dataframe-transform} is running continuously. 
+  Also determines the retry interval in the event of transient failures while 
+  the {dataframe-transform} is searching or indexing. The minimum value is `1s` 
+  and the maximum is `1h`. The default value is `1m`.
 
 `source`::
   (Optional, object) The source configuration, which has the following
@@ -115,8 +115,8 @@ delays.
 
 --
     `delay`::::
-      (Optional, time units) The time delay between the current time and the
-      latest input data time. The default value is `60s`.
+      (Optional, <<time-units, time units>>) The time delay between the current 
+      time and the latest input data time. The default value is `60s`.
 
 [[update-data-frame-transform-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
@@ -83,8 +83,8 @@ when there are no matches or only partial matches.
   which has not responded to its initial close request.
 
 `timeout`::
-  (Optional, time units) Controls the time to wait until a job has closed.
-  The default value is 30 minutes.
+  (Optional, <<time-units, time units>>) Controls the time to wait until a job 
+  has closed. The default value is 30 minutes.
 
 [[ml-close-job-response-codes]]
 ==== {api-response-codes-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
@@ -58,10 +58,9 @@ For more information, see
   error. The default value is `true`.
 
 `timeout`::
-  (Optional, time units) Specifies the period of time to wait for the completion
-  of the delete operation. When this period of time elapses, the API fails and
-  returns an error. The default value is `30s`. For more information about time
-  units, see <<time-units>>.
+  (Optional, <<time-units, time units>>) Specifies the period of time to wait 
+  for the completion of the delete operation. When this period of time elapses, 
+  the API fails and returns an error. The default value is `30s`.
 
 [[ml-delete-forecast-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
@@ -43,16 +43,15 @@ forecast. For more information about this property, see <<ml-job-resource>>.
 ==== {api-request-body-title}
 
 `duration`::
-  (Optional, time units) A period of time that indicates how far into the future
-  to forecast. For example, `30d` corresponds to 30 days. The default value is 1
-  day. The forecast starts at the last record that was processed. For more
-  information about time units, see <<time-units>>.
+  (Optional, <<time-units, time units>>) A period of time that indicates how far 
+  into the future to forecast. For example, `30d` corresponds to 30 days. The 
+  default value is 1 day. The forecast starts at the last record that was 
+  processed.
 
 `expires_in`::
-  (Optional, time units) The period of time that forecast results are retained.
+  (Optional, <<time-units, time units>>) The period of time that forecast results are retained.
   After a forecast expires, the results are deleted. The default value is 14 days.
   If set to a value of `0`, the forecast is never automatically deleted.
-  For more information about time units, see <<time-units>>.
 
 [[ml-forecast-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
@@ -64,10 +64,10 @@ those same roles.
   the size of the window. See <<ml-datafeed-delayed-data-check-config>>.
 
 `frequency`::
-  (Optional, time units) The interval at which scheduled queries are made while
-  the {dfeed} runs in real time. The default value is either the bucket span for
-  short bucket spans, or, for longer bucket spans, a sensible fraction of the
-  bucket span. For example: `150s`.
+  (Optional, <<time-units, time units>>) The interval at which scheduled queries 
+  are made while the {dfeed} runs in real time. The default value is either the 
+  bucket span for short bucket spans, or, for longer bucket spans, a sensible 
+  fraction of the bucket span. For example: `150s`.
 
 `indices`::
   (Required, array) An array of index names. Wildcards are supported. For
@@ -85,9 +85,10 @@ those same roles.
   `{"match_all": {"boost": 1}}`.
 
 `query_delay`::
-  (Optional, time units) The number of seconds behind real time that data is
-  queried. For example, if data from 10:04 a.m. might not be searchable in {es}
-  until 10:06 a.m., set this property to 120 seconds. The default value is `60s`.
+  (Optional, <<time-units, time units>>) The number of seconds behind real time 
+  that data is queried. For example, if data from 10:04 a.m. might not be 
+  searchable in {es} until 10:06 a.m., set this property to 120 seconds. The 
+  default value is `60s`.
 
 `script_fields`::
   (Optional, object) Specifies scripts that evaluate custom expressions and

--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -48,8 +48,8 @@ a job directly to the `.ml-config` index using the {es} index API. If {es}
   <<ml-apilimits,analysis limits>>.
 
 `background_persist_interval`::
-  (Optional, time units) Advanced configuration option. The time between each
-  periodic persistence of the model. See <<ml-job-resource>>.
+  (Optional, <<time-units, time units>>) Advanced configuration option. The time 
+  between each periodic persistence of the model. See <<ml-job-resource>>.
 
 `custom_settings`::
   (Optional, object) Advanced configuration option. Contains custom meta data

--- a/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
@@ -56,10 +56,10 @@ The following properties can be updated after the {dfeed} is created:
   the size of the window. See <<ml-datafeed-delayed-data-check-config>>.  
 
 `frequency`::
-  (Optional, time units) The interval at which scheduled queries are made while
-  the {dfeed} runs in real time. The default value is either the bucket span for
-  short bucket spans, or, for longer bucket spans, a sensible fraction of the
-  bucket span. For example: `150s`.
+  (Optional, <<time-units, time units>>) The interval at which scheduled queries 
+  are made while the {dfeed} runs in real time. The default value is either the 
+  bucket span for short bucket spans, or, for longer bucket spans, a sensible 
+  fraction of the bucket span. For example: `150s`.
 
 `indices`::
   (Optional, array) An array of index names. Wildcards are supported. For
@@ -77,9 +77,10 @@ The following properties can be updated after the {dfeed} is created:
   `{"match_all": {"boost": 1}}`.
 
 `query_delay`::
-  (Optional, time units) The number of seconds behind real-time that data is
-  queried. For example, if data from 10:04 a.m. might not be searchable in {es}
-  until 10:06 a.m., set this property to 120 seconds. The default value is `60s`.
+  (Optional, <<time-units, time units>>) The number of seconds behind real-time 
+  that data is queried. For example, if data from 10:04 a.m. might not be 
+  searchable in {es} until 10:06 a.m., set this property to 120 seconds. The 
+  default value is `60s`.
 
 `script_fields`::
   (Optional, object) Specifies scripts that evaluate custom expressions and


### PR DESCRIPTION
This PR adds a link to the relevant params of the ML and DF APIs that points to the supported time units table.

Related issue: https://github.com/elastic/ml-team/issues/187#issuecomment-519122394