### PR TITLE
Add input and outut tracking of built bwc versions

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
@@ -93,7 +93,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             ext.set("minimumCompilerVersion", minimumCompilerVersion);
             ext.set("minimumRuntimeVersion", minimumRuntimeVersion);
             ext.set("gradleJavaVersion", Jvm.current().getJavaVersion());
-            ext.set("gitRevision", gitRevision(project));
+            ext.set("gitRevision", gitRevision(project.getRootProject().getRootDir()));
             ext.set("buildDate", ZonedDateTime.now(ZoneOffset.UTC));
         });
     }
@@ -204,7 +204,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         return _defaultParallel;
     }
 
-    private String gitRevision(final Project project) {
+    public static String gitRevision(File rootDir) {
         try {
             /*
              * We want to avoid forking another process to run git rev-parse HEAD. Instead, we will read the refs manually. The
@@ -222,7 +222,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
              * In the case of a worktree, we read the gitdir from the plain text .git file. This resolves to a directory from which we read
              * the HEAD file and resolve commondir to the plain git repository.
              */
-            final Path dotGit = project.getRootProject().getRootDir().toPath().resolve(".git");
+            final Path dotGit = rootDir.toPath().resolve(".git");
             final String revision;
             if (Files.exists(dotGit) == false) {
                 return "unknown";
@@ -259,7 +259,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         }
     }
 
-    private String readFirstLine(final Path path) throws IOException {
+    private static String readFirstLine(final Path path) throws IOException {
         return Files.lines(path, StandardCharsets.UTF_8)
             .findFirst()
             .orElseThrow(() -> new IOException("file [" + path + "] is empty"));

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -21,6 +21,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 import org.elasticsearch.gradle.LoggedExec
 import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.BwcVersions
+import org.elasticsearch.gradle.info.GlobalBuildInfoPlugin
 
 import java.nio.charset.StandardCharsets
 
@@ -145,6 +146,7 @@ bwcVersions.forPreviousUnreleased { BwcVersions.UnreleasedVersionInfo unreleased
                 spec.workingDir = checkoutDir
                 spec.commandLine "git", "checkout", refspec
             }
+            file("${project.buildDir}/refspec").text = GlobalBuildInfoPlugin.gitRevision(checkoutDir)
         }
     }
 
@@ -217,6 +219,8 @@ bwcVersions.forPreviousUnreleased { BwcVersions.UnreleasedVersionInfo unreleased
 
     Closure createBuildBwcTask = { projectName, projectDir, projectArtifact ->
         Task bwcTask = createRunBwcGradleTask(buildBwcTaskName(projectName)) {
+            inputs.file("${project.buildDir}/refspec")
+            outputs.files(projectArtifact)
             args ":${projectDir.replace('/', ':')}:assemble"
             doLast {
                 if (projectArtifact.exists() == false) {

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -221,6 +221,7 @@ bwcVersions.forPreviousUnreleased { BwcVersions.UnreleasedVersionInfo unreleased
         Task bwcTask = createRunBwcGradleTask(buildBwcTaskName(projectName)) {
             inputs.file("${project.buildDir}/refspec")
             outputs.files(projectArtifact)
+            outputs.cacheIf { true }
             args ":${projectDir.replace('/', ':')}:assemble"
             doLast {
                 if (projectArtifact.exists() == false) {


### PR DESCRIPTION
This PR adds tracking of the bwc versions git has as input and all the
expected files as output.
The effect is that `gradlew` is not called at all when the git has
doesn't change and the version was allready built.
Previusly gradlew would be called for the bwc version and it would have
to configure the project and go trough up to date checks to figure out
that nothing changed.
This helps when working on bwc tests locally needing to run the test
multiple times.
This should also help in CI not re-build bwc versions across different
runs.

