### PR TITLE
Assert no unreleased store reference nor searcher

### DIFF
--- a/server/src/main/java/org/elasticsearch/env/ShardLock.java
+++ b/server/src/main/java/org/elasticsearch/env/ShardLock.java
@@ -22,6 +22,7 @@ package org.elasticsearch.env;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.io.Closeable;
+import java.util.Collection;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -50,7 +51,7 @@ public abstract class ShardLock implements Closeable {
     @Override
     public final void close() {
         if (this.closed.compareAndSet(false, true)) {
-           closeInternal();
+            closeInternal();
         }
     }
 
@@ -63,4 +64,9 @@ public abstract class ShardLock implements Closeable {
                 '}';
     }
 
+    public abstract boolean addNewAcquirer(Object key, String source);
+
+    public abstract boolean removeAcquirer(Object key);
+
+    public abstract Collection<Exception> acquirers();
 }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -399,13 +399,13 @@ public class RecoverySourceHandler {
      * We must never release the store using an interruptible thread as we can risk invalidating the node lock.
      */
     private Releasable acquireStore(Store store) {
-        store.incRef();
+        final Releasable releaseStore = store.incRef("peer_recovery");
         return Releasables.releaseOnce(() -> {
             final PlainActionFuture<Void> future = new PlainActionFuture<>();
             threadPool.generic().execute(new ActionRunnable<>(future) {
                 @Override
                 protected void doRun() {
-                    store.decRef();
+                    releaseStore.close();
                     listener.onResponse(null);
                 }
             });

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/FileRestoreContext.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/FileRestoreContext.java
@@ -26,6 +26,7 @@ import org.apache.lucene.index.IndexFormatTooNewException;
 import org.apache.lucene.index.IndexFormatTooOldException;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexOutput;
+import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.util.iterable.Iterables;
 import org.elasticsearch.index.shard.ShardId;
@@ -86,8 +87,7 @@ public abstract class FileRestoreContext {
      * Performs restore operation
      */
     public void restore(SnapshotFiles snapshotFiles, Store store) throws IOException {
-        store.incRef();
-        try {
+        try (Releasable ignored = store.incRef("restore_snapshot")) {
             logger.debug("[{}] [{}] restoring to [{}] ...", snapshotId, repositoryName, shardId);
 
             if (snapshotFiles.indexFiles().size() == 1
@@ -205,8 +205,6 @@ public abstract class FileRestoreContext {
             } catch (IOException e) {
                 logger.warn("[{}] [{}] failed to list directory - some of files might not be deleted", shardId, snapshotId);
             }
-        } finally {
-            store.decRef();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -2211,10 +2211,10 @@ public class IndexShardTests extends IndexShardTestCase {
         }
 
         Store store = shard.store();
-        store.incRef();
+        final Releasable storeRef = store.incRef("test");
         closeShards(shard);
         cleanLuceneIndex(store.directory());
-        store.decRef();
+        storeRef.close();
         IndexShard newShard = reinitShard(shard);
         DiscoveryNode localNode = new DiscoveryNode("foo", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT);
         ShardRouting routing = newShard.routingEntry();

--- a/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
@@ -70,7 +70,6 @@ import org.elasticsearch.indices.store.TransportNodesListShardStoreMetaData;
 import org.elasticsearch.test.DummyShardLock;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
-import org.hamcrest.Matchers;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -107,47 +106,47 @@ public class StoreTests extends ESTestCase {
     private static final Version MIN_SUPPORTED_LUCENE_VERSION = org.elasticsearch.Version.CURRENT
         .minimumIndexCompatibilityVersion().luceneVersion;
 
-    public void testRefCount() {
-        final ShardId shardId = new ShardId("index", "_na_", 1);
-        IndexSettings indexSettings = INDEX_SETTINGS;
-        Store store = new Store(shardId, indexSettings, StoreTests.newDirectory(random()), new DummyShardLock(shardId));
-        int incs = randomIntBetween(1, 100);
-        for (int i = 0; i < incs; i++) {
-            if (randomBoolean()) {
-                store.incRef();
-            } else {
-                assertTrue(store.tryIncRef());
-            }
-            store.ensureOpen();
-        }
-
-        for (int i = 0; i < incs; i++) {
-            store.decRef();
-            store.ensureOpen();
-        }
-
-        store.incRef();
-        store.close();
-        for (int i = 0; i < incs; i++) {
-            if (randomBoolean()) {
-                store.incRef();
-            } else {
-                assertTrue(store.tryIncRef());
-            }
-            store.ensureOpen();
-        }
-
-        for (int i = 0; i < incs; i++) {
-            store.decRef();
-            store.ensureOpen();
-        }
-
-        store.decRef();
-        assertThat(store.refCount(), Matchers.equalTo(0));
-        assertFalse(store.tryIncRef());
-        expectThrows(IllegalStateException.class, store::incRef);
-        expectThrows(IllegalStateException.class, store::ensureOpen);
-    }
+//    public void testRefCount() {
+//        final ShardId shardId = new ShardId("index", "_na_", 1);
+//        IndexSettings indexSettings = INDEX_SETTINGS;
+//        Store store = new Store(shardId, indexSettings, StoreTests.newDirectory(random()), new DummyShardLock(shardId));
+//        int incs = randomIntBetween(1, 100);
+//        for (int i = 0; i < incs; i++) {
+//            if (randomBoolean()) {
+//                store.incRef();
+//            } else {
+//                assertTrue(store.tryIncRef());
+//            }
+//            store.ensureOpen();
+//        }
+//
+//        for (int i = 0; i < incs; i++) {
+//            store.decRef();
+//            store.ensureOpen();
+//        }
+//
+//        store.incRef();
+//        store.close();
+//        for (int i = 0; i < incs; i++) {
+//            if (randomBoolean()) {
+//                store.incRef();
+//            } else {
+//                assertTrue(store.tryIncRef());
+//            }
+//            store.ensureOpen();
+//        }
+//
+//        for (int i = 0; i < incs; i++) {
+//            store.decRef();
+//            store.ensureOpen();
+//        }
+//
+//        store.decRef();
+//        assertThat(store.refCount(), Matchers.equalTo(0));
+//        assertFalse(store.tryIncRef());
+//        expectThrows(IllegalStateException.class, store::incRef);
+//        expectThrows(IllegalStateException.class, store::ensureOpen);
+//    }
 
     public void testVerifyingIndexOutput() throws IOException {
         Directory dir = newDirectory();

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -112,6 +112,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -1236,5 +1237,14 @@ public abstract class EngineTestCase extends ESTestCase {
      */
     public static long getNumVersionLookups(Engine engine) {
         return ((InternalEngine) engine).getNumVersionLookups();
+    }
+
+    public static void assertNoPendingSearchers(Engine engine) {
+        final Collection<Exception> pendingSearchers = engine.assertPendingSearchers.values();
+        if (pendingSearchers.isEmpty() == false) {
+            AssertionError e = new AssertionError("not all searchers have been released");
+            pendingSearchers.forEach(e::addSuppressed);
+            throw e;
+        }
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/DummyShardLock.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/DummyShardLock.java
@@ -22,6 +22,9 @@ package org.elasticsearch.test;
 import org.elasticsearch.env.ShardLock;
 import org.elasticsearch.index.shard.ShardId;
 
+import java.util.Collection;
+import java.util.Collections;
+
 /*
  * A ShardLock that does nothing... for tests only
  */
@@ -33,5 +36,20 @@ public class DummyShardLock extends ShardLock {
 
     @Override
     protected void closeInternal() {
+    }
+
+    @Override
+    public boolean addNewAcquirer(Object key, String source) {
+        return true;
+    }
+
+    @Override
+    public boolean removeAcquirer(Object key) {
+        return true;
+    }
+
+    @Override
+    public Collection<Exception> acquirers() {
+        return Collections.emptyList();
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1191,7 +1191,9 @@ public final class InternalTestCluster extends TestCluster {
                 for (IndexService indexService : indexServices) {
                     for (IndexShard indexShard : indexService) {
                         try {
-                            if (IndexShardTestCase.getEngine(indexShard) instanceof InternalEngine) {
+                            final Engine engine = IndexShardTestCase.getEngine(indexShard);
+                            EngineTestCase.assertNoPendingSearchers(engine);
+                            if (engine instanceof InternalEngine) {
                                 IndexShardTestCase.getTranslog(indexShard).getDeletionPolicy().assertNoOpenTranslogRefs();
                             }
                         } catch (AlreadyClosedException ok) {

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.metrics.CounterMetric;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -361,13 +362,10 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
     }
 
     private void createEmptyStore(Store store) {
-        store.incRef();
-        try {
+        try (Releasable ignored = store.incRef("ccr_create_empty_store")) {
             store.createEmpty(store.indexSettings().getIndexVersionCreated().luceneVersion);
         } catch (final EngineException | IOException e) {
             throw new IndexShardRecoveryException(store.shardId(), "failed to create empty store", e);
-        } finally {
-            store.decRef();
         }
     }
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRestoreSourceService.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRestoreSourceService.java
@@ -199,11 +199,8 @@ public class CcrRestoreSourceService extends AbstractLifecycleComponent implemen
         }
 
         private Store.MetadataSnapshot getMetaData() throws IOException {
-            indexShard.store().incRef();
-            try {
+            try (Releasable ignored = indexShard.store().incRef("ccr_meta_data_source")) {
                 return indexShard.store().getMetadata(commitRef.getIndexCommit());
-            } finally {
-                indexShard.store().decRef();
             }
         }
 


### PR DESCRIPTION
I do not intend to merge this PR. I opened it to try to reproduce the shard lock issue with our CI. I suspect that async peer recoveries do not release searchers properly.