### PR TITLE
Suppress warning logs from background sync on relocated primary

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -67,6 +67,7 @@ import org.elasticsearch.index.shard.IndexingOperationListener;
 import org.elasticsearch.index.shard.SearchOperationListener;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardNotFoundException;
+import org.elasticsearch.index.shard.ShardNotInPrimaryModeException;
 import org.elasticsearch.index.shard.ShardPath;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.index.store.Store;
@@ -835,14 +836,11 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                     case STARTED:
                         try {
                             shard.runUnderPrimaryPermit(
-                                    () -> {
-                                        if (shard.isRelocatedPrimary() == false) {
-                                            sync.accept(shard);
-                                        }
-                                    },
+                                    () -> sync.accept(shard),
                                     e -> {
                                         if (e instanceof AlreadyClosedException == false
-                                                && e instanceof IndexShardClosedException == false) {
+                                            && e instanceof IndexShardClosedException == false
+                                            && e instanceof ShardNotInPrimaryModeException == false) {
                                             logger.warn(
                                                     new ParameterizedMessage(
                                                             "{} failed to execute {} sync", shard.shardId(), source), e);


### PR DESCRIPTION
If a primary is being relocated, then the global checkpoint and retention lease background sync can emit unnecessary warning logs. This side effect was introduced in #42241.

```
[2019-08-30T00:01:35,353][WARN ][o.e.i.IndexService       ] [prod-elk-es-10] [kubernetes-shad-index-v1-000451] [kubernetes-shad-index-v1-000451][0] failed to execute global checkpoint sync
org.elasticsearch.index.shard.ShardNotInPrimaryModeException: CurrentState[STARTED] shard is not in primary mode
    at org.elasticsearch.index.shard.IndexShard.lambda$wrapPrimaryOperationPermitListener$14(IndexShard.java:2589) ~[elasticsearch-6.8.1.jar:6.8.1]
    at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:61) [elasticsearch-6.8.1.jar:6.8.1]
    at org.elasticsearch.index.shard.IndexShardOperationPermits.acquire(IndexShardOperationPermits.java:273) [elasticsearch-6.8.1.jar:6.8.1]
    at org.elasticsearch.index.shard.IndexShardOperationPermits.acquire(IndexShardOperationPermits.java:240) [elasticsearch-6.8.1.jar:6.8.1]
    at org.elasticsearch.index.shard.IndexShard.acquirePrimaryOperationPermit(IndexShard.java:2561) [elasticsearch-6.8.1.jar:6.8.1]
    at org.elasticsearch.index.shard.IndexShard.runUnderPrimaryPermit(IndexShard.java:2637) [elasticsearch-6.8.1.jar:6.8.1]
    at org.elasticsearch.index.IndexService.sync(IndexService.java:800) [elasticsearch-6.8.1.jar:6.8.1]
    at org.elasticsearch.index.IndexService.maybeSyncGlobalCheckpoints(IndexService.java:778) [elasticsearch-6.8.1.jar:6.8.1]
    at org.elasticsearch.index.IndexService.access$700(IndexService.java:100) [elasticsearch-6.8.1.jar:6.8.1]
    at org.elasticsearch.index.IndexService$AsyncGlobalCheckpointTask.runInternal(IndexService.java:942) [elasticsearch-6.8.1.jar:6.8.1]
    at org.elasticsearch.common.util.concurrent.AbstractAsyncTask.run(AbstractAsyncTask.java:141) [elasticsearch-6.8.1.jar:6.8.1]
    at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:681) [elasticsearch-6.8.1.jar:6.8.1]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_212]
```

Relates #40800
Relates #42241