### PR TITLE
[ML][Transforms] fix doSaveState check

### DIFF
--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
@@ -922,6 +922,9 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
                                             next.run();
                                         }
                                     ));
+                                } else {
+                                    logger.trace("[{}] no need to cleanup on stats document.", transformId);
+                                    next.run();
                                 }
                             },
                             statsExc -> {

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
@@ -923,7 +923,6 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
                                         }
                                     ));
                                 } else {
-                                    logger.trace("[{}] no need to cleanup on stats document.", transformId);
                                     next.run();
                                 }
                             },


### PR DESCRIPTION
With the recent PR: #45375  a bug was introduced where the transform would lock up and not persist state. Additionally, the work flow of the indexer would stop. 

This fixes that bug, and introduces a check in our integration tests that reproduced the buggy behavior, and confirms that it is fixed. 