### PR TITLE
[DOCS] Add anchor to  version types list.

### DIFF
--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -429,6 +429,7 @@ whatever reason.
 In addition to the `external` version type, Elasticsearch
 also supports other types for specific use cases:
 
+[[_version_types]]
 `internal`:: Only index the document if the given version is identical to the version
 of the stored document.
 


### PR DESCRIPTION
The Logstash versioned plugins doc links to the Version types section using an auto-generated anchor. That heading now has a real anchor defined, so explicitly adding one that maps to the autogenerated one so cross doc links continue to work.