### PR TITLE
Docs _cat/health verification fix

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -181,7 +181,7 @@ epoch      timestamp cluster       status node.total node.data shards pri relo i
 --------------------------------------------------
 // TESTRESPONSE[s/1565052807 00:53:27  elasticsearch/\\d+ \\d+:\\d+:\\d+ integTest/]
 // TESTRESPONSE[s/3         3      6   3/\\d+         \\d+      \\d+   \\d+/]
-// TESTRESPONSE[s/0             0                  -/0             \\d+                  -/]
+// TESTRESPONSE[s/0             0                  -/0             \\d+                  (-|\\d+(micros|ms|s))/]
 // TESTRESPONSE[non_json]
 +
 NOTE: The cluster status will remain yellow if you are only running a single


### PR DESCRIPTION
The _cat/health call in getting-started assumes that the master task max
wait time is always 0 (-), however, the test could sometimes run into a
short wait time (like some ms). Fixed to allow this.
