### PR TITLE
Always check that cgroup data is present

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -76,27 +76,20 @@ In order to set an Elasticsearch setting, provide a setting with the following p
 
 === Test case filtering.
 
-- `tests.class` is a class-filtering shell-like glob pattern,
-- `tests.method` is a method-filtering glob pattern.
+You can run a single test, provided that you specify the Gradle project.  See the documentation on
+https://docs.gradle.org/current/userguide/userguide_single.html#simple_name_pattern[simple name pattern filtering].
 
-Run a single test case (variants)
+Run a single test case in the `server` project:
 
 ----------------------------------------------------------
-./gradlew test -Dtests.class=org.elasticsearch.package.ClassName
-./gradlew test "-Dtests.class=*.ClassName"
+./gradlew :server:test --tests org.elasticsearch.package.ClassName
 ----------------------------------------------------------
 
-Run all tests in a package and its sub-packages
+Run all tests in a package and its sub-packages:
 
 ----------------------------------------------------
-./gradlew test "-Dtests.class=org.elasticsearch.package.*"
+./gradlew :server:test --tests 'org.elasticsearch.package.*'
 ----------------------------------------------------
-
-Run any test methods that contain 'esi' (like: ...r*esi*ze...)
-
--------------------------------
-./gradlew test "-Dtests.method=*esi*"
--------------------------------
 
 Run all tests that are waiting for a bugfix (disabled by default)
 
@@ -118,7 +111,7 @@ Every test repetition will have a different method seed
 (derived from a single random master seed).
 
 --------------------------------------------------
-./gradlew test -Dtests.iters=N -Dtests.class=*.ClassName
+./gradlew :server:test -Dtests.iters=N --tests org.elasticsearch.package.ClassName
 --------------------------------------------------
 
 === Repeats _all_ tests of ClassName N times.
@@ -127,7 +120,7 @@ Every test repetition will have exactly the same master (0xdead) and
 method-level (0xbeef) seed.
 
 ------------------------------------------------------------------------
-./gradlew test -Dtests.iters=N -Dtests.class=*.ClassName -Dtests.seed=DEAD:BEEF
+./gradlew :server:test -Dtests.iters=N -Dtests.seed=DEAD:BEEF --tests org.elasticsearch.package.ClassName
 ------------------------------------------------------------------------
 
 === Repeats a given test N times
@@ -137,14 +130,14 @@ ie: testFoo[0], testFoo[1], etc... so using testmethod or tests.method
 ending in a glob is necessary to ensure iterations are run).
 
 -------------------------------------------------------------------------
-./gradlew test -Dtests.iters=N -Dtests.class=*.ClassName -Dtests.method=mytest*
+./gradlew :server:test -Dtests.iters=N --tests org.elasticsearch.package.ClassName.methodName
 -------------------------------------------------------------------------
 
 Repeats N times but skips any tests after the first failure or M initial failures.
 
 -------------------------------------------------------------
-./gradlew test -Dtests.iters=N -Dtests.failfast=true -Dtestcase=...
-./gradlew test -Dtests.iters=N -Dtests.maxfailures=M -Dtestcase=...
+./gradlew test -Dtests.iters=N -Dtests.failfast=true ...
+./gradlew test -Dtests.iters=N -Dtests.maxfailures=M ...
 -------------------------------------------------------------
 
 === Test groups.
@@ -175,7 +168,7 @@ systemProp.tests.jvms=8
 ----------------------------
 
 Its difficult to pick the "right" number here. Hypercores don't count for CPU
-intensive tests and you should leave some slack for JVM-interal threads like
+intensive tests and you should leave some slack for JVM-internal threads like
 the garbage collector. And you have to have enough RAM to handle each JVM.
 
 === Test compatibility.

--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -76,20 +76,27 @@ In order to set an Elasticsearch setting, provide a setting with the following p
 
 === Test case filtering.
 
-You can run a single test, provided that you specify the Gradle project.  See the documentation on
-https://docs.gradle.org/current/userguide/userguide_single.html#simple_name_pattern[simple name pattern filtering].
+- `tests.class` is a class-filtering shell-like glob pattern,
+- `tests.method` is a method-filtering glob pattern.
 
-Run a single test case in the `server` project:
+Run a single test case (variants)
 
 ----------------------------------------------------------
-./gradlew :server:test --tests org.elasticsearch.package.ClassName
+./gradlew test -Dtests.class=org.elasticsearch.package.ClassName
+./gradlew test "-Dtests.class=*.ClassName"
 ----------------------------------------------------------
 
-Run all tests in a package and its sub-packages:
+Run all tests in a package and its sub-packages
 
 ----------------------------------------------------
