### PR TITLE
Change awaitBusy to assertBusy for RollupIndexerStateTests#testBulkFailure

### DIFF
--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerStateTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerStateTests.java
@@ -944,7 +944,7 @@ public class RollupIndexerStateTests extends ESTestCase {
             assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
             assertThat(indexer.getState(), equalTo(IndexerState.INDEXING));
             latch.countDown();
-            ESTestCase.awaitBusy(() -> isFinished.get());
+            assertBusy(() -> assertTrue(isFinished.get()));
 
             // Despite failure in bulk, we should move back to STARTED and wait to try again on next trigger
             assertThat(indexer.getState(), equalTo(IndexerState.STARTED));


### PR DESCRIPTION
RollupIndexerStateTests#testBulkFailure recently failed a build. 
assertBusy will fail if the wait the condition is not met, 
awaitBusy requires explicit checking and failing.  
Since the existing awaitBusy does not check for a true/false state, 
there is not a way to tell the difference between a failure of logic
or simply a failure due to a timeout. 