### PR TITLE
Add audit messages for Data Frame Analytics

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
@@ -153,6 +153,7 @@ import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.xpack.core.ml.notifications.AuditorField;
 import org.junit.After;
 
 import java.io.IOException;
@@ -167,20 +168,20 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
 public class MachineLearningIT extends ESRestHighLevelClientTestCase {
@@ -1245,6 +1246,9 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
         assertThat(createdConfig.getAnalyzedFields(), equalTo(config.getAnalyzedFields()));
         assertThat(createdConfig.getModelMemoryLimit(), equalTo(ByteSizeValue.parseBytesSizeValue("1gb", "")));  // default value
         assertThat(createdConfig.getDescription(), equalTo("some description"));
+
+        assertThatAuditMessagesAreEqualTo(configId,
+            "Created analytics with analysis type [outlier detection]");
     }
 
     public void testPutDataFrameAnalyticsConfig_GivenRegression() throws Exception {
@@ -1280,6 +1284,9 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
         assertThat(createdConfig.getAnalyzedFields(), equalTo(config.getAnalyzedFields()));
         assertThat(createdConfig.getModelMemoryLimit(), equalTo(ByteSizeValue.parseBytesSizeValue("1gb", "")));  // default value
         assertThat(createdConfig.getDescription(), equalTo("this is a regression"));
+
+        assertThatAuditMessagesAreEqualTo(configId,
+            "Created analytics with analysis type [regression]");
     }
 
     public void testGetDataFrameAnalyticsConfig_SingleConfig() throws Exception {
@@ -1464,6 +1471,14 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
 
         // Verify that the destination index got created.
         assertTrue(highLevelClient().indices().exists(new GetIndexRequest(destIndex), RequestOptions.DEFAULT));
+
+        assertThatAuditMessagesAreEqualTo(configId,
+            "Created analytics with analysis type [outlier detection]",
+            "Estimated memory usage for this analytics to be [3kb]",
+            "Started analytics",
+            "Creating destination index [start-test-dest-index]",
+            "Finished reindexing to destination index [start-test-dest-index]",
+            "Finished analysis");
     }
 
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/43924")
@@ -1507,6 +1522,11 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
             machineLearningClient::stopDataFrameAnalytics, machineLearningClient::stopDataFrameAnalyticsAsync);
         assertTrue(stopDataFrameAnalyticsResponse.isStopped());
         assertThat(getAnalyticsState(configId), equalTo(DataFrameAnalyticsState.STOPPED));
+
+        assertThatAuditMessagesAreEqualTo(configId,
+            "Created analytics with analysis type [outlier detection]",
+            "Started analytics",
+            "Stopped analytics");
     }
 
     private DataFrameAnalyticsState getAnalyticsState(String configId) throws IOException {
@@ -1557,6 +1577,10 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
             new GetDataFrameAnalyticsRequest(configId + "*"),
             machineLearningClient::getDataFrameAnalytics, machineLearningClient::getDataFrameAnalyticsAsync);
         assertThat(getDataFrameAnalyticsResponse.getAnalytics(), hasSize(0));
