### PR TITLE
[DOCS] Reformat cat API titles

### DIFF
--- a/docs/reference/cat/alias.asciidoc
+++ b/docs/reference/cat/alias.asciidoc
@@ -1,5 +1,8 @@
 [[cat-alias]]
-=== cat aliases
+=== cat aliases API
+++++
+<titleabbrev>cat aliases</titleabbrev>
+++++
 
 Returns information about currently configured aliases to indices, including
 filter and routing information.

--- a/docs/reference/cat/allocation.asciidoc
+++ b/docs/reference/cat/allocation.asciidoc
@@ -1,5 +1,9 @@
 [[cat-allocation]]
-=== cat allocation
+=== cat allocation API
+++++
+<titleabbrev>cat allocation</titleabbrev>
+++++
+
 
 Provides a snapshot of the number of shards allocated to each data node
 and their disk space.

--- a/docs/reference/cat/count.asciidoc
+++ b/docs/reference/cat/count.asciidoc
@@ -1,5 +1,8 @@
 [[cat-count]]
-=== cat count
+=== cat count API
+++++
+<titleabbrev>cat count</titleabbrev>
+++++
 
 Provides quick access to a document count of individual indices or all indices
 in a cluster.

--- a/docs/reference/cat/fielddata.asciidoc
+++ b/docs/reference/cat/fielddata.asciidoc
@@ -1,5 +1,8 @@
 [[cat-fielddata]]
-=== cat fielddata
+=== cat fielddata API
+++++
+<titleabbrev>cat fielddata</titleabbrev>
+++++
 
 Returns the amount of heap memory currently used by fielddata on every data node
 in the cluster.

--- a/docs/reference/cat/health.asciidoc
+++ b/docs/reference/cat/health.asciidoc
@@ -1,5 +1,8 @@
 [[cat-health]]
-=== cat health
+=== cat health API
+++++
+<titleabbrev>cat health</titleabbrev>
+++++
 
 Returns the health status of a cluster, similar to the <<cluster-health,cluster
 health>> API.

--- a/docs/reference/cat/indices.asciidoc
+++ b/docs/reference/cat/indices.asciidoc
@@ -1,5 +1,8 @@
 [[cat-indices]]
-=== cat indices
+=== cat indices API
+++++
+<titleabbrev>cat indices</titleabbrev>
+++++
 
 Returns high-level information about indices in a cluster.
 

--- a/docs/reference/cat/master.asciidoc
+++ b/docs/reference/cat/master.asciidoc
@@ -1,5 +1,8 @@
 [[cat-master]]
-=== cat master
+=== cat master API
+++++
+<titleabbrev>cat master</titleabbrev>
+++++
 
 Returns information about the master node, including the ID, bound IP address,
 and name.

--- a/docs/reference/cat/nodeattrs.asciidoc
+++ b/docs/reference/cat/nodeattrs.asciidoc
@@ -1,5 +1,8 @@
 [[cat-nodeattrs]]
-=== cat nodeattrs
+=== cat nodeattrs API
+++++
+<titleabbrev>cat nodeattrs</titleabbrev>
+++++
 
 Returns information about custom node attributes.
 

--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -1,5 +1,8 @@
 [[cat-nodes]]
-=== cat nodes
+=== cat nodes API
+++++
+<titleabbrev>cat nodes</titleabbrev>
+++++
 
 Returns information about a cluster's nodes.
 

--- a/docs/reference/cat/pending_tasks.asciidoc
+++ b/docs/reference/cat/pending_tasks.asciidoc
@@ -1,5 +1,8 @@
 [[cat-pending-tasks]]
-=== cat pending tasks
+=== cat pending tasks API
+++++
+<titleabbrev>cat pending tasks</titleabbrev>
+++++
 
 Returns cluster-level changes that have not yet been executed, similar to the
 <<cluster-pending, pending cluster tasks>> API.

--- a/docs/reference/cat/plugins.asciidoc
+++ b/docs/reference/cat/plugins.asciidoc
@@ -1,5 +1,8 @@
 [[cat-plugins]]
-=== cat plugins
+=== cat plugins API
+++++
+<titleabbrev>cat plugins</titleabbrev>
+++++
 
 Returns a list of plugins running on each node of a cluster.
 

--- a/docs/reference/cat/recovery.asciidoc
+++ b/docs/reference/cat/recovery.asciidoc
@@ -1,5 +1,8 @@
 [[cat-recovery]]
-=== cat recovery
+=== cat recovery API
+++++
+<titleabbrev>cat recovery</titleabbrev>
+++++
 
 The `recovery` command is a view of index shard recoveries, both on-going and previously
 completed. It is a more compact view of the JSON <<indices-recovery,recovery>> API.

--- a/docs/reference/cat/repositories.asciidoc
+++ b/docs/reference/cat/repositories.asciidoc
@@ -1,5 +1,8 @@
 [[cat-repositories]]
-=== cat repositories
+=== cat repositories API
+++++
+<titleabbrev>cat repositories</titleabbrev>
+++++
 
 The `repositories` command shows the snapshot repositories registered in the
 cluster. For example:

--- a/docs/reference/cat/segments.asciidoc
+++ b/docs/reference/cat/segments.asciidoc
@@ -1,5 +1,8 @@
 [[cat-segments]]
-=== cat segments
+=== cat segments API
+++++
+<titleabbrev>cat segments</titleabbrev>
+++++
 
 The `segments` command provides low level information about the segments
 in the shards of an index. It provides information similar to the

--- a/docs/reference/cat/shards.asciidoc
+++ b/docs/reference/cat/shards.asciidoc
@@ -1,5 +1,8 @@
 [[cat-shards]]
-=== cat shards
+=== cat shards API
+++++
+<titleabbrev>cat shards</titleabbrev>
+++++
 
 The `shards` command is the detailed view of what nodes contain which
 shards.  It will tell you if it's a primary or replica, the number of

--- a/docs/reference/cat/snapshots.asciidoc
+++ b/docs/reference/cat/snapshots.asciidoc
@@ -1,5 +1,8 @@
 [[cat-snapshots]]
-=== cat snapshots
+=== cat snapshots API
+++++
+<titleabbrev>cat snapshots</titleabbrev>
+++++
 
 The `snapshots` command shows all snapshots that belong to a specific repository
 or multiple repositories.

--- a/docs/reference/cat/templates.asciidoc
+++ b/docs/reference/cat/templates.asciidoc
@@ -1,5 +1,8 @@
 [[cat-templates]]
-=== cat templates
+=== cat templates API
+++++
+<titleabbrev>cat templates</titleabbrev>
+++++
 
 The `templates` command provides information about existing templates.
 

--- a/docs/reference/cat/thread_pool.asciidoc
+++ b/docs/reference/cat/thread_pool.asciidoc
@@ -1,5 +1,8 @@
 [[cat-thread-pool]]
-=== cat thread pool
+=== cat thread pool API
+++++
+<titleabbrev>cat thread pool</titleabbrev>
+++++
 
 The `thread_pool` command shows cluster wide thread pool statistics per node. By default the active, queue and rejected
 statistics are returned for all thread pools.


### PR DESCRIPTION
This PR adds title abbreviations and updates the titles for cat APIs to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc).

Relates to elastic/docs#937 and #45196