### PR TITLE
Add deprecation check for processors

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -41,7 +41,7 @@ public class DeprecationChecks {
 
     static List<BiFunction<Settings, PluginsAndModules, DeprecationIssue>> NODE_SETTINGS_CHECKS =
         Collections.unmodifiableList(Arrays.asList(
-            // STUB
+            NodeDeprecationChecks::checkProcessors
         ));
 
     static List<Function<IndexMetaData, DeprecationIssue>> INDEX_SETTINGS_CHECKS =

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -25,7 +25,7 @@ class NodeDeprecationChecks {
             EsExecutors.PROCESSORS_SETTING.getKey(),
             EsExecutors.NODE_PROCESSORS_SETTING.getKey());
         final String url =
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.x/breaking-changes-7.4.html#deprecate-processors";
+            "https://www.elastic.co/guide/en/elasticsearch/reference/7.4/breaking-changes-7.4.html#deprecate-processors";
         final String details = String.format(
             Locale.ROOT,
             "the setting [%s] is currently set to [%d], instead set [%s] to [%d]",

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
 package org.elasticsearch.xpack.deprecation;
 
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -1,0 +1,32 @@
+package org.elasticsearch.xpack.deprecation;
+
+import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
+
+import java.util.Locale;
+
+class NodeDeprecationChecks {
+
+    static DeprecationIssue checkProcessors(final Settings settings , final PluginsAndModules pluginsAndModules) {
+        if (EsExecutors.PROCESSORS_SETTING.exists(settings) == false) {
+            return null;
+        }
+        final String message = String.format(
+            Locale.ROOT,
+            "setting [%s] is deprecated in favor of setting [%s]",
+            EsExecutors.PROCESSORS_SETTING.getKey(),
+            EsExecutors.NODE_PROCESSORS_SETTING.getKey());
+        final String url = "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html#remove-processors";
+        final String details = String.format(
+            Locale.ROOT,
+            "the setting [%s] is currently set to [%d], instead set [%s] to [%d]",
+            EsExecutors.PROCESSORS_SETTING.getKey(),
+            EsExecutors.PROCESSORS_SETTING.get(settings),
+            EsExecutors.NODE_PROCESSORS_SETTING.getKey(),
+            EsExecutors.PROCESSORS_SETTING.get(settings));
+        return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details);
+    }
+
+}

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -25,7 +25,7 @@ class NodeDeprecationChecks {
             EsExecutors.PROCESSORS_SETTING.getKey(),
             EsExecutors.NODE_PROCESSORS_SETTING.getKey());
         final String url =
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.4/breaking_74_plugin_changes.html#breaking_74_settings_changes";
+            "https://www.elastic.co/guide/en/elasticsearch/reference/7.x/breaking-changes-7.4.html#deprecate-processors";
         final String details = String.format(
             Locale.ROOT,
             "the setting [%s] is currently set to [%d], instead set [%s] to [%d]",

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -24,7 +24,8 @@ class NodeDeprecationChecks {
             "setting [%s] is deprecated in favor of setting [%s]",
             EsExecutors.PROCESSORS_SETTING.getKey(),
             EsExecutors.NODE_PROCESSORS_SETTING.getKey());
-        final String url = "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html#remove-processors";
+        final String url =
+            "https://www.elastic.co/guide/en/elasticsearch/reference/7.4/breaking_74_plugin_changes.html#breaking_74_settings_changes";
         final String details = String.format(
             Locale.ROOT,
             "the setting [%s] is currently set to [%d], instead set [%s] to [%d]",

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -30,7 +30,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
             "setting [processors] is deprecated in favor of setting [node.processors]",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html#remove-processors",
+            "https://www.elastic.co/guide/en/elasticsearch/reference/7.4/breaking_74_plugin_changes.html#breaking_74_settings_changes",
             "the setting [processors] is currently set to [" + processors + "], instead set [node.processors] to [" + processors + "]");
         assertThat(issues, contains(expected));
         assertSettingDeprecationsAndWarnings(new Setting<?>[]{EsExecutors.PROCESSORS_SETTING});

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -30,7 +30,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
             "setting [processors] is deprecated in favor of setting [node.processors]",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.4/breaking_74_plugin_changes.html#breaking_74_settings_changes",
+            "https://www.elastic.co/guide/en/elasticsearch/reference/7.x/breaking-changes-7.4.html#deprecate-processors",
             "the setting [processors] is currently set to [" + processors + "], instead set [node.processors] to [" + processors + "]");
         assertThat(issues, contains(expected));
         assertSettingDeprecationsAndWarnings(new Setting<?>[]{EsExecutors.PROCESSORS_SETTING});

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
 package org.elasticsearch.xpack.deprecation;
 
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -1,0 +1,41 @@
+package org.elasticsearch.xpack.deprecation;
+
+import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+
+public class NodeDeprecationChecksTests extends ESTestCase {
+
+    public void testCheckProcessors() {
+        final int processors = randomIntBetween(1, 4);
+        final Settings settings = Settings.builder().put(EsExecutors.PROCESSORS_SETTING.getKey(), processors).build();
+        final PluginsAndModules pluginsAndModules = new PluginsAndModules(Collections.emptyList(), Collections.emptyList());
+        final List<DeprecationIssue> issues =
+            DeprecationChecks.filterChecks(DeprecationChecks.NODE_SETTINGS_CHECKS, c -> c.apply(settings, pluginsAndModules));
+        final DeprecationIssue expected = new DeprecationIssue(
+            DeprecationIssue.Level.CRITICAL,
+            "setting [processors] is deprecated in favor of setting [node.processors]",
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html#remove-processors",
+            "the setting [processors] is currently set to [" + processors + "], instead set [node.processors] to [" + processors + "]");
+        assertThat(issues, contains(expected));
+        assertSettingDeprecationsAndWarnings(new Setting<?>[]{EsExecutors.PROCESSORS_SETTING});
+    }
+
+    public void testCheckProcessorsNotSet() {
+        final Settings settings = Settings.EMPTY;
+        final PluginsAndModules pluginsAndModules = new PluginsAndModules(Collections.emptyList(), Collections.emptyList());
+        final List<DeprecationIssue> issues =
+            DeprecationChecks.filterChecks(DeprecationChecks.NODE_SETTINGS_CHECKS, c -> c.apply(settings, pluginsAndModules));
+        assertThat(issues, empty());
+    }
+
+}

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -30,7 +30,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final DeprecationIssue expected = new DeprecationIssue(
             DeprecationIssue.Level.CRITICAL,
             "setting [processors] is deprecated in favor of setting [node.processors]",
-            "https://www.elastic.co/guide/en/elasticsearch/reference/7.x/breaking-changes-7.4.html#deprecate-processors",
+            "https://www.elastic.co/guide/en/elasticsearch/reference/7.4/breaking-changes-7.4.html#deprecate-processors",
             "the setting [processors] is currently set to [" + processors + "], instead set [node.processors] to [" + processors + "]");
         assertThat(issues, contains(expected));
         assertSettingDeprecationsAndWarnings(new Setting<?>[]{EsExecutors.PROCESSORS_SETTING});


### PR DESCRIPTION
The processors setting is deprecated. This commit adds a deprecation check for the use of the processors setting.

Relates #45855 
Relates #45905
