### PR TITLE
Enhance logging when no client TLS certificate is provided

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/transport/SSLExceptionHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/transport/SSLExceptionHelper.java
@@ -10,6 +10,7 @@ import io.netty.handler.codec.DecoderException;
 import io.netty.handler.ssl.NotSslRecordException;
 
 import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLHandshakeException;
 
 public class SSLExceptionHelper {
 
@@ -17,8 +18,8 @@ public class SSLExceptionHelper {
     }
 
     public static boolean isNotSslRecordException(Throwable e) {
-        return e instanceof DecoderException &&
-                e.getCause() instanceof NotSslRecordException;
+        return e instanceof DecoderException
+                && e.getCause() instanceof NotSslRecordException;
     }
 
     public static boolean isCloseDuringHandshakeException(Throwable e) {
@@ -31,5 +32,11 @@ public class SSLExceptionHelper {
         return e instanceof DecoderException
                 && e.getCause() instanceof SSLException
                 && "Received fatal alert: certificate_unknown".equals(e.getCause().getMessage());
+    }
+
+    public static boolean isNoCertificateException(Throwable e) {
+        return e instanceof DecoderException
+                && e.getCause() instanceof SSLHandshakeException
+                && "null cert chain".equals(e.getCause().getMessage());
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/transport/SecurityTransportExceptionHandler.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/transport/SecurityTransportExceptionHandler.java
@@ -13,6 +13,8 @@ import org.elasticsearch.transport.TcpChannel;
 
 import java.util.function.BiConsumer;
 
+import static org.elasticsearch.xpack.core.security.transport.SSLExceptionHelper.isNoCertificateException;
+
 public final class SecurityTransportExceptionHandler implements BiConsumer<TcpChannel, Exception> {
 
     private final Lifecycle lifecycle;
@@ -45,6 +47,9 @@ public final class SecurityTransportExceptionHandler implements BiConsumer<TcpCh
             } else {
                 logger.warn("client did not trust this server's certificate, closing connection {}", channel);
             }
+            CloseableChannel.closeChannel(channel);
+        }  else if (isNoCertificateException(e)) {
+            logger.warn("client did not provide client certificate, closing connection {}", channel);
             CloseableChannel.closeChannel(channel);
         } else {
             fallback.accept(channel, e);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityHttpExceptionHandler.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityHttpExceptionHandler.java
@@ -14,6 +14,7 @@ import org.elasticsearch.http.HttpChannel;
 import java.util.function.BiConsumer;
 
 import static org.elasticsearch.xpack.core.security.transport.SSLExceptionHelper.isCloseDuringHandshakeException;
+import static org.elasticsearch.xpack.core.security.transport.SSLExceptionHelper.isNoCertificateException;
 import static org.elasticsearch.xpack.core.security.transport.SSLExceptionHelper.isNotSslRecordException;
 import static org.elasticsearch.xpack.core.security.transport.SSLExceptionHelper.isReceivedCertificateUnknownException;
 
@@ -56,6 +57,9 @@ public final class SecurityHttpExceptionHandler implements BiConsumer<HttpChanne
             } else {
                 logger.warn("http client did not trust this server's certificate, closing connection {}", channel);
             }
+            CloseableChannel.closeChannel(channel);
+        } else if (isNoCertificateException(e)) {
+            logger.warn("http client did not provide client certificate, closing connection {}", channel);
             CloseableChannel.closeChannel(channel);
         } else {
             fallback.accept(channel, e);


### PR DESCRIPTION
Currently we don't have specific handling for the case when no TLS certificate is provided (for both transport and HTTP) and the following error message along with stack trace is logged:
```
[2018-08-07T13:02:34,247][WARN ][o.e.x.s.t.n.SecurityNetty4ServerTransport] [node01] exception caught on transport layer [NettyTcpChannel{localAddress=0.0.0.0/0.0.0.0:9300, remoteAddress=/0:0:0:0:0:0:0:1:56158}], closing connection
io.netty.handler.codec.DecoderException: javax.net.ssl.SSLHandshakeException: null cert chain
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:459) ~[netty-codec-4.1.16.Final.jar:4.1.16.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:265) ~[netty-codec-4.1.16.Final.jar:4.1.16.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [netty-transport-4.1.16.Final.jar:4.1.16.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [netty-transport-4.1.16.Final.jar:4.1.16.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) [netty-transport-4.1.16.Final.jar:4.1.16.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1359) [netty-transport-4.1.16.Final.jar:4.1.16.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [netty-transport-4.1.16.Final.jar:4.1.16.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [netty-transport-4.1.16.Final.jar:4.1.16.Final]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:935) [netty-transport-4.1.16.Final.jar:4.1.16.Final]
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:134) [netty-transport-4.1.16.Final.jar:4.1.16.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:645) [netty-transport-4.1.16.Final.jar:4.1.16.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysPlain(NioEventLoop.java:545) [netty-transport-4.1.16.Final.jar:4.1.16.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:499) [netty-transport-4.1.16.Final.jar:4.1.16.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:459) [netty-transport-4.1.16.Final.jar:4.1.16.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:858) [netty-common-4.1.16.Final.jar:4.1.16.Final]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_172]
Caused by: javax.net.ssl.SSLHandshakeException: null cert chain
	at sun.security.ssl.Handshaker.checkThrown(Handshaker.java:1529) ~[?:?]
	at sun.security.ssl.SSLEngineImpl.checkTaskThrown(SSLEngineImpl.java:535) ~[?:?]
	at sun.security.ssl.SSLEngineImpl.readNetRecord(SSLEngineImpl.java:813) ~[?:?]
	at sun.security.ssl.SSLEngineImpl.unwrap(SSLEngineImpl.java:781) ~[?:?]
	at javax.net.ssl.SSLEngine.unwrap(SSLEngine.java:624) ~[?:1.8.0_172]
	at io.netty.handler.ssl.SslHandler$SslEngineType$3.unwrap(SslHandler.java:281) ~[?:?]
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1215) ~[?:?]
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1127) ~[?:?]
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1162) ~[?:?]
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:489) ~[?:?]
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:428) ~[?:?]
	... 15 more
Caused by: javax.net.ssl.SSLHandshakeException: null cert chain
	at sun.security.ssl.Alerts.getSSLException(Alerts.java:192) ~[?:?]
	at sun.security.ssl.SSLEngineImpl.fatal(SSLEngineImpl.java:1666) ~[?:?]
	at sun.security.ssl.Handshaker.fatalSE(Handshaker.java:330) ~[?:?]
	at sun.security.ssl.Handshaker.fatalSE(Handshaker.java:318) ~[?:?]
	at sun.security.ssl.ServerHandshaker.clientCertificate(ServerHandshaker.java:1935) ~[?:?]
	at sun.security.ssl.ServerHandshaker.processMessage(ServerHandshaker.java:237) ~[?:?]
	at sun.security.ssl.Handshaker.processLoop(Handshaker.java:1052) ~[?:?]
	at sun.security.ssl.Handshaker$1.run(Handshaker.java:992) ~[?:?]
	at sun.security.ssl.Handshaker$1.run(Handshaker.java:989) ~[?:?]
	at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_172]
	at sun.security.ssl.Handshaker$DelegatedTask.run(Handshaker.java:1467) ~[?:?]
	at io.netty.handler.ssl.SslHandler.runDelegatedTasks(SslHandler.java:1364) ~[?:?]
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1272) ~[?:?]
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1127) ~[?:?]
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1162) ~[?:?]
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:489) ~[?:?]
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:428) ~[?:?]
	... 15 more
```
This PR condenses logging into one line
For transport client
```
client did not provide client certificate, closing connection
```
For HTTP client
```
http client did not provide client certificate, closing connection
```
Relates #32688 (case 2)