### PR TITLE
[DOCS] Add validation to Painless Watcher examples

### DIFF
--- a/docs/painless/painless-contexts/painless-watcher-context-example.asciidoc
+++ b/docs/painless/painless-contexts/painless-watcher-context-example.asciidoc
@@ -100,7 +100,7 @@ POST _watcher/watch/_execute
 }
 ----
 // CONSOLE
-// TEST[skip: requires setup from other pages]
+// TEST[setup:seats]
 
 The following example shows the use of metadata and transforming dates into a readable format.
 
@@ -158,4 +158,4 @@ POST _watcher/watch/_execute
 }
 ----
 // CONSOLE
-// TEST[skip: requires setup from other pages]
+// TEST[setup:seats]


### PR DESCRIPTION
Replaces several `// TEST[skip...` comments with a setup comment so the examples are validated by CI builds, etc.

These examples are included in the [Watcher condition context](https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-watcher-condition-context.html) docs.

Relates to #45493.