### PR TITLE
[DOCS] Add index alias exists API docs

### DIFF
--- a/docs/reference/indices.asciidoc
+++ b/docs/reference/indices.asciidoc
@@ -33,6 +33,7 @@ index settings, aliases, mappings, and index templates.
 [float]
 [[alias-management]]
 === Alias management:
+* <<indices-alias-exists>>
 * <<indices-aliases>>
 
 [float]
@@ -88,6 +89,8 @@ include::indices/get-mapping.asciidoc[]
 include::indices/get-field-mapping.asciidoc[]
 
 include::indices/types-exists.asciidoc[]
+
+include::indices/alias-exists.asciidoc[]
 
 include::indices/aliases.asciidoc[]
 

--- a/docs/reference/indices/alias-exists.asciidoc
+++ b/docs/reference/indices/alias-exists.asciidoc
@@ -1,0 +1,83 @@
+[[indices-alias-exists]]
+=== Index alias exists API
+++++
+<titleabbrev>Index alias exists</titleabbrev>
+++++
+
+Checks if an index alias exists.
+
+An index alias is a secondary name
+used to refer to one or more existing indices.
+
+The returned HTTP status code indicates whether the index alias exists or not.
+A `404` means it does not exist,
+and `200` means it does.
+
+[source,js]
+----
+HEAD /_alias/alias1
+----
+// CONSOLE
+// TEST[setup:twitter]
+// TEST[s/^/PUT twitter\/_alias\/alias1\n/]
+
+
+[[alias-exists-api-request]]
+==== {api-request-title}
+
+`HEAD /_alias/<alias>`
+
+`HEAD /<index>/_alias/<alias>`
+
+
+[[alias-exists-api-path-params]]
+==== {api-path-parms-title}
+
+`<index>`::
+(Optional, string)
+Comma-separated list
+or wildcard expression of index names
+used to limit the request.
+
+
+`<alias>`::
+(Required, string)
+Comma-separated list
+or wildcard expression of index alias names
+used to limit the request.
+
+[[alias-exists-api-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
++
+Defaults to `all`.
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+
+
+[[alias-exists-api-response-codes]]
+==== {api-response-codes-title}
+
+`200`::
+Indicates all specified index aliases exist.
+
+ `404`::
+Indicates one or more specified index aliases **do not** exist.
+
+
+[[alias-exists-api-example]]
+==== {api-examples-title}
+
+[source,js]
+----
+HEAD /_alias/2030
+HEAD /_alias/20*
+HEAD /logs_20302801/_alias/*
+----
+// CONSOLE
+// TEST[s/^/PUT logs_20302801\nPUT logs_20302801\/_alias\/2030\n/]

--- a/docs/reference/indices/alias-exists.asciidoc
+++ b/docs/reference/indices/alias-exists.asciidoc
@@ -37,15 +37,13 @@ HEAD /_alias/alias1
 
 `<index>`::
 (Optional, string)
-Comma-separated list
-or wildcard expression of index names
+Comma-separated list or wildcard expression of index names
 used to limit the request.
 
 
 `<alias>`::
 (Required, string)
-Comma-separated list
-or wildcard expression of index alias names
+Comma-separated list or wildcard expression of index alias names
 used to limit the request.
 
 [[alias-exists-api-query-params]]

--- a/docs/reference/indices/alias-exists.asciidoc
+++ b/docs/reference/indices/alias-exists.asciidoc
@@ -35,10 +35,7 @@ HEAD /_alias/alias1
 [[alias-exists-api-path-params]]
 ==== {api-path-parms-title}
 
-`<index>`::
-(Optional, string)
-Comma-separated list or wildcard expression of index names
-used to limit the request.
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
 
 
 `<alias>`::

--- a/docs/reference/indices/alias-exists.asciidoc
+++ b/docs/reference/indices/alias-exists.asciidoc
@@ -6,8 +6,10 @@
 
 Checks if an index alias exists.
 
+//tag::index-alias-def[]
 An index alias is a secondary name
 used to refer to one or more existing indices.
+//end::index-alias-def[]
 
 The returned HTTP status code indicates whether the index alias exists or not.
 A `404` means it does not exist,

--- a/docs/reference/indices/alias-exists.asciidoc
+++ b/docs/reference/indices/alias-exists.asciidoc
@@ -35,13 +35,12 @@ HEAD /_alias/alias1
 [[alias-exists-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
-
-
 `<alias>`::
 (Required, string)
 Comma-separated list or wildcard expression of index alias names
 used to limit the request.
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
 
 [[alias-exists-api-query-params]]
 ==== {api-query-parms-title}

--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -575,16 +575,3 @@ Response:
 }
 --------------------------------------------------
 // TESTRESPONSE
-
-There is also a HEAD variant of the get indices aliases api to check if
-index aliases exist. The indices aliases exists api supports the same
-option as the get indices aliases api. Examples:
-
-[source,js]
---------------------------------------------------
-HEAD /_alias/2016
-HEAD /_alias/20*
-HEAD /logs_20162801/_alias/*
---------------------------------------------------
-// CONSOLE
-// TEST[continued]


### PR DESCRIPTION
This PR adds the index alias exists API docs to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc). Removes brief alias exists section from the [update index aliases API docs](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html).

Relates to elastic/docs#937 and #43765