### PR TITLE
Handle multiple loopback addresses

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -2533,7 +2533,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             assertTrue(profileBoundAddresses.get("some_profile").publishAddress().getPort() < 9000);
             assertTrue(profileBoundAddresses.get("some_other_profile").publishAddress().getPort() >= 8700);
             assertTrue(profileBoundAddresses.get("some_other_profile").publishAddress().getPort() < 8800);
-            assertEquals(profileBoundAddresses.get("some_profile").boundAddresses().length, 1);
+            assertTrue(profileBoundAddresses.get("some_profile").boundAddresses().length >= 1);
             if (doIPV6) {
                 assertTrue(profileBoundAddresses.get("some_other_profile").boundAddresses().length >= 2);
                 int ipv4 = 0;
@@ -2550,7 +2550,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 assertTrue("num ipv4 is wrong: " + ipv4, ipv4 >= 1);
                 assertTrue("num ipv6 is wrong: " + ipv6, ipv6 >= 1);
             } else {
-                assertEquals(profileBoundAddresses.get("some_other_profile").boundAddresses().length, 1);
+                assertTrue(profileBoundAddresses.get("some_other_profile").boundAddresses().length >= 1);
             }
             assertTrue(profileBoundAddresses.get("some_other_profile").publishAddress().address().getAddress() instanceof Inet4Address);
         }


### PR DESCRIPTION
`AbstractSimpleTransportTestCase.testTransportProfilesWithPortAndHost` expects a host to only have a single IPv4 loopback address, which isn't necessarily the case. Allow for >= 1 address.

Backport of #45901.