### PR TITLE
Polish and format code in consent.css

### DIFF
--- a/x-pack/test/idp-fixture/idp/shibboleth-idp/webapp/css/consent.css
+++ b/x-pack/test/idp-fixture/idp/shibboleth-idp/webapp/css/consent.css
@@ -90,7 +90,7 @@ a:focus, a:hover, a:active {
 
 #attributeRelease table {
     border-collapse: collapse;
-    border: none 0px white;
+    border: none 0 white;
     width: 100%;
 }
 
@@ -103,7 +103,7 @@ a:focus, a:hover, a:active {
     text-align: left;
     font-size: 18px;
     padding: 5px 7px;
-    background-color:#00247D;
+    background-color: #00247D;
     color: white;
 }
 


### PR DESCRIPTION
1. Unit of measure 'px' was redundant, removed unit qualifier;
2. Added a space.