### PR TITLE
Remove non task aware execute methods from TransportAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
@@ -275,7 +275,7 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
         @Override
         public void messageReceived(Request request, final TransportChannel channel, Task task) throws Exception {
             // if we have a local operation, execute it on a thread since we don't spawn
-            execute(request, new ChannelActionListener<>(channel, actionName, request));
+            execute(task, request, new ChannelActionListener<>(channel, actionName, request));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -593,7 +593,7 @@ public class Node implements Closeable {
                 .map(p -> (LifecycleComponent) p).collect(Collectors.toList());
             resourcesToClose.addAll(pluginLifecycleComponents);
             this.pluginLifecycleComponents = Collections.unmodifiableList(pluginLifecycleComponents);
-            client.initialize(injector.getInstance(new Key<Map<ActionType, TransportAction>>() {}),
+            client.initialize(injector.getInstance(new Key<Map<ActionType, TransportAction>>() {}), transportService.getTaskManager(),
                     () -> clusterService.localNode().getId(), transportService.getRemoteClusterService());
             this.namedWriteableRegistry = namedWriteableRegistry;
 

--- a/server/src/main/java/org/elasticsearch/tasks/TaskManager.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskManager.java
@@ -26,7 +26,9 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterStateApplier;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -50,6 +52,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
 
 import static org.elasticsearch.common.unit.TimeValue.timeValueMillis;
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_MAX_HEADER_SIZE;
@@ -124,6 +127,33 @@ public class TaskManager implements ClusterStateApplier {
             Task previousTask = tasks.put(task.getId(), task);
             assert previousTask == null;
         }
+        return task;
+    }
+
+    public <Request extends ActionRequest, Response extends ActionResponse>
+    Task registerAndExecute(String type, TransportAction<Request, Response> action, Request request,
+                            BiConsumer<Task, Response> onResponse, BiConsumer<Task, Exception> onFailure) {
+        Task task = register(type, action.actionName, request);
+        // NOTE: ActionListener cannot infer Response, see https://bugs.openjdk.java.net/browse/JDK-8203195
+        action.execute(task, request, new ActionListener<Response>() {
+            @Override
+            public void onResponse(Response response) {
+                try {
+                    unregister(task);
+                } finally {
+                    onResponse.accept(task, response);
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                try {
+                    unregister(task);
+                } finally {
+                    onFailure.accept(task, e);
+                }
+            }
+        });
         return task;
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksTests.java
@@ -200,7 +200,8 @@ public class CancellableTasksTests extends TaskManagerTestCase {
             actions[i] = new CancellableTestNodesAction("internal:testAction", threadPool, testNodes[i]
                 .clusterService, testNodes[i].transportService, shouldBlock, actionLatch);
         }
-        Task task = actions[0].execute(request, listener);
+        Task task = testNodes[0].transportService.getTaskManager().registerAndExecute("transport", actions[0], request,
+            (t, r) -> listener.onResponse(r), (t, e) -> listener.onFailure(e));
         if (waitForActionToStart) {
             logger.info("Awaiting for all actions to start");
             actionLatch.await();

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
@@ -278,7 +278,8 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
         for (TestNode node : testNodes) {
             assertEquals(0, node.transportService.getTaskManager().getTasks().size());
         }
-        Task task = actions[0].execute(request, listener);
+        Task task = testNodes[0].transportService.getTaskManager().registerAndExecute("transport", actions[0], request,
+            (t, r) -> listener.onResponse(r), (t, e) -> listener.onFailure(e));
         logger.info("Awaiting for all actions to start");
         assertTrue(actionLatch.await(10, TimeUnit.SECONDS));
         logger.info("Done waiting for all actions to start");
@@ -527,7 +528,8 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
             assertEquals(0, testNode.transportService.getTaskManager().getTasks().size());
         }
         NodesRequest request = new NodesRequest("Test Request");
-        NodesResponse responses = ActionTestUtils.executeBlocking(actions[0], request);
+        NodesResponse responses = ActionTestUtils.executeBlockingWithTask(
+            testNodes[0].transportService.getTaskManager(), actions[0], request);
         assertEquals(nodesCount, responses.failureCount());
 
         // Make sure that actions are still registered in the task manager on all nodes
@@ -689,7 +691,8 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
         // Get the parent task
         ListTasksRequest listTasksRequest = new ListTasksRequest();
         listTasksRequest.setActions(ListTasksAction.NAME + "*");
-        ListTasksResponse response = ActionTestUtils.executeBlocking(testNodes[0].transportListTasksAction, listTasksRequest);
+        ListTasksResponse response = ActionTestUtils.executeBlockingWithTask(
+            testNodes[0].transportService.getTaskManager(), testNodes[0].transportListTasksAction, listTasksRequest);
         assertEquals(testNodes.length + 1, response.getTasks().size());
 
         Map<String, Object> byNodes = serialize(response, true);

--- a/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
@@ -196,7 +196,7 @@ public class ClusterStateChanges {
         Map<ActionType, TransportAction> actions = new HashMap<>();
         actions.put(TransportVerifyShardBeforeCloseAction.TYPE, new TransportVerifyShardBeforeCloseAction(SETTINGS,
             transportService, clusterService, indicesService, threadPool, null, actionFilters, indexNameExpressionResolver));
-        client.initialize(actions, null, null);
+        client.initialize(actions, transportService.getTaskManager(), null, null);
 
         MetaDataIndexStateService indexStateService = new MetaDataIndexStateService(clusterService, allocationService,
             metaDataIndexUpgradeService, indicesService, threadPool, client);

--- a/server/src/test/java/org/elasticsearch/indices/cluster/IndicesClusterStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/IndicesClusterStateServiceTests.java
@@ -58,6 +58,7 @@ import static org.elasticsearch.mock.orig.Mockito.when;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -87,8 +88,10 @@ public class IndicesClusterStateServiceTests extends ESTestCase {
         when(indexShard.shardId()).thenReturn(shardId);
 
         final Logger mockLogger = mock(Logger.class);
+        final TaskManager taskManager = mock(TaskManager.class);
+        when(taskManager.registerAndExecute(any(), any(), any(), any(), any())).thenCallRealMethod();
         final TransportService transportService = mock(TransportService.class);
-        when(transportService.getTaskManager()).thenReturn(mock(TaskManager.class));
+        when(transportService.getTaskManager()).thenReturn(taskManager);
 
         final RetentionLeases retentionLeases = mock(RetentionLeases.class);
         final AtomicBoolean invoked = new AtomicBoolean();
@@ -134,7 +137,7 @@ public class IndicesClusterStateServiceTests extends ESTestCase {
         };
         NodeClient client = new NodeClient(Settings.EMPTY, null);
         Map<ActionType, TransportAction> actions = Collections.singletonMap(RetentionLeaseBackgroundSyncAction.TYPE, action);
-        client.initialize(actions, null, null);
+        client.initialize(actions, taskManager, null, null);
         IndicesClusterStateService service = new IndicesClusterStateService(Settings.EMPTY, null, null, threadPool, null, null, null,
             null, null, null, null, null, null, client) {
             @Override
@@ -162,8 +165,10 @@ public class IndicesClusterStateServiceTests extends ESTestCase {
         when(indexShard.shardId()).thenReturn(shardId);
 
         final Logger mockLogger = mock(Logger.class);
+        final TaskManager taskManager = mock(TaskManager.class);
+        when(taskManager.registerAndExecute(any(), any(), any(), any(), any())).thenCallRealMethod();
         final TransportService transportService = mock(TransportService.class);
-        when(transportService.getTaskManager()).thenReturn(mock(TaskManager.class));
+        when(transportService.getTaskManager()).thenReturn(taskManager);
 
         final RetentionLeases retentionLeases = mock(RetentionLeases.class);
         final AtomicBoolean invoked = new AtomicBoolean();
@@ -204,7 +209,7 @@ public class IndicesClusterStateServiceTests extends ESTestCase {
         };
         NodeClient client = new NodeClient(Settings.EMPTY, null);
         Map<ActionType, TransportAction> actions = Collections.singletonMap(RetentionLeaseSyncAction.TYPE, action);
-        client.initialize(actions, null, null);
+        client.initialize(actions, taskManager, null, null);
         IndicesClusterStateService service = new IndicesClusterStateService(Settings.EMPTY, null, null, threadPool, null, null, null,
             null, null, null, null, null, null, client) {
             @Override

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryActionTests.java
@@ -82,7 +82,7 @@ public class RestValidateQueryActionTests extends AbstractSearchTestCase {
         final Map<ActionType, TransportAction> actions = new HashMap<>();
         actions.put(ValidateQueryAction.INSTANCE, transportAction);
 
-        client.initialize(actions, () -> "local", null);
+        client.initialize(actions, taskManager, () -> "local", null);
     }
 
     @AfterClass

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -1030,7 +1030,8 @@ public class SnapshotResiliencyTests extends ESTestCase {
                     transportService, clusterService, threadPool,
                     snapshotsService, actionFilters, indexNameExpressionResolver
                 ));
-            client.initialize(actions, () -> clusterService.localNode().getId(), transportService.getRemoteClusterService());
+            client.initialize(actions, transportService.getTaskManager(),
+                () -> clusterService.localNode().getId(), transportService.getRemoteClusterService());
         }
 
         private Repository.Factory getRepoFactory(Environment environment) {

--- a/test/framework/src/main/java/org/elasticsearch/action/support/ActionTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/action/support/ActionTestUtils.java
@@ -24,8 +24,10 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskManager;
 
 import static org.elasticsearch.action.support.PlainActionFuture.newFuture;
+import static org.mockito.Mockito.mock;
 
 public class ActionTestUtils {
 
@@ -34,7 +36,15 @@ public class ActionTestUtils {
     public static <Request extends ActionRequest, Response extends ActionResponse>
     Response executeBlocking(TransportAction<Request, Response> action, Request request) {
         PlainActionFuture<Response> future = newFuture();
-        action.execute(request, future);
+        Task task = mock(Task.class);
+        action.execute(task, request, future);
+        return future.actionGet();
+    }
+
+    public static <Request extends ActionRequest, Response extends ActionResponse>
+    Response executeBlockingWithTask(TaskManager taskManager, TransportAction<Request, Response> action, Request request) {
+        PlainActionFuture<Response> future = newFuture();
+        taskManager.registerAndExecute("transport", action, request, (t, r) -> future.onResponse(r), (t, e) -> future.onFailure(e));
         return future.actionGet();
     }
 


### PR DESCRIPTION
The TransportAction class has several ways to execute the action, some
of which will create a task. This commit removes those non task aware
variants in favor of handling task creation inside NodeClient for local
actions.