### PR TITLE
Add HLRC support for enrich get policy API.

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/EnrichClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/EnrichClient.java
@@ -20,6 +20,8 @@ package org.elasticsearch.client;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.core.AcknowledgedResponse;
+import org.elasticsearch.client.enrich.GetPolicyRequest;
+import org.elasticsearch.client.enrich.GetPolicyResponse;
 import org.elasticsearch.client.enrich.PutPolicyRequest;
 
 import java.io.IOException;
@@ -79,6 +81,50 @@ public final class EnrichClient {
             EnrichRequestConverters::putPolicy,
             options,
             AcknowledgedResponse::fromXContent,
+            listener,
+            Collections.emptySet()
+        );
+    }
+
+    /**
+     * Executes the get policy api, which retrieves an enrich policy.
+     *
+     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-processor.html#get-policy-api">
+     * the docs</a> for more.
+     *
+     * @param request the {@link PutPolicyRequest}
+     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @return the response
+     * @throws IOException in case there is a problem sending the request or parsing back the response
+     */
+    public GetPolicyResponse getPolicy(GetPolicyRequest request, RequestOptions options) throws IOException {
+        return restHighLevelClient.performRequestAndParseEntity(
+            request,
+            EnrichRequestConverters::getPolicy,
+            options,
+            GetPolicyResponse::new,
+            Collections.emptySet()
+        );
+    }
+
+    /**
+     * Asynchronously executes the get policy api, which retrieves an enrich policy.
+     *
+     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-processor.html#get-policy-api">
+     * the docs</a> for more.
+     *
+     * @param request the {@link PutPolicyRequest}
+     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @param listener the listener to be notified upon request completion
+     */
+    public void getPolicyAsync(GetPolicyRequest request,
+                               RequestOptions options,
+                               ActionListener<GetPolicyResponse> listener) {
+        restHighLevelClient.performRequestAsyncAndParseEntity(
+            request,
+            EnrichRequestConverters::getPolicy,
+            options,
+            GetPolicyResponse::new,
             listener,
             Collections.emptySet()
         );

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/EnrichRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/EnrichRequestConverters.java
@@ -18,7 +18,9 @@
  */
 package org.elasticsearch.client;
 
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPut;
+import org.elasticsearch.client.enrich.GetPolicyRequest;
 import org.elasticsearch.client.enrich.PutPolicyRequest;
 
 import java.io.IOException;
@@ -36,6 +38,14 @@ final class EnrichRequestConverters {
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
         request.setEntity(createEntity(putPolicyRequest, REQUEST_BODY_CONTENT_TYPE));
         return request;
+    }
+
+    static Request getPolicy(GetPolicyRequest getPolicyRequest) throws IOException {
+        String endpoint = new RequestConverters.EndpointBuilder()
+            .addPathPartAsIs("_enrich", "policy")
+            .addPathPart(getPolicyRequest.getName())
+            .build();
+        return new Request(HttpGet.METHOD_NAME, endpoint);
     }
 
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/enrich/EnrichPolicy.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/enrich/EnrichPolicy.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.client.enrich;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.List;
+
+public final class EnrichPolicy {
+
+    static final ParseField TYPE_FIELD = new ParseField("type");
+    static final ParseField QUERY_FIELD = new ParseField("query");
+    static final ParseField INDICES_FIELD = new ParseField("indices");
+    static final ParseField ENRICH_KEY_FIELD = new ParseField("enrich_key");
+    static final ParseField ENRICH_VALUES_FIELD = new ParseField("enrich_values");
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<EnrichPolicy, Void> PARSER = new ConstructingObjectParser<>("policy",
+        args -> new EnrichPolicy(
+            (String) args[0],
+            (BytesReference) args[1],
+            (List<String>) args[2],
+            (String) args[3],
+            (List<String>) args[4]
+        )
+    );
+
+    static {
+        declareParserOptions(PARSER);
+    }
+
+    private static void declareParserOptions(ConstructingObjectParser<?, ?> parser) {
+        parser.declareString(ConstructingObjectParser.constructorArg(), TYPE_FIELD);
+        parser.declareObject(ConstructingObjectParser.optionalConstructorArg(), (p, c) -> {
+            XContentBuilder builder = XContentBuilder.builder(p.contentType().xContent());
+            builder.copyCurrentStructure(p);
+            return BytesArray.bytes(builder);
+        }, QUERY_FIELD);
+        parser.declareStringArray(ConstructingObjectParser.constructorArg(), INDICES_FIELD);
+        parser.declareString(ConstructingObjectParser.constructorArg(), ENRICH_KEY_FIELD);
+        parser.declareStringArray(ConstructingObjectParser.constructorArg(), ENRICH_VALUES_FIELD);
+    }
+
+    public static EnrichPolicy fromXContent(XContentParser parser) throws IOException {
+        return PARSER.parse(parser, null);
+    }
+
+    private final String type;
+    private final BytesReference query;
+    private final List<String> indices;
+    private final String enrichKey;
+    private final List<String> enrichValues;
+
+    EnrichPolicy(String type, BytesReference query, List<String> indices, String enrichKey, List<String> enrichValues) {
+        this.type = type;
+        this.query = query;
+        this.indices = indices;
+        this.enrichKey = enrichKey;
+        this.enrichValues = enrichValues;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public BytesReference getQuery() {
+        return query;
+    }
+
+    public List<String> getIndices() {
+        return indices;
+    }
+
+    public String getEnrichKey() {
+        return enrichKey;
+    }
+
+    public List<String> getEnrichValues() {
+        return enrichValues;
+    }
+}

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/enrich/GetPolicyRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/enrich/GetPolicyRequest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.client.enrich;
+
+import org.elasticsearch.client.Validatable;
+import org.elasticsearch.common.Strings;
+
+public final class GetPolicyRequest implements Validatable {
+
+    private final String name;
+
+    public GetPolicyRequest(String name) {
+        if (Strings.hasLength(name) == false) {
+            throw new IllegalArgumentException("name must be a non-null and non-empty string");
+        }
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/enrich/GetPolicyResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/enrich/GetPolicyResponse.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.client.enrich;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+
+public final class GetPolicyResponse {
+
+    private final EnrichPolicy policy;
+
+    public GetPolicyResponse(XContentParser parser) throws IOException {
+        this(EnrichPolicy.fromXContent(parser));
+    }
+
+    GetPolicyResponse(EnrichPolicy policy) {
+        this.policy = policy;
+    }
+
+    public EnrichPolicy getPolicy() {
+        return policy;
+    }
+}

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/enrich/PutPolicyRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/enrich/PutPolicyRequest.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.client.enrich;
 
 import org.elasticsearch.client.Validatable;
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -34,13 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-public class PutPolicyRequest implements Validatable, ToXContentObject {
-
-    static final ParseField TYPE_FIELD = new ParseField("type");
-    static final ParseField QUERY_FIELD = new ParseField("query");
-    static final ParseField INDICES_FIELD = new ParseField("indices");
-    static final ParseField ENRICH_KEY_FIELD = new ParseField("enrich_key");
-    static final ParseField ENRICH_VALUES_FIELD = new ParseField("enrich_values");
+public final class PutPolicyRequest implements Validatable, ToXContentObject {
 
     private final String name;
     private final String type;
@@ -108,13 +101,13 @@ public class PutPolicyRequest implements Validatable, ToXContentObject {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(TYPE_FIELD.getPreferredName(), type);
-        builder.field(INDICES_FIELD.getPreferredName(), indices);
+        builder.field(EnrichPolicy.TYPE_FIELD.getPreferredName(), type);
+        builder.field(EnrichPolicy.INDICES_FIELD.getPreferredName(), indices);
         if (query != null) {
-            builder.field(QUERY_FIELD.getPreferredName(), asMap(query, builder.contentType()));
+            builder.field(EnrichPolicy.QUERY_FIELD.getPreferredName(), asMap(query, builder.contentType()));
         }
-        builder.field(ENRICH_KEY_FIELD.getPreferredName(), enrichKey);
-        builder.field(ENRICH_VALUES_FIELD.getPreferredName(), enrichValues);
+        builder.field(EnrichPolicy.ENRICH_KEY_FIELD.getPreferredName(), enrichKey);
+        builder.field(EnrichPolicy.ENRICH_VALUES_FIELD.getPreferredName(), enrichValues);
         builder.endObject();
         return builder;
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/AbstractResponseTestCase.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/AbstractResponseTestCase.java
@@ -42,9 +42,8 @@ import java.io.IOException;
 public abstract class AbstractResponseTestCase<S extends ToXContent, C> extends ESTestCase {
 
     public final void testFromXContent() throws IOException {
-        final S serverTestInstance = createServerTestInstance();
-
         final XContentType xContentType = randomFrom(XContentType.values());
+        final S serverTestInstance = createServerTestInstance(xContentType);
         final BytesReference bytes = toShuffledXContent(serverTestInstance, xContentType, getParams(), randomBoolean());
 
         final XContent xContent = XContentFactory.xContent(xContentType);
@@ -56,7 +55,7 @@ public abstract class AbstractResponseTestCase<S extends ToXContent, C> extends 
         assertInstances(serverTestInstance, clientInstance);
     }
 
-    protected abstract S createServerTestInstance();
+    protected abstract S createServerTestInstance(XContentType xContentType) throws IOException;
 
     protected abstract C doParseToClientInstance(XContentParser parser) throws IOException;
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/EnrichIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/EnrichIT.java
@@ -18,18 +18,16 @@
  */
 package org.elasticsearch.client;
 
-import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.core.AcknowledgedResponse;
+import org.elasticsearch.client.enrich.GetPolicyRequest;
+import org.elasticsearch.client.enrich.GetPolicyResponse;
 import org.elasticsearch.client.enrich.PutPolicyRequest;
-import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
 
-import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class EnrichIT extends ESRestHighLevelClientTestCase {
 
@@ -40,19 +38,13 @@ public class EnrichIT extends ESRestHighLevelClientTestCase {
         AcknowledgedResponse putPolicyResponse = execute(putPolicyRequest, enrichClient::putPolicy, enrichClient::putPolicyAsync);
         assertThat(putPolicyResponse.isAcknowledged(), is(true));
 
-        // TODO: Replace with get policy hlrc code:
-        Request getPolicyRequest = new Request("get", "/_enrich/policy/my-policy");
-        Response getPolicyResponse = highLevelClient().getLowLevelClient().performRequest(getPolicyRequest);
-        assertThat(getPolicyResponse.getHttpResponse().getStatusLine().getStatusCode(), equalTo(200));
-        Map<String, Object> responseBody = toMap(getPolicyResponse);
-        assertThat(responseBody.get("type"), equalTo(putPolicyRequest.getType()));
-        assertThat(responseBody.get("indices"), equalTo(putPolicyRequest.getIndices()));
-        assertThat(responseBody.get("enrich_key"), equalTo(putPolicyRequest.getEnrichKey()));
-        assertThat(responseBody.get("enrich_values"), equalTo(putPolicyRequest.getEnrichValues()));
-    }
-
-    private static Map<String, Object> toMap(Response response) throws IOException {
-        return XContentHelper.convertToMap(JsonXContent.jsonXContent, EntityUtils.toString(response.getEntity()), false);
+        GetPolicyRequest getPolicyRequest = new GetPolicyRequest("my-policy");
+        GetPolicyResponse getPolicyResponse = execute(getPolicyRequest, enrichClient::getPolicy, enrichClient::getPolicyAsync);
+        assertThat(getPolicyResponse.getPolicy(), notNullValue());
+        assertThat(getPolicyResponse.getPolicy().getType(), equalTo(putPolicyRequest.getType()));
+        assertThat(getPolicyResponse.getPolicy().getIndices(), equalTo(putPolicyRequest.getIndices()));
+        assertThat(getPolicyResponse.getPolicy().getEnrichKey(), equalTo(putPolicyRequest.getEnrichKey()));
+        assertThat(getPolicyResponse.getPolicy().getEnrichValues(), equalTo(putPolicyRequest.getEnrichValues()));
     }
 
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/EnrichRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/EnrichRequestConvertersTests.java
@@ -18,12 +18,15 @@
  */
 package org.elasticsearch.client;
 
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPut;
+import org.elasticsearch.client.enrich.GetPolicyRequest;
 import org.elasticsearch.client.enrich.PutPolicyRequest;
 import org.elasticsearch.client.enrich.PutPolicyRequestTests;
 import org.elasticsearch.test.ESTestCase;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 
 public class EnrichRequestConvertersTests extends ESTestCase {
 
@@ -34,6 +37,16 @@ public class EnrichRequestConvertersTests extends ESTestCase {
         assertThat(result.getMethod(), equalTo(HttpPut.METHOD_NAME));
         assertThat(result.getEndpoint(), equalTo("/_enrich/policy/" + request.getName()));
         RequestConvertersTests.assertToXContentBody(request, result.getEntity());
+    }
+
+    public void testGetPolicy() throws Exception {
+        GetPolicyRequest request = new GetPolicyRequest(randomAlphaOfLength(4));
+        Request result = EnrichRequestConverters.getPolicy(request);
+
+        assertThat(result.getMethod(), equalTo(HttpGet.METHOD_NAME));
+        assertThat(result.getEndpoint(), equalTo("/_enrich/policy/" + request.getName()));
+        assertThat(result.getParameters().size(), equalTo(0));
+        assertThat(result.getEntity(), nullValue());
     }
 
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/XPackInfoResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/XPackInfoResponseTests.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.client;
 
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.protocol.xpack.XPackInfoResponse;
 import org.elasticsearch.protocol.xpack.XPackInfoResponse.BuildInfo;
 import org.elasticsearch.protocol.xpack.XPackInfoResponse.FeatureSetsInfo;
@@ -85,7 +86,7 @@ public class XPackInfoResponseTests extends AbstractResponseTestCase<XPackInfoRe
     }
 
     @Override
-    protected XPackInfoResponse createServerTestInstance() {
+    protected XPackInfoResponse createServerTestInstance(XContentType xContentType) {
         return new XPackInfoResponse(
             randomBoolean() ? null : randomBuildInfo(),
             randomBoolean() ? null : randomLicenseInfo(),

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ccr/CcrStatsResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ccr/CcrStatsResponseTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.client.ccr.IndicesFollowStats.ShardFollowStats;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ccr.ShardFollowNodeTaskStatus;
 import org.elasticsearch.xpack.core.ccr.action.CcrStatsAction;
 import org.elasticsearch.xpack.core.ccr.action.FollowStatsAction;
@@ -44,7 +45,7 @@ import static org.hamcrest.Matchers.instanceOf;
 public class CcrStatsResponseTests extends AbstractResponseTestCase<CcrStatsAction.Response, CcrStatsResponse> {
 
     @Override
-    protected CcrStatsAction.Response createServerTestInstance() {
+    protected CcrStatsAction.Response createServerTestInstance(XContentType xContentType) {
         org.elasticsearch.xpack.core.ccr.AutoFollowStats autoFollowStats = new org.elasticsearch.xpack.core.ccr.AutoFollowStats(
             randomNonNegativeLong(),
             randomNonNegativeLong(),

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ccr/FollowInfoResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ccr/FollowInfoResponseTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ccr.action.FollowInfoAction;
 import org.elasticsearch.xpack.core.ccr.action.FollowParameters;
 
@@ -37,7 +38,7 @@ import static org.hamcrest.Matchers.nullValue;
 public class FollowInfoResponseTests extends AbstractResponseTestCase<FollowInfoAction.Response, FollowInfoResponse> {
 
     @Override
-    protected FollowInfoAction.Response createServerTestInstance() {
+    protected FollowInfoAction.Response createServerTestInstance(XContentType xContentType) {
         int numInfos = randomIntBetween(0, 32);
         List<FollowInfoAction.Response.FollowerInfo> infos = new ArrayList<>(numInfos);
         for (int i = 0; i < numInfos; i++) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ccr/FollowStatsResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ccr/FollowStatsResponseTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.client.ccr.IndicesFollowStats.ShardFollowStats;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ccr.ShardFollowNodeTaskStatus;
 import org.elasticsearch.xpack.core.ccr.action.FollowStatsAction;
 
@@ -41,7 +42,7 @@ import static org.hamcrest.Matchers.instanceOf;
 public class FollowStatsResponseTests extends AbstractResponseTestCase<FollowStatsAction.StatsResponses, FollowStatsResponse> {
 
     @Override
-    protected FollowStatsAction.StatsResponses createServerTestInstance() {
+    protected FollowStatsAction.StatsResponses createServerTestInstance(XContentType xContentType) {
         return createStatsResponse();
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ccr/GetAutoFollowPatternResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ccr/GetAutoFollowPatternResponseTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ccr.AutoFollowMetadata;
 import org.elasticsearch.xpack.core.ccr.action.GetAutoFollowPatternAction;
 
@@ -41,7 +42,7 @@ public class GetAutoFollowPatternResponseTests extends AbstractResponseTestCase<
     GetAutoFollowPatternResponse> {
 
     @Override
-    protected GetAutoFollowPatternAction.Response createServerTestInstance() {
+    protected GetAutoFollowPatternAction.Response createServerTestInstance(XContentType xContentType) {
         int numPatterns = randomIntBetween(0, 16);
         NavigableMap<String, AutoFollowMetadata.AutoFollowPattern> patterns = new TreeMap<>();
         for (int i = 0; i < numPatterns; i++) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ccr/PutFollowResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ccr/PutFollowResponseTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.client.ccr;
 
 import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ccr.action.PutFollowAction;
 
 import java.io.IOException;
@@ -30,7 +31,7 @@ import static org.hamcrest.Matchers.is;
 public class PutFollowResponseTests extends AbstractResponseTestCase<PutFollowAction.Response, PutFollowResponse> {
 
     @Override
-    protected PutFollowAction.Response createServerTestInstance() {
+    protected PutFollowAction.Response createServerTestInstance(XContentType xContentType) {
         return new PutFollowAction.Response(randomBoolean(), randomBoolean(), randomBoolean());
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/core/AcknowledgedResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/core/AcknowledgedResponseTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.client.core;
 import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 
@@ -30,7 +31,7 @@ public class AcknowledgedResponseTests extends AbstractResponseTestCase<org.elas
     AcknowledgedResponse> {
 
     @Override
-    protected org.elasticsearch.action.support.master.AcknowledgedResponse createServerTestInstance() {
+    protected org.elasticsearch.action.support.master.AcknowledgedResponse createServerTestInstance(XContentType xContentType) {
         return new org.elasticsearch.action.support.master.AcknowledgedResponse(randomBoolean());
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/core/BroadcastResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/core/BroadcastResponseTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.client.core;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.seqno.RetentionLeaseNotFoundException;
 
 import java.io.IOException;
@@ -43,7 +44,7 @@ public class BroadcastResponseTests extends AbstractResponseTestCase<org.elastic
     private Set<Integer> shardIds;
 
     @Override
-    protected org.elasticsearch.action.support.broadcast.BroadcastResponse createServerTestInstance() {
+    protected org.elasticsearch.action.support.broadcast.BroadcastResponse createServerTestInstance(XContentType xContentType) {
         index = randomAlphaOfLength(8);
         id = randomAlphaOfLength(8);
         final int total = randomIntBetween(1, 16);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/core/MainResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/core/MainResponseTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.VersionUtils;
 
 import java.io.IOException;
@@ -33,7 +34,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class MainResponseTests extends AbstractResponseTestCase<org.elasticsearch.action.main.MainResponse, MainResponse> {
     @Override
-    protected org.elasticsearch.action.main.MainResponse createServerTestInstance() {
+    protected org.elasticsearch.action.main.MainResponse createServerTestInstance(XContentType xContentType) {
         String clusterUuid = randomAlphaOfLength(10);
         ClusterName clusterName = new ClusterName(randomAlphaOfLength(10));
         String nodeName = randomAlphaOfLength(10);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameIndexerPositionTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameIndexerPositionTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.client.dataframe.transforms.hlrc;
 
 import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameIndexerPosition;
 
 import java.util.LinkedHashMap;
@@ -45,7 +46,7 @@ public class DataFrameIndexerPositionTests extends AbstractResponseTestCase<
     }
 
     @Override
-    protected DataFrameIndexerPosition createServerTestInstance() {
+    protected DataFrameIndexerPosition createServerTestInstance(XContentType xContentType) {
         return randomDataFrameIndexerPosition();
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformProgressTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/DataFrameTransformProgressTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.client.dataframe.transforms.hlrc;
 
 import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformProgress;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -43,7 +44,7 @@ public class DataFrameTransformProgressTests extends AbstractResponseTestCase<
     }
 
     @Override
-    protected DataFrameTransformProgress createServerTestInstance() {
+    protected DataFrameTransformProgress createServerTestInstance(XContentType xContentType) {
         return randomDataFrameTransformProgress();
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/TimeSyncConfigTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/hlrc/TimeSyncConfigTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.client.dataframe.transforms.TimeSyncConfig;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 
@@ -41,7 +42,7 @@ public class TimeSyncConfigTests
     }
 
     @Override
-    protected org.elasticsearch.xpack.core.dataframe.transforms.TimeSyncConfig createServerTestInstance() {
+    protected org.elasticsearch.xpack.core.dataframe.transforms.TimeSyncConfig createServerTestInstance(XContentType xContentType) {
         return randomTimeSyncConfig();
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/pivot/hlrc/DateHistogramGroupSourceTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/dataframe/transforms/pivot/hlrc/DateHistogramGroupSourceTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.client.dataframe.transforms.pivot.hlrc;
 
 import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.xpack.core.dataframe.transforms.pivot.DateHistogramGroupSource;
 
@@ -48,7 +49,7 @@ public class DateHistogramGroupSourceTests extends AbstractResponseTestCase<
     }
 
     @Override
-    protected DateHistogramGroupSource createServerTestInstance() {
+    protected DateHistogramGroupSource createServerTestInstance(XContentType xContentType) {
         return randomDateHistogramGroupSource();
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/enrich/GetPolicyResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/enrich/GetPolicyResponseTests.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.client.enrich;
+
+import org.elasticsearch.client.AbstractResponseTestCase;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
+import org.elasticsearch.xpack.core.enrich.action.GetEnrichPolicyAction;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+public class GetPolicyResponseTests extends AbstractResponseTestCase<GetEnrichPolicyAction.Response, GetPolicyResponse> {
+
+    @Override
+    protected GetEnrichPolicyAction.Response createServerTestInstance(XContentType xContentType) throws IOException {
+        return new GetEnrichPolicyAction.Response(createRandomEnrichPolicy(xContentType));
+    }
+
+    @Override
+    protected GetPolicyResponse doParseToClientInstance(XContentParser parser) throws IOException {
+        return new GetPolicyResponse(parser);
+    }
+
+    @Override
+    protected void assertInstances(GetEnrichPolicyAction.Response serverTestInstance, GetPolicyResponse clientInstance) {
+        assertThat(clientInstance.getPolicy().getType(), equalTo(serverTestInstance.getPolicy().getType()));
+        assertThat(clientInstance.getPolicy().getIndices(), equalTo(serverTestInstance.getPolicy().getIndices()));
+        if (clientInstance.getPolicy().getQuery() !=  null) {
+            assertThat(clientInstance.getPolicy().getQuery(), equalTo(serverTestInstance.getPolicy().getQuery().getQuery()));
+        } else {
+            assertThat(serverTestInstance.getPolicy().getQuery(), nullValue());
+        }
+        assertThat(clientInstance.getPolicy().getEnrichKey(), equalTo(serverTestInstance.getPolicy().getEnrichKey()));
+        assertThat(clientInstance.getPolicy().getEnrichValues(), equalTo(serverTestInstance.getPolicy().getEnrichValues()));
+    }
+
+    private static EnrichPolicy createRandomEnrichPolicy(XContentType xContentType) throws IOException {
+        XContentBuilder builder = XContentBuilder.builder(xContentType.xContent());
+        builder.startObject();
+        builder.endObject();
+        BytesReference querySource = BytesArray.bytes(builder);
+
+        return new EnrichPolicy(
+            randomAlphaOfLength(4),
+            randomBoolean() ? new EnrichPolicy.QuerySource(querySource, xContentType) : null,
+            Arrays.asList(generateRandomStringArray(8, 4, false, false)),
+            randomAlphaOfLength(4),
+            Arrays.asList(generateRandomStringArray(8, 4, false, false))
+        );
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/AnalyzeResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/AnalyzeResponseTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.client.indices;
 import org.elasticsearch.action.admin.indices.analyze.AnalyzeAction;
 import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.RandomObjects;
 
 import java.io.IOException;
@@ -30,7 +31,7 @@ import java.util.Arrays;
 public class AnalyzeResponseTests extends AbstractResponseTestCase<AnalyzeAction.Response, AnalyzeResponse> {
 
     @Override
-    protected AnalyzeAction.Response createServerTestInstance() {
+    protected AnalyzeAction.Response createServerTestInstance(XContentType xContentType) {
         int tokenCount = randomIntBetween(1, 30);
         AnalyzeAction.AnalyzeToken[] tokens = new AnalyzeAction.AnalyzeToken[tokenCount];
         for (int i = 0; i < tokenCount; i++) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/CloseIndexResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/CloseIndexResponseTests.java
@@ -51,7 +51,7 @@ public class CloseIndexResponseTests extends
     AbstractResponseTestCase<org.elasticsearch.action.admin.indices.close.CloseIndexResponse, CloseIndexResponse> {
 
     @Override
-    protected org.elasticsearch.action.admin.indices.close.CloseIndexResponse createServerTestInstance() {
+    protected org.elasticsearch.action.admin.indices.close.CloseIndexResponse createServerTestInstance(XContentType xContentType) {
         boolean acknowledged = true;
         final String[] indicesNames = generateRandomStringArray(10, 10, false, true);
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/ReloadAnalyzersResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/ReloadAnalyzersResponseTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.client.indices;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.seqno.RetentionLeaseNotFoundException;
 import org.elasticsearch.xpack.core.action.ReloadAnalyzersResponse.ReloadDetails;
 
@@ -48,7 +49,7 @@ public class ReloadAnalyzersResponseTests
     private Set<Integer> shardIds;
 
     @Override
-    protected org.elasticsearch.xpack.core.action.ReloadAnalyzersResponse createServerTestInstance() {
+    protected org.elasticsearch.xpack.core.action.ReloadAnalyzersResponse createServerTestInstance(XContentType xContentType) {
         index = randomAlphaOfLength(8);
         id = randomAlphaOfLength(8);
         final int total = randomIntBetween(1, 16);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/license/GetBasicStatusResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/license/GetBasicStatusResponseTests.java
@@ -20,6 +20,7 @@ package org.elasticsearch.client.license;
 
 import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 
@@ -27,7 +28,7 @@ public class GetBasicStatusResponseTests
     extends AbstractResponseTestCase<org.elasticsearch.license.GetBasicStatusResponse, GetBasicStatusResponse> {
 
     @Override
-    protected org.elasticsearch.license.GetBasicStatusResponse createServerTestInstance() {
+    protected org.elasticsearch.license.GetBasicStatusResponse createServerTestInstance(XContentType xContentType) {
         return new org.elasticsearch.license.GetBasicStatusResponse(randomBoolean());
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/license/GetTrialStatusResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/license/GetTrialStatusResponseTests.java
@@ -20,6 +20,7 @@ package org.elasticsearch.client.license;
 
 import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 
@@ -27,7 +28,7 @@ public class GetTrialStatusResponseTests extends
     AbstractResponseTestCase<org.elasticsearch.license.GetTrialStatusResponse, GetTrialStatusResponse> {
 
     @Override
-    protected org.elasticsearch.license.GetTrialStatusResponse createServerTestInstance() {
+    protected org.elasticsearch.license.GetTrialStatusResponse createServerTestInstance(XContentType xContentType) {
         return new org.elasticsearch.license.GetTrialStatusResponse(randomBoolean());
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/MlInfoActionResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/MlInfoActionResponseTests.java
@@ -20,6 +20,7 @@ package org.elasticsearch.client.ml;
 
 import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ml.action.MlInfoAction.Response;
 
 import java.io.IOException;
@@ -31,7 +32,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class MlInfoActionResponseTests extends AbstractResponseTestCase<Response, MlInfoResponse> {
 
     @Override
-    protected Response createServerTestInstance() {
+    protected Response createServerTestInstance(XContentType xContentType) {
         int size = randomInt(10);
         Map<String, Object> info = new HashMap<>();
         for (int j = 0; j < size; j++) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/PutCalendarActionResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/PutCalendarActionResponseTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.client.ml;
 import com.carrotsearch.randomizedtesting.generators.CodepointSetGenerator;
 import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ml.action.PutCalendarAction;
 import org.elasticsearch.xpack.core.ml.calendars.Calendar;
 
@@ -33,7 +34,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class PutCalendarActionResponseTests extends AbstractResponseTestCase<PutCalendarAction.Response, PutCalendarResponse> {
 
     @Override
-    protected PutCalendarAction.Response createServerTestInstance() {
+    protected PutCalendarAction.Response createServerTestInstance(XContentType xContentType) {
         String calendarId = new CodepointSetGenerator("abcdefghijklmnopqrstuvwxyz".toCharArray()).ofCodePointsLength(random(), 10, 10);
         int size = randomInt(10);
         List<String> items = new ArrayList<>(size);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/security/hlrc/HasPrivilegesResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/security/hlrc/HasPrivilegesResponseTests.java
@@ -82,7 +82,7 @@ public class HasPrivilegesResponseTests extends AbstractResponseTestCase<
     }
 
     @Override
-    protected org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse createServerTestInstance() {
+    protected org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse createServerTestInstance(XContentType xContentType) {
         return randomResponse();
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/watcher/GetWatchResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/watcher/GetWatchResponseTests.java
@@ -43,7 +43,7 @@ import static org.hamcrest.Matchers.nullValue;
 public class GetWatchResponseTests extends AbstractResponseTestCase<GetWatchResponse, org.elasticsearch.client.watcher.GetWatchResponse> {
 
     @Override
-    protected GetWatchResponse createServerTestInstance() {
+    protected GetWatchResponse createServerTestInstance(XContentType xContentType) {
         String id = randomAlphaOfLength(10);
         if (LuceneTestCase.rarely()) {
             return new GetWatchResponse(id);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/watcher/hlrc/DeleteWatchResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/watcher/hlrc/DeleteWatchResponseTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.client.watcher.hlrc;
 import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.client.watcher.DeleteWatchResponse;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 
@@ -30,7 +31,7 @@ public class DeleteWatchResponseTests extends AbstractResponseTestCase<
     org.elasticsearch.protocol.xpack.watcher.DeleteWatchResponse, DeleteWatchResponse> {
 
     @Override
-    protected org.elasticsearch.protocol.xpack.watcher.DeleteWatchResponse createServerTestInstance() {
+    protected org.elasticsearch.protocol.xpack.watcher.DeleteWatchResponse createServerTestInstance(XContentType xContentType) {
         String id = randomAlphaOfLength(10);
         long version = randomLongBetween(1, 10);
         boolean found = randomBoolean();

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/watcher/hlrc/ExecuteWatchResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/watcher/hlrc/ExecuteWatchResponseTests.java
@@ -35,7 +35,7 @@ public class ExecuteWatchResponseTests extends AbstractResponseTestCase<
     ExecuteWatchResponse, org.elasticsearch.client.watcher.ExecuteWatchResponse> {
 
     @Override
-    protected ExecuteWatchResponse createServerTestInstance() {
+    protected ExecuteWatchResponse createServerTestInstance(XContentType xContentType) {
         String id = "my_watch_0-2015-06-02T23:17:55.124Z";
         try {
             XContentBuilder builder = XContentFactory.jsonBuilder();

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/watcher/hlrc/PutWatchResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/watcher/hlrc/PutWatchResponseTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.client.watcher.hlrc;
 import org.elasticsearch.client.AbstractResponseTestCase;
 import org.elasticsearch.client.watcher.PutWatchResponse;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 
@@ -30,7 +31,7 @@ public class PutWatchResponseTests extends AbstractResponseTestCase<
     org.elasticsearch.protocol.xpack.watcher.PutWatchResponse, PutWatchResponse> {
 
     @Override
-    protected org.elasticsearch.protocol.xpack.watcher.PutWatchResponse createServerTestInstance() {
+    protected org.elasticsearch.protocol.xpack.watcher.PutWatchResponse createServerTestInstance(XContentType xContentType) {
         String id = randomAlphaOfLength(10);
         long seqNo = randomNonNegativeLong();
         long primaryTerm = randomLongBetween(1, 20);

--- a/docs/java-rest/high-level/enrich/get_policy.asciidoc
+++ b/docs/java-rest/high-level/enrich/get_policy.asciidoc
@@ -1,0 +1,31 @@
+--
+:api: enrich-get-policy
+:request: GetPolicyRequest
+:response: GetPolicyResponse
+--
+
+[id="{upid}-{api}"]
+=== Get Policy API
+
+[id="{upid}-{api}-request"]
+==== Request
+
+The Get Policy API allows to retrieve an enrich policy by name.
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests-file}[{api}-request]
+--------------------------------------------------
+
+[id="{upid}-{api}-response"]
+==== Response
+
+The returned +{response}+ includes the requested enrich policy.
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests-file}[{api}-response]
+--------------------------------------------------
+<1> The actual enrich policy.
+
+include::../execution.asciidoc[]

--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -601,5 +601,7 @@ include::dataframe/stop_data_frame.asciidoc[]
 The Java High Level REST Client supports the following Enrich APIs:
 
 * <<{upid}-enrich-put-policy>>
+* <<{upid}-enrich-get-policy>>
 
 include::enrich/put_policy.asciidoc[]
+include::enrich/get_policy.asciidoc[]


### PR DESCRIPTION
Changed the signature of AbstractResponseTestCase#createServerTestInstance(...)
to include the randomly selected xcontent type. This is needed for the
creating a server response instance with a query which is represented as BytesReference.
Maybe this should go into a different change?

This PR also includes HLRC docs for the get policy api.

Relates to #32789