### PR TITLE
Fix SearchService.createContext exception handling

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -643,6 +643,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             if (success == false) {
                 IOUtils.closeWhileHandlingException(searchContext);
                 if (searchContext == null) {
+                    // we handle the case where the DefaultSearchContext constructor throws an exception since we would otherwise
+                    // leak a searcher and this can have severe implications (unable to obtain shard lock exceptions).
                     IOUtils.closeWhileHandlingException(searcher);
                 }
             }


### PR DESCRIPTION
An exception from the DefaultSearchContext constructor could leak a
searcher, causing future issues like shard lock obtained failures. The
underlying cause of the exception in the constructor has been fixed, but
as a safety precaution we also fix the exception handling in
createContext.

Closes #45378