### PR TITLE
Remove processors setting

### DIFF
--- a/docs/reference/migration/migrate_8_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/settings.asciidoc
@@ -13,11 +13,18 @@ refuse to start if you have these settings in your configuration or cluster
 state.
 
 [float]
-==== `processors` can no longer exceed the available number of processors
+==== `processors` setting is replaced by `node.processors`
+
+To ensure that all settings are in a proper namespace, the `processors` setting
+was previously deprecated in version 7.4.0 of Elasticsearch, and is removed in
+version 8.0.0. Instead, use `node.processors`.
+
+[float]
+==== `node.processors` can no longer exceed the available number of processors
 
 Previously it was possible to set the number of processors used to set the
 default sizes for the thread pools to be more than the number of available
 processors. As this leads to more context switches and more threads but without
 an increase in the number of physical CPUs on which to schedule these additional
-threads, the `processors` setting is now bounded by the number of available
+threads, the `node.processors` setting is now bounded by the number of available
 processors.

--- a/docs/reference/migration/migrate_8_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/settings.asciidoc
@@ -13,6 +13,7 @@ refuse to start if you have these settings in your configuration or cluster
 state.
 
 [float]
+[[remove-processors]
 ==== `processors` setting is replaced by `node.processors`
 
 To ensure that all settings are in a proper namespace, the `processors` setting

--- a/docs/reference/migration/migrate_8_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/settings.asciidoc
@@ -13,7 +13,7 @@ refuse to start if you have these settings in your configuration or cluster
 state.
 
 [float]
-[[remove-processors]
+[[remove-processors]]
 ==== `processors` setting is replaced by `node.processors`
 
 To ensure that all settings are in a proper namespace, the `processors` setting

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -389,7 +389,6 @@ public final class ClusterSettings extends AbstractScopedSettings {
             ClusterName.CLUSTER_NAME_SETTING,
             Client.CLIENT_TYPE_SETTING_S,
             ClusterModule.SHARDS_ALLOCATOR_TYPE_SETTING,
-            EsExecutors.PROCESSORS_SETTING,
             EsExecutors.NODE_PROCESSORS_SETTING,
             ThreadContext.DEFAULT_HEADERS_SETTING,
             Loggers.LOG_DEFAULT_LEVEL_SETTING,

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -1053,15 +1053,6 @@ public class Setting<T> implements ToXContentObject {
         return new Setting<>(key, fallbackSetting, (s) -> parseInt(s, minValue, key), properties);
     }
 
-    public static Setting<Integer> intSetting(
-        final String key,
-        final Setting<Integer> fallbackSetting,
-        final int minValue,
-        final int maxValue,
-        final Property... properties) {
-        return new Setting<>(key, fallbackSetting, (s) -> parseInt(s, minValue, maxValue, key), properties);
-    }
-
     public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, Validator<Integer> validator,
                                               Property... properties) {
         return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, (s) -> parseInt(s, minValue, key),validator,

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -46,21 +46,12 @@ import java.util.stream.Collectors;
 
 public class EsExecutors {
 
-    public static final Setting<Integer> PROCESSORS_SETTING = Setting.intSetting(
-        "processors",
-        Runtime.getRuntime().availableProcessors(),
-        1,
-        Runtime.getRuntime().availableProcessors(),
-        Property.Deprecated,
-        Property.NodeScope);
-
     /**
      * Setting to manually set the number of available processors. This setting is used to adjust thread pool sizes per node.
      */
-    // TODO: when removing "processors" setting, the default value is Runtime.getRuntime().availableProcessors()
     public static final Setting<Integer> NODE_PROCESSORS_SETTING = Setting.intSetting(
         "node.processors",
-        PROCESSORS_SETTING,
+        Runtime.getRuntime().availableProcessors(),
         1,
         Runtime.getRuntime().availableProcessors(),
         Property.NodeScope);

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
@@ -392,14 +392,7 @@ public class EsExecutorsTests extends ESTestCase {
     }
 
     public void testNodeProcessorsBound() {
-        runProcessorsBoundTest(EsExecutors.NODE_PROCESSORS_SETTING);
-    }
-
-    public void testProcessorsBound() {
-        runProcessorsBoundTest(EsExecutors.PROCESSORS_SETTING);
-    }
-
-    private void runProcessorsBoundTest(final Setting<Integer> processorsSetting) {
+        final Setting<Integer> processorsSetting = EsExecutors.NODE_PROCESSORS_SETTING;
         final int available = Runtime.getRuntime().availableProcessors();
         final int processors = randomIntBetween(available + 1, Integer.MAX_VALUE);
         final Settings settings = Settings.builder().put(processorsSetting.getKey(), processors).build();
@@ -412,9 +405,6 @@ public class EsExecutorsTests extends ESTestCase {
             processorsSetting.getKey(),
             available);
         assertThat(e, hasToString(containsString(expected)));
-        if (processorsSetting.getProperties().contains(Setting.Property.Deprecated)) {
-            assertSettingDeprecationsAndWarnings(new Setting<?>[]{processorsSetting});
-        }
     }
 
 }


### PR DESCRIPTION
The processors setting was deprecated in version 7.4.0 of Elasticsearch for removal in Elasticsearch 8.0.0. This commit removes the processors setting.

Relates #45855
