### PR TITLE
Improve naming of enrich policy fields.

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/enrich/PutPolicyRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/enrich/PutPolicyRequest.java
@@ -39,17 +39,17 @@ public class PutPolicyRequest implements Validatable, ToXContentObject {
     static final ParseField TYPE_FIELD = new ParseField("type");
     static final ParseField QUERY_FIELD = new ParseField("query");
     static final ParseField INDICES_FIELD = new ParseField("indices");
-    static final ParseField ENRICH_KEY_FIELD = new ParseField("enrich_key");
-    static final ParseField ENRICH_VALUES_FIELD = new ParseField("enrich_values");
+    static final ParseField MATCH_FIELD_FIELD = new ParseField("match_field");
+    static final ParseField ENRICH_FIELDS_FIELD = new ParseField("enrich_fields");
 
     private final String name;
     private final String type;
     private BytesReference query;
     private final List<String> indices;
-    private final String enrichKey;
-    private final List<String> enrichValues;
+    private final String matchField;
+    private final List<String> enrichFields;
 
-    public PutPolicyRequest(String name, String type, List<String> indices, String enrichKey, List<String> enrichValues) {
+    public PutPolicyRequest(String name, String type, List<String> indices, String matchField, List<String> enrichFields) {
         if (Strings.hasLength(name) == false) {
             throw new IllegalArgumentException("name must be a non-null and non-empty string");
         }
@@ -59,18 +59,18 @@ public class PutPolicyRequest implements Validatable, ToXContentObject {
         if (indices == null || indices.isEmpty()) {
             throw new IllegalArgumentException("indices must be specified");
         }
-        if (Strings.hasLength(enrichKey) == false) {
-            throw new IllegalArgumentException("enrichKey must be a non-null and non-empty string");
+        if (Strings.hasLength(matchField) == false) {
+            throw new IllegalArgumentException("matchField must be a non-null and non-empty string");
         }
-        if (enrichValues == null || enrichValues.isEmpty()) {
-            throw new IllegalArgumentException("enrichValues must be specified");
+        if (enrichFields == null || enrichFields.isEmpty()) {
+            throw new IllegalArgumentException("enrichFields must be specified");
         }
 
         this.name = name;
         this.type = type;
         this.indices = indices;
-        this.enrichKey = enrichKey;
-        this.enrichValues = enrichValues;
+        this.matchField = matchField;
+        this.enrichFields = enrichFields;
     }
 
     public String getName() {
@@ -97,12 +97,12 @@ public class PutPolicyRequest implements Validatable, ToXContentObject {
         return indices;
     }
 
-    public String getEnrichKey() {
-        return enrichKey;
+    public String getMatchField() {
+        return matchField;
     }
 
-    public List<String> getEnrichValues() {
-        return enrichValues;
+    public List<String> getEnrichFields() {
+        return enrichFields;
     }
 
     @Override
@@ -113,8 +113,8 @@ public class PutPolicyRequest implements Validatable, ToXContentObject {
         if (query != null) {
             builder.field(QUERY_FIELD.getPreferredName(), asMap(query, builder.contentType()));
         }
-        builder.field(ENRICH_KEY_FIELD.getPreferredName(), enrichKey);
-        builder.field(ENRICH_VALUES_FIELD.getPreferredName(), enrichValues);
+        builder.field(MATCH_FIELD_FIELD.getPreferredName(), matchField);
+        builder.field(ENRICH_FIELDS_FIELD.getPreferredName(), enrichFields);
         builder.endObject();
         return builder;
     }
@@ -128,13 +128,13 @@ public class PutPolicyRequest implements Validatable, ToXContentObject {
             Objects.equals(type, that.type) &&
             Objects.equals(query, that.query) &&
             Objects.equals(indices, that.indices) &&
-            Objects.equals(enrichKey, that.enrichKey) &&
-            Objects.equals(enrichValues, that.enrichValues);
+            Objects.equals(matchField, that.matchField) &&
+            Objects.equals(enrichFields, that.enrichFields);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, type, query, indices, enrichKey, enrichValues);
+        return Objects.hash(name, type, query, indices, matchField, enrichFields);
     }
 
     private static BytesReference xContentToBytes(ToXContentObject object) throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/EnrichIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/EnrichIT.java
@@ -47,8 +47,8 @@ public class EnrichIT extends ESRestHighLevelClientTestCase {
         Map<String, Object> responseBody = toMap(getPolicyResponse);
         assertThat(responseBody.get("type"), equalTo(putPolicyRequest.getType()));
         assertThat(responseBody.get("indices"), equalTo(putPolicyRequest.getIndices()));
-        assertThat(responseBody.get("enrich_key"), equalTo(putPolicyRequest.getEnrichKey()));
-        assertThat(responseBody.get("enrich_values"), equalTo(putPolicyRequest.getEnrichValues()));
+        assertThat(responseBody.get("enrich_key"), equalTo(putPolicyRequest.getMatchField()));
+        assertThat(responseBody.get("enrich_values"), equalTo(putPolicyRequest.getEnrichFields()));
     }
 
     private static Map<String, Object> toMap(Response response) throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/EnrichIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/EnrichIT.java
@@ -47,8 +47,8 @@ public class EnrichIT extends ESRestHighLevelClientTestCase {
         Map<String, Object> responseBody = toMap(getPolicyResponse);
         assertThat(responseBody.get("type"), equalTo(putPolicyRequest.getType()));
         assertThat(responseBody.get("indices"), equalTo(putPolicyRequest.getIndices()));
-        assertThat(responseBody.get("enrich_key"), equalTo(putPolicyRequest.getMatchField()));
-        assertThat(responseBody.get("enrich_values"), equalTo(putPolicyRequest.getEnrichFields()));
+        assertThat(responseBody.get("match_field"), equalTo(putPolicyRequest.getMatchField()));
+        assertThat(responseBody.get("enrich_fields"), equalTo(putPolicyRequest.getEnrichFields()));
     }
 
     private static Map<String, Object> toMap(Response response) throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/enrich/PutPolicyRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/enrich/PutPolicyRequestTests.java
@@ -41,7 +41,7 @@ public class PutPolicyRequestTests extends AbstractRequestTestCase<PutPolicyRequ
         assertThat(request.validate().isPresent(), is(false));
 
         Exception e = expectThrows(IllegalArgumentException.class,
-            () -> new PutPolicyRequest(request.getName(), request.getType(), request.getIndices(), null, request.getEnrichValues()));
+            () -> new PutPolicyRequest(request.getName(), request.getType(), request.getIndices(), null, request.getEnrichFields()));
         assertThat(e.getMessage(), containsString("enrichKey must be a non-null and non-empty string"));
     }
 
@@ -49,7 +49,7 @@ public class PutPolicyRequestTests extends AbstractRequestTestCase<PutPolicyRequ
         PutPolicyRequest testInstance = createTestInstance();
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(testInstance, (original) -> {
             PutPolicyRequest copy = new PutPolicyRequest(original.getName(), original.getType(), original.getIndices(),
-                original.getEnrichKey(), original.getEnrichValues());
+                original.getMatchField(), original.getEnrichFields());
             copy.setQuery(original.getQuery());
             return copy;
         });
@@ -99,7 +99,7 @@ public class PutPolicyRequestTests extends AbstractRequestTestCase<PutPolicyRequ
         } else {
             assertThat(serverInstance.getPolicy().getQuery(), nullValue());
         }
-        assertThat(clientTestInstance.getEnrichKey(), equalTo(serverInstance.getPolicy().getEnrichKey()));
-        assertThat(clientTestInstance.getEnrichValues(), equalTo(serverInstance.getPolicy().getEnrichValues()));
+        assertThat(clientTestInstance.getMatchField(), equalTo(serverInstance.getPolicy().getMatchField()));
+        assertThat(clientTestInstance.getEnrichFields(), equalTo(serverInstance.getPolicy().getEnrichFields()));
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/enrich/PutPolicyRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/enrich/PutPolicyRequestTests.java
@@ -42,7 +42,7 @@ public class PutPolicyRequestTests extends AbstractRequestTestCase<PutPolicyRequ
 
         Exception e = expectThrows(IllegalArgumentException.class,
             () -> new PutPolicyRequest(request.getName(), request.getType(), request.getIndices(), null, request.getEnrichFields()));
-        assertThat(e.getMessage(), containsString("enrichKey must be a non-null and non-empty string"));
+        assertThat(e.getMessage(), containsString("matchField must be a non-null and non-empty string"));
     }
 
     public void testEqualsAndHashcode() {

--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -813,8 +813,8 @@ The main piece to configure is the enrich policy:
 | `type`             | yes       | -                    | The policy type.
 | `indices`          | yes       | -                    | The indices to fetch the data from.
 | `query`            | no        | `match_all` query    | The query to be used to select which documents are included.
-| `match_field`      | yes       | -                    | The field that the enrich processor will query against.
-| `enrich_fields`    | yes       | -                    | The fields to include in the enrich index.
+| `match_field`      | yes       | -                    | The field that will be used to match against an input document.
+| `enrich_fields`    | yes       | -                    | The fields that will be available to enrich the input document.
 |======
 
 [[enrich-policy-types]]

--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -986,8 +986,8 @@ PUT /_enrich/policy/my-policy
 {
     "type": "exact_match",
     "indices": "users",
-    "enrich_key": "email",
-    "enrich_values": ["first_name", "last_name", "address", "city", "zip", "state"]
+    "match_field": "email",
+    "enrich_fields": ["first_name", "last_name", "address", "city", "zip", "state"]
 }
 --------------------------------------------------
 // CONSOLE
@@ -1023,8 +1023,8 @@ Response:
 {
     "type": "exact_match",
     "indices": ["users"],
-    "enrich_key": "email",
-    "enrich_values": ["first_name", "last_name", "address", "city", "zip", "state"]
+    "match_field": "email",
+    "enrich_fields": ["first_name", "last_name", "address", "city", "zip", "state"]
 }
 --------------------------------------------------
 // TESTRESPONSE

--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -813,8 +813,8 @@ The main piece to configure is the enrich policy:
 | `type`             | yes       | -                    | The policy type.
 | `indices`          | yes       | -                    | The indices to fetch the data from.
 | `query`            | no        | `match_all` query    | The query to be used to select which documents are included.
-| `enrich_key`       | yes       | -                    | The field that the enrich processor will query against.
-| `enrich_values`    | yes       | -                    | The fields to include in the enrich index.
+| `match_field`      | yes       | -                    | The field that the enrich processor will query against.
+| `enrich_fields`    | yes       | -                    | The fields to include in the enrich index.
 |======
 
 [[enrich-policy-types]]
@@ -859,8 +859,8 @@ PUT /_enrich/policy/users-policy
 {
     "type": "exact_match",
     "indices": "users",
-    "enrich_key": "email",
-    "enrich_values": ["first_name", "last_name", "address", "city", "zip", "state"]
+    "match_field": "email",
+    "enrich_fields": ["first_name", "last_name", "address", "city", "zip", "state"]
 }
 --------------------------------------------------
 // CONSOLE
@@ -1053,8 +1053,8 @@ Response:
             "name" : "my-policy",
             "type" : "exact_match",
             "indices" : ["users"],
-            "enrich_key" : "email",
-            "enrich_values" : [
+            "match_field" : "email",
+            "enrich_fields" : [
                 "first_name",
                 "last_name",
                 "address",

--- a/docs/reference/ingest/processors/enrich.asciidoc
+++ b/docs/reference/ingest/processors/enrich.asciidoc
@@ -43,8 +43,8 @@ PUT /_enrich/policy/users-policy
 {
     "type": "exact_match",
     "indices": "users",
-    "enrich_key": "email",
-    "enrich_values": ["first_name", "last_name", "address", "city", "zip", "state"]
+    "match_field": "email",
+    "enrich_fields": ["first_name", "last_name", "address", "city", "zip", "state"]
 }
 --------------------------------------------------
 // CONSOLE

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichPolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichPolicy.java
@@ -37,8 +37,8 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
     private static final ParseField TYPE = new ParseField("type");
     private static final ParseField QUERY = new ParseField("query");
     private static final ParseField INDICES = new ParseField("indices");
-    private static final ParseField ENRICH_KEY = new ParseField("enrich_key");
-    private static final ParseField ENRICH_VALUES = new ParseField("enrich_values");
+    private static final ParseField MATCH_FIELD = new ParseField("match_field");
+    private static final ParseField ENRICH_FIELDS = new ParseField("enrich_fields");
 
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<EnrichPolicy, Void> PARSER = new ConstructingObjectParser<>("policy",
@@ -63,8 +63,8 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
             return new QuerySource(BytesReference.bytes(contentBuilder), contentBuilder.contentType());
         }, QUERY);
         parser.declareStringArray(ConstructingObjectParser.constructorArg(), INDICES);
-        parser.declareString(ConstructingObjectParser.constructorArg(), ENRICH_KEY);
-        parser.declareStringArray(ConstructingObjectParser.constructorArg(), ENRICH_VALUES);
+        parser.declareString(ConstructingObjectParser.constructorArg(), MATCH_FIELD);
+        parser.declareStringArray(ConstructingObjectParser.constructorArg(), ENRICH_FIELDS);
     }
 
     public static EnrichPolicy fromXContent(XContentParser parser) throws IOException {
@@ -74,8 +74,8 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
     private final String type;
     private final QuerySource query;
     private final List<String> indices;
-    private final String enrichKey;
-    private final List<String> enrichValues;
+    private final String matchField;
+    private final List<String> enrichFields;
 
     public EnrichPolicy(StreamInput in) throws IOException {
         this(
@@ -90,13 +90,13 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
     public EnrichPolicy(String type,
                         QuerySource query,
                         List<String> indices,
-                        String enrichKey,
-                        List<String> enrichValues) {
+                        String matchField,
+                        List<String> enrichFields) {
         this.type = type;
         this.query= query;
         this.indices = indices;
-        this.enrichKey = enrichKey;
-        this.enrichValues = enrichValues;
+        this.matchField = matchField;
+        this.enrichFields = enrichFields;
     }
 
     public String getType() {
@@ -111,12 +111,12 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
         return indices;
     }
 
-    public String getEnrichKey() {
-        return enrichKey;
+    public String getMatchField() {
+        return matchField;
     }
 
-    public List<String> getEnrichValues() {
-        return enrichValues;
+    public List<String> getEnrichFields() {
+        return enrichFields;
     }
 
     public static String getBaseName(String policyName) {
@@ -128,8 +128,8 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
         out.writeString(type);
         out.writeOptionalWriteable(query);
         out.writeStringCollection(indices);
-        out.writeString(enrichKey);
-        out.writeStringCollection(enrichValues);
+        out.writeString(matchField);
+        out.writeStringCollection(enrichFields);
     }
 
     @Override
@@ -139,8 +139,8 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
             builder.field(QUERY.getPreferredName(), query.getQueryAsMap());
         }
         builder.array(INDICES.getPreferredName(), indices.toArray(new String[0]));
-        builder.field(ENRICH_KEY.getPreferredName(), enrichKey);
-        builder.array(ENRICH_VALUES.getPreferredName(), enrichValues.toArray(new String[0]));
+        builder.field(MATCH_FIELD.getPreferredName(), matchField);
+        builder.array(ENRICH_FIELDS.getPreferredName(), enrichFields.toArray(new String[0]));
         return builder;
     }
 
@@ -152,8 +152,8 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
         return type.equals(policy.type) &&
             Objects.equals(query, policy.query) &&
             indices.equals(policy.indices) &&
-            enrichKey.equals(policy.enrichKey) &&
-            enrichValues.equals(policy.enrichValues);
+            matchField.equals(policy.matchField) &&
+            enrichFields.equals(policy.enrichFields);
     }
 
     @Override
@@ -162,8 +162,8 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
             type,
             query,
             indices,
-            enrichKey,
-            enrichValues
+            matchField,
+            enrichFields
         );
     }
 

--- a/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
+++ b/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
@@ -36,8 +36,8 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
     public void testBasicFlow() throws Exception {
         // Create the policy:
         Request putPolicyRequest = new Request("PUT", "/_enrich/policy/my_policy");
-        putPolicyRequest.setJsonEntity("{\"type\": \"exact_match\",\"indices\": [\"my-source-index\"], \"enrich_key\": \"host\", " +
-            "\"enrich_values\": [\"globalRank\", \"tldRank\", \"tld\"]}");
+        putPolicyRequest.setJsonEntity("{\"type\": \"exact_match\",\"indices\": [\"my-source-index\"], \"match_field\": \"host\", " +
+            "\"enrich_fields\": [\"globalRank\", \"tldRank\", \"tld\"]}");
         assertOK(client().performRequest(putPolicyRequest));
 
         // Add entry to source index and then refresh:
@@ -79,8 +79,8 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
 
     public void testImmutablePolicy() throws IOException {
         Request putPolicyRequest = new Request("PUT", "/_enrich/policy/my_policy");
-        putPolicyRequest.setJsonEntity("{\"type\": \"exact_match\",\"indices\": [\"my-source-index\"], \"enrich_key\": \"host\", " +
-            "\"enrich_values\": [\"globalRank\", \"tldRank\", \"tld\"]}");
+        putPolicyRequest.setJsonEntity("{\"type\": \"exact_match\",\"indices\": [\"my-source-index\"], \"match_field\": \"host\", " +
+            "\"enrich_fields\": [\"globalRank\", \"tldRank\", \"tld\"]}");
         assertOK(client().performRequest(putPolicyRequest));
 
         ResponseException exc = expectThrows(ResponseException.class, () -> client().performRequest(putPolicyRequest));

--- a/x-pack/plugin/enrich/qa/rest-with-security/src/test/java/org/elasticsearch/xpack/enrich/EnrichSecurityFailureIT.java
+++ b/x-pack/plugin/enrich/qa/rest-with-security/src/test/java/org/elasticsearch/xpack/enrich/EnrichSecurityFailureIT.java
@@ -34,8 +34,8 @@ public class EnrichSecurityFailureIT extends ESRestTestCase {
 
     public void testFailure() {
         Request putPolicyRequest = new Request("PUT", "/_enrich/policy/my_policy");
-        putPolicyRequest.setJsonEntity("{\"type\": \"exact_match\",\"indices\": [\"my-source-index\"], \"enrich_key\": \"host\", " +
-            "\"enrich_values\": [\"globalRank\", \"tldRank\", \"tld\"]}");
+        putPolicyRequest.setJsonEntity("{\"type\": \"exact_match\",\"indices\": [\"my-source-index\"], \"match_field\": \"host\", " +
+            "\"enrich_fields\": [\"globalRank\", \"tldRank\", \"tld\"]}");
         ResponseException exc = expectThrows(ResponseException.class, () -> client().performRequest(putPolicyRequest));
         assertTrue(exc.getMessage().contains("action [cluster:admin/xpack/enrich/put] is unauthorized for user [test_enrich_no_privs]"));
     }

--- a/x-pack/plugin/enrich/qa/rest-with-security/src/test/java/org/elasticsearch/xpack/enrich/EnrichSecurityIT.java
+++ b/x-pack/plugin/enrich/qa/rest-with-security/src/test/java/org/elasticsearch/xpack/enrich/EnrichSecurityIT.java
@@ -37,8 +37,8 @@ public class EnrichSecurityIT extends CommonEnrichRestTestCase {
         // This test is here because it requires a valid user that has permission to execute policy PUTs but should fail if the user
         // does not have access to read the backing indices used to enrich the data.
         Request putPolicyRequest = new Request("PUT", "/_enrich/policy/my_policy");
-        putPolicyRequest.setJsonEntity("{\"type\": \"exact_match\",\"indices\": [\"some-other-index\"], \"enrich_key\": \"host\", " +
-            "\"enrich_values\": [\"globalRank\", \"tldRank\", \"tld\"]}");
+        putPolicyRequest.setJsonEntity("{\"type\": \"exact_match\",\"indices\": [\"some-other-index\"], \"match_field\": \"host\", " +
+            "\"enrich_fields\": [\"globalRank\", \"tldRank\", \"tld\"]}");
         ResponseException exc = expectThrows(ResponseException.class, () -> client().performRequest(putPolicyRequest));
         assertThat(exc.getMessage(),
             containsString("unable to store policy because no indices match with the specified index patterns [some-other-index]"));

--- a/x-pack/plugin/enrich/qa/rest/src/test/resources/rest-api-spec/test/enrich/10_basic.yml
+++ b/x-pack/plugin/enrich/qa/rest/src/test/resources/rest-api-spec/test/enrich/10_basic.yml
@@ -7,8 +7,8 @@
         body:
           type: exact_match
           indices: ["bar*"]
-          enrich_key: baz
-          enrich_values: ["a", "b"]
+          match_field: baz
+          enrich_fields: ["a", "b"]
   - is_true: acknowledged
 
   - do:
@@ -21,8 +21,8 @@
         name: policy-crud
   - match: { type: exact_match }
   - match: { indices: ["bar*"] }
-  - match: { enrich_key: baz }
-  - match: { enrich_values: ["a", "b"] }
+  - match: { match_field: baz }
+  - match: { enrich_fields: ["a", "b"] }
 
   - do:
       enrich.list_policy: {}
@@ -30,8 +30,8 @@
   - match: { policies.0.name: policy-crud }
   - match: { policies.0.type: exact_match }
   - match: { policies.0.indices: ["bar*"] }
-  - match: { policies.0.enrich_key: baz }
-  - match: { policies.0.enrich_values: ["a", "b"] }
+  - match: { policies.0.match_field: baz }
+  - match: { policies.0.enrich_fields: ["a", "b"] }
 
   - do:
       enrich.delete_policy:

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
@@ -128,8 +128,8 @@ public class EnrichPolicyRunner implements Runnable {
             }
             // Validate the key and values
             try {
-                validateField(mapping, policy.getEnrichKey(), true);
-                for (String valueFieldName : policy.getEnrichValues()) {
+                validateField(mapping, policy.getMatchField(), true);
+                for (String valueFieldName : policy.getEnrichFields()) {
                     validateField(mapping, valueFieldName, false);
                 }
             } catch (ElasticsearchException e) {
@@ -210,14 +210,14 @@ public class EnrichPolicyRunner implements Runnable {
                         .field("enabled", true)
                     .endObject()
                     .startObject("properties")
-                        .startObject(policy.getEnrichKey())
+                        .startObject(policy.getMatchField())
                             .field("type", keyType)
                             .field("doc_values", false)
                         .endObject()
                     .endObject()
                     .startObject("_meta")
                         .field(ENRICH_POLICY_FIELD_NAME, policyName)
-                        .field(ENRICH_KEY_FIELD_NAME, policy.getEnrichKey())
+                        .field(ENRICH_KEY_FIELD_NAME, policy.getMatchField())
                     .endObject()
                 .endObject()
             .endObject();
@@ -254,8 +254,8 @@ public class EnrichPolicyRunner implements Runnable {
         logger.debug("Policy [{}]: Transferring source data to new enrich index [{}]", policyName, destinationIndexName);
         // Filter down the source fields to just the ones required by the policy
         final Set<String> retainFields = new HashSet<>();
-        retainFields.add(policy.getEnrichKey());
-        retainFields.addAll(policy.getEnrichValues());
+        retainFields.add(policy.getMatchField());
+        retainFields.addAll(policy.getEnrichFields());
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchSourceBuilder.size(fetchSize);
         searchSourceBuilder.fetchSource(retainFields.toArray(new String[0]), new String[0]);

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichProcessorFactory.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichProcessorFactory.java
@@ -34,7 +34,7 @@ final class EnrichProcessorFactory implements Processor.Factory, Consumer<Cluste
             throw new IllegalArgumentException("policy [" + policyName + "] does not exists");
         }
 
-        String enrichKey = ConfigurationUtils.readStringProperty(TYPE, tag, config, "enrich_key", policy.getEnrichKey());
+        String enrichKey = ConfigurationUtils.readStringProperty(TYPE, tag, config, "enrich_key", policy.getMatchField());
         boolean ignoreMissing = ConfigurationUtils.readBooleanProperty(TYPE, tag, config, "ignore_missing", false);
         boolean overrideEnabled = ConfigurationUtils.readBooleanProperty(TYPE, tag, config, "override", true);
 
@@ -61,7 +61,7 @@ final class EnrichProcessorFactory implements Processor.Factory, Consumer<Cluste
         }
 
         for (EnrichSpecification specification : specifications) {
-            if (policy.getEnrichValues().contains(specification.sourceField) == false) {
+            if (policy.getEnrichFields().contains(specification.sourceField) == false) {
                 throw new IllegalArgumentException("source field [" + specification.sourceField + "] does not exist in policy [" +
                     policyName + "]");
             }

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyTests.java
@@ -89,7 +89,7 @@ public class EnrichPolicyTests extends AbstractSerializingTestCase<EnrichPolicy>
             assertThat(expectedInstance.getQuery(), nullValue());
         }
         assertThat(newInstance.getIndices(), equalTo(expectedInstance.getIndices()));
-        assertThat(newInstance.getEnrichKey(), equalTo(expectedInstance.getEnrichKey()));
-        assertThat(newInstance.getEnrichValues(), equalTo(expectedInstance.getEnrichValues()));
+        assertThat(newInstance.getMatchField(), equalTo(expectedInstance.getMatchField()));
+        assertThat(newInstance.getEnrichFields(), equalTo(expectedInstance.getEnrichFields()));
     }
 }


### PR DESCRIPTION
Renamed `enrich_key` to `match_field` and
renamed `enrich_values` to `enrich_fields`.

Relates #32789