### PR TITLE
[7.x] Add is_write_index column to cat.aliases

### DIFF
--- a/docs/reference/cat/alias.asciidoc
+++ b/docs/reference/cat/alias.asciidoc
@@ -79,11 +79,11 @@ The API returns the following response:
 
 [source,txt]
 --------------------------------------------------
-alias  index filter routing.index routing.search
-alias1 test1 -      -            -
-alias2 test1 *      -            -
-alias3 test1 -      1            1
-alias4 test1 -      2            1,2
+alias  index filter routing.index routing.search is_write_index
+alias1 test1 -      -            -              -
+alias2 test1 *      -            -              -
+alias3 test1 -      1            1              -
+alias4 test1 -      2            1,2            -
 --------------------------------------------------
 // TESTRESPONSE[s/[*]/[*]/ non_json]
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/10_basic.yml
@@ -2,8 +2,8 @@
 ---
 "Help":
   - skip:
-      version: " - 7.99.99"
-      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+      version: " - 7.3.99"
+      reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
 
   - do:
       cat.aliases:
@@ -20,15 +20,15 @@
         $/
 
 ---
-"Help (pre 8.0)":
+"Help (pre 7.4.0)":
   - skip:
-      version: "8.0.0 - "
+      version: "7.4.0 - "
       features: node_selector
-      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+      reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
 
   - do:
       node_selector:
-        version: " - 7.99.99"
+        version: " - 7.3.99"
       cat.aliases:
         help: true
 
@@ -55,8 +55,8 @@
 ---
 "Simple alias":
   - skip:
-      version: " - 7.99.99"
-      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+      version: " - 7.3.99"
+      reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
 
   - do:
         indices.create:
@@ -82,11 +82,11 @@
                 $/
 
 ---
-"Simple alias (pre 8.0)":
+"Simple alias (pre 7.4.0)":
   - skip:
-      version: "8.0.0 - "
+      version: "7.4.0 - "
       features: node_selector
-      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+      reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
 
   - do:
       indices.create:
@@ -99,7 +99,7 @@
 
   - do:
       node_selector:
-        version: " - 7.99.99"
+        version: " - 7.3.99"
       cat.aliases: {}
 
   - match:
@@ -115,8 +115,8 @@
 ---
 "Complex alias":
   - skip:
-      version: " - 7.99.99"
-      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+      version: " - 7.3.99"
+      reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
 
   - do:
         indices.create:
@@ -153,11 +153,11 @@
                 $/
 
 ---
-"Complex alias (pre 8.0)":
+"Complex alias (pre 7.4.0)":
   - skip:
-      version: "8.0.0 - "
+      version: "7.4.0 - "
       features: node_selector
-      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+      reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
 
   - do:
       indices.create:
@@ -180,7 +180,7 @@
               foo: bar
   - do:
       node_selector:
-        version: " - 7.99.99"
+        version: " - 7.3.99"
       cat.aliases: {}
 
   - match:
@@ -279,8 +279,8 @@
 ---
 "Column headers":
   - skip:
-      version: " - 7.99.99"
-      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+      version: " - 7.3.99"
+      reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
 
   - do:
         indices.create:
@@ -313,11 +313,11 @@
                $/
 
 ---
-"Column headers (pre 8.0)":
+"Column headers (pre 7.4.0)":
   - skip:
-      version: "8.0.0 - "
+      version: "7.4.0 - "
       features: node_selector
-      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+      reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
 
   - do:
       indices.create:
@@ -330,7 +330,7 @@
 
   - do:
       node_selector:
-        version: " - 7.99.99"
+        version: " - 7.3.99"
       cat.aliases:
         v: true
 
@@ -383,8 +383,8 @@
 ---
 "Alias against closed index":
   - skip:
-      version: " - 7.99.99"
-      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+      version: " - 7.3.99"
+      reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
 
   - do:
       indices.create:
@@ -412,11 +412,11 @@
                 $/
 
 ---
-"Alias against closed index (pre 8.0)":
+"Alias against closed index (pre 7.4.0)":
   - skip:
-      version: "8.0.0 - "
+      version: "7.4.0 - "
       features: node_selector
-      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+      reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
 
   - do:
       indices.create:
@@ -431,7 +431,7 @@
 
   - do:
       node_selector:
-        version: " - 7.99.99"
+        version: " - 7.3.99"
       cat.aliases: {}
 
   - match:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/10_basic.yml
@@ -1,6 +1,34 @@
+
 ---
 "Help":
+  - skip:
+      version: " - 7.99.99"
+      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+
   - do:
+      cat.aliases:
+        help: true
+
+  - match:
+      $body: |
+        /^  alias            .+   \n
+            index            .+   \n
+            filter           .+   \n
+            routing.index    .+   \n
+            routing.search   .+   \n
+            is_write_index   .+   \n
+        $/
+
+---
+"Help (pre 8.0)":
+  - skip:
+      version: "8.0.0 - "
+      features: node_selector
+      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+
+  - do:
+      node_selector:
+        version: " - 7.99.99"
       cat.aliases:
         help: true
 
@@ -26,6 +54,9 @@
 
 ---
 "Simple alias":
+  - skip:
+      version: " - 7.99.99"
+      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
 
   - do:
         indices.create:
@@ -47,10 +78,45 @@
                     -                   \s+
                     -                   \s+
                     -                   \s+
+                    -                   \s+
                 $/
 
 ---
