### PR TITLE
[Backport 7.x] Set security index refresh interval to 1s

### DIFF
--- a/x-pack/plugin/core/src/main/resources/security-index-template-7.json
+++ b/x-pack/plugin/core/src/main/resources/security-index-template-7.json
@@ -6,6 +6,7 @@
     "number_of_replicas" : 0,
     "auto_expand_replicas" : "0-1",
     "index.priority": 1000,
+    "index.refresh_interval": "1s",
     "index.format": 6,
     "analysis" : {
       "filter" : {

--- a/x-pack/plugin/core/src/main/resources/security-tokens-index-template-7.json
+++ b/x-pack/plugin/core/src/main/resources/security-tokens-index-template-7.json
@@ -6,6 +6,7 @@
     "number_of_replicas" : 0,
     "auto_expand_replicas" : "0-1",
     "index.priority": 1000,
+    "index.refresh_interval": "1s",
     "index.format": 7
   },
   "mappings" : {


### PR DESCRIPTION
The security indices were being created without specifying the
refresh interval, which means it would inherit a value from any
templates that exists.
However, certain security functionality depends on being able to
wait_for refresh, and causes errors (e.g. in Kibana) if that time
exceeds 30s.

This commit changes the security indices configuration to always be
created with a 1s refresh interval. This prevents any templates from
inadvertantly interfering with the proper functioning of security.
It is possible for an administrator to explicitly change the refresh
interval after the indices have been created.

Backport of: #45434
