### PR TITLE
Revert "Mute all GC Disruption Simulating Tests (#45032)"

### DIFF
--- a/server/src/test/java/org/elasticsearch/discovery/MasterDisruptionIT.java
+++ b/server/src/test/java/org/elasticsearch/discovery/MasterDisruptionIT.java
@@ -55,7 +55,6 @@ public class MasterDisruptionIT extends AbstractDisruptionTestCase {
     /**
      * Test that cluster recovers from a long GC on master that causes other nodes to elect a new one
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/43387")
     public void testMasterNodeGCs() throws Exception {
         List<String> nodes = startCluster(3);
 

--- a/server/src/test/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
+++ b/server/src/test/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
@@ -173,7 +173,6 @@ public class StableMasterDisruptionIT extends ESIntegTestCase {
      * Tests that emulates a frozen elected master node that unfreezes and pushes its cluster state to other nodes that already are
      * following another elected master node. These nodes should reject this cluster state and prevent them from following the stale master.
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/43387")
     public void testStaleMasterNotHijackingMajority() throws Exception {
         final List<String> nodes = internalCluster().startNodes(3, Settings.builder()
             .put(LeaderChecker.LEADER_CHECK_TIMEOUT_SETTING.getKey(), "1s")

--- a/test/framework/src/test/java/org/elasticsearch/test/disruption/LongGCDisruptionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/disruption/LongGCDisruptionTests.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.test.disruption;
 
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.test.ESTestCase;
 
@@ -37,7 +36,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/43387")
 public class LongGCDisruptionTests extends ESTestCase {
 
     static class LockedExecutor {


### PR DESCRIPTION
This reverts commit 10d37dbafb1bb65bae630b5bef2f45ee14b611e3 (#45032) as it turned out these tests are not responsible for #43387
