### PR TITLE
[DOCS] Remove coming tag for 7.3.1 rns

### DIFF
--- a/docs/reference/release-notes/7.3.asciidoc
+++ b/docs/reference/release-notes/7.3.asciidoc
@@ -3,8 +3,6 @@
 
 Also see <<breaking-changes-7.3,Breaking changes in 7.3>>.
 
-coming[7.3.1]
-
 [[release-notes-7.3.0]]
 == {es} version 7.3.0
 


### PR DESCRIPTION
Removes the `coming[7.3.1]` tags for the 7.3.1 release.