### PR TITLE
Fix rollover alias in SLM history index template

### DIFF
--- a/x-pack/plugin/core/src/main/resources/slm-history.json
+++ b/x-pack/plugin/core/src/main/resources/slm-history.json
@@ -8,6 +8,7 @@
     "index.number_of_replicas": 0,
     "index.auto_expand_replicas": "0-1",
     "index.lifecycle.name": "slm-history-ilm-policy",
+    "index.lifecycle.rollover_alias": ".slm-history-${xpack.slm.template.version}",
     "index.format": 1
   },
   "mappings": {

--- a/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
@@ -8,6 +8,8 @@ package org.elasticsearch.xpack.ilm;
 
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
@@ -65,6 +67,8 @@ import static org.hamcrest.Matchers.nullValue;
 public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
     private String index;
     private String policy;
+
+    private static final Logger logger = LogManager.getLogger(TimeSeriesLifecycleActionsIT.class);
 
     @Before
     public void refreshIndex() {
@@ -961,7 +965,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         return (Map<String, Object>) response.get("settings");
     }
 
-    private StepKey getStepKeyForIndex(String indexName) throws IOException {
+    public static StepKey getStepKeyForIndex(String indexName) throws IOException {
         Map<String, Object> indexResponse = explainIndex(indexName);
         if (indexResponse == null) {
             return new StepKey(null, null, null);
@@ -988,11 +992,12 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         return ((Map<String, String>) indexResponse.get("step_info")).get("reason");
     }
 
-    private Map<String, Object> explainIndex(String indexName) throws IOException {
+    private static Map<String, Object> explainIndex(String indexName) throws IOException {
         return explain(indexName, false, false).get(indexName);
     }
 
-    private Map<String, Map<String, Object>> explain(String indexPattern, boolean onlyErrors, boolean onlyManaged) throws IOException {
+    private static Map<String, Map<String, Object>> explain(String indexPattern, boolean onlyErrors,
+                                                            boolean onlyManaged) throws IOException {
         Request explainRequest = new Request("GET", indexPattern + "/_ilm/explain");
         explainRequest.addParameter("only_errors", Boolean.toString(onlyErrors));
         explainRequest.addParameter("only_managed", Boolean.toString(onlyManaged));

--- a/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleIT.java
@@ -12,6 +12,7 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.ilm.RolloverAction;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -22,6 +23,8 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.xpack.core.ilm.Step;
+import org.elasticsearch.xpack.core.ilm.WaitForRolloverReadyStep;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecyclePolicy;
 
 import java.io.IOException;
@@ -34,6 +37,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.xpack.core.slm.history.SnapshotHistoryStore.SLM_HISTORY_INDEX_PREFIX;
+import static org.elasticsearch.xpack.ilm.TimeSeriesLifecycleActionsIT.getStepKeyForIndex;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -48,8 +53,10 @@ public class SnapshotLifecycleIT extends ESRestTestCase {
     }
 
     public void testMissingRepo() throws Exception {
-        SnapshotLifecyclePolicy policy = new SnapshotLifecyclePolicy("test-policy", "snap",
-            "*/1 * * * * ?", "missing-repo", Collections.emptyMap());
+        final String policyId = "test-policy";
+        final String missingRepoName = "missing-repo";
+        SnapshotLifecyclePolicy policy = new SnapshotLifecyclePolicy(policyId, "snap",
+            "*/1 * * * * ?", missingRepoName, Collections.emptyMap());
 
         Request putLifecycle = new Request("PUT", "/_slm/policy/test-policy");
         XContentBuilder lifecycleBuilder = JsonXContent.contentBuilder();
@@ -160,6 +167,7 @@ public class SnapshotLifecycleIT extends ESRestTestCase {
                 assertThat(snapshotName, startsWith("snap-"));
             }
             assertHistoryIsPresent(policyName, false, repoName);
+            assertHistoryIndexWaitingForRollover();
         });
     }
 
@@ -319,6 +327,16 @@ public class SnapshotLifecycleIT extends ESRestTestCase {
             logger.error(e);
             fail("failed to perform search:" + e.getMessage());
         }
+
+        // Finally, check that the history index is in a good state
+        assertHistoryIndexWaitingForRollover();
+    }
+
+    private void assertHistoryIndexWaitingForRollover() throws IOException {
+        Step.StepKey stepKey = getStepKeyForIndex(SLM_HISTORY_INDEX_PREFIX + "000001");
+        assertEquals("hot", stepKey.getPhase());
+        assertEquals(RolloverAction.NAME, stepKey.getAction());
+        assertEquals(WaitForRolloverReadyStep.NAME, stepKey.getName());
     }
 
     private void createSnapshotPolicy(String policyName, String snapshotNamePattern, String schedule, String repoId,

--- a/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleIT.java
@@ -167,7 +167,6 @@ public class SnapshotLifecycleIT extends ESRestTestCase {
                 assertThat(snapshotName, startsWith("snap-"));
             }
             assertHistoryIsPresent(policyName, false, repoName);
-            assertHistoryIndexWaitingForRollover();
         });
     }
 


### PR DESCRIPTION
This commit adds the `rollover_alias` setting required for ILM to work
correctly to the SLM history index template and adds assertions to the
SLM integration tests to ensure that it works correctly.

Labelled `>non-issue` as SLM has not yet shipped so this doesn't need to be in the release notes.