### PR TITLE
Fix remote cache misses for checkstyle tasks

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
@@ -237,16 +237,12 @@ class PrecommitTasks {
         // on them. We also want `precommit` to depend on `checkstyle`.
         project.pluginManager.apply('checkstyle')
         project.checkstyle {
-            config = project.resources.text.fromFile(checkstyleConf, 'UTF-8')
-            configProperties = [
-                    suppressions: checkstyleSuppressions
-            ]
+            configDir = checkstyleDir
             toolVersion = CHECKSTYLE_VERSION
         }
 
         project.tasks.withType(Checkstyle).configureEach { task ->
             task.dependsOn(copyCheckstyleConf)
-            task.inputs.file(checkstyleSuppressions)
             task.reports {
                 html.enabled false
             }

--- a/buildSrc/src/main/resources/checkstyle.xml
+++ b/buildSrc/src/main/resources/checkstyle.xml
@@ -7,7 +7,7 @@
   <property name="charset" value="UTF-8" />
 
   <module name="SuppressionFilter">
-    <property name="file" value="${suppressions}" />
+    <property name="file" value="${config_loc}/checkstyle_suppressions.xml" />
   </module>
 
   <!-- Checks Java files and forbids empty Javadoc comments -->


### PR DESCRIPTION
This PR addresses a problem with cache misses for checkstyle tasks. As you can see from this build scan comparison, these two builds of the identical source tree differ in the `Checkstyle` task `configProperties` property, as well as a runtime API file input.

https://gradle-enterprise.elastic.co/c/u4minwutaak3g/jabxgddp2tql6/task-inputs?expanded=WzI5Niw0MjksMTE2Ml0&task-text=checkstyleTest#j4kf4fqcsbb54

The issue here is the property replacement being done by checkstyle for the location of our suppressions config file. We use a token `${suppressions}` in our `checkstyle.xml` file to be a stand in for the location of the suppression file to use. We then pass the real value to the task via the `configProperties` task property. The issue here is that because the value given to `configProperties` is an _absolute_ path, this makes cache reusing across different workspaces impossible.

To fix this we simply use the `configDir` task property instead, since we already copy these files into project-specific build directories. We can then use the standard `${config_loc}` checkstyle property to resolve a relative path to an absolute one without the absolute path leaking into the Gradle task inputs.