### PR TITLE
Update slowlog.asciidoc with x-opaque-id information

### DIFF
--- a/docs/reference/index-modules/slowlog.asciidoc
+++ b/docs/reference/index-modules/slowlog.asciidoc
@@ -83,6 +83,36 @@ logger.index_search_slowlog_rolling.appenderRef.index_search_slowlog_rolling.ref
 logger.index_search_slowlog_rolling.additivity = false
 --------------------------------------------------
 
+==== Identifying search slow log origin
+
+It is often useful to identify what triggered a slow running query. If a call was initiated with an `X-Opaque-ID` header, then this value
+will be present in Search Slow logs as an additional **id** field (scroll to the right).
+```
+[2019-08-30T11:59:37,786][WARN ][i.s.s.query              ] [node-0] [index6][0] took[78.4micros], took_millis[0], total_hits[0 hits], stats[], search_type[QUERY_THEN_FETCH], total_shards[1], source[{"query":{"match_all":{"boost":1.0}}}], id[MY_USER_ID],
+```
+the same applies to JSON logs
+```
+{
+  "type": "index_search_slowlog",
+  "timestamp": "2019-08-30T11:59:37,786+02:00",
+  "level": "WARN",
+  "component": "i.s.s.query",
+  "cluster.name": "distribution_run",
+  "node.name": "node-0",
+  "message": "[index6][0]",
+  "took": "78.4micros",
+  "took_millis": "0",
+  "total_hits": "0 hits",
+  "stats": "[]",
+  "search_type": "QUERY_THEN_FETCH",
+  "total_shards": "1",
+  "source": "{\"query\":{\"match_all\":{\"boost\":1.0}}}",
+  "id": "MY_USER_ID",
+  "cluster.uuid": "Aq-c-PAeQiK3tfBYtig9Bw",
+  "node.id": "D7fUYfnfTLa2D7y-xw6tZg"
+}
+```
+
 [float]
 [[index-slow-log]]
 === Index Slow log


### PR DESCRIPTION
this field can be present in search slow logs and deprecation logs. The
docs describes how to enable this functionality and what expect in logs.
closes #44851