+
+        assertThatAuditMessagesAreEqualTo(configId,
+            "Created analytics with analysis type [outlier detection]",
+            "Deleted analytics");
     }
 
     public void testDeleteDataFrameAnalyticsConfig_ConfigNotFound() {
@@ -1782,6 +1806,27 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
 
     private void createIndex(String indexName, XContentBuilder mapping) throws IOException {
         highLevelClient().indices().create(new CreateIndexRequest(indexName).mapping(mapping), RequestOptions.DEFAULT);
+    }
+
+    private static void assertThatAuditMessagesAreEqualTo(String configId, String... expectedAuditMessages) throws Exception {
+        // Make sure we wrote to the audit
+        // Since calls to write the AbstractAuditor are sent and forgot (async) we could have returned from the start,
+        // finished the job (as this is a very short analytics job), all without the audit being fully written.
+        assertBusy(() -> assertTrue(indexExists(AuditorField.NOTIFICATIONS_INDEX)));
+        assertBusy(() -> assertThat(fetchAllAuditMessages(configId), equalTo(List.of(expectedAuditMessages))));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> fetchAllAuditMessages(String dataFrameAnalyticsId) throws Exception {
+        assertOK(client().performRequest(new Request("POST", AuditorField.NOTIFICATIONS_INDEX + "/_refresh")));
+        Request request = new Request("GET", AuditorField.NOTIFICATIONS_INDEX + "/_search?sort=timestamp");
+        request.setJsonEntity("{\"query\":{\"term\":{\"job_id\":\"" + dataFrameAnalyticsId + "\"}}}");
+        Map<String, Object> response = entityAsMap(client().performRequest(request));
+        List<Map<String, Object>> hitList = ((List<Map<String, Object>>) ((Map<String, Object>) response.get("hits")).get("hits"));
+        return hitList
+            .stream()
+            .map(hit -> (String) ((Map<String, Object>) hit.get("_source")).get("message"))
+            .collect(Collectors.toList());
     }
 
     public void testEstimateMemoryUsage() throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditMessage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditMessage.java
@@ -27,6 +27,7 @@ public abstract class AbstractAuditMessage implements ToXContentObject {
     public static final ParseField LEVEL = new ParseField("level");
     public static final ParseField TIMESTAMP = new ParseField("timestamp");
     public static final ParseField NODE_NAME = new ParseField("node_name");
+    public static final ParseField JOB_TYPE = new ParseField("job_type");
 
     protected static final <T extends AbstractAuditMessage> ConstructingObjectParser<T, Void> createParser(
             String name, AbstractAuditMessageFactory<T> messageFactory, ParseField resourceField) {
@@ -99,13 +100,17 @@ public abstract class AbstractAuditMessage implements ToXContentObject {
         if (nodeName != null) {
             builder.field(NODE_NAME.getPreferredName(), nodeName);
         }
+        String jobType = getJobType();
+        if (jobType != null) {
+            builder.field(JOB_TYPE.getPreferredName(), jobType);
+        }
         builder.endObject();
         return builder;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(resourceId, message, level, timestamp, nodeName);
+        return Objects.hash(resourceId, message, level, timestamp, nodeName, getJobType());
     }
 
     @Override
@@ -122,8 +127,17 @@ public abstract class AbstractAuditMessage implements ToXContentObject {
             Objects.equals(message, other.message) &&
             Objects.equals(level, other.level) &&
             Objects.equals(timestamp, other.timestamp) &&
-            Objects.equals(nodeName, other.nodeName);
+            Objects.equals(nodeName, other.nodeName) &&
+            Objects.equals(getJobType(), other.getJobType());
     }
 
+    /**
+     * @return job type string used to tell apart jobs of different types stored in the same index
+     */
+    public abstract String getJobType();
+
+    /**
+     * @return resource id field name used when storing a new message
+     */
     protected abstract String getResourceField();
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/notifications/DataFrameAuditMessage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/dataframe/notifications/DataFrameAuditMessage.java
@@ -24,6 +24,11 @@ public class DataFrameAuditMessage extends AbstractAuditMessage {
     }
 
     @Override
+    public final String getJobType() {
+        return null;
+    }
+
+    @Override
     protected String getResourceField() {
         return TRANSFORM_ID.getPreferredName();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
@@ -14,6 +14,13 @@ import java.util.Map;
 public interface DataFrameAnalysis extends ToXContentObject, NamedWriteable {
 
     /**
+     * @return Name of this analysis that can be presented to the user
+     */
+    default String getUserFriendlyName() {
+        return getWriteableName().replace('_', ' ');
+    }
+
+    /**
      * @return The analysis parameters as a map
      */
     Map<String, Object> getParams();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -56,6 +56,20 @@ public final class Messages {
     public static final String DATA_FRAME_ANALYTICS_BAD_QUERY_FORMAT = "Data Frame Analytics config query is not parsable";
     public static final String DATA_FRAME_ANALYTICS_BAD_FIELD_FILTER = "No field [{0}] could be detected";
 
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_CREATED = "Created analytics with analysis type [{0}]";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_STARTED = "Started analytics";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_STOPPED = "Stopped analytics";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_DELETED = "Deleted analytics";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_ALREADY_STARTED = "Cannot start analytics because it has already been started";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_START_TIMEOUT = "Starting analytics timed out after [{0}]";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_CANCELED = "Canceled analytics";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_UPDATED_STATE = "Successfully updated analytics task state to [{0}]";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_ESTIMATED_MEMORY_USAGE = "Estimated memory usage for this analytics to be [{0}]";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_CREATING_DEST_INDEX = "Creating destination index [{0}]";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_REUSING_DEST_INDEX = "Using existing destination index [{0}]";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_FINISHED_REINDEXING = "Finished reindexing to destination index [{0}]";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_FINISHED_ANALYSIS = "Finished analysis";
+
     public static final String FILTER_CANNOT_DELETE = "Cannot delete filter [{0}] currently used by jobs {1}";
     public static final String FILTER_CONTAINS_TOO_MANY_ITEMS = "Filter [{0}] contains too many items; up to [{1}] items are allowed";
     public static final String FILTER_NOT_FOUND = "No filter with id [{0}] exists";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
@@ -1117,38 +1117,6 @@ public class ElasticsearchMappings {
         .endObject();
     }
 
-    public static XContentBuilder auditMessageMappingLegacy() throws IOException {
-        XContentBuilder builder = jsonBuilder().startObject();
-        builder.startObject(SINGLE_MAPPING_NAME);
-        addMetaInformation(builder);
-        builder.startObject(PROPERTIES)
-                .startObject(Job.ID.getPreferredName())
-                    .field(TYPE, KEYWORD)
-                .endObject()
-                .startObject(AnomalyDetectionAuditMessage.LEVEL.getPreferredName())
-                   .field(TYPE, KEYWORD)
-                .endObject()
-                .startObject(AnomalyDetectionAuditMessage.MESSAGE.getPreferredName())
-                    .field(TYPE, TEXT)
-                    .startObject(FIELDS)
-                        .startObject(RAW)
-                            .field(TYPE, KEYWORD)
-                        .endObject()
-                    .endObject()
-                .endObject()
-                .startObject(AnomalyDetectionAuditMessage.TIMESTAMP.getPreferredName())
-                    .field(TYPE, DATE)
-                .endObject()
-                .startObject(AnomalyDetectionAuditMessage.NODE_NAME.getPreferredName())
-                    .field(TYPE, KEYWORD)
-                .endObject()
-        .endObject()
-        .endObject()
-        .endObject();
-
-        return builder;
-    }
-
     public static XContentBuilder auditMessageMapping() throws IOException {
         XContentBuilder builder = jsonBuilder().startObject();
         builder.startObject(SINGLE_MAPPING_NAME);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappings.java
@@ -1117,7 +1117,7 @@ public class ElasticsearchMappings {
         .endObject();
     }
 
-    public static XContentBuilder auditMessageMapping() throws IOException {
+    public static XContentBuilder auditMessageMappingLegacy() throws IOException {
         XContentBuilder builder = jsonBuilder().startObject();
         builder.startObject(SINGLE_MAPPING_NAME);
         addMetaInformation(builder);
@@ -1140,6 +1140,42 @@ public class ElasticsearchMappings {
                     .field(TYPE, DATE)
                 .endObject()
                 .startObject(AnomalyDetectionAuditMessage.NODE_NAME.getPreferredName())
+                    .field(TYPE, KEYWORD)
+                .endObject()
+        .endObject()
+        .endObject()
+        .endObject();
+
+        return builder;
+    }
+
+    public static XContentBuilder auditMessageMapping() throws IOException {
+        XContentBuilder builder = jsonBuilder().startObject();
+        builder.startObject(SINGLE_MAPPING_NAME);
+        addMetaInformation(builder);
+        builder.field(DYNAMIC, "false");
+        builder.startObject(PROPERTIES)
+                .startObject(Job.ID.getPreferredName())
+                    .field(TYPE, KEYWORD)
+                .endObject()
+                .startObject(AnomalyDetectionAuditMessage.LEVEL.getPreferredName())
+                    .field(TYPE, KEYWORD)
+                .endObject()
+                .startObject(AnomalyDetectionAuditMessage.MESSAGE.getPreferredName())
+                    .field(TYPE, TEXT)
+                    .startObject(FIELDS)
+                        .startObject(RAW)
+                            .field(TYPE, KEYWORD)
+                        .endObject()
+                    .endObject()
+                .endObject()
+                .startObject(AnomalyDetectionAuditMessage.TIMESTAMP.getPreferredName())
+                    .field(TYPE, DATE)
+                .endObject()
+                .startObject(AnomalyDetectionAuditMessage.NODE_NAME.getPreferredName())
+                    .field(TYPE, KEYWORD)
+                .endObject()
+                .startObject(AnomalyDetectionAuditMessage.JOB_TYPE.getPreferredName())
                     .field(TYPE, KEYWORD)
                 .endObject()
         .endObject()

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/notifications/AnomalyDetectionAuditMessage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/notifications/AnomalyDetectionAuditMessage.java
@@ -25,7 +25,7 @@ public class AnomalyDetectionAuditMessage extends AbstractAuditMessage {
 
     @Override
     public final String getJobType() {
-        return "anomaly_detector";
+        return Job.ANOMALY_DETECTOR_JOB_TYPE;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/notifications/AuditorField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/notifications/AuditorField.java
@@ -7,7 +7,6 @@ package org.elasticsearch.xpack.core.ml.notifications;
 
 public final class AuditorField {
 
-    public static final String NOTIFICATIONS_INDEX_LEGACY = ".ml-notifications";
     public static final String NOTIFICATIONS_INDEX = ".ml-notifications-000001";
 
     private AuditorField() {}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/notifications/AuditorField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/notifications/AuditorField.java
@@ -6,8 +6,9 @@
 package org.elasticsearch.xpack.core.ml.notifications;
 
 public final class AuditorField {
-    public static final String NOTIFICATIONS_INDEX = ".ml-notifications";
+
+    public static final String NOTIFICATIONS_INDEX_LEGACY = ".ml-notifications";
+    public static final String NOTIFICATIONS_INDEX = ".ml-notifications-000001";
 
     private AuditorField() {}
-
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/notifications/DataFrameAnalyticsAuditMessage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/notifications/DataFrameAnalyticsAuditMessage.java
@@ -13,19 +13,19 @@ import org.elasticsearch.xpack.core.ml.job.config.Job;
 
 import java.util.Date;
 
-public class AnomalyDetectionAuditMessage extends AbstractAuditMessage {
+public class DataFrameAnalyticsAuditMessage extends AbstractAuditMessage {
 
     private static final ParseField JOB_ID = Job.ID;
-    public static final ConstructingObjectParser<AnomalyDetectionAuditMessage, Void> PARSER =
-        createParser("ml_audit_message", AnomalyDetectionAuditMessage::new, JOB_ID);
+    public static final ConstructingObjectParser<DataFrameAnalyticsAuditMessage, Void> PARSER =
+        createParser("ml_analytics_audit_message", DataFrameAnalyticsAuditMessage::new, JOB_ID);
 
-    public AnomalyDetectionAuditMessage(String resourceId, String message, Level level, Date timestamp, String nodeName) {
+    public DataFrameAnalyticsAuditMessage(String resourceId, String message, Level level, Date timestamp, String nodeName) {
         super(resourceId, message, level, timestamp, nodeName);
     }
 
     @Override
     public final String getJobType() {
-        return "anomaly_detector";
+        return "ml_analytics";
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/notifications/DataFrameAnalyticsAuditMessage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/notifications/DataFrameAnalyticsAuditMessage.java
@@ -25,7 +25,7 @@ public class DataFrameAnalyticsAuditMessage extends AbstractAuditMessage {
 
     @Override
     public final String getJobType() {
-        return "ml_analytics";
+        return "data_frame_analytics";
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditMessageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditMessageTests.java
@@ -27,6 +27,11 @@ public class AbstractAuditMessageTests extends AbstractXContentTestCase<Abstract
         }
 
         @Override
+        public String getJobType() {
+            return "test_type";
+        }
+
+        @Override
         protected String getResourceField() {
             return TEST_ID.getPreferredName();
         }
@@ -40,6 +45,11 @@ public class AbstractAuditMessageTests extends AbstractXContentTestCase<Abstract
     public void testGetResourceField() {
         TestAuditMessage message = new TestAuditMessage(RESOURCE_ID, MESSAGE, Level.INFO, TIMESTAMP, NODE_NAME);
         assertThat(message.getResourceField(), equalTo(TestAuditMessage.TEST_ID.getPreferredName()));
+    }
+
+    public void testGetJobType() {
+        TestAuditMessage message = createTestInstance();
+        assertThat(message.getJobType(), equalTo("test_type"));
     }
 
     public void testNewInfo() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/notifications/DataFrameAuditMessageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/dataframe/notifications/DataFrameAuditMessageTests.java
@@ -11,7 +11,14 @@ import org.elasticsearch.xpack.core.common.notifications.Level;
 
 import java.util.Date;
 
+import static org.hamcrest.Matchers.nullValue;
+
 public class DataFrameAuditMessageTests extends AbstractXContentTestCase<DataFrameAuditMessage> {
+
+    public void testGetJobType() {
+        DataFrameAuditMessage message = createTestInstance();
+        assertThat(message.getJobType(), nullValue());
+    }
 
     @Override
     protected DataFrameAuditMessage doParseInstance(XContentParser parser) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/notifications/AnomalyDetectionAuditMessageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/notifications/AnomalyDetectionAuditMessageTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.core.ml.notifications;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractXContentTestCase;
 import org.elasticsearch.xpack.core.common.notifications.Level;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
 
 import java.util.Date;
 
@@ -17,7 +18,7 @@ public class AnomalyDetectionAuditMessageTests extends AbstractXContentTestCase<
 
     public void testGetJobType() {
         AnomalyDetectionAuditMessage message = createTestInstance();
-        assertThat(message.getJobType(), equalTo("anomaly_detector"));
+        assertThat(message.getJobType(), equalTo(Job.ANOMALY_DETECTOR_JOB_TYPE));
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/notifications/DataFrameAnalyticsAuditMessageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/notifications/DataFrameAnalyticsAuditMessageTests.java
@@ -13,16 +13,16 @@ import java.util.Date;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class AnomalyDetectionAuditMessageTests extends AbstractXContentTestCase<AnomalyDetectionAuditMessage> {
+public class DataFrameAnalyticsAuditMessageTests extends AbstractXContentTestCase<DataFrameAnalyticsAuditMessage> {
 
     public void testGetJobType() {
-        AnomalyDetectionAuditMessage message = createTestInstance();
-        assertThat(message.getJobType(), equalTo("anomaly_detector"));
+        DataFrameAnalyticsAuditMessage message = createTestInstance();
+        assertThat(message.getJobType(), equalTo("ml_analytics"));
     }
-
+    
     @Override
-    protected AnomalyDetectionAuditMessage doParseInstance(XContentParser parser) {
-        return AnomalyDetectionAuditMessage.PARSER.apply(parser, null);
+    protected DataFrameAnalyticsAuditMessage doParseInstance(XContentParser parser) {
+        return DataFrameAnalyticsAuditMessage.PARSER.apply(parser, null);
     }
 
     @Override
@@ -31,8 +31,8 @@ public class AnomalyDetectionAuditMessageTests extends AbstractXContentTestCase<
     }
 
     @Override
-    protected AnomalyDetectionAuditMessage createTestInstance() {
-        return new AnomalyDetectionAuditMessage(
+    protected DataFrameAnalyticsAuditMessage createTestInstance() {
+        return new DataFrameAnalyticsAuditMessage(
             randomBoolean() ? null : randomAlphaOfLength(10),
             randomAlphaOfLengthBetween(1, 20),
             randomFrom(Level.values()),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/notifications/DataFrameAnalyticsAuditMessageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/notifications/DataFrameAnalyticsAuditMessageTests.java
@@ -17,7 +17,7 @@ public class DataFrameAnalyticsAuditMessageTests extends AbstractXContentTestCas
 
     public void testGetJobType() {
         DataFrameAnalyticsAuditMessage message = createTestInstance();
-        assertThat(message.getJobType(), equalTo("ml_analytics"));
+        assertThat(message.getJobType(), equalTo("data_frame_analytics"));
     }
     
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1010,6 +1010,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertOnlyReadAllowed(role, MlMetaIndex.INDEX_NAME);
         assertOnlyReadAllowed(role, AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX);
         assertOnlyReadAllowed(role, AnomalyDetectorsIndexFields.RESULTS_INDEX_PREFIX + AnomalyDetectorsIndexFields.RESULTS_INDEX_DEFAULT);
+        assertOnlyReadAllowed(role, AuditorField.NOTIFICATIONS_INDEX_LEGACY);
         assertOnlyReadAllowed(role, AuditorField.NOTIFICATIONS_INDEX);
         assertReadWriteDocsButNotDeleteIndexAllowed(role, AnnotationIndex.INDEX_NAME);
 
@@ -1096,6 +1097,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertNoAccessAllowed(role, MlMetaIndex.INDEX_NAME);
         assertNoAccessAllowed(role, AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX);
         assertOnlyReadAllowed(role, AnomalyDetectorsIndexFields.RESULTS_INDEX_PREFIX + AnomalyDetectorsIndexFields.RESULTS_INDEX_DEFAULT);
+        assertOnlyReadAllowed(role, AuditorField.NOTIFICATIONS_INDEX_LEGACY);
         assertOnlyReadAllowed(role, AuditorField.NOTIFICATIONS_INDEX);
         assertReadWriteDocsButNotDeleteIndexAllowed(role, AnnotationIndex.INDEX_NAME);
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1010,7 +1010,6 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertOnlyReadAllowed(role, MlMetaIndex.INDEX_NAME);
         assertOnlyReadAllowed(role, AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX);
         assertOnlyReadAllowed(role, AnomalyDetectorsIndexFields.RESULTS_INDEX_PREFIX + AnomalyDetectorsIndexFields.RESULTS_INDEX_DEFAULT);
-        assertOnlyReadAllowed(role, AuditorField.NOTIFICATIONS_INDEX_LEGACY);
         assertOnlyReadAllowed(role, AuditorField.NOTIFICATIONS_INDEX);
         assertReadWriteDocsButNotDeleteIndexAllowed(role, AnnotationIndex.INDEX_NAME);
 
@@ -1097,7 +1096,6 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertNoAccessAllowed(role, MlMetaIndex.INDEX_NAME);
         assertNoAccessAllowed(role, AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX);
         assertOnlyReadAllowed(role, AnomalyDetectorsIndexFields.RESULTS_INDEX_PREFIX + AnomalyDetectorsIndexFields.RESULTS_INDEX_DEFAULT);
-        assertOnlyReadAllowed(role, AuditorField.NOTIFICATIONS_INDEX_LEGACY);
         assertOnlyReadAllowed(role, AuditorField.NOTIFICATIONS_INDEX);
         assertReadWriteDocsButNotDeleteIndexAllowed(role, AnnotationIndex.INDEX_NAME);
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
@@ -29,6 +29,7 @@ import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 import org.elasticsearch.xpack.core.ml.job.results.Bucket;
 import org.elasticsearch.xpack.core.ml.job.results.ForecastRequestStats;
+import org.elasticsearch.xpack.core.ml.notifications.AuditorField;
 import org.junit.After;
 import org.junit.Before;
 
@@ -183,7 +184,8 @@ public class DeleteExpiredDataIT extends MlNativeAutodetectIntegTestCase {
         long totalModelSizeStatsBeforeDelete = client().prepareSearch("*")
                 .setQuery(QueryBuilders.termQuery("result_type", "model_size_stats"))
                 .get().getHits().getTotalHits().value;
-        long totalNotificationsCountBeforeDelete = client().prepareSearch(".ml-notifications").get().getHits().getTotalHits().value;
+        long totalNotificationsCountBeforeDelete =
+            client().prepareSearch(AuditorField.NOTIFICATIONS_INDEX).get().getHits().getTotalHits().value;
         assertThat(totalModelSizeStatsBeforeDelete, greaterThan(0L));
         assertThat(totalNotificationsCountBeforeDelete, greaterThan(0L));
 
@@ -233,7 +235,8 @@ public class DeleteExpiredDataIT extends MlNativeAutodetectIntegTestCase {
         long totalModelSizeStatsAfterDelete = client().prepareSearch("*")
                 .setQuery(QueryBuilders.termQuery("result_type", "model_size_stats"))
                 .get().getHits().getTotalHits().value;
-        long totalNotificationsCountAfterDelete = client().prepareSearch(".ml-notifications").get().getHits().getTotalHits().value;
+        long totalNotificationsCountAfterDelete =
+            client().prepareSearch(AuditorField.NOTIFICATIONS_INDEX).get().getHits().getTotalHits().value;
         assertThat(totalModelSizeStatsAfterDelete, equalTo(totalModelSizeStatsBeforeDelete));
         assertThat(totalNotificationsCountAfterDelete, greaterThanOrEqualTo(totalNotificationsCountBeforeDelete));
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.core.ml.job.config.Operator;
 import org.elasticsearch.xpack.core.ml.job.config.RuleCondition;
 import org.elasticsearch.xpack.core.ml.job.config.RuleScope;
 import org.elasticsearch.xpack.core.ml.job.results.AnomalyRecord;
+import org.elasticsearch.xpack.core.ml.notifications.AuditorField;
 import org.junit.After;
 
 import java.io.IOException;
@@ -186,7 +187,8 @@ public class DetectionRulesIT extends MlNativeAutodetectIntegTestCase {
 
         // Wait until the notification that the filter was updated is indexed
         assertBusy(() -> {
-            SearchResponse searchResponse = client().prepareSearch(".ml-notifications")
+            SearchResponse searchResponse =
+                client().prepareSearch(AuditorField.NOTIFICATIONS_INDEX)
                     .setSize(1)
                     .addSort("timestamp", SortOrder.DESC)
                     .setQuery(QueryBuilders.boolQuery()

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ScheduledEventsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ScheduledEventsIT.java
@@ -21,6 +21,7 @@ import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobUpdate;
 import org.elasticsearch.xpack.core.ml.job.results.AnomalyRecord;
 import org.elasticsearch.xpack.core.ml.job.results.Bucket;
+import org.elasticsearch.xpack.core.ml.notifications.AuditorField;
 import org.junit.After;
 
 import java.io.IOException;
@@ -223,7 +224,8 @@ public class ScheduledEventsIT extends MlNativeAutodetectIntegTestCase {
 
         // Wait until the notification that the process was updated is indexed
         assertBusy(() -> {
-            SearchResponse searchResponse = client().prepareSearch(".ml-notifications")
+            SearchResponse searchResponse =
+                client().prepareSearch(AuditorField.NOTIFICATIONS_INDEX)
                     .setSize(1)
                     .addSort("timestamp", SortOrder.DESC)
                     .setQuery(QueryBuilders.boolQuery()
@@ -298,7 +300,8 @@ public class ScheduledEventsIT extends MlNativeAutodetectIntegTestCase {
 
         // Wait until the notification that the job was updated is indexed
         assertBusy(() -> {
-            SearchResponse searchResponse = client().prepareSearch(".ml-notifications")
+            SearchResponse searchResponse =
+                client().prepareSearch(AuditorField.NOTIFICATIONS_INDEX)
                     .setSize(1)
                     .addSort("timestamp", SortOrder.DESC)
                     .setQuery(QueryBuilders.boolQuery()

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -370,6 +370,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
     private final SetOnce<AutodetectProcessManager> autodetectProcessManager = new SetOnce<>();
     private final SetOnce<DatafeedManager> datafeedManager = new SetOnce<>();
     private final SetOnce<DataFrameAnalyticsManager> dataFrameAnalyticsManager = new SetOnce<>();
+    private final SetOnce<DataFrameAnalyticsAuditor> dataFrameAnalyticsAuditor = new SetOnce<>();
     private final SetOnce<MlMemoryTracker> memoryTracker = new SetOnce<>();
 
     public MachineLearning(Settings settings, Path configPath) {
@@ -473,6 +474,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
 
         AnomalyDetectionAuditor anomalyDetectionAuditor = new AnomalyDetectionAuditor(client, clusterService.getNodeName());
         DataFrameAnalyticsAuditor dataFrameAnalyticsAuditor = new DataFrameAnalyticsAuditor(client, clusterService.getNodeName());
+        this.dataFrameAnalyticsAuditor.set(dataFrameAnalyticsAuditor);
         JobResultsProvider jobResultsProvider = new JobResultsProvider(client, settings);
         JobResultsPersister jobResultsPersister = new JobResultsPersister(client);
         JobDataCountsPersister jobDataCountsPersister = new JobDataCountsPersister(client);
@@ -562,8 +564,8 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                 threadPool.generic(), threadPool.executor(MachineLearning.JOB_COMMS_THREAD_POOL_NAME), memoryEstimationProcessFactory);
         DataFrameAnalyticsConfigProvider dataFrameAnalyticsConfigProvider = new DataFrameAnalyticsConfigProvider(client);
         assert client instanceof NodeClient;
-        DataFrameAnalyticsManager dataFrameAnalyticsManager = new DataFrameAnalyticsManager((NodeClient) client,
-            dataFrameAnalyticsConfigProvider, analyticsProcessManager);
+        DataFrameAnalyticsManager dataFrameAnalyticsManager = new DataFrameAnalyticsManager(
+            (NodeClient) client, dataFrameAnalyticsConfigProvider, analyticsProcessManager, dataFrameAnalyticsAuditor);
         this.dataFrameAnalyticsManager.set(dataFrameAnalyticsManager);
 
         // Components shared by anomaly detection and data frame analytics
@@ -618,7 +620,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                     memoryTracker.get(), client),
                 new TransportStartDatafeedAction.StartDatafeedPersistentTasksExecutor(datafeedManager.get()),
                 new TransportStartDataFrameAnalyticsAction.TaskExecutor(settings, client, clusterService, dataFrameAnalyticsManager.get(),
-                    memoryTracker.get())
+                    dataFrameAnalyticsAuditor.get(), memoryTracker.get())
         );
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -801,24 +801,6 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                 delayedNodeTimeOutSetting = TimeValue.timeValueNanos(0);
             }
 
-            try (XContentBuilder auditMapping = ElasticsearchMappings.auditMessageMappingLegacy()) {
-                IndexTemplateMetaData notificationMessageTemplate =
-                    IndexTemplateMetaData.builder(AuditorField.NOTIFICATIONS_INDEX_LEGACY)
-                        .putMapping(SINGLE_MAPPING_NAME, Strings.toString(auditMapping))
-                        .patterns(Collections.singletonList(AuditorField.NOTIFICATIONS_INDEX_LEGACY))
-                        .version(Version.CURRENT.id)
-                        .settings(Settings.builder()
-                                // Our indexes are small and one shard puts the
-                                // least possible burden on Elasticsearch
-                                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
-                                .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
-                                .put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), delayedNodeTimeOutSetting))
-                        .build();
-                templates.put(AuditorField.NOTIFICATIONS_INDEX_LEGACY, notificationMessageTemplate);
-            } catch (IOException e) {
-                logger.warn("Error loading the template for the legacy notification message index", e);
-            }
-
             try (XContentBuilder auditMapping = ElasticsearchMappings.auditMessageMapping()) {
                 IndexTemplateMetaData notificationMessageTemplate =
                     IndexTemplateMetaData.builder(AuditorField.NOTIFICATIONS_INDEX)
@@ -921,7 +903,6 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
         boolean allPresent = true;
         List<String> templateNames =
             Arrays.asList(
-                AuditorField.NOTIFICATIONS_INDEX_LEGACY,
                 AuditorField.NOTIFICATIONS_INDEX,
                 MlMetaIndex.INDEX_NAME,
                 AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
@@ -46,6 +46,7 @@ import org.elasticsearch.xpack.core.security.authz.permission.ResourcePrivileges
 import org.elasticsearch.xpack.core.security.support.Exceptions;
 import org.elasticsearch.xpack.ml.dataframe.SourceDestValidator;
 import org.elasticsearch.xpack.ml.dataframe.persistence.DataFrameAnalyticsConfigProvider;
+import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -64,6 +65,7 @@ public class TransportPutDataFrameAnalyticsAction
     private final Client client;
     private final ClusterService clusterService;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
+    private final DataFrameAnalyticsAuditor auditor;
 
     private volatile ByteSizeValue maxModelMemoryLimit;
 
@@ -71,7 +73,7 @@ public class TransportPutDataFrameAnalyticsAction
     public TransportPutDataFrameAnalyticsAction(Settings settings, TransportService transportService, ActionFilters actionFilters,
                                                 XPackLicenseState licenseState, Client client, ThreadPool threadPool,
                                                 ClusterService clusterService, IndexNameExpressionResolver indexNameExpressionResolver,
-                                                DataFrameAnalyticsConfigProvider configProvider) {
+                                                DataFrameAnalyticsConfigProvider configProvider, DataFrameAnalyticsAuditor auditor) {
         super(PutDataFrameAnalyticsAction.NAME, transportService, actionFilters, PutDataFrameAnalyticsAction.Request::new);
         this.licenseState = licenseState;
         this.configProvider = configProvider;
@@ -81,6 +83,7 @@ public class TransportPutDataFrameAnalyticsAction
         this.client = client;
         this.clusterService = clusterService;
         this.indexNameExpressionResolver = Objects.requireNonNull(indexNameExpressionResolver);
+        this.auditor = Objects.requireNonNull(auditor);
 
         maxModelMemoryLimit = MachineLearningField.MAX_MODEL_MEMORY_LIMIT.get(settings);
         clusterService.getClusterSettings()
@@ -179,7 +182,14 @@ public class TransportPutDataFrameAnalyticsAction
             client,
             clusterState,
             ActionListener.wrap(
-                unused -> configProvider.put(config, headers, listener),
+                unused -> configProvider.put(config, headers, ActionListener.wrap(
+                    indexResponse -> {
+                        auditor.info(
+                            config.getId(),
+                            Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_AUDIT_CREATED, config.getAnalysis().getUserFriendlyName()));
+                        listener.onResponse(indexResponse);
+                    },
+                    listener::onFailure)),
                 listener::onFailure));
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -54,6 +54,7 @@ import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsTaskState;
+import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.ml.MachineLearning;
@@ -64,6 +65,7 @@ import org.elasticsearch.xpack.ml.dataframe.SourceDestValidator;
 import org.elasticsearch.xpack.ml.dataframe.extractor.DataFrameDataExtractorFactory;
 import org.elasticsearch.xpack.ml.dataframe.persistence.DataFrameAnalyticsConfigProvider;
 import org.elasticsearch.xpack.ml.job.JobNodeSelector;
+import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
 
 import java.io.IOException;
@@ -92,13 +94,15 @@ public class TransportStartDataFrameAnalyticsAction
     private final PersistentTasksService persistentTasksService;
     private final DataFrameAnalyticsConfigProvider configProvider;
     private final MlMemoryTracker memoryTracker;
+    private final DataFrameAnalyticsAuditor auditor;
 
     @Inject
     public TransportStartDataFrameAnalyticsAction(TransportService transportService, Client client, ClusterService clusterService,
                                                   ThreadPool threadPool, ActionFilters actionFilters, XPackLicenseState licenseState,
                                                   IndexNameExpressionResolver indexNameExpressionResolver,
                                                   PersistentTasksService persistentTasksService,
-                                                  DataFrameAnalyticsConfigProvider configProvider, MlMemoryTracker memoryTracker) {
+                                                  DataFrameAnalyticsConfigProvider configProvider, MlMemoryTracker memoryTracker,
+                                                  DataFrameAnalyticsAuditor auditor) {
         super(StartDataFrameAnalyticsAction.NAME, transportService, clusterService, threadPool, actionFilters,
                 StartDataFrameAnalyticsAction.Request::new, indexNameExpressionResolver);
         this.licenseState = licenseState;
@@ -106,6 +110,7 @@ public class TransportStartDataFrameAnalyticsAction
         this.persistentTasksService = persistentTasksService;
         this.configProvider = configProvider;
         this.memoryTracker = memoryTracker;
+        this.auditor = Objects.requireNonNull(auditor);
     }
 
     @Override
@@ -147,8 +152,9 @@ public class TransportStartDataFrameAnalyticsAction
                 @Override
                 public void onFailure(Exception e) {
                     if (e instanceof ResourceAlreadyExistsException) {
-                        e = new ElasticsearchStatusException("Cannot open data frame analytics [" + request.getId() +
-                            "] because it has already been opened", RestStatus.CONFLICT, e);
+                        auditor.error(request.getId(), Messages.DATA_FRAME_ANALYTICS_AUDIT_ALREADY_STARTED);
+                        e = new ElasticsearchStatusException("Cannot start data frame analytics [" + request.getId() +
+                            "] because it has already been started", RestStatus.CONFLICT, e);
                     }
                     listener.onFailure(e);
                 }
@@ -170,6 +176,11 @@ public class TransportStartDataFrameAnalyticsAction
         // Tell the job tracker to refresh the memory requirement for this job and all other jobs that have persistent tasks
         ActionListener<EstimateMemoryUsageAction.Response> estimateMemoryUsageListener = ActionListener.wrap(
             estimateMemoryUsageResponse -> {
+                auditor.info(
+                    request.getId(),
+                    Messages.getMessage(
+                        Messages.DATA_FRAME_ANALYTICS_AUDIT_ESTIMATED_MEMORY_USAGE,
+                        estimateMemoryUsageResponse.getExpectedMemoryWithoutDisk()));
                 // Validate that model memory limit is sufficient to run the analysis
                 if (configHolder.get().getModelMemoryLimit()
                     .compareTo(estimateMemoryUsageResponse.getExpectedMemoryWithoutDisk()) < 0) {
@@ -303,6 +314,7 @@ public class TransportStartDataFrameAnalyticsAction
                         // what would have happened if the error had been detected in the "fast fail" validation
                         cancelAnalyticsStart(task, predicate.exception, listener);
                     } else {
+                        auditor.info(task.getParams().getId(), Messages.DATA_FRAME_ANALYTICS_AUDIT_STARTED);
                         listener.onResponse(new AcknowledgedResponse(true));
                     }
                 }
@@ -314,8 +326,10 @@ public class TransportStartDataFrameAnalyticsAction
 
                 @Override
                 public void onTimeout(TimeValue timeout) {
-                    listener.onFailure(new ElasticsearchException("Starting data frame analytics [" + task.getParams().getId()
-                        + "] timed out after [" + timeout + "]"));
+                    auditor.error(
+                        task.getParams().getId(), Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_AUDIT_START_TIMEOUT, timeout));
+                    listener.onFailure(new ElasticsearchException(
+                        "Starting data frame analytics [" + task.getParams().getId() + "] timed out after [" + timeout + "]"));
                 }
         });
     }
@@ -324,7 +338,7 @@ public class TransportStartDataFrameAnalyticsAction
      * Important: the methods of this class must NOT throw exceptions.  If they did then the callers
      * of endpoints waiting for a condition tested by this predicate would never get a response.
      */
-    private class AnalyticsPredicate implements Predicate<PersistentTasksCustomMetaData.PersistentTask<?>> {
+    private static class AnalyticsPredicate implements Predicate<PersistentTasksCustomMetaData.PersistentTask<?>> {
 
         private volatile Exception exception;
 
@@ -375,6 +389,7 @@ public class TransportStartDataFrameAnalyticsAction
             new ActionListener<PersistentTasksCustomMetaData.PersistentTask<?>>() {
                 @Override
                 public void onResponse(PersistentTasksCustomMetaData.PersistentTask<?> task) {
+                    auditor.warning(persistentTask.getParams().getId(), Messages.DATA_FRAME_ANALYTICS_AUDIT_CANCELED);
                     // We succeeded in cancelling the persistent task, but the
                     // problem that caused us to cancel it is the overall result
                     listener.onFailure(exception);
@@ -408,6 +423,7 @@ public class TransportStartDataFrameAnalyticsAction
         private final Client client;
         private final ClusterService clusterService;
         private final DataFrameAnalyticsManager manager;
+        private final DataFrameAnalyticsAuditor auditor;
         private final MlMemoryTracker memoryTracker;
 
         private volatile int maxMachineMemoryPercent;
@@ -415,11 +431,12 @@ public class TransportStartDataFrameAnalyticsAction
         private volatile int maxOpenJobs;
 
         public TaskExecutor(Settings settings, Client client, ClusterService clusterService, DataFrameAnalyticsManager manager,
-                            MlMemoryTracker memoryTracker) {
+                            DataFrameAnalyticsAuditor auditor, MlMemoryTracker memoryTracker) {
             super(MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME, MachineLearning.UTILITY_THREAD_POOL_NAME);
             this.client = Objects.requireNonNull(client);
             this.clusterService = Objects.requireNonNull(clusterService);
             this.manager = Objects.requireNonNull(manager);
+            this.auditor = Objects.requireNonNull(auditor);
             this.memoryTracker = Objects.requireNonNull(memoryTracker);
             this.maxMachineMemoryPercent = MachineLearning.MAX_MACHINE_MEMORY_PERCENT.get(settings);
             this.maxLazyMLNodes = MachineLearning.MAX_LAZY_ML_NODES.get(settings);
@@ -435,8 +452,8 @@ public class TransportStartDataFrameAnalyticsAction
             long id, String type, String action, TaskId parentTaskId,
             PersistentTasksCustomMetaData.PersistentTask<StartDataFrameAnalyticsAction.TaskParams> persistentTask,
             Map<String, String> headers) {
-            return new DataFrameAnalyticsTask(id, type, action, parentTaskId, headers, client, clusterService, manager,
-                persistentTask.getParams());
+            return new DataFrameAnalyticsTask(
+                id, type, action, parentTaskId, headers, client, clusterService, manager, auditor, persistentTask.getParams());
         }
 
         @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
@@ -30,10 +30,12 @@ import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsTaskState;
+import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.ml.dataframe.extractor.DataFrameDataExtractorFactory;
 import org.elasticsearch.xpack.ml.dataframe.persistence.DataFrameAnalyticsConfigProvider;
 import org.elasticsearch.xpack.ml.dataframe.process.AnalyticsProcessManager;
+import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 
 import java.time.Clock;
 import java.util.Objects;
@@ -51,12 +53,14 @@ public class DataFrameAnalyticsManager {
     private final NodeClient client;
     private final DataFrameAnalyticsConfigProvider configProvider;
     private final AnalyticsProcessManager processManager;
+    private final DataFrameAnalyticsAuditor auditor;
 
     public DataFrameAnalyticsManager(NodeClient client, DataFrameAnalyticsConfigProvider configProvider,
-                                     AnalyticsProcessManager processManager) {
+                                     AnalyticsProcessManager processManager, DataFrameAnalyticsAuditor auditor) {
         this.client = Objects.requireNonNull(client);
         this.configProvider = Objects.requireNonNull(configProvider);
         this.processManager = Objects.requireNonNull(processManager);
+        this.auditor = Objects.requireNonNull(auditor);
     }
 
     public void execute(DataFrameAnalyticsTask task, DataFrameAnalyticsState currentState) {
@@ -143,6 +147,9 @@ public class DataFrameAnalyticsManager {
                     return;
                 }
                 task.setReindexingFinished();
+                auditor.info(
+                    config.getId(),
+                    Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_AUDIT_FINISHED_REINDEXING, config.getDest().getIndex()));
                 ClientHelper.executeAsyncWithOrigin(client,
                     ClientHelper.ML_ORIGIN,
                     RefreshAction.INSTANCE,
@@ -175,6 +182,9 @@ public class DataFrameAnalyticsManager {
         // Create destination index if it does not exist
         ActionListener<GetIndexResponse> destIndexListener = ActionListener.wrap(
             indexResponse -> {
+                auditor.info(
+                    config.getId(),
+                    Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_AUDIT_REUSING_DEST_INDEX, indexResponse.indices()[0]));
                 LOGGER.info("[{}] Using existing destination index [{}]", config.getId(), indexResponse.indices()[0]);
                 DataFrameAnalyticsIndex.updateMappingsToDestIndex(client, config, indexResponse, ActionListener.wrap(
                     acknowledgedResponse -> copyIndexCreatedListener.onResponse(null),
@@ -183,6 +193,9 @@ public class DataFrameAnalyticsManager {
             },
             e -> {
                 if (org.elasticsearch.ExceptionsHelper.unwrapCause(e) instanceof IndexNotFoundException) {
+                    auditor.info(
+                        config.getId(),
+                        Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_AUDIT_CREATING_DEST_INDEX, config.getDest().getIndex()));
                     LOGGER.info("[{}] Creating destination index [{}]", config.getId(), config.getDest().getIndex());
                     DataFrameAnalyticsIndex.createDestinationIndex(client, Clock.systemUTC(), config, copyIndexCreatedListener);
                 } else {
@@ -210,6 +223,7 @@ public class DataFrameAnalyticsManager {
                             if (error != null) {
                                 task.updateState(DataFrameAnalyticsState.FAILED, error.getMessage());
                             } else {
+                                auditor.info(config.getId(), Messages.DATA_FRAME_ANALYTICS_AUDIT_FINISHED_ANALYSIS);
                                 task.markAsCompleted();
                             }
                         }),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTask.java
@@ -31,10 +31,12 @@ import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsTaskState;
+import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.ml.utils.PhaseProgress;
 import org.elasticsearch.xpack.core.watcher.watch.Payload;
+import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 
 import java.util.Arrays;
 import java.util.List;
@@ -52,6 +54,7 @@ public class DataFrameAnalyticsTask extends AllocatedPersistentTask implements S
     private final Client client;
     private final ClusterService clusterService;
     private final DataFrameAnalyticsManager analyticsManager;
+    private final DataFrameAnalyticsAuditor auditor;
     private final StartDataFrameAnalyticsAction.TaskParams taskParams;
     @Nullable
     private volatile Long reindexingTaskId;
@@ -61,11 +64,12 @@ public class DataFrameAnalyticsTask extends AllocatedPersistentTask implements S
 
     public DataFrameAnalyticsTask(long id, String type, String action, TaskId parentTask, Map<String, String> headers,
                                   Client client, ClusterService clusterService, DataFrameAnalyticsManager analyticsManager,
-                                  StartDataFrameAnalyticsAction.TaskParams taskParams) {
+                                  DataFrameAnalyticsAuditor auditor, StartDataFrameAnalyticsAction.TaskParams taskParams) {
         super(id, type, action, MlTasks.DATA_FRAME_ANALYTICS_TASK_ID_PREFIX + taskParams.getId(), parentTask, headers);
         this.client = Objects.requireNonNull(client);
         this.clusterService = Objects.requireNonNull(clusterService);
         this.analyticsManager = Objects.requireNonNull(analyticsManager);
+        this.auditor = Objects.requireNonNull(auditor);
         this.taskParams = Objects.requireNonNull(taskParams);
     }
 
@@ -154,11 +158,17 @@ public class DataFrameAnalyticsTask extends AllocatedPersistentTask implements S
 
     public void updateState(DataFrameAnalyticsState state, @Nullable String reason) {
         DataFrameAnalyticsTaskState newTaskState = new DataFrameAnalyticsTaskState(state, getAllocationId(), reason);
-        updatePersistentTaskState(newTaskState, ActionListener.wrap(
-            updatedTask -> LOGGER.info("[{}] Successfully update task state to [{}]", getParams().getId(), state),
-            e -> LOGGER.error(new ParameterizedMessage("[{}] Could not update task state to [{}] with reason [{}]",
-                getParams().getId(), state, reason), e)
-        ));
+        updatePersistentTaskState(
+            newTaskState,
+            ActionListener.wrap(
+                updatedTask -> {
+                    auditor.info(getParams().getId(), Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_AUDIT_UPDATED_STATE, state));
+                    LOGGER.info("[{}] Successfully update task state to [{}]", getParams().getId(), state);
+                },
+                e -> LOGGER.error(new ParameterizedMessage("[{}] Could not update task state to [{}] with reason [{}]",
+                    getParams().getId(), state, reason), e)
+            )
+        );
     }
 
     public void updateReindexTaskProgress(ActionListener<Void> listener) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/notifications/DataFrameAnalyticsAuditor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/notifications/DataFrameAnalyticsAuditor.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.notifications;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.xpack.core.common.notifications.AbstractAuditor;
+import org.elasticsearch.xpack.core.ml.notifications.AuditorField;
+import org.elasticsearch.xpack.core.ml.notifications.DataFrameAnalyticsAuditMessage;
+
+import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
+
+public class DataFrameAnalyticsAuditor extends AbstractAuditor<DataFrameAnalyticsAuditMessage> {
+
+    public DataFrameAnalyticsAuditor(Client client, String nodeName) {
+        super(client, nodeName, AuditorField.NOTIFICATIONS_INDEX, ML_ORIGIN, DataFrameAnalyticsAuditMessage::new);
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportOpenJobActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportOpenJobActionTests.java
@@ -205,6 +205,7 @@ public class TransportOpenJobActionTests extends ESTestCase {
         indices.add(AnomalyDetectorsIndex.configIndexName());
         indices.add(AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX);
         indices.add(MlMetaIndex.INDEX_NAME);
+        indices.add(AuditorField.NOTIFICATIONS_INDEX_LEGACY);
         indices.add(AuditorField.NOTIFICATIONS_INDEX);
         indices.add(AnomalyDetectorsIndexFields.RESULTS_INDEX_PREFIX + AnomalyDetectorsIndexFields.RESULTS_INDEX_DEFAULT);
         for (String indexName : indices) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportOpenJobActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportOpenJobActionTests.java
@@ -205,7 +205,6 @@ public class TransportOpenJobActionTests extends ESTestCase {
         indices.add(AnomalyDetectorsIndex.configIndexName());
         indices.add(AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX);
         indices.add(MlMetaIndex.INDEX_NAME);
-        indices.add(AuditorField.NOTIFICATIONS_INDEX_LEGACY);
         indices.add(AuditorField.NOTIFICATIONS_INDEX);
         indices.add(AnomalyDetectorsIndexFields.RESULTS_INDEX_PREFIX + AnomalyDetectorsIndexFields.RESULTS_INDEX_DEFAULT);
         for (String indexName : indices) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/AnnotationIndexIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/AnnotationIndexIT.java
@@ -57,7 +57,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
         AnomalyDetectionAuditor auditor = new AnomalyDetectionAuditor(client(), "node_1");
         auditor.info("whatever", "blah");
 
-        // Creating a document in the .ml-notifications index should cause .ml-annotations
+        // Creating a document in the .ml-notifications-000001 index should cause .ml-annotations
         // to be created, as it should get created as soon as any other ML index exists
 
         assertBusy(() -> {

--- a/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/XPackRestIT.java
+++ b/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/XPackRestIT.java
@@ -87,7 +87,11 @@ public class XPackRestIT extends ESClientYamlSuiteTestCase {
     private void waitForTemplates() throws Exception {
         if (installTemplates()) {
             List<String> templates = new ArrayList<>();
-            templates.addAll(Arrays.asList(AuditorField.NOTIFICATIONS_INDEX, MlMetaIndex.INDEX_NAME,
+            templates.addAll(
+                Arrays.asList(
+                    AuditorField.NOTIFICATIONS_INDEX_LEGACY,
+                    AuditorField.NOTIFICATIONS_INDEX,
+                    MlMetaIndex.INDEX_NAME,
                     AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX,
                     AnomalyDetectorsIndex.jobResultsIndexPrefix(),
                     AnomalyDetectorsIndex.configIndexName()));

--- a/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/XPackRestIT.java
+++ b/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/XPackRestIT.java
@@ -89,7 +89,6 @@ public class XPackRestIT extends ESClientYamlSuiteTestCase {
             List<String> templates = new ArrayList<>();
             templates.addAll(
                 Arrays.asList(
-                    AuditorField.NOTIFICATIONS_INDEX_LEGACY,
                     AuditorField.NOTIFICATIONS_INDEX,
                     MlMetaIndex.INDEX_NAME,
                     AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX,

--- a/x-pack/qa/src/main/java/org/elasticsearch/xpack/test/rest/XPackRestTestConstants.java
+++ b/x-pack/qa/src/main/java/org/elasticsearch/xpack/test/rest/XPackRestTestConstants.java
@@ -21,14 +21,21 @@ public final class XPackRestTestConstants {
 
     // ML constants:
     public static final String ML_META_INDEX_NAME = ".ml-meta";
-    public static final String AUDITOR_NOTIFICATIONS_INDEX = ".ml-notifications";
+    public static final String AUDITOR_NOTIFICATIONS_INDEX_LEGACY = ".ml-notifications";
+    public static final String AUDITOR_NOTIFICATIONS_INDEX = ".ml-notifications-000001";
     public static final String CONFIG_INDEX = ".ml-config";
     public static final String RESULTS_INDEX_PREFIX = ".ml-anomalies-";
     public static final String STATE_INDEX_PREFIX = ".ml-state";
     public static final String RESULTS_INDEX_DEFAULT = "shared";
 
     public static final List<String> ML_POST_V660_TEMPLATES =
-        List.of(AUDITOR_NOTIFICATIONS_INDEX, ML_META_INDEX_NAME, STATE_INDEX_PREFIX, RESULTS_INDEX_PREFIX, CONFIG_INDEX);
+        List.of(
+            AUDITOR_NOTIFICATIONS_INDEX_LEGACY,
+            AUDITOR_NOTIFICATIONS_INDEX,
+            ML_META_INDEX_NAME,
+            STATE_INDEX_PREFIX,
+            RESULTS_INDEX_PREFIX,
+            CONFIG_INDEX);
 
     // Data Frame constants:
     public static final String DATA_FRAME_INTERNAL_INDEX = ".data-frame-internal-1";


### PR DESCRIPTION
Adds auditing in the various places of DF analytics lifecycle.

Relates https://github.com/elastic/ml-team/issues/184