### PR TITLE
[DOCS] Bump docs version from 7.3.0 to 7.3.1

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -1,8 +1,8 @@
-:version:               7.3.0
+:version:               7.3.1
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:          7.3.0
+:bare_version:          7.3.1
 :major-version:         7.x
 :prev-major-version:    6.x
 :lucene_version:        8.1.0


### PR DESCRIPTION
Increments the Elasticsearch documentation for the 7.3.1 release.

**DO NOT MERGE UNTIL RELEASE DAY.**