### PR TITLE
[7.x] Shorten field names in EstimateMemoryUsageResponse (#45719)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/EstimateMemoryUsageResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/EstimateMemoryUsageResponse.java
@@ -35,10 +35,8 @@ import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optiona
 
 public class EstimateMemoryUsageResponse implements ToXContentObject {
     
-    public static final ParseField EXPECTED_MEMORY_USAGE_WITH_ONE_PARTITION =
-        new ParseField("expected_memory_usage_with_one_partition");
-    public static final ParseField EXPECTED_MEMORY_USAGE_WITH_MAX_PARTITIONS =
-        new ParseField("expected_memory_usage_with_max_partitions");
+    public static final ParseField EXPECTED_MEMORY_WITHOUT_DISK = new ParseField("expected_memory_without_disk");
+    public static final ParseField EXPECTED_MEMORY_WITH_DISK = new ParseField("expected_memory_with_disk");
 
     static final ConstructingObjectParser<EstimateMemoryUsageResponse, Void> PARSER =
         new ConstructingObjectParser<>(
@@ -49,13 +47,13 @@ public class EstimateMemoryUsageResponse implements ToXContentObject {
     static {
         PARSER.declareField(
             optionalConstructorArg(),
-            (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), EXPECTED_MEMORY_USAGE_WITH_ONE_PARTITION.getPreferredName()),
-            EXPECTED_MEMORY_USAGE_WITH_ONE_PARTITION,
+            (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), EXPECTED_MEMORY_WITHOUT_DISK.getPreferredName()),
+            EXPECTED_MEMORY_WITHOUT_DISK,
             ObjectParser.ValueType.VALUE);
         PARSER.declareField(
             optionalConstructorArg(),
-            (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), EXPECTED_MEMORY_USAGE_WITH_MAX_PARTITIONS.getPreferredName()),
-            EXPECTED_MEMORY_USAGE_WITH_MAX_PARTITIONS,
+            (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), EXPECTED_MEMORY_WITH_DISK.getPreferredName()),
+            EXPECTED_MEMORY_WITH_DISK,
             ObjectParser.ValueType.VALUE);
     }
 
@@ -63,33 +61,30 @@ public class EstimateMemoryUsageResponse implements ToXContentObject {
         return PARSER.apply(parser, null);
     }
 
-    private final ByteSizeValue expectedMemoryUsageWithOnePartition;
-    private final ByteSizeValue expectedMemoryUsageWithMaxPartitions;
+    private final ByteSizeValue expectedMemoryWithoutDisk;
+    private final ByteSizeValue expectedMemoryWithDisk;
 
