### PR TITLE
fix a wrong guide tip

### DIFF
--- a/docs/java-api/docs/index_.asciidoc
+++ b/docs/java-api/docs/index_.asciidoc
@@ -103,7 +103,7 @@ If you need to see the generated JSON content, you can use the
 
 [source,java]
 --------------------------------------------------
-String json = builder.string();
+String json = builder.getOutputStream().toString();
 --------------------------------------------------
 
 

--- a/docs/java-api/docs/index_.asciidoc
+++ b/docs/java-api/docs/index_.asciidoc
@@ -103,7 +103,7 @@ If you need to see the generated JSON content, you can use the
 
 [source,java]
 --------------------------------------------------
-String json = builder.getOutputStream().toString();
+String json = Strings.toString(builder);
 --------------------------------------------------
 
 


### PR DESCRIPTION
`builder.getOutputStream().toString()` will do the trick while `builder.string()` only prints the object reference (kind of address like `"org.elasticsearch.common.xcontent.XContentBuilder@66e889df"`)

