### PR TITLE
[DOCS] Bump docs version to 7.5.0

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -1,8 +1,8 @@
-:version:               7.4.0
+:version:               7.5.0
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:          7.4.0
+:bare_version:          7.5.0
 :major-version:         7.x
 :prev-major-version:    6.x
 :lucene_version:        8.2.0


### PR DESCRIPTION
Bumps version attributes for Elasticsearch docs to `7.5.0` for the 7.x branch.