### PR TITLE
Use snake casing for document field

### DIFF
--- a/docs/reference/search.asciidoc
+++ b/docs/reference/search.asciidoc
@@ -19,7 +19,7 @@ the user name:
 POST /twitter/_doc?routing=kimchy
 {
     "user" : "kimchy",
-    "postDate" : "2009-11-15T14:12:12",
+    "post_date" : "2009-11-15T14:12:12",
     "message" : "trying out Elasticsearch"
 }
 --------------------------------------------------


### PR DESCRIPTION
This commit updates the search example to use snake casing for the document field. This is consistent with other examples
