### PR TITLE
Refactor AllocatedPersistentTask#init(), move rollup logic out of ctor

### DIFF
--- a/server/src/main/java/org/elasticsearch/persistent/AllocatedPersistentTask.java
+++ b/server/src/main/java/org/elasticsearch/persistent/AllocatedPersistentTask.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.persistent;
 
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
@@ -37,13 +38,13 @@ import java.util.function.Predicate;
  */
 public class AllocatedPersistentTask extends CancellableTask {
 
+    private static final Logger logger = LogManager.getLogger(AllocatedPersistentTask.class);
     private final AtomicReference<State> state;
 
     private volatile String persistentTaskId;
     private volatile long allocationId;
     private volatile @Nullable Exception failure;
     private volatile PersistentTasksService persistentTasksService;
-    private volatile Logger logger;
     private volatile TaskManager taskManager;
 
     public AllocatedPersistentTask(long id, String type, String action, String description, TaskId parentTask,
@@ -85,10 +86,9 @@ public class AllocatedPersistentTask extends CancellableTask {
         return persistentTaskId;
     }
 
-    void init(PersistentTasksService persistentTasksService, TaskManager taskManager, Logger logger, String persistentTaskId, long
-            allocationId) {
+    protected void init(PersistentTasksService persistentTasksService, TaskManager taskManager, String persistentTaskId,
+                        long allocationId, PersistentTaskState state) {
         this.persistentTasksService = persistentTasksService;
-        this.logger = logger;
         this.taskManager = taskManager;
         this.persistentTaskId = persistentTaskId;
         this.allocationId = allocationId;

--- a/server/src/main/java/org/elasticsearch/persistent/AllocatedPersistentTask.java
+++ b/server/src/main/java/org/elasticsearch/persistent/AllocatedPersistentTask.java
@@ -86,8 +86,8 @@ public class AllocatedPersistentTask extends CancellableTask {
         return persistentTaskId;
     }
 
-    protected void init(PersistentTasksService persistentTasksService, TaskManager taskManager, String persistentTaskId,
-                        long allocationId, PersistentTaskState state) {
+    protected void init(PersistentTasksService persistentTasksService, TaskManager taskManager,
+                        String persistentTaskId, long allocationId) {
         this.persistentTasksService = persistentTasksService;
         this.taskManager = taskManager;
         this.persistentTaskId = persistentTaskId;

--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksNodeService.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksNodeService.java
@@ -183,7 +183,8 @@ public class PersistentTasksNodeService implements ClusterStateListener {
 
         boolean processed = false;
         try {
-            task.init(persistentTasksService, taskManager, logger, taskInProgress.getId(), taskInProgress.getAllocationId());
+            task.init(persistentTasksService, taskManager, taskInProgress.getId(),
+                taskInProgress.getAllocationId(), taskInProgress.getState());
             logger.trace("Persistent task [{}] with id [{}] and allocation id [{}] was created", task.getAction(),
                     task.getPersistentTaskId(), task.getAllocationId());
             try {

--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksNodeService.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksNodeService.java
@@ -183,8 +183,7 @@ public class PersistentTasksNodeService implements ClusterStateListener {
 
         boolean processed = false;
         try {
-            task.init(persistentTasksService, taskManager, taskInProgress.getId(),
-                taskInProgress.getAllocationId(), taskInProgress.getState());
+            task.init(persistentTasksService, taskManager, taskInProgress.getId(), taskInProgress.getAllocationId());
             logger.trace("Persistent task [{}] with id [{}] and allocation id [{}] was created", task.getAction(),
                     task.getPersistentTaskId(), task.getAllocationId());
             try {

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/RollupJobTask.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/RollupJobTask.java
@@ -200,7 +200,7 @@ public class RollupJobTask extends AllocatedPersistentTask implements SchedulerE
 
         }
         this.indexer = new ClientRollupPageManager(job, initialState, initialPosition,
-            new ParentTaskAssigningClient(client, new TaskId(getPersistentTaskId())));
+            new ParentTaskAssigningClient(client, getParentTaskId()));
     }
 
     @Override

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupJobTaskTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupJobTaskTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
 import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -67,8 +68,10 @@ public class RollupJobTaskTests extends ESTestCase {
         Client client = mock(Client.class);
         when(client.settings()).thenReturn(Settings.EMPTY);
         SchedulerEngine schedulerEngine = new SchedulerEngine(SETTINGS, Clock.systemUTC());
-        RollupJobTask task = new RollupJobTask(1, "type", "action", new TaskId("node", 123), job,
-            status, client, schedulerEngine, pool, Collections.emptyMap());
+        TaskId taskId = new TaskId("node", 123);
+        RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
+            client, schedulerEngine, pool, Collections.emptyMap());
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertThat(((RollupJobStatus)task.getStatus()).getPosition().size(), equalTo(1));
         assertTrue(((RollupJobStatus)task.getStatus()).getPosition().containsKey("foo"));
@@ -80,8 +83,10 @@ public class RollupJobTaskTests extends ESTestCase {
         Client client = mock(Client.class);
         when(client.settings()).thenReturn(Settings.EMPTY);
         SchedulerEngine schedulerEngine = new SchedulerEngine(SETTINGS, Clock.systemUTC());
-        RollupJobTask task = new RollupJobTask(1, "type", "action", new TaskId("node", 123), job,
-            status, client, schedulerEngine, pool, Collections.emptyMap());
+        TaskId taskId = new TaskId("node", 123);
+        RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
+            client, schedulerEngine, pool, Collections.emptyMap());
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertThat(((RollupJobStatus)task.getStatus()).getPosition().size(), equalTo(1));
         assertTrue(((RollupJobStatus)task.getStatus()).getPosition().containsKey("foo"));
@@ -93,8 +98,10 @@ public class RollupJobTaskTests extends ESTestCase {
         Client client = mock(Client.class);
         when(client.settings()).thenReturn(Settings.EMPTY);
         SchedulerEngine schedulerEngine = new SchedulerEngine(SETTINGS, Clock.systemUTC());
-        RollupJobTask task = new RollupJobTask(1, "type", "action", new TaskId("node", 123), job,
-            status, client, schedulerEngine, pool, Collections.emptyMap());
+        TaskId taskId = new TaskId("node", 123);
+        RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
+            client, schedulerEngine, pool, Collections.emptyMap());
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertThat(((RollupJobStatus)task.getStatus()).getPosition().size(), equalTo(1));
         assertTrue(((RollupJobStatus)task.getStatus()).getPosition().containsKey("foo"));
@@ -106,8 +113,10 @@ public class RollupJobTaskTests extends ESTestCase {
         Client client = mock(Client.class);
         when(client.settings()).thenReturn(Settings.EMPTY);
         SchedulerEngine schedulerEngine = new SchedulerEngine(SETTINGS, Clock.systemUTC());
-        RollupJobTask task = new RollupJobTask(1, "type", "action", new TaskId("node", 123), job,
-            status, client, schedulerEngine, pool, Collections.emptyMap());
+        TaskId taskId = new TaskId("node", 123);
+        RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
+            client, schedulerEngine, pool, Collections.emptyMap());
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STARTED));
         assertThat(((RollupJobStatus)task.getStatus()).getPosition().size(), equalTo(1));
         assertTrue(((RollupJobStatus)task.getStatus()).getPosition().containsKey("foo"));
@@ -119,8 +128,10 @@ public class RollupJobTaskTests extends ESTestCase {
         Client client = mock(Client.class);
         when(client.settings()).thenReturn(Settings.EMPTY);
         SchedulerEngine schedulerEngine = new SchedulerEngine(SETTINGS, Clock.systemUTC());
-        RollupJobTask task = new RollupJobTask(1, "type", "action", new TaskId("node", 123), job,
-            status, client, schedulerEngine, pool, Collections.emptyMap());
+        TaskId taskId = new TaskId("node", 123);
+        RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
+            client, schedulerEngine, pool, Collections.emptyMap());
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STARTED));
         assertThat(((RollupJobStatus)task.getStatus()).getPosition().size(), equalTo(1));
         assertTrue(((RollupJobStatus)task.getStatus()).getPosition().containsKey("foo"));
@@ -132,8 +143,10 @@ public class RollupJobTaskTests extends ESTestCase {
         Client client = mock(Client.class);
         when(client.settings()).thenReturn(Settings.EMPTY);
         SchedulerEngine schedulerEngine = new SchedulerEngine(SETTINGS, Clock.systemUTC());
-        RollupJobTask task = new RollupJobTask(1, "type", "action", new TaskId("node", 123), job,
-            status, client, schedulerEngine, pool, Collections.emptyMap());
+        TaskId taskId = new TaskId("node", 123);
+        RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
+            client, schedulerEngine, pool, Collections.emptyMap());
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STARTED));
         assertThat(((RollupJobStatus)task.getStatus()).getPosition().size(), equalTo(1));
         assertTrue(((RollupJobStatus)task.getStatus()).getPosition().containsKey("foo"));
@@ -144,8 +157,10 @@ public class RollupJobTaskTests extends ESTestCase {
         Client client = mock(Client.class);
         when(client.settings()).thenReturn(Settings.EMPTY);
         SchedulerEngine schedulerEngine = new SchedulerEngine(SETTINGS, Clock.systemUTC());
-        RollupJobTask task = new RollupJobTask(1, "type", "action", new TaskId("node", 123), job,
-            null, client, schedulerEngine, pool, Collections.emptyMap());
+        TaskId taskId = new TaskId("node", 123);
+        RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
+            client, schedulerEngine, pool, Collections.emptyMap());
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123, null);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertNull(((RollupJobStatus)task.getStatus()).getPosition());
     }
@@ -156,8 +171,10 @@ public class RollupJobTaskTests extends ESTestCase {
         Client client = mock(Client.class);
         when(client.settings()).thenReturn(Settings.EMPTY);
         SchedulerEngine schedulerEngine = new SchedulerEngine(SETTINGS, Clock.systemUTC());
-        RollupJobTask task = new RollupJobTask(1, "type", "action", new TaskId("node", 123), job,
-            status, client, schedulerEngine, pool, Collections.emptyMap());
+        TaskId taskId = new TaskId("node", 123);
+        RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
+            client, schedulerEngine, pool, Collections.emptyMap());
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STARTED));
         assertThat(((RollupJobStatus)task.getStatus()).getPosition().size(), equalTo(1));
         assertTrue(((RollupJobStatus)task.getStatus()).getPosition().containsKey("foo"));
