### PR TITLE
[DOCS] Reformats cat templates API

### DIFF
--- a/docs/reference/cat/templates.asciidoc
+++ b/docs/reference/cat/templates.asciidoc
@@ -1,7 +1,45 @@
 [[cat-templates]]
 === cat templates
 
-The `templates` command provides information about existing templates.
+Returns information about <<indices-templates,index templates>> in a cluster.
+You can use index templates to apply <<index-modules-settings,index settings>>
+and <<mapping,field mappings>> to new indices at creation.
+
+
+[[cat-templates-api-request]]
+==== {api-request-title}
+
+`GET /_cat/templates/{template_name}`
+
+
+[[cat-templates-path-params]]
+==== {api-path-parms-title}
+
+`{template_name}`::
+(Optional, string) Comma-separated list of index template names used to limit
+the request. Accepts wildcard expressions.
+
+
+[[cat-templates-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+
+
+[[cat-templates-api-example]]
+==== {api-examples-title}
 
 [source,js]
 --------------------------------------------------
@@ -19,7 +57,7 @@ GET /_cat/templates?v&s=name
 //    templates.
 // 2. Create some templates to expect in the response.
 
-which looks like
+The API returns the following response:
 
 [source,txt]
 --------------------------------------------------
@@ -29,10 +67,3 @@ template1 [tea*]         1
 template2 [teak*]        2     7
 --------------------------------------------------
 // TESTRESPONSE[s/\*/\\*/ s/\[/\\[/ s/\]/\\]/ non_json]
-
-The output shows that there are three existing templates,
-with template2 having a version value.
-
-The endpoint also supports giving a template name or pattern in the url
-to filter the results, for example `/_cat/templates/template*` or
-`/_cat/templates/template0`.


### PR DESCRIPTION
This PR updates the cat templates API to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc).

Relates to elastic/docs#937 and #45196

### Preview
http://elasticsearch_45403.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/cat-templates.html