### PR TITLE
Cleanup Redundant TransportLogger Instantiation (#43265)

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/InboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundHandler.java
@@ -49,7 +49,6 @@ public class InboundHandler {
     private final OutboundHandler outboundHandler;
     private final CircuitBreakerService circuitBreakerService;
     private final InboundMessage.Reader reader;
-    private final TransportLogger transportLogger;
     private final TransportHandshaker handshaker;
     private final TransportKeepAlive keepAlive;
 
@@ -58,13 +57,11 @@ public class InboundHandler {
     private volatile TransportMessageListener messageListener = TransportMessageListener.NOOP_LISTENER;
 
     InboundHandler(ThreadPool threadPool, OutboundHandler outboundHandler, InboundMessage.Reader reader,
-                   CircuitBreakerService circuitBreakerService, TransportLogger transportLogger, TransportHandshaker handshaker,
-                   TransportKeepAlive keepAlive) {
+                   CircuitBreakerService circuitBreakerService, TransportHandshaker handshaker, TransportKeepAlive keepAlive) {
         this.threadPool = threadPool;
         this.outboundHandler = outboundHandler;
         this.circuitBreakerService = circuitBreakerService;
         this.reader = reader;
-        this.transportLogger = transportLogger;
         this.handshaker = handshaker;
         this.keepAlive = keepAlive;
     }
@@ -98,7 +95,7 @@ public class InboundHandler {
 
     void inboundMessage(TcpChannel channel, BytesReference message) throws Exception {
         channel.getChannelStats().markAccessed(threadPool.relativeTimeInMillis());
-        transportLogger.logInboundMessage(channel, message);
+        TransportLogger.logInboundMessage(channel, message);
         readBytesMetric.inc(message.length() + TcpHeader.MARKER_BYTES_SIZE + TcpHeader.MESSAGE_LENGTH_SIZE);
         // Message length of 0 is a ping
         if (message.length() != 0) {
@@ -226,7 +223,7 @@ public class InboundHandler {
         });
     }
 
-    private void handlerResponseError(StreamInput stream, final TransportResponseHandler handler) {
+    private void handlerResponseError(StreamInput stream, final TransportResponseHandler<?> handler) {
         Exception error;
         try {
             error = stream.readException();
@@ -236,7 +233,7 @@ public class InboundHandler {
         handleException(handler, error);
     }
 
-    private void handleException(final TransportResponseHandler handler, Throwable error) {
+    private void handleException(final TransportResponseHandler<?> handler, Throwable error) {
         if (!(error instanceof RemoteTransportException)) {
             error = new RemoteTransportException(error.getMessage(), error);
         }
@@ -255,7 +252,7 @@ public class InboundHandler {
         private final TransportRequest request;
         private final TransportChannel transportChannel;
 
-        RequestHandler(RequestHandlerRegistry reg, TransportRequest request, TransportChannel transportChannel) {
+        RequestHandler(RequestHandlerRegistry<?> reg, TransportRequest request, TransportChannel transportChannel) {
             this.reg = reg;
             this.request = request;
             this.transportChannel = transportChannel;

--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -53,17 +53,14 @@ final class OutboundHandler {
     private final String[] features;
     private final ThreadPool threadPool;
     private final BigArrays bigArrays;
-    private final TransportLogger transportLogger;
     private volatile TransportMessageListener messageListener = TransportMessageListener.NOOP_LISTENER;
 
-    OutboundHandler(String nodeName, Version version, String[] features, ThreadPool threadPool, BigArrays bigArrays,
-                    TransportLogger transportLogger) {
+    OutboundHandler(String nodeName, Version version, String[] features, ThreadPool threadPool, BigArrays bigArrays) {
         this.nodeName = nodeName;
         this.version = version;
         this.features = features;
         this.threadPool = threadPool;
         this.bigArrays = bigArrays;
-        this.transportLogger = transportLogger;
     }
 
     void sendBytes(TcpChannel channel, BytesReference bytes, ActionListener<Void> listener) {
@@ -201,7 +198,7 @@ final class OutboundHandler {
             try {
                 message = messageSupplier.get();
                 messageSize = message.length();
-                transportLogger.logOutboundMessage(channel, message);
+                TransportLogger.logOutboundMessage(channel, message);
                 return message;
             } catch (Exception e) {
                 onFailure(e);

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -134,7 +134,6 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         this.threadPool = threadPool;
         this.pageCacheRecycler = pageCacheRecycler;
         this.networkService = networkService;
-        TransportLogger transportLogger = new TransportLogger();
         String nodeName = Node.NODE_NAME_SETTING.get(settings);
         final Settings defaultFeatures = TransportSettings.DEFAULT_FEATURES_SETTING.get(settings);
         String[] features;
@@ -151,7 +150,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         }
         BigArrays bigArrays = new BigArrays(pageCacheRecycler, circuitBreakerService, CircuitBreaker.IN_FLIGHT_REQUESTS);
 
-        this.outboundHandler = new OutboundHandler(nodeName, version, features, threadPool, bigArrays, transportLogger);
+        this.outboundHandler = new OutboundHandler(nodeName, version, features, threadPool, bigArrays);
         this.handshaker = new TransportHandshaker(version, threadPool,
             (node, channel, requestId, v) -> outboundHandler.sendRequest(node, channel, requestId,
                 TransportHandshaker.HANDSHAKE_ACTION_NAME, new TransportHandshaker.HandshakeRequest(version),
@@ -160,7 +159,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 TransportHandshaker.HANDSHAKE_ACTION_NAME, response, false, true));
         InboundMessage.Reader reader = new InboundMessage.Reader(version, namedWriteableRegistry, threadPool.getThreadContext());
         this.keepAlive = new TransportKeepAlive(threadPool, this.outboundHandler::sendBytes);
-        this.inboundHandler = new InboundHandler(threadPool, outboundHandler, reader, circuitBreakerService, transportLogger, handshaker,
+        this.inboundHandler = new InboundHandler(threadPool, outboundHandler, reader, circuitBreakerService, handshaker,
             keepAlive);
     }
 

--- a/server/src/main/java/org/elasticsearch/transport/TransportLogger.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportLogger.java
@@ -36,7 +36,7 @@ public final class TransportLogger {
     private static final Logger logger = LogManager.getLogger(TransportLogger.class);
     private static final int HEADER_SIZE = TcpHeader.MARKER_BYTES_SIZE + TcpHeader.MESSAGE_LENGTH_SIZE;
 
-    void logInboundMessage(TcpChannel channel, BytesReference message) {
+    static void logInboundMessage(TcpChannel channel, BytesReference message) {
         if (logger.isTraceEnabled()) {
             try {
                 String logMessage = format(channel, message, "READ");
@@ -47,7 +47,7 @@ public final class TransportLogger {
         }
     }
 
-    void logOutboundMessage(TcpChannel channel, BytesReference message) {
+    static void logOutboundMessage(TcpChannel channel, BytesReference message) {
         if (logger.isTraceEnabled()) {
             try {
                 if (message.get(0) != 'E') {
@@ -63,7 +63,7 @@ public final class TransportLogger {
         }
     }
 
-    private String format(TcpChannel channel, BytesReference message, String event) throws IOException {
+    private static String format(TcpChannel channel, BytesReference message, String event) throws IOException {
         final StringBuilder sb = new StringBuilder();
         sb.append(channel);
         int messageLengthWithHeader = HEADER_SIZE + message.length();

--- a/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
@@ -54,7 +54,6 @@ public class InboundHandlerTests extends ESTestCase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        TransportLogger transportLogger = new TransportLogger();
         taskManager = new TaskManager(Settings.EMPTY, threadPool, Collections.emptySet());
         channel = new FakeTcpChannel(randomBoolean(), buildNewFakeTransportAddress().address(), buildNewFakeTransportAddress().address());
         NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(Collections.emptyList());
@@ -63,10 +62,9 @@ public class InboundHandlerTests extends ESTestCase {
         }, (v, f, c, r, r_id) -> {
         });
         TransportKeepAlive keepAlive = new TransportKeepAlive(threadPool, TcpChannel::sendMessage);
-        OutboundHandler outboundHandler = new OutboundHandler("node", version, new String[0], threadPool, BigArrays.NON_RECYCLING_INSTANCE,
-            transportLogger);
-        handler = new InboundHandler(threadPool, outboundHandler, reader, new NoneCircuitBreakerService(), transportLogger, handshaker,
-            keepAlive);
+        OutboundHandler outboundHandler =
+            new OutboundHandler("node", version, new String[0], threadPool, BigArrays.NON_RECYCLING_INSTANCE);
+        handler = new InboundHandler(threadPool, outboundHandler, reader, new NoneCircuitBreakerService(), handshaker, keepAlive);
     }
 
     @After

--- a/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
@@ -62,12 +62,11 @@ public class OutboundHandlerTests extends ESTestCase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        TransportLogger transportLogger = new TransportLogger();
         channel = new FakeTcpChannel(randomBoolean(), buildNewFakeTransportAddress().address(), buildNewFakeTransportAddress().address());
         TransportAddress transportAddress = buildNewFakeTransportAddress();
         node = new DiscoveryNode("", transportAddress, Version.CURRENT);
         String[] features = {feature1, feature2};
-        handler = new OutboundHandler("node", Version.CURRENT, features, threadPool, BigArrays.NON_RECYCLING_INSTANCE, transportLogger);
+        handler = new OutboundHandler("node", Version.CURRENT, features, threadPool, BigArrays.NON_RECYCLING_INSTANCE);
     }
 
     @After

--- a/server/src/test/java/org/elasticsearch/transport/TransportLoggerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportLoggerTests.java
@@ -56,8 +56,6 @@ public class TransportLoggerTests extends ESTestCase {
     }
 
     public void testLoggingHandler() throws IOException {
-        TransportLogger transportLogger = new TransportLogger();
-
         final String writePattern =
             ".*\\[length: \\d+" +
                 ", request id: \\d+" +
@@ -84,8 +82,8 @@ public class TransportLoggerTests extends ESTestCase {
         appender.addExpectation(writeExpectation);
         appender.addExpectation(readExpectation);
         BytesReference bytesReference = buildRequest();
-        transportLogger.logInboundMessage(mock(TcpChannel.class), bytesReference.slice(6, bytesReference.length() - 6));
-        transportLogger.logOutboundMessage(mock(TcpChannel.class), bytesReference);
+        TransportLogger.logInboundMessage(mock(TcpChannel.class), bytesReference.slice(6, bytesReference.length() - 6));
+        TransportLogger.logOutboundMessage(mock(TcpChannel.class), bytesReference);
         appender.assertAllExpectationsMatched();
     }
 


### PR DESCRIPTION
* This class' methods are all effectively `static` => make them `static` and stop instantiating it needlessly

backport of #43265 