### PR TITLE
Upgrade to build scan plugin 2.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ import org.gradle.plugins.ide.eclipse.model.SourceFolder
 import static org.elasticsearch.gradle.tool.Boilerplate.maybeConfigure
 
 plugins {
-    id 'com.gradle.build-scan' version '2.3'
+    id 'com.gradle.build-scan' version '2.4'
     id 'base'
     id 'elasticsearch.global-build-info'
 }


### PR DESCRIPTION
Upgrade to latest build scan plugin version. This version now [captures more information with regards to resolved dependency metadata](https://docs.gradle.com/build-scan-plugin/#plugin_release_history). We've already upgraded our Gradle Enterprise instance to 2019.3 which supports this plugin version.