### PR TITLE
Quote the task name in reproduction line printer

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -79,7 +79,7 @@ public class ReproduceInfoPrinter extends RunListener {
         String task = System.getProperty("tests.task");
 
         // append Gradle test runner test filter string
-        b.append(task);
+        b.append("'" + task + "'");
         b.append(" --tests \"");
         b.append(failure.getDescription().getClassName());
         final String methodName = failure.getDescription().getMethodName();


### PR DESCRIPTION
Some tasks have `#` for instance that doesn't play well with some shells
( e.x. zsh )

