### PR TITLE
Pass COMPUTERNAME env var to elasticsearch.bat (#45763)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
@@ -23,6 +23,7 @@ import com.sun.jna.Native
 import com.sun.jna.WString
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.elasticsearch.gradle.Version
+import org.elasticsearch.gradle.testclusters.ElasticsearchNode
 import org.gradle.api.Project
 
 import java.nio.file.Files
@@ -196,6 +197,8 @@ class NodeInfo {
         else {
             env.put('ES_PATH_CONF', pathConf)
         }
+        env.put('HOSTNAME', ElasticsearchNode.HOSTNAME_OVERRIDE)
+        env.put('COMPUTERNAME', ElasticsearchNode.COMPUTERNAME_OVERRIDE)
         if (!System.properties.containsKey("tests.es.path.data")) {
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 /*

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -69,6 +69,8 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         "path.repo",
         "discovery.seed_providers"
     );
+    private static final String HOSTNAME_OVERRIDE = "LinuxDarwinHostname";
+    private static final String COMPUTERNAME_OVERRIDE = "WindowsComputername";
 
     private final String path;
     private final String name;
@@ -460,6 +462,10 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         defaultEnv.put("ES_TMPDIR", tmpDir.toString());
         // Windows requires this as it defaults to `c:\windows` despite ES_TMPDIR
         defaultEnv.put("TMP", tmpDir.toString());
+
+        // Override the system hostname variables for testing
+        defaultEnv.put("HOSTNAME", HOSTNAME_OVERRIDE);
+        defaultEnv.put("COMPUTERNAME", COMPUTERNAME_OVERRIDE);
 
         Set<String> commonKeys = new HashSet<>(environment.keySet());
         commonKeys.retainAll(defaultEnv.keySet());

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -69,8 +69,8 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         "path.repo",
         "discovery.seed_providers"
     );
-    private static final String HOSTNAME_OVERRIDE = "LinuxDarwinHostname";
-    private static final String COMPUTERNAME_OVERRIDE = "WindowsComputername";
+    public static final String HOSTNAME_OVERRIDE = "LinuxDarwinHostname";
+    public static final String COMPUTERNAME_OVERRIDE = "WindowsComputername";
 
     private final String path;
     private final String name;

--- a/qa/unconfigured-node-name/build.gradle
+++ b/qa/unconfigured-node-name/build.gradle
@@ -1,5 +1,3 @@
-import org.elasticsearch.gradle.OS
-
 /*
  * Licensed to Elasticsearch under one or more contributor
  * license agreements. See the NOTICE file distributed with
@@ -28,13 +26,6 @@ integTestCluster {
   // "out-of-the-box" configuration can automatically bootstrap a cluster
   autoSetInitialMasterNodes = false
   autoSetHostsProvider = false
-}
-
-// https://github.com/elastic/elasticsearch/issues/44656
-if ( OS.WINDOWS.equals(OS.current()) ) {
-    integTestRunner.enabled = false
-    integTest.enabled = false
-    testingConventions.enabled = false
 }
 
 integTestRunner {

--- a/qa/unconfigured-node-name/src/test/java/org/elasticsearch/unconfigured_node_name/JsonLogsFormatAndParseIT.java
+++ b/qa/unconfigured-node-name/src/test/java/org/elasticsearch/unconfigured_node_name/JsonLogsFormatAndParseIT.java
@@ -30,12 +30,22 @@ import java.nio.file.Path;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.equalTo;
 
 public class JsonLogsFormatAndParseIT extends JsonLogsIntegTestCase {
+    private static final String OS_NAME = System.getProperty("os.name");
+    private static final boolean WINDOWS = OS_NAME.startsWith("Windows");
+
+    // These match the values defined in org.elasticsearch.gradle.testclusters.ElasticsearchNode
+    private static final String COMPUTERNAME = "WindowsComputername";
+    private static final String HOSTNAME = "LinuxDarwinHostname";
+
     @Override
     protected Matcher<String> nodeNameMatcher() {
-        return not("");
+        if (WINDOWS) {
+            return equalTo(COMPUTERNAME);
+        }
+        return equalTo(HOSTNAME);
     }
 
     @Override


### PR DESCRIPTION
* Pass COMPUTERNAME env var to elasticsearch.bat

When we run bin/elasticsearch with bash, we get a $HOSTNAME builtin that
contains the hostname of the machine the script is running on. When
there's no provided nodename, Elasticsearch uses the HOSTNAME to create
a nodename. On Windows, Powershell provides a $COMPUTERNAME variable for
the same purpose. CMD.EXE provides the same thing, except it's called
%COMPUTERNAME%. bin/elasticsearch.bat sets $HOSTNAME to the value of
$COMPUTERNAME. However, when testclusters invokes bin/elasticsearch.bat,
the COMPUTERNAME variable doesn't get passed in, leaving HOSTNAME null
and breaking an integration test on Windows.

This commit sets COMPUTERNAME in the environment so that our tests get
the value that Elasticsearch would have when bin/elasticsearch.bat is
invoked from the shell.

* Add null check to protect in non-Windows case

What good is it a developer to gain the whole Windows if they forfeit
their Unix? The value that fixes things on Windows is null on
Linux/Darwin, so let's null-check it.

* Override system hostnames for testclusters

Rather than relying on variable system behavior, let's just override
HOSTNAME and COMPUTERNAME and test for correct values in the integration
test that was originally failing.

* Rename constants for clarity

Since we are setting HOSTNAME and COMPUTERNAME regardless of whether the
tests are running on Windows or Linux, we shouldn't imply that constants
are only used in one case or the other.