### PR TITLE
Partly revert globalInfo.ready check

### DIFF
--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -80,8 +80,7 @@ task bwcTest {
 
 task copyTestNodeKeyMaterial(type: Copy) {
     from project(':x-pack:plugin:core').files('src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.pem',
-            'src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt',
-            'src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.jks')
+            'src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt')
     into outputDir
 }
 
@@ -116,21 +115,15 @@ for (Version version : bwcVersions.indexCompatible) {
 
         setting 'xpack.security.enabled', 'true'
         setting 'xpack.security.transport.ssl.enabled', 'true'
-        rootProject.globalInfo.ready {
-            if (project.inFipsJvm) {
-                setting 'xpack.security.transport.ssl.key', 'testnode.pem'
-                setting 'xpack.security.transport.ssl.certificate', 'testnode.crt'
-                keystoreSetting 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
-            } else {
-                setting 'xpack.security.transport.ssl.keystore.path', 'testnode.jks'
-                setting 'xpack.security.transport.ssl.keystore.password', 'testnode'
-            }
-        }
+
+        setting 'xpack.security.transport.ssl.key', 'testnode.pem'
+        setting 'xpack.security.transport.ssl.certificate', 'testnode.crt'
+        keystoreSetting 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
+
         setting 'xpack.license.self_generated.type', 'trial'
         dependsOn copyTestNodeKeyMaterial
         extraConfigFile 'testnode.pem', new File(outputDir + '/testnode.pem')
         extraConfigFile 'testnode.crt', new File(outputDir + '/testnode.crt')
-        extraConfigFile 'testnode.jks', new File(outputDir + '/testnode.jks')
 
         keystoreFile 'xpack.watcher.encryption_key', "${project.projectDir}/src/test/resources/system_key"
         setting 'xpack.watcher.encrypt_sensitive_data', 'true'
@@ -162,19 +155,13 @@ for (Version version : bwcVersions.indexCompatible) {
         // some tests rely on the translog not being flushed
         setting 'indices.memory.shard_inactive_time', '20m'
         setting 'xpack.security.enabled', 'true'
-        rootProject.globalInfo.ready {
-            if (project.inFipsJvm) {
-                setting 'xpack.security.transport.ssl.key', 'testnode.pem'
-                setting 'xpack.security.transport.ssl.certificate', 'testnode.crt'
-                keystoreSetting 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
-            } else {
-                setting 'xpack.security.transport.ssl.keystore.path', 'testnode.jks'
-                setting 'xpack.security.transport.ssl.keystore.password', 'testnode'
-            }
-        }
+
+        setting 'xpack.security.transport.ssl.key', 'testnode.pem'
+        setting 'xpack.security.transport.ssl.certificate', 'testnode.crt'
+        keystoreSetting 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
+
         setting 'xpack.license.self_generated.type', 'trial'
         dependsOn copyTestNodeKeyMaterial
-        extraConfigFile 'testnode.jks', new File(outputDir + '/testnode.jks')
         extraConfigFile 'testnode.pem', new File(outputDir + '/testnode.pem')
         extraConfigFile 'testnode.crt', new File(outputDir + '/testnode.crt')
 

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -83,8 +83,7 @@ task bwcTest {
 
 task copyTestNodeKeyMaterial(type: Copy) {
     from project(':x-pack:plugin:core').files('src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.pem',
-            'src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt',
-            'src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.jks')
+            'src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt')
     into outputDir
 }
 
@@ -122,18 +121,11 @@ for (Version version : bwcVersions.wireCompatible) {
         setting 'xpack.security.authc.token.enabled', 'true'
         setting 'xpack.security.authc.token.timeout', '60m'
         setting 'xpack.security.audit.enabled', 'true'
-        rootProject.globalInfo.ready {
-            if (project.inFipsJvm) {
-                setting 'xpack.security.transport.ssl.key', 'testnode.pem'
-                setting 'xpack.security.transport.ssl.certificate', 'testnode.crt'
-                keystoreSetting 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
-            } else {
-                setting 'xpack.security.transport.ssl.keystore.path', 'testnode.jks'
-                setting 'xpack.security.transport.ssl.keystore.password', 'testnode'
-            }
-        }
+        setting 'xpack.security.transport.ssl.key', 'testnode.pem'
+        setting 'xpack.security.transport.ssl.certificate', 'testnode.crt'
+        keystoreSetting 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
+      
         dependsOn copyTestNodeKeyMaterial
-        extraConfigFile 'testnode.jks', new File(outputDir + '/testnode.jks')
         extraConfigFile 'testnode.pem', new File(outputDir + '/testnode.pem')
         extraConfigFile 'testnode.crt', new File(outputDir + '/testnode.crt')
         if (version.onOrAfter('7.0.0')) {
@@ -188,22 +180,15 @@ for (Version version : bwcVersions.wireCompatible) {
             setting 'xpack.security.enabled', 'true'
             setting 'xpack.security.transport.ssl.enabled', 'true'
             setting 'xpack.security.authc.token.timeout', '60m'
-            rootProject.globalInfo.ready {
-                if (project.inFipsJvm) {
-                    setting 'xpack.security.transport.ssl.key', 'testnode.pem'
-                    setting 'xpack.security.transport.ssl.certificate', 'testnode.crt'
-                    keystoreSetting 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
-                } else {
-                    setting 'xpack.security.transport.ssl.keystore.path', 'testnode.jks'
-                    setting 'xpack.security.transport.ssl.keystore.password', 'testnode'
-                }
-            }
+            setting 'xpack.security.transport.ssl.key', 'testnode.pem'
+            setting 'xpack.security.transport.ssl.certificate', 'testnode.crt'
+            keystoreSetting 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
+                
             setting 'node.attr.upgraded', 'true'
             setting 'xpack.security.authc.token.enabled', 'true'
             setting 'xpack.security.audit.enabled', 'true'
             setting 'node.name', "upgraded-node-${stopNode}"
             dependsOn copyTestNodeKeyMaterial
-            extraConfigFile 'testnode.jks', new File(outputDir + '/testnode.jks')
             extraConfigFile 'testnode.pem', new File(outputDir + '/testnode.pem')
             extraConfigFile 'testnode.crt', new File(outputDir + '/testnode.crt')
             if (version.onOrAfter('7.0.0')) {


### PR DESCRIPTION
This check was introduced in #41392 but had the unwanted side-effect
that the keystore settings in such blocks would note be added in the
node's keystore. Given that we have a mid-term plan for FIPS testing
that would made such checks unnecessary, and that the conditional
in these two cases is not really that important, this change removes
this conditional logic so that full-cluster-restart and rolling
upgrade tests will run with PEM files for key/certificate material
no matter if we're in a FIPS JVM or not.

Resolves: #45475