### PR TITLE
Consider artifact repositories backed by S3 secure

### DIFF
--- a/buildSrc/src/test/groovy/org/elasticsearch/gradle/BuildPluginTests.java
+++ b/buildSrc/src/test/groovy/org/elasticsearch/gradle/BuildPluginTests.java
@@ -45,6 +45,11 @@ public class BuildPluginTests extends GradleUnitTestCase {
         BuildPlugin.assertRepositoryURIIsSecure("test", "test", uri);
     }
 
+    public void testRepositoryThatUsesFileScheme() throws URISyntaxException {
+        final URI uri = new URI("file:/tmp/maven");
+        BuildPlugin.assertRepositoryURIIsSecure("test", "test", uri);
+    }
+
     public void testRepositoryURIThatUsesHttpsScheme() throws URISyntaxException {
         final URI uri = new URI("https://s3.amazonaws.com/artifacts.elastic.co/maven");
         BuildPlugin.assertRepositoryURIIsSecure("test", "test", uri);

--- a/buildSrc/src/test/groovy/org/elasticsearch/gradle/BuildPluginTests.java
+++ b/buildSrc/src/test/groovy/org/elasticsearch/gradle/BuildPluginTests.java
@@ -22,6 +22,9 @@ import org.elasticsearch.gradle.test.GradleUnitTestCase;
 import org.gradle.api.GradleException;
 import org.junit.Test;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 
 public class BuildPluginTests extends GradleUnitTestCase {
 
@@ -34,6 +37,22 @@ public class BuildPluginTests extends GradleUnitTestCase {
     @Test(expected = GradleException.class)
     public void testFailingDockerVersions() {
         BuildPlugin.checkDockerVersionRecent("Docker version 17.04.0, build e68fc7a");
+    }
+
+    @Test(expected = GradleException.class)
+    public void testRepositoryURIThatUsesHttpScheme() throws URISyntaxException {
+        final URI uri = new URI("http://s3.amazonaws.com/artifacts.elastic.co/maven");
+        BuildPlugin.assertRepositoryURIIsSecure("test", "test", uri);
+    }
+
+    public void testRepositoryURIThatUsesHttpsScheme() throws URISyntaxException {
+        final URI uri = new URI("https://s3.amazonaws.com/artifacts.elastic.co/maven");
+        BuildPlugin.assertRepositoryURIIsSecure("test", "test", uri);
+    }
+
+    public void testRepositoryURIThatUsesS3Scheme() throws URISyntaxException {
+        final URI uri = new URI("s3://artifacts.elastic.co/maven");
+        BuildPlugin.assertRepositoryURIIsSecure("test", "test", uri);
     }
 
 }

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/BuildPluginIT.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/BuildPluginIT.java
@@ -18,18 +18,28 @@
  */
 package org.elasticsearch.gradle;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.elasticsearch.gradle.test.GradleIntegrationTestCase;
 import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 public class BuildPluginIT extends GradleIntegrationTestCase {
+
+    @Rule
+    public TemporaryFolder tmpDir = new TemporaryFolder();
 
     public void testPluginCanBeApplied() {
         BuildResult result = getGradleRunner("elasticsearch.build")
@@ -44,6 +54,31 @@ public class BuildPluginIT extends GradleIntegrationTestCase {
             .withArguments("check", "assemble", "-s", "-Dlocal.repo.path=" + getLocalTestRepoPath())
             .build();
         assertTaskSuccessful(result, ":check");
+    }
+
+    public void testInsecure() throws IOException {
+        final File projectDir = getProjectDir("elasticsearch.build");
+        FileUtils.copyDirectory(projectDir, tmpDir.getRoot(), pathname -> pathname.getPath().contains("/build/") == false);
+        final List<String> buildGradleLines =
+            Files.readAllLines(tmpDir.getRoot().toPath().resolve("build.gradle"), StandardCharsets.UTF_8);
+        // add an insecure repository to the build.gradle
+        final String url = "http://s3.amazonaws.com/artifacts.elastic.co/maven";
+        buildGradleLines.addAll(Arrays.asList(
+            "repositories {",
+                "  maven {",
+                "    name \"elastic-maven\"",
+                "    url \"" +  url + "\"\n",
+                "  }",
+                "}"));
+        Files.write(tmpDir.getRoot().toPath().resolve("build.gradle"), buildGradleLines, StandardCharsets.UTF_8);
+        final BuildResult result = GradleRunner.create()
+            .withProjectDir(tmpDir.getRoot())
+            .withArguments("clean", "hello", "-s", "-i", "--warning-mode=all", "--scan")
+            .withPluginClasspath()
+            .buildAndFail();
+        assertOutputContains(
+            result.getOutput(),
+            "repository [elastic-maven] on project with path [:] is not using a secure protocol for artifacts on [" + url + "]");
     }
 
     public void testLicenseAndNotice() throws IOException {

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/BuildPluginIT.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/BuildPluginIT.java
@@ -56,7 +56,7 @@ public class BuildPluginIT extends GradleIntegrationTestCase {
         assertTaskSuccessful(result, ":check");
     }
 
-    public void testInsecure() throws IOException {
+    public void testInsecureMavenRepository() throws IOException {
         final File projectDir = getProjectDir("elasticsearch.build");
         FileUtils.copyDirectory(projectDir, tmpDir.getRoot(), pathname -> pathname.getPath().contains("/build/") == false);
         final List<String> buildGradleLines =

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/BuildPluginIT.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/BuildPluginIT.java
@@ -76,7 +76,7 @@ public class BuildPluginIT extends GradleIntegrationTestCase {
         // add an insecure ivy repository to the build.gradle
         final List<String> lines = Arrays.asList(
             "repositories {",
-            "  maven {",
+            "  ivy {",
             "    name \"elastic-ivy\"",
             "    url \"" +  url + "\"\n",
             "  }",

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/BuildPluginIT.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/BuildPluginIT.java
@@ -56,12 +56,12 @@ public class BuildPluginIT extends GradleIntegrationTestCase {
         assertTaskSuccessful(result, ":check");
     }
 
-    public void testInsecureMavenRepository() throws IOException {
+    public void testInsecureArtifactRepository() throws IOException {
         final File projectDir = getProjectDir("elasticsearch.build");
         FileUtils.copyDirectory(projectDir, tmpDir.getRoot(), pathname -> pathname.getPath().contains("/build/") == false);
         final List<String> buildGradleLines =
             Files.readAllLines(tmpDir.getRoot().toPath().resolve("build.gradle"), StandardCharsets.UTF_8);
-        // add an insecure repository to the build.gradle
+        // add an insecure artifact repository to the build.gradle
         final String url = "http://s3.amazonaws.com/artifacts.elastic.co/maven";
         buildGradleLines.addAll(Arrays.asList(
             "repositories {",


### PR DESCRIPTION
Since credentials are required to access such a repository, and these repositories are accessed over an encrypted protocol (https), this commit adds support to consider S3-backed artifact repositories as secure. Additionally, we add tests for this functionality.

Closes #42732