### PR TITLE
[DOCS] Identify reloadable EC2 Discovery Plugin settings

### DIFF
--- a/docs/plugins/discovery-ec2.asciidoc
+++ b/docs/plugins/discovery-ec2.asciidoc
@@ -56,24 +56,22 @@ bin/elasticsearch-keystore add discovery.ec2.secret_key
 
 The available settings for the EC2 discovery plugin are as follows.
 
-`discovery.ec2.access_key`::
+`discovery.ec2.access_key` ({ref}/secure-settings.html[Secure], {ref}/secure-settings.html#reloadable-secure-settings[reloadable])::
 
     An EC2 access key. If set, you must also set `discovery.ec2.secret_key`.
     If unset, `discovery-ec2` will instead use the instance role. This setting
-    is sensitive and must be stored in the {ref}/secure-settings.html[{es}
-    keystore].
+    is sensitive and must be stored in the {es} keystore.
 
-`discovery.ec2.secret_key`::
+`discovery.ec2.secret_key` ({ref}/secure-settings.html[Secure], {ref}/secure-settings.html#reloadable-secure-settings[reloadable])::
 
     An EC2 secret key. If set, you must also set `discovery.ec2.access_key`.
-    This setting is sensitive and must be stored in the
-    {ref}/secure-settings.html[{es} keystore].
+    This setting is sensitive and must be stored in the {es} keystore.
 
-`discovery.ec2.session_token`::
+`discovery.ec2.session_token` ({ref}/secure-settings.html[Secure], {ref}/secure-settings.html#reloadable-secure-settings[reloadable])::
 
     An EC2 session token. If set, you must also set `discovery.ec2.access_key`
     and `discovery.ec2.secret_key`. This setting is sensitive and must be
-    stored in the {ref}/secure-settings.html[{es} keystore].
+    stored in the {es} keystore.
 
 `discovery.ec2.endpoint`::
 
@@ -99,19 +97,19 @@ The available settings for the EC2 discovery plugin are as follows.
     this setting determines the port to use to connect to the proxy. Defaults to
     `80`.
 
-`discovery.ec2.proxy.username`::
+`discovery.ec2.proxy.username` ({ref}/secure-settings.html[Secure], {ref}/secure-settings.html#reloadable-secure-settings[reloadable])::
 
     When the address of an HTTP proxy is given in `discovery.ec2.proxy.host`,
     this setting determines the username to use to connect to the proxy. When
     not set, no username is used. This setting is sensitive and must be stored
-    in the {ref}/secure-settings.html[{es} keystore].
+    in the {es} keystore.
 
-`discovery.ec2.proxy.password`::
+`discovery.ec2.proxy.password` ({ref}/secure-settings.html[Secure], {ref}/secure-settings.html#reloadable-secure-settings[reloadable])::
 
     When the address of an HTTP proxy is given in `discovery.ec2.proxy.host`,
     this setting determines the password to use to connect to the proxy. When
     not set, no password is used. This setting is sensitive and must be stored
-    in the {ref}/secure-settings.html[{es} keystore].
+    in the {es} keystore.
 
 `discovery.ec2.read_timeout`::
 

--- a/docs/reference/setup/secure-settings.asciidoc
+++ b/docs/reference/setup/secure-settings.asciidoc
@@ -119,3 +119,8 @@ had the new value from the start.
 When changing multiple *reloadable* secure settings, modify all of them, on
 each cluster node, and then issue a `reload_secure_settings` call, instead
 of reloading after each modification.
+
+There are reloadable secure settings for:
+
+* {plugins}/discovery-ec2-usage.html#_configuring_ec2_discovery[The EC2 Discovery Plugin]
+


### PR DESCRIPTION
This PR updates the list of settings for the EC2 Discovery Plugin (https://www.elastic.co/guide/en/elasticsearch/plugins/current/discovery-ec2-usage.html) such that the secure and reloadable settings are more clearly identified. 

In particular, it follows the formatting for dynamic and secure settings in pages like https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-settings.html and https://www.elastic.co/guide/en/elasticsearch/reference/master/security-settings.html

Related to https://discuss.elastic.co/t/reloadable-secure-settings-elasticsearch/196127