@@ -186,8 +203,9 @@ public class RollupJobTaskTests extends ESTestCase {
         SchedulerEngine schedulerEngine = mock(SchedulerEngine.class);
 
         AtomicInteger counter = new AtomicInteger(0);
-        RollupJobTask task = new RollupJobTask(1, "type", "action", new TaskId("node", 123), job,
-            null, client, schedulerEngine, pool, Collections.emptyMap()) {
+        TaskId taskId = new TaskId("node", 123);
+        RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
+             client, schedulerEngine, pool, Collections.emptyMap()) {
             @Override
             public void updatePersistentTaskState(PersistentTaskState taskState,
                                                   ActionListener<PersistentTasksCustomMetaData.PersistentTask<?>> listener) {
@@ -205,6 +223,7 @@ public class RollupJobTaskTests extends ESTestCase {
                 counter.incrementAndGet();
             }
         };
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123, null);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertNull(((RollupJobStatus)task.getStatus()).getPosition());
 
@@ -263,8 +282,9 @@ public class RollupJobTaskTests extends ESTestCase {
         Client client = mock(Client.class);
         when(client.settings()).thenReturn(Settings.EMPTY);
         SchedulerEngine schedulerEngine = mock(SchedulerEngine.class);
-        RollupJobTask task = new RollupJobTask(1, "type", "action", new TaskId("node", 123), job,
-            status, client, schedulerEngine, pool, Collections.emptyMap()) {
+        TaskId taskId = new TaskId("node", 123);
+        RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
+            client, schedulerEngine, pool, Collections.emptyMap()) {
             @Override
             public void updatePersistentTaskState(PersistentTaskState taskState,
                                                   ActionListener<PersistentTasksCustomMetaData.PersistentTask<?>> listener) {
@@ -274,6 +294,7 @@ public class RollupJobTaskTests extends ESTestCase {
                     new PersistentTasksCustomMetaData.Assignment("foo", "foo")));
             }
         };
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertThat(((RollupJobStatus)task.getStatus()).getPosition().size(), equalTo(1));
         assertTrue(((RollupJobStatus)task.getStatus()).getPosition().containsKey("foo"));
@@ -301,8 +322,9 @@ public class RollupJobTaskTests extends ESTestCase {
         Client client = mock(Client.class);
         when(client.settings()).thenReturn(Settings.EMPTY);
         SchedulerEngine schedulerEngine = mock(SchedulerEngine.class);
-        RollupJobTask task = new RollupJobTask(1, "type", "action", new TaskId("node", 123), job,
-            status, client, schedulerEngine, pool, Collections.emptyMap()) {
+        TaskId taskId = new TaskId("node", 123);
+        RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
+            client, schedulerEngine, pool, Collections.emptyMap()) {
             @Override
             public void updatePersistentTaskState(PersistentTaskState taskState,
                                                   ActionListener<PersistentTasksCustomMetaData.PersistentTask<?>> listener) {
@@ -312,6 +334,7 @@ public class RollupJobTaskTests extends ESTestCase {
                     new PersistentTasksCustomMetaData.Assignment("foo", "foo")));
             }
         };
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertThat(((RollupJobStatus)task.getStatus()).getPosition().size(), equalTo(1));
         assertTrue(((RollupJobStatus)task.getStatus()).getPosition().containsKey("foo"));
@@ -342,8 +365,9 @@ public class RollupJobTaskTests extends ESTestCase {
         when(client.settings()).thenReturn(Settings.EMPTY);
         when(client.threadPool()).thenReturn(pool);
         SchedulerEngine schedulerEngine = mock(SchedulerEngine.class);
-        RollupJobTask task = new RollupJobTask(1, "type", "action", new TaskId("node", 123), job,
-            null, client, schedulerEngine, pool, Collections.emptyMap()) {
+        TaskId taskId = new TaskId("node", 123);
+        RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
+            client, schedulerEngine, pool, Collections.emptyMap()) {
             @Override
             public void updatePersistentTaskState(PersistentTaskState taskState,
                                                   ActionListener<PersistentTasksCustomMetaData.PersistentTask<?>> listener) {
@@ -353,6 +377,7 @@ public class RollupJobTaskTests extends ESTestCase {
                     new PersistentTasksCustomMetaData.Assignment("foo", "foo")));
             }
         };
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123, null);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertNull(((RollupJobStatus)task.getStatus()).getPosition());
 
