### PR TITLE
[DOCS] Reformat indices exists API docs

### DIFF
--- a/docs/reference/indices/indices-exists.asciidoc
+++ b/docs/reference/indices/indices-exists.asciidoc
@@ -1,17 +1,59 @@
 [[indices-exists]]
-=== Indices Exists
+=== Indices exists API
+++++
+<titleabbrev>Indices exists</titleabbrev>
+++++
 
-Used to check if the index (indices) exists or not. For example:
+Checks if an index exists.
+The returned HTTP status code indicates if the index exists or not.
+A `404` means it does not exist, and `200` means it does.
 
 [source,js]
 --------------------------------------------------
-HEAD twitter
+HEAD /twitter
 --------------------------------------------------
 // CONSOLE
 // TEST[setup:twitter]
 
-The HTTP status code indicates if the index exists or not. A `404` means
-it does not exist, and `200` means it does.
 
-IMPORTANT: This request does not distinguish between an index and an alias,
+[[indices-exists-api-request]]
+==== {api-request-title}
+
+`HEAD /<index>`
+
+
+[[indices-exists-api-path-params]]
+==== {api-path-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
++
+IMPORTANT: This parameter does not distinguish between an index name and <<indices-aliases,alias>>,
 i.e. status code `200` is also returned if an alias exists with that name.
+
+
+[[indices-exists-api-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
++
+Defaults to `open`.
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=include-defaults]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+
+
+[[indices-exists-api-response-codes]]
+==== {api-response-codes-title}
+
+`200`::
+Indicates all specified indices or index aliases exist.
+
+ `404`::
+Indicates one or more specified indices or index aliases **do not** exist.


### PR DESCRIPTION
This PR updates the indices exists API to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc).

Relates to elastic/docs#937 and #43765

### Preview
http://elasticsearch_45918.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/indices-exists.html