### PR TITLE
[7.x] [ML][Data Frame] have DataFrameTransformConfigUpdate#apply set Version (#45391)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformConfig.java
@@ -447,6 +447,11 @@ public class DataFrameTransformConfig extends AbstractDiffable<DataFrameTransfor
             return this;
         }
 
+        Builder setVersion(Version version) {
+            this.transformVersion = version;
+            return this;
+        }
+
         public DataFrameTransformConfig build() {
             return new DataFrameTransformConfig(id,
                 source,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformConfigUpdate.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.core.dataframe.transforms;
 
 import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -248,6 +249,7 @@ public class DataFrameTransformConfigUpdate implements Writeable, ToXContentObje
         if (headers != null) {
             builder.setHeaders(headers);
         }
+        builder.setVersion(Version.CURRENT);
         return builder.build();
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/transforms/DataFrameTransformConfigUpdateTests.java
@@ -87,7 +87,7 @@ public class DataFrameTransformConfigUpdateTests extends AbstractSerializingData
             PivotConfigTests.randomPivotConfig(),
             randomBoolean() ? null : randomAlphaOfLengthBetween(1, 1000),
             randomBoolean() ? null : Instant.now(),
-            randomBoolean() ? null : Version.CURRENT.toString());
+            randomBoolean() ? null : Version.V_7_2_0.toString());
         DataFrameTransformConfigUpdate update = new DataFrameTransformConfigUpdate(null, null, null, null, null);
 
         assertThat(config, equalTo(update.apply(config)));
@@ -108,6 +108,7 @@ public class DataFrameTransformConfigUpdateTests extends AbstractSerializingData
         assertThat(updatedConfig.getSyncConfig(), equalTo(syncConfig));
         assertThat(updatedConfig.getDescription(), equalTo(newDescription));
         assertThat(updatedConfig.getHeaders(), equalTo(headers));
+        assertThat(updatedConfig.getVersion(), equalTo(Version.CURRENT));
     }
 
     public void testApplyWithSyncChange() {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML][Data Frame] have DataFrameTransformConfigUpdate#apply set Version  (#45391)