### PR TITLE
Fix Failures when Closing Indices in EsBlobStoreRepositoryIntegTestCase

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
@@ -131,6 +131,8 @@ public abstract class ESBlobStoreRepositoryIntegTestCase extends ESIntegTestCase
                 }
             }
 
+            // Wait for green so the close does not fail in the edge case of coinciding with a shard recovery that hasn't fully synced yet
+            ensureGreen();
             logger.info("-->  close indices {}", closeIndices);
             assertAcked(client().admin().indices().prepareClose(closeIndices.toArray(new String[closeIndices.size()])));
         }
@@ -195,6 +197,8 @@ public abstract class ESBlobStoreRepositoryIntegTestCase extends ESIntegTestCase
             int iterationToRestore = randomIntBetween(0, iterationCount - 1);
             logger.info("-->  performing restore of the iteration {}", iterationToRestore);
 
+            // Wait for green so the close does not fail in the edge case of coinciding with a shard recovery that hasn't fully synced yet
+            ensureGreen();
             logger.info("-->  close index");
             assertAcked(client().admin().indices().prepareClose(indexName));
 


### PR DESCRIPTION
* Same issue as in #44754 as far as I can see: in case of async translog persistence we randomly fail to close
* Closes #45335
* Closes #45334
