### PR TITLE
[DOCS] Reformat open index API docs

### DIFF
--- a/docs/reference/indices/open-close.asciidoc
+++ b/docs/reference/indices/open-close.asciidoc
@@ -1,8 +1,32 @@
 [[indices-open-close]]
-=== Open / Close Index API
+=== Open index API
+++++
+<titleabbrev>Open index</titleabbrev>
+++++
 
-The open and close index APIs allow to close an index, and later on
-opening it.
+Opens a closed index.
+
+[source,js]
+--------------------------------------------------
+POST /twitter/_open
+--------------------------------------------------
+// CONSOLE
+// TEST[setup:twitter]
+// TEST[s/^/POST \/twitter\/_close\n/]
+
+
+[[open-index-api-request]]
+==== {api-request-title}
+
+`POST /<index>/_open`
+
+
+[[open-index-api-desc]]
+==== {api-description-title}
+
+You can use the open index API to re-open a closed index.
+
+// tag:closed-index
 
 A closed index is blocked for read/write operations and does not allow
 all operations that opened indices allow. It is not possible to index
@@ -18,53 +42,6 @@ data of opened/closed indices is automatically replicated by the
 cluster to ensure that enough shard copies are safely kept around
 at all times.
 
-The REST endpoint is `/{index}/_close` and `/{index}/_open`.
-
-The following example shows how to close an index:
-
-[source,js]
---------------------------------------------------
-POST /my_index/_close
---------------------------------------------------
-// CONSOLE
-// TEST[s/^/PUT my_index\n/]
-
-This will return the following response:
-
-[source,js]
---------------------------------------------------
-{
-    "acknowledged" : true,
-    "shards_acknowledged" : true,
-    "indices" : {
-        "my_index" : {
-            "closed" : true
-        }
-    }
-}
---------------------------------------------------
-// TESTRESPONSE
-
-A closed index can be reopened like this:
-
-[source,js]
---------------------------------------------------
-POST /my_index/_open
---------------------------------------------------
-// CONSOLE
-// TEST[s/^/PUT my_index\nPOST my_index\/_close\n/]
-
-which will yield the following response:
-
-[source,js]
---------------------------------------------------
-{
-    "acknowledged" : true,
-    "shards_acknowledged" : true
-}
---------------------------------------------------
-// TESTRESPONSE
-
 It is possible to open and close multiple indices. An error will be thrown
 if the request explicitly refers to a missing index. This behaviour can be
 disabled using the `ignore_unavailable=true` parameter.
@@ -79,9 +56,62 @@ This setting can also be changed via the cluster update settings api.
 Closed indices consume a significant amount of disk-space which can cause problems in managed environments. Closing indices can be disabled via the cluster settings
 API by setting `cluster.indices.close.enable` to `false`. The default is `true`.
 
-[float]
-==== Wait For Active Shards
+===== Wait For active shards
 
 Because opening or closing an index allocates its shards, the
 <<create-index-wait-for-active-shards,`wait_for_active_shards`>> setting on
 index creation applies to the `_open` and `_close` index actions as well.
+
+// end:closed-index
+
+
+[[open-index-api-path-params]]
+==== {api-path-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
++
+To open all indices, use `_all` or `*`.
+To disallow the opening of indices with `_all` or wildcard expressions,
+change the `action.destructive_requires_name` cluster setting to `true`.
+You can update this setting in the `elasticsearch.yml` file
+or using the <<cluster-update-settings,cluster update settings>> API.
+
+
+[[open-index-api-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
++
+Defaults to `closed`.
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=doc-wait-for-active-shards]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+
+
+[[open-index-api-example]]
+==== {api-examples-title}
+
+A closed index can be re-opened like this:
+
+[source,js]
+--------------------------------------------------
+POST /my_index/_open
+--------------------------------------------------
+// CONSOLE
+// TEST[s/^/PUT my_index\nPOST my_index\/_close\n/]
+
+The API returns the following response:
+
+[source,js]
+--------------------------------------------------
+{
+    "acknowledged" : true,
+    "shards_acknowledged" : true
+}
+--------------------------------------------------
+// TESTRESPONSE

--- a/docs/reference/indices/open-close.asciidoc
+++ b/docs/reference/indices/open-close.asciidoc
@@ -42,7 +42,7 @@ data of opened/closed indices is automatically replicated by the
 cluster to ensure that enough shard copies are safely kept around
 at all times.
 
-It is possible to open and close multiple indices. An error will be thrown
+It is possible to open and close multiple indices. An error is thrown
 if the request explicitly refers to a missing index. This behaviour can be
 disabled using the `ignore_unavailable=true` parameter.
 

--- a/docs/reference/indices/open-close.asciidoc
+++ b/docs/reference/indices/open-close.asciidoc
@@ -24,7 +24,7 @@ POST /twitter/_open
 [[open-index-api-desc]]
 ==== {api-description-title}
 
-You can use the open index API to re-open a closed index.
+You use the open index API to re-open closed indices.
 
 // tag:closed-index
 
@@ -42,7 +42,7 @@ data of opened/closed indices is automatically replicated by the
 cluster to ensure that enough shard copies are safely kept around
 at all times.
 
-It is possible to open and close multiple indices. An error is thrown
+You can open and close multiple indices. An error is thrown
 if the request explicitly refers to a missing index. This behaviour can be
 disabled using the `ignore_unavailable=true` parameter.
 


### PR DESCRIPTION
This PR updates the open index APIs to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc).

This PR also removes the close index AP docs, which are included separately as part of #45922.

Relates to elastic/docs#937 and #43765