### PR TITLE
[DOCS] Reformat get index API docs

### DIFF
--- a/docs/reference/indices/get-index.asciidoc
+++ b/docs/reference/indices/get-index.asciidoc
@@ -21,13 +21,13 @@ through the parameter include_type_name. For more details, please see <<removal-
 [[get-index-api-request]]
 ==== {api-request-title}
 
-`GET /{index}`
+`GET /<index>`
 
 
 [[get-index-api-path-params]]
 ==== {api-path-parms-title}
 
-`{index}`::
+`<index>`::
 +
 --
 (Required, string) Comma-separated list or wildcard expression of index names

--- a/docs/reference/indices/get-index.asciidoc
+++ b/docs/reference/indices/get-index.asciidoc
@@ -1,7 +1,10 @@
 [[indices-get-index]]
-=== Get Index
+=== Get index API
+++++
+<titleabbrev>Get index</titleabbrev>
+++++
 
-The get index API allows to retrieve information about one or more indexes.
+Returns information about one or more indexes.
 
 [source,js]
 --------------------------------------------------
@@ -10,12 +13,47 @@ GET /twitter
 // CONSOLE
 // TEST[setup:twitter]
 
-The above example gets the information for an index called `twitter`. Specifying an index,
-alias or wildcard expression is required.
-
-The get index API can also be applied to more than one index, or on
-all indices by using `_all` or `*` as index.
-
 NOTE: Before 7.0.0, the 'mappings' definition used to include a type name. Although mappings
 in responses no longer contain a type name by default, you can still request the old format
 through the parameter include_type_name. For more details, please see <<removal-of-types>>.
+
+
+[[get-index-api-request]]
+==== {api-request-title}
+
+`GET /{index}`
+
+
+[[get-index-api-path-params]]
+==== {api-path-parms-title}
+
+`{index}`::
++
+--
+(Required, string) Comma-separated list or wildcard expression of index names
+used to limit the request.
+
+Use a value of `_all` to retrieve information for all indices in the cluster.
+--
+
+
+[[get-index-api-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
++
+Defaults to `open`.
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=include-defaults]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=include-type-name]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -57,6 +57,12 @@ https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html[HTTP accept header].
 Valid values include JSON, YAML, etc.
 end::http-format[]
 
+tag::include-defaults[]
+`include_defaults`::
+(Optional, string) If `true`, return all default settings in the response.
+Defaults to `false`.
+end::include-defaults[]
+
 tag::include-type-name[]
 `include_type_name`::
 deprecated:[7.0.0, Mapping types have been deprecated. See <<removal-of-types>>.]


### PR DESCRIPTION
This PR updates the get index API to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc).

Relates to elastic/docs#937 and #43765

Dependent on #45699. CI failures are expected until that PR is merged.