### PR TITLE
Handle "null" value of Estimate memory usage API response gracefully.

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -173,8 +173,9 @@ public class TransportStartDataFrameAnalyticsAction
         ActionListener<EstimateMemoryUsageAction.Response> estimateMemoryUsageListener = ActionListener.wrap(
             estimateMemoryUsageResponse -> {
                 // Validate that model memory limit is sufficient to run the analysis
-                if (configHolder.get().getModelMemoryLimit()
-                    .compareTo(estimateMemoryUsageResponse.getExpectedMemoryUsageWithOnePartition()) < 0) {
+                if (estimateMemoryUsageResponse.getExpectedMemoryUsageWithOnePartition() != null &&
+                        configHolder.get().getModelMemoryLimit().compareTo(
+                            estimateMemoryUsageResponse.getExpectedMemoryUsageWithOnePartition()) < 0) {
                     ElasticsearchStatusException e =
                         ExceptionsHelper.badRequestException(
                             "Cannot start because the configured model memory limit [{}] is lower than the expected memory usage [{}]",


### PR DESCRIPTION
Handle "null" value of estimateMemoryUsageResponse.getExpectedMemoryUsageWithOnePartition() correctly in the code of "_start" action i.e. in case of "null", the validation of "model_memory_limit" against estimate is not performed at all.

Relates https://github.com/elastic/elasticsearch/issues/44699