### PR TITLE
Do not use ifSeqNo if doc does not have seq_no

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -38,6 +38,7 @@ import org.hamcrest.Matcher;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -438,13 +439,30 @@ public class RecoveryIT extends AbstractRollingTestCase {
                 .put(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
                 .put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 2);
             createIndex(index, settings.build());
+            indexDocs(index, 0, 100);
         }
-        ensureGreen(index);
-        indexDocs(index, 0, 10);
-        for (int i = 0; i < 10; i++) {
-            Request update = new Request("POST", index + "/test/" + i + "/_update");
-            update.setJsonEntity("{\"doc\": {\"f\": " + randomNonNegativeLong() + "}}");
-            client().performRequest(update);
+        if (randomBoolean()) {
+            ensureGreen(index);
+        }
+        Map<Integer, Long> updates = new HashMap<>();
+        for (int docId = 0; docId < 100; docId++) {
+            final int times = randomIntBetween(0, 2);
+            for (int i = 0; i < times; i++) {
+                Request update = new Request("POST", index + "/test/" + docId + "/_update");
+                long value = randomNonNegativeLong();
+                update.setJsonEntity("{\"doc\": {\"updated_field\": " + value + "}}");
+                client().performRequest(update);
+                updates.put(docId, value);
+            }
+        }
+        client().performRequest(new Request("POST", index + "/_refresh"));
+        for (int docId : updates.keySet()) {
+            Request get = new Request("GET", index + "/test/" + docId);
+            Map<String, Object> doc = entityAsMap(client().performRequest(get));
+            assertThat(XContentMapValues.extractValue("_source.updated_field", doc), equalTo(updates.get(docId)));
+        }
+        if (randomBoolean()) {
+            syncedFlush(index);
         }
     }
 


### PR DESCRIPTION
This change fixes a bug where we can't partially update documents created in a mixed cluster between 5.x and 6.x. The problem is that those documents have primary terms but not sequence numbers. Hence, we have to fallback using the legacy versioning for updates of those documents.

```
{
  "error": {
    "root_cause": [
      {
        "type": "action_request_validation_exception",
        "reason": "Validation Failed: 1: ifSeqNo is unassigned, but primary term is [4];"
      }
    ],
    "type": "action_request_validation_exception",
    "reason": "Validation Failed: 1: ifSeqNo is unassigned, but primary term is [4];"
  }
```

Thanks, @imotov for pointing out these discussions:
- https://discuss.elastic.co/t/es-upgrade-from-5-6-to-6-8/196873
- https://discuss.elastic.co/t/validation-problem-after-moving-from-5-6-to-6-7/178382

I will forward-port the upgrade test to 7.4, 7.x and 8.0.