### PR TITLE
[ML][Transforms] add CCS capabilities to pivot transforms

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameMessages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameMessages.java
@@ -31,6 +31,10 @@ public class DataFrameMessages {
     public static final String DATA_FRAME_FAILED_TO_PERSIST_STATS = "Failed to persist data frame statistics for transform [{0}]";
     public static final String DATA_FRAME_UNKNOWN_TRANSFORM_STATS = "Statistics for transform [{0}] could not be found";
 
+    public static final String TRANSFORM_NEEDS_REMOTE_CLUSTER_SEARCH = "Transform [{0}] is configured with a remote index pattern(s) {1}" +
+        " but the current node is not allowed to connect to remote clusters." +
+        " Please enable cluster.remote.connect for all data nodes (currently disabled on [{2}]).";
+
     public static final String DATA_FRAME_CANNOT_STOP_FAILED_TRANSFORM =
         "Unable to stop data frame transform [{0}] as it is in a failed state with reason [{1}]." +
             " Use force stop to stop the data frame transform.";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameMessages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/DataFrameMessages.java
@@ -32,8 +32,8 @@ public class DataFrameMessages {
     public static final String DATA_FRAME_UNKNOWN_TRANSFORM_STATS = "Statistics for transform [{0}] could not be found";
 
     public static final String TRANSFORM_NEEDS_REMOTE_CLUSTER_SEARCH = "Transform [{0}] is configured with a remote index pattern(s) {1}" +
-        " but the current node is not allowed to connect to remote clusters." +
-        " Please enable cluster.remote.connect for all data nodes (currently disabled on [{2}]).";
+        " but the current node [{2}] is not allowed to connect to remote clusters." +
+        " Please enable cluster.remote.connect for all data nodes.";
 
     public static final String DATA_FRAME_CANNOT_STOP_FAILED_TRANSFORM =
         "Unable to stop data frame transform [{0}] as it is in a failed state with reason [{1}]." +

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportPutDataFrameTransformAction.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/action/TransportPutDataFrameTransformAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.LicenseUtils;
+import org.elasticsearch.license.RemoteClusterLicenseChecker;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.rest.RestStatus;
@@ -54,6 +55,7 @@ import org.elasticsearch.xpack.dataframe.transforms.pivot.Pivot;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -109,7 +111,10 @@ public class TransportPutDataFrameTransformAction extends TransportMasterNodeAct
             .build();
 
         RoleDescriptor.IndicesPrivileges sourceIndexPrivileges = RoleDescriptor.IndicesPrivileges.builder()
-            .indices(config.getSource().getIndex())
+            // We can only really do permission checks against local indices.
+            .indices(Arrays.stream(config.getSource().getIndex())
+                .filter(i -> RemoteClusterLicenseChecker.isRemoteIndex(i) == false)
+                .toArray(String[]::new))
             .privileges(srcPrivileges)
             .build();
 

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/SourceDestValidator.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/SourceDestValidator.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.license.RemoteClusterLicenseChecker;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.dataframe.DataFrameMessages;
 import org.elasticsearch.xpack.core.dataframe.transforms.DataFrameTransformConfig;
@@ -76,7 +77,8 @@ public final class SourceDestValidator {
                 String[] concreteNames = indexNameExpressionResolver.concreteIndexNames(clusterState,
                     IndicesOptions.lenientExpandOpen(),
                     src);
-                if (concreteNames.length == 0) {
+                // We will not have concrete index data about a remote index
+                if (concreteNames.length == 0 && RemoteClusterLicenseChecker.isRemoteIndex(src) == false) {
                     throw new ElasticsearchStatusException(
                         DataFrameMessages.getMessage(DataFrameMessages.REST_PUT_DATA_FRAME_SOURCE_INDEX_MISSING, src),
                         RestStatus.BAD_REQUEST);

--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/pivot/SchemaUtil.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/pivot/SchemaUtil.java
@@ -9,9 +9,9 @@ package org.elasticsearch.xpack.dataframe.transforms.pivot;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsAction;
-import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsRequest;
-import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse.FieldMappingMetaData;
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesAction;
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
@@ -118,15 +118,16 @@ public final class SchemaUtil {
     public static void getDestinationFieldMappings(final Client client,
                                                    final String index,
                                                    final ActionListener<Map<String, String>> listener) {
-        GetFieldMappingsRequest fieldMappingRequest = new GetFieldMappingsRequest();
-        fieldMappingRequest.indices(index);
-        fieldMappingRequest.fields("*");
+        FieldCapabilitiesRequest fieldCapabilitiesRequest = new FieldCapabilitiesRequest()
+            .indices(index)
+            .fields("*")
+            .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
         ClientHelper.executeAsyncWithOrigin(client,
             ClientHelper.DATA_FRAME_ORIGIN,
-            GetFieldMappingsAction.INSTANCE,
-            fieldMappingRequest,
+            FieldCapabilitiesAction.INSTANCE,
+            fieldCapabilitiesRequest,
             ActionListener.wrap(
-                r -> listener.onResponse(extractFieldMappings(r.mappings())),
+                r -> listener.onResponse(extractFieldMappings(r)),
                 listener::onFailure
             ));
     }
@@ -172,41 +173,24 @@ public final class SchemaUtil {
      */
     private static void getSourceFieldMappings(Client client, String[] index, String[] fields,
             ActionListener<Map<String, String>> listener) {
-        GetFieldMappingsRequest fieldMappingRequest = new GetFieldMappingsRequest();
-        fieldMappingRequest.indices(index);
-        fieldMappingRequest.fields(fields);
-        fieldMappingRequest.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
-
-        client.execute(GetFieldMappingsAction.INSTANCE, fieldMappingRequest, ActionListener.wrap(
-            response -> listener.onResponse(extractFieldMappings(response.mappings())),
+        FieldCapabilitiesRequest fieldCapabilitiesRequest = new FieldCapabilitiesRequest()
+            .indices(index)
+            .fields(fields)
+            .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        client.execute(FieldCapabilitiesAction.INSTANCE, fieldCapabilitiesRequest, ActionListener.wrap(
+            response -> listener.onResponse(extractFieldMappings(response)),
             listener::onFailure));
     }
 
-    private static Map<String, String> extractFieldMappings(Map<String, Map<String, Map<String, FieldMappingMetaData>>> mappings) {
+    private static Map<String, String> extractFieldMappings(FieldCapabilitiesResponse response) {
         Map<String, String> extractedTypes = new HashMap<>();
 
-        mappings.forEach((indexName, docTypeToMapping) -> {
-            // "_doc" ->
-            docTypeToMapping.forEach((docType, fieldNameToMapping) -> {
-                // "my_field" ->
-                fieldNameToMapping.forEach((fieldName, fieldMapping) -> {
-                    // "mapping" -> "my_field" ->
-                    fieldMapping.sourceAsMap().forEach((name, typeMap) -> {
-                        // expected object: { "type": type }
-                        if (typeMap instanceof Map) {
-                            final Map<?, ?> map = (Map<?, ?>) typeMap;
-                            if (map.containsKey("type")) {
-                                String type = map.get("type").toString();
-                                if (logger.isTraceEnabled()) {
-                                    logger.trace("Extracted type for [" + fieldName + "] : [" + type + "] from index [" + indexName + "]");
-                                }
-                                // TODO: overwrites types, requires resolve if
-                                // types are mixed
-                                extractedTypes.put(fieldName, type);
-                            }
-                        }
-                    });
-                });
+        response.get().forEach((fieldName, capabilitiesMap) -> {
+            // TODO: overwrites types, requires resolve if
+            // types are mixed
+            capabilitiesMap.forEach((name, capability) -> {
+                logger.trace("Extracted type for [{}] : [{}]", fieldName, capability.getType());
+                extractedTypes.put(fieldName, capability.getType());
             });
         });
         return extractedTypes;


### PR DESCRIPTION
This is the first step for CCS support in transforms.

There is one outstanding issue in regards to this:

- How do we generate checkpoints for remote indices?

From what I can tell, the only way to get cluster aliases is via the `TransportService`. This service does not seem to be available outside of transport classes, at least it is not available via the `createComponents` logic in the `DataFrame.java` class. 

It seems to me that the only way to generate checkpoints for remote indices is to add a `remote_clusters` field to the transform configuration. This field could get set on `PUT` and `UPDATE`. This will allow the transform to pass in the known remote cluster aliases (given the remote indices configured) to the checkpoint service.

In short, the checkpoint service needs to know the cluster aliases to create a remote capable client.

Opening as WIP to keep track of work. Given other priorities, this may not be merged for some time.
