### PR TITLE
[DOCS] [8.0] Add upgrade matrix to docs

### DIFF
--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -8,7 +8,63 @@ process so upgrading does not interrupt service. Rolling upgrades are supported:
 
 * Between minor versions
 * From 5.6 to 6.8
-* From 6.8 to {version}
+* From 6.8 to {prev-major-version}
+* From {prev-major-version} to {version}
+
+
+The following table shows the recommended upgrade paths to {version}.
+
+[cols="<1m,3",options="header",]
+|====
+|Upgrade from   
+|Recommended upgrade path  to {version}
+
+|5.0–5.5
+a|
+
+. <<rolling-upgrades,Rolling upgrade>> to 5.6
+. Rolling upgrade to 6.8
+. Rolling upgrade to {prev-major-version}
+. Rolling upgrade to {version}
+
+|5.6
+a|
+
+. <<rolling-upgrades,Rolling upgrade>> to 6.8
+. Rolling upgrade to {prev-major-version}
+. Rolling upgrade to {version}
+
+|6.0–6.7
+a|
+
+. <<rolling-upgrades,Rolling upgrade>> to 6.8
+. Rolling upgrade to {prev-major-version}
+. Rolling upgrade to {version}
+
+|6.8
+a|
+. <<rolling-upgrades,Rolling upgrade>> to {prev-major-version}
+. Rolling upgrade to {version}
+
+|7.0–7.3
+a|
+. <<rolling-upgrades,Rolling upgrade>> to {prev-major-version}
+. Rolling upgrade to {version}
+. Rolling upgrade to {version}
+
+|{prev-major-version}
+|<<rolling-upgrades,Rolling upgrade>> to {version}
+
+|====
+
+
+[WARNING]
+====
+The following upgrade paths are *not* supported:
+
+* 6.8 to 7.0.
+* 6.7 to 7.1.–{prev-major-version}.
+====
 
 {es} can read indices created in the previous major version. If you
 have indices created in 5.x or before, you must reindex or delete them

--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -19,42 +19,25 @@ The following table shows the recommended upgrade paths to {version}.
 |Upgrade from   
 |Recommended upgrade path  to {version}
 
-|5.0–5.5
+|{prev-major-version}
+|<<rolling-upgrades,Rolling upgrade>> to {version}
+
+|7.0–7.3
 a|
+. https://www.elastic.co/guide/en/elasticsearch/reference/{prev-major-version}/rolling-upgrades.html[Rolling upgrade] to {prev-major-version}
+. <<rolling-upgrades,Rolling upgrade>> to {version}
 
-. <<rolling-upgrades,Rolling upgrade>> to 5.6
-. Rolling upgrade to 6.8
-. Rolling upgrade to {prev-major-version}
-. Rolling upgrade to {version}
-
-|5.6
+|6.8
 a|
-
-. <<rolling-upgrades,Rolling upgrade>> to 6.8
-. Rolling upgrade to {prev-major-version}
-. Rolling upgrade to {version}
+. https://www.elastic.co/guide/en/elasticsearch/reference/{prev-major-version}/rolling-upgrades.html[Rolling upgrade] to {prev-major-version}
+. <<rolling-upgrades,Rolling upgrade>> to {version}
 
 |6.0–6.7
 a|
 
-. <<rolling-upgrades,Rolling upgrade>> to 6.8
-. Rolling upgrade to {prev-major-version}
-. Rolling upgrade to {version}
-
-|6.8
-a|
-. <<rolling-upgrades,Rolling upgrade>> to {prev-major-version}
-. Rolling upgrade to {version}
-
-|7.0–7.3
-a|
-. <<rolling-upgrades,Rolling upgrade>> to {prev-major-version}
-. Rolling upgrade to {version}
-. Rolling upgrade to {version}
-
-|{prev-major-version}
-|<<rolling-upgrades,Rolling upgrade>> to {version}
-
+. https://www.elastic.co/guide/en/elasticsearch/reference/6.8/rolling-upgrades.html[Rolling upgrade] to 6.8
+. https://www.elastic.co/guide/en/elasticsearch/reference/{prev-major-version}/rolling-upgrades.html[Rolling upgrade] to {prev-major-version}
+. <<rolling-upgrades,Rolling upgrade>> to {version}
 |====
 
 


### PR DESCRIPTION
Adds an upgrade support matrix, similar to those in [6.x docs](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/setup-upgrade.html#setup-upgrade).

Backport of #45790.

### Preview
http://elasticsearch_46027.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/setup-upgrade.html