### PR TITLE
Rename system property to change bwc checkout behavior

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -553,10 +553,10 @@ When running `./gradlew check`, minimal bwc checks are also run against compatib
 Sometimes a backward compatibility change spans two versions. A common case is a new functionality
 that needs a BWC bridge in an unreleased versioned of a release branch (for example, 5.x).
 To test the changes, you can instruct Gradle to build the BWC version from a another remote/branch combination instead of
-pulling the release branch from GitHub. You do so using the `tests.bwc.remote` and `tests.bwc.refspec.BRANCH` system properties:
+pulling the release branch from GitHub. You do so using the `tests.bwc.remote` and `org.elasticsearch.bwc.refspec.BRANCH` system properties:
 
 -------------------------------------------------
-./gradlew check -Dtests.bwc.remote=${remote} -Dtests.bwc.refspec.5.x=index_req_bwc_5.x
+./gradlew check -Dtests.bwc.remote=${remote} -Dorg.elasticsearch.bwc.refspec.5.x=index_req_bwc_5.x
 -------------------------------------------------
 
 The branch needs to be available on the remote that the BWC makes of the
@@ -571,7 +571,7 @@ will need to:
 will contain your change.
 . Create a branch called `index_req_bwc_5.x` off `5.x`. This will contain your bwc layer.
 . Push both branches to your remote repository.
-. Run the tests with `./gradlew check -Dtests.bwc.remote=${remote} -Dtests.bwc.refspec.5.x=index_req_bwc_5.x`.
+. Run the tests with `./gradlew check -Dtests.bwc.remote=${remote} -Dorg.elasticsearch.bwc.refspec.5.x=index_req_bwc_5.x`.
 
 ==== Skip fetching latest
 

--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -553,10 +553,10 @@ When running `./gradlew check`, minimal bwc checks are also run against compatib
 Sometimes a backward compatibility change spans two versions. A common case is a new functionality
 that needs a BWC bridge in an unreleased versioned of a release branch (for example, 5.x).
 To test the changes, you can instruct Gradle to build the BWC version from a another remote/branch combination instead of
-pulling the release branch from GitHub. You do so using the `tests.bwc.remote` and `org.elasticsearch.bwc.refspec.BRANCH` system properties:
+pulling the release branch from GitHub. You do so using the `bwc.remote` and `bwc.refspec.BRANCH` system properties:
 
 -------------------------------------------------
-./gradlew check -Dtests.bwc.remote=${remote} -Dorg.elasticsearch.bwc.refspec.5.x=index_req_bwc_5.x
+./gradlew check -Dbwc.remote=${remote} -Dbwc.refspec.5.x=index_req_bwc_5.x
 -------------------------------------------------
 
 The branch needs to be available on the remote that the BWC makes of the
@@ -571,7 +571,7 @@ will need to:
 will contain your change.
 . Create a branch called `index_req_bwc_5.x` off `5.x`. This will contain your bwc layer.
 . Push both branches to your remote repository.