+"Simple alias (pre 8.0)":
+  - skip:
+      version: "8.0.0 - "
+      features: node_selector
+      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+
+  - do:
+      indices.create:
+        index: test
+
+  - do:
+      indices.put_alias:
+        index: test
+        name:  test_alias
+
+  - do:
+      node_selector:
+        version: " - 7.99.99"
+      cat.aliases: {}
+
+  - match:
+      $body: |
+        /^
+            test_alias          \s+
+            test                \s+
+            -                   \s+
+            -                   \s+
+            -                   \s+
+        $/
+
+---
 "Complex alias":
+  - skip:
+      version: " - 7.99.99"
+      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
 
   - do:
         indices.create:
@@ -68,6 +134,7 @@
             body:
                 index_routing:  ir
                 search_routing: "sr1,sr2"
+                is_write_index: true
                 filter:
                     term:
                         foo: bar
@@ -82,7 +149,49 @@
                     [*]                 \s+
                     ir                  \s+
                     sr1,sr2             \s+
+                    true                \s+
                 $/
+
+---
+"Complex alias (pre 8.0)":
+  - skip:
+      version: "8.0.0 - "
+      features: node_selector
+      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              foo:
+                type: text
+
+  - do:
+      indices.put_alias:
+        index: test
+        name:  test_alias
+        body:
+          index_routing:  ir
+          search_routing: "sr1,sr2"
+          filter:
+            term:
+              foo: bar
+  - do:
+      node_selector:
+        version: " - 7.99.99"
+      cat.aliases: {}
+
+  - match:
+      $body: |
+        /^
+            test_alias          \s+
+            test                \s+
+            [*]                 \s+
+            ir                  \s+
+            sr1,sr2             \s+
+        $/
 
 ---
 "Alias name":
@@ -169,6 +278,9 @@
 
 ---
 "Column headers":
+  - skip:
+      version: " - 7.99.99"
+      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
 
   - do:
         indices.create:
@@ -189,15 +301,53 @@
                    index           \s+
                    filter          \s+
                    routing.index   \s+
-                   routing.search
+                   routing.search  \s+
+                   is_write_index
                    \n
                    test_1          \s+
                    test            \s+
                    -               \s+
                    -               \s+
                    -               \s+
+                   -               \s+
                $/
 
+---
+"Column headers (pre 8.0)":
+  - skip:
+      version: "8.0.0 - "
+      features: node_selector
+      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+
+  - do:
+      indices.create:
+        index: test
+
+  - do:
+      indices.put_alias:
+        index: test
+        name:  test_1
+
+  - do:
+      node_selector:
+        version: " - 7.99.99"
+      cat.aliases:
+        v: true
+
+  - match:
+      $body: |
+        /^  alias           \s+
+            index           \s+
+            filter          \s+
+            routing.index   \s+
+            routing.search
+            \n
+            test_1          \s+
+            test            \s+
+            -               \s+
+            -               \s+
+            -               \s+
+        $/
 
 ---
 "Select columns":
@@ -232,6 +382,9 @@
 
 ---
 "Alias against closed index":
+  - skip:
+      version: " - 7.99.99"
+      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
 
   - do:
       indices.create:
@@ -255,7 +408,41 @@
                     -                   \s+
                     -                   \s+
                     -                   \s+
+                    -                   \s+
                 $/
+
+---
+"Alias against closed index (pre 8.0)":
+  - skip:
+      version: "8.0.0 - "
+      features: node_selector
+      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          aliases:
+            test_alias: {}
+
+  - do:
+      indices.close:
+        index: test_index
+
+  - do:
+      node_selector:
+        version: " - 7.99.99"
+      cat.aliases: {}
+
+  - match:
+      $body: |
+        /^
+            test_alias          \s+
+            test_index          \s+
+            -                   \s+
+            -                   \s+
+            -                   \s+
+        $/
 
 ---
 "Alias sorting":

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestAliasAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestAliasAction.java
@@ -77,6 +77,7 @@ public class RestAliasAction extends AbstractCatAction {
         table.addCell("filter", "alias:f,fi;desc:filter");
         table.addCell("routing.index", "alias:ri,routingIndex;desc:index routing");
         table.addCell("routing.search", "alias:rs,routingSearch;desc:search routing");
+        table.addCell("is_write_index", "alias:w,isWriteIndex;desc:write index");
         table.endHeaders();
         return table;
     }
@@ -95,6 +96,8 @@ public class RestAliasAction extends AbstractCatAction {
                 table.addCell(indexRouting);
                 String searchRouting = Strings.hasLength(aliasMetaData.searchRouting()) ? aliasMetaData.searchRouting() : "-";
                 table.addCell(searchRouting);
+                String isWriteIndex = aliasMetaData.writeIndex() == null ? "-" : aliasMetaData.writeIndex().toString();
+                table.addCell(isWriteIndex);
                 table.endRow();
             }
         }


### PR DESCRIPTION
Aliases have had the option to set `is_write_index` since 6.4,
but the cat.aliases action was never updated.

example:

```
alias            index                              filter routing.index routing.search  is_write_index
filebeat-7.0.1   filebeat-7.0.1-2019.07.23-000011   -      -             -               -
metricbeat-7.0.1 metricbeat-7.0.1-2019.07.23-000005 -      -             -               true
metricbeat-7.0.1 metricbeat-7.0.1-2019.07.21-000003 -      -             -               false
```

backport of #44772