### PR TITLE
re-enable bwc tests and update cat.alias rest tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,8 +176,8 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
-final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/45798" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = true
+final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/10_basic.yml
@@ -2,8 +2,8 @@
 ---
 "Help":
   - skip:
-      version: " - 7.99.99"
-      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+      version: " - 7.3.99"
+      reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
 
   - do:
       cat.aliases:
@@ -20,15 +20,15 @@
         $/
 
 ---
-"Help (pre 8.0)":
+"Help (pre 7.4.0)":
   - skip:
-      version: "8.0.0 - "
+      version: "7.4.0 - "
       features: node_selector
-      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+      reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
 
   - do:
       node_selector:
-        version: " - 7.99.99"
+        version: " - 7.3.99"
       cat.aliases:
         help: true
 
@@ -55,8 +55,8 @@
 ---
 "Simple alias":
   - skip:
-      version: " - 7.99.99"
-      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+      version: " - 7.3.99"
+      reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
 
   - do:
         indices.create:
@@ -82,11 +82,11 @@
                 $/
 
 ---
-"Simple alias (pre 8.0)":
+"Simple alias (pre 7.4.0)":
   - skip:
-      version: "8.0.0 - "
+      version: "7.4.0 - "
       features: node_selector
-      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+      reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
 
   - do:
       indices.create:
@@ -99,7 +99,7 @@
 
   - do:
       node_selector:
-        version: " - 7.99.99"
+        version: " - 7.3.99"
       cat.aliases: {}
 
   - match:
@@ -115,8 +115,8 @@
 ---
 "Complex alias":
   - skip:
-      version: " - 7.99.99"
-      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+      version: " - 7.3.99"
+      reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
 
   - do:
         indices.create:
@@ -153,11 +153,11 @@
                 $/
 
 ---
-"Complex alias (pre 8.0)":
+"Complex alias (pre 7.4.0)":
   - skip:
-      version: "8.0.0 - "
+      version: "7.4.0 - "
       features: node_selector
-      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+      reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
 
   - do:
       indices.create:
@@ -180,7 +180,7 @@
               foo: bar
   - do:
       node_selector:
-        version: " - 7.99.99"
+        version: " - 7.3.99"
       cat.aliases: {}
 
   - match:
@@ -279,8 +279,8 @@
 ---
 "Column headers":
   - skip:
-      version: " - 7.99.99"
-      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+      version: " - 7.3.99"
+      reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
 
   - do:
         indices.create:
@@ -313,11 +313,11 @@
                $/
 
 ---
-"Column headers (pre 8.0)":
+"Column headers (pre 7.4.0)":
   - skip:
-      version: "8.0.0 - "
+      version: "7.4.0 - "
       features: node_selector
-      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+      reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
 
   - do:
       indices.create:
@@ -330,7 +330,7 @@
 
   - do:
       node_selector:
-        version: " - 7.99.99"
+        version: " - 7.3.99"
       cat.aliases:
         v: true
 
@@ -383,8 +383,8 @@
 ---
 "Alias against closed index":
   - skip:
-      version: " - 7.99.99"
-      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+      version: " - 7.3.99"
+      reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
 
   - do:
       indices.create:
@@ -412,11 +412,11 @@
                 $/
 
 ---
-"Alias against closed index (pre 8.0)":
+"Alias against closed index (pre 7.4.0)":
   - skip:
-      version: "8.0.0 - "
+      version: "7.4.0 - "
       features: node_selector
-      reason:  "is_write_index is shown in cat.aliases starting version 8.0"
+      reason:  "is_write_index is shown in cat.aliases starting version 7.4.0"
 
   - do:
       indices.create:
@@ -431,7 +431,7 @@
 
   - do:
       node_selector:
-        version: " - 7.99.99"
+        version: " - 7.3.99"
       cat.aliases: {}
 
   - match:


### PR DESCRIPTION
1) #44772 with master-7.x version bounds was merged into master
2) #45816 disabled bwc tests in master
3) #45798 with 7.4 version bounds was merged in 7.x

4) this PR is to update master's version bounds to reflect the update to 7.x
    and re-enable bwc tests