### PR TITLE
Remove plugins dir reference from docs

### DIFF
--- a/docs/reference/upgrade/set-paths-tip.asciidoc
+++ b/docs/reference/upgrade/set-paths-tip.asciidoc
@@ -2,8 +2,7 @@
 ================================================
 
 When you extract the zip or tarball packages, the `elasticsearch-n.n.n`
-directory contains the {es} `config`, `data`, `logs` and
-`plugins` directories.
+directory contains the {es} `config`, `data`, and `logs` directories.
 
 We recommend moving these directories out of the {es} directory
 so that there is no chance of deleting them when you upgrade {es}.


### PR DESCRIPTION
While the plugin installation directory used to be settable, it has not
been so for several major versions. This commit removes a lingering
reference to the plugins directory in upgrade docs.

closes #45889