### PR TITLE
Don't use assemble task on root project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ import static org.elasticsearch.gradle.tool.Boilerplate.maybeConfigure
 
 plugins {
     id 'com.gradle.build-scan' version '2.4'
-    id 'base'
+    id 'lifecycle-base'
     id 'elasticsearch.global-build-info'
 }
 


### PR DESCRIPTION
The root project uses the base plugin to get a clean task, but does not
actually need the assemble task. This commit changes the root project to
use the lifecycle-base plugin, which while still creating the assemble
task, won't add any dependencies to it.