### PR TITLE
Adding USER id to avoid run as `root` in OpenShift

### DIFF
--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -89,6 +89,8 @@ LABEL org.label-schema.build-date="${build_date}" \
   org.opencontainers.image.vendor="Elastic" \
   org.opencontainers.image.version="${version}"
 
+USER 1000
+
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 # Dummy overridable parameter parsed by entrypoint
 CMD ["eswrapper"]


### PR DESCRIPTION
This change is needed because: "If the image does not specify a USER, it inherits the USER from the parent image" [1]

[1] [OpenShift Guidelines](https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html)