### PR TITLE
Clarify read-only index in docs

### DIFF
--- a/docs/reference/indices/apis/freeze.asciidoc
+++ b/docs/reference/indices/apis/freeze.asciidoc
@@ -20,7 +20,8 @@ Freezes an index.
 ==== {api-description-title}
 
 A frozen index has almost no overhead on the cluster (except
-for maintaining its metadata in memory), and is blocked for write operations.
+for maintaining its metadata in memory), and is blocked for write operations. 
+In other words, a frozen index is a read-only index.
 See <<frozen-indices>> and <<unfreeze-index-api>>.
 
 IMPORTANT: Freezing an index will close the index and reopen it within the same

--- a/docs/reference/indices/forcemerge.asciidoc
+++ b/docs/reference/indices/forcemerge.asciidoc
@@ -10,8 +10,8 @@ This call will block until the merge is complete. If the http connection is
 lost, the request will continue in the background, and any new requests will
 block until the previous force merge is complete.
 
-WARNING: Force merge should only be called against *read-only indices*. Running 
-force merge against a read-write index can cause very large segments to be produced 
+WARNING: Force merge should only be called against *read-only indices*. See <<freeze-index-api>>.
+Running force merge against a read-write index can cause very large segments to be produced 
 (>5Gb per segment), and the merge policy will never consider it for merging again until 
 it mostly consists of deleted docs. This can cause very large segments to remain in the shards.
 


### PR DESCRIPTION
Updated force-merge and freeze index API pages to clarify read-only indices.