### PR TITLE
[7.x] Call the new _estimate_memory_usage API endpoint on df analytics _start (#45536)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -51,6 +51,7 @@ import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.MlTasks;
+import org.elasticsearch.xpack.core.ml.action.EstimateMemoryUsageAction;
 import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
@@ -168,11 +169,36 @@ public class TransportStartDataFrameAnalyticsAction
         );
 
         // Tell the job tracker to refresh the memory requirement for this job and all other jobs that have persistent tasks
+        ActionListener<EstimateMemoryUsageAction.Response> estimateMemoryUsageListener = ActionListener.wrap(
+            estimateMemoryUsageResponse -> {
+                // Validate that model memory limit is sufficient to run the analysis
+                if (configHolder.get().getModelMemoryLimit()
+                    .compareTo(estimateMemoryUsageResponse.getExpectedMemoryUsageWithOnePartition()) < 0) {
+                    ElasticsearchStatusException e =
+                        ExceptionsHelper.badRequestException(
+                            "Cannot start because the configured model memory limit [{}] is lower than the expected memory usage [{}]",
+                            configHolder.get().getModelMemoryLimit(), estimateMemoryUsageResponse.getExpectedMemoryUsageWithOnePartition());
+                    listener.onFailure(e);
+                    return;
+                }
+                // Refresh memory requirement for jobs
+                memoryTracker.addDataFrameAnalyticsJobMemoryAndRefreshAllOthers(
+                    request.getId(), configHolder.get().getModelMemoryLimit().getBytes(), memoryRequirementRefreshListener);
+            },
+            listener::onFailure
+        );
+
+        // Perform memory usage estimation for this config
         ActionListener<DataFrameAnalyticsConfig> configListener = ActionListener.wrap(
             config -> {
                 configHolder.set(config);
-                memoryTracker.addDataFrameAnalyticsJobMemoryAndRefreshAllOthers(
-                    request.getId(), config.getModelMemoryLimit().getBytes(), memoryRequirementRefreshListener);
+                EstimateMemoryUsageAction.Request estimateMemoryUsageRequest = new EstimateMemoryUsageAction.Request(config);
+                ClientHelper.executeAsyncWithOrigin(
+                    client,
+                    ClientHelper.ML_ORIGIN,
+                    EstimateMemoryUsageAction.INSTANCE,
+                    estimateMemoryUsageRequest,
+                    estimateMemoryUsageListener);
             },
             listener::onFailure
         );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/MemoryUsageEstimationProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/MemoryUsageEstimationProcessManager.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
@@ -66,7 +67,9 @@ public class MemoryUsageEstimationProcessManager {
             new AnalyticsProcessConfig(
                 dataSummary.rows,
                 dataSummary.cols,
-                DataFrameAnalyticsConfig.MIN_MODEL_MEMORY_LIMIT,
+                // For memory estimation the model memory limit here should be set high enough not to trigger an error when C++ code
+                // compares the limit to the result of estimation.
+                new ByteSizeValue(1, ByteSizeUnit.PB),
                 1,
                 "",
                 categoricalFields,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Call the new _estimate_memory_usage API endpoint on df analytics _start  (#45536)