### PR TITLE
Improve distro tests base class (#45761)

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.packaging.test;
 
 import org.apache.http.client.fluent.Request;
 import org.elasticsearch.packaging.util.Archives;
-import org.elasticsearch.packaging.util.Distribution;
 import org.elasticsearch.packaging.util.FileUtils;
 import org.elasticsearch.packaging.util.Installation;
 import org.elasticsearch.packaging.util.Platforms;
@@ -52,7 +51,6 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
@@ -60,9 +58,8 @@ import static org.junit.Assume.assumeTrue;
 public class ArchiveTests extends PackagingTestCase {
 
     @BeforeClass
-    public static void assumptions() {
-        assumeTrue("only archive distributions",
-            distribution().packaging == Distribution.Packaging.TAR || distribution().packaging == Distribution.Packaging.ZIP);
+    public static void filterDistros() {
+        assumeTrue("only archives", distribution.isArchive());
     }
 
     public void test10Install() throws Exception {
@@ -71,20 +68,14 @@ public class ArchiveTests extends PackagingTestCase {
     }
 
     public void test20PluginsListWithNoPlugins() throws Exception {
-        assumeThat(installation, is(notNullValue()));
-
         final Installation.Executables bin = installation.executables();
-        final Shell sh = newShell();
         final Result r = sh.run(bin.elasticsearchPlugin + " list");
 
         assertThat(r.stdout, isEmptyString());
     }
 
     public void test30NoJava() throws Exception {
-        assumeThat(installation, is(notNullValue()));
-
         final Installation.Executables bin = installation.executables();
-        final Shell sh = newShell();
         sh.getEnv().remove("JAVA_HOME");
 
         final Path relocatedJdk = installation.bundledJdk.getParent().resolve("jdk.relocated");
@@ -105,10 +96,7 @@ public class ArchiveTests extends PackagingTestCase {
     }
 
     public void test40CreateKeystoreManually() throws Exception {
-        assumeThat(installation, is(notNullValue()));
-
         final Installation.Executables bin = installation.executables();
-        final Shell sh = newShell();
 
         Platforms.onLinux(() -> sh.run("sudo -u " + ARCHIVE_OWNER + " " + bin.elasticsearchKeystore + " create"));
 
@@ -138,12 +126,10 @@ public class ArchiveTests extends PackagingTestCase {
     }
 
     public void test50StartAndStop() throws Exception {
-        assumeThat(installation, is(notNullValue()));
-
         // cleanup from previous test
         rm(installation.config("elasticsearch.keystore"));
 
-        Archives.runElasticsearch(installation, newShell());
+        Archives.runElasticsearch(installation, sh);
 
         final String gcLogName = Platforms.LINUX && distribution().hasJdk == false
             ? "gc.log.0.current"
@@ -156,8 +142,6 @@ public class ArchiveTests extends PackagingTestCase {
     }
 
     public void assertRunsWithJavaHome() throws Exception {
-        Shell sh = newShell();
-
         Platforms.onLinux(() -> {
             String systemJavaHome = sh.run("echo $SYSTEM_JAVA_HOME").stdout.trim();
             sh.getEnv().put("JAVA_HOME", systemJavaHome);
@@ -177,13 +161,10 @@ public class ArchiveTests extends PackagingTestCase {
     }
 
     public void test51JavaHomeOverride() throws Exception {
-        assumeThat(installation, is(notNullValue()));
-
         assertRunsWithJavaHome();
     }
 
     public void test52BundledJdkRemoved() throws Exception {
-        assumeThat(installation, is(notNullValue()));
         assumeThat(distribution().hasJdk, is(true));
 
         Path relocatedJdk = installation.bundledJdk.getParent().resolve("jdk.relocated");
@@ -196,8 +177,6 @@ public class ArchiveTests extends PackagingTestCase {
     }
 
     public void test53JavaHomeWithSpecialCharacters() throws Exception {
-        assumeThat(installation, is(notNullValue()));
-
         Platforms.onWindows(() -> {
             final Shell sh = new Shell();
             try {
@@ -251,13 +230,9 @@ public class ArchiveTests extends PackagingTestCase {
     }
 
     public void test60AutoCreateKeystore() throws Exception {
-        assumeThat(installation, is(notNullValue()));
-
         assertThat(installation.config("elasticsearch.keystore"), file(File, ARCHIVE_OWNER, ARCHIVE_OWNER, p660));
 
         final Installation.Executables bin = installation.executables();
-        final Shell sh = newShell();
-
         Platforms.onLinux(() -> {
             final Result result = sh.run("sudo -u " + ARCHIVE_OWNER + " " + bin.elasticsearchKeystore + " list");
             assertThat(result.stdout, containsString("keystore.seed"));
@@ -270,7 +245,6 @@ public class ArchiveTests extends PackagingTestCase {
     }
 
     public void test70CustomPathConfAndJvmOptions() throws Exception {
-        assumeThat(installation, is(notNullValue()));
 
         final Path tempConf = getTempDir().resolve("esconf-alternate");
 
@@ -288,7 +262,6 @@ public class ArchiveTests extends PackagingTestCase {
                 "-Dlog4j2.disable.jmx=true\n";
             append(tempConf.resolve("jvm.options"), jvmOptions);
 
-            final Shell sh = newShell();
             Platforms.onLinux(() -> sh.run("chown -R elasticsearch:elasticsearch " + tempConf));
             Platforms.onWindows(() -> sh.run(
                 "$account = New-Object System.Security.Principal.NTAccount 'vagrant'; " +
@@ -301,11 +274,10 @@ public class ArchiveTests extends PackagingTestCase {
                 "}"
             ));
 
-            final Shell serverShell = newShell();
-            serverShell.getEnv().put("ES_PATH_CONF", tempConf.toString());
-            serverShell.getEnv().put("ES_JAVA_OPTS", "-XX:-UseCompressedOops");
+            sh.getEnv().put("ES_PATH_CONF", tempConf.toString());
+            sh.getEnv().put("ES_JAVA_OPTS", "-XX:-UseCompressedOops");
 
-            Archives.runElasticsearch(installation, serverShell);
+            Archives.runElasticsearch(installation, sh);
 
             final String nodesResponse = makeRequest(Request.Get("http://localhost:9200/_nodes"));
             assertThat(nodesResponse, containsString("\"heap_init_in_bytes\":536870912"));
@@ -319,7 +291,6 @@ public class ArchiveTests extends PackagingTestCase {
     }
 
     public void test80RelativePathConf() throws Exception {
-        assumeThat(installation, is(notNullValue()));
 
         final Path temp = getTempDir().resolve("esconf-alternate");
         final Path tempConf = temp.resolve("config");
@@ -334,7 +305,6 @@ public class ArchiveTests extends PackagingTestCase {
 
             append(tempConf.resolve("elasticsearch.yml"), "node.name: relative");
 
-            final Shell sh = newShell();
             Platforms.onLinux(() -> sh.run("chown -R elasticsearch:elasticsearch " + temp));
             Platforms.onWindows(() -> sh.run(
                 "$account = New-Object System.Security.Principal.NTAccount 'vagrant'; " +
@@ -347,10 +317,9 @@ public class ArchiveTests extends PackagingTestCase {
                 "}"
             ));
 
-            final Shell serverShell = newShell();
-            serverShell.setWorkingDirectory(temp);
-            serverShell.getEnv().put("ES_PATH_CONF", "config");
-            Archives.runElasticsearch(installation, serverShell);
+            sh.setWorkingDirectory(temp);
+            sh.getEnv().put("ES_PATH_CONF", "config");
+            Archives.runElasticsearch(installation, sh);
 
             final String nodesResponse = makeRequest(Request.Get("http://localhost:9200/_nodes"));
             assertThat(nodesResponse, containsString("\"name\":\"relative\""));
@@ -363,10 +332,7 @@ public class ArchiveTests extends PackagingTestCase {
     }
 
     public void test90SecurityCliPackaging() throws Exception {
-        assumeThat(installation, is(notNullValue()));
-
         final Installation.Executables bin = installation.executables();
-        final Shell sh = newShell();
 
         if (distribution().isDefault()) {
             assertTrue(Files.exists(installation.lib.resolve("tools").resolve("security-cli")));
@@ -387,10 +353,7 @@ public class ArchiveTests extends PackagingTestCase {
     }
 
     public void test91ElasticsearchShardCliPackaging() throws Exception {
-        assumeThat(installation, is(notNullValue()));
-
         final Installation.Executables bin = installation.executables();
-        final Shell sh = newShell();
 
         Platforms.PlatformAction action = () -> {
             final Result result = sh.run(bin.elasticsearchShard + " -h");
@@ -405,10 +368,7 @@ public class ArchiveTests extends PackagingTestCase {
     }
 
     public void test92ElasticsearchNodeCliPackaging() throws Exception {
-        assumeThat(installation, is(notNullValue()));
-
         final Installation.Executables bin = installation.executables();
-        final Shell sh = newShell();
 
         Platforms.PlatformAction action = () -> {
             final Result result = sh.run(bin.elasticsearchNode + " -h");
@@ -424,12 +384,9 @@ public class ArchiveTests extends PackagingTestCase {
     }
 
     public void test93ElasticsearchNodeCustomDataPathAndNotEsHomeWorkDir() throws Exception {
-        assumeThat(installation, is(notNullValue()));
-
         Path relativeDataPath = installation.data.relativize(installation.home);
         append(installation.config("elasticsearch.yml"), "path.data: " + relativeDataPath);
 
-        final Shell sh = newShell();
         sh.setWorkingDirectory(getTempDir());
 
         Archives.runElasticsearch(installation, sh);
@@ -440,10 +397,7 @@ public class ArchiveTests extends PackagingTestCase {
     }
 
     public void test94ElasticsearchNodeExecuteCliNotEsHomeWorkDir() throws Exception {
-        assumeThat(installation, is(notNullValue()));
-
         final Installation.Executables bin = installation.executables();
-        final Shell sh = newShell();
         // Run the cli tools from the tmp dir
         sh.setWorkingDirectory(getTempDir());
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageTests.java
@@ -19,15 +19,12 @@
 
 package org.elasticsearch.packaging.test;
 
-import com.carrotsearch.randomizedtesting.annotations.TestCaseOrdering;
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 import org.apache.http.client.fluent.Request;
-import org.elasticsearch.packaging.util.Distribution;
 import org.elasticsearch.packaging.util.FileUtils;
-import org.elasticsearch.packaging.util.Shell;
 import org.elasticsearch.packaging.util.Shell.Result;
 import org.hamcrest.CoreMatchers;
-import org.junit.Before;
+import org.junit.BeforeClass;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -50,53 +47,39 @@ import static org.elasticsearch.packaging.util.FileUtils.slurp;
 import static org.elasticsearch.packaging.util.Packages.SYSTEMD_SERVICE;
 import static org.elasticsearch.packaging.util.Packages.assertInstalled;
 import static org.elasticsearch.packaging.util.Packages.assertRemoved;
-import static org.elasticsearch.packaging.util.Packages.install;
+import static org.elasticsearch.packaging.util.Packages.installPackage;
 import static org.elasticsearch.packaging.util.Packages.remove;
 import static org.elasticsearch.packaging.util.Packages.restartElasticsearch;
 import static org.elasticsearch.packaging.util.Packages.startElasticsearch;
 import static org.elasticsearch.packaging.util.Packages.stopElasticsearch;
 import static org.elasticsearch.packaging.util.Packages.verifyPackageInstallation;
 import static org.elasticsearch.packaging.util.Platforms.getOsRelease;
-import static org.elasticsearch.packaging.util.Platforms.isDPKG;
 import static org.elasticsearch.packaging.util.Platforms.isSystemd;
 import static org.elasticsearch.packaging.util.ServerUtils.makeRequest;
 import static org.elasticsearch.packaging.util.ServerUtils.runElasticsearchTests;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
 
-@TestCaseOrdering(TestCaseOrdering.AlphabeticOrder.class)
 public class PackageTests extends PackagingTestCase {
-    private Shell sh;
 
-    @Before
-    public void onlyCompatibleDistributions() throws Exception {
-        assumeTrue("only compatible distributions", distribution().packaging.compatible);
-        assumeTrue("rpm or deb",
-            distribution().packaging == Distribution.Packaging.DEB || distribution().packaging == Distribution.Packaging.RPM);
-        sh = newShell();
-    }
-
-    public void test05CheckLintian() throws Exception {
-        assumeTrue(isDPKG());
-        sh.run("lintian --fail-on-warnings " + FileUtils.getDistributionFile(distribution()));
+    @BeforeClass
+    public static void filterDistros() {
+        assumeTrue("rpm or deb", distribution.isPackage());
     }
 
     public void test10InstallPackage() throws Exception {
         assertRemoved(distribution());
-        installation = install(distribution());
+        installation = installPackage(distribution());
         assertInstalled(distribution());
         verifyPackageInstallation(installation, distribution(), sh);
     }
 
     public void test20PluginsCommandWhenNoPlugins() throws Exception {
-        assumeThat(installation, is(notNullValue()));
-
         assertThat(sh.run(installation.bin("elasticsearch-plugin") + " list").stdout, isEmptyString());
     }
 
@@ -109,13 +92,10 @@ public class PackageTests extends PackagingTestCase {
     }
 
     public void test31InstallDoesNotStartServer() {
-        assumeThat(installation, is(notNullValue()));
-
         assertThat(sh.run("ps aux").stdout, not(containsString("org.elasticsearch.bootstrap.Elasticsearch")));
     }
 
     public void assertRunsWithJavaHome() throws Exception {
-        String systemJavaHome = sh.run("echo $SYSTEM_JAVA_HOME").stdout.trim();
         byte[] originalEnvFile = Files.readAllBytes(installation.envFile);
         try {
             Files.write(installation.envFile, ("JAVA_HOME=" + systemJavaHome + "\n").getBytes(StandardCharsets.UTF_8),
@@ -132,7 +112,6 @@ public class PackageTests extends PackagingTestCase {
     }
 
     public void test32JavaHomeOverride() throws Exception {
-        assumeThat(installation, is(notNullValue()));
         // we always run with java home when no bundled jdk is included, so this test would be repetitive
         assumeThat(distribution().hasJdk, is(true));
 
@@ -159,7 +138,6 @@ public class PackageTests extends PackagingTestCase {
     }
 
     public void test42BundledJdkRemoved() throws Exception {
-        assumeThat(installation, is(notNullValue()));
         assumeThat(distribution().hasJdk, is(true));
 
         Path relocatedJdk = installation.bundledJdk.getParent().resolve("jdk.relocated");
@@ -173,8 +151,6 @@ public class PackageTests extends PackagingTestCase {
 
     public void test40StartServer() throws Exception {
         String start = sh.runIgnoreExitCode("date ").stdout.trim();
-        assumeThat(installation, is(notNullValue()));
-
         startElasticsearch(sh);
 
         String journalEntries = sh.runIgnoreExitCode("journalctl _SYSTEMD_UNIT=elasticsearch.service " +
@@ -190,8 +166,6 @@ public class PackageTests extends PackagingTestCase {
     }
 
     public void test50Remove() throws Exception {
-        assumeThat(installation, is(notNullValue()));
-
         // add fake bin directory as if a plugin was installed
         Files.createDirectories(installation.bin.resolve("myplugin"));
 
@@ -243,9 +217,7 @@ public class PackageTests extends PackagingTestCase {
     }
 
     public void test60Reinstall() throws Exception {
-        assumeThat(installation, is(notNullValue()));
-
-        installation = install(distribution());
+        installation = installPackage(distribution());
         assertInstalled(distribution());
         verifyPackageInstallation(installation, distribution(), sh);
 
@@ -255,7 +227,7 @@ public class PackageTests extends PackagingTestCase {
 
     public void test70RestartServer() throws Exception {
         try {
-            installation = install(distribution());
+            installation = installPackage(distribution());
             assertInstalled(distribution());
 
             startElasticsearch(sh);
@@ -270,7 +242,7 @@ public class PackageTests extends PackagingTestCase {
 
     public void test72TestRuntimeDirectory() throws Exception {
         try {
-            installation = install(distribution());
+            installation = installPackage(distribution());
             FileUtils.rm(installation.pidDir);
             startElasticsearch(sh);
             assertPathsExist(installation.pidDir);
@@ -281,7 +253,7 @@ public class PackageTests extends PackagingTestCase {
     }
 
     public void test73gcLogsExist() throws Exception {
-        installation = install(distribution());
+        installation = installPackage(distribution());
         startElasticsearch(sh);
         // it can be gc.log or gc.log.0.current
         assertThat(installation.logs, fileWithGlobExist("gc.log*"));
@@ -316,7 +288,6 @@ public class PackageTests extends PackagingTestCase {
     public void test81CustomPathConfAndJvmOptions() throws Exception {
         assumeTrue(isSystemd());
 
-        assumeThat(installation, is(notNullValue()));
         assertPathsExist(installation.envFile);
 
         stopElasticsearch(sh);
@@ -344,18 +315,17 @@ public class PackageTests extends PackagingTestCase {
 
             sh.runIgnoreExitCode("chown -R elasticsearch:elasticsearch " + tempConf);
 
-            final Shell serverShell = newShell();
             cp(installation.envFile, tempConf.resolve("elasticsearch.bk"));//backup
             append(installation.envFile, "ES_PATH_CONF=" + tempConf + "\n");
             append(installation.envFile, "ES_JAVA_OPTS=-XX:-UseCompressedOops");
 
-            startElasticsearch(serverShell);
+            startElasticsearch(sh);
 
             final String nodesResponse = makeRequest(Request.Get("http://localhost:9200/_nodes"));
             assertThat(nodesResponse, CoreMatchers.containsString("\"heap_init_in_bytes\":536870912"));
             assertThat(nodesResponse, CoreMatchers.containsString("\"using_compressed_ordinary_object_pointers\":\"false\""));
 
-            stopElasticsearch(serverShell);
+            stopElasticsearch(sh);
 
         } finally {
             rm(installation.envFile);
@@ -371,7 +341,7 @@ public class PackageTests extends PackagingTestCase {
 
             sh.run("systemctl mask systemd-sysctl.service");
 
-            installation = install(distribution());
+            installation = installPackage(distribution());
 
             sh.run("systemctl unmask systemd-sysctl.service");
         } finally {
@@ -383,7 +353,7 @@ public class PackageTests extends PackagingTestCase {
         // Limits are changed on systemd platforms only
         assumeTrue(isSystemd());
 
-        installation = install(distribution());
+        installation = installPackage(distribution());
 
         startElasticsearch(sh);
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/RpmMetadataTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/RpmMetadataTests.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.packaging.test;
+
+import junit.framework.TestCase;
+import org.elasticsearch.packaging.util.Distribution;
+import org.elasticsearch.packaging.util.Platforms;
+import org.elasticsearch.packaging.util.Shell;
+import org.junit.Before;
+
+import java.util.regex.Pattern;
+
+import static org.elasticsearch.packaging.util.FileUtils.getDistributionFile;
+import static org.junit.Assume.assumeTrue;
+
+public class RpmMetadataTests extends PackagingTestCase {
+
+    @Before
+    public void filterDistros() {
+        assumeTrue("only rpm", distribution.packaging == Distribution.Packaging.RPM);
+    }
+
+    public void test11Dependencies() {
+        // TODO: rewrite this test to not use a real second distro to try and install
+        assumeTrue(Platforms.isRPM());
+
+        final Shell sh = new Shell();
+
+        final Shell.Result deps = sh.run("rpm -qpR " + getDistributionFile(distribution()));
+
+        TestCase.assertTrue(Pattern.compile("(?m)^/bin/bash\\s*$").matcher(deps.stdout).find());
+
+        final Shell.Result conflicts = sh.run("rpm -qp --conflicts " + getDistributionFile(distribution()));
+
+        String oppositePackageName = "elasticsearch";
+        if (distribution().isDefault()) {
+            oppositePackageName += "-oss";
+        }
+
+        TestCase.assertTrue(Pattern.compile("(?m)^" + oppositePackageName + "\\s*$").matcher(conflicts.stdout).find());
+    }
+}

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/RpmPreservationTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/RpmPreservationTests.java
@@ -19,10 +19,9 @@
 
 package org.elasticsearch.packaging.test;
 
-import com.carrotsearch.randomizedtesting.annotations.TestCaseOrdering;
 import org.elasticsearch.packaging.util.Distribution;
 import org.elasticsearch.packaging.util.Shell;
-import org.junit.Before;
+import org.junit.BeforeClass;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -34,37 +33,29 @@ import static org.elasticsearch.packaging.util.Packages.SYSTEMD_SERVICE;
 import static org.elasticsearch.packaging.util.Packages.SYSVINIT_SCRIPT;
 import static org.elasticsearch.packaging.util.Packages.assertInstalled;
 import static org.elasticsearch.packaging.util.Packages.assertRemoved;
-import static org.elasticsearch.packaging.util.Packages.install;
+import static org.elasticsearch.packaging.util.Packages.installPackage;
 import static org.elasticsearch.packaging.util.Packages.remove;
 import static org.elasticsearch.packaging.util.Packages.verifyPackageInstallation;
-import static org.elasticsearch.packaging.util.Platforms.isRPM;
 import static org.elasticsearch.packaging.util.Platforms.isSystemd;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
 
-@TestCaseOrdering(TestCaseOrdering.AlphabeticOrder.class)
 public class RpmPreservationTests extends PackagingTestCase {
 
-    @Before
-    public void onlyCompatibleDistributions() {
-        assumeTrue("only rpm platforms", isRPM());
-        assumeTrue("rpm distributions", distribution().packaging == Distribution.Packaging.RPM);
+    @BeforeClass
+    public static void filterDistros() {
+        assumeTrue("only rpm", distribution.packaging == Distribution.Packaging.RPM);
         assumeTrue("only bundled jdk", distribution().hasJdk);
-        assumeTrue("only compatible distributions", distribution().packaging.compatible);
     }
 
     public void test10Install() throws Exception {
         assertRemoved(distribution());
-        installation = install(distribution());
+        installation = installPackage(distribution());
         assertInstalled(distribution());
         verifyPackageInstallation(installation, distribution(), newShell());
     }
 
     public void test20Remove() throws Exception {
-        assumeThat(installation, is(notNullValue()));
-
         remove(distribution());
 
         // config was removed
@@ -80,7 +71,7 @@ public class RpmPreservationTests extends PackagingTestCase {
     public void test30PreserveConfig() throws Exception {
         final Shell sh = new Shell();
 
-        installation = install(distribution());
+        installation = installPackage(distribution());
         assertInstalled(distribution());
         verifyPackageInstallation(installation, distribution(), newShell());
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/WindowsServiceTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/WindowsServiceTests.java
@@ -26,7 +26,6 @@ import org.elasticsearch.packaging.util.ServerUtils;
 import org.elasticsearch.packaging.util.Shell;
 import org.elasticsearch.packaging.util.Shell.Result;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
@@ -46,13 +45,6 @@ public class WindowsServiceTests extends PackagingTestCase {
     private static final String DEFAULT_ID = "elasticsearch-service-x64";
     private static final String DEFAULT_DISPLAY_NAME = "Elasticsearch " + FileUtils.getCurrentVersion() + " (elasticsearch-service-x64)";
     private static String serviceScript;
-
-    private Shell sh;
-
-    @Before
-    public void createShell() {
-        sh = new Shell();
-    }
 
     @BeforeClass
     public static void ensureWindows() {

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Distribution.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Distribution.java
@@ -49,6 +49,14 @@ public class Distribution {
         return flavor.equals(Flavor.OSS);
     }
 
+    public boolean isArchive() {
+        return packaging == Packaging.TAR || packaging == Packaging.ZIP;
+    }
+
+    public boolean isPackage() {
+        return packaging == Packaging.RPM || packaging == Packaging.DEB;
+    }
+
     public enum Packaging {
 
         TAR(".tar.gz", Platforms.LINUX || Platforms.DARWIN),

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
@@ -94,7 +94,7 @@ public class Packages {
         return result;
     }
 
-    public static Installation install(Distribution distribution) throws IOException {
+    public static Installation installPackage(Distribution distribution) throws IOException {
         Shell sh = new Shell();
         String systemJavaHome = sh.run("echo $SYSTEM_JAVA_HOME").stdout.trim();
         if (distribution.hasJdk == false) {


### PR DESCRIPTION
This commit moves many features of individual distro tests into the base
class so that other test cases can utilize them. It also standardizes
the pattern for tests adding assumptions for the particular
distributions to test.

