### PR TITLE
Pass COMPUTERNAME env var to elasticsearch.bat (#45763)

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -105,6 +105,8 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         "is a pre-release version of Elasticsearch",
         "max virtual memory areas vm.max_map_count"
     );
+    private static final String HOSTNAME_OVERRIDE = "LinuxDarwinHostname";
+    private static final String COMPUTERNAME_OVERRIDE = "WindowsComputername";
 
     private final String path;
     private final String name;
@@ -603,6 +605,10 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         defaultEnv.put("ES_TMPDIR", tmpDir.toString());
         // Windows requires this as it defaults to `c:\windows` despite ES_TMPDIR
         defaultEnv.put("TMP", tmpDir.toString());
+
+        // Override the system hostname variables for testing
+        defaultEnv.put("HOSTNAME", HOSTNAME_OVERRIDE);
+        defaultEnv.put("COMPUTERNAME", COMPUTERNAME_OVERRIDE);
 
         Set<String> commonKeys = new HashSet<>(environment.keySet());
         commonKeys.retainAll(defaultEnv.keySet());

--- a/qa/unconfigured-node-name/build.gradle
+++ b/qa/unconfigured-node-name/build.gradle
@@ -30,6 +30,4 @@ testClusters.integTest {
 integTest.runner {
   nonInputProperties.systemProperty 'tests.logfile',
     "${ -> testClusters.integTest.singleNode().getServerLog() }"
-  // https://github.com/elastic/elasticsearch/issues/44656
-  onlyIf { OS.WINDOWS.equals(OS.current()) == false }
 }

--- a/qa/unconfigured-node-name/src/test/java/org/elasticsearch/unconfigured_node_name/JsonLogsFormatAndParseIT.java
+++ b/qa/unconfigured-node-name/src/test/java/org/elasticsearch/unconfigured_node_name/JsonLogsFormatAndParseIT.java
@@ -30,12 +30,22 @@ import java.nio.file.Path;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.equalTo;
 
 public class JsonLogsFormatAndParseIT extends JsonLogsIntegTestCase {
+    private static final String OS_NAME = System.getProperty("os.name");
+    private static final boolean WINDOWS = OS_NAME.startsWith("Windows");
+
+    // These match the values defined in org.elasticsearch.gradle.testclusters.ElasticsearchNode
+    private static final String COMPUTERNAME = "WindowsComputername";
+    private static final String HOSTNAME = "LinuxDarwinHostname";
+
     @Override
     protected Matcher<String> nodeNameMatcher() {
-        return not("");
+        if (WINDOWS) {
+            return equalTo(COMPUTERNAME);
+        }
+        return equalTo(HOSTNAME);
     }
 
     @Override


### PR DESCRIPTION
* Pass COMPUTERNAME env var to elasticsearch.bat

When we run bin/elasticsearch with bash, we get a $HOSTNAME builtin that
contains the hostname of the machine the script is running on. When
there's no provided nodename, Elasticsearch uses the HOSTNAME to create
a nodename. On Windows, Powershell provides a $COMPUTERNAME variable for
the same purpose. CMD.EXE provides the same thing, except it's called
%COMPUTERNAME%. bin/elasticsearch.bat sets $HOSTNAME to the value of
$COMPUTERNAME. However, when testclusters invokes bin/elasticsearch.bat,
the COMPUTERNAME variable doesn't get passed in, leaving HOSTNAME null
and breaking an integration test on Windows.

This commit sets COMPUTERNAME in the environment so that our tests get
the value that Elasticsearch would have when bin/elasticsearch.bat is
invoked from the shell.