### PR TITLE
Fix backwards compatibility with pre-Java11 build-tools users

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -71,12 +71,6 @@ sourceSets {
     minimumRuntime { }
 }
 
-allprojects {
-    apply plugin: 'java'
-    targetCompatibility = 11
-    sourceCompatibility = 11
-}
-
 configurations {
   reaper
 }
@@ -160,8 +154,8 @@ if (project != rootProject) {
   apply plugin: 'nebula.maven-scm'
 
   allprojects {
-    targetCompatibility = 11
-    sourceCompatibility = 11
+    targetCompatibility = 10
+    sourceCompatibility = 10
   }
 
   // groovydoc succeeds, but has some weird internal exception...

--- a/buildSrc/reaper/build.gradle
+++ b/buildSrc/reaper/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: 'java'
+
 jar {
     archiveName = "${project.name}.jar"
     manifest {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ReaperService.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ReaperService.java
@@ -24,6 +24,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.logging.Logger;
 import org.gradle.internal.jvm.Jvm;
 
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -31,6 +32,7 @@ import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -68,8 +70,8 @@ public class ReaperService {
     public void registerCommand(String serviceId, String... command) {
         ensureReaperStarted();
 
-        try {
-            Files.writeString(getCmdFile(serviceId), String.join(" ", command));
+        try (FileWriter writer = new FileWriter(getCmdFile(serviceId).toFile())) {
+            writer.write(String.join(" ", command));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -143,7 +145,7 @@ public class ReaperService {
 
             if (matcher.matches()) {
                 String path = matcher.group(1);
-                return Path.of(
+                return Paths.get(
                     OS.<String>conditional()
                         .onWindows(() -> path.substring(1))
                         .onUnix(() -> path)


### PR DESCRIPTION
More Java [compatibility issues](https://elastic.slack.com/archives/CEPSTEDM0/p1565895832124200)with the elasticsearch-hadoop project.

This time we introduced a requirement on Java11 into the 7.x branch. This refactors some things so we can run in a Java8 runtime.