### PR TITLE
Modify docs for setup passwords and saml metadata cli

### DIFF
--- a/docs/reference/commands/saml-metadata.asciidoc
+++ b/docs/reference/commands/saml-metadata.asciidoc
@@ -41,7 +41,7 @@ The key used for signing the metadata file need not necessarily be the same as
 the keys already used in the saml realm configuration for SAML message signing.
 
 If your {es} keystore is password protected, you
-will be prompted to enter the password to decrypt it when running the
+are prompted to enter the password when you run the
 `elasticsearch-saml-metadata` command.
 
 [float]

--- a/docs/reference/commands/saml-metadata.asciidoc
+++ b/docs/reference/commands/saml-metadata.asciidoc
@@ -40,6 +40,10 @@ ensure its integrity and authenticity before sharing it with the Identity Provid
 The key used for signing the metadata file need not necessarily be the same as
 the keys already used in the saml realm configuration for SAML message signing.
 
+If your {es} keystore is password protected, you
+will be prompted to enter the password to decrypt it when running the
+`elasticsearch-saml-metadata` command.
+
 [float]
 === Parameters
 

--- a/docs/reference/commands/setup-passwords.asciidoc
+++ b/docs/reference/commands/setup-passwords.asciidoc
@@ -22,7 +22,9 @@ bin/elasticsearch-setup-passwords auto|interactive
 This command is intended for use only during the initial configuration of the
 {es} {security-features}. It uses the
 {stack-ov}/built-in-users.html#bootstrap-elastic-passwords[`elastic` bootstrap password]
-to run user management API requests. After you set a password for the `elastic`
+to run user management API requests. If your {es} keystore is password protected, you
+will be prompted to enter the password to decrypt it before you can set the passwords.
+After you set a password for the `elastic`
 user, the bootstrap password is no longer active and you cannot use this command.
 Instead, you can change passwords by using the *Management > Users* UI in {kib}
 or the <<security-api-change-password,Change Password API>>.

--- a/docs/reference/commands/setup-passwords.asciidoc
+++ b/docs/reference/commands/setup-passwords.asciidoc
@@ -22,8 +22,8 @@ bin/elasticsearch-setup-passwords auto|interactive
 This command is intended for use only during the initial configuration of the
 {es} {security-features}. It uses the
 {stack-ov}/built-in-users.html#bootstrap-elastic-passwords[`elastic` bootstrap password]
-to run user management API requests. If your {es} keystore is password protected, you
-will be prompted to enter the password to decrypt it before you can set the passwords.
+to run user management API requests. If your {es} keystore is password protected,
+before you can set the passwords for the built-in users, you must enter the keystore password.
 After you set a password for the `elastic`
 user, the bootstrap password is no longer active and you cannot use this command.
 Instead, you can change passwords by using the *Management > Users* UI in {kib}


### PR DESCRIPTION
Adds a sentence in the documentation of `elasticsearch-setup-passwords`
and `elasticsearch-saml-metadata` to describe that users would be
prompted for the keystore's password when running these CLI tools,
when the keystore is password protected.

This was missed in #45289