### PR TITLE
[ML-DataFrame] fix starting a batch data frame after stopping at runtime 

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformState.java
@@ -151,15 +151,6 @@ public class DataFrameTransformState implements Task.Status, PersistentTaskState
         return progress;
     }
 
-    /**
-     * Get the in-progress checkpoint
-     *
-     * @return checkpoint in progress or 0 if task/indexer is not active
-     */
-    public long getInProgressCheckpoint() {
-        return indexerState.equals(IndexerState.INDEXING) ? checkpoint + 1L : 0;
-    }
-
     public String getReason() {
         return reason;
     }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
@@ -148,7 +148,7 @@ public class DataFrameTransformPersistentTasksExecutor extends PersistentTasksEx
 
                     if (nextCheckpoint.isEmpty()) {
                         // extra safety: reset position and progress if next checkpoint is empty
-                        // prevents if a failure if for some reason next checkpoint has been deleted
+                        // prevents a failure if for some reason the next checkpoint has been deleted
                         indexerBuilder.setInitialPosition(null);
                         indexerBuilder.setProgress(null);
                     } else {

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
@@ -207,7 +207,7 @@ public class DataFrameTransformPersistentTasksExecutor extends PersistentTasksEx
                 if (lastCheckpoint == 0) {
                     logger.trace("[{}] No last checkpoint found, looking for next checkpoint", transformId);
                     transformsConfigManager.getTransformCheckpoint(transformId, lastCheckpoint + 1, getTransformNextCheckpointListener);
-                                    } else {
+                } else {
                     logger.trace ("[{}] Restore last checkpoint: [{}]", transformId, lastCheckpoint);
                     transformsConfigManager.getTransformCheckpoint(transformId, lastCheckpoint, getTransformLastCheckpointListener);
                 }

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
@@ -152,7 +152,8 @@ public class DataFrameTransformPersistentTasksExecutor extends PersistentTasksEx
                         indexerBuilder.setInitialPosition(null);
                         indexerBuilder.setProgress(null);
                     } else {
-                        logger.trace("[{}] Loaded next checkpoint [{}] found, starting the task", transformId, nextCheckpoint.getCheckpoint());
+                        logger.trace("[{}] Loaded next checkpoint [{}] found, starting the task", transformId,
+                                nextCheckpoint.getCheckpoint());
                         indexerBuilder.setNextCheckpoint(nextCheckpoint);
                     }
 

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformPersistentTasksExecutor.java
@@ -147,8 +147,8 @@ public class DataFrameTransformPersistentTasksExecutor extends PersistentTasksEx
                 nextCheckpoint -> {
 
                     if (nextCheckpoint.isEmpty()) {
-                        // corner case which should not happen ;-)
-                        // reset the position to force a full re-run with checkpoint creation
+                        // extra safety: reset position and progress if next checkpoint is empty
+                        // prevents if a failure if for some reason next checkpoint has been deleted
                         indexerBuilder.setInitialPosition(null);
                         indexerBuilder.setProgress(null);
                     } else {


### PR DESCRIPTION
fix loading of next checkpoint after data frame transform has been stopped/started within one run

closes #45339 

The logic introduced in #44219 wrongly assumed no next checkpoint if no checkpoint has not been created yet. The fix properly loads the next checkpoint.