### PR TITLE
[DOCS] [7.0] Add upgrade matrix to docs

### DIFF
--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -17,27 +17,28 @@ The following table shows the recommended upgrade paths to {version}.
 |Upgrade from   
 |Recommended upgrade path  to {version}
 
-|5.0–5.5
-a|
-
-. <<rolling-upgrades,Rolling upgrade>> to 5.6
-. Rolling upgrade to 6.7
-. Rolling upgrade to {version}
-
-|5.6
-a|
-
-. <<rolling-upgrades,Rolling upgrade>> to 6.7
-. Rolling upgrade to {version}
+|6.7
+|<<rolling-upgrades,Rolling upgrade>> to {version}
 
 |6.0–6.6
 a|
 
-. <<rolling-upgrades,Rolling upgrade>> to 6.7
-. Rolling upgrade to {version}
+. https://www.elastic.co/guide/en/elasticsearch/reference/6.7/rolling-upgrades.html[Rolling upgrade] to 6.7
+. <<rolling-upgrades,Rolling upgrade>> to {version}
 
-|6.7
-|<<rolling-upgrades,Rolling upgrade>> to {version}
+|5.6
+a|
+
+. https://www.elastic.co/guide/en/elasticsearch/reference/6.7/rolling-upgrades.html[Rolling upgrade] to 6.7
+. <<rolling-upgrades,Rolling upgrade>> to {version}
+
+|5.0–5.5
+a|
+
+. https://www.elastic.co/guide/en/elasticsearch/reference/5.6/rolling-upgrades.html[Rolling upgrade] to 5.6
+. https://www.elastic.co/guide/en/elasticsearch/reference/6.7/rolling-upgrades.html[Rolling upgrade] to 6.7
+. <<rolling-upgrades,Rolling upgrade>> to {version}
+
 |====
 
 [WARNING]
@@ -45,6 +46,9 @@ a|
 The following upgrade paths are *not* supported:
 
 * 6.8 to {version}.
+
+Instead, perform a rolling upgrade from 6.8 directly to 7.1.
+See https://www.elastic.co/guide/en/elasticsearch/reference/7.1/rolling-upgrades.html[7.1 Rolling upgrades].
 ====
 
 {es} can read indices created in the previous major version. If you

--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -10,6 +10,43 @@ process so upgrading does not interrupt service. Rolling upgrades are supported:
 * From 5.6 to 6.7
 * From 6.7 to {version}
 
+The following table shows the recommended upgrade paths to {version}.
+
+[cols="<1m,3",options="header"]
+|====
+|Upgrade from   
+|Recommended upgrade path  to {version}
+
+|5.0–5.5
+a|
+
+. <<rolling-upgrades,Rolling upgrade>> to 5.6
+. Rolling upgrade to 6.7
+. Rolling upgrade to {version}
+
+|5.6
+a|
+
+. <<rolling-upgrades,Rolling upgrade>> to 6.7
+. Rolling upgrade to {version}
+
+|6.0–6.6
+a|
+
+. <<rolling-upgrades,Rolling upgrade>> to 6.7
+. Rolling upgrade to {version}
+
+|6.7
+|<<rolling-upgrades,Rolling upgrade>> to {version}
+|====
+
+[WARNING]
+====
+The following upgrade paths are *not* supported:
+
+* 6.8 to {version}.
+====
+
 {es} can read indices created in the previous major version. If you
 have indices created in 5.x or before, you must reindex or delete them
 before upgrading to {version}. {es} nodes will fail to start if


### PR DESCRIPTION
Adds an upgrade support matrix, similar to those in [6.x docs](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/setup-upgrade.html#setup-upgrade).

Backport of #45790.