### PR TITLE
[DOCS] Relocate 'node discovery' and 'shard allocation' chapters

### DIFF
--- a/docs/reference/administering.asciidoc
+++ b/docs/reference/administering.asciidoc
@@ -4,9 +4,34 @@
 [partintro]
 --
 Elasticsearch is a complex piece of software, with many moving parts. There are
-many APIs and features that are designed to help you manage your Elasticsearch
-cluster.
+many APIs, features, and settings designed to help you manage your
+Elasticsearch cluster.
+
+[float]
+[[setting-types]]
+== Cluster setting types
+There are two types of cluster settings:
+
+// tag::setting-types[]
+
+Static::
+
+These settings must be set at the node level, either in the
+`elasticsearch.yml` file, or as an environment variable or on the command line
+when starting a node. They must be set on every relevant node in the cluster.
+
+
+Dynamic::
+
+These settings can be dynamically updated on a live cluster with the
+<<cluster-update-settings,cluster-update-settings>> API.
+
+// end::setting-types[]
 
 --
+
+include::modules/discovery.asciidoc[]
+
+include::modules/cluster.asciidoc[]
 
 include::administering/backup-cluster.asciidoc[]

--- a/docs/reference/modules.asciidoc
+++ b/docs/reference/modules.asciidoc
@@ -5,26 +5,9 @@
 --
 This section contains modules responsible for various aspects of the functionality in Elasticsearch.  Each module has settings which may be:
 
-_static_::
-
-These settings must be set at the node level, either in the
-`elasticsearch.yml` file, or as an environment variable or on the command line
-when starting a node.  They must be set on every relevant node in the cluster.
-
-_dynamic_::
-
-These settings can be dynamically updated on a live cluster with the
-<<cluster-update-settings,cluster-update-settings>> API.
+include::{docdir}/administering.asciidoc[tag=setting-types]
 
 The modules in this section are:
-
-<<modules-discovery,Discovery and cluster formation>>::
-
-    How nodes discover each other, elect a master and form a cluster.
-
-<<modules-cluster,Shard allocation and cluster-level routing>>::
-
-    Settings to control where, when, and how shards are allocated to nodes.
 
 <<modules-gateway,Gateway>>::
 
@@ -73,11 +56,6 @@ The modules in this section are:
     {ccs-cap} enables executing search requests across more than one cluster
     without joining them and acts as a federated client across them.
 --
-
-
-include::modules/discovery.asciidoc[]
-
-include::modules/cluster.asciidoc[]
 
 include::modules/gateway.asciidoc[]
 


### PR DESCRIPTION
### Changes
- Moves the "Nodes discovery..." and "Shard allocation..." chapters under "Administering ES"
- Adds a tagged region and include for dynamic/static cluster settings

Since we eventually plan to remove the "Modules" section, the tagged region should be considered temporary.