### PR TITLE
Rename CoordinatorProxyAction to EnrichCoordinatorProxyAction

### DIFF
--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPlugin.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPlugin.java
@@ -40,7 +40,7 @@ import org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyAction;
 import org.elasticsearch.xpack.core.enrich.action.GetEnrichPolicyAction;
 import org.elasticsearch.xpack.core.enrich.action.ListEnrichPolicyAction;
 import org.elasticsearch.xpack.core.enrich.action.PutEnrichPolicyAction;
-import org.elasticsearch.xpack.enrich.action.CoordinatorProxyAction;
+import org.elasticsearch.xpack.enrich.action.EnrichCoordinatorProxyAction;
 import org.elasticsearch.xpack.enrich.action.EnrichShardMultiSearchAction;
 import org.elasticsearch.xpack.enrich.action.TransportDeleteEnrichPolicyAction;
 import org.elasticsearch.xpack.enrich.action.TransportExecuteEnrichPolicyAction;
@@ -116,7 +116,7 @@ public class EnrichPlugin extends Plugin implements ActionPlugin, IngestPlugin {
             new ActionHandler<>(ListEnrichPolicyAction.INSTANCE, TransportListEnrichPolicyAction.class),
             new ActionHandler<>(PutEnrichPolicyAction.INSTANCE, TransportPutEnrichPolicyAction.class),
             new ActionHandler<>(ExecuteEnrichPolicyAction.INSTANCE, TransportExecuteEnrichPolicyAction.class),
-            new ActionHandler<>(CoordinatorProxyAction.INSTANCE, CoordinatorProxyAction.TransportAction.class),
+            new ActionHandler<>(EnrichCoordinatorProxyAction.INSTANCE, EnrichCoordinatorProxyAction.TransportAction.class),
             new ActionHandler<>(EnrichShardMultiSearchAction.INSTANCE, EnrichShardMultiSearchAction.TransportAction.class)
         );
     }
@@ -152,7 +152,7 @@ public class EnrichPlugin extends Plugin implements ActionPlugin, IngestPlugin {
         return List.of(
             enrichPolicyLocks,
             enrichPolicyExecutor,
-            new CoordinatorProxyAction.Coordinator(client, settings),
+            new EnrichCoordinatorProxyAction.Coordinator(client, settings),
             enrichPolicyMaintenanceService
         );
     }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/ExactMatchProcessor.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/ExactMatchProcessor.java
@@ -17,7 +17,7 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 import org.elasticsearch.xpack.enrich.EnrichProcessorFactory.EnrichSpecification;
-import org.elasticsearch.xpack.enrich.action.CoordinatorProxyAction;
+import org.elasticsearch.xpack.enrich.action.EnrichCoordinatorProxyAction;
 
 import java.util.List;
 import java.util.Map;
@@ -152,7 +152,7 @@ public final class ExactMatchProcessor extends AbstractEnrichProcessor {
 
     private static BiConsumer<SearchRequest, BiConsumer<SearchResponse, Exception>> createSearchRunner(Client client) {
         return (req, handler) -> {
-            client.execute(CoordinatorProxyAction.INSTANCE, req, ActionListener.wrap(
+            client.execute(EnrichCoordinatorProxyAction.INSTANCE, req, ActionListener.wrap(
                 resp -> {
                     handler.accept(resp, null);
                 },

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichCoordinatorProxyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichCoordinatorProxyAction.java
@@ -41,12 +41,12 @@ import java.util.concurrent.atomic.AtomicInteger;
  * This is because the enrich processor executes asynchronously and a bulk request could easily overload
  * the search tp.
  */
-public class CoordinatorProxyAction extends ActionType<SearchResponse> {
+public class EnrichCoordinatorProxyAction extends ActionType<SearchResponse> {
 
-    public static final CoordinatorProxyAction INSTANCE = new CoordinatorProxyAction();
+    public static final EnrichCoordinatorProxyAction INSTANCE = new EnrichCoordinatorProxyAction();
     public static final String NAME = "indices:data/read/xpack/enrich/coordinate_lookups";
 
-    private CoordinatorProxyAction() {
+    private EnrichCoordinatorProxyAction() {
         super(NAME, SearchResponse::new);
     }
 

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchAction.java
@@ -79,7 +79,7 @@ import java.util.Set;
  * handles multi search requests targeting enrich indices more efficiently by executing them in a bulk using the same
  * searcher and query shard context.
  *
- * This action (plus some coordination logic in {@link CoordinatorProxyAction}) can be removed when msearch can
+ * This action (plus some coordination logic in {@link EnrichCoordinatorProxyAction}) can be removed when msearch can
  * execute search requests targeted to the same shard more efficiently in a bulk like style.
  *
  * Note that this 'msearch' implementation only supports executing a query, pagination and source filtering.
@@ -203,13 +203,12 @@ public class EnrichShardMultiSearchAction extends ActionType<MultiSearchResponse
 
         @Override
         protected MultiSearchResponse shardOperation(Request request, ShardId shardId) throws IOException {
-            final long nowInMillis = System.currentTimeMillis();
             final IndexService indexService = indicesService.indexService(shardId.getIndex());
             final IndexShard indexShard = indicesService.getShardOrNull(shardId);
             try (Engine.Searcher searcher = indexShard.acquireSearcher("enrich_msearch")) {
                 final FieldsVisitor visitor = new FieldsVisitor(true);
-                final QueryShardContext context =
-                    indexService.newQueryShardContext(shardId.id(), searcher.getIndexReader(), () -> nowInMillis, null);
+                final QueryShardContext context = indexService.newQueryShardContext(shardId.id(),
+                    searcher.getIndexReader(), () -> {throw new UnsupportedOperationException();}, null);
                 final MapperService mapperService = context.getMapperService();
                 final Text typeText = mapperService.documentMapper().typeText();
 

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/CoordinatorTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/CoordinatorTests.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.elasticsearch.xpack.enrich.action.CoordinatorProxyAction.Coordinator;
+import static org.elasticsearch.xpack.enrich.action.EnrichCoordinatorProxyAction.Coordinator;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;


### PR DESCRIPTION
and fail EnrichShardMultiSearchAction request if QueryShardContext needs current time. Certain queries / scripts rely on current time, but in the enrich context this is not used.