### PR TITLE
Add package docs for bundled jdk location

### DIFF
--- a/docs/reference/setup/install/deb.asciidoc
+++ b/docs/reference/setup/install/deb.asciidoc
@@ -238,6 +238,12 @@ locations for a Debian-based system:
   | /var/lib/elasticsearch
   | path.data
 
+| jdk
+  | The bundled Java Development Kit used to run Elasticsearch. Can
+    be overriden by setting the `JAVA_HOME` environment variable.
+  | /usr/share/elasticsearch/jdk
+ d|
+
 | logs
   | Log files location.
   | /var/log/elasticsearch

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -225,6 +225,12 @@ locations for an RPM-based system:
   | /var/lib/elasticsearch
   | path.data
 
+| jdk
+  | The bundled Java Development Kit used to run Elasticsearch. Can
+    be overriden by setting the `JAVA_HOME` environment variable.
+  | /usr/share/elasticsearch/jdk
+ d|
+
 | logs
   | Log files location.
   | /var/log/elasticsearch


### PR DESCRIPTION
This commit expands the documented directory layout of the rpm and deb
packages to include the bundled jdk.

closes #45150