### PR TITLE
add geo_shape support to geo_bounds agg

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregationBuilder.java
@@ -61,7 +61,7 @@ public abstract class GeoGridAggregationBuilder extends ValuesSourceAggregationB
 
     public static ObjectParser<GeoGridAggregationBuilder, Void> createParser(String name, PrecisionParser precisionParser) {
         ObjectParser<GeoGridAggregationBuilder, Void> parser = new ObjectParser<>(name);
-        ValuesSourceParserHelper.declareGeoFields(parser, false, false);
+        ValuesSourceParserHelper.declareGeoPointFields(parser, false, false);
         parser.declareField((p, builder, context) -> builder.precision(precisionParser.parse(p)), FIELD_PRECISION,
             org.elasticsearch.common.xcontent.ObjectParser.ValueType.INT);
         parser.declareInt(GeoGridAggregationBuilder::size, FIELD_SIZE);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java
@@ -60,7 +60,7 @@ public class GeoDistanceAggregationBuilder extends ValuesSourceAggregationBuilde
     private static final ObjectParser<GeoDistanceAggregationBuilder, Void> PARSER;
     static {
         PARSER = new ObjectParser<>(GeoDistanceAggregationBuilder.NAME);
-        ValuesSourceParserHelper.declareGeoFields(PARSER, true, false);
+        ValuesSourceParserHelper.declareGeoPointFields(PARSER, true, false);
 
         PARSER.declareBoolean(GeoDistanceAggregationBuilder::keyed, RangeAggregator.KEYED_FIELD);
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregationBuilder.java
@@ -39,7 +39,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 
-public class GeoBoundsAggregationBuilder extends ValuesSourceAggregationBuilder<ValuesSource.GeoPoint, GeoBoundsAggregationBuilder> {
+public class GeoBoundsAggregationBuilder extends ValuesSourceAggregationBuilder<ValuesSource.Geo, GeoBoundsAggregationBuilder> {
     public static final String NAME = "geo_bounds";
 
     private static final ObjectParser<GeoBoundsAggregationBuilder, Void> PARSER;
@@ -56,7 +56,7 @@ public class GeoBoundsAggregationBuilder extends ValuesSourceAggregationBuilder<
     private boolean wrapLongitude = true;
 
     public GeoBoundsAggregationBuilder(String name) {
-        super(name, ValuesSourceType.GEOPOINT, ValueType.GEOPOINT);
+        super(name, ValuesSourceType.GEO, ValueType.GEO);
     }
 
     protected GeoBoundsAggregationBuilder(GeoBoundsAggregationBuilder clone, Builder factoriesBuilder, Map<String, Object> metaData) {
@@ -73,7 +73,7 @@ public class GeoBoundsAggregationBuilder extends ValuesSourceAggregationBuilder<
      * Read from a stream.
      */
     public GeoBoundsAggregationBuilder(StreamInput in) throws IOException {
-        super(in, ValuesSourceType.GEOPOINT, ValueType.GEOPOINT);
+        super(in, ValuesSourceType.GEO, ValueType.GEO);
         wrapLongitude = in.readBoolean();
     }
 
@@ -98,7 +98,7 @@ public class GeoBoundsAggregationBuilder extends ValuesSourceAggregationBuilder<
     }
 
     @Override
-    protected GeoBoundsAggregatorFactory innerBuild(SearchContext context, ValuesSourceConfig<ValuesSource.GeoPoint> config,
+    protected GeoBoundsAggregatorFactory innerBuild(SearchContext context, ValuesSourceConfig<ValuesSource.Geo> config,
             AggregatorFactory parent, Builder subFactoriesBuilder) throws IOException {
         return new GeoBoundsAggregatorFactory(name, config, wrapLongitude, context, parent, subFactoriesBuilder, metaData);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregatorFactory.java
@@ -32,11 +32,11 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-class GeoBoundsAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.GeoPoint> {
+class GeoBoundsAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.Geo> {
 
     private final boolean wrapLongitude;
 
-    GeoBoundsAggregatorFactory(String name, ValuesSourceConfig<ValuesSource.GeoPoint> config, boolean wrapLongitude,
+    GeoBoundsAggregatorFactory(String name, ValuesSourceConfig<ValuesSource.Geo> config, boolean wrapLongitude,
             SearchContext context, AggregatorFactory parent, AggregatorFactories.Builder subFactoriesBuilder,
             Map<String, Object> metaData) throws IOException {
         super(name, config, context, parent, subFactoriesBuilder, metaData);
@@ -50,7 +50,7 @@ class GeoBoundsAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSou
     }
 
     @Override
-    protected Aggregator doCreateInternal(ValuesSource.GeoPoint valuesSource, Aggregator parent, boolean collectsFromSingleBucket,
+    protected Aggregator doCreateInternal(ValuesSource.Geo valuesSource, Aggregator parent, boolean collectsFromSingleBucket,
             List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
         return new GeoBoundsAggregator(name, context, parent, valuesSource, wrapLongitude, pipelineAggregators, metaData);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregationBuilder.java
@@ -45,7 +45,7 @@ public class GeoCentroidAggregationBuilder
     private static final ObjectParser<GeoCentroidAggregationBuilder, Void> PARSER;
     static {
         PARSER = new ObjectParser<>(GeoCentroidAggregationBuilder.NAME);
-        ValuesSourceParserHelper.declareGeoFields(PARSER, true, false);
+        ValuesSourceParserHelper.declareGeoPointFields(PARSER, true, false);
     }
 
     public static AggregationBuilder parse(String aggregationName, XContentParser parser) throws IOException {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParserHelper.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceParserHelper.java
@@ -51,10 +51,16 @@ public final class ValuesSourceParserHelper {
         declareFields(objectParser, scriptable, formattable, false, ValueType.STRING);
     }
 
-    public static <T> void declareGeoFields(
+    public static <T> void declareGeoPointFields(
             AbstractObjectParser<? extends ValuesSourceAggregationBuilder<ValuesSource.GeoPoint, ?>, T> objectParser,
             boolean scriptable, boolean formattable) {
         declareFields(objectParser, scriptable, formattable, false, ValueType.GEOPOINT);
+    }
+
+    public static <T> void declareGeoFields(
+        AbstractObjectParser<? extends ValuesSourceAggregationBuilder<ValuesSource.Geo, ?>, T> objectParser,
+        boolean scriptable, boolean formattable) {
+        declareFields(objectParser, scriptable, formattable, false, ValueType.GEO);
     }
 
     private static <VS extends ValuesSource, T> void declareFields(

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregatorTests.java
@@ -26,18 +26,37 @@ import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.store.Directory;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.geo.GeometryParser;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.geometry.MultiPoint;
+import org.elasticsearch.geometry.MultiPolygon;
+import org.elasticsearch.geometry.Point;
+import org.elasticsearch.geometry.Polygon;
+import org.elasticsearch.index.mapper.BinaryGeoShapeDocValuesField;
 import org.elasticsearch.index.mapper.GeoPointFieldMapper;
+import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
+import org.elasticsearch.index.mapper.GeoShapeIndexer;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
 import org.elasticsearch.test.geo.RandomGeoGenerator;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.elasticsearch.search.aggregations.metrics.InternalGeoBoundsTests.GEOHASH_TOLERANCE;
 import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
 
 public class GeoBoundsAggregatorTests extends AggregatorTestCase {
-    public void testEmpty() throws Exception {
+
+    public void testEmptyGeoPoint() throws Exception {
         try (Directory dir = newDirectory();
              RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
             GeoBoundsAggregationBuilder aggBuilder = new GeoBoundsAggregationBuilder("my_agg")
@@ -61,7 +80,31 @@ public class GeoBoundsAggregatorTests extends AggregatorTestCase {
         }
     }
 
-    public void testRandom() throws Exception {
+    public void testEmptyGeoShape() throws Exception {
+        try (Directory dir = newDirectory();
+             RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
+            GeoBoundsAggregationBuilder aggBuilder = new GeoBoundsAggregationBuilder("my_agg")
+                .field("field")
+                .wrapLongitude(false);
+
+            MappedFieldType fieldType = new GeoShapeFieldMapper.GeoShapeFieldType();
+            fieldType.setHasDocValues(true);
+            fieldType.setName("field");
+            try (IndexReader reader = w.getReader()) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+                InternalGeoBounds bounds = search(searcher, new MatchAllDocsQuery(), aggBuilder, fieldType);
+                assertTrue(Double.isInfinite(bounds.top));
+                assertTrue(Double.isInfinite(bounds.bottom));
+                assertTrue(Double.isInfinite(bounds.posLeft));
+                assertTrue(Double.isInfinite(bounds.posRight));
+                assertTrue(Double.isInfinite(bounds.negLeft));
+                assertTrue(Double.isInfinite(bounds.negRight));
+                assertFalse(AggregationInspectionHelper.hasValue(bounds));
+            }
+        }
+    }
+
+    public void testRandomPoints() throws Exception {
         double top = Double.NEGATIVE_INFINITY;
         double bottom = Double.POSITIVE_INFINITY;
         double posLeft = Double.POSITIVE_INFINITY;
@@ -115,6 +158,214 @@ public class GeoBoundsAggregatorTests extends AggregatorTestCase {
                 assertThat(bounds.negRight, closeTo(negRight, GEOHASH_TOLERANCE));
                 assertThat(bounds.negLeft, closeTo(negLeft, GEOHASH_TOLERANCE));
                 assertTrue(AggregationInspectionHelper.hasValue(bounds));
+            }
+        }
+    }
+
+    public void testRandomShapes() throws Exception {
+        double top = Double.NEGATIVE_INFINITY;
+        double bottom = Double.POSITIVE_INFINITY;
+        double posLeft = Double.POSITIVE_INFINITY;
+        double posRight = Double.NEGATIVE_INFINITY;
+        double negLeft = Double.POSITIVE_INFINITY;
+        double negRight = Double.NEGATIVE_INFINITY;
+        int numDocs = randomIntBetween(50, 100);
+        try (Directory dir = newDirectory();
+             RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
+            for (int i = 0; i < numDocs; i++) {
+                Document doc = new Document();
+                int numValues = randomIntBetween(1, 5);
+                List<Point> points = new ArrayList<>();
+                for (int j = 0; j < numValues; j++) {
+                    GeoPoint point = RandomGeoGenerator.randomPoint(random());
+                    points.add(new Point(point.getLon(), point.getLat()));
+                    if (point.getLat() > top) {
+                        top = point.getLat();
+                    }
+                    if (point.getLat() < bottom) {
+                        bottom = point.getLat();
+                    }
+                    if (point.getLon() >= 0 && point.getLon() < posLeft) {
+                        posLeft = point.getLon();
+                    }
+                    if (point.getLon() >= 0 && point.getLon() > posRight) {
+                        posRight = point.getLon();
+                    }
+                    if (point.getLon() < 0 && point.getLon() < negLeft) {
+                        negLeft = point.getLon();
+                    }
+                    if (point.getLon() < 0 && point.getLon() > negRight) {
+                        negRight = point.getLon();
+                    }
+                }
+                doc.add(new BinaryGeoShapeDocValuesField("field", new MultiPoint(points)));
+                w.addDocument(doc);
+            }
+            GeoBoundsAggregationBuilder aggBuilder = new GeoBoundsAggregationBuilder("my_agg")
+                .field("field")
+                .wrapLongitude(false);
+
+            MappedFieldType fieldType = new GeoShapeFieldMapper.GeoShapeFieldType();
+            fieldType.setHasDocValues(true);
+            fieldType.setName("field");
+            try (IndexReader reader = w.getReader()) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+                InternalGeoBounds bounds = search(searcher, new MatchAllDocsQuery(), aggBuilder, fieldType);
+                assertThat(bounds.top, closeTo(top, GEOHASH_TOLERANCE));
+                assertThat(bounds.bottom, closeTo(bottom, GEOHASH_TOLERANCE));
+                assertThat(bounds.posLeft, closeTo(posLeft, GEOHASH_TOLERANCE));
+                assertThat(bounds.posRight, closeTo(posRight, GEOHASH_TOLERANCE));
+                assertThat(bounds.negRight, closeTo(negRight, GEOHASH_TOLERANCE));
+                assertThat(bounds.negLeft, closeTo(negLeft, GEOHASH_TOLERANCE));
+                assertTrue(AggregationInspectionHelper.hasValue(bounds));
+            }
+        }
+    }
+
+    public void testFiji() throws Exception {
+        XContentParser fijiParser = XContentHelper.createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+            new BytesArray("{\n" +
+            "  \"type\": \"MultiPolygon\",\n" +
+            "  \"coordinates\": [\n" +
+            "   [\n" +
+            "    [\n" +
+            "     [\n" +
+            "      178.3736,\n" +
+            "      -17.33992\n" +
+            "     ],\n" +
+            "     [\n" +
+            "      178.71806,\n" +
+            "      -17.62846\n" +
+            "     ],\n" +
+            "     [\n" +
+            "      178.55271,\n" +
+            "      -18.15059\n" +
+            "     ],\n" +
+            "     [\n" +
+            "      177.93266,\n" +
+            "      -18.28799\n" +
+            "     ],\n" +
+            "     [\n" +
+            "      177.38146,\n" +
+            "      -18.16432\n" +
+            "     ],\n" +
+            "     [\n" +
+            "      177.28504,\n" +
+            "      -17.72465\n" +
+            "     ],\n" +
+            "     [\n" +
+            "      177.67087,\n" +
+            "      -17.38114\n" +
+            "     ],\n" +
+            "     [\n" +
+            "      178.12557,\n" +
+            "      -17.50481\n" +
+            "     ],\n" +
+            "     [\n" +
+            "      178.3736,\n" +
+            "      -17.33992\n" +
+            "     ]\n" +
+            "    ]\n" +
+            "   ],\n" +
+            "   [\n" +
+            "    [\n" +
+            "     [\n" +
+            "      179.364143,\n" +
+            "      -16.801354\n" +
+            "     ],\n" +
+            "     [\n" +
+            "      178.725059,\n" +
+            "      -17.012042\n" +
+            "     ],\n" +
+            "     [\n" +
+            "      178.596839,\n" +
+            "      -16.63915\n" +
+            "     ],\n" +
+            "     [\n" +
+            "      179.096609,\n" +
+            "      -16.433984\n" +
+            "     ],\n" +
+            "     [\n" +
+            "      179.413509,\n" +
+            "      -16.379054\n" +
+            "     ],\n" +
+            "     [\n" +
+            "      180,\n" +
+            "      -16.067133\n" +
+            "     ],\n" +
+            "     [\n" +
+            "      180,\n" +
+            "      -16.555217\n" +
+            "     ],\n" +
+            "     [\n" +
+            "      179.364143,\n" +
+            "      -16.801354\n" +
+            "     ]\n" +
+            "    ]\n" +
+            "   ],\n" +
+            "   [\n" +
+            "    [\n" +
+            "     [\n" +
+            "      -179.917369,\n" +
+            "      -16.501783\n" +
+            "     ],\n" +
+            "     [\n" +
+            "      -180,\n" +
+            "      -16.555217\n" +
+            "     ],\n" +
+            "     [\n" +
+            "      -180,\n" +
+            "      -16.067133\n" +
+            "     ],\n" +
+            "     [\n" +
+            "      -179.79332,\n" +
+            "      -16.020882\n" +
+            "     ],\n" +
+            "     [\n" +
+            "      -179.917369,\n" +
+            "      -16.501783\n" +
+            "     ]\n" +
+            "    ]\n" +
+            "   ]\n" +
+            "  ]\n" +
+            " }"), XContentType.JSON);
+
+        fijiParser.nextToken();
+        MultiPolygon fiji = (MultiPolygon) new GeometryParser(true, true, true).parse(fijiParser);
+        MultiPolygon geometryForIndexing = (MultiPolygon) new GeoShapeIndexer(true, "indexer").prepareForIndexing(fiji);
+
+        try (Directory dir = newDirectory();
+             RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
+            Document doc = new Document();
+            doc.add(new BinaryGeoShapeDocValuesField("fiji_shape", geometryForIndexing));
+            for (Polygon poly : fiji) {
+                for (int i = 0; i < poly.getPolygon().length(); i++) {
+                    doc.add(new LatLonDocValuesField("fiji_points", poly.getPolygon().getLat(i), poly.getPolygon().getLon(i)));
+                }
+            }
+
+            w.addDocument(doc);
+
+            boolean wrapLongitude = randomBoolean();
+            GeoBoundsAggregationBuilder pointsAggBuilder = new GeoBoundsAggregationBuilder("my_agg")
+                .field("fiji_points").wrapLongitude(wrapLongitude);
+            MappedFieldType pointsType = new GeoPointFieldMapper.GeoPointFieldType();
+            pointsType.setHasDocValues(true);
+            pointsType.setName("fiji_points");
+
+            GeoBoundsAggregationBuilder shapesAggBuilder = new GeoBoundsAggregationBuilder("my_agg")
+                .field("fiji_shape").wrapLongitude(wrapLongitude);
+            MappedFieldType shapeType = new GeoShapeFieldMapper.GeoShapeFieldType();
+            shapeType.setHasDocValues(true);
+            shapeType.setName("fiji_shape");
+
+            try (IndexReader reader = w.getReader()) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+                InternalGeoBounds pointBounds = search(searcher, new MatchAllDocsQuery(), pointsAggBuilder, pointsType);
+                InternalGeoBounds shapeBounds = search(searcher, new MatchAllDocsQuery(), shapesAggBuilder, shapeType);
+                assertTrue(AggregationInspectionHelper.hasValue(pointBounds));
+                assertTrue(AggregationInspectionHelper.hasValue(shapeBounds));
+                assertThat(shapeBounds, equalTo(pointBounds));
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidIT.java
@@ -48,7 +48,7 @@ public class GeoCentroidIT extends AbstractGeoTestCase {
     public void testEmptyAggregation() throws Exception {
         SearchResponse response = client().prepareSearch(EMPTY_IDX_NAME)
                 .setQuery(matchAllQuery())
-                .addAggregation(geoCentroid(aggName).field(SINGLE_VALUED_FIELD_NAME))
+                .addAggregation(geoCentroid(aggName).field(SINGLE_VALUED_GEOPOINT_FIELD_NAME))
                 .get();
         assertSearchResponse(response);
 
@@ -63,7 +63,7 @@ public class GeoCentroidIT extends AbstractGeoTestCase {
 
     public void testUnmapped() throws Exception {
         SearchResponse response = client().prepareSearch(UNMAPPED_IDX_NAME)
-                .addAggregation(geoCentroid(aggName).field(SINGLE_VALUED_FIELD_NAME))
+                .addAggregation(geoCentroid(aggName).field(SINGLE_VALUED_GEOPOINT_FIELD_NAME))
                 .get();
         assertSearchResponse(response);
 
@@ -77,7 +77,7 @@ public class GeoCentroidIT extends AbstractGeoTestCase {
 
     public void testPartiallyUnmapped() throws Exception {
         SearchResponse response = client().prepareSearch(IDX_NAME, UNMAPPED_IDX_NAME)
-                .addAggregation(geoCentroid(aggName).field(SINGLE_VALUED_FIELD_NAME))
+                .addAggregation(geoCentroid(aggName).field(SINGLE_VALUED_GEOPOINT_FIELD_NAME))
                 .get();
         assertSearchResponse(response);
 
@@ -93,7 +93,7 @@ public class GeoCentroidIT extends AbstractGeoTestCase {
     public void testSingleValuedField() throws Exception {
         SearchResponse response = client().prepareSearch(IDX_NAME)
                 .setQuery(matchAllQuery())
-                .addAggregation(geoCentroid(aggName).field(SINGLE_VALUED_FIELD_NAME))
+                .addAggregation(geoCentroid(aggName).field(SINGLE_VALUED_GEOPOINT_FIELD_NAME))
                 .get();
         assertSearchResponse(response);
 
@@ -109,7 +109,7 @@ public class GeoCentroidIT extends AbstractGeoTestCase {
     public void testSingleValueFieldGetProperty() throws Exception {
         SearchResponse response = client().prepareSearch(IDX_NAME)
                 .setQuery(matchAllQuery())
-                .addAggregation(global("global").subAggregation(geoCentroid(aggName).field(SINGLE_VALUED_FIELD_NAME)))
+                .addAggregation(global("global").subAggregation(geoCentroid(aggName).field(SINGLE_VALUED_GEOPOINT_FIELD_NAME)))
                 .get();
         assertSearchResponse(response);
 
@@ -154,8 +154,8 @@ public class GeoCentroidIT extends AbstractGeoTestCase {
 
     public void testSingleValueFieldAsSubAggToGeohashGrid() throws Exception {
         SearchResponse response = client().prepareSearch(HIGH_CARD_IDX_NAME)
-                .addAggregation(geohashGrid("geoGrid").field(SINGLE_VALUED_FIELD_NAME)
-                .subAggregation(geoCentroid(aggName).field(SINGLE_VALUED_FIELD_NAME)))
+                .addAggregation(geohashGrid("geoGrid").field(SINGLE_VALUED_GEOPOINT_FIELD_NAME)
+                .subAggregation(geoCentroid(aggName).field(SINGLE_VALUED_GEOPOINT_FIELD_NAME)))
                 .get();
         assertSearchResponse(response);
 


### PR DESCRIPTION
this commit leverages the new geo_shape doc values and
geo values-source-types to add geo_shape support to the geo_bounds aggregation.