### PR TITLE
Remove joda date deprecation message on startup in 6.8

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
@@ -114,7 +114,7 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
 
     public static final String LICENSE_JOB = "licenseJob";
 
-    private static final DateFormatter DATE_FORMATTER = DateFormatter.forPattern("EEEE, MMMMM dd, yyyy");
+    private static final DateFormatter DATE_FORMATTER = DateFormatter.forPattern("8EEEE, MMMMM dd, uuuu");
 
     private static final String ACKNOWLEDGEMENT_HEADER = "This license update requires acknowledgement. To acknowledge the license, " +
             "please read the following messages and update the license again, this time with the \"acknowledge=true\" parameter:";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
@@ -114,7 +114,7 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
 
     public static final String LICENSE_JOB = "licenseJob";
 
-    private static final DateFormatter DATE_FORMATTER = DateFormatter.forPattern("8EEEE, MMMMM dd, uuuu");
+    private static final DateFormatter DATE_FORMATTER = DateFormatter.forPattern("8EEEE, MMMMM dd, yyyy");
 
     private static final String ACKNOWLEDGEMENT_HEADER = "This license update requires acknowledgement. To acknowledge the license, " +
             "please read the following messages and update the license again, this time with the \"acknowledge=true\" parameter:";


### PR DESCRIPTION
When starting up Elasticsearch 6.8, there is always a deprecation
message logged like this

[WARN ][o.e.d.c.j.Joda           ] [A2Wr_Jx] 'y' year should be replaced with 'u'. Use 'y' for year-of-era. Prefix your date format with '8' to use the new specifier.

tracing this down, result in the LicenseService being the culprit using
an deprecated date. This switches to a java time based date.

**Note**: master/7.x/7.3 branches use `yyyy` in java time and not joda time, but as this is year-of-era, that might be fine for licensing.

Closes #45483