-./gradlew :server:test --tests 'org.elasticsearch.package.*'
+./gradlew test "-Dtests.class=org.elasticsearch.package.*"
 ----------------------------------------------------
+
+Run any test methods that contain 'esi' (like: ...r*esi*ze...)
+
+-------------------------------
+./gradlew test "-Dtests.method=*esi*"
+-------------------------------
 
 Run all tests that are waiting for a bugfix (disabled by default)
 
@@ -111,7 +118,7 @@ Every test repetition will have a different method seed
 (derived from a single random master seed).
 
 --------------------------------------------------
-./gradlew :server:test -Dtests.iters=N --tests org.elasticsearch.package.ClassName
+./gradlew test -Dtests.iters=N -Dtests.class=*.ClassName
 --------------------------------------------------
 
 === Repeats _all_ tests of ClassName N times.
@@ -120,7 +127,7 @@ Every test repetition will have exactly the same master (0xdead) and
 method-level (0xbeef) seed.
 
 ------------------------------------------------------------------------
-./gradlew :server:test -Dtests.iters=N -Dtests.seed=DEAD:BEEF --tests org.elasticsearch.package.ClassName
+./gradlew test -Dtests.iters=N -Dtests.class=*.ClassName -Dtests.seed=DEAD:BEEF
 ------------------------------------------------------------------------
 
 === Repeats a given test N times
@@ -130,14 +137,14 @@ ie: testFoo[0], testFoo[1], etc... so using testmethod or tests.method
 ending in a glob is necessary to ensure iterations are run).
 
 -------------------------------------------------------------------------
-./gradlew :server:test -Dtests.iters=N --tests org.elasticsearch.package.ClassName.methodName
+./gradlew test -Dtests.iters=N -Dtests.class=*.ClassName -Dtests.method=mytest*
 -------------------------------------------------------------------------
 
 Repeats N times but skips any tests after the first failure or M initial failures.
 
 -------------------------------------------------------------
-./gradlew test -Dtests.iters=N -Dtests.failfast=true ...
-./gradlew test -Dtests.iters=N -Dtests.maxfailures=M ...
+./gradlew test -Dtests.iters=N -Dtests.failfast=true -Dtestcase=...
+./gradlew test -Dtests.iters=N -Dtests.maxfailures=M -Dtestcase=...
 -------------------------------------------------------------
 
 === Test groups.
@@ -168,7 +175,7 @@ systemProp.tests.jvms=8
 ----------------------------
 
 Its difficult to pick the "right" number here. Hypercores don't count for CPU
-intensive tests and you should leave some slack for JVM-internal threads like
+intensive tests and you should leave some slack for JVM-interal threads like
 the garbage collector. And you have to have enough RAM to handle each JVM.
 
 === Test compatibility.

