### PR TITLE
[DOCS] Reformats nodes feature usage API

### DIFF
--- a/docs/reference/cluster/nodes-usage.asciidoc
+++ b/docs/reference/cluster/nodes-usage.asciidoc
@@ -13,7 +13,7 @@ Returns information on the usage of features.
 
 `GET _nodes/usage/{metric}` +
 
-`GET _nodes/{node_id}/usage/{metric}`
+`GET /_nodes/{node_id}/usage/{metric}`
 
 
 [[cluster-nodes-usage-api-desc]]

--- a/docs/reference/cluster/nodes-usage.asciidoc
+++ b/docs/reference/cluster/nodes-usage.asciidoc
@@ -19,7 +19,7 @@ Returns information on the usage of features.
 [[cluster-nodes-usage-api-desc]]
 ==== {api-description-title}
 
-The cluster nodes usage API allows to retrieve information on the usage
+The cluster nodes usage API allows you to retrieve information on the usage
 of features for each node. All the nodes selective options are explained
 <<cluster-nodes,here>>.
 

--- a/docs/reference/cluster/nodes-usage.asciidoc
+++ b/docs/reference/cluster/nodes-usage.asciidoc
@@ -7,7 +7,7 @@ Returns information on the usage of features.
 [[cluster-nodes-usage-api-request]]
 ==== {api-request-title}
 
-`GET _nodes/usage` +
+`GET /_nodes/usage` +
 
 `GET /_nodes/{node_id}/usage` +
 

--- a/docs/reference/cluster/nodes-usage.asciidoc
+++ b/docs/reference/cluster/nodes-usage.asciidoc
@@ -9,7 +9,7 @@ Returns information on the usage of features.
 
 `GET _nodes/usage` +
 
-`GET _nodes/{node_id}/usage` +
+`GET /_nodes/{node_id}/usage` +
 
 `GET /_nodes/usage/{metric}` +
 

--- a/docs/reference/cluster/nodes-usage.asciidoc
+++ b/docs/reference/cluster/nodes-usage.asciidoc
@@ -11,7 +11,7 @@ Returns information on the usage of features.
 
 `GET _nodes/{node_id}/usage` +
 
-`GET _nodes/usage/{metric}` +
+`GET /_nodes/usage/{metric}` +
 
 `GET /_nodes/{node_id}/usage/{metric}`
 

--- a/docs/reference/cluster/nodes-usage.asciidoc
+++ b/docs/reference/cluster/nodes-usage.asciidoc
@@ -1,33 +1,62 @@
 [[cluster-nodes-usage]]
 === Nodes Feature Usage
 
-[float]
-==== Nodes usage
+Returns information on the usage of features.
+
+
+[[cluster-nodes-usage-api-request]]
+==== {api-request-title}
+
+`GET _nodes/usage` +
+
+`GET _nodes/{node_id}/usage` +
+
+`GET _nodes/usage/{metric}` +
+
+`GET _nodes/{node_id}/usage/{metric}`
+
+
+[[cluster-nodes-usage-api-desc]]
+==== {api-description-title}
 
 The cluster nodes usage API allows to retrieve information on the usage
-of features for each node.
-
-[source,js]
---------------------------------------------------
-GET _nodes/usage
-GET _nodes/nodeId1,nodeId2/usage
---------------------------------------------------
-// CONSOLE
-// TEST[setup:node]
-// TEST[s/nodeId1,nodeId2/*/]
-
-The first command retrieves usage of all the nodes in the cluster. The
-second command selectively retrieves nodes usage of only `nodeId1` and
-`nodeId2`. All the nodes selective options are explained
+of features for each node. All the nodes selective options are explained
 <<cluster-nodes,here>>.
 
-[float]
-[[rest-usage]]
-===== REST actions usage information
 
-The `rest_actions` field in the response contains a map of the REST
-actions classname with a count of the number of times that action has
-been called on the node:
+[[cluster-nodes-usage-api-path-params]]
+==== {api-path-parms-title}
+
+`{metric}`::
+    (Optional, string) Limits the information returned to the specific metrics. 
+    A comma-separated list of the following options: 
++
+--
+    `_all`::
+        Returns all stats.
+    
+    `rest_actions`::
+        Returns the REST actions classname with a count of the number of times 
+        that action has been called on the node.
+--
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=node-id]
+
+
+[[cluster-nodes-usage-api-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+
+
+[[cluster-nodes-usage-api-example]]
+==== {api-examples-title}
+
+Rest action example:
+
+`GET _nodes/usage/rest_actions`
+
+The API returns the following response:
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/cluster/nodes-usage.asciidoc
+++ b/docs/reference/cluster/nodes-usage.asciidoc
@@ -54,7 +54,12 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 Rest action example:
 
-`GET _nodes/usage/rest_actions`
+[source,js]
+--------------------------------------------------
+GET _nodes/usage
+--------------------------------------------------
+// CONSOLE
+// TEST[setup:node]
 
 The API returns the following response:
 


### PR DESCRIPTION
Relates to elastic/docs#937 and https://github.com/elastic/elasticsearch/issues/45197.

This PR updates the nodes feature usage API to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc).

Resources:
* [Cluster nodes feature usage API spec](https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.usage.json)
* [Cluster nodes feature usage API doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-usage.html)