### PR TITLE
Fix for build runtime classpath instability

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -135,6 +135,7 @@ dependencies {
   testCompile "junit:junit:${props.getProperty('junit')}"
   testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${props.getProperty('randomizedrunner')}"
   testCompile 'com.github.tomakehurst:wiremock-jre8-standalone:2.23.2'
+  reaper project('reaper')
   minimumRuntimeCompile "junit:junit:${props.getProperty('junit')}"
   minimumRuntimeCompile localGroovy()
   minimumRuntimeCompile gradleApi()

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -67,6 +67,7 @@ if (JavaVersion.current() < JavaVersion.VERSION_11) {
 }
 
 allprojects {
+  apply plugin: 'java'
   targetCompatibility = '11'
   sourceCompatibility = '11'
 }
@@ -83,6 +84,13 @@ configurations {
 compileMinimumRuntimeJava {
     targetCompatibility = 8
     sourceCompatibility = 8
+}
+
+normalization {
+    runtimeClasspath {
+        // Ignore the embedded JAR as we track this separately below as a runtime dependency
+        ignore 'META-INF/*.jar'
+    }
 }
 
 jar {
@@ -127,7 +135,6 @@ dependencies {
   testCompile "junit:junit:${props.getProperty('junit')}"
   testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${props.getProperty('randomizedrunner')}"
   testCompile 'com.github.tomakehurst:wiremock-jre8-standalone:2.23.2'
-  reaper project('reaper')
   minimumRuntimeCompile "junit:junit:${props.getProperty('junit')}"
   minimumRuntimeCompile localGroovy()
   minimumRuntimeCompile gradleApi()
@@ -142,6 +149,10 @@ if (project == rootProject) {
     if (System.getProperty("repos.mavenLocal") != null) {
       mavenLocal()
     }
+  }
+  dependencies {
+    // add this so the runtime classpath so Gradle will properly track it as a build runtime classpath input
+    runtimeOnly project('reaper')
   }
   // only run tests as build-tools
   test.enabled = false

--- a/buildSrc/reaper/build.gradle
+++ b/buildSrc/reaper/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'java'
-
 jar {
     manifest {
         attributes 'Main-Class': 'org.elasticsearch.gradle.reaper.Reaper'


### PR DESCRIPTION
The recent addition of the "reaper" project has broken the build cache for all our custom tasks. This PR changes the way we track the reaper JAR as an input such that we use runtime classpath normalization instead of treating it as a regular file.