### PR TITLE
[TEST] Fix assertion regarding instanceof exception

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -2177,7 +2177,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                         assertThat(exp.getCause(), instanceOf(NodeNotConnectedException.class));
                     } else {
                         // here the concurrent disconnect was faster and invoked the listener first
-                        assertThat(exp.getClass(), instanceOf(NodeDisconnectedException.class));
+                        assertThat(exp, instanceOf(NodeDisconnectedException.class));
                     }
                 } finally {
                     latch.countDown();


### PR DESCRIPTION
During refactoring to use `assertThat` the assertion was converted wrongly causing:
```
Expected: an instance of org.elasticsearch.transport.NodeDisconnectedException
    but: <class org.elasticsearch.transport.NodeDisconnectedException> is a java.lang.Class
```

Follows: #45899
