### PR TITLE
Improve documentation for X-Opaque-ID

### DIFF
--- a/docs/reference/index-modules/slowlog.asciidoc
+++ b/docs/reference/index-modules/slowlog.asciidoc
@@ -83,6 +83,18 @@ logger.index_search_slowlog_rolling.appenderRef.index_search_slowlog_rolling.ref
 logger.index_search_slowlog_rolling.additivity = false
 --------------------------------------------------
 
+=== Identifying slow log origin
+
+It is often useful to identify what triggered a slow running query. If a call was initiated with an `X-Opaque-ID` header, then this value
+will be present in Search Slow logs as an additional **id** field.
+```
+[2019-08-30T11:59:37,786][WARN ][i.s.s.query              ] [node-0] [index6][0] took[78.4micros], took_millis[0], total_hits[0 hits], stats[], search_type[QUERY_THEN_FETCH], total_shards[1], source[{"query":{"match_all":{"boost":1.0}}}], id[myuserid],
+```
+the same applies to JSON logs
+```
+{"type": "index_search_slowlog", "timestamp": "2019-08-30T11:59:37,786+02:00", "level": "WARN", "component": "i.s.s.query", "cluster.name": "distribution_run", "node.name": "node-0", "message": "[index6][0]", "took": "78.4micros", "took_millis": "0", "total_hits": "0 hits", "stats": "[]", "search_type": "QUERY_THEN_FETCH", "total_shards": "1", "source": "{\"query\":{\"match_all\":{\"boost\":1.0}}}", "id": "myuserid", "cluster.uuid": "Aq-c-PAeQiK3tfBYtig9Bw", "node.id": "D7fUYfnfTLa2D7y-xw6tZg"  }
+```
+
 [float]
 [[index-slow-log]]
 === Index Slow log

--- a/docs/reference/index-modules/slowlog.asciidoc
+++ b/docs/reference/index-modules/slowlog.asciidoc
@@ -86,13 +86,31 @@ logger.index_search_slowlog_rolling.additivity = false
 === Identifying slow log origin
 
 It is often useful to identify what triggered a slow running query. If a call was initiated with an `X-Opaque-ID` header, then this value
-will be present in Search Slow logs as an additional **id** field.
+will be present in Search Slow logs as an additional **id** field (scroll to the right).
 ```
-[2019-08-30T11:59:37,786][WARN ][i.s.s.query              ] [node-0] [index6][0] took[78.4micros], took_millis[0], total_hits[0 hits], stats[], search_type[QUERY_THEN_FETCH], total_shards[1], source[{"query":{"match_all":{"boost":1.0}}}], id[myuserid],
+[2019-08-30T11:59:37,786][WARN ][i.s.s.query              ] [node-0] [index6][0] took[78.4micros], took_millis[0], total_hits[0 hits], stats[], search_type[QUERY_THEN_FETCH], total_shards[1], source[{"query":{"match_all":{"boost":1.0}}}], id[MY_USER_ID],
 ```
 the same applies to JSON logs
 ```
-{"type": "index_search_slowlog", "timestamp": "2019-08-30T11:59:37,786+02:00", "level": "WARN", "component": "i.s.s.query", "cluster.name": "distribution_run", "node.name": "node-0", "message": "[index6][0]", "took": "78.4micros", "took_millis": "0", "total_hits": "0 hits", "stats": "[]", "search_type": "QUERY_THEN_FETCH", "total_shards": "1", "source": "{\"query\":{\"match_all\":{\"boost\":1.0}}}", "id": "myuserid", "cluster.uuid": "Aq-c-PAeQiK3tfBYtig9Bw", "node.id": "D7fUYfnfTLa2D7y-xw6tZg"  }
+{
+  "type": "index_search_slowlog",
+  "timestamp": "2019-08-30T11:59:37,786+02:00",
+  "level": "WARN",
+  "component": "i.s.s.query",
+  "cluster.name": "distribution_run",
+  "node.name": "node-0",
+  "message": "[index6][0]",
+  "took": "78.4micros",
+  "took_millis": "0",
+  "total_hits": "0 hits",
+  "stats": "[]",
+  "search_type": "QUERY_THEN_FETCH",
+  "total_shards": "1",
+  "source": "{\"query\":{\"match_all\":{\"boost\":1.0}}}",
+  "id": "MY_USER_ID",
+  "cluster.uuid": "Aq-c-PAeQiK3tfBYtig9Bw",
+  "node.id": "D7fUYfnfTLa2D7y-xw6tZg"
+}
 ```
 
 [float]

--- a/docs/reference/index-modules/slowlog.asciidoc
+++ b/docs/reference/index-modules/slowlog.asciidoc
@@ -83,18 +83,22 @@ logger.index_search_slowlog_rolling.appenderRef.index_search_slowlog_rolling.ref
 logger.index_search_slowlog_rolling.additivity = false
 --------------------------------------------------
 
+[float]
 ==== Identifying search slow log origin
 
