### PR TITLE
Fix bats distro test to build distributions

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/DistroTestPlugin.java
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/DistroTestPlugin.java
@@ -283,7 +283,7 @@ public class DistroTestPlugin implements Plugin<Project> {
     }
 
     private static TaskProvider<BatsTestTask> configureBatsTest(Project project, String type, Provider<Directory> distributionsDir,
-                                                                TaskProvider<Copy> copyPackagingArchives, Object... deps) {
+                                                                Object... deps) {
         return project.getTasks().register("destructiveBatsTest." + type, BatsTestTask.class,
             t -> {
                 Directory batsDir = project.getLayout().getProjectDirectory().dir("bats");


### PR DESCRIPTION
The dependency on copying distributions was accidentally masked by an
earlier refactoring. This commit fixes the copyDistributions task to be
run before bats tests run.