### PR TITLE
Prototype for extensible ValuesSources

### DIFF
--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsParser.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsParser.java
@@ -23,7 +23,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.aggregations.support.ArrayValuesSourceParser.NumericValuesSourceParser;
 import org.elasticsearch.search.aggregations.support.ValueType;
-import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceFamily;
 
 import java.io.IOException;
 import java.util.Map;
@@ -49,7 +49,7 @@ public class MatrixStatsParser extends NumericValuesSourceParser {
     }
 
     @Override
-    protected MatrixStatsAggregationBuilder createFactory(String aggregationName, ValuesSourceType valuesSourceType,
+    protected MatrixStatsAggregationBuilder createFactory(String aggregationName, ValuesSourceFamily valuesSourceFamily,
                                                           ValueType targetValueType, Map<ParseField, Object> otherOptions) {
         MatrixStatsAggregationBuilder builder = new MatrixStatsAggregationBuilder(aggregationName);
         String mode = (String)otherOptions.get(MULTIVALUE_MODE_FIELD);

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/ArrayValuesSourceParser.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/ArrayValuesSourceParser.java
@@ -64,11 +64,11 @@ public abstract class ArrayValuesSourceParser<VS extends ValuesSource> implement
     }
 
     private boolean formattable = false;
-    private ValuesSourceType valuesSourceType = null;
+    private ValuesSourceFamily valuesSourceFamily = null;
     private ValueType targetValueType = null;
 
-    private ArrayValuesSourceParser(boolean formattable, ValuesSourceType valuesSourceType, ValueType targetValueType) {
-        this.valuesSourceType = valuesSourceType;
+    private ArrayValuesSourceParser(boolean formattable, ValuesSourceFamily valuesSourceFamily, ValueType targetValueType) {
+        this.valuesSourceFamily = valuesSourceFamily;
         this.targetValueType = targetValueType;
         this.formattable = formattable;
     }
@@ -139,7 +139,7 @@ public abstract class ArrayValuesSourceParser<VS extends ValuesSource> implement
             }
         }
 
