### PR TITLE
Add dmesg dump on failure of vagrant ssh command

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/vagrant/VagrantShellTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/vagrant/VagrantShellTask.java
@@ -89,19 +89,32 @@ public abstract class VagrantShellTask extends DefaultTask {
                 spec.setProgressHandler(progressHandler);
             });
         } else {
-            service.execute(spec -> {
-                spec.setCommand("ssh");
+            try {
+                service.execute(spec -> {
+                    spec.setCommand("ssh");
 
-                List<String> script = new ArrayList<>();
-                script.add("sudo bash -c '"); // start inline bash script
-                script.add("pwd");
-                script.add("cd " + convertLinuxPath(getProject(), rootDir));
-                extension.getVmEnv().forEach((k, v) -> script.add("export " + k + "=" + v));
-                script.addAll(getLinuxScript());
-                script.add("'"); // end inline bash script
-                spec.setArgs("--command", String.join("\n", script));
-                spec.setProgressHandler(progressHandler);
-            });
+                    List<String> script = new ArrayList<>();
+                    script.add("sudo bash -c '"); // start inline bash script
+                    script.add("pwd");
+                    script.add("cd " + convertLinuxPath(getProject(), rootDir));
+                    extension.getVmEnv().forEach((k, v) -> script.add("export " + k + "=" + v));
+                    script.addAll(getLinuxScript());
+                    script.add("'"); // end inline bash script
+                    spec.setArgs("--command", String.join("\n", script));
+                    spec.setProgressHandler(progressHandler);
+                });
+            } catch (Exception e) {
+                getLogger().error("Failed command, dumping dmesg", e);
+                service.execute(spec -> {
+                    spec.setCommand("ssh");
+                    spec.setArgs("--command", "dmesg");
+                    spec.setProgressHandler(line -> {
+                        getLogger().error(line);
+                        return null;
+                    });
+                });
+                throw e;
+            }
         }
     }
 


### PR DESCRIPTION
This commit catches any failure of the ssh command we use to run tasks
within vagrant in order to dump the dmesg output, in order to determine
if something like the OOM killer is killing ssh inside the VM.