### PR TITLE
[DOCS] Separate Enrich API Docs

### DIFF
--- a/docs/reference/ingest/apis/enrich/delete-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/delete-enrich-policy.asciidoc
@@ -28,6 +28,7 @@ DELETE /_enrich/policy/my-policy
 --------------------------------------------------
 // CONSOLE
 
+
 [[delete-enrich-policy-api-request]]
 ==== {api-request-title}
 
@@ -38,6 +39,7 @@ DELETE /_enrich/policy/my-policy
 ==== {api-prereq-title}
 
 include::put-enrich-policy.asciidoc[tag=enrich-policy-api-prereqs]
+
 
 [[delete-enrich-policy-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/ingest/apis/enrich/delete-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/delete-enrich-policy.asciidoc
@@ -16,7 +16,7 @@ PUT /_enrich/policy/my-policy
     "match": {
         "indices": "users",
         "match_field": "email",
-        "enrich_fields": ["first_name", "last_name", "address", "city", "zip", "state"]
+        "enrich_fields": ["first_name", "last_name", "city", "zip", "state"]
     }
 }
 ----

--- a/docs/reference/ingest/apis/enrich/delete-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/delete-enrich-policy.asciidoc
@@ -9,6 +9,8 @@ Deletes an existing enrich policy and its enrich index.
 ////
 [source,js]
 ----
+PUT /users
+
 PUT /_enrich/policy/my-policy
 {
     "match": {

--- a/docs/reference/ingest/apis/enrich/delete-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/delete-enrich-policy.asciidoc
@@ -1,0 +1,63 @@
+[[delete-enrich-policy-api]]
+=== Delete enrich policy API
+++++
+<titleabbrev>Delete enrich policy</titleabbrev>
+++++
+
+Deletes an existing enrich policy and its enrich index.
+
+////
+[source,js]
+----
+PUT /_enrich/policy/my-policy
+{
+    "match": {
+        "indices": "users",
+        "match_field": "email",
+        "enrich_fields": ["first_name", "last_name", "address", "city", "zip", "state"]
+    }
+}
+----
+// CONSOLE
+// TESTSETUP
+////
+
+[source,js]
+--------------------------------------------------
+DELETE /_enrich/policy/my-policy
+--------------------------------------------------
+// CONSOLE
+
+[[delete-enrich-policy-api-request]]
+==== {api-request-title}
+
+`DELETE /_enrich/policy/<enrich-policy>`
+
+
+[[delete-enrich-policy-api-prereqs]]
+==== {api-prereq-title}
+
+include::put-enrich-policy.asciidoc[tag=enrich-policy-api-prereqs]
+
+[[delete-enrich-policy-api-desc]]
+==== {api-description-title}
+
+Use the delete enrich policy API
+to delete an existing enrich policy
+and its enrich index.
+
+[IMPORTANT]
+====
+You must remove an enrich policy
+from any in-use enrich processors and ingest pipelines
+before deletion.
+You cannot remove in-use enrich policies.
+====
+
+
+[[delete-enrich-policy-api-path-params]]
+==== {api-path-parms-title}
+
+`<enrich-policy>`::
+(Required, string)
+Enrich policy to delete.

--- a/docs/reference/ingest/apis/enrich/delete-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/delete-enrich-policy.asciidoc
@@ -53,7 +53,7 @@ and its enrich index.
 [IMPORTANT]
 ====
 You must remove an enrich policy
-from any in-use enrich processors and ingest pipelines
+from any in-use ingest pipelines
 before deletion.
 You cannot remove in-use enrich policies.
 ====

--- a/docs/reference/ingest/apis/enrich/delete-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/delete-enrich-policy.asciidoc
@@ -1,3 +1,5 @@
+[role="xpack"]
+[testenv="basic"]
 [[delete-enrich-policy-api]]
 === Delete enrich policy API
 ++++

--- a/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
@@ -1,3 +1,5 @@
+[role="xpack"]
+[testenv="basic"]
 [[execute-enrich-policy-api]]
 === Execute enrich policy API
 ++++

--- a/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
@@ -10,15 +10,6 @@ Executes an existing enrich policy.
 
 [source,js]
 ----
-PUT /_enrich/policy/my-policy
-{
-    "match": {
-        "indices": "users",
-        "match_field": "email",
-        "enrich_fields": ["first_name", "last_name", "address", "city", "zip", "state"]
-    }
-}
-
 PUT /users/_doc/1?refresh
 {
     "email": "mardy.brown@email.me",
@@ -32,6 +23,15 @@ PUT /users/_doc/1?refresh
     "phone1":"504-621-8927",
     "phone2": "504-845-1427",
     "web": "mardy-brown.me"
+}
+
+PUT /_enrich/policy/my-policy
+{
+    "match": {
+        "indices": "users",
+        "match_field": "email",
+        "enrich_fields": ["first_name", "last_name", "address", "city", "zip", "state"]
+    }
 }
 ----
 // CONSOLE

--- a/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
@@ -41,6 +41,14 @@ PUT /_enrich/policy/my-policy/_execute
 --------------------------------------------------
 // CONSOLE
 
+////
+[source,js]
+--------------------------------------------------
+DELETE /_enrich/policy/my-policy
+--------------------------------------------------
+// CONSOLE
+////
+
 
 [[execute-enrich-policy-api-request]]
 ==== {api-request-title}

--- a/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
@@ -12,17 +12,14 @@ Executes an existing enrich policy.
 ----
 PUT /users/_doc/1?refresh
 {
-    "email": "mardy.brown@email.me",
+    "email": "mardy.brown@asciidocsmith.com",
     "first_name": "Mardy",
     "last_name": "Brown",
-    "address": "6649 N Blue Gum St",
     "city": "New Orleans",
     "county": "Orleans",
     "state": "LA",
     "zip": 70116,
-    "phone1":"504-621-8927",
-    "phone2": "504-845-1427",
-    "web": "mardy-brown.me"
+    "web": "mardy.asciidocsmith.com"
 }
 
 PUT /_enrich/policy/my-policy
@@ -30,7 +27,7 @@ PUT /_enrich/policy/my-policy
     "match": {
         "indices": "users",
         "match_field": "email",
-        "enrich_fields": ["first_name", "last_name", "address", "city", "zip", "state"]
+        "enrich_fields": ["first_name", "last_name", "city", "zip", "state"]
     }
 }
 ----

--- a/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
@@ -49,6 +49,7 @@ PUT /_enrich/policy/my-policy/_execute
 DELETE /_enrich/policy/my-policy
 --------------------------------------------------
 // CONSOLE
+// TEST[continued]
 ////
 
 

--- a/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
@@ -1,0 +1,98 @@
+[[execute-enrich-policy-api]]
+=== Execute enrich policy API
+++++
+<titleabbrev>Execute enrich policy</titleabbrev>
+++++
+
+Executes an existing enrich policy.
+
+////
+
+[source,js]
+----
+PUT /_enrich/policy/my-policy
+{
+    "match": {
+        "indices": "users",
+        "match_field": "email",
+        "enrich_fields": ["first_name", "last_name", "address", "city", "zip", "state"]
+    }
+}
+
+PUT /users/_doc/1?refresh
+{
+    "email": "mardy.brown@email.me",
+    "first_name": "Mardy",
+    "last_name": "Brown",
+    "address": "6649 N Blue Gum St",
+    "city": "New Orleans",
+    "county": "Orleans",
+    "state": "LA",
+    "zip": 70116,
+    "phone1":"504-621-8927",
+    "phone2": "504-845-1427",
+    "web": "mardy-brown.me"
+}
+----
+// CONSOLE
+// TESTSETUP
+////
+
+[source,js]
+--------------------------------------------------
+PUT /_enrich/policy/my-policy/_execute
+--------------------------------------------------
+// CONSOLE
+
+
+[[execute-enrich-policy-api-request]]
+==== {api-request-title}
+
+`PUT /_enrich/policy/<enrich-policy>/_execute`
+
+`POST /_enrich/policy/<enrich-policy>/_execute`
+
+
+[[execute-enrich-policy-api-prereqs]]
+==== {api-prereq-title}
+
+include::put-enrich-policy.asciidoc[tag=enrich-policy-api-prereqs]
+
+
+[[execute-enrich-policy-api-desc]]
+==== {api-description-title}
+
+Use the execute enrich policy API
+to create the enrich index for an existing enrich policy.
+
+// tag::execute-enrich-policy-desc[]
+
+The *enrich index* contains documents from the policy's source indices.
+Enrich indices always begin with `.enrich-*`,
+are read-only,
+and are <<indices-forcemerge,force merged>>.
+
+[WARNING]
+====
+Enrich indices should be used by the <<enrich-processor,enrich processor>> only.
+Avoid using enrich indices for other purposes.
+====
+
+Once created, you cannot update 
+or index documents to an enrich index.
+Instead, update your source indices
+and execute the enrich policy again.
+This creates a new enrich index from your updated source indices
+and deletes the previous enrich index.
+
+Because this API request performs several operations,
+it may take a while to return a response.
+
+// end::execute-enrich-policy-desc[]
+
+[[sample-api-path-params]]
+==== {api-path-parms-title}
+
+`<enrich-policy>`::
+(Required, string)
+Enrich policy to execute.

--- a/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
@@ -90,6 +90,7 @@ it may take a while to return a response.
 
 // end::execute-enrich-policy-desc[]
 
+
 [[sample-api-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
@@ -54,6 +54,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=enrich-policy]
 [[get-enrich-policy-api-example]]
 ==== {api-examples-title}
 
+
 [[get-enrich-policy-api-single-ex]]
 ===== Get a single policy
 
@@ -89,6 +90,7 @@ The API returns the following response:
 }
 --------------------------------------------------
 // TESTRESPONSE
+
 
 [[get-enrich-policy-api-all-ex]]
 ===== Get all policies

--- a/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
@@ -16,7 +16,7 @@ PUT /_enrich/policy/my-policy
     "match": {
         "indices": "users",
         "match_field": "email",
-        "enrich_fields": ["first_name", "last_name", "address", "city", "zip", "state"]
+        "enrich_fields": ["first_name", "last_name", "city", "zip", "state"]
     }
 }
 ----
@@ -81,7 +81,6 @@ The API returns the following response:
                 "enrich_fields" : [
                     "first_name",
                     "last_name",
-                    "address",
                     "city",
                     "zip",
                     "state"
@@ -118,7 +117,6 @@ The API returns the following response:
                 "enrich_fields" : [
                     "first_name",
                     "last_name",
-                    "address",
                     "city",
                     "zip",
                     "state"

--- a/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
@@ -1,3 +1,5 @@
+[role="xpack"]
+[testenv="basic"]
 [[get-enrich-policy-api]]
 === Get enrich policy API
 ++++

--- a/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
@@ -9,6 +9,8 @@ Returns information about an enrich policy.
 ////
 [source,js]
 ----
+PUT /users
+
 PUT /_enrich/policy/my-policy
 {
     "match": {

--- a/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
@@ -127,3 +127,11 @@ The API returns the following response:
 }
 --------------------------------------------------
 // TESTRESPONSE
+
+////
+[source,js]
+--------------------------------------------------
+DELETE /_enrich/policy/my-policy
+--------------------------------------------------
+// CONSOLE
+////

--- a/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
@@ -136,4 +136,5 @@ The API returns the following response:
 DELETE /_enrich/policy/my-policy
 --------------------------------------------------
 // CONSOLE
+// TEST[continued]
 ////

--- a/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
@@ -1,0 +1,127 @@
+[[get-enrich-policy-api]]
+=== Get enrich policy API
+++++
+<titleabbrev>Get enrich policy</titleabbrev>
+++++
+
+Returns information about an enrich policy.
+
+////
+[source,js]
+----
+PUT /_enrich/policy/my-policy
+{
+    "match": {
+        "indices": "users",
+        "match_field": "email",
+        "enrich_fields": ["first_name", "last_name", "address", "city", "zip", "state"]
+    }
+}
+----
+// CONSOLE
+////
+
+[source,js]
+--------------------------------------------------
+GET /_enrich/policy/my-policy
+--------------------------------------------------
+// CONSOLE
+// TEST[continued]
+
+
+[[get-enrich-policy-api-request]]
+==== {api-request-title}
+
+`GET /_enrich/policy/<enrich-policy>`
+
+`GET /_enrich/policy`
+
+
+[[get-enrich-policy-api-prereqs]]
+==== {api-prereq-title}
+
+include::put-enrich-policy.asciidoc[tag=enrich-policy-api-prereqs]
+
+
+[[get-enrich-policy-api-path-params]]
+==== {api-path-parms-title}
+
+`<enrich-policy>`::
+(Optional, string)
+include::{docdir}/rest-api/common-parms.asciidoc[tag=enrich-policy]
+
+
+[[get-enrich-policy-api-example]]
+==== {api-examples-title}
+
+[[get-enrich-policy-api-single-ex]]
+===== Get a single policy
+
+[source,js]
+--------------------------------------------------
+GET /_enrich/policy/my-policy
+--------------------------------------------------
+// CONSOLE
+// TEST[continued]
+
+The API returns the following response:
+
+[source,js]
+--------------------------------------------------
+{
+    "policies": [
+        {
+            "match": {
+                "name" : "my-policy",
+                "indices" : ["users"],
+                "match_field" : "email",
+                "enrich_fields" : [
+                    "first_name",
+                    "last_name",
+                    "address",
+                    "city",
+                    "zip",
+                    "state"
+                ]
+            }
+        }
+    ]
+}
+--------------------------------------------------
+// TESTRESPONSE
+
+[[get-enrich-policy-api-all-ex]]
+===== Get all policies
+
+[source,js]
+--------------------------------------------------
+GET /_enrich/policy
+--------------------------------------------------
+// CONSOLE
+// TEST[continued]
+
+The API returns the following response:
+
+[source,js]
+--------------------------------------------------
+{
+    "policies": [
+        {
+            "match": {
+                "name" : "my-policy",
+                "indices" : ["users"],
+                "match_field" : "email",
+                "enrich_fields" : [
+                    "first_name",
+                    "last_name",
+                    "address",
+                    "city",
+                    "zip",
+                    "state"
+                ]
+            }
+        }
+    ]
+}
+--------------------------------------------------
+// TESTRESPONSE

--- a/docs/reference/ingest/apis/enrich/index.asciidoc
+++ b/docs/reference/ingest/apis/enrich/index.asciidoc
@@ -6,6 +6,7 @@ The following enrich APIs are available for managing enrich policies:
 * <<put-enrich-policy-api>> to add or update an enrich policy
 * <<delete-enrich-policy-api>> to delete an enrich policy
 * <<get-enrich-policy-api>> to return information about an enrich policy
+* <<execute-enrich-policy-api>> to execute an enrich policy
 
 
 include::put-enrich-policy.asciidoc[]
@@ -13,3 +14,5 @@ include::put-enrich-policy.asciidoc[]
 include::delete-enrich-policy.asciidoc[]
 
 include::get-enrich-policy.asciidoc[]
+
+include::execute-enrich-policy.asciidoc[]

--- a/docs/reference/ingest/apis/enrich/index.asciidoc
+++ b/docs/reference/ingest/apis/enrich/index.asciidoc
@@ -4,6 +4,9 @@
 The following enrich APIs are available for managing enrich policies:
 
 * <<put-enrich-policy-api>> to add or update an enrich policy
+* <<get-enrich-policy-api>> to return information about an enrich policy
 
 
 include::put-enrich-policy.asciidoc[]
+
+include::get-enrich-policy.asciidoc[]

--- a/docs/reference/ingest/apis/enrich/index.asciidoc
+++ b/docs/reference/ingest/apis/enrich/index.asciidoc
@@ -2,3 +2,8 @@
 == Enrich APIs
 
 The following enrich APIs are available for managing enrich policies:
+
+* <<put-enrich-policy-api>> to add or update an enrich policy
+
+
+include::put-enrich-policy.asciidoc[]

--- a/docs/reference/ingest/apis/enrich/index.asciidoc
+++ b/docs/reference/ingest/apis/enrich/index.asciidoc
@@ -4,9 +4,12 @@
 The following enrich APIs are available for managing enrich policies:
 
 * <<put-enrich-policy-api>> to add or update an enrich policy
+* <<delete-enrich-policy-api>> to delete an enrich policy
 * <<get-enrich-policy-api>> to return information about an enrich policy
 
 
 include::put-enrich-policy.asciidoc[]
+
+include::delete-enrich-policy.asciidoc[]
 
 include::get-enrich-policy.asciidoc[]

--- a/docs/reference/ingest/apis/enrich/index.asciidoc
+++ b/docs/reference/ingest/apis/enrich/index.asciidoc
@@ -1,0 +1,4 @@
+[[enrich-apis]]
+== Enrich APIs
+
+The following enrich APIs are available for managing enrich policies:

--- a/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
@@ -21,7 +21,7 @@ PUT /_enrich/policy/my-policy
     "match": {
         "indices": "users",
         "match_field": "email",
-        "enrich_fields": ["first_name", "last_name", "address", "city", "zip", "state"]
+        "enrich_fields": ["first_name", "last_name", "city", "zip", "state"]
     }
 }
 ----

--- a/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
@@ -36,6 +36,7 @@ PUT /_enrich/policy/my-policy
 DELETE /_enrich/policy/my-policy
 --------------------------------------------------
 // CONSOLE
+// TEST[continued]
 ////
 
 

--- a/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
@@ -72,16 +72,11 @@ An enrich policy contains:
 You cannot update an existing enrich policy.
 Instead, you can:
 
-.   Create a new enrich policy
-    containing your desired changes.
+.   Create and execute a new enrich policy.
 
-.   Remove the previous enrich policy
-    from any in-use enrich processors
-    and ingest pipelines.
-
-.   Add the new enrich policy
-    to any desired ingest processors
-    and ingest pipelines.
+.   Replace the previous enrich policy
+    with the new enrich policy
+    in any in-use enrich processors.
 
 .   Use the <<delete-enrich-policy-api, delete enrich policy API>>
     to delete the previous enrich policy.

--- a/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
@@ -6,6 +6,14 @@
 
 Creates an enrich policy.
 
+////
+[source,js]
+----
+PUT /users
+----
+// CONSOLE
+////
+
 [source,js]
 ----
 PUT /_enrich/policy/my-policy
@@ -18,7 +26,7 @@ PUT /_enrich/policy/my-policy
 }
 ----
 // CONSOLE
-// TESTSETUP
+// TEST[continued]
 
 
 [[put-enrich-policy-api-request]]

--- a/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
@@ -1,0 +1,132 @@
+[[put-enrich-policy-api]]
+=== Put enrich policy API
+++++
+<titleabbrev>Put enrich policy</titleabbrev>
+++++
+
+Creates an enrich policy.
+
+[source,js]
+----
+PUT /_enrich/policy/my-policy
+{
+    "match": {
+        "indices": "users",
+        "match_field": "email",
+        "enrich_fields": ["first_name", "last_name", "address", "city", "zip", "state"]
+    }
+}
+----
+// CONSOLE
+// TESTSETUP
+
+
+[[put-enrich-policy-api-request]]
+==== {api-request-title}
+
+`PUT /_enrich/policy/<enrich-policy>`
+
+
+[[put-enrich-policy-api-prereqs]]
+==== {api-prereq-title}
+
+// tag::enrich-policy-api-prereqs[]
+If you use {es} {security-features}, you must have:
+
+* `read` index privileges for any indices used
+* The `enrich_user` {stack-ov}/built-in-roles.html[built-in role]
+// end::enrich-policy-api-prereqs[]
+
+[[put-enrich-policy-api-desc]]
+==== {api-description-title}
+
+Use the put enrich policy API
+to create a new enrich policy.
+
+// tag::enrich-policy-def
+An *enrich policy* is a set of rules the enrich processor uses
+to append the appropriate data to incoming documents.
+An enrich policy contains:
+
+* The *policy type*,
+  which determines how the processor enriches incoming documents
+* A list of source indices
+* The *match field*, a field used to match incoming documents
+* *Enrich fields*, fields appended to incoming documents
+  from matching documents
+// end::enrich-policy-def
+
+===== Update an enrich policy
+
+// tag::update-enrich-policy
+You cannot update an existing enrich policy.
+Instead, you can:
+
+.   Create a new enrich policy
+    containing your desired changes.
+
+.   Remove the previous enrich policy
+    from any in-use enrich processors
+    and ingest pipelines.
+
+.   Add the new enrich policy
+    to any desired ingest processors
+    and ingest pipelines.
+
+.   Use the <<delete-enrich-policy-api, delete enrich policy API>>
+    to delete the previous enrich policy.
+// end::update-enrich-policy
+
+[[put-enrich-policy-api-path-params]]
+==== {api-path-parms-title}
+
+`<enrich-policy>`::
+(Required, string)
+include::{docdir}/rest-api/common-parms.asciidoc[tag=enrich-policy]
+
+
+[[put-enrich-policy-api-request-body]]
+==== {api-request-body-title}
+
+`<policy-type>`::
++
+--
+(Required, enrich policy object)
+The parameter key is the enrich policy type.
+The enrich policy type indicates
+how the enrich processor matches incoming documents 
+to documents in the enrich index.
+
+Valid key values are:
+
+`match`::
+Match documents in the enrich index
+using a <<query-dsl-term-query, term query>> for the `match_field`.
+
+The parameter value is the enrich policy.
+The enrich policy is a set of rules
+used to create an <<execute-enrich-policy,enrich index>>.
+The enrich processor also uses these rules
+to append field data to incoming documents.
+
+Parameters include:
+
+`indices`::
+(Required, array of strings)
+Source indices used to create the enrich index.
+
+`query`::
+(Optional, string)
+Query type used to find and select documents in the enrich index.
+Valid value is <<query-dsl-match-all-query,`match_all`>> (default).
+
+`match_field`::
+(Required, string)
+Field used to match incoming documents 
+to documents in the enrich index.
+
+`enrich_fields`::
+(Required, Array of string)
+Fields appended to incoming documents
+from matching documents in the enrich index.
+--

--- a/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
@@ -28,6 +28,14 @@ PUT /_enrich/policy/my-policy
 // CONSOLE
 // TEST[continued]
 
+////
+[source,js]
+--------------------------------------------------
+DELETE /_enrich/policy/my-policy
+--------------------------------------------------
+// CONSOLE
+////
+
 
 [[put-enrich-policy-api-request]]
 ==== {api-request-title}

--- a/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
@@ -37,6 +37,7 @@ If you use {es} {security-features}, you must have:
 * The `enrich_user` {stack-ov}/built-in-roles.html[built-in role]
 // end::enrich-policy-api-prereqs[]
 
+
 [[put-enrich-policy-api-desc]]
 ==== {api-description-title}
 
@@ -55,6 +56,7 @@ An enrich policy contains:
 * *Enrich fields*, fields appended to incoming documents
   from matching documents
 // end::enrich-policy-def
+
 
 ===== Update an enrich policy
 
@@ -76,6 +78,7 @@ Instead, you can:
 .   Use the <<delete-enrich-policy-api, delete enrich policy API>>
     to delete the previous enrich policy.
 // end::update-enrich-policy
+
 
 [[put-enrich-policy-api-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
@@ -1,3 +1,5 @@
+[role="xpack"]
+[testenv="basic"]
 [[put-enrich-policy-api]]
 === Put enrich policy API
 ++++

--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -773,7 +773,9 @@ metadata field to provide the error message.
 [role="xpack"]
 [testenv="basic"]
 [[ingest-enriching-data]]
-== Enriching data with ingest node
+== Enrich your data using the ingest node
+
+
 
 The <<enrich-processor,enrich processor>> allows documents to be enriched with data from
 an enrich index that is managed by an enrich policy prior to indexing.
@@ -956,7 +958,7 @@ DELETE /_enrich/policy/users-policy
 Also there are several APIs in order to manage and execute enrich policies:
 
 * <<put-policy-api,Put policy api>>.
-* <<get-policy-api,Get policy api>>.
+* <<get-enrich-policy-api,Get enrich policy api>>.
 * <<delete-policy-api,Delete policy api>>.
 * <<execute-policy-api,Execute policy api>>.
 
@@ -991,83 +993,6 @@ Response:
 --------------------------------------------------
 {
     "acknowledged": true
-}
---------------------------------------------------
-// TESTRESPONSE
-
-[[get-policy-api]]
-==== Get Policy API
-
-The get policy api allows a policy to be retrieved by id.
-
-Request:
-
-[source,js]
---------------------------------------------------
-GET /_enrich/policy/my-policy
---------------------------------------------------
-// CONSOLE
-// TEST[continued]
-
-Response:
-
-[source,js]
---------------------------------------------------
-{
-    "policies": [
-        {
-            "exact_match": {
-                "name" : "my-policy",
-                "indices" : ["users"],
-                "match_field" : "email",
-                "enrich_fields" : [
-                    "first_name",
-                    "last_name",
-                    "address",
-                    "city",
-                    "zip",
-                    "state"
-                ]
-            }
-        }
-    ]
-}
---------------------------------------------------
-// TESTRESPONSE
-
-The get policy api allows all policies to be returned.
-
-Request:
-
-[source,js]
---------------------------------------------------
-GET /_enrich/policy
---------------------------------------------------
-// CONSOLE
-// TEST[continued]
-
-Response:
-
-[source,js]
---------------------------------------------------
-{
-    "policies": [
-        {
-            "exact_match": {
-                "name" : "my-policy",
-                "indices" : ["users"],
-                "match_field" : "email",
-                "enrich_fields" : [
-                    "first_name",
-                    "last_name",
-                    "address",
-                    "city",
-                    "zip",
-                    "state"
-                ]
-            }
-        }
-    ]
 }
 --------------------------------------------------
 // TESTRESPONSE

--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -959,7 +959,7 @@ Also there are several APIs in order to manage and execute enrich policies:
 
 * <<put-policy-api,Put policy api>>.
 * <<get-enrich-policy-api,Get enrich policy api>>.
-* <<delete-policy-api,Delete policy api>>.
+* <<delete-enrich-policy-api,Delete policy api>>.
 * <<execute-policy-api,Execute policy api>>.
 
 If security is enabled then the user managing enrich policies will need to have
@@ -1041,30 +1041,6 @@ Request:
 [source,js]
 --------------------------------------------------
 POST /_enrich/policy/my-policy/_execute
---------------------------------------------------
-// CONSOLE
-// TEST[continued]
-
-Response:
-
-[source,js]
---------------------------------------------------
-{
-    "acknowledged": true
-}
---------------------------------------------------
-// TESTRESPONSE
-
-[[delete-policy-api]]
-===== Delete Policy API
-
-The delete policy api allows a policy to be removed by id.
-
-Request:
-
-[source,js]
---------------------------------------------------
-DELETE /_enrich/policy/my-policy
 --------------------------------------------------
 // CONSOLE
 // TEST[continued]

--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -865,6 +865,7 @@ Which returns:
 --------------------------------------------------
 // TESTRESPONSE
 
+[[execute-enrich-policy]]
 Execute that enrich policy:
 
 [source,js]
@@ -957,103 +958,14 @@ DELETE /_enrich/policy/users-policy
 
 Also there are several APIs in order to manage and execute enrich policies:
 
-* <<put-policy-api,Put policy api>>.
+* <<put-enrich-policy-api,Put policy api>>.
 * <<get-enrich-policy-api,Get enrich policy api>>.
 * <<delete-enrich-policy-api,Delete policy api>>.
-* <<execute-policy-api,Execute policy api>>.
+* <<execute-enrich-policy-api,Execute policy api>>.
 
 If security is enabled then the user managing enrich policies will need to have
 the `enrich_user` builtin role. Also the user will need to have read privileges
 for the indices the enrich policy is referring to.
-
-[[put-policy-api]]
-==== Put Policy API
-
-The put policy api allows a policy to be stored by an user specified id in the url and
-the enrich policy definition as body.
-
-Request:
-
-[source,js]
---------------------------------------------------
-PUT /_enrich/policy/my-policy
-{
-    "exact_match": {
-        "indices": "users",
-        "match_field": "email",
-        "enrich_fields": ["first_name", "last_name", "address", "city", "zip", "state"]
-    }
-}
---------------------------------------------------
-// CONSOLE
-
-Response:
-
-[source,js]
---------------------------------------------------
-{
-    "acknowledged": true
-}
---------------------------------------------------
-// TESTRESPONSE
-
-[[execute-policy-api]]
-==== Execute Policy API
-
-The execute policy api executes a policy based on the provided id.
-It may take some time before this API returns a response.
-Executing a policy involves creating a new enrich index, indexing the documents from
-the indices specified in policy into the enrich index and some other operations.
-
-Note that this api needs to be re-executed in order to incorporate new changes
-in the index the policy is pointing to after the policy has been executed.
-
-This API creates an index with the `.enrich-*` prefix in the name. This index purpose
-is the be used by the enrich processor only and should not be used by anything else.
-Internally old `.enrich-*` are removed by an internal cleanup mechanism.
-
-//////////////////////////
-
-[source,js]
---------------------------------------------------
-PUT /users/_doc/1?refresh
-{
-    "email": "mardy.brown@email.me",
-    "first_name": "Mardy",
-    "last_name": "Brown",
-    "address": "6649 N Blue Gum St",
-    "city": "New Orleans",
-    "county": "Orleans",
-    "state": "LA",
-    "zip": 70116,
-    "phone1":"504-621-8927",
-    "phone2": "504-845-1427",
-    "web": "mardy-brown.me"
-}
---------------------------------------------------
-// CONSOLE
-// TEST[continued]
-
-//////////////////////////
-
-Request:
-
-[source,js]
---------------------------------------------------
-POST /_enrich/policy/my-policy/_execute
---------------------------------------------------
-// CONSOLE
-// TEST[continued]
-
-Response:
-
-[source,js]
---------------------------------------------------
-{
-    "acknowledged": true
-}
---------------------------------------------------
-// TESTRESPONSE
 
 [[ingest-processors]]
 == Processors

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -40,6 +40,11 @@ tag::df[]
 given in the query string.
 end::df[]
 
+tag::enrich-policy[]
+Enrich policy name
+used to limit the request.
+end::enrich-policy[]
+
 tag::expand-wildcards[]
 `expand_wildcards`::
 +

--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -16,6 +16,7 @@ not be included yet.
 * <<ccr-apis,{ccr-cap} APIs>>
 * <<data-frame-apis,{dataframe-transform-cap} APIs>>
 * <<docs, Document APIs>>
+* <<enrich-apis,Enrich APIs>>
 * <<graph-explore-api,Graph Explore API>>
 * <<indices, Index APIs>>
 * <<index-lifecycle-management-api,Index lifecycle management APIs>>
@@ -39,6 +40,7 @@ include::{es-repo-dir}/cluster.asciidoc[]
 include::{es-repo-dir}/ccr/apis/ccr-apis.asciidoc[]
 include::{es-repo-dir}/data-frames/apis/index.asciidoc[]
 include::{es-repo-dir}/docs.asciidoc[]
+include::{es-repo-dir}/ingest/apis/enrich/index.asciidoc[]
 include::{es-repo-dir}/graph/explore.asciidoc[]
 include::{es-repo-dir}/indices.asciidoc[]
 include::{es-repo-dir}/ilm/apis/ilm-api.asciidoc[]


### PR DESCRIPTION
### Changes
- Moves enrich API documentation into separate files in the [REST APIs](https://www.elastic.co/guide/en/elasticsearch/reference/master/rest-apis.html) section.
- Reformats enrich API docs to follow the [API Reference Docs template](https://github.com/elastic/docs/blame/master/shared/api-ref-ex.asciidoc)

### Dependencies
- #46041 (Could be removed if needed)