### PR TITLE
Read git revision directly from repository

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
@@ -47,8 +47,6 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         File compilerJavaHome = findCompilerJavaHome();
         File runtimeJavaHome = findRuntimeJavaHome(compilerJavaHome);
 
-        Object gitRevisionResolver = createGitRevisionResolver(project);
-
         final List<JavaHome> javaVersions = new ArrayList<>();
         for (int version = 8; version <= Integer.parseInt(minimumCompilerVersion.getMajorVersion()); version++) {
             if (System.getenv(getJavaHomeEnvVarName(Integer.toString(version))) != null) {
@@ -96,7 +94,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             ext.set("minimumCompilerVersion", minimumCompilerVersion);
             ext.set("minimumRuntimeVersion", minimumRuntimeVersion);
             ext.set("gradleJavaVersion", Jvm.current().getJavaVersion());
-            ext.set("gitRevision", gitRevisionResolver);
+            ext.set("gitRevision", gitRevision(project));
             ext.set("buildDate", ZonedDateTime.now(ZoneOffset.UTC));
         });
     }
@@ -207,83 +205,65 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         return _defaultParallel;
     }
 
-    private Object createGitRevisionResolver(final Project project) {
-        return new Object() {
-            private final AtomicReference<String> gitRevision = new AtomicReference<>();
-
-            @Override
-            public String toString() {
-                if (gitRevision.get() == null) {
-                    this.gitRevision.compareAndSet(null, gitRevision());
-                }
-                return gitRevision.get();
+    private String gitRevision(final Project project) {
+        try {
+            /*
+             * We want to avoid forking another process to run git rev-parse HEAD. Instead, we will read the refs manually. The
+             * documentation for this follows from https://git-scm.com/docs/gitrepository-layout and https://git-scm.com/docs/git-worktree.
+             *
+             * There are two cases to consider:
+             *  - a plain repository with .git directory at the root of the working tree
+             *  - a worktree with a plain text .git file at the root of the working tree
+             *
+             * In each case, our goal is to parse the HEAD file to get either a ref or a bare revision (in the case of being in detached
+             * HEAD state).
+             *
+             * In the case of a plain repository, we can read the HEAD file directly, resolved directly from the .git directory.
+             *
+             * In the case of a worktree, we read the gitdir from the plain text .git file. This resolves to a directory from which we read
+             * the HEAD file and resolve commondir to the plain git repository.
+             */
+            final Path dotGit = project.getRootProject().getRootDir().toPath().resolve(".git");
+            final String revision;
+            if (Files.exists(dotGit) == false) {
+                return "unknown";
             }
-
-            private String gitRevision() {
-                try {
-                    /*
-                     * We want to avoid forking another process to run git rev-parse HEAD. Instead, we will read the refs manually. The
-                     * documentation for this follows from https://git-scm.com/docs/gitrepository-layout and
-                     * https://git-scm.com/docs/git-worktree.
-                     *
-                     * There are two cases to consider:
-                     *  - a plain repository with .git directory at the root of the working tree
-                     *  - a worktree with a plain text .git file at the root of the working tree
-                     *
-                     * In each case, our goal is to parse the HEAD file to get either a ref or a bare revision (in the case of being in
-                     * detached HEAD state).
-                     *
-                     * In the case of a plain repository, we can read the HEAD file directly, resolved directly from the .git
-                     * directory.
-                     *
-                     * In the case of a worktree, we read the gitdir from the plain text .git file. This resolves to a directory from
-                     * which we read the HEAD file and resolve commondir to the plain git repository.
-                     */
-                    final Path dotGit = project.getRootProject().getRootDir().toPath().resolve(".git");
-                    final String revision;
-                    if (Files.exists(dotGit) == false) {
-                        return "unknown";
-                    }
-                    final Path head;
-                    final Path gitDir;
-                    if (Files.isDirectory(dotGit)) {
-                        // this is a git repository, we can read HEAD directly
-                        head = dotGit.resolve("HEAD");
-                        gitDir = dotGit;
-                    } else {
-                        // this is a git worktree, follow the pointer to the repository
-                        final Path workTree = Paths.get(readFirstLine(dotGit).substring("gitdir:".length()).trim());
-                        head = workTree.resolve("HEAD");
-                        final Path commonDir = Paths.get(readFirstLine(workTree.resolve("commondir")));
-                        if (commonDir.isAbsolute()) {
-                            gitDir = commonDir;
-                        } else {
-                            // this is the common case
-                            gitDir = workTree.resolve(commonDir);
-                        }
-                    }
-                    final String ref = readFirstLine(head);
-                    if (ref.startsWith("ref:")) {
-                        revision = readFirstLine(gitDir.resolve(ref.substring("ref:".length()).trim()));
-                    } else {
-                        // we are in detached HEAD state
-                        revision = ref;
-                    }
-                    return revision;
-                } catch (final IOException e) {
-                    // for now, do not be lenient until we have better understanding of real-world scenarios where this happens
-                    throw new GradleException("unable to read the git revision", e);
+            final Path head;
+            final Path gitDir;
+            if (Files.isDirectory(dotGit)) {
+                // this is a git repository, we can read HEAD directly
+                head = dotGit.resolve("HEAD");
+                gitDir = dotGit;
+            } else {
+                // this is a git worktree, follow the pointer to the repository
+                final Path workTree = Paths.get(readFirstLine(dotGit).substring("gitdir:".length()).trim());
+                head = workTree.resolve("HEAD");
+                final Path commonDir = Paths.get(readFirstLine(workTree.resolve("commondir")));
+                if (commonDir.isAbsolute()) {
+                    gitDir = commonDir;
+                } else {
+                    // this is the common case
+                    gitDir = workTree.resolve(commonDir);
                 }
             }
-
-            private String readFirstLine(final Path path) throws IOException {
-                return Files.lines(path, StandardCharsets.UTF_8)
-                    .findFirst()
-                    .orElseThrow(() -> new IOException("file [" + path + "] is empty"));
+            final String ref = readFirstLine(head);
+            if (ref.startsWith("ref:")) {
+                revision = readFirstLine(gitDir.resolve(ref.substring("ref:".length()).trim()));
+            } else {
+                // we are in detached HEAD state
+                revision = ref;
             }
+            return revision;
+        } catch (final IOException e) {
+            // for now, do not be lenient until we have better understanding of real-world scenarios where this happens
+            throw new GradleException("unable to read the git revision", e);
+        }
+    }
 
-        };
-
+    private String readFirstLine(final Path path) throws IOException {
+        return Files.lines(path, StandardCharsets.UTF_8)
+            .findFirst()
+            .orElseThrow(() -> new IOException("file [" + path + "] is empty"));
     }
 
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
@@ -214,59 +214,66 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             @Override
             public String toString() {
                 if (gitRevision.get() == null) {
-                    try {
-                        /*
-                         * We want to avoid forking another process to run git rev-parse HEAD. Instead, we will read the refs manually. The
-                         * documentation for this follows from https://git-scm.com/docs/gitrepository-layout and
-                         * https://git-scm.com/docs/git-worktree.
-                         *
-                         * There are two cases to consider:
-                         *  - a plain repository with .git directory at the root of the working tree
-                         *  - a worktree with a plain text .git file at the root of the working tree
-                         *
-                         * In each case, our goal is to parse the HEAD file to get either a ref or a bare revision (in the case of being in
-                         * detached HEAD state).
-                         *
-                         * In the case of a plain repository, we can read the HEAD file directly, resolved directly from the .git
-                         * directory.
-                         *
-                         * In the case of a worktree, we read the gitdir from the plain text .git file. This resolves to a directory from
-                         * which we read the HEAD file and resolve commondir to the plain git repository.
-                         */
-                        final Path dotGit = project.getRootProject().getRootDir().toPath().resolve(".git");
-                        final Path head;
-                        final Path gitDir;
-                        if (Files.isDirectory(dotGit)) {
-                            // this is a git repository, we can read HEAD directly
-                            head = dotGit.resolve("HEAD");
-                            gitDir = dotGit;
-                        } else {
-                            // this is a git worktree, follow the pointer to the repository
-                            final Path workTree = Paths.get(readFirstLine(dotGit).substring("gitdir:".length()).trim());
-                            head = workTree.resolve("HEAD");
-                            final Path commonDir = Paths.get(readFirstLine(workTree.resolve("commondir")));
-                            if (commonDir.isAbsolute()) {
-                                gitDir = commonDir;
-                            } else {
-                                // this is the common case
-                                gitDir = workTree.resolve(commonDir);
-                            }
-                        }
-                        final String ref = readFirstLine(head);
-                        final String revision;
-                        if (ref.startsWith("ref:")) {
-                            revision = readFirstLine(gitDir.resolve(ref.substring("ref:".length()).trim()));
-                        } else {
-                            // we are in detached HEAD state
-                            revision = ref;
-                        }
-                        this.gitRevision.compareAndSet(null, revision);
-                    } catch (final IOException e) {
-                        // for now, do not be lenient until we have better understanding of real-world scenarios where this happens
-                        throw new GradleException("unable to read the git revision", e);
-                    }
+                    this.gitRevision.compareAndSet(null, gitRevision());
                 }
                 return gitRevision.get();
+            }
+
+            private String gitRevision() {
+                try {
+                    /*
+                     * We want to avoid forking another process to run git rev-parse HEAD. Instead, we will read the refs manually. The
+                     * documentation for this follows from https://git-scm.com/docs/gitrepository-layout and
+                     * https://git-scm.com/docs/git-worktree.
+                     *
+                     * There are two cases to consider:
+                     *  - a plain repository with .git directory at the root of the working tree
+                     *  - a worktree with a plain text .git file at the root of the working tree
+                     *
+                     * In each case, our goal is to parse the HEAD file to get either a ref or a bare revision (in the case of being in
+                     * detached HEAD state).
+                     *
+                     * In the case of a plain repository, we can read the HEAD file directly, resolved directly from the .git
+                     * directory.
+                     *
+                     * In the case of a worktree, we read the gitdir from the plain text .git file. This resolves to a directory from
+                     * which we read the HEAD file and resolve commondir to the plain git repository.
+                     */
+                    final Path dotGit = project.getRootProject().getRootDir().toPath().resolve(".git");
+                    final String revision;
+                    if (Files.exists(dotGit) == false) {
+                        return "unknown";
+                    }
+                    final Path head;
+                    final Path gitDir;
+                    if (Files.isDirectory(dotGit)) {
+                        // this is a git repository, we can read HEAD directly
+                        head = dotGit.resolve("HEAD");
+                        gitDir = dotGit;
+                    } else {
+                        // this is a git worktree, follow the pointer to the repository
+                        final Path workTree = Paths.get(readFirstLine(dotGit).substring("gitdir:".length()).trim());
+                        head = workTree.resolve("HEAD");
+                        final Path commonDir = Paths.get(readFirstLine(workTree.resolve("commondir")));
+                        if (commonDir.isAbsolute()) {
+                            gitDir = commonDir;
+                        } else {
+                            // this is the common case
+                            gitDir = workTree.resolve(commonDir);
+                        }
+                    }
+                    final String ref = readFirstLine(head);
+                    if (ref.startsWith("ref:")) {
+                        revision = readFirstLine(gitDir.resolve(ref.substring("ref:".length()).trim()));
+                    } else {
+                        // we are in detached HEAD state
+                        revision = ref;
+                    }
+                    return revision;
+                } catch (final IOException e) {
+                    // for now, do not be lenient until we have better understanding of real-world scenarios where this happens
+                    throw new GradleException("unable to read the git revision", e);
+                }
             }
 
             private String readFirstLine(final Path path) throws IOException {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 public class GlobalBuildInfoPlugin implements Plugin<Project> {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
@@ -7,7 +7,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.gradle.internal.jvm.Jvm;
-import org.gradle.process.ExecResult;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -16,6 +15,10 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -25,8 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class GlobalBuildInfoPlugin implements Plugin<Project> {
     private static final String GLOBAL_INFO_EXTENSION_NAME = "globalInfo";
@@ -213,26 +214,67 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             @Override
             public String toString() {
                 if (gitRevision.get() == null) {
-                    final ByteArrayOutputStream stdout = new ByteArrayOutputStream();
-                    final ByteArrayOutputStream stderr = new ByteArrayOutputStream();
-                    final ExecResult result = project.exec(spec -> {
-                        spec.setExecutable("git");
-                        spec.setArgs(Arrays.asList("rev-parse", "HEAD"));
-                        spec.setStandardOutput(stdout);
-                        spec.setErrorOutput(stderr);
-                        spec.setIgnoreExitValue(true);
-                    });
-
-                    final String revision;
-                    if (result.getExitValue() != 0) {
-                        revision = "unknown";
-                    } else {
-                        revision = stdout.toString(UTF_8).trim();
+                    try {
+                        /*
+                         * We want to avoid forking another process to run git rev-parse HEAD. Instead, we will read the refs manually. The
+                         * documentation for this follows from https://git-scm.com/docs/gitrepository-layout and
+                         * https://git-scm.com/docs/git-worktree.
+                         *
+                         * There are two cases to consider:
+                         *  - a plain repository with .git directory at the root of the working tree
+                         *  - a worktree with a plain text .git file at the root of the working tree
+                         *
+                         * In each case, our goal is to parse the HEAD file to get either a ref or a bare revision (in the case of being in
+                         * detached HEAD state).
+                         *
+                         * In the case of a plain repository, we can read the HEAD file directly, resolved directly from the .git
+                         * directory.
+                         *
+                         * In the case of a worktree, we read the gitdir from the plain text .git file. This resolves to a directory from
+                         * which we read the HEAD file and resolve commondir to the plain git repository.
+                         */
+                        final Path dotGit = project.getRootProject().getRootDir().toPath().resolve(".git");
+                        final Path head;
+                        final Path gitDir;
+                        if (Files.isDirectory(dotGit)) {
+                            // this is a git repository, we can read HEAD directly
+                            head = dotGit.resolve("HEAD");
+                            gitDir = dotGit;
+                        } else {
+                            // this is a git worktree, follow the pointer to the repository
+                            final Path workTree = Paths.get(readFirstLine(dotGit).substring("gitdir:".length()).trim());
+                            head = workTree.resolve("HEAD");
+                            final Path commonDir = Paths.get(readFirstLine(workTree.resolve("commondir")));
+                            if (commonDir.isAbsolute()) {
+                                gitDir = commonDir;
+                            } else {
+                                // this is the common case
+                                gitDir = workTree.resolve(commonDir);
+                            }
+                        }
+                        final String ref = readFirstLine(head);
+                        final String revision;
+                        if (ref.startsWith("ref:")) {
+                            revision = readFirstLine(gitDir.resolve(ref.substring("ref:".length()).trim()));
+                        } else {
+                            // we are in detached HEAD state
+                            revision = ref;
+                        }
+                        this.gitRevision.compareAndSet(null, revision);
+                    } catch (final IOException e) {
+                        // for now, do not be lenient until we have better understanding of real-world scenarios where this happens
+                        throw new GradleException("unable to read the git revision", e);
                     }
-                    this.gitRevision.compareAndSet(null, revision);
                 }
                 return gitRevision.get();
             }
+
+            private String readFirstLine(final Path path) throws IOException {
+                return Files.lines(path, StandardCharsets.UTF_8)
+                    .findFirst()
+                    .orElseThrow(() -> new IOException("file [" + path + "] is empty"));
+            }
+
         };
 
     }


### PR DESCRIPTION
Today we shell out to git rev-parse to read the git revision. Forking another process is slower than reading the revision directly. This commit changes to directly read the git revision from the repository, avoiding to fork another process.

Relates #45162
