### PR TITLE
Remove redundant Java check from Sys V init

### DIFF
--- a/distribution/packages/src/deb/init.d/elasticsearch
+++ b/distribution/packages/src/deb/init.d/elasticsearch
@@ -80,22 +80,8 @@ if [ ! -x "$DAEMON" ]; then
 	exit 1
 fi
 
-checkJava() {
-  if [ ! -z "${JAVA_HOME}" ]; then
-    JAVA="${JAVA_HOME}"/bin/java
-  else
-    JAVA="${ES_HOME}"/jdk/bin/java
-  fi
-
-  if [ ! -x "$JAVA" ]; then
-    echo "could not find java in JAVA_HOME or bundled at ${JAVA}"
-    exit 1
-  fi
-}
-
 case "$1" in
   start)
-	checkJava
 
 	log_daemon_msg "Starting $DESC"
 

--- a/distribution/packages/src/rpm/init.d/elasticsearch
+++ b/distribution/packages/src/rpm/init.d/elasticsearch
@@ -67,21 +67,7 @@ if [ ! -x "$exec" ]; then
     exit 1
 fi
 
-checkJava() {
-  if [ ! -z "${JAVA_HOME}" ]; then
-    JAVA="${JAVA_HOME}"/bin/java
-  else
-    JAVA="${ES_HOME}"/jdk/bin/java
-  fi
-
-  if [ ! -x "$JAVA" ]; then
-    echo "could not find java in JAVA_HOME or bundled at ${JAVA}"
-    exit 1
-  fi
-}
-
 start() {
-    checkJava
     [ -x $exec ] || exit 5
 
     if [ -n "$MAX_OPEN_FILES" ]; then


### PR DESCRIPTION
In the Sys V init scripts, we check for Java. This is not needed, since the same check happens in elasticsearch-env when starting up. Having this duplicate check has bitten us in the past, where we made a change to the logic in elasticsearch-env, but missed updating it here. Since there is no need for this duplicate check, we remove it from the Sys V init scripts.

Relates #45593 
