### PR TITLE
[DOCS] Reformats cluster remote info API

### DIFF
--- a/docs/reference/cluster/remote-info.asciidoc
+++ b/docs/reference/cluster/remote-info.asciidoc
@@ -1,20 +1,24 @@
 [[cluster-remote-info]]
 === Remote Cluster Info
 
+Returns configured remote cluster information.
+
+[[cluster-remote-info-api-request]]
+==== {api-request-title}
+
+`GET /_remote/info`
+
+
+[[cluster-remote-info-api-desc]]
+==== {api-description-title}
+
 The cluster remote info API allows to retrieve all of the configured
-remote cluster information.
+remote cluster information. It returns connection and endpoint information keyed 
+by the configured remote cluster alias.
 
-[source,js]
-----------------------------------
-GET /_remote/info
-----------------------------------
-// CONSOLE
 
-This command returns connection and endpoint information keyed by
-the configured remote cluster alias.
-
-[float]
-[[connection-info]]
+[[cluster-remote-info-api-response-body]]
+==== {api-response-body-title}
 
 `seeds`::
 	The configured initial seed transport addresses of the remote cluster.

--- a/docs/reference/cluster/remote-info.asciidoc
+++ b/docs/reference/cluster/remote-info.asciidoc
@@ -3,6 +3,7 @@
 
 Returns configured remote cluster information.
 
+
 [[cluster-remote-info-api-request]]
 ==== {api-request-title}
 

--- a/docs/reference/cluster/remote-info.asciidoc
+++ b/docs/reference/cluster/remote-info.asciidoc
@@ -13,7 +13,7 @@ Returns configured remote cluster information.
 [[cluster-remote-info-api-desc]]
 ==== {api-description-title}
 
-The cluster remote info API allows to retrieve all of the configured
+The cluster remote info API allows you to retrieve all of the configured
 remote cluster information. It returns connection and endpoint information keyed 
 by the configured remote cluster alias.
 


### PR DESCRIPTION
Relates to elastic/docs#937 and https://github.com/elastic/elasticsearch/issues/45197.

This PR updates the cluster remote info API to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc).

Resources:
* [Remote cluster info API spec](https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.remote_info.json)
* [Remote cluster info API doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-remote-info.html)