### PR TITLE
Throw exception in scroll requests using `from`

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -445,6 +445,9 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
      * If set, will enable scrolling of the search request.
      */
     public SearchRequest scroll(Scroll scroll) {
+        if (scroll != null && this.source != null && this.source.from() > 0) {
+            throw new IllegalArgumentException("scroll cannot be used with a search using [from]");
+        }
         this.scroll = scroll;
         return this;
     }


### PR DESCRIPTION
This commit builds on #26235, and adds the same validation to the
builder so that it will throw an exception when setting a scroll on a
request that has from set.

Relates #9373
Closes #44493
