### PR TITLE
[DOCS] Reformat get mapping API. Reformat and reuse multi-index params.

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -21,33 +21,11 @@ ability to "exclude" (`-`), for example: `test*,-test3`.
 
 All multi index APIs support the following url query string parameters:
 
-[horizontal]
-`ignore_unavailable`::
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
-Controls whether to ignore if any specified indices are unavailable, 
-including indices that don't exist or closed indices. Either `true` or `false`
-can be specified.
+include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 
-`allow_no_indices`::
-
-Controls whether to fail if a wildcard indices expression results in no
-concrete indices. Either `true` or `false` can be specified. For example if
-the wildcard expression `foo*` is specified and no indices are available that
-start with `foo`, then depending on this setting the request will fail. This
-setting is also applicable when `_all`, `*`, or no index has been specified. This
-settings also applies for aliases, in case an alias points to a closed index.
-
-`expand_wildcards`::
-
-Controls what kind of concrete indices that wildcard indices expressions can expand
-to. If `open` is specified then the wildcard expression is expanded to only
-open indices. If `closed` is specified then the wildcard expression is
-expanded only to closed indices. Also both values (`open,closed`) can be
-specified to expand to all indices.
-+
-If `none` is specified then wildcard expansion will be disabled. If `all`
-is specified, wildcard expressions will expand to all indices (this is equivalent
-to specifying `open,closed`).
+include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 
 The defaults settings for the above parameters depend on the API being used.
 

--- a/docs/reference/indices/get-mapping.asciidoc
+++ b/docs/reference/indices/get-mapping.asciidoc
@@ -15,7 +15,7 @@ GET /twitter/_mapping
 
 NOTE: Before 7.0.0, the 'mappings' definition used to include a type name. Although mappings
 in responses no longer contain a type name by default, you can still request the old format
-through the parameter include_type_name. For more details, please see <<removal-of-types>>.
+through the parameter `include_type_name`. For more details, please see <<removal-of-types>>.
 
 
 [[get-mapping-api-request]]
@@ -40,6 +40,8 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=include-type-name]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 

--- a/docs/reference/indices/get-mapping.asciidoc
+++ b/docs/reference/indices/get-mapping.asciidoc
@@ -1,8 +1,10 @@
 [[indices-get-mapping]]
-=== Get Mapping
+=== Get mapping API
+++++
+<titleabbrev>Get mapping</titleabbrev>
+++++
 
-The get mapping API allows to retrieve mapping definitions for an index or
-index/type.
+Retrieves <<mapping,mapping definitions>> for indices in a cluster.
 
 [source,js]
 --------------------------------------------------
@@ -15,8 +17,42 @@ NOTE: Before 7.0.0, the 'mappings' definition used to include a type name. Altho
 in responses no longer contain a type name by default, you can still request the old format
 through the parameter include_type_name. For more details, please see <<removal-of-types>>.
 
-[float]
-==== Multiple Indices
+
+[[get-mapping-api-request]]
+==== {api-request-title}
+
+`GET /_mapping`
+
+`GET /{index}/_mapping`
+
+
+[[get-mapping-api-path-params]]
+==== {api-path-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+
+
+[[get-mapping-api-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
++
+Defaults to `open`.
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+
+
+[[get-mapping-api-example]]
+==== {api-examples-title}
+
+[[get-mapping-api-multi-ex]]
+===== Multiple indices
 
 The get mapping API can be used to get more than one index with a
 single call. General usage of the API follows the following syntax:

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -19,8 +19,8 @@ tag::expand-wildcards[]
 (Optional, string) Controls what kind of indices that wildcard
 expressions can expand to. Valid values are:
 
-`open`::
-Expand only to open and closed indices.
+`all`::
+Expand to open and closed indices.
 
 `open`::
 Expand only to open indices.

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -1,8 +1,37 @@
 
+tag::allow-no-indices[]
+`allow_no_indices`::
+(Optional, boolean) If `true`, the request returns an error if a wildcard
+expression or `_all` value retrieves only missing or closed indices. This
+parameter also applies to <<indices-aliases,index aliases>> that point to a
+missing or closed index.
+end::allow-no-indices[]
+
 tag::bytes[]
 `bytes`::
 (Optional, <<byte-units,byte size units>>) Unit used to display byte values.
 end::bytes[]
+
+tag::expand-wildcards[]
+`expand_wildcards`::
++
+--
+(Optional, string) Controls what kind of indices that wildcard
+expressions can expand to. Valid values are:
+
+`open`::
+Expand only to open and closed indices.
+
+`open`::
+Expand only to open indices.
+
+`closed`::
+Expand only to closed indices.
+
+`none`::
+Wildcard expressions are not accepted.
+--
+end::expand-wildcards[]
 
 tag::cat-h[]
 `h`::
@@ -27,6 +56,12 @@ tag::http-format[]
 https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html[HTTP accept header].
 Valid values include JSON, YAML, etc.
 end::http-format[]
+
+tag::index-ignore-unavailable[]
+`ignore_unavailable`::
+(Optional, boolean) If `true`, missing or closed indices are not included in the
+response. Defaults to `false`.
+end::index-ignore-unavailable[]
 
 tag::include-unloaded-segments[]
 `include_unloaded_segments`::

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -57,6 +57,13 @@ https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html[HTTP accept header].
 Valid values include JSON, YAML, etc.
 end::http-format[]
 
+tag::include-type-name[]
+`include_type_name`::
+deprecated:[7.0.0, Mapping types have been deprecated. See <<removal-of-types>>.
+(Optional, boolean) If `true`, a mapping type is expected in the body of
+mappings. Defaults to `false`.
+end::include-type-name[]
+
 tag::index-ignore-unavailable[]
 `ignore_unavailable`::
 (Optional, boolean) If `true`, missing or closed indices are not included in the

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -59,7 +59,7 @@ end::http-format[]
 
 tag::include-type-name[]
 `include_type_name`::
-deprecated:[7.0.0, Mapping types have been deprecated. See <<removal-of-types>>.
+deprecated:[7.0.0, Mapping types have been deprecated. See <<removal-of-types>>.]
 (Optional, boolean) If `true`, a mapping type is expected in the body of
 mappings. Defaults to `false`.
 end::include-type-name[]


### PR DESCRIPTION
### Changes

* Updates the get mapping API to use the new [Elastic API reference
  template](  https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc).

* Adds documentation for several multi-index parameters to
  `common-parms.asciidoc` for reuse throughout API reference
  documentation.

* Updates API conventions chapter to reuse parameters from
  `common-parms.asciidoc`.

Relates to elastic/docs#937 and #43765

### Preview
http://elasticsearch_45699.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html