### PR TITLE
Guard distro tests for pre oss in distribution filesnames

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/DistroTestPlugin.java
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/DistroTestPlugin.java
@@ -182,8 +182,12 @@ public class DistroTestPlugin implements Plugin<Project> {
                     try {
                         Files.writeString(archivesPath.resolve("version"), VersionProperties.getElasticsearch());
                         Files.writeString(archivesPath.resolve("upgrade_from_version"), upgradeFromVersion);
+                        Path upgradeMarkerPath = archivesPath.resolve("upgrade_is_oss");
+                        project.delete(upgradeMarkerPath);
                         // this is always true, but bats tests rely on it. It is just temporary until bats is removed.
-                        Files.writeString(archivesPath.resolve("upgrade_is_oss"), "");
+                        if (upgradeVersion.onOrAfter("6.3.0")) {
+                            Files.writeString(upgradeMarkerPath, "");
+                        }
                     } catch (IOException e) {
                         throw new UncheckedIOException(e);
                     }


### PR DESCRIPTION
Before #45064, the bats tests skipped the upgrade tests when the random
upgrade version is before 6.3.0. This commit restores that behavior.

closes #45476