### PR TITLE
[DOCS] Reformats cat plugins API

### DIFF
--- a/docs/reference/cat/plugins.asciidoc
+++ b/docs/reference/cat/plugins.asciidoc
@@ -1,7 +1,35 @@
 [[cat-plugins]]
 === cat plugins
 
-The `plugins` command provides a view per node of running plugins. This information *spans nodes*.
+Returns a list of plugins running on each node of a cluster.
+
+
+[[cat-plugins-tasks-api-request]]
+==== {api-request-title}
+
+`GET /_cat/plugins`
+
+
+[[cat-plugins-tasks-api-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+
+
+[[cat-plugins-api-example]]
+==== {api-examples-title}
 
 [source,js]
 ------------------------------------------------------------------------------
@@ -9,7 +37,7 @@ GET /_cat/plugins?v&s=component&h=name,component,version,description
 ------------------------------------------------------------------------------
 // CONSOLE
 
-Might look like:
+The API returns the following response:
 
 ["source","txt",subs="attributes,callouts"]
 ------------------------------------------------------------------------------
@@ -32,5 +60,3 @@ U7321H6 store-smb               {version_qualified} The Store SMB plugin adds su
 U7321H6 transport-nio           {version_qualified} The nio transport.
 ------------------------------------------------------------------------------
 // TESTRESPONSE[s/([.()])/\\$1/ s/U7321H6/.+/ non_json]
-
-We can tell quickly how many plugins per node we have and which versions.


### PR DESCRIPTION
This PR updates the cat plugins API to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc).

Relates to elastic/docs#937 and #45196

### Preview
http://elasticsearch_45344.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/cat-plugins.html