### PR TITLE
Restore check part 1 and 2 order mistakenly reversed in [#45098]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -524,9 +524,9 @@ allprojects {
   def checkPart2 = tasks.register('checkPart2')
   plugins.withId('lifecycle-base') {
       if (project.path.startsWith(":x-pack:")) {
-          checkPart1.configure { dependsOn 'check' }
-      } else {
           checkPart2.configure { dependsOn 'check' }
+      } else {
+          checkPart1.configure { dependsOn 'check' }
       }
   }
 }


### PR DESCRIPTION
As part of the refactoring done in #45098, the configuration of `checkPart1` and `checkPart2` tasks was mistakenly reversed. The intention is for part1 to be all OSS projects and part2 to be x-pack projects. This reverts that change so we are consistent with regards to the scope of these tasks across all branches.