### PR TITLE
 Reindex task state initialized before reindex

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/BulkByScrollParallelizationHelper.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/BulkByScrollParallelizationHelper.java
@@ -68,7 +68,7 @@ class BulkByScrollParallelizationHelper {
         Client client,
         DiscoveryNode node,
         Runnable workerAction) {
-        initTaskState(task, request, client, new ActionListener<>() {
+        initTaskState(task, request, client, new ActionListener<Void>() {
             @Override
             public void onResponse(Void aVoid) {
                 executeSlicedAction(task, request, action, listener, client, node, workerAction);
@@ -125,7 +125,7 @@ class BulkByScrollParallelizationHelper {
         if (configuredSlices == AbstractBulkByScrollRequest.AUTO_SLICES) {
             ClusterSearchShardsRequest shardsRequest = new ClusterSearchShardsRequest();
             shardsRequest.indices(request.getSearchRequest().indices());
-            client.admin().cluster().searchShards(shardsRequest, new ActionListener<>() {
+            client.admin().cluster().searchShards(shardsRequest, new ActionListener<ClusterSearchShardsResponse>() {
                 @Override
                 public void onResponse(ClusterSearchShardsResponse response) {
                     setWorkerCount(request, task, countSlicesBasedOnShards(response));

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/Reindexer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/Reindexer.java
@@ -87,16 +87,19 @@ public class Reindexer {
         this.reindexSslConfig = reindexSslConfig;
     }
 
+    public void initTask(BulkByScrollTask task, ReindexRequest request, ActionListener<Void> listener) {
+        BulkByScrollParallelizationHelper.initTaskState(task, request, client, listener);
+    }
+
     public void execute(BulkByScrollTask task, ReindexRequest request, ActionListener<BulkByScrollResponse> listener) {
-        BulkByScrollParallelizationHelper.startSlicedAction(request, task, ReindexAction.INSTANCE, listener, client,
+        BulkByScrollParallelizationHelper.executeSlicedAction(task, request, ReindexAction.INSTANCE, listener, client,
             clusterService.localNode(),
             () -> {
                 ParentTaskAssigningClient assigningClient = new ParentTaskAssigningClient(client, clusterService.localNode(), task);
                 AsyncIndexBySearchAction searchAction = new AsyncIndexBySearchAction(task, logger, assigningClient, threadPool,
                     scriptService, reindexSslConfig, request, listener);
                 searchAction.start();
-            }
-        );
+            });
 
     }
 

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/TransportReindexAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/TransportReindexAction.java
@@ -60,7 +60,7 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
     protected void doExecute(Task task, ReindexRequest request, ActionListener<BulkByScrollResponse> listener) {
         reindexValidator.initialValidation(request);
         BulkByScrollTask bulkByScrollTask = (BulkByScrollTask) task;
-        reindexer.initTask(bulkByScrollTask, request, new ActionListener<>() {
+        reindexer.initTask(bulkByScrollTask, request, new ActionListener<Void>() {
             @Override
             public void onResponse(Void v) {
                 reindexer.execute(bulkByScrollTask, request, listener);


### PR DESCRIPTION
Currently the process to execute a reindex process is tightly coupled to
step of initializing the task state. This creates problems when this
process is asynchronous. It is possible that the task state has not been
initialized which prevents follow-up actions such as rethrottle. This
commit separates the task initialization so that it can be executed as a
first step in the persistent reindex process.