### PR TITLE
Remove version parameter from Update API doc

### DIFF
--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -333,19 +333,6 @@ Allows to control if and how the updated source should be returned in the respon
 By default the updated source is not returned.
 See <<request-body-search-source-filtering, Source filtering>> for details.
 
-
-`version`::
-
-The update API uses the Elasticsearch versioning support internally to make
-sure the document doesn't change during the update. You can use the `version`
-parameter to specify that the document should only be updated if its version
-matches the one specified.
-+
-NOTE: Update only supports `internal` versioning. External version types 
-(`external` and `external_gte`) or forced versioning are not supported, as it
-would result in Elasticsearch version numbers being out of sync with the 
-external system.  Use the <<docs-index_,`index` API>> instead.
-
 `if_seq_no` and `if_primary_term`::
 
 Update operations can be made conditional and only performed if the last


### PR DESCRIPTION
This PR fixes #45961 docs issue removing the `version` parameter in the documentation page. See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html#_parameters_15

**Note:** This PR should be merged also for 7.2, 7.1 and 7.0 branches, since the `version` parameter is not available since 7.0. ([see API spec](https://github.com/elastic/elasticsearch/blob/v7.0.0/rest-api-spec/src/main/resources/rest-api-spec/api/update.json)).