### PR TITLE
[7.4] [ML][Transforms] fixing listener being called twice (#46284)

### DIFF
--- a/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
+++ b/x-pack/plugin/data-frame/src/main/java/org/elasticsearch/xpack/dataframe/transforms/DataFrameTransformTask.java
@@ -980,6 +980,7 @@ public class DataFrameTransformTask extends AllocatedPersistentTask implements S
                 // So, don't treat this like a checkpoint being completed, as no work was done.
                 if (hasSourceChanged == false) {
                     listener.onResponse(null);
+                    return;
                 }
                 // TODO: needs cleanup super is called with a listener, but listener.onResponse is called below
                 // super.onFinish() fortunately ignores the listener


### PR DESCRIPTION
Backports the following commits to 7.4:
 - [ML][Transforms] fixing listener being called twice  (#46284)