--- a/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -512,14 +512,14 @@ public class OsProbe {
 
                 final String cpuAcctControlGroup = controllerMap.get("cpuacct");
                 if (cpuAcctControlGroup == null) {
-                    logger.debug("no [cpuacct] data found in control group stats");
+                    logger.debug("no [cpuacct] data found in cgroup stats");
                     return null;
                 }
                 final long cgroupCpuAcctUsageNanos = getCgroupCpuAcctUsageNanos(cpuAcctControlGroup);
 
                 final String cpuControlGroup = controllerMap.get("cpu");
                 if (cpuControlGroup == null) {
-                    logger.debug("no [cpu] data found in control group stats");
+                    logger.debug("no [cpu] data found in cgroup stats");
                     return null;
                 }
                 final long cgroupCpuAcctCpuCfsPeriodMicros = getCgroupCpuAcctCpuCfsPeriodMicros(cpuControlGroup);
@@ -528,7 +528,7 @@ public class OsProbe {
 
                 final String memoryControlGroup = controllerMap.get("memory");
                 if (memoryControlGroup == null) {
-                    logger.debug("no [memory] data found in control group stats");
+                    logger.debug("no [memory] data found in cgroup stats");
                     return null;
                 }
                 final String cgroupMemoryLimitInBytes = getCgroupMemoryLimitInBytes(memoryControlGroup);

--- a/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -511,17 +511,26 @@ public class OsProbe {
                 assert !controllerMap.isEmpty();
 
                 final String cpuAcctControlGroup = controllerMap.get("cpuacct");
-                assert cpuAcctControlGroup != null;
+                if (cpuAcctControlGroup == null) {
+                    logger.debug("no [cpuacct] data found in control group stats");
+                    return null;
+                }
                 final long cgroupCpuAcctUsageNanos = getCgroupCpuAcctUsageNanos(cpuAcctControlGroup);
 
                 final String cpuControlGroup = controllerMap.get("cpu");
-                assert cpuControlGroup != null;
+                if (cpuControlGroup == null) {
+                    logger.debug("no [cpu] data found in control group stats");
+                    return null;
+                }
                 final long cgroupCpuAcctCpuCfsPeriodMicros = getCgroupCpuAcctCpuCfsPeriodMicros(cpuControlGroup);
                 final long cgroupCpuAcctCpuCfsQuotaMicros = getCgroupCpuAcctCpuCfsQuotaMicros(cpuControlGroup);
                 final OsStats.Cgroup.CpuStat cpuStat = getCgroupCpuAcctCpuStat(cpuControlGroup);
 
                 final String memoryControlGroup = controllerMap.get("memory");
-                assert memoryControlGroup != null;
+                if (memoryControlGroup == null) {
+                    logger.debug("no [memory] data found in control group stats");
+                    return null;
+                }
                 final String cgroupMemoryLimitInBytes = getCgroupMemoryLimitInBytes(memoryControlGroup);
                 final String cgroupMemoryUsageInBytes = getCgroupMemoryUsageInBytes(memoryControlGroup);
 

--- a/server/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
@@ -188,22 +189,108 @@ public class OsProbeTests extends ESTestCase {
         final boolean areCgroupStatsAvailable = randomBoolean();
         final String hierarchy = randomAlphaOfLength(16);
 
-        final OsProbe probe = new OsProbe() {
+        final OsProbe probe = buildStubOsProbe(areCgroupStatsAvailable, hierarchy);
 
+        final OsStats.Cgroup cgroup = probe.osStats().getCgroup();
+
+        if (areCgroupStatsAvailable) {
+            assertNotNull(cgroup);
+            assertThat(cgroup.getCpuAcctControlGroup(), equalTo("/" + hierarchy));
+            assertThat(cgroup.getCpuAcctUsageNanos(), equalTo(364869866063112L));
+            assertThat(cgroup.getCpuControlGroup(), equalTo("/" + hierarchy));
+            assertThat(cgroup.getCpuCfsPeriodMicros(), equalTo(100000L));
+            assertThat(cgroup.getCpuCfsQuotaMicros(), equalTo(50000L));
+            assertThat(cgroup.getCpuStat().getNumberOfElapsedPeriods(), equalTo(17992L));
+            assertThat(cgroup.getCpuStat().getNumberOfTimesThrottled(), equalTo(1311L));
+            assertThat(cgroup.getCpuStat().getTimeThrottledNanos(), equalTo(139298645489L));
+            assertThat(cgroup.getMemoryLimitInBytes(), equalTo("18446744073709551615"));
+            assertThat(cgroup.getMemoryUsageInBytes(), equalTo("4796416"));
+        } else {
+            assertNull(cgroup);
+        }
+    }
+
+    public void testCgroupProbeWithMissingCpuAcct() {
+        assumeTrue("test runs on Linux only", Constants.LINUX);
+
+        final String hierarchy = randomAlphaOfLength(16);
+
+        // This cgroup data is missing a line about cpuacct
+        List<String> procSelfCgroupLines = getProcSelfGroupLines(hierarchy)
+            .stream()
+            .map(line -> line.replaceFirst(",cpuacct", ""))
+            .collect(Collectors.toList());
+
+        final OsProbe probe = buildStubOsProbe(true, hierarchy, procSelfCgroupLines);
+
+        final OsStats.Cgroup cgroup = probe.osStats().getCgroup();
+
+        assertNull(cgroup);
+    }
+
+    public void testCgroupProbeWithMissingCpu() {
+        assumeTrue("test runs on Linux only", Constants.LINUX);
+
+        final String hierarchy = randomAlphaOfLength(16);
+
+        // This cgroup data is missing a line about cpu
+        List<String> procSelfCgroupLines = getProcSelfGroupLines(hierarchy)
+            .stream()
+            .map(line -> line.replaceFirst(":cpu,", ":"))
+            .collect(Collectors.toList());
+
+
+        final OsProbe probe = buildStubOsProbe(true, hierarchy, procSelfCgroupLines);
+
+        final OsStats.Cgroup cgroup = probe.osStats().getCgroup();
+
+        assertNull(cgroup);
+    }
+
+    public void testCgroupProbeWithMissingMemory() {
+        assumeTrue("test runs on Linux only", Constants.LINUX);
+
+        final String hierarchy = randomAlphaOfLength(16);
+
+        // This cgroup data is missing a line about memory
+        List<String> procSelfCgroupLines = getProcSelfGroupLines(hierarchy)
+            .stream()
+            .filter(line -> !line.contains(":memory:"))
+            .collect(Collectors.toList());
+
+        final OsProbe probe = buildStubOsProbe(true, hierarchy, procSelfCgroupLines);
+
+        final OsStats.Cgroup cgroup = probe.osStats().getCgroup();
+
+        assertNull(cgroup);
+    }
+
+    private static List<String> getProcSelfGroupLines(String hierarchy) {
+        return Arrays.asList(
+            "10:freezer:/",
+            "9:net_cls,net_prio:/",
+            "8:pids:/",
+            "7:blkio:/",
+            "6:memory:/" + hierarchy,
+            "5:devices:/user.slice",
+            "4:hugetlb:/",
+            "3:perf_event:/",
+            "2:cpu,cpuacct,cpuset:/" + hierarchy,
+            "1:name=systemd:/user.slice/user-1000.slice/session-2359.scope",
+            "0::/cgroup2");
+    }
+
+    private static OsProbe buildStubOsProbe(final boolean areCgroupStatsAvailable, final String hierarchy) {
+        List<String> procSelfCgroupLines = getProcSelfGroupLines(hierarchy);
+
+        return buildStubOsProbe(areCgroupStatsAvailable, hierarchy, procSelfCgroupLines);
+    }
+
+    private static OsProbe buildStubOsProbe(final boolean areCgroupStatsAvailable, final String hierarchy, List<String> procSelfCgroupLines) {
+        return new OsProbe() {
             @Override
             List<String> readProcSelfCgroup() {
-                return Arrays.asList(
-                        "10:freezer:/",
-                        "9:net_cls,net_prio:/",
-                        "8:pids:/",
-                        "7:blkio:/",
-                        "6:memory:/" + hierarchy,
-                        "5:devices:/user.slice",
-                        "4:hugetlb:/",
-                        "3:perf_event:/",
-                        "2:cpu,cpuacct,cpuset:/" + hierarchy,
-                        "1:name=systemd:/user.slice/user-1000.slice/session-2359.scope",
-                        "0::/cgroup2");
+                return procSelfCgroupLines;
             }
 
             @Override
@@ -249,26 +336,6 @@ public class OsProbeTests extends ESTestCase {
             boolean areCgroupStatsAvailable() {
                 return areCgroupStatsAvailable;
             }
-
         };
-
-        final OsStats.Cgroup cgroup = probe.osStats().getCgroup();
-
-        if (areCgroupStatsAvailable) {
-            assertNotNull(cgroup);
-            assertThat(cgroup.getCpuAcctControlGroup(), equalTo("/" + hierarchy));
-            assertThat(cgroup.getCpuAcctUsageNanos(), equalTo(364869866063112L));
-            assertThat(cgroup.getCpuControlGroup(), equalTo("/" + hierarchy));
-            assertThat(cgroup.getCpuCfsPeriodMicros(), equalTo(100000L));
-            assertThat(cgroup.getCpuCfsQuotaMicros(), equalTo(50000L));
-            assertThat(cgroup.getCpuStat().getNumberOfElapsedPeriods(), equalTo(17992L));
-            assertThat(cgroup.getCpuStat().getNumberOfTimesThrottled(), equalTo(1311L));
-            assertThat(cgroup.getCpuStat().getTimeThrottledNanos(), equalTo(139298645489L));
-            assertThat(cgroup.getMemoryLimitInBytes(), equalTo("18446744073709551615"));
-            assertThat(cgroup.getMemoryUsageInBytes(), equalTo("4796416"));
-        } else {
-            assertNull(cgroup);
-        }
     }
-
 }

--- a/server/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
@@ -286,7 +286,20 @@ public class OsProbeTests extends ESTestCase {
         return buildStubOsProbe(areCgroupStatsAvailable, hierarchy, procSelfCgroupLines);
     }
 
-    private static OsProbe buildStubOsProbe(final boolean areCgroupStatsAvailable, final String hierarchy, List<String> procSelfCgroupLines) {
+    /**
+     * Builds a test instance of OsProbe. Methods that ordinarily read from the filesystem are overridden to return values based upon
+     * the arguments to this method.
+     *
+     * @param areCgroupStatsAvailable whether or not cgroup data is available. Normally OsProbe establishes this for itself.
+     * @param hierarchy a mock value used to generate a cgroup hierarchy.
+     * @param procSelfCgroupLines the lines that will be used as the content of <code>/proc/self/cgroup</code>
+     * @return a test instance
+     */
+    private static OsProbe buildStubOsProbe(
+        final boolean areCgroupStatsAvailable,
+        final String hierarchy,
+        List<String> procSelfCgroupLines
+    ) {
         return new OsProbe() {
             @Override
             List<String> readProcSelfCgroup() {


### PR DESCRIPTION
`OsProbe` fetches cgroup data from the filesystem, and has asserts that check for missing values. This PR changes most of these asserts into runtime checks, since at least one user has reported an NPE where a piece of cgroup data was missing.

Also update the testing guidelines to reflect current Gradle usage.

Closes #45396.