### PR TITLE
[ML-DataFrame] unmute testGetCheckpointStats

### DIFF
--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/checkpoint/DataFrameTransformCheckpointServiceNodeTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/checkpoint/DataFrameTransformCheckpointServiceNodeTests.java
@@ -178,7 +178,6 @@ public class DataFrameTransformCheckpointServiceNodeTests extends DataFrameSingl
                 DataFrameTransformCheckpoint.EMPTY, null, null);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/45238")
     public void testGetCheckpointStats() throws InterruptedException {
         String transformId = randomAlphaOfLengthBetween(3, 10);
         long timestamp = 1000;


### PR DESCRIPTION
test error #45238 isn't reproducible locally and failure reports are outdated/lack information