### PR TITLE
[7.x] Add test that proves _timing_stats document is deleted when the job is deleted (#45840)

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlJobIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlJobIT.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.core.ml.integration.MlRestTestStateCleaner;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndexFields;
+import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.TimingStats;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.junit.After;
 
@@ -35,6 +36,7 @@ import java.util.regex.Pattern;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.not;
 
 public class MlJobIT extends ESRestTestCase {
@@ -411,6 +413,55 @@ public class MlJobIT extends ESRestTestCase {
         // check that the job itself is gone
         expectThrows(ResponseException.class, () ->
                 client().performRequest(new Request("GET", MachineLearning.BASE_PATH + "anomaly_detectors/" + jobId + "/_stats")));
+    }
+
+    public void testDeleteJob_TimingStatsDocumentIsDeleted() throws Exception {
+        String jobId = "delete-job-with-timing-stats-document-job";
+        String indexName = AnomalyDetectorsIndexFields.RESULTS_INDEX_PREFIX + AnomalyDetectorsIndexFields.RESULTS_INDEX_DEFAULT;
+        createFarequoteJob(jobId);
+
+        assertThat(
+            EntityUtils.toString(client().performRequest(new Request("GET", indexName + "/_count")).getEntity()),
+            containsString("\"count\":0"));  // documents related to the job do not exist yet
+
+        Response openResponse =
+            client().performRequest(new Request("POST", MachineLearning.BASE_PATH + "anomaly_detectors/" + jobId + "/_open"));
+        assertThat(entityAsMap(openResponse), hasEntry("opened", true));
+
+        Request postDataRequest = new Request("POST", MachineLearning.BASE_PATH + "anomaly_detectors/" + jobId + "/_data");
+        postDataRequest.setJsonEntity("{ \"airline\":\"LOT\", \"response_time\":100, \"time\":\"2019-07-01 00:00:00Z\" }");
+        client().performRequest(postDataRequest);
+        postDataRequest.setJsonEntity("{ \"airline\":\"LOT\", \"response_time\":100, \"time\":\"2019-07-01 02:00:00Z\" }");
+        client().performRequest(postDataRequest);
+
+        Response flushResponse =
+            client().performRequest(new Request("POST", MachineLearning.BASE_PATH + "anomaly_detectors/" + jobId + "/_flush"));
+        assertThat(entityAsMap(flushResponse), hasEntry("flushed", true));
+
+        Response closeResponse =
+            client().performRequest(new Request("POST", MachineLearning.BASE_PATH + "anomaly_detectors/" + jobId + "/_close"));
+        assertThat(entityAsMap(closeResponse), hasEntry("closed", true));
+
+        String timingStatsDoc =
+            EntityUtils.toString(
+                client().performRequest(new Request("GET", indexName + "/_doc/" + TimingStats.documentId(jobId))).getEntity());
+        assertThat(timingStatsDoc, containsString("\"bucket_count\":2"));  // TimingStats doc exists, 2 buckets have been processed
+
+        client().performRequest(new Request("DELETE", MachineLearning.BASE_PATH + "anomaly_detectors/" + jobId));
+
+        waitUntilIndexIsEmpty(indexName);  // when job is being deleted, it also deletes all related documents from the shared index
+
+        // check that the TimingStats documents got deleted
+        ResponseException exception = expectThrows(
+            ResponseException.class,
+            () -> client().performRequest(new Request("GET", indexName + "/_doc/" + TimingStats.documentId(jobId))));
+        assertThat(exception.getResponse().getStatusLine().getStatusCode(), equalTo(404));
+
+        // check that the job itself is gone
+        exception = expectThrows(
+            ResponseException.class,
+            () -> client().performRequest(new Request("GET", MachineLearning.BASE_PATH + "anomaly_detectors/" + jobId + "/_stats")));
+        assertThat(exception.getResponse().getStatusLine().getStatusCode(), equalTo(404));
     }
 
     public void testDeleteJobAsync() throws Exception {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add test that proves _timing_stats document is deleted when the job is deleted  (#45840)