### PR TITLE
[DOCS] Reformats nodes hot_threads API

### DIFF
--- a/docs/reference/cluster/nodes-hot-threads.asciidoc
+++ b/docs/reference/cluster/nodes-hot-threads.asciidoc
@@ -50,6 +50,6 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=node-id]
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 `type`::
-		(Optional, ) The type to sample. Available options are `block`, `cpu`, and 
+		(Optional, string) The type to sample. Available options are `block`, `cpu`, and 
 		`wait`. Defaults to `cpu`.
 

--- a/docs/reference/cluster/nodes-hot-threads.asciidoc
+++ b/docs/reference/cluster/nodes-hot-threads.asciidoc
@@ -1,29 +1,55 @@
 [[cluster-nodes-hot-threads]]
 === Nodes hot_threads
 
+Returns the hot threads on each selected node in the cluster.
+
+
+[[cluster-nodes-hot-threads-api-request]]
+==== {api-request-title}
+
+`GET /_nodes/hot_threads` +
+
+`GET /_nodes/{node_id}/hot_threads`
+
+
+[[cluster-nodes-hot-threads-api-desc]]
+==== {api-description-title}
+
 This API yields a breakdown of the hot threads on each selected node in the
-cluster. Its endpoints are `/_nodes/hot_threads` and
-`/_nodes/{nodes}/hot_threads`:
+cluster. The output is plain text with a breakdown of each node's top hot 
+threads.
 
-[source,js]
---------------------------------------------------
-GET /_nodes/hot_threads
-GET /_nodes/nodeId1,nodeId2/hot_threads
---------------------------------------------------
-// CONSOLE
 
-The first command gets the hot threads of all the nodes in the cluster. The
-second command gets the hot threads of only `nodeId1` and `nodeId2`. Nodes can
-be selected using <<cluster-nodes,node filters>>.
+[[cluster-nodes-hot-threads-api-path-params]]
+==== {api-path-parms-title}
 
-The output is plain text with a breakdown of each node's top hot threads.  The
-allowed parameters are:
+include::{docdir}/rest-api/common-parms.asciidoc[tag=node-id]
 
-[horizontal]
-`threads`:: 	number of hot threads to provide, defaults to 3.
-`interval`:: 	the interval to do the second sampling of threads.
-				Defaults to 500ms.
-`type`:: 		The type to sample, defaults to cpu, but supports wait and
-				block to see hot threads that are in wait or block state.
-`ignore_idle_threads`::    If true, known idle threads (e.g. waiting in a socket select, or to
-			   get a task from an empty queue) are filtered out.  Defaults to true.
+
+[[cluster-nodes-hot-threads-api-query-params]]
+==== {api-query-parms-title}
+
+
+`ignore_idle_threads`::
+		(Optional, boolean) If true, known idle threads (e.g. waiting in a socket 
+		select, or to get a task from an empty queue) are filtered out.  Defaults to 
+		true.
+
+`interval`::
+		(Optional, <<time-units, time units>>) The interval to do the second 
+		sampling of threads. Defaults to `500ms`.
+		
+`snapshots`::
+		(Optional, integer) Number of samples of thread stacktrace. Defaults to 
+		`10`.
+
+`threads`::
+		(Optional, integer) Specifies the number of hot threads to provide 
+		information for. Defaults to `3`.
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+
+`type`::
+		(Optional, ) The type to sample. Available options are `block`, `cpu`, and 
+		`wait`. Defaults to `cpu`.
+

--- a/docs/reference/cluster/nodes-hot-threads.asciidoc
+++ b/docs/reference/cluster/nodes-hot-threads.asciidoc
@@ -53,3 +53,13 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 		(Optional, string) The type to sample. Available options are `block`, `cpu`, and 
 		`wait`. Defaults to `cpu`.
 
+
+[[cluster-nodes-hot-threads-api-example]]
+==== {api-examples-title}
+
+[source,js]
+--------------------------------------------------
+GET /_nodes/hot_threads
+GET /_nodes/nodeId1,nodeId2/hot_threads
+--------------------------------------------------
+// CONSOLE


### PR DESCRIPTION
Relates to elastic/docs#937 and https://github.com/elastic/elasticsearch/issues/45197.

This PR updates the nodes hot_threads API to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc).

Resources:
* [Nodes hot_threads API spec](https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.hot_threads.json)
* [Nodes hot_threads API doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-hot-threads.html)