### PR TITLE
[DOCS] Reformats cat repositories API

### DIFF
--- a/docs/reference/cat/repositories.asciidoc
+++ b/docs/reference/cat/repositories.asciidoc
@@ -1,8 +1,35 @@
 [[cat-repositories]]
 === cat repositories
 
-The `repositories` command shows the snapshot repositories registered in the
-cluster. For example:
+Returns the <<snapshots-repositories,snapshot repositories>> for a cluster.
+
+
+[[cat-repositories-api-request]]
+==== {api-request-title}
+
+`GET /_cat/repositories`
+
+
+[[cat-repositories-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+
+
+[[cat-repositories-api-example]]
+==== {api-examples-title}
 
 [source,js]
 --------------------------------------------------
@@ -11,7 +38,7 @@ GET /_cat/repositories?v
 // CONSOLE
 // TEST[s/^/PUT \/_snapshot\/repo1\n{"type": "fs", "settings": {"location": "repo\/1"}}\n/]
 
-might looks like:
+The API returns the following response:
 
 [source,txt]
 --------------------------------------------------
@@ -20,5 +47,3 @@ repo1   fs
 repo2   s3
 --------------------------------------------------
 // TESTRESPONSE[s/\nrepo2   s3// non_json]
-
-We can quickly see which repositories are registered and their type.


### PR DESCRIPTION
This PR updates the cat repositories API to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc).

Relates to elastic/docs#937 and #45196

### Preview
http://elasticsearch_45382.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/cat-repositories.html