### PR TITLE
Fix bug in ingest node documentation

### DIFF
--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -546,6 +546,7 @@ PUT _ingest/pipeline/logs_pipeline
     },
     {
       "fail": {
+        "if": "ctx.service?.name != 'apache_httpd' && ctx.service?.name != 'syslog'",
         "message": "This pipeline requires service.name to be either `syslog` or `apache_httpd`"
       }
     }


### PR DESCRIPTION
The "Conditionals with the Pipeline Processor" incorrectly documents how to 
create a pipeline of pipelines with a failure condition. The example as-is
will always execute the fail processor. The change here updates the documentation
to correct guard the fail processor with an `if` condition. 

--------


To manually test (use any version 6.5+ version of ES)
```
PUT _ingest/pipeline/httpd_pipeline
{
  "processors": [
    {
      "set": {
        "field": "httpd_pipeline",
        "value": true
      }
    }
  ]
}

PUT _ingest/pipeline/syslog_pipeline
{
  "processors": [
    {
      "set": {
        "field": "syslog_pipeline",
        "value": true
      }
    }
  ]
}

PUT _ingest/pipeline/logs_pipeline
{
  "description": "A pipeline of pipelines for log files",
  "version": 1,
  "processors": [
    {
      "pipeline": {
        "if": "ctx.service?.name == 'apache_httpd'",
        "name": "httpd_pipeline"
      }
    },
    {
      "pipeline": {
        "if": "ctx.service?.name == 'syslog'",
        "name": "syslog_pipeline"
      }
    },
    {
      "fail": {
        "if": "ctx.service?.name != 'apache_httpd' && ctx.service?.name != 'syslog'",
        "message": "This pipeline requires service.name to be either `syslog` or `apache_httpd`"
      }
    }
  ]
}


POST testme/_bulk?pipeline=logs_pipeline
{"index":{"_id":"1"}}
{"service":{"name":"apache_httpd"}}
{"index":{"_id":"2"}}
{"service":{"name":"syslog"}}
{"index":{"_id":"3"}}
{"service":{"name":"somethingelse"}}
{"index":{"_id":"4"}}
{"missing":true}


GET /testme/_search

DELETE testme  
```