### PR TITLE
Add rest_total_hits_as_int in HLRC's search requests

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -392,6 +392,7 @@ final class RequestConverters {
 
     private static void addSearchRequestParams(Params params, SearchRequest searchRequest) {
         params.putParam(RestSearchAction.TYPED_KEYS_PARAM, "true");
+        params.putParam(RestSearchAction.TOTAL_HIT_AS_INT_PARAM, "true");
         params.withRouting(searchRequest.routing());
         params.withPreference(searchRequest.preference());
         params.withIndicesOptions(searchRequest.indicesOptions());
@@ -425,6 +426,7 @@ final class RequestConverters {
 
         Params params = new Params(request);
         params.putParam(RestSearchAction.TYPED_KEYS_PARAM, "true");
+        params.putParam(RestSearchAction.TOTAL_HIT_AS_INT_PARAM, "true");
         if (multiSearchRequest.maxConcurrentSearchRequests() != MultiSearchRequest.MAX_CONCURRENT_SEARCH_REQUESTS_DEFAULT) {
             params.putParam("max_concurrent_searches", Integer.toString(multiSearchRequest.maxConcurrentSearchRequests()));
         }
@@ -458,6 +460,7 @@ final class RequestConverters {
 
         Params params = new Params(request);
         params.putParam(RestSearchAction.TYPED_KEYS_PARAM, "true");
+        params.putParam(RestSearchAction.TOTAL_HIT_AS_INT_PARAM, "true");
         if (multiSearchTemplateRequest.maxConcurrentSearchRequests() != MultiSearchRequest.MAX_CONCURRENT_SEARCH_REQUESTS_DEFAULT) {
             params.putParam("max_concurrent_searches", Integer.toString(multiSearchTemplateRequest.maxConcurrentSearchRequests()));
         }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
@@ -1119,6 +1119,7 @@ public class RequestConvertersTests extends ESTestCase {
 
         Map<String, String> expectedParams = new HashMap<>();
         expectedParams.put(RestSearchAction.TYPED_KEYS_PARAM, "true");
+        expectedParams.put(RestSearchAction.TOTAL_HIT_AS_INT_PARAM, "true");
         if (randomBoolean()) {
             multiSearchRequest.maxConcurrentSearchRequests(randomIntBetween(1, 8));
             expectedParams.put("max_concurrent_searches", Integer.toString(multiSearchRequest.maxConcurrentSearchRequests()));
@@ -1733,6 +1734,7 @@ public class RequestConvertersTests extends ESTestCase {
             searchRequest.scroll(randomTimeValue());
             expectedParams.put("scroll", searchRequest.scroll().keepAlive().getStringRep());
         }
+        expectedParams.put(RestSearchAction.TOTAL_HIT_AS_INT_PARAM, "true");
     }
 
     static void setRandomIndicesOptions(Consumer<IndicesOptions> setter, Supplier<IndicesOptions> getter,


### PR DESCRIPTION
This commit adds a query parameter called `rest_total_hits_as_int` to all HLRC's search requests
that support it (_search, _msearch, ...). This makes the HLRC client's search compatible with any node in version >= 6.6.0 since `rest_total_hits_as_int` has been added in 6.6.0. This means that nodes in version < 6.6.0 won't be able to handle search requests sent by an HLRC in version 6.8.3 but we already warn in the docs that the client is forward compatible only:
https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/java-rest-high-compatibility.html

Closes #43925