### PR TITLE
Remove translating processors in Docker entrypoint

### DIFF
--- a/distribution/docker/src/docker/bin/docker-entrypoint.sh
+++ b/distribution/docker/src/docker/bin/docker-entrypoint.sh
@@ -53,7 +53,7 @@ do
   # Elasticsearch settings need to have at least two dot separated lowercase
   # words, e.g. `cluster.name`, except for `processors` which we handle
   # specially
-  if [[ "$envvar_key" =~ ^[a-z0-9_]+\.[a-z0-9_]+ || "$envvar_key" == "processors" ]]; then
+  if [[ "$envvar_key" =~ ^[a-z0-9_]+\.[a-z0-9_]+ ]]; then
     if [[ ! -z $envvar_value ]]; then
       es_opt="-E${envvar_key}=${envvar_value}"
       es_opts+=("${es_opt}")


### PR DESCRIPTION
Now that processors is no longer a valid Elasticsearch setting, this commit removes translation for it in the Docker entrypoint.

Relates #45905