### PR TITLE
Always add Java-9 style file permissions

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/FilePermissionUtils.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/FilePermissionUtils.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.SuppressForbidden;
 
 import java.io.FilePermission;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.Permissions;
 
@@ -40,13 +41,15 @@ public class FilePermissionUtils {
     @SuppressForbidden(reason = "only place where creating Java-9 compatible FilePermission objects is possible")
     public static void addSingleFilePath(Permissions policy, Path path, String permissions) throws IOException {
         policy.add(new FilePermission(path.toString(), permissions));
-        /*
-         * The file permission model since JDK 9 requires this due to the removal of pathname canonicalization. See also
-         * https://github.com/elastic/elasticsearch/issues/21534.
-         */
-        final Path realPath = path.toRealPath();
-        if (path.toString().equals(realPath.toString()) == false) {
-            policy.add(new FilePermission(realPath.toString(), permissions));
+        if (Files.exists(path)) {
+            /*
+             * The file permission model since JDK 9 requires this due to the removal of pathname canonicalization. See also
+             * https://github.com/elastic/elasticsearch/issues/21534.
+             */
+            final Path realPath = path.toRealPath();
+            if (path.toString().equals(realPath.toString()) == false) {
+                policy.add(new FilePermission(realPath.toString(), permissions));
+            }
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/bootstrap/FilePermissionUtils.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/FilePermissionUtils.java
@@ -23,7 +23,6 @@ import org.elasticsearch.common.SuppressForbidden;
 
 import java.io.FilePermission;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.Permissions;
 
@@ -31,8 +30,6 @@ public class FilePermissionUtils {
 
     /** no instantiation */
     private FilePermissionUtils() {}
-
-    private static final boolean VERSION_IS_AT_LEAST_JAVA_9 = JavaVersion.current().compareTo(JavaVersion.parse("9")) >= 0;
 
     /**
      * Add access to single file path
@@ -43,13 +40,13 @@ public class FilePermissionUtils {
     @SuppressForbidden(reason = "only place where creating Java-9 compatible FilePermission objects is possible")
     public static void addSingleFilePath(Permissions policy, Path path, String permissions) throws IOException {
         policy.add(new FilePermission(path.toString(), permissions));
-        if (VERSION_IS_AT_LEAST_JAVA_9 && Files.exists(path)) {
-            // Java 9 FilePermission model requires this due to the removal of pathname canonicalization,
-            // see also https://github.com/elastic/elasticsearch/issues/21534
-            Path realPath = path.toRealPath();
-            if (path.toString().equals(realPath.toString()) == false) {
-                policy.add(new FilePermission(realPath.toString(), permissions));
-            }
+        /*
+         * The file permission model since JDK 9 requires this due to the removal of pathname canonicalization. See also
+         * https://github.com/elastic/elasticsearch/issues/21534.
+         */
+        final Path realPath = path.toRealPath();
+        if (path.toString().equals(realPath.toString()) == false) {
+            policy.add(new FilePermission(realPath.toString(), permissions));
         }
     }
 
@@ -73,14 +70,15 @@ public class FilePermissionUtils {
         // add each path twice: once for itself, again for files underneath it
         policy.add(new FilePermission(path.toString(), permissions));
         policy.add(new FilePermission(path.toString() + path.getFileSystem().getSeparator() + "-", permissions));
-        if (VERSION_IS_AT_LEAST_JAVA_9) {
-            // Java 9 FilePermission model requires this due to the removal of pathname canonicalization,
-            // see also https://github.com/elastic/elasticsearch/issues/21534
-            Path realPath = path.toRealPath();
-            if (path.toString().equals(realPath.toString()) == false) {
-                policy.add(new FilePermission(realPath.toString(), permissions));
-                policy.add(new FilePermission(realPath.toString() + realPath.getFileSystem().getSeparator() + "-", permissions));
-            }
+        /*
+         * The file permission model since JDK 9 requires this due to the removal of pathname canonicalization. See also
+         * https://github.com/elastic/elasticsearch/issues/21534.
+         */
+        final Path realPath = path.toRealPath();
+        if (path.toString().equals(realPath.toString()) == false) {
+            policy.add(new FilePermission(realPath.toString(), permissions));
+            policy.add(new FilePermission(realPath.toString() + realPath.getFileSystem().getSeparator() + "-", permissions));
         }
     }
+
 }


### PR DESCRIPTION
Java 9 removed pathname canonicalization, which means that we need to add permissions for the path and also the real path when adding file permissions. Since master requires a minimum runtime of JDK 11, we no longer need conditional logic here to apply this pathname canonicalization with our bares hands. This commit removes that conditional pathname canonicalization.

Relates #21534
Relates #26302