### PR TITLE
Remove the pidfile setting

### DIFF
--- a/docs/reference/migration/migrate_8_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/settings.asciidoc
@@ -13,6 +13,14 @@ refuse to start if you have these settings in your configuration or cluster
 state.
 
 [float]
+[[remove-pidfile]]
+==== `pidfile` setting is replaced by `node.pidfile`
+
+To ensure that all settings are in a proper namespace, the `pidfile` setting was
+previously deprecated in version 7.4.0 of Elasticsearch, and is removed in
+version 8.0.0. Instead, use `node.pidfile`.
+
+[float]
 [[remove-processors]]
 ==== `processors` setting is replaced by `node.processors`
 

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -362,7 +362,6 @@ public final class ClusterSettings extends AbstractScopedSettings {
             Environment.PATH_LOGS_SETTING,
             Environment.PATH_REPO_SETTING,
             Environment.PATH_SHARED_DATA_SETTING,
-            Environment.PIDFILE_SETTING,
             Environment.NODE_PIDFILE_SETTING,
             NodeEnvironment.NODE_ID_SEED_SETTING,
             Node.INITIAL_STATE_TIMEOUT_SETTING,

--- a/server/src/main/java/org/elasticsearch/env/Environment.java
+++ b/server/src/main/java/org/elasticsearch/env/Environment.java
@@ -60,8 +60,7 @@ public class Environment {
     public static final Setting<List<String>> PATH_REPO_SETTING =
         Setting.listSetting("path.repo", Collections.emptyList(), Function.identity(), Property.NodeScope);
     public static final Setting<String> PATH_SHARED_DATA_SETTING = Setting.simpleString("path.shared_data", Property.NodeScope);
-    public static final Setting<String> PIDFILE_SETTING = Setting.simpleString("pidfile", Property.Deprecated, Property.NodeScope);
-    public static final Setting<String> NODE_PIDFILE_SETTING = Setting.simpleString("node.pidfile", PIDFILE_SETTING, Property.NodeScope);
+    public static final Setting<String> NODE_PIDFILE_SETTING = Setting.simpleString("node.pidfile", Property.NodeScope);
 
     private final Settings settings;
 
@@ -155,7 +154,7 @@ public class Environment {
             logsFile = homeFile.resolve("logs");
         }
 
-        if (NODE_PIDFILE_SETTING.exists(settings) || PIDFILE_SETTING.exists(settings)) {
+        if (NODE_PIDFILE_SETTING.exists(settings)) {
             pidFile = PathUtils.get(NODE_PIDFILE_SETTING.get(settings)).toAbsolutePath().normalize();
         } else {
             pidFile = null;
@@ -183,9 +182,6 @@ public class Environment {
         if (NODE_PIDFILE_SETTING.exists(settings)) {
             assert pidFile != null;
             finalSettings.put(Environment.NODE_PIDFILE_SETTING.getKey(), pidFile.toString());
-        } else if (PIDFILE_SETTING.exists(settings)) {
-            assert pidFile != null;
-            finalSettings.put(Environment.PIDFILE_SETTING.getKey(), pidFile.toString());
         }
         this.settings = finalSettings.build();
     }

--- a/server/src/test/java/org/elasticsearch/env/EnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/EnvironmentTests.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.env;
 
 import org.elasticsearch.common.io.PathUtils;
-import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 

--- a/server/src/test/java/org/elasticsearch/env/EnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/EnvironmentTests.java
@@ -175,20 +175,13 @@ public class EnvironmentTests extends ESTestCase {
 
     // test that environment paths are absolute and normalized
     public void testPathNormalization() throws IOException {
-        final Setting<String> pidFileSetting;
-        if (randomBoolean()) {
-            pidFileSetting = Environment.NODE_PIDFILE_SETTING;
-        } else {
-            pidFileSetting = Environment.PIDFILE_SETTING;
-        }
-
         final Settings settings = Settings.builder()
             .put(Environment.PATH_HOME_SETTING.getKey(), "home")
             .put(Environment.PATH_DATA_SETTING.getKey(), "./home/../home/data")
             .put(Environment.PATH_LOGS_SETTING.getKey(), "./home/../home/logs")
             .put(Environment.PATH_REPO_SETTING.getKey(), "./home/../home/repo")
             .put(Environment.PATH_SHARED_DATA_SETTING.getKey(), "./home/../home/shared_data")
-            .put(pidFileSetting.getKey(), "./home/../home/pidfile")
+            .put(Environment.NODE_PIDFILE_SETTING.getKey(), "./home/../home/pidfile")
             .build();
 
         // the above paths will be treated as relative to the working directory
@@ -214,12 +207,8 @@ public class EnvironmentTests extends ESTestCase {
         final String sharedDataPath = Environment.PATH_SHARED_DATA_SETTING.get(environment.settings());
         assertPath(sharedDataPath, home.resolve("shared_data"));
 
-        final String pidFile = pidFileSetting.get(environment.settings());
+        final String pidFile = Environment.NODE_PIDFILE_SETTING.get(environment.settings());
         assertPath(pidFile, home.resolve("pidfile"));
-
-        if (pidFileSetting.isDeprecated()) {
-            assertSettingDeprecationsAndWarnings(new Setting<?>[] { pidFileSetting });
-        }
     }
 
     private void assertPath(final String actual, final Path expected) {


### PR DESCRIPTION
The pidfile setting was deprecated in version 7.4.0 of Elasticsearch for removal in Elasticsearch 8.0.0. This commit removes the pidfile setting.

Relates #45938