### PR TITLE
Clear vault secrets from the environment

### DIFF
--- a/.ci/init.gradle
+++ b/.ci/init.gradle
@@ -26,7 +26,7 @@ if (System.env.VAULT_TOKEN == null) {
     }
 }
 
-final String vaultToken = System.env.VAULT_TOKEN :?   new Vault(
+final String vaultToken = System.env.VAULT_TOKEN ?:   new Vault(
         new VaultConfig()
             .address(System.env.VAULT_ADDR)
             .engineVersion(1)

--- a/.ci/init.gradle
+++ b/.ci/init.gradle
@@ -13,14 +13,20 @@ initscript {
     }
 }
 
-['VAULT_ADDR', 'VAULT_ROLE_ID', 'VAULT_SECRET_ID'].each {
-    if (System.env."$it" == null) {
-        throw new GradleException("$it must be set!")
+if (System.env.VAULT_ADDR == null) {
+    throw new GradleException("You must set the VAULT_ADDR environment variable to use this init script.")
+}
 
+if (System.env.VAULT_TOKEN == null) {
+    ['VAULT_ROLE_ID', 'VAULT_SECRET_ID'].each {
+        if (System.env."$it" == null) {
+            throw new GradleException("$it must be set!")
+
+        }
     }
 }
 
-final String vaultToken =  new Vault(
+final String vaultToken = System.env.VAULT_TOKEN :?   new Vault(
         new VaultConfig()
             .address(System.env.VAULT_ADDR)
             .engineVersion(1)
@@ -30,7 +36,6 @@ final String vaultToken =  new Vault(
     .auth()
     .loginByAppRole("approle", System.env.VAULT_ROLE_ID, System.env.VAULT_SECRET_ID)
     .getAuthClientToken();
-
 
 
 final Vault vault = new Vault(

--- a/.ci/init.gradle
+++ b/.ci/init.gradle
@@ -1,12 +1,15 @@
 import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.Vault;
+import net.rubygrapefruit.platform.Native;
+import net.rubygrapefruit.platform.Process
 
 initscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
     dependencies {
         classpath 'com.bettercloud:vault-java-driver:4.1.0'
+        classpath "net.rubygrapefruit:native-platform:0.18"
     }
 }
 
@@ -28,6 +31,8 @@ final String vaultToken =  new Vault(
     .loginByAppRole("approle", System.env.VAULT_ROLE_ID, System.env.VAULT_SECRET_ID)
     .getAuthClientToken();
 
+
+
 final Vault vault = new Vault(
      new VaultConfig()
         .address(System.env.VAULT_ADDR)
@@ -36,6 +41,14 @@ final Vault vault = new Vault(
         .build()
 )
         .withRetries(5, 1000)
+    
+Process process = Native.get(Process.class)
+// Remove initial credentials from the envirnemnt so the build can't access them
+['VAULT_ROLE_ID', 'VAULT_SECRET_ID'].each { 
+    process.setEnvironmentVariable(it, null)
+}
+// export the token so the build could still talk with vault
+process.setEnvironmentVariable("VAULT_TOKEN", vaultToken)   
 
 final Map<String,String> artifactoryCredentials = vault.logical()
         .read("secret/elasticsearch-ci/artifactory.elstc.co")


### PR DESCRIPTION
We used to unset the credentials to access the vault app role in CI and
only ever allowed the build to see a token.
With elastic/infra#13480 we changed this so that we could read the
secrets to access artifactory from the init script used in CI, which
made it so that the build could now access these secrets.

With this change we take things back to how they were, the build doesn't
bave access to the Ids any more, only the token.

