### PR TITLE
Dump exceptions from build tools integ tests

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -221,6 +221,11 @@ if (project != rootProject) {
     maxParallelForks System.getProperty('tests.jvms', project.rootProject.ext.defaultParallel.toString()) as Integer
     // These tests run Gradle which doesn't have FIPS support
     onlyIf { project.inFipsJvm == false }
+    testLogging {
+      showExceptions = true
+      showCauses = true
+      exceptionFormat = 'full'
+    }
   }
   check.dependsOn(integTest)
 


### PR DESCRIPTION
The build-tools integ tests (ie testKit) are special and do not have the
normal test setup that the rest of the projects get. This commit adds
full exception dumping when build tools integ tests fail.