### PR TITLE
[7.x][ML] Regression dependent variable must be numeric (#46072)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
@@ -8,8 +8,8 @@ package org.elasticsearch.xpack.core.ml.dataframe.analyses;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public interface DataFrameAnalysis extends ToXContentObject, NamedWriteable {
 
@@ -24,9 +24,9 @@ public interface DataFrameAnalysis extends ToXContentObject, NamedWriteable {
     boolean supportsCategoricalFields();
 
     /**
-     * @return The set of fields that analyzed documents must have for the analysis to operate
+     * @return The names and types of the fields that analyzed documents must have for the analysis to operate
      */
-    Set<String> getRequiredFields();
+    List<RequiredField> getRequiredFields();
 
     /**
      * @return {@code true} if this analysis supports data frame rows with missing values

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
@@ -18,10 +18,10 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 public class OutlierDetection implements DataFrameAnalysis {
 
@@ -160,8 +160,8 @@ public class OutlierDetection implements DataFrameAnalysis {
     }
 
     @Override
-    public Set<String> getRequiredFields() {
-        return Collections.emptySet();
+    public List<RequiredField> getRequiredFields() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
@@ -17,9 +17,9 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 public class Regression implements DataFrameAnalysis {
 
@@ -201,8 +201,8 @@ public class Regression implements DataFrameAnalysis {
     }
 
     @Override
-    public Set<String> getRequiredFields() {
-        return Collections.singleton(dependentVariable);
+    public List<RequiredField> getRequiredFields() {
+        return Collections.singletonList(new RequiredField(dependentVariable, Types.numerical()));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/RequiredField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/RequiredField.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ml.dataframe.analyses;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+public class RequiredField {
+
+    private final String name;
+
+    /**
+     * The required field must have one of those types.
+     * We use a sorted set to ensure types are reported alphabetically in error messages.
+     */
+    private final SortedSet<String> types;
+
+    public RequiredField(String name, Set<String> types) {
+        this.name = Objects.requireNonNull(name);
+        this.types = Collections.unmodifiableSortedSet(new TreeSet<>(types));
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public SortedSet<String> getTypes() {
+        return types;
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Types.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Types.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ml.dataframe.analyses;
+
+import org.elasticsearch.index.mapper.NumberFieldMapper;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Helper class that defines groups of types
+ */
+public final class Types {
+
+    private Types() {}
+
+    private static final Set<String> CATEGORICAL_TYPES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList("text", "keyword", "ip")));
+
+    private static final Set<String> NUMERICAL_TYPES;
+
+    static {
+        Set<String> numericalTypes = Stream.of(NumberFieldMapper.NumberType.values())
+            .map(NumberFieldMapper.NumberType::typeName)
+            .collect(Collectors.toSet());
+        numericalTypes.add("scaled_float");
+        NUMERICAL_TYPES = Collections.unmodifiableSet(numericalTypes);
+    }
+
+    public static Set<String> categorical() {
+        return CATEGORICAL_TYPES;
+    }
+
+    public static Set<String> numerical() {
+        return NUMERICAL_TYPES;
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractor.java
@@ -23,6 +23,7 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.fetch.StoredFieldsContext;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.ml.dataframe.analyses.Types;
 import org.elasticsearch.xpack.ml.datafeed.extractor.fields.ExtractedField;
 import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsIndex;
 
@@ -268,7 +269,7 @@ public class DataFrameDataExtractor {
         Set<String> categoricalFields = new HashSet<>();
         for (ExtractedField extractedField : context.extractedFields.getAllFields()) {
             String fieldName = extractedField.getName();
-            if (ExtractedFieldsDetector.CATEGORICAL_TYPES.containsAll(extractedField.getTypes())) {
+            if (Types.categorical().containsAll(extractedField.getTypes())) {
                 categoricalFields.add(fieldName);
             }
         }


### PR DESCRIPTION
* [ML] Regression dependent variable must be numeric

This adds a validation that the dependent variable of a regression
analysis must be numeric.

* Address review comments and fix some problems

In addition to addressing the review comments, this
commit fixes a few issues I found during testing.

In particular:

- if there were mappings for required fields but they were
not included we were not reporting the error
- if explicitly included fields had unsupported types we were
not reporting the error

Unfortunately, I couldn't get those fixed without refactoring
the code in `ExtractedFieldsDetector`.
 checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
