### PR TITLE
Document PUT as the prefered HTTP method for index API

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
@@ -10,8 +10,8 @@
         {
           "path":"/{index}/_doc/{id}",
           "methods":[
-            "POST",
-            "PUT"
+            "PUT",
+            "POST"
           ],
           "parts":{
             "id":{
@@ -60,8 +60,8 @@
         {
           "path":"/{index}/{type}/{id}",
           "methods":[
-            "POST",
-            "PUT"
+            "PUT",
+            "POST"
           ],
           "parts":{
             "id":{


### PR DESCRIPTION
Follow up from #42346. Since the `methods` array is in order of
preference when calling the index API with an `{id}` we prefer to use
the `PUT` http method.

cc @elastic/es-clients 