### PR TITLE
[DOCS] Relocate Ingest API docs to REST API section

### DIFF
--- a/docs/reference/ingest/apis/index.asciidoc
+++ b/docs/reference/ingest/apis/index.asciidoc
@@ -1,0 +1,15 @@
+[[ingest-apis]]
+== Ingest APIs
+
+The following ingest APIs are available for managing pipelines:
+
+* <<put-pipeline-api>> to add or update a pipeline
+* <<get-pipeline-api>> to return a specific pipeline
+* <<delete-pipeline-api>> to delete a pipeline
+* <<simulate-pipeline-api>> to simulate a call to a pipeline
+
+
+include::put-pipeline.asciidoc[]
+include::get-pipeline.asciidoc[]
+include::delete-pipeline.asciidoc[]
+include::simulate-pipeline.asciidoc[]

--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -20,21 +20,6 @@ what the pipeline does.
 The `processors` parameter defines a list of processors to be executed in
 order.
 
-[[ingest-apis]]
-== Ingest APIs
-
-The following ingest APIs are available for managing pipelines:
-
-* <<put-pipeline-api>> to add or update a pipeline
-* <<get-pipeline-api>> to return a specific pipeline
-* <<delete-pipeline-api>> to delete a pipeline
-* <<simulate-pipeline-api>> to simulate a call to a pipeline
-
-include::apis/put-pipeline.asciidoc[]
-include::apis/get-pipeline.asciidoc[]
-include::apis/delete-pipeline.asciidoc[]
-include::apis/simulate-pipeline.asciidoc[]
-
 [[accessing-data-in-pipelines]]
 == Accessing Data in Pipelines
 

--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -19,6 +19,7 @@ not be included yet.
 * <<graph-explore-api,Graph Explore API>>
 * <<indices, Index APIs>>
 * <<index-lifecycle-management-api,Index lifecycle management APIs>>
+* <<ingest-apis,Ingest APIs>>
 * <<info-api,Info API>>
 * <<licensing-apis,Licensing APIs>>
 * <<ml-apis,{ml-cap} {anomaly-detect} APIs>>
@@ -41,6 +42,7 @@ include::{es-repo-dir}/docs.asciidoc[]
 include::{es-repo-dir}/graph/explore.asciidoc[]
 include::{es-repo-dir}/indices.asciidoc[]
 include::{es-repo-dir}/ilm/apis/ilm-api.asciidoc[]
+include::{es-repo-dir}/ingest/apis/index.asciidoc[]
 include::info.asciidoc[]
 include::{es-repo-dir}/licensing/index.asciidoc[]
 include::{es-repo-dir}/ml/anomaly-detection/apis/ml-api.asciidoc[]


### PR DESCRIPTION
This relocates the Ingest APIs to the [REST APIs](https://www.elastic.co/guide/en/elasticsearch/reference/master/rest-apis.html) section, where most other Elasticsearch API documentation lives.

### Previews
http://elasticsearch_45812.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/rest-apis.html

http://elasticsearch_45812.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ingest-apis.html