### PR TITLE
Combine vector decoding and function computation.

### DIFF
--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/VectorEncoderDecoder.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/VectorEncoderDecoder.java
@@ -165,7 +165,7 @@ public final class VectorEncoderDecoder {
     public static int denseVectorLength(Version indexVersion, BytesRef vectorBR) {
         return indexVersion.onOrAfter(Version.V_7_4_0)
             ? (vectorBR.length - INT_BYTES) / INT_BYTES
-            : vectorBR.length/ INT_BYTES;
+            : vectorBR.length / INT_BYTES;
     }
 
     /**

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/ScoreScriptUtils.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/ScoreScriptUtils.java
@@ -138,7 +138,7 @@ public class ScoreScriptUtils {
             ByteBuffer byteBuffer = ByteBuffer.wrap(vector.bytes, vector.offset, vector.length);
 
             double dotProduct = 0.0;
-            float docVectorMagnitude = 0.0f;
+            double docVectorMagnitude = 0.0f;
             if (scoreScript._getIndexVersion().onOrAfter(Version.V_7_4_0)) {
                 for (int dim = 0; dim < vectorLength; dim++) {
                     dotProduct += queryVectorIter.next().floatValue() * byteBuffer.getFloat();
@@ -301,7 +301,7 @@ public class ScoreScriptUtils {
             float[] docValues = VectorEncoderDecoder.decodeSparseVector(scoreScript._getIndexVersion(), value);
 
             double docQueryDotProduct = intDotProductSparse(queryValues, queryDims, docValues, docDims);
-            float docVectorMagnitude = 0.0f;
+            double docVectorMagnitude = 0.0f;
             if (scoreScript._getIndexVersion().onOrAfter(Version.V_7_4_0)) {
                 docVectorMagnitude = VectorEncoderDecoder.decodeVectorMagnitude(scoreScript._getIndexVersion(), value);
             } else {

--- a/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapperTests.java
+++ b/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapperTests.java
@@ -113,7 +113,7 @@ public class SparseVectorFieldMapperTests extends ESSingleNodeTestCase {
             decodedValues,
             0.001f
         );
-        float decodedMagnitude = VectorEncoderDecoder.getVectorMagnitude(indexVersion, vectorBR, decodedValues);
+        float decodedMagnitude = VectorEncoderDecoder.decodeVectorMagnitude(indexVersion, vectorBR);
         assertEquals(expectedMagnitude, decodedMagnitude, 0.001f);
     }
 

--- a/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/query/ScoreScriptUtilsTests.java
+++ b/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/query/ScoreScriptUtilsTests.java
@@ -9,15 +9,15 @@ package org.elasticsearch.xpack.vectors.query;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
 import org.elasticsearch.script.ScoreScript;
-import org.elasticsearch.xpack.vectors.mapper.VectorEncoderDecoder;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.vectors.query.ScoreScriptUtils.DotProduct;
+import org.elasticsearch.xpack.vectors.mapper.VectorEncoderDecoder;
 import org.elasticsearch.xpack.vectors.query.ScoreScriptUtils.CosineSimilarity;
-import org.elasticsearch.xpack.vectors.query.ScoreScriptUtils.L1Norm;
-import org.elasticsearch.xpack.vectors.query.ScoreScriptUtils.L2Norm;
-import org.elasticsearch.xpack.vectors.query.ScoreScriptUtils.DotProductSparse;
 import org.elasticsearch.xpack.vectors.query.ScoreScriptUtils.CosineSimilaritySparse;
+import org.elasticsearch.xpack.vectors.query.ScoreScriptUtils.DotProduct;
+import org.elasticsearch.xpack.vectors.query.ScoreScriptUtils.DotProductSparse;
+import org.elasticsearch.xpack.vectors.query.ScoreScriptUtils.L1Norm;
 import org.elasticsearch.xpack.vectors.query.ScoreScriptUtils.L1NormSparse;
+import org.elasticsearch.xpack.vectors.query.ScoreScriptUtils.L2Norm;
 import org.elasticsearch.xpack.vectors.query.ScoreScriptUtils.L2NormSparse;
 
 import java.util.Arrays;
@@ -26,21 +26,25 @@ import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.vectors.mapper.VectorEncoderDecoderTests.mockEncodeDenseVector;
-
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-
 public class ScoreScriptUtilsTests extends ESTestCase {
+
     public void testDenseVectorFunctions() {
+        testDenseVectorFunctions(Version.V_7_3_0);
+        testDenseVectorFunctions(Version.CURRENT);
+    }
+
+    public void testDenseVectorFunctions(Version indexVersion) {
         float[] docVector = {230.0f, 300.33f, -34.8988f, 15.555f, -200.0f};
-        BytesRef encodedDocVector =  mockEncodeDenseVector(docVector);
+        BytesRef encodedDocVector = mockEncodeDenseVector(docVector, indexVersion);
         VectorScriptDocValues.DenseVectorScriptDocValues dvs = mock(VectorScriptDocValues.DenseVectorScriptDocValues.class);
         when(dvs.getEncodedValue()).thenReturn(encodedDocVector);
 
         ScoreScript scoreScript = mock(ScoreScript.class);
-        when(scoreScript._getIndexVersion()).thenReturn(Version.CURRENT);
+        when(scoreScript._getIndexVersion()).thenReturn(indexVersion);
 
         List<Number> queryVector = Arrays.asList(0.5f, 111.3f, -13.0f, 14.8f, -156.0f);
 
@@ -84,14 +88,19 @@ public class ScoreScriptUtilsTests extends ESTestCase {
     }
 
     public void testSparseVectorFunctions() {
+        testSparseVectorFunctions(Version.V_7_3_0);
+        testSparseVectorFunctions(Version.CURRENT);
+    }
+
+    public void testSparseVectorFunctions(Version indexVersion) {
         int[] docVectorDims = {2, 10, 50, 113, 4545};
         float[] docVectorValues = {230.0f, 300.33f, -34.8988f, 15.555f, -200.0f};
         BytesRef encodedDocVector = VectorEncoderDecoder.encodeSparseVector(
-            Version.CURRENT, docVectorDims, docVectorValues, docVectorDims.length);
+            indexVersion, docVectorDims, docVectorValues, docVectorDims.length);
         VectorScriptDocValues.SparseVectorScriptDocValues dvs = mock(VectorScriptDocValues.SparseVectorScriptDocValues.class);
         when(dvs.getEncodedValue()).thenReturn(encodedDocVector);
         ScoreScript scoreScript = mock(ScoreScript.class);
-        when(scoreScript._getIndexVersion()).thenReturn(Version.CURRENT);
+        when(scoreScript._getIndexVersion()).thenReturn(indexVersion);
 
         Map<String, Number> queryVector = new HashMap<String, Number>() {{
             put("2", 0.5);

--- a/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/query/ScoreScriptUtilsTests.java
+++ b/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/query/ScoreScriptUtilsTests.java
@@ -37,7 +37,7 @@ public class ScoreScriptUtilsTests extends ESTestCase {
         testDenseVectorFunctions(Version.CURRENT);
     }
 
-    public void testDenseVectorFunctions(Version indexVersion) {
+    private void testDenseVectorFunctions(Version indexVersion) {
         float[] docVector = {230.0f, 300.33f, -34.8988f, 15.555f, -200.0f};
         BytesRef encodedDocVector = mockEncodeDenseVector(docVector, indexVersion);
         VectorScriptDocValues.DenseVectorScriptDocValues dvs = mock(VectorScriptDocValues.DenseVectorScriptDocValues.class);
@@ -92,7 +92,7 @@ public class ScoreScriptUtilsTests extends ESTestCase {
         testSparseVectorFunctions(Version.CURRENT);
     }
 
-    public void testSparseVectorFunctions(Version indexVersion) {
+    private void testSparseVectorFunctions(Version indexVersion) {
         int[] docVectorDims = {2, 10, 50, 113, 4545};
         float[] docVectorValues = {230.0f, 300.33f, -34.8988f, 15.555f, -200.0f};
         BytesRef encodedDocVector = VectorEncoderDecoder.encodeSparseVector(


### PR DESCRIPTION
This commit updates the dense vector functions like `cosineSimilarity` to decode the document vector and compute the result at the same time. Previously, we would fully decode the vector into an array, then calculate the function.

In benchmarks for vector search, it gives a noticeable improvement. Results on the `random-s-100-euclidean` dataset:

```
Algorithm                               Recall      QPS
EsBruteforce()                          1.000       41.694
EsBruteforce(decode_and_compute)        1.000       52.159
```