@@ -410,8 +435,9 @@ public class RollupJobTaskTests extends ESTestCase {
         }).when(client).execute(anyObject(), anyObject(), anyObject());
 
         SchedulerEngine schedulerEngine = mock(SchedulerEngine.class);
-        RollupJobTask task = new RollupJobTask(1, "type", "action", new TaskId("node", 123), job,
-            null, client, schedulerEngine, pool, Collections.emptyMap()) {
+        TaskId taskId = new TaskId("node", 123);
+        RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
+            client, schedulerEngine, pool, Collections.emptyMap()) {
             @Override
             public void updatePersistentTaskState(PersistentTaskState taskState,
                                                   ActionListener<PersistentTasksCustomMetaData.PersistentTask<?>> listener) {
@@ -427,6 +453,7 @@ public class RollupJobTaskTests extends ESTestCase {
 
             }
         };
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123, null);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertNull(((RollupJobStatus)task.getStatus()).getPosition());
 
@@ -494,8 +521,9 @@ public class RollupJobTaskTests extends ESTestCase {
         }).when(client).execute(anyObject(), anyObject(), anyObject());
 
         SchedulerEngine schedulerEngine = mock(SchedulerEngine.class);
-        RollupJobTask task = new RollupJobTask(1, "type", "action", new TaskId("node", 123), job,
-            null, client, schedulerEngine, pool, Collections.emptyMap()) {
+        TaskId taskId = new TaskId("node", 123);
+        RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
+            client, schedulerEngine, pool, Collections.emptyMap()) {
             @Override
             public void updatePersistentTaskState(PersistentTaskState taskState,
                                                   ActionListener<PersistentTasksCustomMetaData.PersistentTask<?>> listener) {
@@ -511,6 +539,7 @@ public class RollupJobTaskTests extends ESTestCase {
 
             }
         };
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123, null);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertNull(((RollupJobStatus)task.getStatus()).getPosition());
 
