### PR TITLE
[7.x] [ML] add supported types to no fields error message (#45926)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetector.java
@@ -84,7 +84,9 @@ public class ExtractedFieldsDetector {
         checkRequiredFieldsArePresent(fields);
 
         if (fields.isEmpty()) {
-            throw ExceptionsHelper.badRequestException("No compatible fields could be detected in index {}", Arrays.toString(index));
+            throw ExceptionsHelper.badRequestException("No compatible fields could be detected in index {}. Supported types are {}.",
+                Arrays.toString(index),
+                getSupportedTypes());
         }
 
         List<String> sortedFields = new ArrayList<>(fields);
@@ -143,12 +145,20 @@ public class ExtractedFieldsDetector {
                 } else if (config.getAnalysis().supportsCategoricalFields() && CATEGORICAL_TYPES.containsAll(fieldTypes)) {
                     LOGGER.debug("[{}] field [{}] is compatible as it is categorical", config.getId(), field);
                 } else {
-                    LOGGER.debug("[{}] Removing field [{}] because its types are not supported; types {}",
-                        config.getId(), field, fieldTypes);
+                    LOGGER.debug("[{}] Removing field [{}] because its types are not supported; types {}; supported {}",
+                        config.getId(), field, fieldTypes, getSupportedTypes());
                     fieldsIterator.remove();
                 }
             }
         }
+    }
+
+    private Set<String> getSupportedTypes() {
+        Set<String> supportedTypes = new HashSet<>(NUMERICAL_TYPES);
+        if (config.getAnalysis().supportsCategoricalFields()) {
+            supportedTypes.addAll(CATEGORICAL_TYPES);
+        }
+        return supportedTypes;
     }
 
     private void includeAndExcludeFields(Set<String> fields) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorTests.java
@@ -75,7 +75,8 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
             SOURCE_INDEX, buildOutlierDetectionConfig(), RESULTS_FIELD, false, 100, fieldCapabilities);
         ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class, () -> extractedFieldsDetector.detect());
 
-        assertThat(e.getMessage(), equalTo("No compatible fields could be detected in index [source_index]"));
+        assertThat(e.getMessage(), equalTo("No compatible fields could be detected in index [source_index]." +
+            " Supported types are [scaled_float, double, byte, short, half_float, integer, float, long]."));
     }
 
     public void testDetect_GivenOutlierDetectionAndFieldWithNumericAndNonNumericTypes() {
@@ -86,7 +87,8 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
             SOURCE_INDEX, buildOutlierDetectionConfig(), RESULTS_FIELD, false, 100, fieldCapabilities);
         ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class, () -> extractedFieldsDetector.detect());
 
-        assertThat(e.getMessage(), equalTo("No compatible fields could be detected in index [source_index]"));
+        assertThat(e.getMessage(), equalTo("No compatible fields could be detected in index [source_index]. " +
+            "Supported types are [scaled_float, double, byte, short, half_float, integer, float, long]."));
     }
 
     public void testDetect_GivenOutlierDetectionAndMultipleFields() {
@@ -150,7 +152,8 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
             SOURCE_INDEX, buildOutlierDetectionConfig(), RESULTS_FIELD, false, 100, fieldCapabilities);
         ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class, () -> extractedFieldsDetector.detect());
 
-        assertThat(e.getMessage(), equalTo("No compatible fields could be detected in index [source_index]"));
+        assertThat(e.getMessage(), equalTo("No compatible fields could be detected in index [source_index]. " +
+            "Supported types are [scaled_float, double, byte, short, half_float, integer, float, long]."));
     }
 
     public void testDetect_ShouldSortFieldsAlphabetically() {
@@ -203,7 +206,8 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             SOURCE_INDEX, buildOutlierDetectionConfig(desiredFields), RESULTS_FIELD, false, 100, fieldCapabilities);
         ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class, () -> extractedFieldsDetector.detect());
-        assertThat(e.getMessage(), equalTo("No compatible fields could be detected in index [source_index]"));
+        assertThat(e.getMessage(), equalTo("No compatible fields could be detected in index [source_index]. " +
+            "Supported types are [scaled_float, double, byte, short, half_float, integer, float, long]."));
     }
 
     public void testDetectedExtractedFields_GivenInclusionsAndExclusions() {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] add supported types to no fields error message  (#45926)