### PR TITLE
HLRC for memory usage estimation API

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/MLRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/MLRequestConverters.java
@@ -39,6 +39,7 @@ import org.elasticsearch.client.ml.DeleteFilterRequest;
 import org.elasticsearch.client.ml.DeleteForecastRequest;
 import org.elasticsearch.client.ml.DeleteJobRequest;
 import org.elasticsearch.client.ml.DeleteModelSnapshotRequest;
+import org.elasticsearch.client.ml.EstimateMemoryUsageRequest;
 import org.elasticsearch.client.ml.EvaluateDataFrameRequest;
 import org.elasticsearch.client.ml.FindFileStructureRequest;
 import org.elasticsearch.client.ml.FlushJobRequest;
@@ -697,6 +698,15 @@ final class MLRequestConverters {
             .build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
         request.setEntity(createEntity(evaluateRequest, REQUEST_BODY_CONTENT_TYPE));
+        return request;
+    }
+
+    static Request estimateMemoryUsage(EstimateMemoryUsageRequest estimateRequest) throws IOException {
+        String endpoint = new EndpointBuilder()
+            .addPathPartAsIs("_ml", "data_frame", "analytics", "_estimate_memory_usage")
+            .build();
+        Request request = new Request(HttpPost.METHOD_NAME, endpoint);
+        request.setEntity(createEntity(estimateRequest, REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/MachineLearningClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/MachineLearningClient.java
@@ -34,6 +34,8 @@ import org.elasticsearch.client.ml.DeleteForecastRequest;
 import org.elasticsearch.client.ml.DeleteJobRequest;
 import org.elasticsearch.client.ml.DeleteJobResponse;
 import org.elasticsearch.client.ml.DeleteModelSnapshotRequest;
+import org.elasticsearch.client.ml.EstimateMemoryUsageRequest;
+import org.elasticsearch.client.ml.EstimateMemoryUsageResponse;
 import org.elasticsearch.client.ml.EvaluateDataFrameRequest;
 import org.elasticsearch.client.ml.EvaluateDataFrameResponse;
 import org.elasticsearch.client.ml.FindFileStructureRequest;
@@ -2182,6 +2184,48 @@ public final class MachineLearningClient {
             MLRequestConverters::evaluateDataFrame,
             options,
             EvaluateDataFrameResponse::fromXContent,
+            listener,
+            Collections.emptySet());
+    }
+
+    /**
+     * Estimates memory usage for the given Data Frame Analytics
+     * <p>
+     * For additional info
+     * see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/estimate-memory-usage-dfanalytics.html">
+     *     Estimate Memory Usage for Data Frame Analytics documentation</a>
+     *
+     * @param request The {@link EstimateMemoryUsageRequest}
+     * @param options Additional request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @return {@link EstimateMemoryUsageResponse} response object
+     * @throws IOException when there is a serialization issue sending the request or receiving the response
+     */
+    public EstimateMemoryUsageResponse estimateMemoryUsage(EstimateMemoryUsageRequest request,
+                                                           RequestOptions options) throws IOException {
+        return restHighLevelClient.performRequestAndParseEntity(request,
+            MLRequestConverters::estimateMemoryUsage,
+            options,
+            EstimateMemoryUsageResponse::fromXContent,
+            Collections.emptySet());
+    }
+
+    /**
+     * Estimates memory usage for the given Data Frame Analytics asynchronously and notifies listener upon completion
+     * <p>
+     * For additional info
+     * see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/estimate-memory-usage-dfanalytics.html">
+     *     Estimate Memory Usage for Data Frame Analytics documentation</a>
+     *
+     * @param request The {@link EstimateMemoryUsageRequest}
+     * @param options Additional request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @param listener Listener to be notified upon request completion
+     */
+    public void estimateMemoryUsageAsync(EstimateMemoryUsageRequest request, RequestOptions options,
+                                         ActionListener<EstimateMemoryUsageResponse> listener) {
+        restHighLevelClient.performRequestAsyncAndParseEntity(request,
+            MLRequestConverters::estimateMemoryUsage,
+            options,
+            EstimateMemoryUsageResponse::fromXContent,
             listener,
             Collections.emptySet());
     }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/EstimateMemoryUsageRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/EstimateMemoryUsageRequest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.ml;
+
+import org.elasticsearch.client.Validatable;
+import org.elasticsearch.client.ml.dataframe.DataFrameAnalyticsConfig;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+
+public class EstimateMemoryUsageRequest implements ToXContentObject, Validatable {
+
+    private static final ParseField DATA_FRAME_ANALYTICS_CONFIG = new ParseField("data_frame_analytics_config");
+
+    private static final ConstructingObjectParser<EstimateMemoryUsageRequest, Void> PARSER =
+        new ConstructingObjectParser<>(
+            "estimate_memory_usage_request",
+            true,
+            args -> {
+                DataFrameAnalyticsConfig config = (DataFrameAnalyticsConfig) args[0];
+                return new EstimateMemoryUsageRequest(config);
+            });
+
+    static {
+        PARSER.declareObject(constructorArg(), (p, c) -> DataFrameAnalyticsConfig.fromXContent(p), DATA_FRAME_ANALYTICS_CONFIG);
+    }
+
+    public static EstimateMemoryUsageRequest fromXContent(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+
+    private final DataFrameAnalyticsConfig config;
+
+    public EstimateMemoryUsageRequest(DataFrameAnalyticsConfig config) {
+        this.config = Objects.requireNonNull(config);
+    }
+
+    public DataFrameAnalyticsConfig getConfig() {
+        return config;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(DATA_FRAME_ANALYTICS_CONFIG.getPreferredName(), config);
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        EstimateMemoryUsageRequest that = (EstimateMemoryUsageRequest) other;
+        return Objects.equals(config, that.config);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(config);
+    }
+}

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/EstimateMemoryUsageResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/EstimateMemoryUsageResponse.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.ml;
+
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+public class EstimateMemoryUsageResponse implements ToXContentObject {
+    
+    public static final ParseField EXPECTED_MEMORY_USAGE_WITH_ONE_PARTITION =
+        new ParseField("expected_memory_usage_with_one_partition");
+    public static final ParseField EXPECTED_MEMORY_USAGE_WITH_MAX_PARTITIONS =
+        new ParseField("expected_memory_usage_with_max_partitions");
+
+    static final ConstructingObjectParser<EstimateMemoryUsageResponse, Void> PARSER =
+        new ConstructingObjectParser<>(
+            "estimate_memory_usage_response",
+            true,
+            args -> new EstimateMemoryUsageResponse((ByteSizeValue) args[0], (ByteSizeValue) args[1]));
+
+    static {
+        PARSER.declareField(
+            optionalConstructorArg(),
+            (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), EXPECTED_MEMORY_USAGE_WITH_ONE_PARTITION.getPreferredName()),
+            EXPECTED_MEMORY_USAGE_WITH_ONE_PARTITION,
+            ObjectParser.ValueType.VALUE);
+        PARSER.declareField(
+            optionalConstructorArg(),
+            (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), EXPECTED_MEMORY_USAGE_WITH_MAX_PARTITIONS.getPreferredName()),
+            EXPECTED_MEMORY_USAGE_WITH_MAX_PARTITIONS,
+            ObjectParser.ValueType.VALUE);
+    }
+
+    public static EstimateMemoryUsageResponse fromXContent(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+
+    private final ByteSizeValue expectedMemoryUsageWithOnePartition;
+    private final ByteSizeValue expectedMemoryUsageWithMaxPartitions;
+
+    public EstimateMemoryUsageResponse(@Nullable ByteSizeValue expectedMemoryUsageWithOnePartition,
+                                       @Nullable ByteSizeValue expectedMemoryUsageWithMaxPartitions) {
+        this.expectedMemoryUsageWithOnePartition = expectedMemoryUsageWithOnePartition;
+        this.expectedMemoryUsageWithMaxPartitions = expectedMemoryUsageWithMaxPartitions;
+    }
+
+    public ByteSizeValue getExpectedMemoryUsageWithOnePartition() {
+        return expectedMemoryUsageWithOnePartition;
+    }
+
+    public ByteSizeValue getExpectedMemoryUsageWithMaxPartitions() {
+        return expectedMemoryUsageWithMaxPartitions;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        if (expectedMemoryUsageWithOnePartition != null) {
+            builder.field(
+                EXPECTED_MEMORY_USAGE_WITH_ONE_PARTITION.getPreferredName(), expectedMemoryUsageWithOnePartition.getStringRep());
+        }
+        if (expectedMemoryUsageWithMaxPartitions != null) {
+            builder.field(
+                EXPECTED_MEMORY_USAGE_WITH_MAX_PARTITIONS.getPreferredName(), expectedMemoryUsageWithMaxPartitions.getStringRep());
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        EstimateMemoryUsageResponse that = (EstimateMemoryUsageResponse) other;
+        return Objects.equals(expectedMemoryUsageWithOnePartition, that.expectedMemoryUsageWithOnePartition)
+            && Objects.equals(expectedMemoryUsageWithMaxPartitions, that.expectedMemoryUsageWithMaxPartitions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(expectedMemoryUsageWithOnePartition, expectedMemoryUsageWithMaxPartitions);
+    }
+}

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -43,8 +43,8 @@ public class DataFrameAnalyticsConfig implements ToXContentObject {
         return PARSER.apply(parser, null).build();
     }
 
-    public static Builder builder(String id) {
-        return new Builder().setId(id);
+    public static Builder builder() {
+        return new Builder();
     }
 
     private static final ParseField ID = new ParseField("id");
@@ -103,13 +103,13 @@ public class DataFrameAnalyticsConfig implements ToXContentObject {
     private final Instant createTime;
     private final Version version;
 
-    private DataFrameAnalyticsConfig(String id, DataFrameAnalyticsSource source, DataFrameAnalyticsDest dest, DataFrameAnalysis analysis,
-                                     @Nullable FetchSourceContext analyzedFields, @Nullable ByteSizeValue modelMemoryLimit,
-                                     @Nullable Instant createTime, @Nullable Version version) {
-        this.id = Objects.requireNonNull(id);
-        this.source = Objects.requireNonNull(source);
-        this.dest = Objects.requireNonNull(dest);
-        this.analysis = Objects.requireNonNull(analysis);
+    private DataFrameAnalyticsConfig(@Nullable String id, @Nullable DataFrameAnalyticsSource source, @Nullable DataFrameAnalyticsDest dest,
+                                     @Nullable DataFrameAnalysis analysis, @Nullable FetchSourceContext analyzedFields,
+                                     @Nullable ByteSizeValue modelMemoryLimit, @Nullable Instant createTime, @Nullable Version version) {
+        this.id = id;
+        this.source = source;
+        this.dest = dest;
+        this.analysis = analysis;
         this.analyzedFields = analyzedFields;
         this.modelMemoryLimit = modelMemoryLimit;
         this.createTime = createTime == null ? null : Instant.ofEpochMilli(createTime.toEpochMilli());;
@@ -151,12 +151,21 @@ public class DataFrameAnalyticsConfig implements ToXContentObject {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(ID.getPreferredName(), id);
-        builder.field(SOURCE.getPreferredName(), source);
-        builder.field(DEST.getPreferredName(), dest);
-        builder.startObject(ANALYSIS.getPreferredName());
-        builder.field(analysis.getName(), analysis);
-        builder.endObject();
+        if (id != null) {
+            builder.field(ID.getPreferredName(), id);
+        }
+        if (source != null) {
+            builder.field(SOURCE.getPreferredName(), source);
+        }
+        if (dest != null) {
+            builder.field(DEST.getPreferredName(), dest);
+        }
+        if (analysis != null) {
+            builder
+                .startObject(ANALYSIS.getPreferredName())
+                .field(analysis.getName(), analysis)
+                .endObject();
+        }
         if (analyzedFields != null) {
             builder.field(ANALYZED_FIELDS.getPreferredName(), analyzedFields);
         }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MLRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MLRequestConvertersTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.client.ml.DeleteFilterRequest;
 import org.elasticsearch.client.ml.DeleteForecastRequest;
 import org.elasticsearch.client.ml.DeleteJobRequest;
 import org.elasticsearch.client.ml.DeleteModelSnapshotRequest;
+import org.elasticsearch.client.ml.EstimateMemoryUsageRequest;
 import org.elasticsearch.client.ml.EvaluateDataFrameRequest;
 import org.elasticsearch.client.ml.FindFileStructureRequest;
 import org.elasticsearch.client.ml.FindFileStructureRequestTests;
@@ -792,6 +793,17 @@ public class MLRequestConvertersTests extends ESTestCase {
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, request.getEntity().getContent())) {
             EvaluateDataFrameRequest parsedRequest = EvaluateDataFrameRequest.fromXContent(parser);
             assertThat(parsedRequest, equalTo(evaluateRequest));
+        }
+    }
+
+    public void testEstimateMemoryUsage() throws IOException {
+        EstimateMemoryUsageRequest estimateRequest = new EstimateMemoryUsageRequest(randomDataFrameAnalyticsConfig());
+        Request request = MLRequestConverters.estimateMemoryUsage(estimateRequest);
+        assertEquals(HttpPost.METHOD_NAME, request.getMethod());
+        assertEquals("/_ml/data_frame/analytics/_estimate_memory_usage", request.getEndpoint());
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, request.getEntity().getContent())) {
+            EstimateMemoryUsageRequest parsedRequest = EstimateMemoryUsageRequest.fromXContent(parser);
+            assertThat(parsedRequest, equalTo(estimateRequest));
         }
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
@@ -44,6 +44,8 @@ import org.elasticsearch.client.ml.DeleteForecastRequest;
 import org.elasticsearch.client.ml.DeleteJobRequest;
 import org.elasticsearch.client.ml.DeleteJobResponse;
 import org.elasticsearch.client.ml.DeleteModelSnapshotRequest;
+import org.elasticsearch.client.ml.EstimateMemoryUsageRequest;
+import org.elasticsearch.client.ml.EstimateMemoryUsageResponse;
 import org.elasticsearch.client.ml.EvaluateDataFrameRequest;
 import org.elasticsearch.client.ml.EvaluateDataFrameResponse;
 import org.elasticsearch.client.ml.FindFileStructureRequest;
@@ -141,6 +143,7 @@ import org.elasticsearch.client.ml.job.config.JobUpdate;
 import org.elasticsearch.client.ml.job.config.MlFilter;
 import org.elasticsearch.client.ml.job.process.ModelSnapshot;
 import org.elasticsearch.client.ml.job.stats.JobStats;
+import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -167,13 +170,16 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.notNullValue;
 
 public class MachineLearningIT extends ESRestHighLevelClientTestCase {
@@ -1211,7 +1217,8 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
     public void testPutDataFrameAnalyticsConfig() throws Exception {
         MachineLearningClient machineLearningClient = highLevelClient().machineLearning();
         String configId = "put-test-config";
-        DataFrameAnalyticsConfig config = DataFrameAnalyticsConfig.builder(configId)
+        DataFrameAnalyticsConfig config = DataFrameAnalyticsConfig.builder()
+            .setId(configId)
             .setSource(DataFrameAnalyticsSource.builder()
                 .setIndex("put-test-source-index")
                 .build())
@@ -1240,7 +1247,8 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
     public void testGetDataFrameAnalyticsConfig_SingleConfig() throws Exception {
         MachineLearningClient machineLearningClient = highLevelClient().machineLearning();
         String configId = "get-test-config";
-        DataFrameAnalyticsConfig config = DataFrameAnalyticsConfig.builder(configId)
+        DataFrameAnalyticsConfig config = DataFrameAnalyticsConfig.builder()
+            .setId(configId)
             .setSource(DataFrameAnalyticsSource.builder()
                 .setIndex("get-test-source-index")
                 .build())
@@ -1273,7 +1281,8 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
         List<DataFrameAnalyticsConfig> createdConfigs = new ArrayList<>();
         for (int i = 0; i < numberOfConfigs; ++i) {
             String configId = configIdPrefix + i;
-            DataFrameAnalyticsConfig config = DataFrameAnalyticsConfig.builder(configId)
+            DataFrameAnalyticsConfig config = DataFrameAnalyticsConfig.builder()
+                .setId(configId)
                 .setSource(DataFrameAnalyticsSource.builder()
                     .setIndex("get-test-source-index")
                     .build())
@@ -1342,7 +1351,8 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
 
         MachineLearningClient machineLearningClient = highLevelClient().machineLearning();
         String configId = "get-stats-test-config";
-        DataFrameAnalyticsConfig config = DataFrameAnalyticsConfig.builder(configId)
+        DataFrameAnalyticsConfig config = DataFrameAnalyticsConfig.builder()
+            .setId(configId)
             .setSource(DataFrameAnalyticsSource.builder()
                 .setIndex(sourceIndex)
                 .build())
@@ -1384,7 +1394,8 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
 
         MachineLearningClient machineLearningClient = highLevelClient().machineLearning();
         String configId = "start-test-config";
-        DataFrameAnalyticsConfig config = DataFrameAnalyticsConfig.builder(configId)
+        DataFrameAnalyticsConfig config = DataFrameAnalyticsConfig.builder()
+            .setId(configId)
             .setSource(DataFrameAnalyticsSource.builder()
                 .setIndex(sourceIndex)
                 .build())
@@ -1424,7 +1435,8 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
 
         MachineLearningClient machineLearningClient = highLevelClient().machineLearning();
         String configId = "stop-test-config";
-        DataFrameAnalyticsConfig config = DataFrameAnalyticsConfig.builder(configId)
+        DataFrameAnalyticsConfig config = DataFrameAnalyticsConfig.builder()
+            .setId(configId)
             .setSource(DataFrameAnalyticsSource.builder()
                 .setIndex(sourceIndex)
                 .build())
@@ -1465,7 +1477,8 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
     public void testDeleteDataFrameAnalyticsConfig() throws Exception {
         MachineLearningClient machineLearningClient = highLevelClient().machineLearning();
         String configId = "delete-test-config";
-        DataFrameAnalyticsConfig config = DataFrameAnalyticsConfig.builder(configId)
+        DataFrameAnalyticsConfig config = DataFrameAnalyticsConfig.builder()
+            .setId(configId)
             .setSource(DataFrameAnalyticsSource.builder()
                 .setIndex("delete-test-source-index")
                 .build())
@@ -1675,6 +1688,54 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
 
     private void createIndex(String indexName, XContentBuilder mapping) throws IOException {
         highLevelClient().indices().create(new CreateIndexRequest(indexName).mapping(mapping), RequestOptions.DEFAULT);
+    }
+
+    public void testEstimateMemoryUsage() throws IOException {
+        String indexName = "estimate-test-index";
+        createIndex(indexName, mappingForClassification());
+        BulkRequest bulk1 = new BulkRequest()
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        for (int i = 0; i < 10; ++i) {
+            bulk1.add(docForClassification(indexName, randomBoolean(), randomDoubleBetween(0.0, 1.0, true)));
+        }
+        highLevelClient().bulk(bulk1, RequestOptions.DEFAULT);
+
+        MachineLearningClient machineLearningClient = highLevelClient().machineLearning();
+        EstimateMemoryUsageRequest estimateMemoryUsageRequest =
+            new EstimateMemoryUsageRequest(
+                DataFrameAnalyticsConfig.builder()
+                    .setSource(DataFrameAnalyticsSource.builder().setIndex(indexName).build())
+                    .setAnalysis(OutlierDetection.createDefault())
+                    .build());
+
+        // We are pretty liberal here as this test does not aim at verifying concrete numbers but rather end-to-end user workflow.
+        ByteSizeValue lowerBound = new ByteSizeValue(1, ByteSizeUnit.KB);
+        ByteSizeValue upperBound = new ByteSizeValue(1, ByteSizeUnit.GB);
+
+        // Data Frame has 10 rows, expect that the returned estimates fall within (1kB, 1GB) range.
+        EstimateMemoryUsageResponse response1 =
+            execute(
+                estimateMemoryUsageRequest, machineLearningClient::estimateMemoryUsage, machineLearningClient::estimateMemoryUsageAsync);
+        assertThat(response1.getExpectedMemoryUsageWithOnePartition(), allOf(greaterThan(lowerBound), lessThan(upperBound)));
+        assertThat(response1.getExpectedMemoryUsageWithMaxPartitions(), allOf(greaterThan(lowerBound), lessThan(upperBound)));
+
+        BulkRequest bulk2 = new BulkRequest()
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        for (int i = 10; i < 100; ++i) {
+            bulk2.add(docForClassification(indexName, randomBoolean(), randomDoubleBetween(0.0, 1.0, true)));
+        }
+        highLevelClient().bulk(bulk2, RequestOptions.DEFAULT);
+
+        // Data Frame now has 100 rows, expect that the returned estimates will be greater than the previous ones.
+        EstimateMemoryUsageResponse response2 =
+            execute(
+                estimateMemoryUsageRequest, machineLearningClient::estimateMemoryUsage, machineLearningClient::estimateMemoryUsageAsync);
+        assertThat(
+            response2.getExpectedMemoryUsageWithOnePartition(),
+            allOf(greaterThan(response1.getExpectedMemoryUsageWithOnePartition()), lessThan(upperBound)));
+        assertThat(
+            response2.getExpectedMemoryUsageWithMaxPartitions(),
+            allOf(greaterThan(response1.getExpectedMemoryUsageWithMaxPartitions()), lessThan(upperBound)));
     }
 
     public void testPutFilter() throws Exception {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
@@ -2941,7 +2941,8 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
             // end::put-data-frame-analytics-analyzed-fields
 
             // tag::put-data-frame-analytics-config
-            DataFrameAnalyticsConfig config = DataFrameAnalyticsConfig.builder("my-analytics-config") // <1>
+            DataFrameAnalyticsConfig config = DataFrameAnalyticsConfig.builder()
+                .setId("my-analytics-config") // <1>
                 .setSource(sourceConfig) // <2>
                 .setDest(destConfig) // <3>
                 .setAnalysis(outlierDetection) // <4>
@@ -3624,7 +3625,8 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
     }
 
     private static final DataFrameAnalyticsConfig DF_ANALYTICS_CONFIG =
-        DataFrameAnalyticsConfig.builder("my-analytics-config")
+        DataFrameAnalyticsConfig.builder()
+            .setId("my-analytics-config")
             .setSource(DataFrameAnalyticsSource.builder()
                 .setIndex("put-test-source-index")
                 .build())

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/EstimateMemoryUsageRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/EstimateMemoryUsageRequestTests.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.client.ml;
+
+import org.elasticsearch.client.ml.dataframe.DataFrameAnalyticsConfigTests;
+import org.elasticsearch.client.ml.dataframe.MlDataFrameAnalysisNamedXContentProvider;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.test.AbstractXContentTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
+
+public class EstimateMemoryUsageRequestTests extends AbstractXContentTestCase<EstimateMemoryUsageRequest> {
+
+    public static EstimateMemoryUsageRequest randomRequest() {
+        return new EstimateMemoryUsageRequest(DataFrameAnalyticsConfigTests.randomDataFrameAnalyticsConfig());
+    }
+
+    @Override
+    protected EstimateMemoryUsageRequest createTestInstance() {
+        return randomRequest();
+    }
+
+    @Override
+    protected EstimateMemoryUsageRequest doParseInstance(XContentParser parser) throws IOException {
+        return EstimateMemoryUsageRequest.fromXContent(parser);
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return true;
+    }
+
+    @Override
+    protected Predicate<String> getRandomFieldsExcludeFilter() {
+        return field -> field.contains(".");
+    }
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        List<NamedXContentRegistry.Entry> namedXContent = new ArrayList<>();
+        namedXContent.addAll(new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedXContents());
+        namedXContent.addAll(new MlDataFrameAnalysisNamedXContentProvider().getNamedXContentParsers());
+        return new NamedXContentRegistry(namedXContent);
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/EstimateMemoryUsageResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/EstimateMemoryUsageResponseTests.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.client.ml;
+
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractXContentTestCase;
+
+import java.io.IOException;
+
+public class EstimateMemoryUsageResponseTests extends AbstractXContentTestCase<EstimateMemoryUsageResponse> {
+
+    public static EstimateMemoryUsageResponse randomResponse() {
+        return new EstimateMemoryUsageResponse(
+            randomBoolean() ? new ByteSizeValue(randomNonNegativeLong()) : null,
+            randomBoolean() ? new ByteSizeValue(randomNonNegativeLong()) : null);
+    }
+
+    @Override
+    protected EstimateMemoryUsageResponse createTestInstance() {
+        return randomResponse();
+    }
+
+    @Override
+    protected EstimateMemoryUsageResponse doParseInstance(XContentParser parser) throws IOException {
+        return EstimateMemoryUsageResponse.fromXContent(parser);
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return true;
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/dataframe/DataFrameAnalyticsConfigTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/dataframe/DataFrameAnalyticsConfigTests.java
@@ -44,7 +44,8 @@ public class DataFrameAnalyticsConfigTests extends AbstractXContentTestCase<Data
 
     public static DataFrameAnalyticsConfig randomDataFrameAnalyticsConfig() {
         DataFrameAnalyticsConfig.Builder builder =
-            DataFrameAnalyticsConfig.builder(randomAlphaOfLengthBetween(1, 10))
+            DataFrameAnalyticsConfig.builder()
+                .setId(randomAlphaOfLengthBetween(1, 10))
                 .setSource(randomSourceConfig())
                 .setDest(randomDestConfig())
                 .setAnalysis(randomOutlierDetection());


### PR DESCRIPTION
This PR implements HLRC for memory usage estimation API introduced in #45188.
Additionally, it makes DataFrameAnalyticsConfig constructor not check for arguments being not-null. This is needed so that memory usage estimation request can be passed without "id" and "dest". For PUT requests, non-nullity of required fields is still validated by the server.

Relates https://github.com/elastic/elasticsearch/issues/44699