### PR TITLE
[TEST] wait for http channels to be closed in ESIntegTestCase

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -509,7 +509,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
         return testCluster;
     }
 
-    private static void clearClusters() throws IOException {
+    private static void clearClusters() throws Exception {
         if (!clusters.isEmpty()) {
             IOUtils.close(clusters.values());
             clusters.clear();
@@ -518,9 +518,9 @@ public abstract class ESIntegTestCase extends ESTestCase {
             restClient.close();
             restClient = null;
         }
-        assertEquals(HttpChannelTaskHandler.INSTANCE.getNumChannels() + " channels still being tracked in " +
-            HttpChannelTaskHandler.class.getSimpleName() + " while there should be none", 0,
-            HttpChannelTaskHandler.INSTANCE.getNumChannels());
+        assertBusy(() -> assertEquals(HttpChannelTaskHandler.INSTANCE.getNumChannels() + " channels still being tracked in " +
+                    HttpChannelTaskHandler.class.getSimpleName() + " while there should be none", 0,
+                HttpChannelTaskHandler.INSTANCE.getNumChannels()));
     }
 
     private void afterInternal(boolean afterClass) throws Exception {


### PR DESCRIPTION
We recently added a check to `ESIntegTestCase` in order to verify that
no http channels are being tracked when we close clusters and the
REST client. Close listeners though are invoked asynchronously, hence
this check may fail if we assert before the close listener that removes
the channel from the map is invoked.

With this commit we add an `assertBusy` so we try and wait for the map
to be empty.

Closes #45914
Closes #45955