-    public EstimateMemoryUsageResponse(@Nullable ByteSizeValue expectedMemoryUsageWithOnePartition,
-                                       @Nullable ByteSizeValue expectedMemoryUsageWithMaxPartitions) {
-        this.expectedMemoryUsageWithOnePartition = expectedMemoryUsageWithOnePartition;
-        this.expectedMemoryUsageWithMaxPartitions = expectedMemoryUsageWithMaxPartitions;
+    public EstimateMemoryUsageResponse(@Nullable ByteSizeValue expectedMemoryWithoutDisk, @Nullable ByteSizeValue expectedMemoryWithDisk) {
+        this.expectedMemoryWithoutDisk = expectedMemoryWithoutDisk;
+        this.expectedMemoryWithDisk = expectedMemoryWithDisk;
     }
 
-    public ByteSizeValue getExpectedMemoryUsageWithOnePartition() {
-        return expectedMemoryUsageWithOnePartition;
+    public ByteSizeValue getExpectedMemoryWithoutDisk() {
+        return expectedMemoryWithoutDisk;
     }
 
-    public ByteSizeValue getExpectedMemoryUsageWithMaxPartitions() {
-        return expectedMemoryUsageWithMaxPartitions;
+    public ByteSizeValue getExpectedMemoryWithDisk() {
+        return expectedMemoryWithDisk;
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        if (expectedMemoryUsageWithOnePartition != null) {
-            builder.field(
-                EXPECTED_MEMORY_USAGE_WITH_ONE_PARTITION.getPreferredName(), expectedMemoryUsageWithOnePartition.getStringRep());
+        if (expectedMemoryWithoutDisk != null) {
+            builder.field(EXPECTED_MEMORY_WITHOUT_DISK.getPreferredName(), expectedMemoryWithoutDisk.getStringRep());
         }
-        if (expectedMemoryUsageWithMaxPartitions != null) {
-            builder.field(
-                EXPECTED_MEMORY_USAGE_WITH_MAX_PARTITIONS.getPreferredName(), expectedMemoryUsageWithMaxPartitions.getStringRep());
+        if (expectedMemoryWithDisk != null) {
+            builder.field(EXPECTED_MEMORY_WITH_DISK.getPreferredName(), expectedMemoryWithDisk.getStringRep());
         }
         builder.endObject();
         return builder;
@@ -105,12 +100,12 @@ public class EstimateMemoryUsageResponse implements ToXContentObject {
         }
 
         EstimateMemoryUsageResponse that = (EstimateMemoryUsageResponse) other;
-        return Objects.equals(expectedMemoryUsageWithOnePartition, that.expectedMemoryUsageWithOnePartition)
-            && Objects.equals(expectedMemoryUsageWithMaxPartitions, that.expectedMemoryUsageWithMaxPartitions);
+        return Objects.equals(expectedMemoryWithoutDisk, that.expectedMemoryWithoutDisk)
+            && Objects.equals(expectedMemoryWithDisk, that.expectedMemoryWithDisk);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(expectedMemoryUsageWithOnePartition, expectedMemoryUsageWithMaxPartitions);
+        return Objects.hash(expectedMemoryWithoutDisk, expectedMemoryWithDisk);
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
@@ -1411,7 +1411,6 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
         assertThat(statsResponse.getTaskFailures(), hasSize(0));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/45741")
     public void testStartDataFrameAnalyticsConfig() throws Exception {
         String sourceIndex = "start-test-source-index";
         String destIndex = "start-test-dest-index";
@@ -1720,7 +1719,6 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
         highLevelClient().indices().create(new CreateIndexRequest(indexName).mapping(mapping), RequestOptions.DEFAULT);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/45741")
     public void testEstimateMemoryUsage() throws IOException {
         String indexName = "estimate-test-index";
         createIndex(indexName, mappingForClassification());
@@ -1747,8 +1745,8 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
         EstimateMemoryUsageResponse response1 =
             execute(
                 estimateMemoryUsageRequest, machineLearningClient::estimateMemoryUsage, machineLearningClient::estimateMemoryUsageAsync);
-        assertThat(response1.getExpectedMemoryUsageWithOnePartition(), allOf(greaterThan(lowerBound), lessThan(upperBound)));
-        assertThat(response1.getExpectedMemoryUsageWithMaxPartitions(), allOf(greaterThan(lowerBound), lessThan(upperBound)));
+        assertThat(response1.getExpectedMemoryWithoutDisk(), allOf(greaterThan(lowerBound), lessThan(upperBound)));
+        assertThat(response1.getExpectedMemoryWithDisk(), allOf(greaterThan(lowerBound), lessThan(upperBound)));
 
         BulkRequest bulk2 = new BulkRequest()
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
@@ -1762,11 +1760,8 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
             execute(
                 estimateMemoryUsageRequest, machineLearningClient::estimateMemoryUsage, machineLearningClient::estimateMemoryUsageAsync);
         assertThat(
-            response2.getExpectedMemoryUsageWithOnePartition(),
-            allOf(greaterThan(response1.getExpectedMemoryUsageWithOnePartition()), lessThan(upperBound)));
-        assertThat(
-            response2.getExpectedMemoryUsageWithMaxPartitions(),
-            allOf(greaterThan(response1.getExpectedMemoryUsageWithMaxPartitions()), lessThan(upperBound)));
+            response2.getExpectedMemoryWithoutDisk(), allOf(greaterThan(response1.getExpectedMemoryWithoutDisk()), lessThan(upperBound)));
+        assertThat(response2.getExpectedMemoryWithDisk(), allOf(greaterThan(response1.getExpectedMemoryWithDisk()), lessThan(upperBound)));
     }
 
     public void testPutFilter() throws Exception {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
@@ -3043,7 +3043,6 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/45741")
     public void testStartDataFrameAnalytics() throws Exception {
         createIndex(DF_ANALYTICS_CONFIG.getSource().getIndex()[0]);
         highLevelClient().index(

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/EstimateMemoryUsageAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/EstimateMemoryUsageAction.java
@@ -35,10 +35,8 @@ public class EstimateMemoryUsageAction extends ActionType<EstimateMemoryUsageAct
 
         public static final ParseField TYPE = new ParseField("memory_usage_estimation_result");
 
-        public static final ParseField EXPECTED_MEMORY_USAGE_WITH_ONE_PARTITION =
-            new ParseField("expected_memory_usage_with_one_partition");
-        public static final ParseField EXPECTED_MEMORY_USAGE_WITH_MAX_PARTITIONS =
-            new ParseField("expected_memory_usage_with_max_partitions");
+        public static final ParseField EXPECTED_MEMORY_WITHOUT_DISK = new ParseField("expected_memory_without_disk");
+        public static final ParseField EXPECTED_MEMORY_WITH_DISK = new ParseField("expected_memory_with_disk");
 
         static final ConstructingObjectParser<Response, Void> PARSER =
             new ConstructingObjectParser<>(
@@ -48,55 +46,52 @@ public class EstimateMemoryUsageAction extends ActionType<EstimateMemoryUsageAct
         static {
             PARSER.declareField(
                 optionalConstructorArg(),
-                (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), EXPECTED_MEMORY_USAGE_WITH_ONE_PARTITION.getPreferredName()),
-                EXPECTED_MEMORY_USAGE_WITH_ONE_PARTITION,
+                (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), EXPECTED_MEMORY_WITHOUT_DISK.getPreferredName()),
+                EXPECTED_MEMORY_WITHOUT_DISK,
                 ObjectParser.ValueType.VALUE);
             PARSER.declareField(
                 optionalConstructorArg(),
-                (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), EXPECTED_MEMORY_USAGE_WITH_MAX_PARTITIONS.getPreferredName()),
-                EXPECTED_MEMORY_USAGE_WITH_MAX_PARTITIONS,
+                (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), EXPECTED_MEMORY_WITH_DISK.getPreferredName()),
+                EXPECTED_MEMORY_WITH_DISK,
                 ObjectParser.ValueType.VALUE);
         }
 
-        private final ByteSizeValue expectedMemoryUsageWithOnePartition;
-        private final ByteSizeValue expectedMemoryUsageWithMaxPartitions;
+        private final ByteSizeValue expectedMemoryWithoutDisk;
+        private final ByteSizeValue expectedMemoryWithDisk;
 
-        public Response(@Nullable ByteSizeValue expectedMemoryUsageWithOnePartition,
-                        @Nullable ByteSizeValue expectedMemoryUsageWithMaxPartitions) {
-            this.expectedMemoryUsageWithOnePartition = expectedMemoryUsageWithOnePartition;
-            this.expectedMemoryUsageWithMaxPartitions = expectedMemoryUsageWithMaxPartitions;
+        public Response(@Nullable ByteSizeValue expectedMemoryWithoutDisk, @Nullable ByteSizeValue expectedMemoryWithDisk) {
+            this.expectedMemoryWithoutDisk = expectedMemoryWithoutDisk;
+            this.expectedMemoryWithDisk = expectedMemoryWithDisk;
         }
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            this.expectedMemoryUsageWithOnePartition = in.readOptionalWriteable(ByteSizeValue::new);
-            this.expectedMemoryUsageWithMaxPartitions = in.readOptionalWriteable(ByteSizeValue::new);
+            this.expectedMemoryWithoutDisk = in.readOptionalWriteable(ByteSizeValue::new);
+            this.expectedMemoryWithDisk = in.readOptionalWriteable(ByteSizeValue::new);
         }
 
-        public ByteSizeValue getExpectedMemoryUsageWithOnePartition() {
-            return expectedMemoryUsageWithOnePartition;
+        public ByteSizeValue getExpectedMemoryWithoutDisk() {
+            return expectedMemoryWithoutDisk;
         }
 
-        public ByteSizeValue getExpectedMemoryUsageWithMaxPartitions() {
-            return expectedMemoryUsageWithMaxPartitions;
+        public ByteSizeValue getExpectedMemoryWithDisk() {
+            return expectedMemoryWithDisk;
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeOptionalWriteable(expectedMemoryUsageWithOnePartition);
-            out.writeOptionalWriteable(expectedMemoryUsageWithMaxPartitions);
+            out.writeOptionalWriteable(expectedMemoryWithoutDisk);
+            out.writeOptionalWriteable(expectedMemoryWithDisk);
         }
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
-            if (expectedMemoryUsageWithOnePartition != null) {
-                builder.field(
-                    EXPECTED_MEMORY_USAGE_WITH_ONE_PARTITION.getPreferredName(), expectedMemoryUsageWithOnePartition.getStringRep());
+            if (expectedMemoryWithoutDisk != null) {
+                builder.field(EXPECTED_MEMORY_WITHOUT_DISK.getPreferredName(), expectedMemoryWithoutDisk.getStringRep());
             }
-            if (expectedMemoryUsageWithMaxPartitions != null) {
-                builder.field(
-                    EXPECTED_MEMORY_USAGE_WITH_MAX_PARTITIONS.getPreferredName(), expectedMemoryUsageWithMaxPartitions.getStringRep());
+            if (expectedMemoryWithDisk != null) {
+                builder.field(EXPECTED_MEMORY_WITH_DISK.getPreferredName(), expectedMemoryWithDisk.getStringRep());
             }
             builder.endObject();
             return builder;
@@ -112,13 +107,13 @@ public class EstimateMemoryUsageAction extends ActionType<EstimateMemoryUsageAct
             }
 
             Response that = (Response) other;
-            return Objects.equals(expectedMemoryUsageWithOnePartition, that.expectedMemoryUsageWithOnePartition)
-                && Objects.equals(expectedMemoryUsageWithMaxPartitions, that.expectedMemoryUsageWithMaxPartitions);
+            return Objects.equals(expectedMemoryWithoutDisk, that.expectedMemoryWithoutDisk)
+                && Objects.equals(expectedMemoryWithDisk, that.expectedMemoryWithDisk);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(expectedMemoryUsageWithOnePartition, expectedMemoryUsageWithMaxPartitions);
+            return Objects.hash(expectedMemoryWithoutDisk, expectedMemoryWithDisk);
         }
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/EstimateMemoryUsageActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/EstimateMemoryUsageActionResponseTests.java
@@ -35,13 +35,13 @@ public class EstimateMemoryUsageActionResponseTests extends AbstractSerializingT
 
     public void testConstructor_NullValues() {
         Response response = new Response(null, null);
-        assertThat(response.getExpectedMemoryUsageWithOnePartition(), nullValue());
-        assertThat(response.getExpectedMemoryUsageWithMaxPartitions(), nullValue());
+        assertThat(response.getExpectedMemoryWithoutDisk(), nullValue());
+        assertThat(response.getExpectedMemoryWithDisk(), nullValue());
     }
 
     public void testConstructor() {
         Response response = new Response(new ByteSizeValue(2048), new ByteSizeValue(1024));
-        assertThat(response.getExpectedMemoryUsageWithOnePartition(), equalTo(new ByteSizeValue(2048)));
-        assertThat(response.getExpectedMemoryUsageWithMaxPartitions(), equalTo(new ByteSizeValue(1024)));
+        assertThat(response.getExpectedMemoryWithoutDisk(), equalTo(new ByteSizeValue(2048)));
+        assertThat(response.getExpectedMemoryWithDisk(), equalTo(new ByteSizeValue(1024)));
     }
 }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/OutlierDetectionWithMissingFieldsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/OutlierDetectionWithMissingFieldsIT.java
@@ -31,7 +31,6 @@ public class OutlierDetectionWithMissingFieldsIT extends MlNativeDataFrameAnalyt
         cleanUp();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/45741")
     public void testMissingFields() throws Exception {
         String sourceIndex = "test-outlier-detection-with-missing-fields";
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
@@ -48,7 +48,6 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
         cleanUp();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/45741")
     public void testOutlierDetectionWithFewDocuments() throws Exception {
         String sourceIndex = "test-outlier-detection-with-few-docs";
 
@@ -116,7 +115,6 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
         assertThat(scoreOfOutlier, is(greaterThan(scoreOfNonOutlier)));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/45741")
     public void testOutlierDetectionWithEnoughDocumentsToScroll() throws Exception {
         String sourceIndex = "test-outlier-detection-with-enough-docs-to-scroll";
 
@@ -160,7 +158,6 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo((long) docCount));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/45741")
     public void testOutlierDetectionWithMoreFieldsThanDocValueFieldLimit() throws Exception {
         String sourceIndex = "test-outlier-detection-with-more-fields-than-docvalue-limit";
 
@@ -280,7 +277,6 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/45741")
     public void testOutlierDetectionWithMultipleSourceIndices() throws Exception {
         String sourceIndex1 = "test-outlier-detection-with-multiple-source-indices-1";
         String sourceIndex2 = "test-outlier-detection-with-multiple-source-indices-2";
@@ -331,7 +327,6 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo((long) bulkRequestBuilder.numberOfActions()));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/45741")
     public void testOutlierDetectionWithPreExistingDestIndex() throws Exception {
         String sourceIndex = "test-outlier-detection-with-pre-existing-dest-index";
         String destIndex = "test-outlier-detection-with-pre-existing-dest-index-results";
@@ -445,7 +440,6 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
         assertThat(resultsWithPrediction, greaterThan(0));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/45741")
     public void testModelMemoryLimitLowerThanEstimatedMemoryUsage() {
         String sourceIndex = "test-model-memory-limit";
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportEstimateMemoryUsageAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportEstimateMemoryUsageAction.java
@@ -91,7 +91,7 @@ public class TransportEstimateMemoryUsageAction
                         ActionListener.wrap(
                             result -> listener.onResponse(
                                 new EstimateMemoryUsageAction.Response(
-                                    result.getExpectedMemoryUsageWithOnePartition(), result.getExpectedMemoryUsageWithMaxPartitions())),
+                                    result.getExpectedMemoryWithoutDisk(), result.getExpectedMemoryWithDisk())),
                             listener::onFailure
                         )
                     );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -174,11 +174,11 @@ public class TransportStartDataFrameAnalyticsAction
             estimateMemoryUsageResponse -> {
                 // Validate that model memory limit is sufficient to run the analysis
                 if (configHolder.get().getModelMemoryLimit()
-                    .compareTo(estimateMemoryUsageResponse.getExpectedMemoryUsageWithOnePartition()) < 0) {
+                    .compareTo(estimateMemoryUsageResponse.getExpectedMemoryWithoutDisk()) < 0) {
                     ElasticsearchStatusException e =
                         ExceptionsHelper.badRequestException(
                             "Cannot start because the configured model memory limit [{}] is lower than the expected memory usage [{}]",
-                            configHolder.get().getModelMemoryLimit(), estimateMemoryUsageResponse.getExpectedMemoryUsageWithOnePartition());
+                            configHolder.get().getModelMemoryLimit(), estimateMemoryUsageResponse.getExpectedMemoryWithoutDisk());
                     listener.onFailure(e);
                     return;
                 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/results/MemoryUsageEstimationResult.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/results/MemoryUsageEstimationResult.java
@@ -22,8 +22,8 @@ public class MemoryUsageEstimationResult implements ToXContentObject {
 
     public static final ParseField TYPE = new ParseField("memory_usage_estimation_result");
 
-    public static final ParseField EXPECTED_MEMORY_USAGE_WITH_ONE_PARTITION = new ParseField("expected_memory_usage_with_one_partition");
-    public static final ParseField EXPECTED_MEMORY_USAGE_WITH_MAX_PARTITIONS = new ParseField("expected_memory_usage_with_max_partitions");
+    public static final ParseField EXPECTED_MEMORY_WITHOUT_DISK = new ParseField("expected_memory_without_disk");
+    public static final ParseField EXPECTED_MEMORY_WITH_DISK = new ParseField("expected_memory_with_disk");
 
     public static final ConstructingObjectParser<MemoryUsageEstimationResult, Void> PARSER =
         new ConstructingObjectParser<>(
@@ -34,43 +34,40 @@ public class MemoryUsageEstimationResult implements ToXContentObject {
     static {
         PARSER.declareField(
             optionalConstructorArg(),
-            (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), EXPECTED_MEMORY_USAGE_WITH_ONE_PARTITION.getPreferredName()),
-            EXPECTED_MEMORY_USAGE_WITH_ONE_PARTITION,
+            (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), EXPECTED_MEMORY_WITHOUT_DISK.getPreferredName()),
+            EXPECTED_MEMORY_WITHOUT_DISK,
             ObjectParser.ValueType.VALUE);
         PARSER.declareField(
             optionalConstructorArg(),
-            (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), EXPECTED_MEMORY_USAGE_WITH_MAX_PARTITIONS.getPreferredName()),
-            EXPECTED_MEMORY_USAGE_WITH_MAX_PARTITIONS,
+            (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), EXPECTED_MEMORY_WITH_DISK.getPreferredName()),
+            EXPECTED_MEMORY_WITH_DISK,
             ObjectParser.ValueType.VALUE);
     }
 
-    private final ByteSizeValue expectedMemoryUsageWithOnePartition;
-    private final ByteSizeValue expectedMemoryUsageWithMaxPartitions;
+    private final ByteSizeValue expectedMemoryWithoutDisk;
+    private final ByteSizeValue expectedMemoryWithDisk;
 
-    public MemoryUsageEstimationResult(@Nullable ByteSizeValue expectedMemoryUsageWithOnePartition,
-                                       @Nullable ByteSizeValue expectedMemoryUsageWithMaxPartitions) {
-        this.expectedMemoryUsageWithOnePartition = expectedMemoryUsageWithOnePartition;
-        this.expectedMemoryUsageWithMaxPartitions = expectedMemoryUsageWithMaxPartitions;
+    public MemoryUsageEstimationResult(@Nullable ByteSizeValue expectedMemoryWithoutDisk, @Nullable ByteSizeValue expectedMemoryWithDisk) {
+        this.expectedMemoryWithoutDisk = expectedMemoryWithoutDisk;
+        this.expectedMemoryWithDisk = expectedMemoryWithDisk;
     }
 
-    public ByteSizeValue getExpectedMemoryUsageWithOnePartition() {
-        return expectedMemoryUsageWithOnePartition;
+    public ByteSizeValue getExpectedMemoryWithoutDisk() {
+        return expectedMemoryWithoutDisk;
     }
 
-    public ByteSizeValue getExpectedMemoryUsageWithMaxPartitions() {
-        return expectedMemoryUsageWithMaxPartitions;
+    public ByteSizeValue getExpectedMemoryWithDisk() {
+        return expectedMemoryWithDisk;
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        if (expectedMemoryUsageWithOnePartition != null) {
-            builder.field(
-                EXPECTED_MEMORY_USAGE_WITH_ONE_PARTITION.getPreferredName(), expectedMemoryUsageWithOnePartition.getStringRep());
+        if (expectedMemoryWithoutDisk != null) {
+            builder.field(EXPECTED_MEMORY_WITHOUT_DISK.getPreferredName(), expectedMemoryWithoutDisk.getStringRep());
         }
-        if (expectedMemoryUsageWithMaxPartitions != null) {
-            builder.field(
-                EXPECTED_MEMORY_USAGE_WITH_MAX_PARTITIONS.getPreferredName(), expectedMemoryUsageWithMaxPartitions.getStringRep());
+        if (expectedMemoryWithDisk != null) {
+            builder.field(EXPECTED_MEMORY_WITH_DISK.getPreferredName(), expectedMemoryWithDisk.getStringRep());
         }
         builder.endObject();
         return builder;
@@ -86,12 +83,12 @@ public class MemoryUsageEstimationResult implements ToXContentObject {
         }
 
         MemoryUsageEstimationResult that = (MemoryUsageEstimationResult) other;
-        return Objects.equals(expectedMemoryUsageWithOnePartition, that.expectedMemoryUsageWithOnePartition)
-            && Objects.equals(expectedMemoryUsageWithMaxPartitions, that.expectedMemoryUsageWithMaxPartitions);
+        return Objects.equals(expectedMemoryWithoutDisk, that.expectedMemoryWithoutDisk)
+            && Objects.equals(expectedMemoryWithDisk, that.expectedMemoryWithDisk);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(expectedMemoryUsageWithOnePartition, expectedMemoryUsageWithMaxPartitions);
+        return Objects.hash(expectedMemoryWithoutDisk, expectedMemoryWithDisk);
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/results/MemoryUsageEstimationResultTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/results/MemoryUsageEstimationResultTests.java
@@ -39,13 +39,13 @@ public class MemoryUsageEstimationResultTests extends AbstractXContentTestCase<M
 
     public void testConstructor_NullValues() {
         MemoryUsageEstimationResult result = new MemoryUsageEstimationResult(null, null);
-        assertThat(result.getExpectedMemoryUsageWithOnePartition(), nullValue());
-        assertThat(result.getExpectedMemoryUsageWithMaxPartitions(), nullValue());
+        assertThat(result.getExpectedMemoryWithoutDisk(), nullValue());
+        assertThat(result.getExpectedMemoryWithDisk(), nullValue());
     }
 
     public void testConstructor() {
         MemoryUsageEstimationResult result = new MemoryUsageEstimationResult(new ByteSizeValue(2048), new ByteSizeValue(1024));
-        assertThat(result.getExpectedMemoryUsageWithOnePartition(), equalTo(new ByteSizeValue(2048)));
-        assertThat(result.getExpectedMemoryUsageWithMaxPartitions(), equalTo(new ByteSizeValue(1024)));
+        assertThat(result.getExpectedMemoryWithoutDisk(), equalTo(new ByteSizeValue(2048)));
+        assertThat(result.getExpectedMemoryWithDisk(), equalTo(new ByteSizeValue(1024)));
     }
 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_memory_usage_estimation.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_memory_usage_estimation.yml
@@ -13,24 +13,16 @@ setup:
 
 ---
 "Test memory usage estimation for empty data frame":
-  - skip:
-      version: "7.4.0 - "
-      reason:  "https://github.com/elastic/elasticsearch/issues/45741"
-
   - do:
       ml.estimate_memory_usage:
         body:
           source: { index: "index-source" }
           analysis: { outlier_detection: {} }
-  - match: { expected_memory_usage_with_one_partition: "0" }
-  - match: { expected_memory_usage_with_max_partitions: "0" }
+  - match: { expected_memory_without_disk: "0" }
+  - match: { expected_memory_with_disk: "0" }
 
 ---
 "Test memory usage estimation for non-empty data frame":
-  - skip:
-      version: "7.4.0 - "
-      reason:  "https://github.com/elastic/elasticsearch/issues/45741"
-
   - do:
       index:
         index: index-source
@@ -43,8 +35,8 @@ setup:
         body:
           source: { index: "index-source" }
           analysis: { outlier_detection: {} }
-  - match: { expected_memory_usage_with_one_partition: "3kb" }
-  - match: { expected_memory_usage_with_max_partitions: "3kb" }
+  - match: { expected_memory_without_disk: "3kb" }
+  - match: { expected_memory_with_disk: "3kb" }
 
   - do:
       index:
@@ -58,8 +50,8 @@ setup:
         body:
           source: { index: "index-source" }
           analysis: { outlier_detection: {} }
-  - match: { expected_memory_usage_with_one_partition: "4kb" }
-  - match: { expected_memory_usage_with_max_partitions: "4kb" }
+  - match: { expected_memory_without_disk: "4kb" }
+  - match: { expected_memory_with_disk: "4kb" }
 
   - do:
       index:
@@ -73,5 +65,5 @@ setup:
         body:
           source: { index: "index-source" }
           analysis: { outlier_detection: {} }
-  - match: { expected_memory_usage_with_one_partition: "6kb" }
-  - match: { expected_memory_usage_with_max_partitions: "5kb" }
+  - match: { expected_memory_without_disk: "6kb" }
+  - match: { expected_memory_with_disk: "5kb" }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Shorten field names in EstimateMemoryUsageResponse  (#45719)