-It is often useful to identify what triggered a slow running query. If a call was initiated with an `X-Opaque-ID` header, then this value
-will be present in Search Slow logs as an additional **id** field (scroll to the right).
-```
-[2019-08-30T11:59:37,786][WARN ][i.s.s.query              ] [node-0] [index6][0] took[78.4micros], took_millis[0], total_hits[0 hits], stats[], search_type[QUERY_THEN_FETCH], total_shards[1], source[{"query":{"match_all":{"boost":1.0}}}], id[MY_USER_ID],
-```
-the same applies to JSON logs
-```
+It is often useful to identify what triggered a slow running query. If a call was initiated with an `X-Opaque-ID` header, then the user ID
+is included in Search Slow logs as an additional **id** field (scroll to the right).
+[source,txt]
+---------------------------
+[2030-08-30T11:59:37,786][WARN ][i.s.s.query              ] [node-0] [index6][0] took[78.4micros], took_millis[0], total_hits[0 hits], stats[], search_type[QUERY_THEN_FETCH], total_shards[1], source[{"query":{"match_all":{"boost":1.0}}}], id[MY_USER_ID],
+---------------------------
+// NOTCONSOLE
+The user ID is also included in JSON logs.
+[source,js]
+---------------------------
 {
   "type": "index_search_slowlog",
-  "timestamp": "2019-08-30T11:59:37,786+02:00",
+  "timestamp": "2030-08-30T11:59:37,786+02:00",
   "level": "WARN",
   "component": "i.s.s.query",
   "cluster.name": "distribution_run",
@@ -111,7 +115,8 @@ the same applies to JSON logs
   "cluster.uuid": "Aq-c-PAeQiK3tfBYtig9Bw",
   "node.id": "D7fUYfnfTLa2D7y-xw6tZg"
 }
-```
+---------------------------
+// NOTCONSOLE
 
 [float]
 [[index-slow-log]]

--- a/docs/reference/index-modules/slowlog.asciidoc
+++ b/docs/reference/index-modules/slowlog.asciidoc
@@ -83,7 +83,7 @@ logger.index_search_slowlog_rolling.appenderRef.index_search_slowlog_rolling.ref
 logger.index_search_slowlog_rolling.additivity = false
 --------------------------------------------------
 
-=== Identifying slow log origin
+==== Identifying search slow log origin
 
 It is often useful to identify what triggered a slow running query. If a call was initiated with an `X-Opaque-ID` header, then this value
 will be present in Search Slow logs as an additional **id** field (scroll to the right).

--- a/docs/reference/setup/logging-config.asciidoc
+++ b/docs/reference/setup/logging-config.asciidoc
@@ -214,9 +214,10 @@ files (four rolled logs, and the active log).
 You can disable it in the `config/log4j2.properties` file by setting the deprecation
 log level to `error`.
 
-You can identify who is triggering deprecated functionality if `X-Opaque-Id` was used as an HTTP header.
-This field will be then present as `X-Opaque-ID` field in deprecation JSON logs.
-```
+You can identify what is triggering deprecated functionality if `X-Opaque-Id` was used as an HTTP header.
+The user ID is included in the `X-Opaque-ID` field in deprecation JSON logs.
+[source,js]
+---------------------------
 {
   "type": "deprecation",
   "timestamp": "2019-08-30T12:07:07,126+02:00",
@@ -229,7 +230,8 @@ This field will be then present as `X-Opaque-ID` field in deprecation JSON logs.
   "cluster.uuid": "Aq-c-PAeQiK3tfBYtig9Bw",
   "node.id": "D7fUYfnfTLa2D7y-xw6tZg"
 }
-```
+---------------------------
+// NOTCONSOLE
 
 [float]
 [[json-logging]]

--- a/docs/reference/setup/logging-config.asciidoc
+++ b/docs/reference/setup/logging-config.asciidoc
@@ -217,7 +217,18 @@ log level to `error`.
 You can identify who is triggering deprecated functionality if `X-Opaque-Id` was used as an HTTP header.
 This field will be then present as `X-Opaque-ID` field in deprecation JSON logs.
 ```
-{"type": "deprecation", "timestamp": "2019-08-30T12:07:07,126+02:00", "level": "WARN", "component": "o.e.d.r.a.a.i.RestCreateIndexAction", "cluster.name": "distribution_run", "node.name": "node-0", "message": "[types removal] Using include_type_name in create index requests is deprecated. The parameter will be removed in the next major version.", "x-opaque-id": "myuserid", "cluster.uuid": "Aq-c-PAeQiK3tfBYtig9Bw", "node.id": "D7fUYfnfTLa2D7y-xw6tZg"  }
+{
+  "type": "deprecation",
+  "timestamp": "2019-08-30T12:07:07,126+02:00",
+  "level": "WARN",
+  "component": "o.e.d.r.a.a.i.RestCreateIndexAction",
+  "cluster.name": "distribution_run",
+  "node.name": "node-0",
+  "message": "[types removal] Using include_type_name in create index requests is deprecated. The parameter will be removed in the next major version.",
+  "x-opaque-id": "MY_USER_ID",
+  "cluster.uuid": "Aq-c-PAeQiK3tfBYtig9Bw",
+  "node.id": "D7fUYfnfTLa2D7y-xw6tZg"
+}
 ```
 
 [float]

--- a/docs/reference/setup/logging-config.asciidoc
+++ b/docs/reference/setup/logging-config.asciidoc
@@ -214,6 +214,11 @@ files (four rolled logs, and the active log).
 You can disable it in the `config/log4j2.properties` file by setting the deprecation
 log level to `error`.
 
+You can identify who is triggering deprecated functionality if `X-Opaque-Id` was used as an HTTP header.
+This field will be then present as `X-Opaque-ID` field in deprecation JSON logs.
+```
+{"type": "deprecation", "timestamp": "2019-08-30T12:07:07,126+02:00", "level": "WARN", "component": "o.e.d.r.a.a.i.RestCreateIndexAction", "cluster.name": "distribution_run", "node.name": "node-0", "message": "[types removal] Using include_type_name in create index requests is deprecated. The parameter will be removed in the next major version.", "x-opaque-id": "myuserid", "cluster.uuid": "Aq-c-PAeQiK3tfBYtig9Bw", "node.id": "D7fUYfnfTLa2D7y-xw6tZg"  }
+```
 
 [float]
 [[json-logging]]


### PR DESCRIPTION
this field can be present in search slow logs and deprecation logs. The
docs describes how to enable this functionality and what expect in logs.
closes #44851
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
