### PR TITLE
IP filter of TRANSPORT and HTTP should be independent

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/filter/IPFilter.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/filter/IPFilter.java
@@ -65,17 +65,11 @@ public class IPFilter {
             "xpack.security.filter.allow", key -> Setting.listSetting(key, Collections.emptyList(), Function.identity(),
             Property.Dynamic, Property.NodeScope));
 
-    private static final Setting<List<String>> HTTP_FILTER_ALLOW_FALLBACK =
-            Setting.listSetting("transport.profiles.default.xpack.security.filter.allow", TRANSPORT_FILTER_ALLOW_SETTING, s -> s,
-                    Property.NodeScope);
     public static final Setting<List<String>> HTTP_FILTER_ALLOW_SETTING = Setting.listSetting(setting("http.filter.allow"),
-            HTTP_FILTER_ALLOW_FALLBACK, Function.identity(), Property.Dynamic, Property.NodeScope);
+        Collections.emptyList(), Function.identity(), Property.Dynamic, Property.NodeScope);
 
-    private static final Setting<List<String>> HTTP_FILTER_DENY_FALLBACK =
-            Setting.listSetting("transport.profiles.default.xpack.security.filter.deny", TRANSPORT_FILTER_DENY_SETTING, s -> s,
-                    Property.NodeScope);
     public static final Setting<List<String>> HTTP_FILTER_DENY_SETTING = Setting.listSetting(setting("http.filter.deny"),
-            HTTP_FILTER_DENY_FALLBACK, Function.identity(), Property.Dynamic, Property.NodeScope);
+        Collections.emptyList(), Function.identity(), Property.Dynamic, Property.NodeScope);
 
     public static final Map<String, Object> DISABLED_USAGE_STATS = Map.of(
             "http", false,


### PR DESCRIPTION
I think the IP filtering of transport and HTTP should be independent.

When I test, I found that when I only set allow or deny for transport, allow or deny for HTTP was also set. If I only want to disable transport requests, then HTTP requests are also disabled.