### PR TITLE
transport.publish_address should contain CNAME

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -881,6 +881,9 @@ class BuildPlugin implements Plugin<Project> {
                 // TODO: remove this once ctx isn't added to update script params in 7.0
                 test.systemProperty 'es.scripting.update.ctx_in_params', 'false'
 
+                // TODO: remove this once cname is prepended to transport.publish_address by default in 8.0
+                test.systemProperty 'es.transport.cname_in_publish_address', 'true'
+
                 test.testLogging { TestLoggingContainer logging ->
                     logging.showExceptions = true
                     logging.showCauses = true

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -59,6 +59,9 @@ testClusters.integTest {
   extraConfigFile 'hunspell/en_US/en_US.dic', project(":server").file('src/test/resources/indices/analyze/conf_dir/hunspell/en_US/en_US.dic')
   // Whitelist reindexing from the local node so we can test it.
   setting 'reindex.remote.whitelist', '127.0.0.1:*'
+
+  // TODO: remove this once cname is prepended to transport.publish_address by default in 8.0
+  systemProperty 'es.transport.cname_in_publish_address', 'true'
 }
 
 // build the cluster with all plugins

--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -28,6 +28,8 @@ esplugin {
 testClusters.integTest {
   module file(project(':modules:mapper-extras').tasks.bundlePlugin.archiveFile)
   systemProperty 'es.scripting.update.ctx_in_params', 'false'
+  // TODO: remove this once cname is prepended to transport.publish_address by default in 8.0
+  systemProperty 'es.transport.cname_in_publish_address', 'true'
 }
 
 dependencies {

--- a/server/src/main/java/org/elasticsearch/common/transport/BoundTransportAddress.java
+++ b/server/src/main/java/org/elasticsearch/common/transport/BoundTransportAddress.java
@@ -22,6 +22,7 @@ package org.elasticsearch.common.transport;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.network.InetAddresses;
 
 import java.io.IOException;
 
@@ -75,7 +76,12 @@ public class BoundTransportAddress implements Writeable {
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder("publish_address {");
-        builder.append(publishAddress);
+        String hostString = publishAddress.address().getHostString();
+        String publishAddressString = publishAddress.toString();
+        if (InetAddresses.isInetAddress(hostString) == false) {
+            publishAddressString = hostString + '/' + publishAddress.toString();
+        }
+        builder.append(publishAddressString);
         builder.append("}, bound_addresses ");
         boolean firstAdded = false;
         for (TransportAddress address : boundAddresses) {

--- a/server/src/main/java/org/elasticsearch/transport/TransportInfo.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportInfo.java
@@ -19,11 +19,15 @@
 
 package org.elasticsearch.transport;
 
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.transport.BoundTransportAddress;
+import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -31,14 +35,29 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.elasticsearch.common.Booleans.parseBoolean;
+
 public class TransportInfo implements Writeable, ToXContentFragment {
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(TransportInfo.class));
+
+    /** Whether to add hostname to publish host field when serializing. */
+    private static final boolean CNAME_IN_PUBLISH_ADDRESS =
+            parseBoolean(System.getProperty("es.transport.cname_in_publish_address"), false);
 
     private BoundTransportAddress address;
     private Map<String, BoundTransportAddress> profileAddresses;
+    private final boolean cnameInPublishAddress;
 
     public TransportInfo(BoundTransportAddress address, @Nullable Map<String, BoundTransportAddress> profileAddresses) {
+        this(address, profileAddresses, CNAME_IN_PUBLISH_ADDRESS);
+    }
+
+    public TransportInfo(BoundTransportAddress address, @Nullable Map<String, BoundTransportAddress> profileAddresses,
+                         boolean cnameInPublishAddress) {
         this.address = address;
         this.profileAddresses = profileAddresses;
+        this.cnameInPublishAddress = cnameInPublishAddress;
     }
 
     public TransportInfo(StreamInput in) throws IOException {
@@ -52,6 +71,7 @@ public class TransportInfo implements Writeable, ToXContentFragment {
                 profileAddresses.put(key, value);
             }
         }
+        this.cnameInPublishAddress = CNAME_IN_PUBLISH_ADDRESS;
     }
 
     @Override
@@ -77,17 +97,35 @@ public class TransportInfo implements Writeable, ToXContentFragment {
         static final String PROFILES = "profiles";
     }
 
+    private String getPublishAddressString(String propertyName, TransportAddress publishAddress){
+        String publishAddressString = publishAddress.toString();
+        String hostString = publishAddress.address().getHostString();
+        if (InetAddresses.isInetAddress(hostString) == false) {
+            if (cnameInPublishAddress) {
+                publishAddressString = hostString + '/' + publishAddress.toString();
+            } else {
+                deprecationLogger.deprecated(
+                        propertyName + " was printed as [ip:port] instead of [hostname/ip:port]. "
+                                + "This format is deprecated and will change to [hostname/ip:port] in a future version. "
+                                + "Use -Des.transport.cname_in_publish_address=true to enforce non-deprecated formatting."
+                );
+            }
+        }
+        return publishAddressString;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.TRANSPORT);
         builder.array(Fields.BOUND_ADDRESS, (Object[]) address.boundAddresses());
-        builder.field(Fields.PUBLISH_ADDRESS, address.publishAddress().toString());
+        builder.field(Fields.PUBLISH_ADDRESS, getPublishAddressString("transport.publish_address", address.publishAddress()));
         builder.startObject(Fields.PROFILES);
         if (profileAddresses != null && profileAddresses.size() > 0) {
             for (Map.Entry<String, BoundTransportAddress> entry : profileAddresses.entrySet()) {
                 builder.startObject(entry.getKey());
                 builder.array(Fields.BOUND_ADDRESS, (Object[]) entry.getValue().boundAddresses());
-                builder.field(Fields.PUBLISH_ADDRESS, entry.getValue().publishAddress().toString());
+                String propertyName = "transport." + entry.getKey() + ".publish_address";
+                builder.field(Fields.PUBLISH_ADDRESS, getPublishAddressString(propertyName, entry.getValue().publishAddress()));
                 builder.endObject();
             }
         }

--- a/server/src/main/java/org/elasticsearch/transport/TransportInfo.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportInfo.java
@@ -97,7 +97,7 @@ public class TransportInfo implements Writeable, ToXContentFragment {
         static final String PROFILES = "profiles";
     }
 
-    private String getPublishAddressString(String propertyName, TransportAddress publishAddress){
+    private String formatPublishAddressString(String propertyName, TransportAddress publishAddress){
         String publishAddressString = publishAddress.toString();
         String hostString = publishAddress.address().getHostString();
         if (InetAddresses.isInetAddress(hostString) == false) {
@@ -118,14 +118,14 @@ public class TransportInfo implements Writeable, ToXContentFragment {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.TRANSPORT);
         builder.array(Fields.BOUND_ADDRESS, (Object[]) address.boundAddresses());
-        builder.field(Fields.PUBLISH_ADDRESS, getPublishAddressString("transport.publish_address", address.publishAddress()));
+        builder.field(Fields.PUBLISH_ADDRESS, formatPublishAddressString("transport.publish_address", address.publishAddress()));
         builder.startObject(Fields.PROFILES);
         if (profileAddresses != null && profileAddresses.size() > 0) {
             for (Map.Entry<String, BoundTransportAddress> entry : profileAddresses.entrySet()) {
                 builder.startObject(entry.getKey());
                 builder.array(Fields.BOUND_ADDRESS, (Object[]) entry.getValue().boundAddresses());
                 String propertyName = "transport." + entry.getKey() + ".publish_address";
-                builder.field(Fields.PUBLISH_ADDRESS, getPublishAddressString(propertyName, entry.getValue().publishAddress()));
+                builder.field(Fields.PUBLISH_ADDRESS, formatPublishAddressString(propertyName, entry.getValue().publishAddress()));
                 builder.endObject();
             }
         }

--- a/server/src/test/java/org/elasticsearch/transport/TransportInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportInfoTests.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.transport;
+
+import org.elasticsearch.common.network.NetworkAddress;
+import org.elasticsearch.common.transport.BoundTransportAddress;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.Map;
+
+public class TransportInfoTests extends ESTestCase {
+
+    private TransportInfo createTransportInfo(InetAddress address, int port, boolean cnameInPublishAddress) {
+        BoundTransportAddress boundAddress = new BoundTransportAddress(
+                new TransportAddress[]{new TransportAddress(address, port)},
+                new TransportAddress(address, port)
+        );
+        Map<String, BoundTransportAddress> profiles = Collections.singletonMap("test_profile", boundAddress);
+        return new TransportInfo(boundAddress, profiles, cnameInPublishAddress);
+    }
+
+    public void testCorrectlyDisplayPublishedCname() throws Exception {
+        InetAddress address = InetAddress.getByName("localhost");
+        int port = 9200;
+        assertPublishAddress(
+            createTransportInfo(address, port,true),
+            "localhost/" + NetworkAddress.format(address) + ':' + port
+        );
+    }
+
+    public void testHideCnameIfDeprecatedFormat() throws Exception {
+        InetAddress address = InetAddress.getByName("localhost");
+        int port = 9200;
+        assertPublishAddress(
+                createTransportInfo(address, port,false),
+                NetworkAddress.format(address) + ':' + port
+        );
+        assertWarnings("transport.publish_address was printed as [ip:port] instead of [hostname/ip:port]. " +
+                "This format is deprecated and will change to [hostname/ip:port] in a future version. " +
+                "Use -Des.transport.cname_in_publish_address=true to enforce non-deprecated formatting.",
+
+                "transport.test_profile.publish_address was printed as [ip:port] instead of [hostname/ip:port]. " +
+                "This format is deprecated and will change to [hostname/ip:port] in a future version. " +
+                "Use -Des.transport.cname_in_publish_address=true to enforce non-deprecated formatting.");
+    }
+
+    public void testCorrectDisplayPublishedIp() throws Exception {
+        InetAddress address = InetAddress.getByName(NetworkAddress.format(InetAddress.getByName("localhost")));
+        int port = 9200;
+        assertPublishAddress(
+                createTransportInfo(address, port,true),
+                NetworkAddress.format(address) + ':' + port
+        );
+    }
+
+    public void testCorrectDisplayPublishedIpv6() throws Exception {
+        InetAddress address = InetAddress.getByName(NetworkAddress.format(InetAddress.getByName("0:0:0:0:0:0:0:1")));
+        int port = 9200;
+        assertPublishAddress(
+                createTransportInfo(address, port,true),
+                new TransportAddress(address, port).toString()
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertPublishAddress(TransportInfo httpInfo, String expected) throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        httpInfo.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+
+        Map<String, Object> transportMap = (Map<String, Object>) createParser(builder).map().get(TransportInfo.Fields.TRANSPORT);
+        Map<String, Object> profilesMap = (Map<String, Object>) transportMap.get("profiles");
+        assertEquals(
+            expected,
+            transportMap.get(TransportInfo.Fields.PUBLISH_ADDRESS)
+        );
+        assertEquals(
+                expected,
+                ((Map<String, Object>)profilesMap.get("test_profile")).get(TransportInfo.Fields.PUBLISH_ADDRESS)
+        );
+    }
+}


### PR DESCRIPTION
This commit adds CNAME reporting for transport.publish_address same way it's done for http.publish_address.
1. This PR goes to 7.x and master (8.0.0).
2. Follow-up PR to master (8.0.0) will output cname anyway and log deprecation warning if system property is specified.
3. Once 8 is released, a new follow-up can remove the property handling completely.

Relates #32806
Relates #39970