-. Run the tests with `./gradlew check -Dtests.bwc.remote=${remote} -Dorg.elasticsearch.bwc.refspec.5.x=index_req_bwc_5.x`.
+. Run the tests with `./gradlew check -Dbwc.remote=${remote} -Dbwc.refspec.5.x=index_req_bwc_5.x`.
 
 ==== Skip fetching latest
 

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -104,7 +104,7 @@ bwcVersions.forPreviousUnreleased { BwcVersions.UnreleasedVersionInfo unreleased
         dependsOn fetchLatest
         doLast {
             String refspec = System.getProperty("tests.bwc.refspec.${bwcBranch}", "${remote}/${bwcBranch}")
-            if (System.getProperty("tests.bwc.checkout.align") != null) {
+            if (System.getProperty("org.elasticsearch.bwc.checkout.align") != null) {
                 /*
                     We use a time based approach to make the bwc versions built deterministic and compatible with the current hash.
                     Most of the time we want to test against latest, but when running delayed exhaustive tests or wanting

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -103,8 +103,8 @@ bwcVersions.forPreviousUnreleased { BwcVersions.UnreleasedVersionInfo unreleased
     task checkoutBwcBranch() {
         dependsOn fetchLatest
         doLast {
-            String refspec = System.getProperty("org.elasticsearch.bwc.refspec.${bwcBranch}", "${remote}/${bwcBranch}")
-            if (System.getProperty("org.elasticsearch.bwc.checkout.align") != null) {
+            String refspec = System.getProperty("org.elasticsearch.bwc.refspec.${bwcBranch}" ?: System.getProperty("tests.bwc.refspec.${bwcBranch}", "${remote}/${bwcBranch}")
+            if (System.getProperty("org.elasticsearch.bwc.checkout.align") != null || System.getProperty("tests.bwc.checkout.align") != null) {
                 /*
                     We use a time based approach to make the bwc versions built deterministic and compatible with the current hash.
                     Most of the time we want to test against latest, but when running delayed exhaustive tests or wanting

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -42,7 +42,7 @@ bwcVersions.forPreviousUnreleased { BwcVersions.UnreleasedVersionInfo unreleased
 
     File checkoutDir = file("${buildDir}/bwc/checkout-${bwcBranch}")
 
-    final String remote = System.getProperty("tests.bwc.remote", "elastic")
+    final String remote = System.getProperty("bwc.remote", "elastic")
 
     boolean gitFetchLatest
     final String gitFetchLatestProperty = System.getProperty("tests.bwc.git_fetch_latest", "true")
@@ -103,8 +103,8 @@ bwcVersions.forPreviousUnreleased { BwcVersions.UnreleasedVersionInfo unreleased
     task checkoutBwcBranch() {
         dependsOn fetchLatest
         doLast {
-            String refspec = System.getProperty("org.elasticsearch.bwc.refspec.${bwcBranch}" ?: System.getProperty("tests.bwc.refspec.${bwcBranch}", "${remote}/${bwcBranch}")
-            if (System.getProperty("org.elasticsearch.bwc.checkout.align") != null || System.getProperty("tests.bwc.checkout.align") != null) {
+            String refspec = System.getProperty("bwc.refspec.${bwcBranch}") ?: System.getProperty("tests.bwc.refspec.${bwcBranch}") ?: "${remote}/${bwcBranch}"
+            if (System.getProperty("bwc.checkout.align") != null || System.getProperty("tests.bwc.checkout.align") != null) {
                 /*
                     We use a time based approach to make the bwc versions built deterministic and compatible with the current hash.
                     Most of the time we want to test against latest, but when running delayed exhaustive tests or wanting

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -103,7 +103,7 @@ bwcVersions.forPreviousUnreleased { BwcVersions.UnreleasedVersionInfo unreleased
     task checkoutBwcBranch() {
         dependsOn fetchLatest
         doLast {
-            String refspec = System.getProperty("tests.bwc.refspec.${bwcBranch}", "${remote}/${bwcBranch}")
+            String refspec = System.getProperty("org.elasticsearch.bwc.refspec.${bwcBranch}", "${remote}/${bwcBranch}")
             if (System.getProperty("org.elasticsearch.bwc.checkout.align") != null) {
                 /*
                     We use a time based approach to make the bwc versions built deterministic and compatible with the current hash.


### PR DESCRIPTION
This renames the `tests.bwc.checkout.align` system property to `org.elasticsearch.bwc.checkout.align`. The reason for this is that system properties prefixed with `tests` are by convention passed to all test workers. We don't want to do this for two reasons. First, there's no need to pass this on to test workers as it's inapplicable to any specific tests. Second, it then is considered an "input" to all test tasks which means changing this property changes the cache key for all tests. Since this system property doesn't directly affect test execution behavior, there should be no reason to track it as an input.