### PR TITLE
Disable test runner task when not running with testclusters

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
@@ -62,6 +62,7 @@ class RestIntegTestTask extends DefaultTask {
         boolean usesTestclusters = project.plugins.hasPlugin(TestClustersPlugin.class)
         if (usesTestclusters == false) {
             clusterConfig = project.extensions.create("${name}Cluster", ClusterConfiguration.class, project)
+            runner.outputs.doNotCacheIf("Caching is disabled when using ClusterFormationTasks", { true })
         } else {
             project.testClusters {
                 "$name" {


### PR DESCRIPTION
This PR disables caching for rest test runner tasks that are not using the test-clusters plugin. Since the "legacy" cluster formation method is not properly tracked as an input, we cannot reliably use the build cache in that scenario.