### PR TITLE
[DOCS] Add upgrade support matrix

### DIFF
--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -10,6 +10,21 @@ process so upgrading does not interrupt service. Rolling upgrades are supported:
 * From 5.6 to 6.8
 * From 6.8 to {version}
 
+The following table shows when you can perform a rolling upgrade, when you need
+to reindex or delete old indices, and when a full cluster restart is required.
+
+[cols="<1m,<1m,3",options="header",]
+|====
+|Upgrade from       |Upgrade to         |Supported upgrade type              
+|<5.x               |6.y (where y > x)  |<<reindex-upgrade,Reindex to upgrade>>     
+|5.0-5.5            |6.8                |<<restart-upgrade,Full cluster restart>>   
+|5.6                |6.8                |<<rolling-upgrades,Rolling upgrade>>       
+|6.0-6.7            |6.8                |<<rolling-upgrades,Rolling upgrade>>
+|6.0-6.7            |{version}          |<<restart-upgrade,Full cluster restart>>
+|6.8                |{version}          |<<rolling-upgrades,Rolling upgrade>>
+|7.x                |{version}  (where {version}  > 7.x) |<<rolling-upgrades,Rolling upgrade>>
+|====
+
 {es} can read indices created in the previous major version. If you
 have indices created in 5.x or before, you must reindex or delete them
 before upgrading to {version}. {es} nodes will fail to start if

--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -15,14 +15,14 @@ to reindex or delete old indices, and when a full cluster restart is required.
 
 [cols="<1m,<1m,3",options="header",]
 |====
-|Upgrade from       |Upgrade to         |Supported upgrade type              
-|<5.x               |6.y (where y > x)  |<<reindex-upgrade,Reindex to upgrade>>     
-|5.0-5.5            |6.8                |<<restart-upgrade,Full cluster restart>>   
-|5.6                |6.8                |<<rolling-upgrades,Rolling upgrade>>       
-|6.0-6.7            |6.8                |<<rolling-upgrades,Rolling upgrade>>
-|6.0-6.7            |{version}          |<<restart-upgrade,Full cluster restart>>
-|6.8                |{version}          |<<rolling-upgrades,Rolling upgrade>>
-|7.x                |{version}  (where {version}  > 7.x) |<<rolling-upgrades,Rolling upgrade>>
+|Upgrade from       |Upgrade to     |Supported upgrade type              
+|<5.x               |6.y            |<<reindex-upgrade,Reindex to upgrade>>  (where y > x)
+|5.0-5.5            |6.8            |<<restart-upgrade,Full cluster restart>>   
+|5.6                |6.8            |<<rolling-upgrades,Rolling upgrade>>       
+|6.0-6.7            |6.8            |<<rolling-upgrades,Rolling upgrade>>
+|6.0-6.7            |{version}      |<<restart-upgrade,Full cluster restart>>
+|6.8                |{version}      |<<rolling-upgrades,Rolling upgrade>>
+|7.x                |{version}      |<<rolling-upgrades,Rolling upgrade>> (where {version}  > 7.x)
 |====
 
 {es} can read indices created in the previous major version. If you

--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -18,30 +18,30 @@ The following table shows the recommended upgrade paths to {version}.
 |Upgrade from   
 |Recommended upgrade path  to {version}
 
-|5.0–5.5
-a|
-
-. <<rolling-upgrades,Rolling upgrade>> to 5.6
-. Rolling upgrade to 6.8
-. Rolling upgrade to {version}
-
-|5.6
-a|
-
-. <<rolling-upgrades,Rolling upgrade>> to 6.8
-. Rolling upgrade to {version}
-
-|6.0–6.7
-a|
-
-. <<rolling-upgrades,Rolling upgrade>> to 6.8
-. Rolling upgrade to {version}
+|7.0–7.2
+|<<rolling-upgrades,Rolling upgrade>> to {version}
 
 |6.8
 |<<rolling-upgrades,Rolling upgrade>> to {version}
 
-|7.0–7.2
-|<<rolling-upgrades,Rolling upgrade>> to {version}
+|6.0–6.7
+a|
+
+. https://www.elastic.co/guide/en/elasticsearch/reference/6.8/rolling-upgrades.html[Rolling upgrade] to 6.8
+. <<rolling-upgrades,Rolling upgrade>> to {version}
+
+|5.6
+a|
+
+. https://www.elastic.co/guide/en/elasticsearch/reference/6.8/rolling-upgrades.html[Rolling upgrade] to 6.8
+. <<rolling-upgrades,Rolling upgrade>> to {version}
+
+|5.0–5.5
+a|
+
+. https://www.elastic.co/guide/en/elasticsearch/reference/5.6/rolling-upgrades.html[Rolling upgrade] to 5.6
+. https://www.elastic.co/guide/en/elasticsearch/reference/6.8/rolling-upgrades.html[Rolling upgrade] to 6.8
+. <<rolling-upgrades,Rolling upgrade>> to {version}
 |====
 
 

--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -10,20 +10,48 @@ process so upgrading does not interrupt service. Rolling upgrades are supported:
 * From 5.6 to 6.8
 * From 6.8 to {version}
 
-The following table shows when you can perform a rolling upgrade, when you need
-to reindex or delete old indices, and when a full cluster restart is required.
 
-[cols="<1m,<1m,3",options="header",]
+The following table shows the recommended upgrade paths to {version}.
+
+[cols="<1m,3",options="header",]
 |====
-|Upgrade from       |Upgrade to     |Supported upgrade type              
-|<5.x               |6.y            |<<reindex-upgrade,Reindex to upgrade>>  (where y > x)
-|5.0-5.5            |6.8            |<<restart-upgrade,Full cluster restart>>   
-|5.6                |6.8            |<<rolling-upgrades,Rolling upgrade>>       
-|6.0-6.7            |6.8            |<<rolling-upgrades,Rolling upgrade>>
-|6.0-6.7            |{version}      |<<restart-upgrade,Full cluster restart>>
-|6.8                |{version}      |<<rolling-upgrades,Rolling upgrade>>
-|7.x                |{version}      |<<rolling-upgrades,Rolling upgrade>> (where {version}  > 7.x)
+|Upgrade from   
+|Recommended upgrade path  to {version}
+
+|5.0–5.5
+a|
+
+. <<rolling-upgrades,Rolling upgrade>> to 5.6
+. Rolling upgrade to 6.8
+. Rolling upgrade to {version}
+
+|5.6
+a|
+
+. <<rolling-upgrades,Rolling upgrade>> to 6.8
+. Rolling upgrade to {version}
+
+|6.0–6.7
+a|
+
+. <<rolling-upgrades,Rolling upgrade>> to 6.8
+. Rolling upgrade to {version}
+
+|6.8
+|<<rolling-upgrades,Rolling upgrade>> to {version}
+
+|7.0–7.2
+|<<rolling-upgrades,Rolling upgrade>> to {version}
 |====
+
+
+[WARNING]
+====
+The following upgrade paths are *not* supported:
+
+* 6.8 to 7.0.
+* 6.7 to 7.1.–{version}.
+====
 
 {es} can read indices created in the previous major version. If you
 have indices created in 5.x or before, you must reindex or delete them


### PR DESCRIPTION
Adds an upgrade support matrix, similar to those in [6.x docs](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/setup-upgrade.html#setup-upgrade).

Plan to port from `7.1`->`7.x`.

Separate PRs for `7.0` and `8.0`:

- 7.0 PR: #46026
- master/8.0 PR: #46027

### Preview
http://elasticsearch_45790.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.3/setup-upgrade.html