### PR TITLE
Clarify mixed license text

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,13 +1,10 @@
-Source code in this repository is variously licensed under the Apache License
-Version 2.0, an Apache compatible license, or the Elastic License. Outside of
-the "x-pack" folder, source code in a given file is licensed under the Apache
-License Version 2.0, unless otherwise noted at the beginning of the file or a
-LICENSE file present in the directory subtree declares a separate license.
-Within the "x-pack" folder, source code in a given file is licensed under the
-Elastic License, unless otherwise noted at the beginning of the file or a
-LICENSE file present in the directory subtree declares a separate license.
+Source code in this repository is covered by one of three licenses: (i) the
+Apache License 2.0 (ii) an Apache License 2.0 compatible license (iii) the
+Elastic License. The default license throughout the repository is Apache License
+2.0 unless the header specifies another license. Elastic Licensed code is found
+only in the x-pack directory.
 
 The build produces two sets of binaries - one set that falls under the Elastic
-License and another set that falls under Apache License Version 2.0. The
-binaries that contain `-oss` in the artifact name are licensed under the Apache
-License Version 2.0.
+License and another set that falls under Apache License 2.0. The binaries that
+contain `-oss` in the artifact name are licensed under Apache License 2.0 and
+these binaries do not package any code from the x-pack directory.


### PR DESCRIPTION
This commit clarifies the mixed licensing in the elasticsearch
repository. A few points of note:
 - we clarify that all code is under the Apache License 2.0 unless noted otherwise
 - we clarify that code under the Elastic License is only in the x-pack directory
 - we clarify that when code is not under the Apache License 2.0 nor the Elastic License that it is Apache License 2.0 compatible
 - we clarify that OSS-builds do not package any code from the x-pack directory
