### PR TITLE
[DOCS] Add 7.3.1 ml-cpp PRs to release notes

### DIFF
--- a/docs/reference/release-notes/7.3.asciidoc
+++ b/docs/reference/release-notes/7.3.asciidoc
@@ -44,7 +44,8 @@ CRUD::
 * Allow _update on write alias {pull}45318[#45318] (issue: {issue}31520[#31520])
 
 Data Frame::
-* Fix starting a batch data frame after stopping at runtime  {pull}45340[#45340] (issues: {issue}44219[#44219], {issue}45339[#45339])
+* Fix starting a batch {dataframe-transform} after stopping at runtime
+{pull}45340[#45340] (issues: {issue}44219[#44219], {issue}45339[#45339])
 * Fix null aggregation handling in indexer {pull}45061[#45061] (issue: {issue}44906[#44906])
 
 Distributed::
@@ -66,8 +67,8 @@ MULTIPLE AREA LABELS::
 * Sparse role queries can throw an NPE {pull}45053[#45053]
 
 Machine Learning::
-* Check dest index is empty when starting DF analytics {pull}45094[#45094]
-* Catch any error thrown while closing data frame analytics process {pull}44958[#44958]
+* Check dest index is empty when starting {dfanalytics} {pull}45094[#45094]
+* Catch any error thrown while closing {dfanalytics} process {pull}44958[#44958]
 * Only trap the case where more rows are supplied to outlier detection than
 expected. Previously, if rows were excluded from the {dataframe-transform} after supplying the row count in the configuration, we detected the inconsistency and
 failed outlier detection. However, this situation legitimately happens in cases

--- a/docs/reference/release-notes/7.3.asciidoc
+++ b/docs/reference/release-notes/7.3.asciidoc
@@ -17,7 +17,7 @@ Infra/Settings::
 * Normalize environment paths {pull}45179[#45179] (issue: {issue}45176[#45176])
 
 Machine Learning::
-* Outlier detection should only fetch docs that have the analyzed fields{pull}44944[#44944]
+* Outlier detection should only fetch docs that have the analyzed fields {pull}44944[#44944]
 
 SQL::
 * Remove deprecated use of "interval" from date_histogram usage {pull}45501[#45501] (issue: {issue}43922[#43922])
@@ -68,6 +68,10 @@ MULTIPLE AREA LABELS::
 Machine Learning::
 * Check dest index is empty when starting DF analytics {pull}45094[#45094]
 * Catch any error thrown while closing data frame analytics process {pull}44958[#44958]
+* Only trap the case where more rows are supplied to outlier detection than
+expected. Previously, if rows were excluded from the {dataframe-transform} after supplying the row count in the configuration, we detected the inconsistency and
+failed outlier detection. However, this situation legitimately happens in cases
+where the field values are non-numeric or array valued. {ml-pull}569[#569]
 
 Mapping::
 * Make sure to validate the type before attempting to merge a new mapping. {pull}45157[#45157] (issues: {issue}29316[#29316], {issue}43012[#43012])


### PR DESCRIPTION
Related to https://github.com/elastic/docs/issues/1073

This PR updates the 7.3.1 Elasticsearch Release Notes to include the PRs from https://github.com/elastic/ml-cpp/blob/7.3/docs/CHANGELOG.asciidoc

It also updates some ML PR descriptions to use attributes in case the terminology changes in the near future.