### PR TITLE
disable bwc tests for #44772

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,8 +176,8 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
-final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = false
+final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/45798" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")


### PR DESCRIPTION
#44772's backport PR #45798 is pending bwc tests being disabled in master so that it can be re-enabled with the updated 7.4 version guards after backport PR is merged.