### PR TITLE
[ML][Transforms] unifying logging, adding some more logging

### DIFF
--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
@@ -933,7 +933,7 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
                 handleFailure(exc);
             } catch (Exception e) {
                 logger.error(
-                    new ParameterizedMessage("[{} data frame transform encountered an unexpected internal exception: ", transformId),
+                    new ParameterizedMessage("[{}] data frame transform encountered an unexpected internal exception: ", transformId),
                     e);
             }
         }
@@ -1070,7 +1070,7 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
         }
 
         synchronized void handleFailure(Exception e) {
-            logger.warn(new ParameterizedMessage("[{} data frame transform encountered an exception: ",
+            logger.warn(new ParameterizedMessage("[{}] data frame transform encountered an exception: ",
                 transformTask.getTransformId()),
                 e);
             if (handleCircuitBreakingException(e)) {

--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/ClientDataFrameIndexerTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/transforms/ClientDataFrameIndexerTests.java
@@ -74,30 +74,30 @@ public class ClientDataFrameIndexerTests extends ESTestCase {
         // Audit every checkpoint for the first 10
         assertTrue(shouldAudit.get(0));
         assertTrue(shouldAudit.get(1));
-        assertTrue(shouldAudit.get(9));
+        assertTrue(shouldAudit.get(10));
 
         // Then audit every 10 while < 100
-        assertFalse(shouldAudit.get(10));
         assertFalse(shouldAudit.get(11));
-        assertTrue(shouldAudit.get(19));
-        assertTrue(shouldAudit.get(29));
-        assertFalse(shouldAudit.get(30));
-        assertTrue(shouldAudit.get(99));
+        assertTrue(shouldAudit.get(20));
+        assertFalse(shouldAudit.get(29));
+        assertTrue(shouldAudit.get(30));
+        assertFalse(shouldAudit.get(99));
 
         // Then audit every 100 < 1000
-        assertFalse(shouldAudit.get(100));
+        assertTrue(shouldAudit.get(100));
         assertFalse(shouldAudit.get(109));
         assertFalse(shouldAudit.get(110));
-        assertTrue(shouldAudit.get(199));
+        assertFalse(shouldAudit.get(199));
 
         // Then audit every 1000 for the rest of time
-        assertTrue(shouldAudit.get(1999));
+        assertFalse(shouldAudit.get(1999));
         assertFalse(shouldAudit.get(2199));
-        assertTrue(shouldAudit.get(2999));
-        assertTrue(shouldAudit.get(9999));
-        assertTrue(shouldAudit.get(10_999));
-        assertFalse(shouldAudit.get(11_000));
-        assertTrue(shouldAudit.get(11_999));
+        assertTrue(shouldAudit.get(3000));
+        assertTrue(shouldAudit.get(10_000));
+        assertFalse(shouldAudit.get(10_999));
+        assertTrue(shouldAudit.get(11_000));
+        assertFalse(shouldAudit.get(11_001));
+        assertFalse(shouldAudit.get(11_999));
     }
 
 }


### PR DESCRIPTION
This PR unifies our logging messages in the transform task so that they are easier to grok. Some new logging entries are added, but one logging message is removed (it was a hold over from previous debugging efforts). 

Additionally, the "when to audit on checkpoint finish" logic is now changed so that we write an audit message for nicely rounded numbers such as `10`, `100`, and not `19`, `99` or `199`. 