### PR TITLE
[ML-DataFrame] Adjust BWC tests following backport

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_data_frame_jobs_crud.yml
@@ -29,10 +29,7 @@
         transform_id: "mixed-simple-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-simple-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we cannot
-  # assert on state in the mixed cluster as it could be state at the top level or state.task_state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
+  - match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
 
   - do:
       data_frame.stop_data_frame_transform:
@@ -45,10 +42,7 @@
         transform_id: "mixed-simple-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-simple-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we cannot
-  # assert on state in the mixed cluster as it could be state at the top level or state.task_state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.state: "stopped" }
+  - match: { transforms.0.state: "stopped" }
 
   - do:
       data_frame.put_data_frame_transform:
@@ -95,10 +89,7 @@
         transform_id: "mixed-complex-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-complex-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we cannot
-  # assert on state in the mixed cluster as it could be state at the top level or state.task_state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
+  - match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
 
   - do:
       data_frame.stop_data_frame_transform:
@@ -111,10 +102,7 @@
         transform_id: "mixed-complex-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-complex-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we cannot
-  # assert on state in the mixed cluster as it could be state at the top level or state.task_state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.state: "stopped" }
+  - match: { transforms.0.state: "stopped" }
 
 ---
 "Test put continuous data frame transform on mixed cluster":
@@ -163,10 +151,7 @@
         transform_id: "mixed-simple-continuous-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-simple-continuous-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we cannot
-  # assert on state in the mixed cluster as it could be state at the top level or state.task_state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.state: "/started|indexing/" }
+  - match: { transforms.0.state: "/started|indexing/" }
 
   - do:
       data_frame.stop_data_frame_transform:
@@ -179,10 +164,7 @@
         transform_id: "mixed-simple-continuous-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-simple-continuous-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we cannot
-  # assert on state in the mixed cluster as it could be state at the top level or state.task_state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.state: "stopped" }
+  - match: { transforms.0.state: "stopped" }
 
 ---
 "Test GET, start, and stop old cluster batch transforms":
@@ -211,10 +193,7 @@
         transform_id: "old-simple-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we cannot
-  # assert on state in the mixed cluster as it could be state at the top level or state.task_state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
+  - match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
 
   - do:
       data_frame.stop_data_frame_transform:
@@ -226,10 +205,7 @@
         transform_id: "old-simple-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we cannot
-  # assert on state in the mixed cluster as it could be state at the top level or state.task_state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.state: "stopped" }
+  - match: { transforms.0.state: "stopped" }
 
   - do:
       data_frame.get_data_frame_transform:
@@ -253,10 +229,7 @@
         transform_id: "old-complex-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-complex-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we cannot
-  # assert on state in the mixed cluster as it could be state at the top level or state.task_state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
+  - match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
 
   - do:
       data_frame.stop_data_frame_transform:
@@ -268,10 +241,7 @@
         transform_id: "old-complex-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-complex-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we cannot
-  # assert on state in the mixed cluster as it could be state at the top level or state.task_state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.state: "stopped" }
+  - match: { transforms.0.state: "stopped" }
 
 ---
 "Test GET, stop, start, old continuous transforms":
@@ -300,10 +270,7 @@
         transform_id: "old-simple-continuous-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-continuous-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we cannot
-  # assert on state in the mixed cluster as it could be state at the top level or state.task_state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.state: "/started|indexing/" }
+  - match: { transforms.0.state: "/started|indexing/" }
 
   - do:
       data_frame.stop_data_frame_transform:
@@ -316,7 +283,4 @@
         transform_id: "old-simple-continuous-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-continuous-transform" }
-  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we cannot
-  # assert on state in the mixed cluster as it could be state at the top level or state.task_state
-  # TODO: uncomment this assertion in master
-  #- match: { transforms.0.state: "stopped" }
+  - match: { transforms.0.state: "stopped" }

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_data_frame_jobs_crud.yml
@@ -1,8 +1,5 @@
 ---
 "Test put batch data frame transforms on mixed cluster":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/45276
   - do:
       cluster.health:
         index: "dataframe-transform-airline-data"
@@ -121,9 +118,6 @@
 
 ---
 "Test put continuous data frame transform on mixed cluster":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/45276
   - do:
       cluster.health:
         index: "dataframe-transform-airline-data-cont"
@@ -192,9 +186,6 @@
 
 ---
 "Test GET, start, and stop old cluster batch transforms":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/45276
   - do:
       cluster.health:
         index: "dataframe-transform-airline-data"
@@ -284,9 +275,6 @@
 
 ---
 "Test GET, stop, start, old continuous transforms":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/45276
   - do:
       cluster.health:
         index: "dataframe-transform-airline-data-cont"

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/80_data_frame_jobs_crud.yml
@@ -1,8 +1,5 @@
 ---
 "Test put batch data frame transforms on old cluster":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/45276
   - do:
       indices.create:
         index: dataframe-transform-airline-data
@@ -139,9 +136,6 @@
 
 ---
 "Test put continuous data frame transform on old cluster":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/45276
   - do:
       indices.create:
         index: dataframe-transform-airline-data-cont

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_data_frame_jobs_crud.yml
@@ -7,9 +7,6 @@ setup:
         timeout: 70s
 ---
 "Get start, stop, and delete old and mixed cluster batch data frame transforms":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/45276
   # Simple and complex OLD transforms
   - do:
       data_frame.get_data_frame_transform:
@@ -165,9 +162,6 @@ setup:
 
 ---
 "Test GET, stop, delete, old and mixed continuous transforms":
-  - skip:
-      version: "7.4.0 - "
-      reason: waiting backport of https://github.com/elastic/elasticsearch/pull/45276
   - do:
       data_frame.get_data_frame_transform:
         transform_id: "old-simple-continuous-transform"


### PR DESCRIPTION
This change adjusts the changes of #45276 to account
for the backport to the 7.x branch in #45324.