### PR TITLE
Be specific about the default behaviour of `action.auto_create_index` when list is given

### DIFF
--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -138,7 +138,8 @@ automatically. You can modify this setting to explicitly allow or block
 automatic creation of indices that match specified patterns, or set it to
 `false` to disable automatic index creation entirely. Specify a
 comma-separated list of patterns you want to allow, or prefix each pattern with
-`+` or `-` to indicate whether it should be allowed or blocked.
+`+` or `-` to indicate whether it should be allowed or blocked.  When a list is
+specified, the default behaviour is to disallow.
 
 [source,js]
 --------------------------------------------------


### PR DESCRIPTION
Be specific about the default behaviour of `action.auto_create_index` when a list is given.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
