### PR TITLE
Fix testHandlerIsInvokedOnConnectionClose

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -2177,7 +2177,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                         assertThat(exp.getCause(), instanceOf(NodeNotConnectedException.class));
                     } else {
                         // here the concurrent disconnect was faster and invoked the listener first
-                        assertThat(exp.getClass(), instanceOf(NodeDisconnectedException.class));
+                        assertThat(exp, instanceOf(NodeDisconnectedException.class));
                     }
                 } finally {
                     latch.countDown();

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -2144,7 +2144,6 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         latch.await();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/46124")
     public void testHandlerIsInvokedOnConnectionClose() throws IOException, InterruptedException {
         List<String> executors = new ArrayList<>(ThreadPool.THREAD_POOL_TYPES.keySet());
         CollectionUtil.timSort(executors); // makes sure it's reproducible


### PR DESCRIPTION
In #45899 we introduced a faulty assertion, which this commit fixes.