### PR TITLE
Fix RemoteClusterConnection close race

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
@@ -368,8 +368,10 @@ final class RemoteClusterConnection implements TransportConnectionListener, Clos
             boolean runConnect = false;
             final ActionListener<Void> listener =
                 ContextPreservingActionListener.wrapPreservingContext(connectListener, threadPool.getThreadContext());
+            boolean closed;
             synchronized (mutex) {
-                if (closed.get()) {
+                closed = this.closed.get();
+                if (closed) {
                     assert listeners.isEmpty();
                 } else {
                     if (listeners.size() >= MAX_LISTENERS) {
@@ -382,7 +384,7 @@ final class RemoteClusterConnection implements TransportConnectionListener, Clos
                     runConnect = listeners.size() == 1;
                 }
             }
-            if (closed.get()) {
+            if (closed) {
                 connectListener.onFailure(new AlreadyClosedException("connect handler is already closed"));
                 return;
             }

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
@@ -637,7 +637,6 @@ public class RemoteClusterConnectionTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/45845")
     public void testCloseWhileConcurrentlyConnecting() throws IOException, InterruptedException, BrokenBarrierException {
         List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
         try (MockTransportService seedTransport = startTransport("seed_node", knownNodes, Version.CURRENT);


### PR DESCRIPTION
Closing a `RemoteClusterConnection` concurrently with trying to connect
could result in double invoking the listener.

This fixes
RemoteClusterConnectionTest#testCloseWhileConcurrentlyConnecting

Closes #45845

Marking as non-issue since this should not be in any official releases.