### PR TITLE
[DOCS] Tolerate more cluster names in docs tests

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -163,7 +163,7 @@ is _green_ and it has three nodes:
 epoch      timestamp cluster       status node.total node.data shards pri relo init unassign pending_tasks max_task_wait_time active_shards_percent
 1565052807 00:53:27  elasticsearch green           3         3      6   3    0    0        0             0                  -                100.0%
 --------------------------------------------------
-// TESTRESPONSE[s/1565052807 00:53:27  elasticsearch/\\d+ \\d+:\\d+:\\d+ integTest/]
+// TESTRESPONSE[s/1565052807 00:53:27  elasticsearch/\\d+ \\d+:\\d+:\\d+ \\w*integTest\\w*/]
 // TESTRESPONSE[s/3         3      6   3/\\d+         \\d+      \\d+   \\d+/]
 // TESTRESPONSE[s/0             0                  -/0             \\d+                  -/]
 // TESTRESPONSE[non_json]


### PR DESCRIPTION
The name of the cluster used for testing the docs
varies between versions.  This change makes the
assertion on the cluster name more tolerant of
variations.

Relates #45009