@@ -579,8 +608,9 @@ public class RollupJobTaskTests extends ESTestCase {
 
         SchedulerEngine schedulerEngine = mock(SchedulerEngine.class);
         RollupJobStatus status = new RollupJobStatus(IndexerState.STOPPED, null);
-        RollupJobTask task = new RollupJobTask(1, "type", "action", new TaskId("node", 123), job,
-            status, client, schedulerEngine, pool, Collections.emptyMap()) {
+        TaskId taskId = new TaskId("node", 123);
+        RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
+            client, schedulerEngine, pool, Collections.emptyMap()) {
             @Override
             public void updatePersistentTaskState(PersistentTaskState taskState,
                                                   ActionListener<PersistentTasksCustomMetaData.PersistentTask<?>> listener) {
@@ -596,6 +626,7 @@ public class RollupJobTaskTests extends ESTestCase {
 
             }
         };
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertNull(((RollupJobStatus)task.getStatus()).getPosition());
 
@@ -630,8 +661,10 @@ public class RollupJobTaskTests extends ESTestCase {
         Client client = mock(Client.class);
         when(client.settings()).thenReturn(Settings.EMPTY);
         SchedulerEngine schedulerEngine = new SchedulerEngine(SETTINGS, Clock.systemUTC());
-        RollupJobTask task = new RollupJobTask(1, "type", "action", new TaskId("node", 123), job,
-            status, client, schedulerEngine, pool, Collections.emptyMap());
+        TaskId taskId = new TaskId("node", 123);
+        RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
+            client, schedulerEngine, pool, Collections.emptyMap());
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
 
         CountDownLatch latch = new CountDownLatch(1);
@@ -658,8 +691,9 @@ public class RollupJobTaskTests extends ESTestCase {
         SchedulerEngine schedulerEngine = mock(SchedulerEngine.class);
 
         AtomicInteger counter = new AtomicInteger(0);
-        RollupJobTask task = new RollupJobTask(1, "type", "action", new TaskId("node", 123), job,
-            null, client, schedulerEngine, pool, Collections.emptyMap()) {
+        TaskId taskId = new TaskId("node", 123);
+        RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
+            client, schedulerEngine, pool, Collections.emptyMap()) {
             @Override
             public void updatePersistentTaskState(PersistentTaskState taskState,
                                                   ActionListener<PersistentTasksCustomMetaData.PersistentTask<?>> listener) {
@@ -680,6 +714,7 @@ public class RollupJobTaskTests extends ESTestCase {
 
             }
         };
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123, null);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertNull(((RollupJobStatus)task.getStatus()).getPosition());
 
@@ -744,13 +779,15 @@ public class RollupJobTaskTests extends ESTestCase {
         // the task would end before stop could be called.  But to help test out all pathways,
         // just in case, we can override markAsCompleted so it's a no-op and test how stop
         // handles the situation
-        RollupJobTask task = new RollupJobTask(1, "type", "action", new TaskId("node", 123), job,
-            status, client, schedulerEngine, pool, Collections.emptyMap()) {
+        TaskId taskId = new TaskId("node", 123);
+        RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
+            client, schedulerEngine, pool, Collections.emptyMap()) {
             @Override
             public void markAsCompleted() {
                 latch.countDown();
             }
         };
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
 
         task.onCancelled();

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupJobTaskTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupJobTaskTests.java
@@ -70,8 +70,8 @@ public class RollupJobTaskTests extends ESTestCase {
         SchedulerEngine schedulerEngine = new SchedulerEngine(SETTINGS, Clock.systemUTC());
         TaskId taskId = new TaskId("node", 123);
         RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
-            client, schedulerEngine, pool, Collections.emptyMap());
-        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
+            status, client, schedulerEngine, pool, Collections.emptyMap());
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertThat(((RollupJobStatus)task.getStatus()).getPosition().size(), equalTo(1));
         assertTrue(((RollupJobStatus)task.getStatus()).getPosition().containsKey("foo"));
@@ -85,8 +85,8 @@ public class RollupJobTaskTests extends ESTestCase {
         SchedulerEngine schedulerEngine = new SchedulerEngine(SETTINGS, Clock.systemUTC());
         TaskId taskId = new TaskId("node", 123);
         RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
-            client, schedulerEngine, pool, Collections.emptyMap());
-        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
+            status, client, schedulerEngine, pool, Collections.emptyMap());
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertThat(((RollupJobStatus)task.getStatus()).getPosition().size(), equalTo(1));
         assertTrue(((RollupJobStatus)task.getStatus()).getPosition().containsKey("foo"));
@@ -100,8 +100,8 @@ public class RollupJobTaskTests extends ESTestCase {
         SchedulerEngine schedulerEngine = new SchedulerEngine(SETTINGS, Clock.systemUTC());
         TaskId taskId = new TaskId("node", 123);
         RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
-            client, schedulerEngine, pool, Collections.emptyMap());
-        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
+            status, client, schedulerEngine, pool, Collections.emptyMap());
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertThat(((RollupJobStatus)task.getStatus()).getPosition().size(), equalTo(1));
         assertTrue(((RollupJobStatus)task.getStatus()).getPosition().containsKey("foo"));
@@ -115,8 +115,8 @@ public class RollupJobTaskTests extends ESTestCase {
         SchedulerEngine schedulerEngine = new SchedulerEngine(SETTINGS, Clock.systemUTC());
         TaskId taskId = new TaskId("node", 123);
         RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
-            client, schedulerEngine, pool, Collections.emptyMap());
-        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
+            status, client, schedulerEngine, pool, Collections.emptyMap());
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STARTED));
         assertThat(((RollupJobStatus)task.getStatus()).getPosition().size(), equalTo(1));
         assertTrue(((RollupJobStatus)task.getStatus()).getPosition().containsKey("foo"));
