### PR TITLE
Validate SLM policy ids strictly

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicy.java
@@ -128,11 +128,9 @@ public class SnapshotLifecyclePolicy extends AbstractDiffable<SnapshotLifecycleP
         ActionRequestValidationException err = new ActionRequestValidationException();
 
         // ID validation
-        if (id.contains(",")) {
-            err.addValidationError("invalid policy id [" + id + "]: must not contain ','");
-        }
-        if (id.contains(" ")) {
-            err.addValidationError("invalid policy id [" + id + "]: must not contain spaces");
+        if (Strings.validFileName(id) == false) {
+            err.addValidationError("invalid policy id [" + id + "]: must not contain the following characters " +
+                Strings.INVALID_FILENAME_CHARS);
         }
         if (id.charAt(0) == '_') {
             err.addValidationError("invalid policy id [" + id + "]: must not start with '_'");

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecyclePolicyTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecyclePolicyTests.java
@@ -56,7 +56,8 @@ public class SnapshotLifecyclePolicyTests extends AbstractSerializingTestCase<Sn
 
         ValidationException e = policy.validate();
         assertThat(e.validationErrors(),
-            containsInAnyOrder("invalid policy id [a,b]: must not contain ','",
+            containsInAnyOrder(
+                "invalid policy id [a,b]: must not contain the following characters [ , \", *, \\, <, |, ,, >, /, ?]",
                 "invalid snapshot name [<my, snapshot-{now/M}>]: must not contain contain" +
                     " the following characters [ , \", *, \\, <, |, ,, >, /, ?]",
                 "invalid repository name [  ]: cannot be empty",


### PR DESCRIPTION
This uses strict validation for SLM policy ids, similar to what we use
for index names.

Resolves #45997
