### PR TITLE
Don't Circuit Break Recovery Requests

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
@@ -70,7 +70,7 @@ public class PeerRecoverySourceService implements IndexEventListener {
         this.transportService = transportService;
         this.indicesService = indicesService;
         this.recoverySettings = recoverySettings;
-        transportService.registerRequestHandler(Actions.START_RECOVERY, ThreadPool.Names.GENERIC, StartRecoveryRequest::new,
+        transportService.registerRequestHandler(Actions.START_RECOVERY, ThreadPool.Names.GENERIC, false, false, StartRecoveryRequest::new,
             new StartRecoveryTransportRequestHandler());
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -105,21 +105,22 @@ public class PeerRecoveryTargetService implements IndexEventListener {
         this.clusterService = clusterService;
         this.onGoingRecoveries = new RecoveriesCollection(logger, threadPool);
 
-        transportService.registerRequestHandler(Actions.FILES_INFO, ThreadPool.Names.GENERIC, RecoveryFilesInfoRequest::new,
+        transportService.registerRequestHandler(Actions.FILES_INFO, ThreadPool.Names.GENERIC, false, false, RecoveryFilesInfoRequest::new,
             new FilesInfoRequestHandler());
-        transportService.registerRequestHandler(Actions.FILE_CHUNK, ThreadPool.Names.GENERIC, RecoveryFileChunkRequest::new,
+        transportService.registerRequestHandler(Actions.FILE_CHUNK, ThreadPool.Names.GENERIC, false, false, RecoveryFileChunkRequest::new,
             new FileChunkTransportRequestHandler());
-        transportService.registerRequestHandler(Actions.CLEAN_FILES, ThreadPool.Names.GENERIC,
+        transportService.registerRequestHandler(Actions.CLEAN_FILES, ThreadPool.Names.GENERIC, false, false,
             RecoveryCleanFilesRequest::new, new CleanFilesRequestHandler());
-        transportService.registerRequestHandler(Actions.PREPARE_TRANSLOG, ThreadPool.Names.GENERIC,
+        transportService.registerRequestHandler(Actions.PREPARE_TRANSLOG, ThreadPool.Names.GENERIC, false, false,
                 RecoveryPrepareForTranslogOperationsRequest::new, new PrepareForTranslogOperationsRequestHandler());
-        transportService.registerRequestHandler(Actions.TRANSLOG_OPS, ThreadPool.Names.GENERIC, RecoveryTranslogOperationsRequest::new,
-            new TranslogOperationsRequestHandler());
-        transportService.registerRequestHandler(Actions.FINALIZE, ThreadPool.Names.GENERIC, RecoveryFinalizeRecoveryRequest::new,
-            new FinalizeRecoveryRequestHandler());
+        transportService.registerRequestHandler(Actions.TRANSLOG_OPS, ThreadPool.Names.GENERIC, false, false,
+            RecoveryTranslogOperationsRequest::new, new TranslogOperationsRequestHandler());
+        transportService.registerRequestHandler(Actions.FINALIZE, ThreadPool.Names.GENERIC, false, false,
+            RecoveryFinalizeRecoveryRequest::new, new FinalizeRecoveryRequestHandler());
         transportService.registerRequestHandler(
                 Actions.HANDOFF_PRIMARY_CONTEXT,
                 ThreadPool.Names.GENERIC,
+                false, false,
                 RecoveryHandoffPrimaryContextRequest::new,
                 new HandoffPrimaryContextRequestHandler());
     }


### PR DESCRIPTION
### Problem

Recovery requests are likely to trip the cirucit breaker under heavy load
which might lead to unfortunate side-effects in nodes under pressure.
A node temporarily under high load will be less likely to fail recovery
leading to permanent changes in allocation.
Moreover, the requests sent by the recovery mechanism are all bound in
byte size by design. If they are sent in rapid succession then the memory
used by strong references to them will be bounded but the memory used
by unreferenced objects that resulted from them could heavily fluctuate.
This makes the real-memory circuit breaker's memory use estimation
that does not account for GC particularly inefficient when it comes to
recoveries (#40115).

### Solution

Turn off the circuit breaker for recoveries. Users have other means of
limiting the memory use of recoveries by setting the recovery chunk
size and parallelism. Given the bounded amount of memory used by
recoveries a user can either lower the amount of resources allocated
to recoveries in the settings or adjust the real-memory circuit breaker
limits slightly to account for this change.
I think its a fair assumption that the number of clusters that would
see nodes running out of memory as a result of this change is small.
Also it would be a subset of those clusters that currently see recovery
failures as a result of the circuit breaker and those should be fixed
regardless.

Unfortunately, I don't think we can use the same solution for the
case of replication requests tripping the circuit breaker as those
are not naturally bounded in size.

Relates #44484
Example of the user impact: https://discuss.elastic.co/t/7-0-1-new-circuitbreaker-segment-bigger-than-heap-should-this-break/195455