### PR TITLE
Deprecate es.http.cname_in_publish_address setting

### DIFF
--- a/server/src/main/java/org/elasticsearch/http/HttpInfo.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpInfo.java
@@ -45,7 +45,7 @@ public class HttpInfo implements Writeable, ToXContentFragment {
 
     private final BoundTransportAddress address;
     private final long maxContentLength;
-    private final boolean cnameInPublishHost;
+    private final boolean cnameInPublishHostProperty;
 
     public HttpInfo(StreamInput in) throws IOException {
         this(new BoundTransportAddress(in), in.readLong(), CNAME_IN_PUBLISH_HOST);
@@ -55,10 +55,10 @@ public class HttpInfo implements Writeable, ToXContentFragment {
         this(address, maxContentLength, CNAME_IN_PUBLISH_HOST);
     }
 
-    HttpInfo(BoundTransportAddress address, long maxContentLength, boolean cnameInPublishHost) {
+    HttpInfo(BoundTransportAddress address, long maxContentLength, boolean cnameInPublishHostProperty) {
         this.address = address;
         this.maxContentLength = maxContentLength;
-        this.cnameInPublishHost = cnameInPublishHost;
+        this.cnameInPublishHostProperty = cnameInPublishHostProperty;
     }
 
     @Override
@@ -83,13 +83,11 @@ public class HttpInfo implements Writeable, ToXContentFragment {
         String publishAddressString = publishAddress.toString();
         String hostString = publishAddress.address().getHostString();
         if (InetAddresses.isInetAddress(hostString) == false) {
-            if (cnameInPublishHost) {
-                publishAddressString = hostString + '/' + publishAddress.toString();
-            } else {
+            publishAddressString = hostString + '/' + publishAddress.toString();
+            if (cnameInPublishHostProperty) {
                 deprecationLogger.deprecated(
-                    "[http.publish_host] was printed as [ip:port] instead of [hostname/ip:port]. "
-                        + "This format is deprecated and will change to [hostname/ip:port] in a future version. "
-                        + "Use -Des.http.cname_in_publish_address=true to enforce non-deprecated formatting."
+                        "es.http.cname_in_publish_address system property is deprecated and no longer affects http.publish_address " +
+                                "formatting. Remove this property to get rid of this deprecation warning."
                 );
             }
         }

--- a/server/src/main/java/org/elasticsearch/http/HttpInfo.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpInfo.java
@@ -19,9 +19,11 @@
 
 package org.elasticsearch.http;
 
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
@@ -31,17 +33,32 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
+import static org.elasticsearch.common.Booleans.parseBoolean;
+
 public class HttpInfo implements Writeable, ToXContentFragment {
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(HttpInfo.class));
+
+    /** Whether to add hostname to publish host field when serializing. */
+    private static final boolean CNAME_IN_PUBLISH_HOST =
+        parseBoolean(System.getProperty("es.http.cname_in_publish_address"), true);
+
     private final BoundTransportAddress address;
     private final long maxContentLength;
+    private final boolean cnameInPublishHost;
 
     public HttpInfo(StreamInput in) throws IOException {
-        this(new BoundTransportAddress(in), in.readLong());
+        this(new BoundTransportAddress(in), in.readLong(), CNAME_IN_PUBLISH_HOST);
     }
 
     public HttpInfo(BoundTransportAddress address, long maxContentLength) {
+        this(address, maxContentLength, CNAME_IN_PUBLISH_HOST);
+    }
+
+    HttpInfo(BoundTransportAddress address, long maxContentLength, boolean cnameInPublishHost) {
         this.address = address;
         this.maxContentLength = maxContentLength;
+        this.cnameInPublishHost = cnameInPublishHost;
     }
 
     @Override
@@ -66,7 +83,15 @@ public class HttpInfo implements Writeable, ToXContentFragment {
         String publishAddressString = publishAddress.toString();
         String hostString = publishAddress.address().getHostString();
         if (InetAddresses.isInetAddress(hostString) == false) {
-            publishAddressString = hostString + '/' + publishAddress.toString();
+            if (cnameInPublishHost) {
+                publishAddressString = hostString + '/' + publishAddress.toString();
+            } else {
+                deprecationLogger.deprecated(
+                    "[http.publish_host] was printed as [ip:port] instead of [hostname/ip:port]. "
+                        + "This format is deprecated and will change to [hostname/ip:port] in a future version. "
+                        + "Use -Des.http.cname_in_publish_address=true to enforce non-deprecated formatting."
+                );
+            }
         }
         builder.field(Fields.PUBLISH_ADDRESS, publishAddressString);
         builder.humanReadableField(Fields.MAX_CONTENT_LENGTH_IN_BYTES, Fields.MAX_CONTENT_LENGTH, maxContentLength());

--- a/server/src/main/java/org/elasticsearch/http/HttpInfo.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpInfo.java
@@ -19,11 +19,9 @@
 
 package org.elasticsearch.http;
 
-import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
@@ -33,32 +31,17 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-import static org.elasticsearch.common.Booleans.parseBoolean;
-
 public class HttpInfo implements Writeable, ToXContentFragment {
-
-    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(HttpInfo.class));
-
-    /** Whether to add hostname to publish host field when serializing. */
-    private static final boolean CNAME_IN_PUBLISH_HOST =
-        parseBoolean(System.getProperty("es.http.cname_in_publish_address"), true);
-
     private final BoundTransportAddress address;
     private final long maxContentLength;
-    private final boolean cnameInPublishHost;
 
     public HttpInfo(StreamInput in) throws IOException {
-        this(new BoundTransportAddress(in), in.readLong(), CNAME_IN_PUBLISH_HOST);
+        this(new BoundTransportAddress(in), in.readLong());
     }
 
     public HttpInfo(BoundTransportAddress address, long maxContentLength) {
-        this(address, maxContentLength, CNAME_IN_PUBLISH_HOST);
-    }
-
-    HttpInfo(BoundTransportAddress address, long maxContentLength, boolean cnameInPublishHost) {
         this.address = address;
         this.maxContentLength = maxContentLength;
-        this.cnameInPublishHost = cnameInPublishHost;
     }
 
     @Override
@@ -83,15 +66,7 @@ public class HttpInfo implements Writeable, ToXContentFragment {
         String publishAddressString = publishAddress.toString();
         String hostString = publishAddress.address().getHostString();
         if (InetAddresses.isInetAddress(hostString) == false) {
-            if (cnameInPublishHost) {
-                publishAddressString = hostString + '/' + publishAddress.toString();
-            } else {
-                deprecationLogger.deprecated(
-                    "[http.publish_host] was printed as [ip:port] instead of [hostname/ip:port]. "
-                        + "This format is deprecated and will change to [hostname/ip:port] in a future version. "
-                        + "Use -Des.http.cname_in_publish_address=true to enforce non-deprecated formatting."
-                );
-            }
+            publishAddressString = hostString + '/' + publishAddress.toString();
         }
         builder.field(Fields.PUBLISH_ADDRESS, publishAddressString);
         builder.humanReadableField(Fields.MAX_CONTENT_LENGTH_IN_BYTES, Fields.MAX_CONTENT_LENGTH, maxContentLength());

--- a/server/src/test/java/org/elasticsearch/http/HttpInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/http/HttpInfoTests.java
@@ -40,21 +40,8 @@ public class HttpInfoTests extends ESTestCase {
                 new BoundTransportAddress(
                     new TransportAddress[]{new TransportAddress(localhost, port)},
                     new TransportAddress(localhost, port)
-                ), 0L, true
+                ), 0L
             ), "localhost/" + NetworkAddress.format(localhost) + ':' + port
-        );
-    }
-
-    public void hideCnameIfDeprecatedFormat() throws Exception {
-        InetAddress localhost = InetAddress.getByName("localhost");
-        int port = 9200;
-        assertPublishAddress(
-            new HttpInfo(
-                new BoundTransportAddress(
-                    new TransportAddress[]{new TransportAddress(localhost, port)},
-                    new TransportAddress(localhost, port)
-                ), 0L, false
-            ), NetworkAddress.format(localhost) + ':' + port
         );
     }
 
@@ -66,7 +53,7 @@ public class HttpInfoTests extends ESTestCase {
                 new BoundTransportAddress(
                     new TransportAddress[]{new TransportAddress(localhost, port)},
                     new TransportAddress(localhost, port)
-                ), 0L, true
+                ), 0L
             ), NetworkAddress.format(localhost) + ':' + port
         );
     }
@@ -77,7 +64,7 @@ public class HttpInfoTests extends ESTestCase {
             new TransportAddress(InetAddress.getByName(NetworkAddress.format(InetAddress.getByName("0:0:0:0:0:0:0:1"))), port);
         assertPublishAddress(
             new HttpInfo(
-                new BoundTransportAddress(new TransportAddress[]{localhost}, localhost), 0L, true
+                new BoundTransportAddress(new TransportAddress[]{localhost}, localhost), 0L
             ), localhost.toString()
         );
     }

--- a/server/src/test/java/org/elasticsearch/http/HttpInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/http/HttpInfoTests.java
@@ -40,13 +40,29 @@ public class HttpInfoTests extends ESTestCase {
                 new BoundTransportAddress(
                     new TransportAddress[]{new TransportAddress(localhost, port)},
                     new TransportAddress(localhost, port)
-                ), 0L, true
+                ), 0L, false
             ), "localhost/" + NetworkAddress.format(localhost) + ':' + port
         );
     }
 
