### PR TITLE
Update zip-targz.asciidoc

### DIFF
--- a/docs/reference/setup/install/zip-targz.asciidoc
+++ b/docs/reference/setup/install/zip-targz.asciidoc
@@ -173,11 +173,6 @@ directory so that you do not delete important data later on.
  d| Not configured
   | path.repo
 
-| script
-  | Location of script files.
-  | $ES_HOME/scripts
-  | path.scripts
-
 |=======================================================================
 
 


### PR DESCRIPTION
Elasticsearch 6.4 doesn't support file script anymore. So there is no path.scripts configuration.

