### PR TITLE
[7.x] Put error message from inside the process into the exception that is thrown when the process doesn't start correctly. (#45846)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/MemoryUsageEstimationProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/MemoryUsageEstimationProcessManager.java
@@ -83,7 +83,8 @@ public class MemoryUsageEstimationProcessManager {
                 onProcessCrash(jobId, processHolder));
         processHolder.process = process;
         if (process.isProcessAlive() == false) {
-            String errorMsg = new ParameterizedMessage("[{}] Error while starting process", jobId).getFormattedMessage();
+            String errorMsg =
+                new ParameterizedMessage("[{}] Error while starting process: {}", jobId, process.readError()).getFormattedMessage();
             throw ExceptionsHelper.serverError(errorMsg);
         }
         try {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/MemoryUsageEstimationProcessManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/MemoryUsageEstimationProcessManagerTests.java
@@ -95,6 +95,7 @@ public class MemoryUsageEstimationProcessManagerTests extends ESTestCase {
 
     public void testRunJob_ProcessNotAlive() {
         when(process.isProcessAlive()).thenReturn(false);
+        when(process.readError()).thenReturn("Error from inside the process");
 
         processManager.runJobAsync(TASK_ID, dataFrameAnalyticsConfig, dataExtractorFactory, listener);
 
@@ -103,8 +104,10 @@ public class MemoryUsageEstimationProcessManagerTests extends ESTestCase {
         assertThat(exception.status(), equalTo(RestStatus.INTERNAL_SERVER_ERROR));
         assertThat(exception.getMessage(), containsString(TASK_ID));
         assertThat(exception.getMessage(), containsString("Error while starting process"));
+        assertThat(exception.getMessage(), containsString("Error from inside the process"));
 
         verify(process).isProcessAlive();
+        verify(process).readError();
         verifyNoMoreInteractions(process, listener);
     }
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Put error message from inside the process into the exception that is thrown when the process doesn't start correctly.  (#45846)