### PR TITLE
Fix policy removal bug in delete policy

### DIFF
--- a/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
+++ b/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
@@ -128,6 +128,10 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
         // delete the pipelines so the policies can be deleted
         client().performRequest(new Request("DELETE", "/_ingest/pipeline/my_pipeline"));
         client().performRequest(new Request("DELETE", "/_ingest/pipeline/another_pipeline"));
+
+        // verify the delete did not happen
+        Request getRequest = new Request("GET", "/_enrich/policy/my_policy");
+        assertOK(client().performRequest(getRequest));
     }
 
     private static Map<String, Object> toMap(Response response) throws IOException {

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportDeleteEnrichPolicyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportDeleteEnrichPolicyAction.java
@@ -83,6 +83,7 @@ public class TransportDeleteEnrichPolicyAction extends TransportMasterNodeAction
             listener.onFailure(
                 new ElasticsearchStatusException("Could not delete policy [{}] because a pipeline is referencing it {}",
                     RestStatus.CONFLICT, request.getName(), pipelinesWithProcessors));
+            return;
         }
 
         EnrichStore.deletePolicy(request.getName(), clusterService, e -> {


### PR DESCRIPTION
The delete policy had a subtle bug in that it would still delete the
policy if pipelines were accessing it, after giving the client back an
error. This commit fixes that and ensures it does not happen by adding
verification in the test.
