### PR TITLE
Move regex error to node

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/Walker.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/Walker.java
@@ -817,11 +817,6 @@ public final class Walker extends PainlessParserBaseVisitor<ANode> {
 
     @Override
     public ANode visitRegex(RegexContext ctx) {
-        if (false == settings.areRegexesEnabled()) {
-            throw location(ctx).createError(new IllegalStateException("Regexes are disabled. Set [script.painless.regex.enabled] to [true] "
-                    + "in elasticsearch.yaml to allow them. Be careful though, regexes break out of Painless's protection against deep "
-                    + "recursion and long loops."));
-        }
         String text = ctx.REGEX().getText();
         int lastSlash = text.lastIndexOf('/');
         String pattern = text.substring(1, lastSlash);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ERegex.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ERegex.java
@@ -40,6 +40,8 @@ public final class ERegex extends AExpression {
     private final int flags;
     private Constant constant;
 
+    private CompilerSettings settings;
+
     public ERegex(Location location, String pattern, String flagsString) {
         super(location);
 
@@ -56,7 +58,7 @@ public final class ERegex extends AExpression {
 
     @Override
     void storeSettings(CompilerSettings settings) {
-        // do nothing
+        this.settings = settings;
     }
 
     @Override
@@ -66,6 +68,12 @@ public final class ERegex extends AExpression {
 
     @Override
     void analyze(Locals locals) {
+        if (false == settings.areRegexesEnabled()) {
+            throw createError(new IllegalStateException("Regexes are disabled. Set [script.painless.regex.enabled] to [true] "
+                    + "in elasticsearch.yaml to allow them. Be careful though, regexes break out of Painless's protection against deep "
+                    + "recursion and long loops."));
+        }
+
         if (!read) {
             throw createError(new IllegalArgumentException("Regex constant may only be read [" + pattern + "]."));
         }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhenThingsGoWrongTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhenThingsGoWrongTests.java
@@ -262,7 +262,7 @@ public class WhenThingsGoWrongTests extends ScriptTestCase {
     }
 
     public void testRegexDisabledByDefault() {
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> exec("return 'foo' ==~ /foo/"));
+        IllegalStateException e = expectScriptThrows(IllegalStateException.class, () -> exec("return 'foo' ==~ /foo/"));
         assertEquals("Regexes are disabled. Set [script.painless.regex.enabled] to [true] in elasticsearch.yaml to allow them. "
                 + "Be careful though, regexes break out of Painless's protection against deep recursion and long loops.", e.getMessage());
     }


### PR DESCRIPTION
This change moves an error checking whether or not regexes are disabled from the Antlr AST to the Painless AST. This is possible now because of the added pass to distribute settings to all the nodes.