@@ -130,8 +130,8 @@ public class RollupJobTaskTests extends ESTestCase {
         SchedulerEngine schedulerEngine = new SchedulerEngine(SETTINGS, Clock.systemUTC());
         TaskId taskId = new TaskId("node", 123);
         RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
-            client, schedulerEngine, pool, Collections.emptyMap());
-        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
+            status, client, schedulerEngine, pool, Collections.emptyMap());
+        task.init(null, mock(TaskManager.class), taskId.toString(),123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STARTED));
         assertThat(((RollupJobStatus)task.getStatus()).getPosition().size(), equalTo(1));
         assertTrue(((RollupJobStatus)task.getStatus()).getPosition().containsKey("foo"));
@@ -145,8 +145,8 @@ public class RollupJobTaskTests extends ESTestCase {
         SchedulerEngine schedulerEngine = new SchedulerEngine(SETTINGS, Clock.systemUTC());
         TaskId taskId = new TaskId("node", 123);
         RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
-            client, schedulerEngine, pool, Collections.emptyMap());
-        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
+            status, client, schedulerEngine, pool, Collections.emptyMap());
+        task.init(null, mock(TaskManager.class), taskId.toString(),123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STARTED));
         assertThat(((RollupJobStatus)task.getStatus()).getPosition().size(), equalTo(1));
         assertTrue(((RollupJobStatus)task.getStatus()).getPosition().containsKey("foo"));
@@ -159,8 +159,8 @@ public class RollupJobTaskTests extends ESTestCase {
         SchedulerEngine schedulerEngine = new SchedulerEngine(SETTINGS, Clock.systemUTC());
         TaskId taskId = new TaskId("node", 123);
         RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
-            client, schedulerEngine, pool, Collections.emptyMap());
-        task.init(null, mock(TaskManager.class), taskId.toString(), 123, null);
+            null, client, schedulerEngine, pool, Collections.emptyMap());
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertNull(((RollupJobStatus)task.getStatus()).getPosition());
     }
