### PR TITLE
[DOCS] Add "get index template" API docs

### DIFF
--- a/docs/reference/indices.asciidoc
+++ b/docs/reference/indices.asciidoc
@@ -51,6 +51,7 @@ index settings, aliases, mappings, and index templates.
 [[index-templates]]
 === Index templates:
 * <<indices-delete-template>>
+* <<indices-get-template>>
 * <<indices-template-exists>>
 * <<indices-templates>>
 
@@ -119,6 +120,8 @@ include::indices/get-settings.asciidoc[]
 include::indices/analyze.asciidoc[]
 
 include::indices/delete-index-template.asciidoc[]
+
+include::indices/get-index-template.asciidoc[]
 
 include::indices/template-exists.asciidoc[]
 

--- a/docs/reference/indices/get-index-template.asciidoc
+++ b/docs/reference/indices/get-index-template.asciidoc
@@ -1,0 +1,89 @@
+[[indices-get-template]]
+=== Get index template API
+++++
+<titleabbrev>Get template index</titleabbrev>
+++++
+
+Returns information about one or more index templates.
+
+////
+[source,js]
+--------------------------------------------------
+PUT _template/template_1
+{
+ "index_patterns" : ["te*"],
+  "settings": {
+    "number_of_shards": 1
+  }
+}
+--------------------------------------------------
+// CONSOLE
+// TESTSETUP
+////
+
+[source,js]
+--------------------------------------------------
+GET /_template/template_1
+--------------------------------------------------
+// CONSOLE
+
+
+[[get-template-api-request]]
+==== {api-request-title}
+
+`GET /_template/<index-template>`
+
+
+[[get-template-api-path-params]]
+==== {api-path-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index-template]
++
+To return all index templates, omit this parameter
+or use a value of `_all` or `*`.
+
+
+[[get-template-api-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=include-type-name]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+
+
+[[get-template-api-example]]
+==== {api-examples-title}
+
+
+[[get-template-api-multiple-ex]]
+===== Get multiple index templates
+
+[source,js]
+--------------------------------------------------
+GET /_template/template_1,template_2
+--------------------------------------------------
+// CONSOLE
+
+
+[[get-template-api-wildcard-ex]]
+===== Get index templates using a wildcard expression
+
+[source,js]
+--------------------------------------------------
+GET /_template/temp*
+--------------------------------------------------
+// CONSOLE
+
+
+[[get-template-api-all-ex]]
+===== Get all index templates
+
+[source,js]
+--------------------------------------------------
+GET /_template
+--------------------------------------------------
+// CONSOLE

--- a/docs/reference/indices/templates.asciidoc
+++ b/docs/reference/indices/templates.asciidoc
@@ -90,6 +90,12 @@ DELETE /_template/template_1
 --------------------------------------------------
 // CONSOLE
 
+[float]	
+[[getting]]	
+==== Getting templates
+
+See <<indices-get-template>>.
+
 [float]
 [[multiple-templates]]
 ==== Multiple Templates Matching

--- a/docs/reference/indices/templates.asciidoc
+++ b/docs/reference/indices/templates.asciidoc
@@ -91,36 +91,6 @@ DELETE /_template/template_1
 // CONSOLE
 
 [float]
-[[getting]]
-==== Getting templates
-
-Index templates are identified by a name (in the above case
-`template_1`) and can be retrieved using the following:
-
-[source,js]
---------------------------------------------------
-GET /_template/template_1
---------------------------------------------------
-// CONSOLE
-
-You can also match several templates by using wildcards like:
-
-[source,js]
---------------------------------------------------
-GET /_template/temp*
-GET /_template/template_1,template_2
---------------------------------------------------
-// CONSOLE
-
-To get list of all index templates you can run:
-
-[source,js]
---------------------------------------------------
-GET /_template
---------------------------------------------------
-// CONSOLE
-
-[float]
 [[multiple-templates]]
 ==== Multiple Templates Matching
 


### PR DESCRIPTION
- Adds the get index template API docs to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc).

- Removes the get index template section from the [put index templates API docs](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html).

Relates to elastic/docs#937 and #43765