-        ArrayValuesSourceAggregationBuilder<VS, ?> factory = createFactory(aggregationName, this.valuesSourceType, this.targetValueType,
+        ArrayValuesSourceAggregationBuilder<VS, ?> factory = createFactory(aggregationName, this.valuesSourceFamily, this.targetValueType,
             otherOptions);
         if (fields != null) {
             factory.fields(fields);
@@ -183,7 +183,7 @@ public abstract class ArrayValuesSourceParser<VS extends ValuesSource> implement
      *
      * @param aggregationName
      *            the name of the aggregation
-     * @param valuesSourceType
+     * @param valuesSourceFamily
      *            the type of the {@link ValuesSource}
      * @param targetValueType
      *            the target type of the final value output by the aggregation
@@ -194,14 +194,14 @@ public abstract class ArrayValuesSourceParser<VS extends ValuesSource> implement
      * @return the created factory
      */
     protected abstract ArrayValuesSourceAggregationBuilder<VS, ?> createFactory(String aggregationName,
-                                                                                ValuesSourceType valuesSourceType,
+                                                                                ValuesSourceFamily valuesSourceFamily,
                                                                                 ValueType targetValueType,
                                                                                 Map<ParseField, Object> otherOptions);
 
     /**
      * Allows subclasses of {@link ArrayValuesSourceParser} to parse extra
      * parameters and store them in a {@link Map} which will later be passed to
-     * {@link #createFactory(String, ValuesSourceType, ValueType, Map)}.
+     * {@link #createFactory(String, ValuesSourceFamily, ValueType, Map)}.
      *
      * @param aggregationName
      *            the name of the aggregation
@@ -214,7 +214,7 @@ public abstract class ArrayValuesSourceParser<VS extends ValuesSource> implement
      * @param otherOptions
      *            a {@link Map} of options to be populated by successive calls
      *            to this method which will then be passed to the
-     *            {@link #createFactory(String, ValuesSourceType, ValueType, Map)}
+     *            {@link #createFactory(String, ValuesSourceFamily, ValueType, Map)}
      *            method
      * @return <code>true</code> if the current token was correctly parsed,
      *         <code>false</code> otherwise

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregationBuilder.java
@@ -50,6 +50,7 @@ import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceFamily;
 import org.elasticsearch.search.aggregations.support.ValuesSourceParserHelper;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.search.internal.SearchContext;
@@ -162,7 +163,7 @@ public class DateHistogramAggregationBuilder extends ValuesSourceAggregationBuil
     }
 
     @Override
-    protected ValuesSourceType resolveScriptAny(Script script) {
+    protected ValuesSourceFamily resolveScriptAny(Script script) {
         // TODO: No idea how we'd support Range scripts here.
         return ValuesSourceType.NUMERIC;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregationBuilder.java
@@ -38,6 +38,7 @@ import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.search.aggregations.support.ValuesSourceFamily;
 import org.elasticsearch.search.aggregations.support.ValuesSourceParserHelper;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.search.internal.SearchContext;
@@ -97,7 +98,7 @@ public class HistogramAggregationBuilder extends ValuesSourceAggregationBuilder<
     private long minDocCount = 0;
 
     @Override
-    protected ValuesSourceType resolveScriptAny(Script script) {
+    protected ValuesSourceFamily resolveScriptAny(Script script) {
         // TODO: No idea how we'd support Range scripts here.
         return ValuesSourceType.NUMERIC;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalGeoDistance.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalGeoDistance.java
@@ -24,6 +24,7 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValueType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceFamily;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
@@ -55,7 +56,7 @@ public class InternalGeoDistance extends InternalRange<InternalGeoDistance.Bucke
 
     public static class Factory extends InternalRange.Factory<InternalGeoDistance.Bucket, InternalGeoDistance> {
         @Override
-        public ValuesSourceType getValueSourceType() {
+        public ValuesSourceFamily getValueSourceType() {
             return ValuesSourceType.GEOPOINT;
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
@@ -28,6 +28,7 @@ import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValueType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceFamily;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
@@ -187,7 +188,7 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
     }
 
     public static class Factory<B extends Bucket, R extends InternalRange<B, R>> {
-        public ValuesSourceType getValueSourceType() {
+        public ValuesSourceFamily getValueSourceType() {
             return ValuesSourceType.NUMERIC;
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregationBuilder.java
@@ -26,6 +26,8 @@ import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
@@ -35,6 +37,8 @@ import org.elasticsearch.search.aggregations.InternalOrder;
 import org.elasticsearch.search.aggregations.InternalOrder.CompoundOrder;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregator.BucketCountThresholds;
+import org.elasticsearch.search.aggregations.support.BuiltInValuesSourceMatchers;
+import org.elasticsearch.search.aggregations.support.SupportedValuesSourceRecord;
 import org.elasticsearch.search.aggregations.support.ValueType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
@@ -45,6 +49,7 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -109,7 +114,16 @@ public class TermsAggregationBuilder extends ValuesSourceAggregationBuilder<Valu
     private boolean showTermDocCountError = false;
 
     public TermsAggregationBuilder(String name, ValueType valueType) {
-        super(name, ValuesSourceType.ANY, valueType);
+        //super(name, ValuesSourceType.ANY, valueType);
+        super(name, List.of(
+            new SupportedValuesSourceRecord(BuiltInValuesSourceMatchers.DATE, ValuesSourceType.NUMERIC,
+                new DocValueFormat.DateTime(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER, ZoneOffset.UTC,
+                    DateFieldMapper.Resolution.MILLISECONDS)),
+            new SupportedValuesSourceRecord(BuiltInValuesSourceMatchers.RAW_NUMBER, ValuesSourceType.NUMERIC, DocValueFormat.RAW),
+            new SupportedValuesSourceRecord(BuiltInValuesSourceMatchers.IP, ValuesSourceType.BYTES, DocValueFormat.IP),
+            new SupportedValuesSourceRecord(BuiltInValuesSourceMatchers.STRING, ValuesSourceType.BYTES, DocValueFormat.RAW),
+        new SupportedValuesSourceRecord(BuiltInValuesSourceMatchers.UNMAPPED, ValuesSourceType.BYTES, DocValueFormat.RAW)
+        ));
     }
 
     protected TermsAggregationBuilder(TermsAggregationBuilder clone, Builder factoriesBuilder, Map<String, Object> metaData) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregationBuilder.java
@@ -26,9 +26,12 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.support.BuiltInValuesSourceMatchers;
+import org.elasticsearch.search.aggregations.support.SupportedValuesSourceRecord;
 import org.elasticsearch.search.aggregations.support.ValueType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
@@ -38,6 +41,7 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -64,7 +68,8 @@ public final class CardinalityAggregationBuilder
     private Long precisionThreshold = null;
 
     public CardinalityAggregationBuilder(String name, ValueType targetValueType) {
-        super(name, ValuesSourceType.ANY, targetValueType);
+        //super(name, ValuesSourceType.ANY, targetValueType);
+        super(name, List.of(new SupportedValuesSourceRecord(BuiltInValuesSourceMatchers.ANY, ValuesSourceType.BYTES, DocValueFormat.RAW)));
     }
 
     public CardinalityAggregationBuilder(CardinalityAggregationBuilder clone, Builder factoriesBuilder, Map<String, Object> metaData) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/BuiltInValuesSourceMatchers.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/BuiltInValuesSourceMatchers.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.support;
+
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.script.Script;
+
+public enum BuiltInValuesSourceMatchers implements ValuesSourceMatcher {
+    ANY {
+        @Override
+        public boolean matches(QueryShardContext context, ValueType valueType, String field, Script script) {
+            return true;
+        }
+    }
+    ;
+
+    @Override
+    public abstract boolean matches(QueryShardContext context, ValueType valueType, String field, Script script);
+
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/SupportedValuesSourceRecord.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/SupportedValuesSourceRecord.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.support;
+
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.search.DocValueFormat;
+
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+public class SupportedValuesSourceRecord {
+    private final ValuesSourceMatcher matcher;
+    private final ValuesSourceFamily family;
+    private final DocValueFormat docValueFormat;
+
+    public ValuesSourceFamily getFamily() {
+        return family;
+    }
+
+    public DocValueFormat resolveFormat(String format, ZoneId tz) {
+        //TODO: Make this plugable
+        if (docValueFormat == null) {
+            return DocValueFormat.RAW; // we can't figure it out
+        }
+        DocValueFormat valueFormat = docValueFormat;
+        if (valueFormat instanceof DocValueFormat.Decimal && format != null) {
+            valueFormat = new DocValueFormat.Decimal(format);
+        }
+        if (valueFormat instanceof DocValueFormat.DateTime && format != null) {
+            valueFormat = new DocValueFormat.DateTime(DateFormatter.forPattern(format), tz != null ? tz : ZoneOffset.UTC,
+                DateFieldMapper.Resolution.MILLISECONDS);
+        }
+        return valueFormat;
+    }
+
+    public boolean matches(QueryShardContext context, ValueType valueType, String field, Script script) {
+        return matcher.matches(context, valueType, field, script);
+    }
+
+    public SupportedValuesSourceRecord(ValuesSourceMatcher matcher, ValuesSourceFamily family, DocValueFormat docValueFormat) {
+        this.matcher = matcher;
+        this.family = family;
+        this.docValueFormat = docValueFormat;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValueType.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValueType.java
@@ -53,7 +53,7 @@ public enum ValueType implements Writeable {
     RANGE((byte) 10, "range", "range", ValuesSourceType.RANGE, BinaryDVIndexFieldData.class, DocValueFormat.RAW);
 
     final String description;
-    final ValuesSourceType valuesSourceType;
+    final ValuesSourceFamily valuesSourceFamily;
     final Class<? extends IndexFieldData> fieldDataType;
     final DocValueFormat defaultFormat;
     private final byte id;
@@ -61,12 +61,12 @@ public enum ValueType implements Writeable {
 
     public static final ParseField VALUE_TYPE = new ParseField("value_type", "valueType");
 
-    ValueType(byte id, String description, String preferredName, ValuesSourceType valuesSourceType,
+    ValueType(byte id, String description, String preferredName, ValuesSourceFamily valuesSourceFamily,
             Class<? extends IndexFieldData> fieldDataType, DocValueFormat defaultFormat) {
         this.id = id;
         this.description = description;
         this.preferredName = preferredName;
-        this.valuesSourceType = valuesSourceType;
+        this.valuesSourceFamily = valuesSourceFamily;
         this.fieldDataType = fieldDataType;
         this.defaultFormat = defaultFormat;
     }
@@ -75,12 +75,12 @@ public enum ValueType implements Writeable {
         return preferredName;
     }
 
-    public ValuesSourceType getValuesSourceType() {
-        return valuesSourceType;
+    public ValuesSourceFamily getValuesSourceType() {
+        return valuesSourceFamily;
     }
 
     public boolean isA(ValueType valueType) {
-        return valueType.valuesSourceType == valuesSourceType &&
+        return valueType.valuesSourceFamily == valuesSourceFamily &&
                 valueType.fieldDataType.isAssignableFrom(fieldDataType);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValueType.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValueType.java
@@ -35,11 +35,8 @@ import java.time.ZoneOffset;
 
 public enum ValueType implements Writeable {
 
-    STRING((byte) 1, "string", "string", ValuesSourceType.BYTES,
-            IndexFieldData.class, DocValueFormat.RAW),
-    LONG((byte) 2, "byte|short|integer|long", "long",
-                    ValuesSourceType.NUMERIC,
-            IndexNumericFieldData.class, DocValueFormat.RAW),
+    STRING((byte) 1, "string", "string", ValuesSourceType.BYTES, IndexFieldData.class, DocValueFormat.RAW),
+    LONG((byte) 2, "byte|short|integer|long", "long", ValuesSourceType.NUMERIC, IndexNumericFieldData.class, DocValueFormat.RAW),
     DOUBLE((byte) 3, "float|double", "double", ValuesSourceType.NUMERIC, IndexNumericFieldData.class, DocValueFormat.RAW),
     NUMBER((byte) 4, "number", "number", ValuesSourceType.NUMERIC, IndexNumericFieldData.class, DocValueFormat.RAW),
     DATE((byte) 5, "date", "date", ValuesSourceType.NUMERIC, IndexNumericFieldData.class,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregationBuilder.java
@@ -41,8 +41,8 @@ public abstract class ValuesSourceAggregationBuilder<VS extends ValuesSource, AB
     public abstract static class LeafOnly<VS extends ValuesSource, AB extends ValuesSourceAggregationBuilder<VS, AB>>
             extends ValuesSourceAggregationBuilder<VS, AB> {
 
-        protected LeafOnly(String name, ValuesSourceType valuesSourceType, ValueType targetValueType) {
-            super(name, valuesSourceType, targetValueType);
+        protected LeafOnly(String name, ValuesSourceFamily valuesSourceFamily, ValueType targetValueType) {
+            super(name, valuesSourceFamily, targetValueType);
         }
 
         protected LeafOnly(LeafOnly<VS, AB> clone, Builder factoriesBuilder, Map<String, Object> metaData) {
@@ -56,16 +56,16 @@ public abstract class ValuesSourceAggregationBuilder<VS extends ValuesSource, AB
         /**
          * Read an aggregation from a stream that does not serialize its targetValueType. This should be used by most subclasses.
          */
-        protected LeafOnly(StreamInput in, ValuesSourceType valuesSourceType, ValueType targetValueType) throws IOException {
-            super(in, valuesSourceType, targetValueType);
+        protected LeafOnly(StreamInput in, ValuesSourceFamily valuesSourceFamily, ValueType targetValueType) throws IOException {
+            super(in, valuesSourceFamily, targetValueType);
         }
 
         /**
          * Read an aggregation from a stream that serializes its targetValueType. This should only be used by subclasses that override
          * {@link #serializeTargetValueType(Version)} to return true.
          */
-        protected LeafOnly(StreamInput in, ValuesSourceType valuesSourceType) throws IOException {
-            super(in, valuesSourceType);
+        protected LeafOnly(StreamInput in, ValuesSourceFamily valuesSourceFamily) throws IOException {
+            super(in, valuesSourceFamily);
         }
 
         @Override
@@ -75,7 +75,7 @@ public abstract class ValuesSourceAggregationBuilder<VS extends ValuesSource, AB
         }
     }
 
-    private final ValuesSourceType valuesSourceType;
+    private final ValuesSourceFamily valuesSourceFamily;
     private final ValueType targetValueType;
     private String field = null;
     private Script script = null;
@@ -85,19 +85,19 @@ public abstract class ValuesSourceAggregationBuilder<VS extends ValuesSource, AB
     private ZoneId timeZone = null;
     protected ValuesSourceConfig<VS> config;
 
-    protected ValuesSourceAggregationBuilder(String name, ValuesSourceType valuesSourceType, ValueType targetValueType) {
+    protected ValuesSourceAggregationBuilder(String name, ValuesSourceFamily valuesSourceFamily, ValueType targetValueType) {
         super(name);
-        if (valuesSourceType == null) {
+        if (valuesSourceFamily == null) {
             throw new IllegalArgumentException("[valuesSourceType] must not be null: [" + name + "]");
         }
-        this.valuesSourceType = valuesSourceType;
+        this.valuesSourceFamily = valuesSourceFamily;
         this.targetValueType = targetValueType;
     }
 
     protected ValuesSourceAggregationBuilder(ValuesSourceAggregationBuilder<VS, AB> clone,
                                              Builder factoriesBuilder, Map<String, Object> metaData) {
         super(clone, factoriesBuilder, metaData);
-        this.valuesSourceType = clone.valuesSourceType;
+        this.valuesSourceFamily = clone.valuesSourceFamily;
         this.targetValueType = clone.targetValueType;
         this.field = clone.field;
         this.valueType = clone.valueType;
@@ -114,10 +114,10 @@ public abstract class ValuesSourceAggregationBuilder<VS extends ValuesSource, AB
      * constructor, providing the old, constant value for TargetValueType and override {@link #serializeTargetValueType(Version)} to return
      * true only for versions that support the serialization.
      */
-    protected ValuesSourceAggregationBuilder(StreamInput in, ValuesSourceType valuesSourceType, ValueType targetValueType)
+    protected ValuesSourceAggregationBuilder(StreamInput in, ValuesSourceFamily valuesSourceFamily, ValueType targetValueType)
             throws IOException {
         super(in);
-        this.valuesSourceType = valuesSourceType;
+        this.valuesSourceFamily = valuesSourceFamily;
         if (serializeTargetValueType(in.getVersion())) {
             this.targetValueType = in.readOptionalWriteable(ValueType::readFromStream);
         } else {
@@ -130,11 +130,11 @@ public abstract class ValuesSourceAggregationBuilder<VS extends ValuesSource, AB
      * Read an aggregation from a stream that serializes its targetValueType. This should only be used by subclasses that override
      * {@link #serializeTargetValueType(Version)} to return true.
      */
-    protected ValuesSourceAggregationBuilder(StreamInput in, ValuesSourceType valuesSourceType) throws IOException {
+    protected ValuesSourceAggregationBuilder(StreamInput in, ValuesSourceFamily valuesSourceFamily) throws IOException {
         super(in);
         // TODO: Can we get rid of this constructor and always use the three value version? Does this assert provide any value?
         assert serializeTargetValueType(in.getVersion()) : "Wrong read constructor called for subclass that serializes its targetValueType";
-        this.valuesSourceType = valuesSourceType;
+        this.valuesSourceFamily = valuesSourceFamily;
         this.targetValueType = in.readOptionalWriteable(ValueType::readFromStream);
         read(in);
     }
@@ -322,7 +322,7 @@ public abstract class ValuesSourceAggregationBuilder<VS extends ValuesSource, AB
      * @param script - The user supplied script
      * @return The ValuesSourceType we expect this script to yield.
      */
-    protected ValuesSourceType resolveScriptAny(Script script) {
+    protected ValuesSourceFamily resolveScriptAny(Script script) {
         return ValuesSourceType.BYTES;
     }
 
@@ -376,7 +376,7 @@ public abstract class ValuesSourceAggregationBuilder<VS extends ValuesSource, AB
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), field, format, missing, script,
-            targetValueType, timeZone, valueType, valuesSourceType);
+            targetValueType, timeZone, valueType, valuesSourceFamily);
     }
 
     @Override
@@ -385,7 +385,7 @@ public abstract class ValuesSourceAggregationBuilder<VS extends ValuesSource, AB
         if (obj == null || getClass() != obj.getClass()) return false;
         if (super.equals(obj) == false) return false;
         ValuesSourceAggregationBuilder<?, ?> other = (ValuesSourceAggregationBuilder<?, ?>) obj;
-        return Objects.equals(valuesSourceType, other.valuesSourceType)
+        return Objects.equals(valuesSourceFamily, other.valuesSourceFamily)
             && Objects.equals(field, other.field)
             && Objects.equals(format, other.format)
             && Objects.equals(missing, other.missing)

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
@@ -66,7 +66,7 @@ public class ValuesSourceConfig<VS extends ValuesSource> {
         Object missing,
         ZoneId timeZone,
         String format,
-        Function<Script, ValuesSourceType> resolveScriptAny
+        Function<Script, ValuesSourceFamily> resolveScriptAny
     ) {
 
         if (field == null) {
@@ -75,15 +75,15 @@ public class ValuesSourceConfig<VS extends ValuesSource> {
                 config.format(resolveFormat(null, valueType, timeZone));
                 return config;
             }
-            ValuesSourceType valuesSourceType = valueType != null ? valueType.getValuesSourceType() : ValuesSourceType.ANY;
-            if (valuesSourceType == ValuesSourceType.ANY) {
+            ValuesSourceFamily valuesSourceFamily = valueType != null ? valueType.getValuesSourceType() : ValuesSourceType.ANY;
+            if (valuesSourceFamily == ValuesSourceType.ANY) {
                 // the specific value source type is undefined, but for scripts,
                 // we need to have a specific value source
                 // type to know how to handle the script values, so we fallback
                 // on Bytes
-                valuesSourceType = resolveScriptAny.apply(script);
+                valuesSourceFamily = resolveScriptAny.apply(script);
             }
-            ValuesSourceConfig<VS> config = new ValuesSourceConfig<>(valuesSourceType);
+            ValuesSourceConfig<VS> config = new ValuesSourceConfig<>(valuesSourceFamily);
             config.missing(missing);
             config.timezone(timeZone);
             config.format(resolveFormat(format, valueType, timeZone));
@@ -94,8 +94,8 @@ public class ValuesSourceConfig<VS extends ValuesSource> {
 
         MappedFieldType fieldType = context.fieldMapper(field);
         if (fieldType == null) {
-            ValuesSourceType valuesSourceType = valueType != null ? valueType.getValuesSourceType() : ValuesSourceType.ANY;
-            ValuesSourceConfig<VS> config = new ValuesSourceConfig<>(valuesSourceType);
+            ValuesSourceFamily valuesSourceFamily = valueType != null ? valueType.getValuesSourceType() : ValuesSourceType.ANY;
+            ValuesSourceConfig<VS> config = new ValuesSourceConfig<>(valuesSourceFamily);
             config.missing(missing);
             config.timezone(timeZone);
             config.format(resolveFormat(format, valueType, timeZone));
@@ -157,7 +157,7 @@ public class ValuesSourceConfig<VS extends ValuesSource> {
         return valueFormat;
     }
 
-    private final ValuesSourceType valueSourceType;
+    private final ValuesSourceFamily valueSourceType;
     private FieldContext fieldContext;
     private AggregationScript.LeafFactory script;
     private ValueType scriptValueType;
@@ -166,11 +166,11 @@ public class ValuesSourceConfig<VS extends ValuesSource> {
     private Object missing;
     private ZoneId timeZone;
 
-    public ValuesSourceConfig(ValuesSourceType valueSourceType) {
+    public ValuesSourceConfig(ValuesSourceFamily valueSourceType) {
         this.valueSourceType = valueSourceType;
     }
 
-    public ValuesSourceType valueSourceType() {
+    public ValuesSourceFamily valueSourceType() {
         return valueSourceType;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceFamily.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceFamily.java
@@ -19,7 +19,9 @@
 
 package org.elasticsearch.search.aggregations.support;
 
+import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.script.AggregationScript;
+import org.elasticsearch.search.DocValueFormat;
 
 public interface ValuesSourceFamily {
     ValuesSource getEmpty();
@@ -28,5 +30,5 @@ public interface ValuesSourceFamily {
 
     ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script);
 
-    ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing);
+    ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing, DocValueFormat format, QueryShardContext queryShardContext);
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceFamily.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceFamily.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.support;
+
+import org.elasticsearch.script.AggregationScript;
+
+public interface ValuesSourceFamily {
+    ValuesSource getEmpty();
+
+    ValuesSource getScript(AggregationScript.LeafFactory script, ValueType scriptValueType);
+
+    ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script);
+
+    ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing);
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceMatcher.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceMatcher.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.support;
+
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.script.Script;
+
+public interface ValuesSourceMatcher {
+    boolean matches(
+        QueryShardContext context,
+        ValueType valueType,
+        String field,
+        Script script
+    );
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceType.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceType.java
@@ -19,19 +19,180 @@
 
 package org.elasticsearch.search.aggregations.support;
 
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.RangeFieldMapper;
+import org.elasticsearch.script.AggregationScript;
+import org.elasticsearch.search.aggregations.AggregationExecutionException;
 
 import java.io.IOException;
 import java.util.Locale;
 
 public enum ValuesSourceType implements Writeable {
-    ANY,
-    NUMERIC,
-    BYTES,
-    GEOPOINT,
-    RANGE;
+    ANY {
+        @Override
+        public ValuesSource getEmpty() {
+            throw new UnsupportedOperationException("ValuesSourceType.ANY is still a special case");
+        }
+
+        @Override
+        public ValuesSource getScript(AggregationScript.LeafFactory script, ValueType scriptValueType) {
+            throw new UnsupportedOperationException("ValuesSourceType.ANY is still a special case");
+        }
+
+        @Override
+        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
+            throw new UnsupportedOperationException("ValuesSourceType.ANY is still a special case");
+        }
+
+        @Override
+        public ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing) {
+            throw new UnsupportedOperationException("ValuesSourceType.ANY is still a special case");
+        }
+    },
+    NUMERIC {
+        @Override
+        public ValuesSource getEmpty() {
+            return ValuesSource.Numeric.EMPTY;
+        }
+
+        @Override
+        public ValuesSource getScript(AggregationScript.LeafFactory script, ValueType scriptValueType) {
+            return new ValuesSource.Numeric.Script(script, scriptValueType);
+        }
+
+        @Override
+        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
+            if (!(fieldContext.indexFieldData() instanceof IndexNumericFieldData)) {
+                throw new IllegalArgumentException("Expected numeric type on field [" + fieldContext.field() +
+                    "], but got [" + fieldContext.fieldType().typeName() + "]");
+            }
+
+            ValuesSource.Numeric dataSource = new ValuesSource.Numeric.FieldData((IndexNumericFieldData)fieldContext.indexFieldData());
+            if (script != null) {
+                dataSource = new ValuesSource.Numeric.WithScript(dataSource, script);
+            }
+            return dataSource;
+        }
+
+        @Override
+        public ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing) {
+            if (rawMissing instanceof Number == false) {
+                throw new IllegalArgumentException("Can't apply missing value [" +
+                    (rawMissing == null ? "null" : rawMissing.toString())
+                    + "] to Numeric values source");
+            }
+            Number missing = (Number) rawMissing;
+            return MissingValues.replaceMissing((ValuesSource.Numeric) valuesSource, missing);
+        }
+    },
+    BYTES {
+        @Override
+        public ValuesSource getEmpty() {
+            return ValuesSource.Bytes.WithOrdinals.EMPTY;
+        }
+
+        @Override
+        public ValuesSource getScript(AggregationScript.LeafFactory script, ValueType scriptValueType) {
+            return new ValuesSource.Bytes.Script(script);
+        }
+
+        @Override
+        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
+            final IndexFieldData<?> indexFieldData = fieldContext.indexFieldData();
+            ValuesSource dataSource;
+            if (indexFieldData instanceof IndexOrdinalsFieldData) {
+                dataSource = new ValuesSource.Bytes.WithOrdinals.FieldData((IndexOrdinalsFieldData) indexFieldData);
+            } else {
+                dataSource = new ValuesSource.Bytes.FieldData(indexFieldData);
+            }
+            if (script != null) {
+                dataSource = new ValuesSource.WithScript(dataSource, script);
+            }
+            return dataSource;
+        }
+
+        @Override
+        public ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing) {
+            if (rawMissing instanceof BytesRef == false) {
+                throw new IllegalArgumentException("Can't apply missing value [" +
+                    (rawMissing == null ? "null" : rawMissing.toString())
+                    + "] to Bytes values source");
+            }
+            BytesRef missing = (BytesRef) rawMissing;
+            if (valuesSource instanceof ValuesSource.Bytes.WithOrdinals) {
+                return MissingValues.replaceMissing((ValuesSource.Bytes.WithOrdinals) valuesSource, missing);
+            } else {
+                return MissingValues.replaceMissing((ValuesSource.Bytes) valuesSource, missing);
+            }
+        }
+    },
+    GEOPOINT {
+        @Override
+        public ValuesSource getEmpty() {
+            return ValuesSource.GeoPoint.EMPTY;
+        }
+
+        @Override
+        public ValuesSource getScript(AggregationScript.LeafFactory script, ValueType scriptValueType) {
+            throw new AggregationExecutionException("value source of type [" + this.name() + "] is not supported by scripts");
+        }
+
+        @Override
+        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
+            if (!(fieldContext.indexFieldData() instanceof IndexGeoPointFieldData)) {
+                throw new IllegalArgumentException("Expected geo_point type on field [" + fieldContext.field() +
+                    "], but got [" + fieldContext.fieldType().typeName() + "]");
+            }
+            return new ValuesSource.GeoPoint.Fielddata((IndexGeoPointFieldData) fieldContext.indexFieldData());
+        }
+
+        @Override
+        public ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing) {
+            if (rawMissing instanceof GeoPoint == false) {
+                throw new IllegalArgumentException("Can't apply missing value [" +
+                    (rawMissing == null ? "null" : rawMissing.toString())
+                    + "] to Geopoint values source");
+            }
+            GeoPoint missing = (GeoPoint) rawMissing;
+            return MissingValues.replaceMissing((ValuesSource.GeoPoint) valuesSource, missing);
+        }
+    },
+    RANGE {
+        @Override
+        public ValuesSource getEmpty() {
+            throw new IllegalArgumentException("Can't deal with unmapped ValuesSource type range");
+        }
+
+        @Override
+        public ValuesSource getScript(AggregationScript.LeafFactory script, ValueType scriptValueType) {
+            throw new AggregationExecutionException("value source of type [" + this.name() + "] is not supported by scripts");
+        }
+
+        @Override
+        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
+            MappedFieldType fieldType = fieldContext.fieldType();
+
+            if (fieldType instanceof RangeFieldMapper.RangeFieldType == false) {
+                throw new IllegalStateException("Asked for range ValuesSource, but field is of type " + fieldType.name());
+            }
+            RangeFieldMapper.RangeFieldType rangeFieldType = (RangeFieldMapper.RangeFieldType)fieldType;
+            return new ValuesSource.Range(fieldContext.indexFieldData(), rangeFieldType.rangeType());
+        }
+
+        @Override
+        public ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing) {
+            throw new IllegalArgumentException("Can't apply missing values on a Range values source");
+        }
+    };
 
     public static ValuesSourceType fromString(String name) {
         return valueOf(name.trim().toUpperCase(Locale.ROOT));
@@ -50,4 +211,12 @@ public enum ValuesSourceType implements Writeable {
     public String value() {
         return name().toLowerCase(Locale.ROOT);
     }
+
+    public abstract ValuesSource getEmpty();
+
+    public abstract ValuesSource getScript(AggregationScript.LeafFactory script, ValueType scriptValueType);
+
+    public abstract ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script);
+
+    public abstract ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing);
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceType.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceType.java
@@ -36,7 +36,7 @@ import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import java.io.IOException;
 import java.util.Locale;
 
-public enum ValuesSourceType implements Writeable {
+public enum ValuesSourceType implements Writeable, ValuesSourceFamily {
     ANY {
         @Override
         public ValuesSource getEmpty() {
@@ -194,11 +194,11 @@ public enum ValuesSourceType implements Writeable {
         }
     };
 
-    public static ValuesSourceType fromString(String name) {
+    public static ValuesSourceFamily fromString(String name) {
         return valueOf(name.trim().toUpperCase(Locale.ROOT));
     }
 
-    public static ValuesSourceType fromStream(StreamInput in) throws IOException {
+    public static ValuesSourceFamily fromStream(StreamInput in) throws IOException {
         return in.readEnum(ValuesSourceType.class);
     }
 
@@ -212,11 +212,4 @@ public enum ValuesSourceType implements Writeable {
         return name().toLowerCase(Locale.ROOT);
     }
 
-    public abstract ValuesSource getEmpty();
-
-    public abstract ValuesSource getScript(AggregationScript.LeafFactory script, ValueType scriptValueType);
-
-    public abstract ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script);
-
-    public abstract ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing);
 }


### PR DESCRIPTION
Currently, `ValuesSourceConfig` hard codes `ValuesSource` classes all over the place.  This isn't going to work if we want to make `ValuesSource`s dynamic and extensible.  Presented here is a first draft at pulling that logic out of `ValuesSourceConfig` in a way that provides an interface for plugins to follow when adding new `ValuesSources`. This is just a prototype for discussion purposes, although if we're happy with it and CI likes it, we could add some javadoc and go with this.

This only addresses half the problem, even with formatters solved.  Specifically, this pattern gets `ValuesSourceConfig#toValuesSource()` out of the hard coded `ValuesSource` business, but `ValuesSourceConfig#resolve()` still hard codes `ValuesSourceType`s all over the place.  The next big step will be pulling that out in an extensible way.