@@ -173,8 +173,8 @@ public class RollupJobTaskTests extends ESTestCase {
         SchedulerEngine schedulerEngine = new SchedulerEngine(SETTINGS, Clock.systemUTC());
         TaskId taskId = new TaskId("node", 123);
         RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
-            client, schedulerEngine, pool, Collections.emptyMap());
-        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
+            status, client, schedulerEngine, pool, Collections.emptyMap());
+        task.init(null, mock(TaskManager.class), taskId.toString(),123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STARTED));
         assertThat(((RollupJobStatus)task.getStatus()).getPosition().size(), equalTo(1));
         assertTrue(((RollupJobStatus)task.getStatus()).getPosition().containsKey("foo"));
@@ -205,7 +205,7 @@ public class RollupJobTaskTests extends ESTestCase {
         AtomicInteger counter = new AtomicInteger(0);
         TaskId taskId = new TaskId("node", 123);
         RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
-             client, schedulerEngine, pool, Collections.emptyMap()) {
+             null, client, schedulerEngine, pool, Collections.emptyMap()) {
             @Override
             public void updatePersistentTaskState(PersistentTaskState taskState,
                                                   ActionListener<PersistentTasksCustomMetaData.PersistentTask<?>> listener) {
@@ -223,7 +223,7 @@ public class RollupJobTaskTests extends ESTestCase {
                 counter.incrementAndGet();
             }
         };
-        task.init(null, mock(TaskManager.class), taskId.toString(), 123, null);
+        task.init(null, mock(TaskManager.class), taskId.toString(),123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertNull(((RollupJobStatus)task.getStatus()).getPosition());
 
@@ -284,7 +284,7 @@ public class RollupJobTaskTests extends ESTestCase {
         SchedulerEngine schedulerEngine = mock(SchedulerEngine.class);
         TaskId taskId = new TaskId("node", 123);
         RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
-            client, schedulerEngine, pool, Collections.emptyMap()) {
+            status, client, schedulerEngine, pool, Collections.emptyMap()) {
             @Override
             public void updatePersistentTaskState(PersistentTaskState taskState,
                                                   ActionListener<PersistentTasksCustomMetaData.PersistentTask<?>> listener) {
@@ -294,7 +294,7 @@ public class RollupJobTaskTests extends ESTestCase {
                     new PersistentTasksCustomMetaData.Assignment("foo", "foo")));
             }
         };
-        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
+        task.init(null, mock(TaskManager.class), taskId.toString(),123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertThat(((RollupJobStatus)task.getStatus()).getPosition().size(), equalTo(1));
         assertTrue(((RollupJobStatus)task.getStatus()).getPosition().containsKey("foo"));
@@ -324,7 +324,7 @@ public class RollupJobTaskTests extends ESTestCase {
         SchedulerEngine schedulerEngine = mock(SchedulerEngine.class);
         TaskId taskId = new TaskId("node", 123);
         RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
-            client, schedulerEngine, pool, Collections.emptyMap()) {
+            status, client, schedulerEngine, pool, Collections.emptyMap()) {
             @Override
             public void updatePersistentTaskState(PersistentTaskState taskState,
                                                   ActionListener<PersistentTasksCustomMetaData.PersistentTask<?>> listener) {
@@ -334,7 +334,7 @@ public class RollupJobTaskTests extends ESTestCase {
                     new PersistentTasksCustomMetaData.Assignment("foo", "foo")));
             }
         };
-        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
+        task.init(null, mock(TaskManager.class), taskId.toString(),123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertThat(((RollupJobStatus)task.getStatus()).getPosition().size(), equalTo(1));
         assertTrue(((RollupJobStatus)task.getStatus()).getPosition().containsKey("foo"));
@@ -367,7 +367,7 @@ public class RollupJobTaskTests extends ESTestCase {
         SchedulerEngine schedulerEngine = mock(SchedulerEngine.class);
         TaskId taskId = new TaskId("node", 123);
         RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
-            client, schedulerEngine, pool, Collections.emptyMap()) {
+            null, client, schedulerEngine, pool, Collections.emptyMap()) {
             @Override
             public void updatePersistentTaskState(PersistentTaskState taskState,
                                                   ActionListener<PersistentTasksCustomMetaData.PersistentTask<?>> listener) {
@@ -377,7 +377,7 @@ public class RollupJobTaskTests extends ESTestCase {
                     new PersistentTasksCustomMetaData.Assignment("foo", "foo")));
             }
         };
-        task.init(null, mock(TaskManager.class), taskId.toString(), 123, null);
+        task.init(null, mock(TaskManager.class), taskId.toString(),123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertNull(((RollupJobStatus)task.getStatus()).getPosition());
 
@@ -437,7 +437,7 @@ public class RollupJobTaskTests extends ESTestCase {
         SchedulerEngine schedulerEngine = mock(SchedulerEngine.class);
         TaskId taskId = new TaskId("node", 123);
         RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
-            client, schedulerEngine, pool, Collections.emptyMap()) {
+            null, client, schedulerEngine, pool, Collections.emptyMap()) {
             @Override
             public void updatePersistentTaskState(PersistentTaskState taskState,
                                                   ActionListener<PersistentTasksCustomMetaData.PersistentTask<?>> listener) {
@@ -453,7 +453,7 @@ public class RollupJobTaskTests extends ESTestCase {
 
             }
         };
-        task.init(null, mock(TaskManager.class), taskId.toString(), 123, null);
+        task.init(null, mock(TaskManager.class), taskId.toString(),123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertNull(((RollupJobStatus)task.getStatus()).getPosition());
 
@@ -523,7 +523,7 @@ public class RollupJobTaskTests extends ESTestCase {
         SchedulerEngine schedulerEngine = mock(SchedulerEngine.class);
         TaskId taskId = new TaskId("node", 123);
         RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
-            client, schedulerEngine, pool, Collections.emptyMap()) {
+            null, client, schedulerEngine, pool, Collections.emptyMap()) {
             @Override
             public void updatePersistentTaskState(PersistentTaskState taskState,
                                                   ActionListener<PersistentTasksCustomMetaData.PersistentTask<?>> listener) {
@@ -539,7 +539,7 @@ public class RollupJobTaskTests extends ESTestCase {
 
             }
         };
-        task.init(null, mock(TaskManager.class), taskId.toString(), 123, null);
+        task.init(null, mock(TaskManager.class), taskId.toString(),123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertNull(((RollupJobStatus)task.getStatus()).getPosition());
 
@@ -610,7 +610,7 @@ public class RollupJobTaskTests extends ESTestCase {
         RollupJobStatus status = new RollupJobStatus(IndexerState.STOPPED, null);
         TaskId taskId = new TaskId("node", 123);
         RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
-            client, schedulerEngine, pool, Collections.emptyMap()) {
+            status, client, schedulerEngine, pool, Collections.emptyMap()) {
             @Override
             public void updatePersistentTaskState(PersistentTaskState taskState,
                                                   ActionListener<PersistentTasksCustomMetaData.PersistentTask<?>> listener) {
@@ -626,7 +626,7 @@ public class RollupJobTaskTests extends ESTestCase {
 
             }
         };
-        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
+        task.init(null, mock(TaskManager.class), taskId.toString(),123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertNull(((RollupJobStatus)task.getStatus()).getPosition());
 
@@ -663,8 +663,8 @@ public class RollupJobTaskTests extends ESTestCase {
         SchedulerEngine schedulerEngine = new SchedulerEngine(SETTINGS, Clock.systemUTC());
         TaskId taskId = new TaskId("node", 123);
         RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
-            client, schedulerEngine, pool, Collections.emptyMap());
-        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
+            status, client, schedulerEngine, pool, Collections.emptyMap());
+        task.init(null, mock(TaskManager.class), taskId.toString(),123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
 
         CountDownLatch latch = new CountDownLatch(1);
@@ -693,7 +693,7 @@ public class RollupJobTaskTests extends ESTestCase {
         AtomicInteger counter = new AtomicInteger(0);
         TaskId taskId = new TaskId("node", 123);
         RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
-            client, schedulerEngine, pool, Collections.emptyMap()) {
+            null, client, schedulerEngine, pool, Collections.emptyMap()) {
             @Override
             public void updatePersistentTaskState(PersistentTaskState taskState,
                                                   ActionListener<PersistentTasksCustomMetaData.PersistentTask<?>> listener) {
@@ -714,7 +714,7 @@ public class RollupJobTaskTests extends ESTestCase {
 
             }
         };
-        task.init(null, mock(TaskManager.class), taskId.toString(), 123, null);
+        task.init(null, mock(TaskManager.class), taskId.toString(),123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertNull(((RollupJobStatus)task.getStatus()).getPosition());
 
@@ -781,13 +781,13 @@ public class RollupJobTaskTests extends ESTestCase {
         // handles the situation
         TaskId taskId = new TaskId("node", 123);
         RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
-            client, schedulerEngine, pool, Collections.emptyMap()) {
+            status, client, schedulerEngine, pool, Collections.emptyMap()) {
             @Override
             public void markAsCompleted() {
                 latch.countDown();
             }
         };
-        task.init(null, mock(TaskManager.class), taskId.toString(), 123, status);
+        task.init(null, mock(TaskManager.class), taskId.toString(),123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
 
         task.onCancelled();

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupJobTaskTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupJobTaskTests.java
@@ -131,7 +131,7 @@ public class RollupJobTaskTests extends ESTestCase {
         TaskId taskId = new TaskId("node", 123);
         RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
             status, client, schedulerEngine, pool, Collections.emptyMap());
-        task.init(null, mock(TaskManager.class), taskId.toString(),123);
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STARTED));
         assertThat(((RollupJobStatus)task.getStatus()).getPosition().size(), equalTo(1));
         assertTrue(((RollupJobStatus)task.getStatus()).getPosition().containsKey("foo"));
@@ -146,7 +146,7 @@ public class RollupJobTaskTests extends ESTestCase {
         TaskId taskId = new TaskId("node", 123);
         RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
             status, client, schedulerEngine, pool, Collections.emptyMap());
-        task.init(null, mock(TaskManager.class), taskId.toString(),123);
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STARTED));
         assertThat(((RollupJobStatus)task.getStatus()).getPosition().size(), equalTo(1));
         assertTrue(((RollupJobStatus)task.getStatus()).getPosition().containsKey("foo"));
@@ -174,7 +174,7 @@ public class RollupJobTaskTests extends ESTestCase {
         TaskId taskId = new TaskId("node", 123);
         RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
             status, client, schedulerEngine, pool, Collections.emptyMap());
-        task.init(null, mock(TaskManager.class), taskId.toString(),123);
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STARTED));
         assertThat(((RollupJobStatus)task.getStatus()).getPosition().size(), equalTo(1));
         assertTrue(((RollupJobStatus)task.getStatus()).getPosition().containsKey("foo"));
@@ -223,7 +223,7 @@ public class RollupJobTaskTests extends ESTestCase {
                 counter.incrementAndGet();
             }
         };
-        task.init(null, mock(TaskManager.class), taskId.toString(),123);
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertNull(((RollupJobStatus)task.getStatus()).getPosition());
 
@@ -294,7 +294,7 @@ public class RollupJobTaskTests extends ESTestCase {
                     new PersistentTasksCustomMetaData.Assignment("foo", "foo")));
             }
         };
-        task.init(null, mock(TaskManager.class), taskId.toString(),123);
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertThat(((RollupJobStatus)task.getStatus()).getPosition().size(), equalTo(1));
         assertTrue(((RollupJobStatus)task.getStatus()).getPosition().containsKey("foo"));
@@ -334,7 +334,7 @@ public class RollupJobTaskTests extends ESTestCase {
                     new PersistentTasksCustomMetaData.Assignment("foo", "foo")));
             }
         };
