### PR TITLE
Wait for all Rec. to Stop on Node Close

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
@@ -24,10 +24,13 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ChannelActionListener;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.shard.IndexEventListener;
 import org.elasticsearch.index.shard.IndexShard;
@@ -50,7 +53,7 @@ import java.util.Set;
  * The source recovery accepts recovery requests from other peer shards and start the recovery process from this
  * source shard to the target shard.
  */
-public class PeerRecoverySourceService implements IndexEventListener {
+public class PeerRecoverySourceService extends AbstractLifecycleComponent implements IndexEventListener {
 
     private static final Logger logger = LogManager.getLogger(PeerRecoverySourceService.class);
 
@@ -72,6 +75,19 @@ public class PeerRecoverySourceService implements IndexEventListener {
         this.recoverySettings = recoverySettings;
         transportService.registerRequestHandler(Actions.START_RECOVERY, ThreadPool.Names.GENERIC, StartRecoveryRequest::new,
             new StartRecoveryTransportRequestHandler());
+    }
+
+    @Override
+    protected void doStart() {
+    }
+
+    @Override
+    protected void doStop() {
+        ongoingRecoveries.awaitEmpty();
+    }
+
+    @Override
+    protected void doClose() {
     }
 
     @Override
@@ -118,6 +134,9 @@ public class PeerRecoverySourceService implements IndexEventListener {
     }
 
     final class OngoingRecoveries {
+
+        private final List<ActionListener<Void>> emptyListeners = new ArrayList<>();
+
         private final Map<IndexShard, ShardRecoveryContext> ongoingRecoveries = new HashMap<>();
 
         synchronized RecoverySourceHandler addNewRecovery(StartRecoveryRequest request, IndexShard shard) {
@@ -138,6 +157,10 @@ public class PeerRecoverySourceService implements IndexEventListener {
             if (shardRecoveryContext.recoveryHandlers.isEmpty()) {
                 ongoingRecoveries.remove(shard);
             }
+            if (ongoingRecoveries.isEmpty()) {
+                ActionListener.onResponse(emptyListeners, null);
+                emptyListeners.clear();
+            }
         }
 
         synchronized void cancel(IndexShard shard, String reason) {
@@ -155,6 +178,19 @@ public class PeerRecoverySourceService implements IndexEventListener {
                 }
                 ExceptionsHelper.maybeThrowRuntimeAndSuppress(failures);
             }
+        }
+
+        void awaitEmpty() {
+            assert lifecycle.stoppedOrClosed();
+            final PlainActionFuture<Void> future;
+            synchronized (this) {
+                if (ongoingRecoveries.isEmpty()) {
+                    return;
+                }
+                future = new PlainActionFuture<>();
+                emptyListeners.add(future);
+            }
+            FutureUtils.get(future);
         }
 
         private final class ShardRecoveryContext {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
@@ -137,9 +137,11 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
 
         private final Map<IndexShard, ShardRecoveryContext> ongoingRecoveries = new HashMap<>();
 
-        private List<ActionListener<Void>> emptyListeners = new ArrayList<>();
+        @Nullable
+        private List<ActionListener<Void>> emptyListeners;
 
         synchronized RecoverySourceHandler addNewRecovery(StartRecoveryRequest request, IndexShard shard) {
+            assert lifecycle.started();
             final ShardRecoveryContext shardContext = ongoingRecoveries.computeIfAbsent(shard, s -> new ShardRecoveryContext());
             RecoverySourceHandler handler = shardContext.addNewRecovery(request, shard);
             shard.recoveryStats().incCurrentAsSource();

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -402,13 +402,14 @@ public class RecoverySourceHandler {
         store.incRef();
         return Releasables.releaseOnce(() -> {
             final PlainActionFuture<Void> future = new PlainActionFuture<>();
-            threadPool.generic().execute(new ActionRunnable<>(future) {
-                @Override
-                protected void doRun() {
-                    store.decRef();
-                    listener.onResponse(null);
-                }
-            });
+            assert threadPool.generic().isShutdown() == false;
+            // TODO: We shouldn't use the generic thread pool here as we already execute this from the generic pool.
+            //       While practically unlikely at a min pool size of 128 we could technically block the whole pool by waiting on futures
+            //       below and thus make it impossible for the store release to execute which in turn would block the futures forever
+            threadPool.generic().execute(ActionRunnable.wrap(future, l -> {
+                store.decRef();
+                l.onResponse(null);
+            }));
             FutureUtils.get(future);
         });
     }

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -592,6 +592,7 @@ public class Node implements Closeable {
                 .filter(p -> p instanceof LifecycleComponent)
                 .map(p -> (LifecycleComponent) p).collect(Collectors.toList());
             resourcesToClose.addAll(pluginLifecycleComponents);
+            resourcesToClose.add(injector.getInstance(PeerRecoverySourceService.class));
             this.pluginLifecycleComponents = Collections.unmodifiableList(pluginLifecycleComponents);
             client.initialize(injector.getInstance(new Key<Map<ActionType, TransportAction>>() {}), transportService.getTaskManager(),
                     () -> clusterService.localNode().getId(), transportService.getRemoteClusterService());
@@ -688,6 +689,7 @@ public class Node implements Closeable {
         assert localNodeFactory.getNode() != null;
         assert transportService.getLocalNode().equals(localNodeFactory.getNode())
             : "transportService has a different local node than the factory provided";
+        injector.getInstance(PeerRecoverySourceService.class).start();
         final MetaData onDiskMetadata;
         // we load the global state here (the persistent part of the cluster state stored on disk) to
         // pass it to the bootstrap checks to allow plugins to enforce certain preconditions based on the recovered state.
@@ -833,6 +835,7 @@ public class Node implements Closeable {
         toClose.add(injector.getInstance(IndicesService.class));
         // close filter/fielddata caches after indices
         toClose.add(injector.getInstance(IndicesStore.class));
+        toClose.add(injector.getInstance(PeerRecoverySourceService.class));
         toClose.add(() -> stopWatch.stop().start("cluster"));
         toClose.add(injector.getInstance(ClusterService.class));
         toClose.add(() -> stopWatch.stop().start("node_connections_service"));

--- a/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoverySourceServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoverySourceServiceTests.java
@@ -43,6 +43,7 @@ public class PeerRecoverySourceServiceTests extends IndexShardTestCase {
         StartRecoveryRequest startRecoveryRequest = new StartRecoveryRequest(primary.shardId(), randomAlphaOfLength(10),
             getFakeDiscoNode("source"), getFakeDiscoNode("target"), Store.MetadataSnapshot.EMPTY, randomBoolean(), randomLong(),
             SequenceNumbers.UNASSIGNED_SEQ_NO);
+        peerRecoverySourceService.start();
         RecoverySourceHandler handler = peerRecoverySourceService.ongoingRecoveries.addNewRecovery(startRecoveryRequest, primary);
         DelayRecoveryException delayRecoveryException = expectThrows(DelayRecoveryException.class,
             () -> peerRecoverySourceService.ongoingRecoveries.addNewRecovery(startRecoveryRequest, primary));


### PR DESCRIPTION
* This issue is in the `RecoverySourceHandler#acquireStore`. If we submit the store release to the generic threadpool while it is getting shut down we never complete the futue we wait on (in the generic pool as well) and fail to ever release the store potentially (see David's explanation in https://github.com/elastic/elasticsearch/issues/45956#issuecomment-526106651)
* Fixed by waiting for all recoveries to end on node close so that we aways have a healthy thread pool here
   * The alternative of fixing this via the `ThreadPool` isn't really viable. If the pool is shut down it's shut down. We can make that visible maybe but it seems wrong when we use waiting for a clean state before stopping in other compontents as well. Also, the generic pool is specifically documented as quietly swallowing executions when shut down.
* In theory there is still a deadlock spot left here that seems practically close to impossible though (I added a TODO for it regardless).
* Closes #45956
