### PR TITLE
Fix a bug where mappings are dropped from rollover requests.

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequest.java
@@ -82,7 +82,7 @@ public class RolloverRequest extends AcknowledgedRequest<RolloverRequest> implem
                     throw new IllegalArgumentException("The mapping definition cannot be nested under a type " +
                         "[" + MapperService.SINGLE_MAPPING_NAME + "] unless include_type_name is set to true.");
                 }
-                request.createIndexRequest.mapping(MapperService.SINGLE_MAPPING_NAME, parser.map());
+                request.createIndexRequest.mapping(MapperService.SINGLE_MAPPING_NAME, mappings);
             }
         }, CreateIndexRequest.MAPPINGS, ObjectParser.ValueType.OBJECT);
         PARSER.declareField((parser, request, context) -> request.createIndexRequest.aliases(parser.map()),

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequestTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.admin.indices.rollover;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequestTests;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
@@ -32,9 +33,11 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.RandomCreateIndexGenerator;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.XContentTestUtils;
@@ -112,6 +115,35 @@ public class RolloverRequestTests extends ESTestCase {
         assertThat(request.getCreateIndexRequest().mappings().size(), equalTo(1));
         assertThat(request.getCreateIndexRequest().aliases().size(), equalTo(1));
         assertThat(request.getCreateIndexRequest().settings().getAsInt("number_of_shards", 0), equalTo(10));
+    }
+
+    public void testTypelessMappingParsing() throws Exception {
+        final RolloverRequest request = new RolloverRequest(randomAlphaOfLength(10), randomAlphaOfLength(10));
+        final XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+                .startObject("mappings")
+                    .startObject("properties")
+                        .startObject("field1")
+                            .field("type", "keyword")
+                        .endObject()
+                    .endObject()
+                .endObject()
+            .endObject();
+
+        boolean includeTypeName = false;
+        request.fromXContent(includeTypeName, createParser(builder));
+
+        CreateIndexRequest createIndexRequest = request.getCreateIndexRequest();
+        String mapping = createIndexRequest.mappings().get(MapperService.SINGLE_MAPPING_NAME);
+        assertNotNull(mapping);
+
+        Map<String, Object> parsedMapping = XContentHelper.convertToMap(
+            new BytesArray(mapping), false, XContentType.JSON).v2();
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> properties = (Map<String, Object>) parsedMapping.get(MapperService.SINGLE_MAPPING_NAME);
+        assertNotNull(properties);
+        assertFalse(properties.isEmpty());
     }
 
     public void testSerialize() throws Exception {


### PR DESCRIPTION
We accidentally introduced this bug when adding a typeless version of the
rollover request. The bug is not present if `include_type_name` is set to true.

Addresses #45399.