-        task.init(null, mock(TaskManager.class), taskId.toString(),123);
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertThat(((RollupJobStatus)task.getStatus()).getPosition().size(), equalTo(1));
         assertTrue(((RollupJobStatus)task.getStatus()).getPosition().containsKey("foo"));
@@ -377,7 +377,7 @@ public class RollupJobTaskTests extends ESTestCase {
                     new PersistentTasksCustomMetaData.Assignment("foo", "foo")));
             }
         };
-        task.init(null, mock(TaskManager.class), taskId.toString(),123);
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertNull(((RollupJobStatus)task.getStatus()).getPosition());
 
@@ -453,7 +453,7 @@ public class RollupJobTaskTests extends ESTestCase {
 
             }
         };
-        task.init(null, mock(TaskManager.class), taskId.toString(),123);
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertNull(((RollupJobStatus)task.getStatus()).getPosition());
 
@@ -539,7 +539,7 @@ public class RollupJobTaskTests extends ESTestCase {
 
             }
         };
-        task.init(null, mock(TaskManager.class), taskId.toString(),123);
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertNull(((RollupJobStatus)task.getStatus()).getPosition());
 
@@ -626,7 +626,7 @@ public class RollupJobTaskTests extends ESTestCase {
 
             }
         };
-        task.init(null, mock(TaskManager.class), taskId.toString(),123);
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertNull(((RollupJobStatus)task.getStatus()).getPosition());
 
