### PR TITLE
Change `{var}` convention to `<var>`

### DIFF
--- a/docs/reference/cat/alias.asciidoc
+++ b/docs/reference/cat/alias.asciidoc
@@ -11,7 +11,7 @@ filter and routing information.
 [[cat-alias-api-request]]
 ==== {api-request-title}
 
-`GET /_cat/aliases/{name}`
+`GET /_cat/aliases/<name>`
 
 [[cat-alias-api-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/cat/allocation.asciidoc
+++ b/docs/reference/cat/allocation.asciidoc
@@ -12,7 +12,7 @@ and their disk space.
 [[cat-allocation-api-request]]
 ==== {api-request-title}
 
-`GET /_cat/allocation/{node_id}`
+`GET /_cat/allocation/<node_id>`
 
 [[cat-allocation-api-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/cat/count.asciidoc
+++ b/docs/reference/cat/count.asciidoc
@@ -14,7 +14,7 @@ which have not yet been removed by the merge process.
 [[cat-count-api-request]]
 ==== {api-request-title}
 
-`GET /_cat/count/{index}`
+`GET /_cat/count/<index>`
 
 
 [[cat-count-api-path-params]]

--- a/docs/reference/cat/fielddata.asciidoc
+++ b/docs/reference/cat/fielddata.asciidoc
@@ -11,13 +11,13 @@ in the cluster.
 [[cat-fielddata-api-request]]
 ==== {api-request-title}
 
-`GET /_cat/fielddata/{fields}`
+`GET /_cat/fielddata/<field>`
 
 
 [[cat-fielddata-api-path-params]]
 ==== {api-path-parms-title}
 
-`{fields}`::
+`<field>`::
 (Optional, string) Comma-separated list of fields used to limit returned
 information.
 

--- a/docs/reference/cat/indices.asciidoc
+++ b/docs/reference/cat/indices.asciidoc
@@ -10,7 +10,7 @@ Returns high-level information about indices in a cluster.
 [[cat-indices-api-request]]
 ==== {api-request-title}
 
-`GET /_cat/indices/{index}`
+`GET /_cat/indices/<index>`
 
 
 [[cat-indices-api-desc]]

--- a/docs/reference/cat/recovery.asciidoc
+++ b/docs/reference/cat/recovery.asciidoc
@@ -11,7 +11,7 @@ to the <<indices-recovery, indices recovery>> API.
 [[cat-recovery-api-request]]
 ==== {api-request-title}
 
-`GET /_cat/recovery/{index}`
+`GET /_cat/recovery/<index>`
 
 
 [[cat-recovery-api-desc]]

--- a/docs/reference/cat/segments.asciidoc
+++ b/docs/reference/cat/segments.asciidoc
@@ -11,7 +11,7 @@ API.
 [[cat-segments-api-request]]
 ==== {api-request-title}
 
-`GET /_cat/segments/{index}`
+`GET /_cat/segments/<index>`
 
 
 [[cat-segments-path-params]]

--- a/docs/reference/cat/shards.asciidoc
+++ b/docs/reference/cat/shards.asciidoc
@@ -12,7 +12,7 @@ docs, the bytes it takes on disk, and the node where it's located.
 [[cat-shards-api-request]]
 ==== {api-request-title}
 
-`GET /_cat/shards/{index}`
+`GET /_cat/shards/<index>`
 
 
 [[cat-shards-path-params]]

--- a/docs/reference/cat/snapshots.asciidoc
+++ b/docs/reference/cat/snapshots.asciidoc
@@ -11,13 +11,13 @@ more repositories. A snapshot is a backup of an index or running {es} cluster.
 [[cat-snapshots-api-request]]
 ==== {api-request-title}
 
-`GET /_cat/snapshots/{repository}`
+`GET /_cat/snapshots/<repository>`
 
 
 [[cat-snapshots-path-params]]
 ==== {api-path-parms-title}
 
-`{repository}`::
+`<repository>`::
 +
 --
 (Optional, string) Comma-separated list of snapshot repositories used to limit

--- a/docs/reference/cat/templates.asciidoc
+++ b/docs/reference/cat/templates.asciidoc
@@ -12,13 +12,13 @@ and <<mapping,field mappings>> to new indices at creation.
 [[cat-templates-api-request]]
 ==== {api-request-title}
 
-`GET /_cat/templates/{template_name}`
+`GET /_cat/templates/<template_name>`
 
 
 [[cat-templates-path-params]]
 ==== {api-path-parms-title}
 
-`{template_name}`::
+`<template_name>`::
 (Optional, string) Comma-separated list of index template names used to limit
 the request. Accepts wildcard expressions.
 

--- a/docs/reference/cat/thread_pool.asciidoc
+++ b/docs/reference/cat/thread_pool.asciidoc
@@ -12,12 +12,12 @@ pools.
 [[cat-thread-pool-api-request]]
 ==== {api-request-title}
 
-`GET /_cat/thread_pool/{thread_pool}`
+`GET /_cat/thread_pool/<thread_pool>`
 
 [[cat-thread-pool-path-params]]
 ==== {api-path-parms-title}
 
-`{thread_pool}`::
+`<thread_pool>`::
 (Optional, string) Comma-separated list of thread pool names used to limit the
 request. Accepts wildcard expressions.
 

--- a/docs/reference/cluster/health.asciidoc
+++ b/docs/reference/cluster/health.asciidoc
@@ -6,7 +6,7 @@ Returns the health status of a cluster.
 [[cluster-health-api-request]]
 ==== {api-request-title}
 
-`GET _cluster/health/{index}`
+`GET _cluster/health/<index>`
 
 [[cluster-health-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/cluster/nodes-hot-threads.asciidoc
+++ b/docs/reference/cluster/nodes-hot-threads.asciidoc
@@ -9,7 +9,7 @@ Returns the hot threads on each selected node in the cluster.
 
 `GET /_nodes/hot_threads` +
 
-`GET /_nodes/{node_id}/hot_threads`
+`GET /_nodes/<node_id>/hot_threads`
 
 
 [[cluster-nodes-hot-threads-api-desc]]

--- a/docs/reference/cluster/nodes-info.asciidoc
+++ b/docs/reference/cluster/nodes-info.asciidoc
@@ -9,11 +9,11 @@ Returns cluster nodes information.
 
 `GET /_nodes` +
 
-`GET /_nodes/{node_id}` +
+`GET /_nodes/<node_id>` +
 
-`GET /_nodes/{metric}` +
+`GET /_nodes/<metric>` +
 
-`GET /_nodes/{node_id}/{metric}`
+`GET /_nodes/<node_id>/<metric>`
 
 
 [[cluster-nodes-info-api-desc]]
@@ -29,7 +29,7 @@ By default, it returns all attributes and core settings for a node.
 [[cluster-nodes-info-api-path-params]]
 ==== {api-path-parms-title}
 
-`{metric}`::
+`<metric>`::
 		(Optional, string) Limits the information returned to the specific metrics. 
 		A comma-separated list of the following options:
 +

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -9,15 +9,15 @@ Returns cluster nodes statistics.
 
 `GET /_nodes/stats` +
 
-`GET /_nodes/{node_id}/stats` +
+`GET /_nodes/<node_id>/stats` +
 
-`GET/_nodes/stats/{metric}` +
+`GET/_nodes/stats/<metric>` +
 
-`GET/_nodes/{node_id}/stats/{metric}` +
+`GET/_nodes/<node_id>/stats/<metric>` +
 
-`GET /_nodes/stats/{metric}/{index_metric}` +
+`GET /_nodes/stats/<metric>/<index_metric>` +
 
-`GET /_nodes/{node_id}/stats/{metric}/{index_metric}`
+`GET /_nodes/<node_id>/stats/<metric>/<index_metric>`
 
 
 [[cluster-nodes-stats-api-desc]]
@@ -35,7 +35,7 @@ using metrics.
 ==== {api-path-parms-title}
 
 
-`{metric}`::
+`<metric>`::
     (Optional, string) Limits the information returned to the specific metrics. 
     A comma-separated list of the following options: 
 +
@@ -83,7 +83,7 @@ using metrics.
       communication.
 --
 
-`{index_metric}`::
+`<index_metric>`::
     (Optional, string) Limit the information returned for `indices` metric to 
     the specific index metrics. It can be used only if `indices` (or `all`) 
     metric is specified. Supported metrics are:

--- a/docs/reference/cluster/nodes-usage.asciidoc
+++ b/docs/reference/cluster/nodes-usage.asciidoc
@@ -9,11 +9,11 @@ Returns information on the usage of features.
 
 `GET /_nodes/usage` +
 
-`GET /_nodes/{node_id}/usage` +
+`GET /_nodes/<node_id</usage` +
 
-`GET /_nodes/usage/{metric}` +
+`GET /_nodes/usage/<metric>` +
 
-`GET /_nodes/{node_id}/usage/{metric}`
+`GET /_nodes/<node_id>/usage/<metric>`
 
 
 [[cluster-nodes-usage-api-desc]]
@@ -27,7 +27,7 @@ of features for each node. All the nodes selective options are explained
 [[cluster-nodes-usage-api-path-params]]
 ==== {api-path-parms-title}
 
-`{metric}`::
+`<metric>`::
     (Optional, string) Limits the information returned to the specific metrics. 
     A comma-separated list of the following options: 
 +

--- a/docs/reference/cluster/nodes-usage.asciidoc
+++ b/docs/reference/cluster/nodes-usage.asciidoc
@@ -9,7 +9,7 @@ Returns information on the usage of features.
 
 `GET /_nodes/usage` +
 
-`GET /_nodes/<node_id</usage` +
+`GET /_nodes/<node_id>/usage` +
 
 `GET /_nodes/usage/<metric>` +
 

--- a/docs/reference/cluster/state.asciidoc
+++ b/docs/reference/cluster/state.asciidoc
@@ -6,7 +6,7 @@ Returns metadata about the state of the cluster.
 [[cluster-state-api-request]]
 ==== {api-request-title}
 
-`GET /_cluster/state/{metrics}/{index}`
+`GET /_cluster/state/<metrics>/<index>`
 
 [[cluster-state-api-desc]]
 ==== {api-description-title}
@@ -50,7 +50,7 @@ including their mappings, as well as templates and other metadata. This means it
 can sometimes be quite large. To avoid the need to process all this information
 you can request only the part of the cluster state that you need:
 
-`{metrics}`::
+`<metrics>`::
     (Optional, string) A comma-separated list of the following options:
 +
 --

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -9,7 +9,7 @@ Returns cluster statistics.
 
 `GET /_cluster/stats` +
 
-`GET /_cluster/stats/nodes/{node_id}`
+`GET /_cluster/stats/nodes/<node_id>`
 
 
 [[cluster-stats-api-desc]]

--- a/docs/reference/cluster/tasks.asciidoc
+++ b/docs/reference/cluster/tasks.asciidoc
@@ -10,7 +10,7 @@ Returns information about the tasks currently executing in the cluster.
 
 `GET /_tasks` +
 
-`GET /_tasks/{task_id}`
+`GET /_tasks/<task_id>`
 
 
 [[tasks-api-desc]]
@@ -23,7 +23,7 @@ executing on one or more nodes in the cluster.
 [[tasks-api-path-params]]
 ==== {api-path-parms-title}
 
-{task_id}
+`<task_id>`::
     (Optional, string) The ID of the task to return (`node_id:task_number`).
 
 

--- a/docs/reference/cluster/voting-exclusions.asciidoc
+++ b/docs/reference/cluster/voting-exclusions.asciidoc
@@ -11,7 +11,7 @@ Adds or removes master-eligible nodes from the
 [[voting-config-exclusions-api-request]]
 ==== {api-request-title}
 
-`POST _cluster/voting_config_exclusions/{node_name}` +
+`POST _cluster/voting_config_exclusions/<node_name>` +
 
 `DELETE _cluster/voting_config_exclusions`
 
@@ -46,7 +46,7 @@ For more information, see <<modules-discovery-removing-nodes>>.
 [[voting-config-exclusions-api-path-params]]
 ==== {api-path-parms-title}
 
-`{node_name}`::
+`<node_name>`::
   A <<cluster-nodes,node filter>> that identifies {es} nodes.
 
 

--- a/docs/reference/indices/get-mapping.asciidoc
+++ b/docs/reference/indices/get-mapping.asciidoc
@@ -23,7 +23,7 @@ through the parameter `include_type_name`. For more details, please see <<remova
 
 `GET /_mapping`
 
-`GET /{index}/_mapping`
+`GET /<index>/_mapping`
 
 
 [[get-mapping-api-path-params]]

--- a/docs/reference/indices/put-mapping.asciidoc
+++ b/docs/reference/indices/put-mapping.asciidoc
@@ -30,7 +30,7 @@ please see <<removal-of-types>>.
 [[put-mapping-api-request]]
 ==== {api-request-title}
 
-`PUT /{index}/_mapping`
+`PUT /<index>/_mapping`
 
 `PUT /_mapping`
 

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -77,7 +77,7 @@ that are **not** loaded into memory. Defaults to `false`.
 end::include-unloaded-segments[]
 
 tag::index[]
-`{index}`::
+`<index>`::
 (Optional, string) Comma-separated list or wildcard expression of index names
 used to limit the request.
 end::index[]
@@ -90,12 +90,12 @@ the master node.
 end::local[]
 
 tag::name[]
-`{name}`::
+`<name>`::
 (Optional, string) Comma-separated list of alias names to return.
 end::name[]
 
 tag::node-id[]
-`{node_id}`::
+`<node_id>`::
 (Optional, string) Comma-separated list of node IDs or names used to limit
 returned information.
 end::node-id[]

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -14,7 +14,7 @@ GET /twitter/_search?q=user:kimchy
 [[search-search-api-request]]
 ==== {api-request-title}
 
-`GET /{index}/_search` +
+`GET /<index>/_search` +
 
 `GET /all/_search`
 


### PR DESCRIPTION
Changes several variables documented using the `{var}` convention to `<var>` to ensure consistency across documentation.