### PR TITLE
Fix old name of script context in docs

### DIFF
--- a/docs/reference/scripting/security.asciidoc
+++ b/docs/reference/scripting/security.asciidoc
@@ -101,7 +101,7 @@ to be `none`.
 
 [source,yaml]
 ----
-script.allowed_contexts: search, update <1>
+script.allowed_contexts: score, update <1>
 ----
-<1> This will allow only search and update scripts to be executed but not
+<1> This will allow only scoring and update scripts to be executed but not
 aggs or plugin scripts (or any other contexts).


### PR DESCRIPTION
The docs contain an example how to limit the scripting contexts allowed,
but the example used an outdated name for the scoring context.

closes #44232