@@ -664,7 +664,7 @@ public class RollupJobTaskTests extends ESTestCase {
         TaskId taskId = new TaskId("node", 123);
         RollupJobTask task = new RollupJobTask(1, "type", "action", taskId, job,
             status, client, schedulerEngine, pool, Collections.emptyMap());
-        task.init(null, mock(TaskManager.class), taskId.toString(),123);
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
 
         CountDownLatch latch = new CountDownLatch(1);
@@ -714,7 +714,7 @@ public class RollupJobTaskTests extends ESTestCase {
 
             }
         };
-        task.init(null, mock(TaskManager.class), taskId.toString(),123);
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
         assertNull(((RollupJobStatus)task.getStatus()).getPosition());
 
@@ -787,7 +787,7 @@ public class RollupJobTaskTests extends ESTestCase {
                 latch.countDown();
             }
         };
-        task.init(null, mock(TaskManager.class), taskId.toString(),123);
+        task.init(null, mock(TaskManager.class), taskId.toString(), 123);
         assertThat(((RollupJobStatus)task.getStatus()).getIndexerState(), equalTo(IndexerState.STOPPED));
 
         task.onCancelled();


### PR DESCRIPTION
This makes the `AllocatedPersistentTask#init()` method protected so that implementing classes can perform their initialization logic there, instead of the constructor.  Rollup's task is adjusted to use this init method.

This is a follow-on to https://github.com/elastic/elasticsearch/pull/45300.  Rollup got in trouble for a few reasons (poison task due to bad validation, no error catching on task creation), but some of the trouble would have been avoided if we had used `init()` instead of the ctor to initialize potentially-exceptional state

It also slightly refactors the methods to:
- Provide the persistent task state as part of `init()`
- Use a static logger in the AllocatedTask instead of passing it in via an argument.  This is simpler, logged messages come from the task instead of the service, and is easier for tests

/cc @benwtrent since data-frames may want to do similar, assuming you have potentially exception-throwing initialization in the ctor