### PR TITLE
Remove deprecated es.http.cname_in_publish_address setting

### DIFF
--- a/server/src/main/java/org/elasticsearch/http/HttpInfo.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpInfo.java
@@ -19,11 +19,9 @@
 
 package org.elasticsearch.http;
 
-import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
@@ -33,32 +31,18 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-import static org.elasticsearch.common.Booleans.parseBoolean;
-
 public class HttpInfo implements Writeable, ToXContentFragment {
-
-    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(HttpInfo.class));
-
-    /** Whether to add hostname to publish host field when serializing. */
-    private static final boolean CNAME_IN_PUBLISH_HOST =
-        parseBoolean(System.getProperty("es.http.cname_in_publish_address"), true);
 
     private final BoundTransportAddress address;
     private final long maxContentLength;
-    private final boolean cnameInPublishHostProperty;
 
     public HttpInfo(StreamInput in) throws IOException {
-        this(new BoundTransportAddress(in), in.readLong(), CNAME_IN_PUBLISH_HOST);
+        this(new BoundTransportAddress(in), in.readLong());
     }
 
     public HttpInfo(BoundTransportAddress address, long maxContentLength) {
-        this(address, maxContentLength, CNAME_IN_PUBLISH_HOST);
-    }
-
-    HttpInfo(BoundTransportAddress address, long maxContentLength, boolean cnameInPublishHostProperty) {
         this.address = address;
         this.maxContentLength = maxContentLength;
-        this.cnameInPublishHostProperty = cnameInPublishHostProperty;
     }
 
     @Override
@@ -84,12 +68,6 @@ public class HttpInfo implements Writeable, ToXContentFragment {
         String hostString = publishAddress.address().getHostString();
         if (InetAddresses.isInetAddress(hostString) == false) {
             publishAddressString = hostString + '/' + publishAddress.toString();
-            if (cnameInPublishHostProperty) {
-                deprecationLogger.deprecated(
-                        "es.http.cname_in_publish_address system property is deprecated and no longer affects http.publish_address " +
-                                "formatting. Remove this property to get rid of this deprecation warning."
-                );
-            }
         }
         builder.field(Fields.PUBLISH_ADDRESS, publishAddressString);
         builder.humanReadableField(Fields.MAX_CONTENT_LENGTH_IN_BYTES, Fields.MAX_CONTENT_LENGTH, maxContentLength());

--- a/server/src/test/java/org/elasticsearch/http/HttpInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/http/HttpInfoTests.java
@@ -40,25 +40,9 @@ public class HttpInfoTests extends ESTestCase {
                 new BoundTransportAddress(
                     new TransportAddress[]{new TransportAddress(localhost, port)},
                     new TransportAddress(localhost, port)
-                ), 0L, false
+                ), 0L
             ), "localhost/" + NetworkAddress.format(localhost) + ':' + port
         );
-    }
-
-    public void testDeprecatedWarningIfPropertySpecified() throws Exception {
-        InetAddress localhost = InetAddress.getByName("localhost");
-        int port = 9200;
-        assertPublishAddress(
-                new HttpInfo(
-                        new BoundTransportAddress(
-                                new TransportAddress[]{new TransportAddress(localhost, port)},
-                                new TransportAddress(localhost, port)
-                        ), 0L, true
-                ), "localhost/" + NetworkAddress.format(localhost) + ':' + port
-        );
-        assertWarnings(
-                "es.http.cname_in_publish_address system property is deprecated and no longer affects http.publish_address " +
-                "formatting. Remove this property to get rid of this deprecation warning.");
     }
 
     public void testCorrectDisplayPublishedIp() throws Exception {
@@ -69,7 +53,7 @@ public class HttpInfoTests extends ESTestCase {
                 new BoundTransportAddress(
                     new TransportAddress[]{new TransportAddress(localhost, port)},
                     new TransportAddress(localhost, port)
-                ), 0L, false
+                ), 0L
             ), NetworkAddress.format(localhost) + ':' + port
         );
     }
@@ -80,7 +64,7 @@ public class HttpInfoTests extends ESTestCase {
             new TransportAddress(InetAddress.getByName(NetworkAddress.format(InetAddress.getByName("0:0:0:0:0:0:0:1"))), port);
         assertPublishAddress(
             new HttpInfo(
-                new BoundTransportAddress(new TransportAddress[]{localhost}, localhost), 0L, false
+                new BoundTransportAddress(new TransportAddress[]{localhost}, localhost), 0L
             ), localhost.toString()
         );
     }


### PR DESCRIPTION
Follow-up of https://github.com/elastic/elasticsearch/pull/45616.

Starting with 8.0.0 `es.http.cname_in_publish_address` setting support is completely removed.