### PR TITLE
HLRC: add support for retrieval/invalidation of owned API keys

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/SecurityRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/SecurityRequestConverters.java
@@ -294,7 +294,7 @@ final class SecurityRequestConverters {
         if (Strings.hasText(getApiKeyRequest.getRealmName())) {
             request.addParameter("realm_name", getApiKeyRequest.getRealmName());
         }
-
+        request.addParameter("owner", Boolean.toString(getApiKeyRequest.ownedByAuthenticatedUser()));
         return request;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/security/GetApiKeyRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/security/GetApiKeyRequest.java
@@ -36,18 +36,24 @@ public final class GetApiKeyRequest implements Validatable, ToXContentObject {
     private final String userName;
     private final String id;
     private final String name;
+    private final boolean ownedByAuthenticatedUser;
 
     // pkg scope for testing
     GetApiKeyRequest(@Nullable String realmName, @Nullable String userName, @Nullable String apiKeyId,
-            @Nullable String apiKeyName) {
+                     @Nullable String apiKeyName, boolean ownedByAuthenticatedUser) {
         if (Strings.hasText(realmName) == false && Strings.hasText(userName) == false && Strings.hasText(apiKeyId) == false
-                && Strings.hasText(apiKeyName) == false) {
-            throwValidationError("One of [api key id, api key name, username, realm name] must be specified");
+                && Strings.hasText(apiKeyName) == false && ownedByAuthenticatedUser == false) {
+            throwValidationError("One of [api key id, api key name, username, realm name] must be specified if [owner] flag is false");
         }
         if (Strings.hasText(apiKeyId) || Strings.hasText(apiKeyName)) {
             if (Strings.hasText(realmName) || Strings.hasText(userName)) {
                 throwValidationError(
                         "username or realm name must not be specified when the api key id or api key name is specified");
+            }
+        }
+        if (ownedByAuthenticatedUser) {
+            if (Strings.hasText(realmName) || Strings.hasText(userName)) {
+                throwValidationError("neither username nor realm-name may be specified when retrieving owned API keys");
             }
         }
         if (Strings.hasText(apiKeyId) && Strings.hasText(apiKeyName)) {
@@ -57,6 +63,7 @@ public final class GetApiKeyRequest implements Validatable, ToXContentObject {
         this.userName = userName;
         this.id = apiKeyId;
         this.name = apiKeyName;
+        this.ownedByAuthenticatedUser = ownedByAuthenticatedUser;
     }
 
     private void throwValidationError(String message) {
@@ -79,13 +86,17 @@ public final class GetApiKeyRequest implements Validatable, ToXContentObject {
         return name;
     }
 
+    public boolean ownedByAuthenticatedUser() {
+        return ownedByAuthenticatedUser;
+    }
+
     /**
      * Creates get API key request for given realm name
      * @param realmName realm name
      * @return {@link GetApiKeyRequest}
      */
     public static GetApiKeyRequest usingRealmName(String realmName) {
-        return new GetApiKeyRequest(realmName, null, null, null);
+        return new GetApiKeyRequest(realmName, null, null, null, false);
     }
 
     /**
@@ -94,7 +105,7 @@ public final class GetApiKeyRequest implements Validatable, ToXContentObject {
      * @return {@link GetApiKeyRequest}
      */
     public static GetApiKeyRequest usingUserName(String userName) {
-        return new GetApiKeyRequest(null, userName, null, null);
+        return new GetApiKeyRequest(null, userName, null, null, false);
     }
 
     /**
@@ -104,25 +115,36 @@ public final class GetApiKeyRequest implements Validatable, ToXContentObject {
      * @return {@link GetApiKeyRequest}
      */
     public static GetApiKeyRequest usingRealmAndUserName(String realmName, String userName) {
-        return new GetApiKeyRequest(realmName, userName, null, null);
+        return new GetApiKeyRequest(realmName, userName, null, null, false);
     }
 
     /**
      * Creates get API key request for given api key id
      * @param apiKeyId api key id
+     * @param ownedByAuthenticatedUser set {@code true} if the request is only for the API keys owned by current
+     * authenticated user else{@code false}
      * @return {@link GetApiKeyRequest}
      */
-    public static GetApiKeyRequest usingApiKeyId(String apiKeyId) {
-        return new GetApiKeyRequest(null, null, apiKeyId, null);
+    public static GetApiKeyRequest usingApiKeyId(String apiKeyId, boolean ownedByAuthenticatedUser) {
+        return new GetApiKeyRequest(null, null, apiKeyId, null, ownedByAuthenticatedUser);
     }
 
     /**
      * Creates get API key request for given api key name
      * @param apiKeyName api key name
+     * @param ownedByAuthenticatedUser set {@code true} if the request is only for the API keys owned by current
+     * authenticated user else{@code false}
      * @return {@link GetApiKeyRequest}
      */
-    public static GetApiKeyRequest usingApiKeyName(String apiKeyName) {
-        return new GetApiKeyRequest(null, null, null, apiKeyName);
+    public static GetApiKeyRequest usingApiKeyName(String apiKeyName, boolean ownedByAuthenticatedUser) {
+        return new GetApiKeyRequest(null, null, null, apiKeyName, ownedByAuthenticatedUser);
+    }
+
+    /**
+     * Creates get api key request to retrieve api key information for the api keys owned by the current authenticated user.
+     */
+    public static GetApiKeyRequest forOwnedApiKeys() {
+        return new GetApiKeyRequest(null, null, null, null, true);
     }
 
     @Override

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/security/InvalidateApiKeyRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/security/InvalidateApiKeyRequest.java
@@ -36,18 +36,24 @@ public final class InvalidateApiKeyRequest implements Validatable, ToXContentObj
     private final String userName;
     private final String id;
     private final String name;
+    private final boolean ownedByAuthenticatedUser;
 
     // pkg scope for testing
     InvalidateApiKeyRequest(@Nullable String realmName, @Nullable String userName, @Nullable String apiKeyId,
-            @Nullable String apiKeyName) {
+                            @Nullable String apiKeyName, boolean ownedByAuthenticatedUser) {
         if (Strings.hasText(realmName) == false && Strings.hasText(userName) == false && Strings.hasText(apiKeyId) == false
-                && Strings.hasText(apiKeyName) == false) {
-            throwValidationError("One of [api key id, api key name, username, realm name] must be specified");
+                && Strings.hasText(apiKeyName) == false && ownedByAuthenticatedUser == false) {
+            throwValidationError("One of [api key id, api key name, username, realm name] must be specified if [owner] flag is false");
         }
         if (Strings.hasText(apiKeyId) || Strings.hasText(apiKeyName)) {
             if (Strings.hasText(realmName) || Strings.hasText(userName)) {
                 throwValidationError(
                         "username or realm name must not be specified when the api key id or api key name is specified");
+            }
+        }
+        if (ownedByAuthenticatedUser) {
+            if (Strings.hasText(realmName) || Strings.hasText(userName)) {
+                throwValidationError("neither username nor realm-name may be specified when invalidating owned API keys");
             }
         }
         if (Strings.hasText(apiKeyId) && Strings.hasText(apiKeyName)) {
@@ -57,6 +63,7 @@ public final class InvalidateApiKeyRequest implements Validatable, ToXContentObj
         this.userName = userName;
         this.id = apiKeyId;
         this.name = apiKeyName;
+        this.ownedByAuthenticatedUser = ownedByAuthenticatedUser;
     }
 
     private void throwValidationError(String message) {
@@ -79,13 +86,17 @@ public final class InvalidateApiKeyRequest implements Validatable, ToXContentObj
         return name;
     }
 
+    public boolean ownedByAuthenticatedUser() {
+        return ownedByAuthenticatedUser;
+    }
+
     /**
      * Creates invalidate API key request for given realm name
      * @param realmName realm name
      * @return {@link InvalidateApiKeyRequest}
      */
     public static InvalidateApiKeyRequest usingRealmName(String realmName) {
-        return new InvalidateApiKeyRequest(realmName, null, null, null);
+        return new InvalidateApiKeyRequest(realmName, null, null, null, false);
     }
 
     /**
@@ -94,7 +105,7 @@ public final class InvalidateApiKeyRequest implements Validatable, ToXContentObj
      * @return {@link InvalidateApiKeyRequest}
      */
     public static InvalidateApiKeyRequest usingUserName(String userName) {
-        return new InvalidateApiKeyRequest(null, userName, null, null);
+        return new InvalidateApiKeyRequest(null, userName, null, null, false);
     }
 
     /**
@@ -104,25 +115,36 @@ public final class InvalidateApiKeyRequest implements Validatable, ToXContentObj
      * @return {@link InvalidateApiKeyRequest}
      */
     public static InvalidateApiKeyRequest usingRealmAndUserName(String realmName, String userName) {
-        return new InvalidateApiKeyRequest(realmName, userName, null, null);
+        return new InvalidateApiKeyRequest(realmName, userName, null, null, false);
     }
 
     /**
      * Creates invalidate API key request for given api key id
      * @param apiKeyId api key id
+     * @param ownedByAuthenticatedUser set {@code true} if the request is only for the API keys owned by current authenticated user else
+     * {@code false}
      * @return {@link InvalidateApiKeyRequest}
      */
-    public static InvalidateApiKeyRequest usingApiKeyId(String apiKeyId) {
-        return new InvalidateApiKeyRequest(null, null, apiKeyId, null);
+    public static InvalidateApiKeyRequest usingApiKeyId(String apiKeyId, boolean ownedByAuthenticatedUser) {
+        return new InvalidateApiKeyRequest(null, null, apiKeyId, null, ownedByAuthenticatedUser);
     }
 
     /**
      * Creates invalidate API key request for given api key name
      * @param apiKeyName api key name
+     * @param ownedByAuthenticatedUser set {@code true} if the request is only for the API keys owned by current authenticated user else
+     * {@code false}
      * @return {@link InvalidateApiKeyRequest}
      */
-    public static InvalidateApiKeyRequest usingApiKeyName(String apiKeyName) {
-        return new InvalidateApiKeyRequest(null, null, null, apiKeyName);
+    public static InvalidateApiKeyRequest usingApiKeyName(String apiKeyName, boolean ownedByAuthenticatedUser) {
+        return new InvalidateApiKeyRequest(null, null, null, apiKeyName, ownedByAuthenticatedUser);
+    }
+
+    /**
+     * Creates invalidate api key request to invalidate api keys owned by the current authenticated user.
+     */
+    public static InvalidateApiKeyRequest forOwnedApiKeys() {
+        return new InvalidateApiKeyRequest(null, null, null, null, true);
     }
 
     @Override
@@ -140,6 +162,7 @@ public final class InvalidateApiKeyRequest implements Validatable, ToXContentObj
         if (name != null) {
             builder.field("name", name);
         }
+        builder.field("owner", ownedByAuthenticatedUser);
         return builder.endObject();
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/SecurityRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/SecurityRequestConvertersTests.java
@@ -446,10 +446,11 @@ public class SecurityRequestConvertersTests extends ESTestCase {
         final Request request = SecurityRequestConverters.getApiKey(getApiKeyRequest);
         assertEquals(HttpGet.METHOD_NAME, request.getMethod());
         assertEquals("/_security/api_key", request.getEndpoint());
-        Map<String, String> mapOfParameters = new HashMap<>();
-        mapOfParameters.put("realm_name", realmName);
-        mapOfParameters.put("username", userName);
-        assertThat(request.getParameters(), equalTo(mapOfParameters));
+        Map<String, String> expectedMapOfParameters = new HashMap<>();
+        expectedMapOfParameters.put("realm_name", realmName);
+        expectedMapOfParameters.put("username", userName);
+        expectedMapOfParameters.put("owner", Boolean.FALSE.toString());
+        assertThat(request.getParameters(), equalTo(expectedMapOfParameters));
     }
 
     public void testInvalidateApiKey() throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/security/GetApiKeyRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/security/GetApiKeyRequestTests.java
@@ -30,10 +30,10 @@ import static org.hamcrest.Matchers.equalTo;
 public class GetApiKeyRequestTests extends ESTestCase {
 
     public void testRequestValidation() {
-        GetApiKeyRequest request = GetApiKeyRequest.usingApiKeyId(randomAlphaOfLength(5));
+        GetApiKeyRequest request = GetApiKeyRequest.usingApiKeyId(randomAlphaOfLength(5), randomBoolean());
         Optional<ValidationException> ve = request.validate();
         assertFalse(ve.isPresent());
-        request = GetApiKeyRequest.usingApiKeyName(randomAlphaOfLength(5));
+        request = GetApiKeyRequest.usingApiKeyName(randomAlphaOfLength(5), randomBoolean());
         ve = request.validate();
         assertFalse(ve.isPresent());
         request = GetApiKeyRequest.usingRealmName(randomAlphaOfLength(5));
@@ -45,28 +45,40 @@ public class GetApiKeyRequestTests extends ESTestCase {
         request = GetApiKeyRequest.usingRealmAndUserName(randomAlphaOfLength(5), randomAlphaOfLength(7));
         ve = request.validate();
         assertFalse(ve.isPresent());
+        request = GetApiKeyRequest.forOwnedApiKeys();
+        ve = request.validate();
+        assertFalse(ve.isPresent());
     }
 
     public void testRequestValidationFailureScenarios() throws IOException {
         String[][] inputs = new String[][] {
-                { randomFrom(new String[] { null, "" }), randomFrom(new String[] { null, "" }), randomFrom(new String[] { null, "" }),
-                        randomFrom(new String[] { null, "" }) },
-                { randomFrom(new String[] { null, "" }), "user", "api-kid", "api-kname" },
-                { "realm", randomFrom(new String[] { null, "" }), "api-kid", "api-kname" },
-                { "realm", "user", "api-kid", randomFrom(new String[] { null, "" }) },
-                { randomFrom(new String[] { null, "" }), randomFrom(new String[] { null, "" }), "api-kid", "api-kname" } };
-        String[] expectedErrorMessages = new String[] { "One of [api key id, api key name, username, realm name] must be specified",
+                { randomNullOrEmptyString(), randomNullOrEmptyString(), randomNullOrEmptyString(), randomNullOrEmptyString(), "false" },
+                { randomNullOrEmptyString(), "user", "api-kid", "api-kname", "false" },
+                { "realm", randomNullOrEmptyString(), "api-kid", "api-kname", "false" },
+                { "realm", "user", "api-kid", randomNullOrEmptyString(), "false" },
+                { randomNullOrEmptyString(), randomNullOrEmptyString(), "api-kid", "api-kname", "false" },
+                { "realm", randomNullOrEmptyString(), randomNullOrEmptyString(), randomNullOrEmptyString(), "true"},
+                { randomNullOrEmptyString(), "user", randomNullOrEmptyString(), randomNullOrEmptyString(), "true"} };
+        String[] expectedErrorMessages = new String[] {
+                "One of [api key id, api key name, username, realm name] must be specified if [owner] flag is false",
                 "username or realm name must not be specified when the api key id or api key name is specified",
                 "username or realm name must not be specified when the api key id or api key name is specified",
                 "username or realm name must not be specified when the api key id or api key name is specified",
-                "only one of [api key id, api key name] can be specified" };
+                "only one of [api key id, api key name] can be specified",
+                "neither username nor realm-name may be specified when retrieving owned API keys",
+                "neither username nor realm-name may be specified when retrieving owned API keys" };
 
         for (int i = 0; i < inputs.length; i++) {
             final int caseNo = i;
             IllegalArgumentException ve = expectThrows(IllegalArgumentException.class,
-                    () -> new GetApiKeyRequest(inputs[caseNo][0], inputs[caseNo][1], inputs[caseNo][2], inputs[caseNo][3]));
+                    () -> new GetApiKeyRequest(inputs[caseNo][0], inputs[caseNo][1], inputs[caseNo][2], inputs[caseNo][3],
+                        Boolean.valueOf(inputs[caseNo][4])));
             assertNotNull(ve);
             assertThat(ve.getMessage(), equalTo(expectedErrorMessages[caseNo]));
         }
+    }
+
+    private static String randomNullOrEmptyString() {
+        return randomBoolean() ? "" : null;
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/security/InvalidateApiKeyRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/security/InvalidateApiKeyRequestTests.java
@@ -31,10 +31,10 @@ import static org.hamcrest.Matchers.is;
 public class InvalidateApiKeyRequestTests extends ESTestCase {
 
     public void testRequestValidation() {
-        InvalidateApiKeyRequest request = InvalidateApiKeyRequest.usingApiKeyId(randomAlphaOfLength(5));
+        InvalidateApiKeyRequest request = InvalidateApiKeyRequest.usingApiKeyId(randomAlphaOfLength(5), randomBoolean());
         Optional<ValidationException> ve = request.validate();
         assertThat(ve.isPresent(), is(false));
-        request = InvalidateApiKeyRequest.usingApiKeyName(randomAlphaOfLength(5));
+        request = InvalidateApiKeyRequest.usingApiKeyName(randomAlphaOfLength(5), randomBoolean());
         ve = request.validate();
         assertThat(ve.isPresent(), is(false));
         request = InvalidateApiKeyRequest.usingRealmName(randomAlphaOfLength(5));
@@ -46,28 +46,40 @@ public class InvalidateApiKeyRequestTests extends ESTestCase {
         request = InvalidateApiKeyRequest.usingRealmAndUserName(randomAlphaOfLength(5), randomAlphaOfLength(7));
         ve = request.validate();
         assertThat(ve.isPresent(), is(false));
+        request = InvalidateApiKeyRequest.forOwnedApiKeys();
+        ve = request.validate();
+        assertFalse(ve.isPresent());
     }
 
     public void testRequestValidationFailureScenarios() throws IOException {
         String[][] inputs = new String[][] {
-                { randomFrom(new String[] { null, "" }), randomFrom(new String[] { null, "" }), randomFrom(new String[] { null, "" }),
-                        randomFrom(new String[] { null, "" }) },
-                { randomFrom(new String[] { null, "" }), "user", "api-kid", "api-kname" },
-                { "realm", randomFrom(new String[] { null, "" }), "api-kid", "api-kname" },
-                { "realm", "user", "api-kid", randomFrom(new String[] { null, "" }) },
-                { randomFrom(new String[] { null, "" }), randomFrom(new String[] { null, "" }), "api-kid", "api-kname" } };
-        String[] expectedErrorMessages = new String[] { "One of [api key id, api key name, username, realm name] must be specified",
+                { randomNullOrEmptyString(), randomNullOrEmptyString(), randomNullOrEmptyString(), randomNullOrEmptyString(), "false" },
+                { randomNullOrEmptyString(), "user", "api-kid", "api-kname", "false" },
+                { "realm", randomNullOrEmptyString(), "api-kid", "api-kname", "false" },
+                { "realm", "user", "api-kid", randomNullOrEmptyString(), "false" },
+                { randomNullOrEmptyString(), randomNullOrEmptyString(), "api-kid", "api-kname", "false" },
+                { "realm", randomNullOrEmptyString(), randomNullOrEmptyString(), randomNullOrEmptyString(), "true" },
+                { randomNullOrEmptyString(), "user", randomNullOrEmptyString(), randomNullOrEmptyString(), "true" } };
+        String[] expectedErrorMessages = new String[] {
+                "One of [api key id, api key name, username, realm name] must be specified if [owner] flag is false",
                 "username or realm name must not be specified when the api key id or api key name is specified",
                 "username or realm name must not be specified when the api key id or api key name is specified",
                 "username or realm name must not be specified when the api key id or api key name is specified",
-                "only one of [api key id, api key name] can be specified" };
+                "only one of [api key id, api key name] can be specified",
+                "neither username nor realm-name may be specified when invalidating owned API keys",
+                "neither username nor realm-name may be specified when invalidating owned API keys" };
 
         for (int i = 0; i < inputs.length; i++) {
             final int caseNo = i;
             IllegalArgumentException ve = expectThrows(IllegalArgumentException.class,
-                    () -> new InvalidateApiKeyRequest(inputs[caseNo][0], inputs[caseNo][1], inputs[caseNo][2], inputs[caseNo][3]));
+                    () -> new InvalidateApiKeyRequest(inputs[caseNo][0], inputs[caseNo][1], inputs[caseNo][2], inputs[caseNo][3],
+                        Boolean.valueOf(inputs[caseNo][4])));
             assertNotNull(ve);
             assertThat(ve.getMessage(), equalTo(expectedErrorMessages[caseNo]));
         }
+    }
+
+    private static String randomNullOrEmptyString() {
+        return randomBoolean() ? "" : null;
     }
 }

--- a/docs/java-rest/high-level/security/get-api-key.asciidoc
+++ b/docs/java-rest/high-level/security/get-api-key.asciidoc
@@ -21,6 +21,8 @@ The +{request}+ supports retrieving API key information for
 
 . All API keys for a specific user in a specific realm
 
+. A specific key or all API keys owned by the current authenticated user
+
 ===== Retrieve a specific API key by its id
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
@@ -49,6 +51,12 @@ include-tagged::{doc-tests-file}[get-user-api-keys-request]
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[get-user-realm-api-keys-request]
+--------------------------------------------------
+
+===== Retrieve all API keys for the current authenticated user
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests-file}[get-api-keys-owned-by-authenticated-user-request]
 --------------------------------------------------
 
 include::../execution.asciidoc[]

--- a/docs/java-rest/high-level/security/invalidate-api-key.asciidoc
+++ b/docs/java-rest/high-level/security/invalidate-api-key.asciidoc
@@ -21,6 +21,8 @@ The +{request}+ supports invalidating
 
 . All API keys for a specific user in a specific realm
 
+. A specific key or all API keys owned by the current authenticated user
+
 ===== Specific API key by API key id
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
@@ -49,6 +51,12 @@ include-tagged::{doc-tests-file}[invalidate-user-api-keys-request]
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[invalidate-user-realm-api-keys-request]
+--------------------------------------------------
+
+===== Retrieve all API keys for the current authenticated user
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests-file}[invalidate-api-keys-owned-by-authenticated-user-request]
 --------------------------------------------------
 
 include::../execution.asciidoc[]


### PR DESCRIPTION
This commit updates Rest client(get/invalidate API keys APIs) to support retrieval
or invalidation of API keys owned by the currently authenticated user.

Relates: #40031