### PR TITLE
[DOCS] Document `throttle_period_in_millis` for watcher actions

### DIFF
--- a/x-pack/docs/en/rest-api/watcher/put-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/put-watch.asciidoc
@@ -68,7 +68,15 @@ A watch has the following fields:
 
 | `throttle_period` | The minimum time between actions being run, the default
                       for this is 5 seconds. This default can be changed in the
-                      config file with the setting `xpack.watcher.throttle.period.default_period`.
+                      config file with the setting
+                      `xpack.watcher.throttle.period.default_period`. If
+                      provided, the `throttle_period_in_millis` value overrides
+                      this parameter.
+
+| `throttle_period_in_millis` | Minimum time in milliseconds between actions
+                                being run. Defaults to `5000`. If provided, this
+                                value overrides the `throttle_period` value.
+
 |======
 
 [float]

--- a/x-pack/docs/en/rest-api/watcher/put-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/put-watch.asciidoc
@@ -69,14 +69,16 @@ A watch has the following fields:
 | `throttle_period` | The minimum time between actions being run, the default
                       for this is 5 seconds. This default can be changed in the
                       config file with the setting
-                      `xpack.watcher.throttle.period.default_period`. If
-                      provided, this value overrides the
-                      `throttle_period_in_millis` value.
+                      `xpack.watcher.throttle.period.default_period`. If both
+                      this value and the `throttle_period_in_millis` parameter
+                      are specified, {watcher} uses the last parameter
+                      included in the request.
 
 | `throttle_period_in_millis` | Minimum time in milliseconds between actions
-                                being run. Defaults to `5000`. If provided, the
-                                `throttle_period`` value overrides this
-                                parameter.
+                                being run. Defaults to `5000`. If both this
+                                value and the `throttle_period` parameter are
+                                specified, {watcher} uses the last parameter
+                                included in the request.
 
 |======
 

--- a/x-pack/docs/en/rest-api/watcher/put-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/put-watch.asciidoc
@@ -70,12 +70,13 @@ A watch has the following fields:
                       for this is 5 seconds. This default can be changed in the
                       config file with the setting
                       `xpack.watcher.throttle.period.default_period`. If
-                      provided, the `throttle_period_in_millis` value overrides
-                      this parameter.
+                      provided, this value overrides the
+                      `throttle_period_in_millis` value.
 
 | `throttle_period_in_millis` | Minimum time in milliseconds between actions
-                                being run. Defaults to `5000`. If provided, this
-                                value overrides the `throttle_period` value.
+                                being run. Defaults to `5000`. If provided, the
+                                `throttle_period`` value overrides this
+                                parameter.
 
 |======
 


### PR DESCRIPTION
Closes #45346.

### Preview
http://elasticsearch_45607.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/watcher-api-put-watch.html#_request_body_7