### PR TITLE
[DOCS] Reformats voting configuration exclusion API

### DIFF
--- a/docs/reference/cluster/voting-exclusions.asciidoc
+++ b/docs/reference/cluster/voting-exclusions.asciidoc
@@ -7,21 +7,17 @@
 Adds or removes master-eligible nodes from the
 <<modules-discovery-voting,voting configuration exclusion list>>.
 
-[float]
-==== Request
 
-`POST _cluster/voting_config_exclusions/<node_name>` +
+[[voting-config-exclusions-api-request]]
+==== {api-request-title}
+
+`POST _cluster/voting_config_exclusions/{node_name}` +
 
 `DELETE _cluster/voting_config_exclusions`
 
-[float]
-==== Path parameters
 
-`node_name`::
-  A <<cluster-nodes,node filter>> that identifies {es} nodes.
-
-[float]
-==== Description
+[[voting-config-exclusions-api-desc]]
+==== {api-description-title}
   
 By default, if there are more than three master-eligible nodes in the cluster
 and you remove fewer than half of the master-eligible nodes in the cluster at
@@ -44,23 +40,35 @@ master-eligible nodes from a cluster in a short time period. They are not
 required when removing master-ineligible nodes or fewer than half of the
 master-eligible nodes.
 
-The <<modules-discovery-settings,`cluster.max_voting_config_exclusions`
-setting>> limits the size of the voting configuration exclusion list. The
-default value is `10`. Since voting configuration exclusions are persistent and
-limited in number, you must clear the voting config exclusions list once the
-exclusions are no longer required.
-
-There is also a
-<<modules-discovery-settings,`cluster.auto_shrink_voting_configuration` setting>>,
-which is set to true by default. If it is set to false, you must use this API to
-maintain the voting configuration.
-
 For more information, see <<modules-discovery-removing-nodes>>.
 
-[float]
-==== Examples
+
+[[voting-config-exclusions-api-path-params]]
+==== {api-path-parms-title}
+
+`{node_name}`::
+  A <<cluster-nodes,node filter>> that identifies {es} nodes.
+
+
+[[voting-config-exclusions-api-query-params]]
+==== {api-query-parms-title}
+
+`cluster.auto_shrink_voting_configuration`::
+    (Optional, boolean) If `false`, you must use this API to maintain the voting 
+    configuration. Defaults to `true`.
+
+`cluster.max_voting_config_exclusions`::
+    (Optional, integer) Limits the size of the voting configuration exclusion 
+    list. The default value is `10`. Since voting configuration exclusions are 
+    persistent and limited in number, you must clear the voting config 
+    exclusions list once the exclusions are no longer required.
+
+  
+[[voting-config-exclusions-api-example]]
+==== {api-examples-title}
 
 Add `nodeId1` to the voting configuration exclusions list:
+
 [source,js]
 -------------------------------------------------- 
 POST /_cluster/voting_config_exclusions/nodeId1
@@ -68,7 +76,9 @@ POST /_cluster/voting_config_exclusions/nodeId1
 // CONSOLE
 // TEST[catch:bad_request]
 
+
 Remove all exclusions from the list:
+
 [source,js]
 --------------------------------------------------
 DELETE /_cluster/voting_config_exclusions


### PR DESCRIPTION
Relates to elastic/docs#937 and https://github.com/elastic/elasticsearch/issues/45197.

This PR updates the voting configuration exclusion API to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc).

Resources:
* [Voting configuration exclusion API doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/voting-config-exclusions.html)