### PR TITLE
Add filters in examples of vector functions

### DIFF
--- a/docs/reference/vectors/vector-functions.asciidoc
+++ b/docs/reference/vectors/vector-functions.asciidoc
@@ -29,6 +29,9 @@ PUT my_index
       },
       "my_sparse_vector" : {
         "type" : "sparse_vector"
+      },
+      "status" : {
+        "type" : "keyword"
       }
     }
   }
@@ -37,13 +40,15 @@ PUT my_index
 PUT my_index/_doc/1
 {
   "my_dense_vector": [0.5, 10, 6],
-  "my_sparse_vector": {"2": 1.5, "15" : 2, "50": -1.1, "4545": 1.1}
+  "my_sparse_vector": {"2": 1.5, "15" : 2, "50": -1.1, "4545": 1.1},
+  "status" : "published"
 }
 
 PUT my_index/_doc/2
 {
   "my_dense_vector": [-0.5, 10, 10],
-  "my_sparse_vector": {"2": 2.5, "10" : 1.3, "55": -2.3, "113": 1.6}
+  "my_sparse_vector": {"2": 2.5, "10" : 1.3, "55": -2.3, "113": 1.6},
+  "status" : "published"
 }
 
 --------------------------------------------------
@@ -59,13 +64,19 @@ GET my_index/_search
 {
   "query": {
     "script_score": {
-      "query": {
-        "match_all": {}
+      "query" : {
+        "bool" : {
+          "filter" : {
+            "term" : {
+              "status" : "published" <1>
+            }
+          }
+        }
       },
       "script": {
-        "source": "cosineSimilarity(params.query_vector, doc['my_dense_vector']) + 1.0", <1>
+        "source": "cosineSimilarity(params.query_vector, doc['my_dense_vector']) + 1.0", <2>
         "params": {
-          "query_vector": [4, 3.4, -0.2]  <2>
+          "query_vector": [4, 3.4, -0.2]  <3>
         }
       }
     }
@@ -73,8 +84,9 @@ GET my_index/_search
 }
 --------------------------------------------------
 // CONSOLE
-<1> The script adds 1.0 to the cosine similarity to prevent the score from being negative.
-<2> To take advantage of the script optimizations, provide a query vector as a script parameter.
+<1> To restrict the number of documents on which script score calculation is applied, provide a filter.
+<2> The script adds 1.0 to the cosine similarity to prevent the score from being negative.
+<3> To take advantage of the script optimizations, provide a query vector as a script parameter.
 
 NOTE: If a document's dense vector field has a number of dimensions
 different from the query's vector, an error will be thrown.
@@ -88,8 +100,14 @@ GET my_index/_search
 {
   "query": {
     "script_score": {
-      "query": {
-        "match_all": {}
+      "query" : {
+        "bool" : {
+          "filter" : {
+            "term" : {
+              "status" : "published"
+            }
+          }
+        }
       },
       "script": {
         "source": "cosineSimilaritySparse(params.query_vector, doc['my_sparse_vector']) + 1.0",
@@ -112,8 +130,14 @@ GET my_index/_search
 {
   "query": {
     "script_score": {
-      "query": {
-        "match_all": {}
+      "query" : {
+        "bool" : {
+          "filter" : {
+            "term" : {
+              "status" : "published"
+            }
+          }
+        }
       },
       "script": {
         "source": """
@@ -141,8 +165,14 @@ GET my_index/_search
 {
   "query": {
     "script_score": {
-      "query": {
-        "match_all": {}
+      "query" : {
+        "bool" : {
+          "filter" : {
+            "term" : {
+              "status" : "published"
+            }
+          }
+        }
       },
       "script": {
         "source": """
@@ -169,8 +199,14 @@ GET my_index/_search
 {
   "query": {
     "script_score": {
-      "query": {
-        "match_all": {}
+      "query" : {
+        "bool" : {
+          "filter" : {
+            "term" : {
+              "status" : "published"
+            }
+          }
+        }
       },
       "script": {
         "source": "1 / (1 + l1norm(params.queryVector, doc['my_dense_vector']))", <1>
@@ -202,8 +238,14 @@ GET my_index/_search
 {
   "query": {
     "script_score": {
-      "query": {
-        "match_all": {}
+      "query" : {
+        "bool" : {
+          "filter" : {
+            "term" : {
+              "status" : "published"
+            }
+          }
+        }
       },
       "script": {
         "source": "1 / (1 + l1normSparse(params.queryVector, doc['my_sparse_vector']))",
@@ -227,8 +269,14 @@ GET my_index/_search
 {
   "query": {
     "script_score": {
-      "query": {
-        "match_all": {}
+      "query" : {
+        "bool" : {
+          "filter" : {
+            "term" : {
+              "status" : "published"
+            }
+          }
+        }
       },
       "script": {
         "source": "1 / (1 + l2norm(params.queryVector, doc['my_dense_vector']))",
@@ -251,8 +299,14 @@ GET my_index/_search
 {
   "query": {
     "script_score": {
-      "query": {
-        "match_all": {}
+      "query" : {
+        "bool" : {
+          "filter" : {
+            "term" : {
+              "status" : "published"
+            }
+          }
+        }
       },
       "script": {
         "source": "1 / (1 + l2normSparse(params.queryVector, doc['my_sparse_vector']))",


### PR DESCRIPTION
As vector functions can be slow, it is recommended to limit
the number of docs on which vector functions are applied.
Here we add examples how to do that with filters.