### PR TITLE
[DOCS] Separate and reformat close index API docs

### DIFF
--- a/docs/reference/indices.asciidoc
+++ b/docs/reference/indices.asciidoc
@@ -12,6 +12,7 @@ index settings, aliases, mappings, and index templates.
 * <<indices-delete-index>>
 * <<indices-get-index>>
 * <<indices-exists>>
+* <<indices-close>>
 * <<indices-open-close>>
 * <<indices-shrink-index>>
 * <<indices-split-index>>
@@ -66,6 +67,8 @@ include::indices/delete-index.asciidoc[]
 include::indices/get-index.asciidoc[]
 
 include::indices/indices-exists.asciidoc[]
+
+include::indices/close.asciidoc[]
 
 include::indices/open-close.asciidoc[]
 

--- a/docs/reference/indices/close.asciidoc
+++ b/docs/reference/indices/close.asciidoc
@@ -1,0 +1,85 @@
+[[indices-close]]
+=== Close index API
+++++
+<titleabbrev>Close index</titleabbrev>
+++++
+
+Closes an index.
+
+[source,js]
+--------------------------------------------------
+POST /twitter/_close
+--------------------------------------------------
+// CONSOLE
+// TEST[setup:twitter]
+
+
+[[close-index-api-request]]
+==== {api-request-title}
+
+`POST /<index>/_close`
+
+
+[[close-index-api-desc]]
+==== {api-description-title}
+
+You can use the close index API to close an open index.
+
+include::{docdir}/indices/open-close.asciidoc[tag=closed-index]
+
+
+[[close-index-api-path-params]]
+==== {api-path-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
++
+To close all indices, use `_all` or `*`.
+To disallow the closing of indices with `_all` or wildcard expressions,
+change the `action.destructive_requires_name` cluster setting to `true`.
+You can update this setting in the `elasticsearch.yml` file
+or using the <<cluster-update-settings,cluster update settings>> API.
+
+
+[[close-index-api-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
++
+Defaults to `open`.
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=doc-wait-for-active-shards]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+
+
+[[close-index-api-example]]
+==== {api-examples-title}
+
+The following example shows how to close an index:
+
+[source,js]
+--------------------------------------------------
+POST /my_index/_close
+--------------------------------------------------
+// CONSOLE
+// TEST[s/^/PUT my_index\n/]
+
+The API returns following response:
+
+[source,js]
+--------------------------------------------------
+{
+    "acknowledged" : true,
+    "shards_acknowledged" : true,
+    "indices" : {
+        "my_index" : {
+            "closed" : true
+        }
+    }
+}
+--------------------------------------------------
+// TESTRESPONSE

--- a/docs/reference/indices/close.asciidoc
+++ b/docs/reference/indices/close.asciidoc
@@ -23,7 +23,7 @@ POST /twitter/_close
 [[close-index-api-desc]]
 ==== {api-description-title}
 
-You can use the close index API to close an open index.
+You use the close index API to close open indices.
 
 include::{docdir}/indices/open-close.asciidoc[tag=closed-index]
 

--- a/docs/reference/indices/open-close.asciidoc
+++ b/docs/reference/indices/open-close.asciidoc
@@ -26,7 +26,7 @@ POST /twitter/_open
 
 You use the open index API to re-open closed indices.
 
-// tag:closed-index
+// tag::closed-index[]
 
 A closed index is blocked for read/write operations and does not allow
 all operations that opened indices allow. It is not possible to index
@@ -62,7 +62,7 @@ Because opening or closing an index allocates its shards, the
 <<create-index-wait-for-active-shards,`wait_for_active_shards`>> setting on
 index creation applies to the `_open` and `_close` index actions as well.
 
-// end:closed-index
+// end::closed-index[]
 
 
 [[open-index-api-path-params]]


### PR DESCRIPTION
Separates and adds the close index API.

The close index API docs are formatted to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc).

Dependent on #45921. CI failures are expected until that PR is merged.