### PR TITLE
Safe publication of DelayedAllocationService and SnapshotShardsService

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/DelayedAllocationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/DelayedAllocationService.java
@@ -135,20 +135,20 @@ public class DelayedAllocationService extends AbstractLifecycleComponent impleme
         this.threadPool = threadPool;
         this.clusterService = clusterService;
         this.allocationService = allocationService;
-        clusterService.addListener(this);
     }
 
     @Override
     protected void doStart() {
+        clusterService.addListener(this);
     }
 
     @Override
     protected void doStop() {
+        clusterService.removeListener(this);
     }
 
     @Override
     protected void doClose() {
-        clusterService.removeListener(this);
         removeTaskAndCancel();
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/DelayedAllocationServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/DelayedAllocationServiceTests.java
@@ -69,11 +69,13 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
         clusterService = mock(ClusterService.class);
         allocationService = createAllocationService(Settings.EMPTY, new DelayedShardsMockGatewayAllocator());
         delayedAllocationService = new TestDelayAllocationService(threadPool, clusterService, allocationService);
+        delayedAllocationService.doStart();
         verify(clusterService).addListener(delayedAllocationService);
     }
 
     @After
     public void shutdownThreadPool() throws Exception {
+        delayedAllocationService.doStop();
         terminate(threadPool);
     }
 


### PR DESCRIPTION
These two classes were leaking a reference to themselves when adding themselves
as listeners to the cluster service prior to being completely initialized

these two instances were fixed by leveraging doStart/doStop to represent
start/stop lifecycle points for when these objects are registered listeners.

Relates #38560