### PR TITLE
PKI realm accept only verified certificates

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLService.java
@@ -278,9 +278,9 @@ public class SSLService {
     /**
      * Indicates whether client authentication is enabled for a particular configuration
      */
-    public boolean isSSLClientAuthEnabled(SSLConfiguration sslConfiguration) {
+    public boolean isClientAuthEnabledWithVerification(SSLConfiguration sslConfiguration) {
         Objects.requireNonNull(sslConfiguration, "SSLConfiguration cannot be null");
-        return sslConfiguration.sslClientAuth().enabled();
+        return sslConfiguration.sslClientAuth().enabled() && sslConfiguration.verificationMode().isCertificateVerificationEnabled();
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLService.java
@@ -276,7 +276,7 @@ public class SSLService {
     }
 
     /**
-     * Indicates whether client authentication is enabled for a particular configuration
+     * Indicates whether client authentication is enabled and that the client's certificates are verified
      */
     public boolean isClientAuthEnabledWithVerification(SSLConfiguration sslConfiguration) {
         Objects.requireNonNull(sslConfiguration, "SSLConfiguration cannot be null");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SSLServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SSLServiceTests.java
@@ -298,8 +298,8 @@ public class SSLServiceTests extends ESTestCase {
             .put("transport.profiles.foo.port", "9400-9410")
             .build();
         sslService = new SSLService(settings, env);
-        assertTrue(sslService.isSSLClientAuthEnabled(sslService.getSSLConfiguration("xpack.security.transport.ssl")));
-        assertTrue(sslService.isSSLClientAuthEnabled(sslService.getSSLConfiguration("transport.profiles.foo.xpack.security.ssl")));
+        assertTrue(sslService.isClientAuthEnabledWithVerification(sslService.getSSLConfiguration("xpack.security.transport.ssl")));
+        assertTrue(sslService.isClientAuthEnabledWithVerification(sslService.getSSLConfiguration("transport.profiles.foo.xpack.security.ssl")));
     }
 
     public void testThatHttpClientAuthDefaultsToNone() throws Exception {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SSLServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SSLServiceTests.java
@@ -299,7 +299,8 @@ public class SSLServiceTests extends ESTestCase {
             .build();
         sslService = new SSLService(settings, env);
         assertTrue(sslService.isClientAuthEnabledWithVerification(sslService.getSSLConfiguration("xpack.security.transport.ssl")));
-        assertTrue(sslService.isClientAuthEnabledWithVerification(sslService.getSSLConfiguration("transport.profiles.foo.xpack.security.ssl")));
+        assertTrue(sslService
+                .isClientAuthEnabledWithVerification(sslService.getSSLConfiguration("transport.profiles.foo.xpack.security.ssl")));
     }
 
     public void testThatHttpClientAuthDefaultsToNone() throws Exception {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/PkiRealmBootstrapCheck.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/PkiRealmBootstrapCheck.java
@@ -45,7 +45,7 @@ class PkiRealmBootstrapCheck implements BootstrapCheck {
         if (pkiRealmEnabled) {
             for (String contextName : getSslContextNames(settings)) {
                 final SSLConfiguration configuration = sslService.getSSLConfiguration(contextName);
-                if (sslService.isSSLClientAuthEnabled(configuration)) {
+                if (sslService.isClientAuthEnabledWithVerification(configuration)) {
                     return BootstrapCheckResult.success();
                 }
             }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -911,7 +911,7 @@ public class Security extends Plugin implements ActionPlugin, IngestPlugin, Netw
         }
         final boolean ssl = HTTP_SSL_ENABLED.get(settings);
         final SSLConfiguration httpSSLConfig = getSslService().getHttpTransportSSLConfiguration();
-        boolean extractClientCertificate = ssl && getSslService().isSSLClientAuthEnabled(httpSSLConfig);
+        boolean extractClientCertificate = ssl && getSslService().isClientAuthEnabledWithVerification(httpSSLConfig);
         return handler -> new SecurityRestFilter(getLicenseState(), threadContext, authcService.get(), handler, extractClientCertificate);
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptor.java
@@ -172,7 +172,7 @@ public class SecurityServerTransportInterceptor implements TransportInterceptor 
         final boolean transportSSLEnabled = XPackSettings.TRANSPORT_SSL_ENABLED.get(settings);
         for (Map.Entry<String, SSLConfiguration> entry : profileConfigurations.entrySet()) {
             final SSLConfiguration profileConfiguration = entry.getValue();
-            final boolean extractClientCert = transportSSLEnabled && sslService.isSSLClientAuthEnabled(profileConfiguration);
+            final boolean extractClientCert = transportSSLEnabled && sslService.isClientAuthEnabledWithVerification(profileConfiguration);
             profileFilters.put(entry.getKey(), new ServerTransportFilter(authcService, authzService, threadPool.getThreadContext(),
                 extractClientCert, destructiveOperations, securityContext, licenseState));
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/PkiRealmBootstrapCheckTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/PkiRealmBootstrapCheckTests.java
@@ -51,9 +51,17 @@ public class PkiRealmBootstrapCheckTests extends AbstractBootstrapCheckTestCase 
         env = TestEnvironment.newEnvironment(settings);
         assertFalse(runCheck(settings, env).isFailure());
 
+        // disable verification mode
+        settings = Settings.builder().put(settings)
+                .put("xpack.security.http.ssl.verification_mode", "none")
+                .build();
+        env = TestEnvironment.newEnvironment(settings);
+        assertTrue(runCheck(settings, env).isFailure());
+
         // disable http ssl
         settings = Settings.builder().put(settings)
                 .put("xpack.security.http.ssl.enabled", false)
+                .put("xpack.security.http.ssl.verification_mode", randomFrom("certificate", "full"))
                 .build();
         env = TestEnvironment.newEnvironment(settings);
         assertTrue(runCheck(settings, env).isFailure());
@@ -68,11 +76,18 @@ public class PkiRealmBootstrapCheckTests extends AbstractBootstrapCheckTestCase 
         // test with transport profile
         settings = Settings.builder().put(settings)
                 .put("xpack.security.transport.ssl.enabled", true)
-                .put("xpack.security.transport.client_authentication", "none")
+                .put("xpack.security.transport.ssl.client_authentication", "none")
                 .put("transport.profiles.foo.xpack.security.ssl.client_authentication", randomFrom("required", "optional"))
                 .build();
         env = TestEnvironment.newEnvironment(settings);
         assertFalse(runCheck(settings, env).isFailure());
+
+        // disable verification mode for profile
+        settings = Settings.builder().put(settings)
+                .put("transport.profiles.foo.xpack.security.ssl.verification_mode", "none")
+                .build();
+        env = TestEnvironment.newEnvironment(settings);
+        assertTrue(runCheck(settings, env).isFailure());
     }
 
     private BootstrapCheck.BootstrapCheckResult runCheck(Settings settings, Environment env) throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/pki/PkiAuthenticationFailUnverifiedTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/pki/PkiAuthenticationFailUnverifiedTests.java
@@ -3,6 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.xpack.security.authc.pki;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -19,10 +20,8 @@ import org.elasticsearch.xpack.core.common.socket.SocketAccess;
 import org.elasticsearch.xpack.core.ssl.CertParsingUtils;
 import org.elasticsearch.xpack.core.ssl.PemUtils;
 import org.elasticsearch.xpack.core.ssl.SSLClientAuth;
+import org.elasticsearch.xpack.core.ssl.VerificationMode;
 
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
 import java.net.InetSocketAddress;
 import java.security.SecureRandom;
 import java.util.Arrays;
@@ -31,14 +30,15 @@ import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
 
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+
 import static org.elasticsearch.test.SecuritySettingsSource.addSSLSettingsForNodePEMFiles;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
-/**
- * Test authentication via PKI on both REST and Transport layers
- */
-public class PkiAuthenticationTests extends SecuritySingleNodeTestCase {
+public class PkiAuthenticationFailUnverifiedTests extends SecuritySingleNodeTestCase {
 
     @Override
     protected boolean addMockHttpTransport() {
@@ -48,28 +48,22 @@ public class PkiAuthenticationTests extends SecuritySingleNodeTestCase {
     @Override
     protected Settings nodeSettings() {
         SSLClientAuth sslClientAuth = randomBoolean() ? SSLClientAuth.REQUIRED : SSLClientAuth.OPTIONAL;
-
         Settings.Builder builder = Settings.builder()
             .put(super.nodeSettings());
         addSSLSettingsForNodePEMFiles(builder, "xpack.security.http.", true);
         builder.put("xpack.security.http.ssl.enabled", true)
             .put("xpack.security.http.ssl.client_authentication", sslClientAuth)
+            // verification mode does not validate certificates, hence those should not be used by the PKI realm
+            .put("xpack.security.http.ssl.verification_mode", VerificationMode.NONE)
             .put("xpack.security.authc.realms.file.file.order", "0")
             .put("xpack.security.authc.realms.pki.pki1.order", "1")
             .putList("xpack.security.authc.realms.pki.pki1.certificate_authorities",
                 getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testclient.crt").toString())
-            .put("xpack.security.authc.realms.pki.pki1.files.role_mapping", getDataPath("role_mapping.yml"))
-            // pki1 never authenticates because of the principal pattern
-            .put("xpack.security.authc.realms.pki.pki1.username_pattern", "CN=(MISMATCH.*?)(?:,|$)")
-            .put("xpack.security.authc.realms.pki.pki2.order", "2")
-            .putList("xpack.security.authc.realms.pki.pki2.certificate_authorities",
-                getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt").toString(),
-                getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode_ec.crt").toString())
-            .put("xpack.security.authc.realms.pki.pki2.files.role_mapping", getDataPath("role_mapping.yml"));
+            .put("xpack.security.authc.realms.pki.pki1.files.role_mapping", getDataPath("role_mapping.yml"));
         return builder.build();
     }
 
-    public void testRestAuthenticationViaPki() throws Exception {
+    public void testAuthenticationFailsWithMissingCredentials() throws Exception {
         SSLContext context = getRestSSLContext("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.pem",
             "testnode",
             "/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt",
@@ -79,24 +73,9 @@ public class PkiAuthenticationTests extends SecuritySingleNodeTestCase {
         try (CloseableHttpClient client = HttpClients.custom().setSSLContext(context).build()) {
             HttpPut put = new HttpPut(getNodeUrl() + "foo");
             try (CloseableHttpResponse response = SocketAccess.doPrivileged(() -> client.execute(put))) {
-                String body = EntityUtils.toString(response.getEntity());
-                assertThat(body, containsString("\"acknowledged\":true"));
-            }
-        }
-    }
-
-    public void testRestAuthenticationFailure() throws Exception {
-        SSLContext context = getRestSSLContext("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testclient.pem",
-            "testclient", "/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testclient.crt",
-            Arrays.asList("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testclient.crt",
-                "/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt",
-                "/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode_ec.crt"));
-        try (CloseableHttpClient client = HttpClients.custom().setSSLContext(context).build()) {
-            HttpPut put = new HttpPut(getNodeUrl() + "foo");
-            try (CloseableHttpResponse response = SocketAccess.doPrivileged(() -> client.execute(put))) {
                 assertThat(response.getStatusLine().getStatusCode(), is(401));
                 String body = EntityUtils.toString(response.getEntity());
-                assertThat(body, containsString("unable to authenticate user [Elasticsearch Test Client]"));
+                assertThat(body, containsString("missing authentication credentials for REST request"));
             }
         }
     }


### PR DESCRIPTION
The PKI realm relies on the certificate validation from the network layer (HTTP or transport). It then reads those and extracts the principal from the Subject.

However, the network layer accepts client certificates even if it does not verify them.
This commit does not permit the PKI realm to extract unverified certificates.