### PR TITLE
[DOCS] Reformat get index settings API docs

### DIFF
--- a/docs/reference/indices/get-settings.asciidoc
+++ b/docs/reference/indices/get-settings.asciidoc
@@ -1,7 +1,10 @@
 [[indices-get-settings]]
-=== Get Settings
+=== Get index settings API
+++++
+<titleabbrev>Get index settings</titleabbrev>
+++++
 
-The get settings API allows to retrieve settings of index/indices:
+Returns setting information for an index.
 
 [source,js]
 --------------------------------------------------
@@ -10,14 +13,54 @@ GET /twitter/_settings
 // CONSOLE
 // TEST[setup:twitter]
 
-[float]
-==== Multiple Indices and Types
 
-The get settings API can be used to get settings for more than one index
-with a single call. General usage of the API follows the
-following syntax: `host:port/{index}/_settings` where
-`{index}` can stand for comma-separated list of index names and aliases. To
-get settings for all indices you can use `_all` for `{index}`.
+[[get-index-settings-api-request]]
+==== {api-request-title}
+
+`GET /<index>/_settings`
+
+`GET /<index>/_settings/<setting>`
+
+
+[[get-index-settings-api-path-params]]
+==== {api-path-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
++
+Use a value of `_all` to retrieve information for all indices in the cluster.
+
+`<setting>`::
+(Optional, string) Comma-separated list or wildcard expression of setting names
+used to limit the request.
+
+
+[[get-index-settings-api-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
++
+Defaults to `all`.
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=include-defaults]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+
+
+[[get-index-settings-api-example]]
+==== {api-examples-title}
+
+===== Multiple indices
+
+The get settings API can be used to get settings for more than one index with a
+single call. To get settings for all indices you can use `_all` for `<index>`.
 Wildcard expressions are also supported. The following are some examples:
 
 [source,js]
@@ -32,8 +75,7 @@ GET /log_2013_*/_settings
 // TEST[setup:twitter]
 // TEST[s/^/PUT kimchy\nPUT log_2013_01_01\n/]
 
-[float]
-==== Filtering settings by name
+===== Filtering settings by name
 
 The settings that are returned can be filtered with wildcard matching
 as follows:


### PR DESCRIPTION
This PR updates the get index settings API docs to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc).

Relates to elastic/docs#937 and #43765

### Preview
http://elasticsearch_45924.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/indices-get-settings.html