-    public void hideCnameIfDeprecatedFormat() throws Exception {
+    public void testDeprecatedWarningIfPropertySpecified() throws Exception {
         InetAddress localhost = InetAddress.getByName("localhost");
+        int port = 9200;
+        assertPublishAddress(
+                new HttpInfo(
+                        new BoundTransportAddress(
+                                new TransportAddress[]{new TransportAddress(localhost, port)},
+                                new TransportAddress(localhost, port)
+                        ), 0L, true
+                ), "localhost/" + NetworkAddress.format(localhost) + ':' + port
+        );
+        assertWarnings(
+                "es.http.cname_in_publish_address system property is deprecated and no longer affects http.publish_address " +
+                "formatting. Remove this property to get rid of this deprecation warning.");
+    }
+
+    public void testCorrectDisplayPublishedIp() throws Exception {
+        InetAddress localhost = InetAddress.getByName(NetworkAddress.format(InetAddress.getByName("localhost")));
         int port = 9200;
         assertPublishAddress(
             new HttpInfo(
@@ -58,26 +74,13 @@ public class HttpInfoTests extends ESTestCase {
         );
     }
 
-    public void testCorrectDisplayPublishedIp() throws Exception {
-        InetAddress localhost = InetAddress.getByName(NetworkAddress.format(InetAddress.getByName("localhost")));
-        int port = 9200;
-        assertPublishAddress(
-            new HttpInfo(
-                new BoundTransportAddress(
-                    new TransportAddress[]{new TransportAddress(localhost, port)},
-                    new TransportAddress(localhost, port)
-                ), 0L, true
-            ), NetworkAddress.format(localhost) + ':' + port
-        );
-    }
-
     public void testCorrectDisplayPublishedIpv6() throws Exception {
         int port = 9200;
         TransportAddress localhost =
             new TransportAddress(InetAddress.getByName(NetworkAddress.format(InetAddress.getByName("0:0:0:0:0:0:0:1"))), port);
         assertPublishAddress(
             new HttpInfo(
-                new BoundTransportAddress(new TransportAddress[]{localhost}, localhost), 0L, true
+                new BoundTransportAddress(new TransportAddress[]{localhost}, localhost), 0L, false
             ), localhost.toString()
         );
     }

--- a/server/src/test/java/org/elasticsearch/http/HttpInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/http/HttpInfoTests.java
@@ -40,8 +40,21 @@ public class HttpInfoTests extends ESTestCase {
                 new BoundTransportAddress(
                     new TransportAddress[]{new TransportAddress(localhost, port)},
                     new TransportAddress(localhost, port)
-                ), 0L
+                ), 0L, true
             ), "localhost/" + NetworkAddress.format(localhost) + ':' + port
+        );
+    }
+
+    public void hideCnameIfDeprecatedFormat() throws Exception {
+        InetAddress localhost = InetAddress.getByName("localhost");
+        int port = 9200;
+        assertPublishAddress(
+            new HttpInfo(
+                new BoundTransportAddress(
+                    new TransportAddress[]{new TransportAddress(localhost, port)},
+                    new TransportAddress(localhost, port)
+                ), 0L, false
+            ), NetworkAddress.format(localhost) + ':' + port
         );
     }
 
@@ -53,7 +66,7 @@ public class HttpInfoTests extends ESTestCase {
                 new BoundTransportAddress(
                     new TransportAddress[]{new TransportAddress(localhost, port)},
                     new TransportAddress(localhost, port)
-                ), 0L
+                ), 0L, true
             ), NetworkAddress.format(localhost) + ':' + port
         );
     }
@@ -64,7 +77,7 @@ public class HttpInfoTests extends ESTestCase {
             new TransportAddress(InetAddress.getByName(NetworkAddress.format(InetAddress.getByName("0:0:0:0:0:0:0:1"))), port);
         assertPublishAddress(
             new HttpInfo(
-                new BoundTransportAddress(new TransportAddress[]{localhost}, localhost), 0L
+                new BoundTransportAddress(new TransportAddress[]{localhost}, localhost), 0L, true
             ), localhost.toString()
         );
     }


### PR DESCRIPTION
Follow up on https://github.com/elastic/elasticsearch/pull/32806.

The system property `es.http.cname_in_publish_address` is deprecated starting from 7.0.0 and deprecation warning should be added if the property is specified.
This PR will go to 7.x and master.
Follow-up PR to remove es.http.cname_in_publish_address property completely will go to the master.