### PR TITLE
Build: Support `console-result` language

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/SnippetsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/SnippetsTask.groovy
@@ -123,7 +123,7 @@ public class SnippetsTask extends DefaultTask {
                     }
                 }
                 if (snippet.testResponse
-                        && 'js' == snippet.language
+                        && ('js' == snippet.language || 'console-result' == snippet.language)
                         && null == snippet.skip) {
                     String quoted = snippet.contents
                         // quote values starting with $
@@ -162,7 +162,7 @@ public class SnippetsTask extends DefaultTask {
                     }
                     return
                 }
-                matcher = line =~ /\["?source"?,\s*"?(\w+)"?(,.*)?].*/
+                matcher = line =~ /\["?source"?,\s*"?([-\w]+)"?(,.*)?].*/
                 if (matcher.matches()) {
                     lastLanguage = matcher.group(1)
                     lastLanguageLine = lineNumber

--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -240,7 +240,7 @@ GET twitter/_doc/0
 
 The API returns the following result:
 
-[source,js]
+[source,console-result]
 --------------------------------------------------
 {
     "_index" : "twitter",
@@ -359,7 +359,7 @@ GET twitter/_doc/1?stored_fields=tags,counter
 
 The API returns the following result:
 
-[source,js]
+[source,console-result]
 --------------------------------------------------
 {
    "_index": "twitter",
@@ -403,7 +403,7 @@ GET twitter/_doc/2?routing=user1&stored_fields=tags,counter
 
 The API returns the following result:
 
-[source,js]
+[source,console-result]
 --------------------------------------------------
 {
    "_index": "twitter",


### PR DESCRIPTION
This adds support for verifying that snippets with the `console-result`
language are valid json. It also switches the response snippets on the
`docs/get` page from `js` to `console-result` which will allow clients
to provide "alternatives" for them like they can now do with
`// CONSOLE` snippets.
