### PR TITLE
Remove stack trace logging in Security(Transport|Http)ExceptionHandler

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/transport/SecurityTransportExceptionHandler.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/transport/SecurityTransportExceptionHandler.java
@@ -6,7 +6,6 @@
 package org.elasticsearch.xpack.core.security.transport;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.network.CloseableChannel;
 import org.elasticsearch.transport.TcpChannel;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/transport/SecurityTransportExceptionHandler.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/transport/SecurityTransportExceptionHandler.java
@@ -33,18 +33,10 @@ public final class SecurityTransportExceptionHandler implements BiConsumer<TcpCh
             logger.warn("received plaintext traffic on an encrypted channel, closing connection {}", channel);
             CloseableChannel.closeChannel(channel);
         } else if (SSLExceptionHelper.isCloseDuringHandshakeException(e)) {
-            if (logger.isTraceEnabled()) {
-                logger.trace(new ParameterizedMessage("connection {} closed during ssl handshake", channel), e);
-            } else {
-                logger.debug("connection {} closed during handshake", channel);
-            }
+            logger.debug("connection {} closed during handshake", channel);
             CloseableChannel.closeChannel(channel);
         } else if (SSLExceptionHelper.isReceivedCertificateUnknownException(e)) {
-            if (logger.isTraceEnabled()) {
-                logger.trace(new ParameterizedMessage("client did not trust server's certificate, closing connection {}", channel), e);
-            } else {
-                logger.warn("client did not trust this server's certificate, closing connection {}", channel);
-            }
+            logger.warn("client did not trust this server's certificate, closing connection {}", channel);
             CloseableChannel.closeChannel(channel);
         } else {
             fallback.accept(channel, e);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityHttpExceptionHandler.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityHttpExceptionHandler.java
@@ -35,27 +35,13 @@ public final class SecurityHttpExceptionHandler implements BiConsumer<HttpChanne
         }
 
         if (isNotSslRecordException(e)) {
-            if (logger.isTraceEnabled()) {
-                logger.trace(new ParameterizedMessage("received plaintext http traffic on an https channel, closing connection {}",
-                    channel), e);
-            } else {
-                logger.warn("received plaintext http traffic on an https channel, closing connection {}", channel);
-            }
+            logger.warn("received plaintext http traffic on an https channel, closing connection {}", channel);
             CloseableChannel.closeChannel(channel);
         } else if (isCloseDuringHandshakeException(e)) {
-            if (logger.isTraceEnabled()) {
-                logger.trace(new ParameterizedMessage("connection {} closed during ssl handshake", channel), e);
-            } else {
-                logger.debug("connection {} closed during ssl handshake", channel);
-            }
+            logger.debug("connection {} closed during ssl handshake", channel);
             CloseableChannel.closeChannel(channel);
         } else if (isReceivedCertificateUnknownException(e)) {
-            if (logger.isTraceEnabled()) {
-                logger.trace(new ParameterizedMessage("http client did not trust server's certificate, closing connection {}",
-                    channel), e);
-            } else {
-                logger.warn("http client did not trust this server's certificate, closing connection {}", channel);
-            }
+            logger.warn("http client did not trust this server's certificate, closing connection {}", channel);
             CloseableChannel.closeChannel(channel);
         } else {
             fallback.accept(channel, e);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityHttpExceptionHandler.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityHttpExceptionHandler.java
@@ -6,7 +6,6 @@
 package org.elasticsearch.xpack.security.transport;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.network.CloseableChannel;
 import org.elasticsearch.http.HttpChannel;


### PR DESCRIPTION
As per https://github.com/elastic/elasticsearch/pull/45852#discussion_r316994896 we no longer need to log stack-traces in SecurityTransportExceptionHandler and SecurityHttpExceptionHandler even if trace logging is enabled.