### PR TITLE
Fix Watcher Context Examples in Painless

### DIFF
--- a/docs/painless/painless-contexts/painless-context-examples.asciidoc
+++ b/docs/painless/painless-contexts/painless-context-examples.asciidoc
@@ -48,7 +48,7 @@ PUT /seats
   "mappings": {
     "properties": {
       "theatre":  { "type": "keyword" },
-      "play":     { "type": "text"    },
+      "play":     { "type": "keyword" },
       "actors":   { "type": "text"    },
       "row":      { "type": "integer" },
       "number":   { "type": "integer" },
@@ -72,7 +72,7 @@ seat data is indexed.
 +
 [source,js]
 ----
-curl -XPOST localhost:9200/seats/seat/_bulk?pipeline=seats -H "Content-Type: application/x-ndjson" --data-binary "@/<local-file-path>/seats.json"
+curl -XPOST "localhost:9200/seats/_bulk?pipeline=seats" -H "Content-Type: application/x-ndjson" --data-binary "@/<local-file-path>/seats.json"
 ----
 // NOTCONSOLE
 

--- a/docs/painless/painless-contexts/painless-filter-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-filter-context.asciidoc
@@ -43,7 +43,7 @@ all available theatre seats for evening performances that are under $18.
 
 [source,js]
 ----
-GET evening/_search
+GET seats/_search
 {
     "query": {
         "bool" : {

--- a/docs/painless/painless-contexts/painless-watcher-condition-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-watcher-condition-context.asciidoc
@@ -18,7 +18,7 @@ The standard <<painless-api-reference-shared, Painless API>> is available.
 
 *Example*
 
-[source,Painless]
+[source,js]
 ----
 POST _watcher/watch/_execute
 {
@@ -65,6 +65,8 @@ POST _watcher/watch/_execute
   }
 }
 ----
+// CONSOLE
+// TEST[skip: requires setup from other pages]
 
 <1> The Java Stream API is used in the condition. This API allows manipulation of
 the elements of the list in a pipeline.
@@ -76,7 +78,7 @@ on the value of the seats sold for the plays in the data set. The script aggrega
 the total sold seats for each play and returns true if there is at least one play
 that has sold over $50,000.
 
-[source,Painless]
+[source,js]
 ----
 POST _watcher/watch/_execute
 {
@@ -121,6 +123,8 @@ POST _watcher/watch/_execute
   }
 }
 ----
+// CONSOLE
+// TEST[skip: requires setup from other pages]
 
 This example uses a nearly identical condition as the previous example. The
 differences below are subtle and are worth calling out.

--- a/docs/painless/painless-contexts/painless-watcher-context-example.asciidoc
+++ b/docs/painless/painless-contexts/painless-watcher-context-example.asciidoc
@@ -1,4 +1,4 @@
-[source,Painless]
+[source,js]
 ----
 POST _watcher/watch/_execute
 {
@@ -99,10 +99,12 @@ POST _watcher/watch/_execute
   }
 }
 ----
+// CONSOLE
+// TEST[skip: requires setup from other pages]
 
 The following example shows the use of metadata and transforming dates into a readable format.
 
-[source,Painless]
+[source,js]
 ----
 POST _watcher/watch/_execute
 {
@@ -155,3 +157,5 @@ POST _watcher/watch/_execute
   }
 }
 ----
+// CONSOLE
+// TEST[skip: requires setup from other pages]

--- a/docs/painless/painless-contexts/painless-watcher-transform-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-watcher-transform-context.asciidoc
@@ -18,7 +18,7 @@ The standard <<painless-api-reference-shared, Painless API>> is available.
 
 *Example*
 
-[source,Painless]
+[source,js]
 ----
 POST _watcher/watch/_execute
 {
@@ -75,6 +75,8 @@ POST _watcher/watch/_execute
   }
 }
 ----
+// CONSOLE
+// TEST[skip: requires setup from other pages]
 
 <1> The Java Stream API is used in the transform. This API allows manipulation of
 the elements of the list in a pipeline.
@@ -86,7 +88,7 @@ the elements of the list in a pipeline.
 The following action transform changes each value in the mod_log action into a `String`.
 This transform does not change the values in the unmod_log action.
 
-[source,Painless]
+[source,js]
 ----
 POST _watcher/watch/_execute
 {
@@ -140,6 +142,8 @@ POST _watcher/watch/_execute
   }
 }
 ----
+// CONSOLE
+// TEST[skip: requires setup from other pages]
 
 This example uses the streaming API in a very similar manner. The differences below are
 subtle and worth calling out.


### PR DESCRIPTION
This fixes the mappings and types required to run watcher and other examples.  A new set of seat data will be updated and available for download to go with this change.

Relates to (https://github.com/elastic/elasticsearch/issues/45491)
and (https://github.com/elastic/elasticsearch/issues/45492)