### PR TITLE
Add debug assertions for userhome not existing

### DIFF
--- a/qa/os/bats/default/certgen.bash
+++ b/qa/os/bats/default/certgen.bash
@@ -94,9 +94,11 @@ install_node_using_archive() {
     export ESHOME="$DEFAULT_ARCHIVE_ESHOME"
     export_elasticsearch_paths
 
+    assert_file_not_exist "/home/elasticsearch"
     install_archive
     set_debug_logging
     verify_archive_installation
+    assert_file_not_exist "/home/elasticsearch"
 
     export ESPLUGIN_COMMAND_USER=$DEFAULT_ARCHIVE_USER
     generate_trial_license
@@ -122,6 +124,7 @@ install_node_using_package() {
     export ESHOME="$DEFAULT_PACKAGE_ESHOME"
     export_elasticsearch_paths
 
+    assert_file_not_exist "/home/elasticsearch"
     install_package
     set_debug_logging
     verify_package_installation


### PR DESCRIPTION
The elasticsearch user should not have a homedir, yet we have seen this
particular test fail rather frequently with a failed check that the
userhome does not exist. This commit adds some additional assertions on
the presumptive userhome to narrow down where it might be created.

relates #45903