### PR TITLE
Use bundled JDK in Sys V init

### DIFF
--- a/distribution/packages/src/deb/init.d/elasticsearch
+++ b/distribution/packages/src/deb/init.d/elasticsearch
@@ -81,10 +81,10 @@ if [ ! -x "$DAEMON" ]; then
 fi
 
 checkJava() {
-	if [ -x "$JAVA_HOME/bin/java" ]; then
-		JAVA="$JAVA_HOME/bin/java"
+	if [ ! -z "${JAVA_HOME}" ]; then
+		JAVA="${JAVA_HOME}"/bin/java
 	else
-		JAVA=`which java`
+		JAVA="${ES_HOME}"/jdk/bin/java
 	fi
 
 	if [ ! -x "$JAVA" ]; then

--- a/distribution/packages/src/deb/init.d/elasticsearch
+++ b/distribution/packages/src/deb/init.d/elasticsearch
@@ -88,7 +88,7 @@ checkJava() {
   fi
 
   if [ ! -x "$JAVA" ]; then
-    echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
+    echo "could not find java in JAVA_HOME or bundled at ${JAVA}"
     exit 1
   fi
 }

--- a/distribution/packages/src/deb/init.d/elasticsearch
+++ b/distribution/packages/src/deb/init.d/elasticsearch
@@ -81,16 +81,16 @@ if [ ! -x "$DAEMON" ]; then
 fi
 
 checkJava() {
-	if [ ! -z "${JAVA_HOME}" ]; then
-		JAVA="${JAVA_HOME}"/bin/java
-	else
-		JAVA="${ES_HOME}"/jdk/bin/java
-	fi
+  if [ ! -z "${JAVA_HOME}" ]; then
+    JAVA="${JAVA_HOME}"/bin/java
+  else
+    JAVA="${ES_HOME}"/jdk/bin/java
+  fi
 
-	if [ ! -x "$JAVA" ]; then
-		echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
-		exit 1
-	fi
+  if [ ! -x "$JAVA" ]; then
+    echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
+    exit 1
+  fi
 }
 
 case "$1" in

--- a/distribution/packages/src/rpm/init.d/elasticsearch
+++ b/distribution/packages/src/rpm/init.d/elasticsearch
@@ -68,16 +68,16 @@ if [ ! -x "$exec" ]; then
 fi
 
 checkJava() {
-	if [ ! -z "${JAVA_HOME}" ]; then
-		JAVA="${JAVA_HOME}"/bin/java
-	else
-		JAVA="${ES_HOME}"/jdk/bin/java
-	fi
+  if [ ! -z "${JAVA_HOME}" ]; then
+    JAVA="${JAVA_HOME}"/bin/java
+  else
+    JAVA="${ES_HOME}"/jdk/bin/java
+  fi
 
-	if [ ! -x "$JAVA" ]; then
-		echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
-		exit 1
-	fi
+  if [ ! -x "$JAVA" ]; then
+    echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
+    exit 1
+  fi
 }
 
 start() {

--- a/distribution/packages/src/rpm/init.d/elasticsearch
+++ b/distribution/packages/src/rpm/init.d/elasticsearch
@@ -75,7 +75,7 @@ checkJava() {
   fi
 
   if [ ! -x "$JAVA" ]; then
-    echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
+    echo "could not find java in JAVA_HOME or bundled at ${JAVA}"
     exit 1
   fi
 }

--- a/distribution/packages/src/rpm/init.d/elasticsearch
+++ b/distribution/packages/src/rpm/init.d/elasticsearch
@@ -68,16 +68,16 @@ if [ ! -x "$exec" ]; then
 fi
 
 checkJava() {
-    if [ -x "$JAVA_HOME/bin/java" ]; then
-        JAVA="$JAVA_HOME/bin/java"
-    else
-        JAVA=`which java`
-    fi
+	if [ ! -z "${JAVA_HOME}" ]; then
+		JAVA="${JAVA_HOME}"/bin/java
+	else
+		JAVA="${ES_HOME}"/jdk/bin/java
+	fi
 
-    if [ ! -x "$JAVA" ]; then
-        echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
-        exit 1
-    fi
+	if [ ! -x "$JAVA" ]; then
+		echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
+		exit 1
+	fi
 }
 
 start() {

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageTestCase.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageTestCase.java
@@ -136,6 +136,22 @@ public abstract class PackageTestCase extends PackagingTestCase {
         assertRunsWithJavaHome();
     }
 
+    public void test33RunsIfJavaNotOnPath() throws Exception {
+        assumeThat(distribution().hasJdk, is(true));
+
+        final Result readlink = sh.run("readlink /usr/bin/java");
+        assertThat(readlink.exitCode, equalTo(0));
+        final Result unlink = sh.run("unlink /usr/bin/java");
+        assertThat(unlink.exitCode, equalTo(0));
+
+        startElasticsearch(sh);
+        runElasticsearchTests();
+        stopElasticsearch(sh);
+
+        final Result ln = sh.run("ln -sf " + readlink.stdout + " /usr/bin/java");
+        assertThat(ln.exitCode, equalTo(0));
+    }
+
     public void test42BundledJdkRemoved() throws Exception {
         assumeThat(installation, is(notNullValue()));
         assumeThat(distribution().hasJdk, is(true));

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageTestCase.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageTestCase.java
@@ -150,7 +150,7 @@ public abstract class PackageTestCase extends PackagingTestCase {
             stopElasticsearch(sh);
         } finally {
             if (unlinked) {
-                sh.run("ln -sf " + readlink.stdout + " /usr/bin/java");
+                sh.run("ln -sf " + readlink.stdout.trim() + " /usr/bin/java");
             }
         }
     }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageTestCase.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageTestCase.java
@@ -140,16 +140,19 @@ public abstract class PackageTestCase extends PackagingTestCase {
         assumeThat(distribution().hasJdk, is(true));
 
         final Result readlink = sh.run("readlink /usr/bin/java");
-        assertThat(readlink.exitCode, equalTo(0));
-        final Result unlink = sh.run("unlink /usr/bin/java");
-        assertThat(unlink.exitCode, equalTo(0));
+        boolean unlinked = false;
+        try {
+            sh.run("unlink /usr/bin/java");
+            unlinked = true;
 
-        startElasticsearch(sh);
-        runElasticsearchTests();
-        stopElasticsearch(sh);
-
-        final Result ln = sh.run("ln -sf " + readlink.stdout + " /usr/bin/java");
-        assertThat(ln.exitCode, equalTo(0));
+            startElasticsearch(sh);
+            runElasticsearchTests();
+            stopElasticsearch(sh);
+        } finally {
+            if (unlinked) {
+                sh.run("ln -sf " + readlink.stdout + " /usr/bin/java");
+            }
+        }
     }
 
     public void test42BundledJdkRemoved() throws Exception {


### PR DESCRIPTION
This commit addresses an issue when trying to using Elasticsearch on systems with Sys V init and the bundled JDK was not being used. Instead, we were still inadvertently trying to fallback on the path. This commit removes that fallback as that is against our intentions for 7.x where we only support the bundled JDK or an explicit JDK via JAVA_HOME.

Closes #45542