### PR TITLE
Add geo_shape support to geo_centroid aggregation

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/geo/CentroidCalculator.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/CentroidCalculator.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.geo;
+
+/**
+ * This class keeps a running Kahan-sum of coordinates
+ * that are to be averaged in {@link GeometryTreeWriter} for use
+ * as the centroid of a shape.
+ */
+public class CentroidCalculator {
+
+    private double compX;
+    private double compY;
+    private double sumX;
+    private double sumY;
+    private int count;
+
+    public CentroidCalculator() {
+        this.sumX = 0.0;
+        this.compX = 0.0;
+        this.sumY = 0.0;
+        this.compY = 0.0;
+        this.count = 0;
+    }
+
+    /**
+     * adds a single coordinate to the running sum and count of coordinates
+     * for centroid calculation
+     *
+     * @param x the x-coordinate of the point
+     * @param y the y-coordinate of the point
+     */
+    public void addCoordinate(double x, double y) {
+        double correctedX = x - compX;
+        double newSumX = sumX + correctedX;
+        compX = (newSumX - sumX) - correctedX;
+        sumX = newSumX;
+
+        double correctedY = y - compY;
+        double newSumY = sumY + correctedY;
+        compY = (newSumY - sumY) - correctedY;
+        sumY = newSumY;
+
+        count += 1;
+    }
+
+    /**
+     * Adjusts the existing calculator to add the running sum and count
+     * from another {@link CentroidCalculator}. This is used to keep
+     * a running count of points from different sub-shapes of a single
+     * geo-shape field
+     *
+     * @param otherCalculator the other centroid calculator to add from
+     */
+    void addFrom(CentroidCalculator otherCalculator) {
+        addCoordinate(otherCalculator.sumX, otherCalculator.sumY);
+        // adjust count
+        count += otherCalculator.count - 1;
+    }
+
+    /**
+     * @return the x-coordinate centroid
+     */
+    public double getX() {
+        return sumX / count;
+    }
+
+    /**
+     * @return the y-coordinate centroid
+     */
+    public double getY() {
+        return sumY / count;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/geo/Point2DWriter.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/Point2DWriter.java
@@ -36,10 +36,12 @@ public class Point2DWriter extends ShapeTreeWriter {
     // size of a leaf node where searches are done sequentially.
     static final int LEAF_SIZE = 64;
     private final CoordinateEncoder coordinateEncoder;
+    private final CentroidCalculator centroidCalculator;
 
     Point2DWriter(double[] x, double[] y, CoordinateEncoder coordinateEncoder) {
         assert x.length == y.length;
         this.coordinateEncoder = coordinateEncoder;
+        this.centroidCalculator = new CentroidCalculator();
         double top = Double.NEGATIVE_INFINITY;
         double bottom = Double.POSITIVE_INFINITY;
         double negLeft = Double.POSITIVE_INFINITY;
@@ -47,6 +49,7 @@ public class Point2DWriter extends ShapeTreeWriter {
         double posLeft = Double.POSITIVE_INFINITY;
         double posRight = Double.NEGATIVE_INFINITY;
         coords = new double[x.length * K];
+
         for (int i = 0; i < x.length; i++) {
             double xi = x[i];
             double yi = y[i];
@@ -66,6 +69,8 @@ public class Point2DWriter extends ShapeTreeWriter {
             }
             coords[2 * i] = xi;
             coords[2 * i + 1] = yi;
+
+            centroidCalculator.addCoordinate(xi, yi);
         }
         sort(0, x.length - 1, 0);
         this.extent = new Extent(coordinateEncoder.encodeY(top), coordinateEncoder.encodeY(bottom), coordinateEncoder.encodeX(negLeft),
@@ -76,6 +81,8 @@ public class Point2DWriter extends ShapeTreeWriter {
         this.coordinateEncoder = coordinateEncoder;
         coords = new double[] {x, y};
         this.extent = Extent.fromPoint(coordinateEncoder.encodeX(x), coordinateEncoder.encodeY(y));
+        this.centroidCalculator = new CentroidCalculator();
+        centroidCalculator.addCoordinate(x, y);
     }
 
     @Override
@@ -86,6 +93,11 @@ public class Point2DWriter extends ShapeTreeWriter {
     @Override
     public ShapeType getShapeType() {
         return ShapeType.MULTIPOINT;
+    }
+
+    @Override
+    public CentroidCalculator getCentroidCalculator() {
+        return centroidCalculator;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/geo/PolygonTreeWriter.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/PolygonTreeWriter.java
@@ -35,8 +35,8 @@ public class PolygonTreeWriter extends ShapeTreeWriter {
     private final EdgeTreeWriter holes;
 
     public PolygonTreeWriter(double[] x, double[] y, List<double[]> holesX, List<double[]> holesY, CoordinateEncoder coordinateEncoder) {
-        outerShell = new EdgeTreeWriter(x, y, coordinateEncoder);
-        holes = holesX.isEmpty() ? null : new EdgeTreeWriter(holesX, holesY, coordinateEncoder);
+        outerShell = new EdgeTreeWriter(x, y, coordinateEncoder, true);
+        holes = holesX.isEmpty() ? null : new EdgeTreeWriter(holesX, holesY, coordinateEncoder, true);
     }
 
     public Extent getExtent() {
@@ -45,6 +45,11 @@ public class PolygonTreeWriter extends ShapeTreeWriter {
 
     public ShapeType getShapeType() {
         return ShapeType.POLYGON;
+    }
+
+    @Override
+    public CentroidCalculator getCentroidCalculator() {
+        return outerShell.getCentroidCalculator();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/geo/ShapeTreeWriter.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/ShapeTreeWriter.java
@@ -29,4 +29,6 @@ public abstract class ShapeTreeWriter implements Writeable {
     public abstract Extent getExtent();
 
     public abstract ShapeType getShapeType();
+
+    public abstract CentroidCalculator getCentroidCalculator();
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/MultiGeoValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/MultiGeoValues.java
@@ -128,14 +128,28 @@ public abstract class MultiGeoValues {
             return new BoundingBox(extent, GeoShapeCoordinateEncoder.INSTANCE);
         }
 
+        /**
+         * @return the latitude of the centroid of the shape
+         */
         @Override
         public double lat() {
-            throw new UnsupportedOperationException("centroid of GeoShape is not defined");
+            try {
+                return reader.getCentroidY();
+            } catch (IOException e) {
+                throw new IllegalStateException("unable to read centroid of shape", e);
+            }
         }
 
+        /**
+         * @return the longitude of the centroid of the shape
+         */
         @Override
         public double lon() {
-            throw new UnsupportedOperationException("centroid of GeoShape is not defined");
+            try {
+                return reader.getCentroidX();
+            } catch (IOException e) {
+                throw new IllegalStateException("unable to read centroid of shape", e);
+            }
         }
 
         public static GeoShapeValue missing(String missing) {

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/LatLonShapeDVAtomicFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/LatLonShapeDVAtomicFieldData.java
@@ -23,6 +23,7 @@ import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.GeoShapeCoordinateEncoder;
 import org.elasticsearch.common.geo.GeometryTreeReader;
 import org.elasticsearch.index.fielddata.MultiGeoValues;
 
@@ -74,7 +75,7 @@ final class LatLonShapeDVAtomicFieldData extends AbstractAtomicGeoShapeFieldData
                 @Override
                 public GeoValue nextValue() throws IOException {
                     final BytesRef encoded = binaryValues.binaryValue();
-                    return new GeoShapeValue(new GeometryTreeReader(encoded));
+                    return new GeoShapeValue(new GeometryTreeReader(encoded, GeoShapeCoordinateEncoder.INSTANCE));
                 }
             };
         } catch (IOException e) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregationBuilder.java
@@ -39,13 +39,13 @@ import java.io.IOException;
 import java.util.Map;
 
 public class GeoCentroidAggregationBuilder
-        extends ValuesSourceAggregationBuilder.LeafOnly<ValuesSource.GeoPoint, GeoCentroidAggregationBuilder> {
+        extends ValuesSourceAggregationBuilder.LeafOnly<ValuesSource.Geo, GeoCentroidAggregationBuilder> {
     public static final String NAME = "geo_centroid";
 
     private static final ObjectParser<GeoCentroidAggregationBuilder, Void> PARSER;
     static {
         PARSER = new ObjectParser<>(GeoCentroidAggregationBuilder.NAME);
-        ValuesSourceParserHelper.declareGeoPointFields(PARSER, true, false);
+        ValuesSourceParserHelper.declareGeoFields(PARSER, true, false);
     }
 
     public static AggregationBuilder parse(String aggregationName, XContentParser parser) throws IOException {
@@ -78,7 +78,7 @@ public class GeoCentroidAggregationBuilder
     }
 
     @Override
-    protected GeoCentroidAggregatorFactory innerBuild(SearchContext context, ValuesSourceConfig<ValuesSource.GeoPoint> config,
+    protected GeoCentroidAggregatorFactory innerBuild(SearchContext context, ValuesSourceConfig<ValuesSource.Geo> config,
             AggregatorFactory parent, Builder subFactoriesBuilder) throws IOException {
         return new GeoCentroidAggregatorFactory(name, config, context, parent, subFactoriesBuilder, metaData);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregator.java
@@ -42,12 +42,12 @@ import java.util.Map;
  * A geo metric aggregator that computes a geo-centroid from a {@code geo_point} type field
  */
 final class GeoCentroidAggregator extends MetricsAggregator {
-    private final ValuesSource.GeoPoint valuesSource;
+    private final ValuesSource.Geo valuesSource;
     private DoubleArray lonSum, lonCompensations, latSum, latCompensations;
     private LongArray counts;
 
     GeoCentroidAggregator(String name, SearchContext context, Aggregator parent,
-                                    ValuesSource.GeoPoint valuesSource, List<PipelineAggregator> pipelineAggregators,
+                                    ValuesSource.Geo valuesSource, List<PipelineAggregator> pipelineAggregators,
                                     Map<String, Object> metaData) throws IOException {
         super(name, context, parent, pipelineAggregators, metaData);
         this.valuesSource = valuesSource;
@@ -89,6 +89,9 @@ final class GeoCentroidAggregator extends MetricsAggregator {
                     double compensationLon = lonCompensations.get(bucket);
 
                     // update the sum
+                    //
+                    // this calculates the centroid of centroid of shapes when
+                    // executing against geo-shape fields.
                     for (int i = 0; i < valueCount; ++i) {
                         MultiGeoValues.GeoValue value = values.nextValue();
                         //latitude

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregatorFactory.java
@@ -32,9 +32,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-class GeoCentroidAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.GeoPoint> {
+class GeoCentroidAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.Geo> {
 
-    GeoCentroidAggregatorFactory(String name, ValuesSourceConfig<ValuesSource.GeoPoint> config,
+    GeoCentroidAggregatorFactory(String name, ValuesSourceConfig<ValuesSource.Geo> config,
             SearchContext context, AggregatorFactory parent, AggregatorFactories.Builder subFactoriesBuilder,
             Map<String, Object> metaData) throws IOException {
         super(name, config, context, parent, subFactoriesBuilder, metaData);
@@ -47,7 +47,7 @@ class GeoCentroidAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesS
     }
 
     @Override
-    protected Aggregator doCreateInternal(ValuesSource.GeoPoint valuesSource, Aggregator parent,
+    protected Aggregator doCreateInternal(ValuesSource.Geo valuesSource, Aggregator parent,
             boolean collectsFromSingleBucket, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData)
                     throws IOException {
         return new GeoCentroidAggregator(name, context, parent, valuesSource, pipelineAggregators, metaData);

--- a/server/src/test/java/org/elasticsearch/common/geo/CentroidCalculatorTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/CentroidCalculatorTests.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.common.geo;
+
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class CentroidCalculatorTests extends ESTestCase {
+
+    public void test() {
+        double[] x = new double[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        double[] y = new double[] { 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 };
+        double[] xRunningAvg = new double[] { 1, 1.5, 2.0, 2.5, 3, 3.5, 4, 4.5, 5, 5.5 };
+        double[] yRunningAvg = new double[] { 10, 15, 20, 25, 30, 35, 40, 45, 50, 55 };
+        CentroidCalculator calculator = new CentroidCalculator();
+        for (int i = 0; i < 10; i++) {
+            calculator.addCoordinate(x[i], y[i]);
+            assertThat(calculator.getX(), equalTo(xRunningAvg[i]));
+            assertThat(calculator.getY(), equalTo(yRunningAvg[i]));
+        }
+        CentroidCalculator otherCalculator = new CentroidCalculator();
+        otherCalculator.addCoordinate(0.0, 0.0);
+        calculator.addFrom(otherCalculator);
+        assertThat(calculator.getX(), equalTo(5.0));
+        assertThat(calculator.getY(), equalTo(50.0));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/common/geo/EdgeTreeTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/EdgeTreeTests.java
@@ -47,11 +47,15 @@ public class EdgeTreeTests extends ESTestCase {
             int maxY = randomIntBetween(minY + 10, 180);
             double[] x = new double[]{minX, maxX, maxX, minX, minX};
             double[] y = new double[]{minY, minY, maxY, maxY, minY};
-            EdgeTreeWriter writer = new EdgeTreeWriter(x, y, TestCoordinateEncoder.INSTANCE);
+            EdgeTreeWriter writer = new EdgeTreeWriter(x, y, TestCoordinateEncoder.INSTANCE, true);
             BytesStreamOutput output = new BytesStreamOutput();
             writer.writeTo(output);
             output.close();
-            EdgeTreeReader reader = new EdgeTreeReader(new ByteBufferStreamInput(ByteBuffer.wrap(output.bytes().toBytesRef().bytes)), true);
+            EdgeTreeReader reader = new EdgeTreeReader(
+                new ByteBufferStreamInput(ByteBuffer.wrap(output.bytes().toBytesRef().bytes)), true);
+
+            assertThat(writer.getCentroidCalculator().getX(), equalTo((minX + maxX)/2.0));
+            assertThat(writer.getCentroidCalculator().getY(), equalTo((minY + maxY)/2.0));
 
             // box-query touches bottom-left corner
             assertTrue(reader.intersects(Extent.fromPoints(minX - randomIntBetween(1, 180), minY - randomIntBetween(1, 180), minX, minY)));
@@ -119,7 +123,7 @@ public class EdgeTreeTests extends ESTestCase {
             double[] x = testPolygon.getPolygon().getLons();
             double[] y = testPolygon.getPolygon().getLats();
 
-            EdgeTreeWriter writer = new EdgeTreeWriter(x, y, TestCoordinateEncoder.INSTANCE);
+            EdgeTreeWriter writer = new EdgeTreeWriter(x, y, TestCoordinateEncoder.INSTANCE, true);
             BytesStreamOutput output = new BytesStreamOutput();
             writer.writeTo(output);
             output.close();
@@ -155,7 +159,7 @@ public class EdgeTreeTests extends ESTestCase {
         int yMax = 1;//5;
 
         // test cell crossing poly
-        EdgeTreeWriter writer = new EdgeTreeWriter(px, py, TestCoordinateEncoder.INSTANCE);
+        EdgeTreeWriter writer = new EdgeTreeWriter(px, py, TestCoordinateEncoder.INSTANCE, true);
         BytesStreamOutput output = new BytesStreamOutput();
         writer.writeTo(output);
         output.close();
@@ -165,10 +169,10 @@ public class EdgeTreeTests extends ESTestCase {
 
     public void testGetShapeType() {
         double[] pointCoord = new double[] { 0 };
-        assertThat(new EdgeTreeWriter(pointCoord, pointCoord, TestCoordinateEncoder.INSTANCE).getShapeType(),
+        assertThat(new EdgeTreeWriter(pointCoord, pointCoord, TestCoordinateEncoder.INSTANCE, false).getShapeType(),
             equalTo(ShapeType.LINESTRING));
         assertThat(new EdgeTreeWriter(List.of(pointCoord, pointCoord), List.of(pointCoord, pointCoord),
-                TestCoordinateEncoder.INSTANCE).getShapeType(),
+                TestCoordinateEncoder.INSTANCE, false).getShapeType(),
             equalTo(ShapeType.MULTILINESTRING));
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/geo/GeometryTreeTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeometryTreeTests.java
@@ -52,9 +52,12 @@ public class GeometryTreeTests extends ESTestCase {
             BytesStreamOutput output = new BytesStreamOutput();
             writer.writeTo(output);
             output.close();
-            GeometryTreeReader reader = new GeometryTreeReader(output.bytes().toBytesRef());
+            GeometryTreeReader reader = new GeometryTreeReader(output.bytes().toBytesRef(), TestCoordinateEncoder.INSTANCE);
 
             assertThat(Extent.fromPoints(minX, minY, maxX, maxY), equalTo(reader.getExtent()));
+            // encoder loses precision when casting to integer, so centroid is calculated using integer division here
+            assertThat(reader.getCentroidX(), equalTo((double) ((minX + maxX)/2)));
+            assertThat(reader.getCentroidY(), equalTo((double) ((minY + maxY)/2)));
 
             // box-query touches bottom-left corner
             assertTrue(reader.intersects(Extent.fromPoints(minX - randomIntBetween(1, 10), minY - randomIntBetween(1, 10), minX, minY)));
@@ -105,7 +108,7 @@ public class GeometryTreeTests extends ESTestCase {
         BytesStreamOutput output = new BytesStreamOutput();
         writer.writeTo(output);
         output.close();
-        GeometryTreeReader reader = new GeometryTreeReader(output.bytes().toBytesRef());
+        GeometryTreeReader reader = new GeometryTreeReader(output.bytes().toBytesRef(), TestCoordinateEncoder.INSTANCE);
         assertTrue(reader.intersects(Extent.fromPoints(2, -1, 11, 1)));
         assertTrue(reader.intersects(Extent.fromPoints(-12, -12, 12, 12)));
         assertTrue(reader.intersects(Extent.fromPoints(-2, -1, 2, 0)));
@@ -121,7 +124,7 @@ public class GeometryTreeTests extends ESTestCase {
         BytesStreamOutput output = new BytesStreamOutput();
         writer.writeTo(output);
         output.close();
-        GeometryTreeReader reader = new GeometryTreeReader(output.bytes().toBytesRef());
+        GeometryTreeReader reader = new GeometryTreeReader(output.bytes().toBytesRef(), null);
 
         assertFalse(reader.intersects(Extent.fromPoints(6, -6, 6, -6))); // in the hole
         assertTrue(reader.intersects(Extent.fromPoints(25, -25, 25, -25))); // on the mainland
@@ -144,7 +147,7 @@ public class GeometryTreeTests extends ESTestCase {
         BytesStreamOutput output = new BytesStreamOutput();
         writer.writeTo(output);
         output.close();
-        GeometryTreeReader reader = new GeometryTreeReader(output.bytes().toBytesRef());
+        GeometryTreeReader reader = new GeometryTreeReader(output.bytes().toBytesRef(), TestCoordinateEncoder.INSTANCE);
         assertTrue(reader.intersects(Extent.fromPoints(5, 10, 5, 10)));
         assertFalse(reader.intersects(Extent.fromPoints(15, 10, 15, 10)));
         assertFalse(reader.intersects(Extent.fromPoints(25, 10, 25, 10)));
@@ -160,7 +163,7 @@ public class GeometryTreeTests extends ESTestCase {
         BytesStreamOutput output = new BytesStreamOutput();
         writer.writeTo(output);
         output.close();
-        GeometryTreeReader reader = new GeometryTreeReader(output.bytes().toBytesRef());
+        GeometryTreeReader reader = new GeometryTreeReader(output.bytes().toBytesRef(), TestCoordinateEncoder.INSTANCE);
         assertTrue(reader.intersects(Extent.fromPoints(2, -1, 11, 1)));
         assertTrue(reader.intersects(Extent.fromPoints(-12, -12, 12, 12)));
         assertTrue(reader.intersects(Extent.fromPoints(-2, -1, 2, 0)));
@@ -177,7 +180,7 @@ public class GeometryTreeTests extends ESTestCase {
         BytesStreamOutput output = new BytesStreamOutput();
         writer.writeTo(output);
         output.close();
-        GeometryTreeReader reader = new GeometryTreeReader(output.bytes().toBytesRef());
+        GeometryTreeReader reader = new GeometryTreeReader(output.bytes().toBytesRef(), TestCoordinateEncoder.INSTANCE);
         assertTrue(reader.intersects(Extent.fromPoints(2, -1, 11, 1)));
         assertTrue(reader.intersects(Extent.fromPoints(-12, -12, 12, 12)));
         assertTrue(reader.intersects(Extent.fromPoints(-2, -1, 2, 0)));
@@ -211,7 +214,7 @@ public class GeometryTreeTests extends ESTestCase {
         BytesStreamOutput output = new BytesStreamOutput();
         writer.writeTo(output);
         output.close();
-        GeometryTreeReader reader = new GeometryTreeReader(output.bytes().toBytesRef());
+        GeometryTreeReader reader = new GeometryTreeReader(output.bytes().toBytesRef(), TestCoordinateEncoder.INSTANCE);
         assertTrue(reader.intersects(Extent.fromPoints(xMin, yMin, xMax, yMax)));
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractGeoTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractGeoTestCase.java
@@ -68,7 +68,7 @@ public abstract class AbstractGeoTestCase extends ESIntegTestCase {
     protected static int numUniqueGeoPoints;
     protected static GeoPoint[] singleValues, multiValues;
     protected static GeoPoint singleTopLeft, singleBottomRight, multiTopLeft, multiBottomRight,
-        singleCentroid, multiCentroid, unmappedCentroid;
+        singleCentroid, singleShapeCentroid, multiCentroid, unmappedCentroid;
     protected static ObjectIntMap<String> expectedDocCountsForGeoHash = null;
     protected static ObjectObjectMap<String, GeoPoint> expectedCentroidsForGeoHash = null;
     protected static final double GEOHASH_TOLERANCE = 1E-5D;
@@ -85,6 +85,7 @@ public abstract class AbstractGeoTestCase extends ESIntegTestCase {
         multiTopLeft = new GeoPoint(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
         multiBottomRight = new GeoPoint(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY);
         singleCentroid = new GeoPoint(0, 0);
+        singleShapeCentroid = new GeoPoint(9.4, 34.4);
         multiCentroid = new GeoPoint(0, 0);
         unmappedCentroid = new GeoPoint(0, 0);
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidIT.java
@@ -106,6 +106,22 @@ public class GeoCentroidIT extends AbstractGeoTestCase {
         assertEquals(numDocs, geoCentroid.count());
     }
 
+    public void testShapeField() throws Exception {
+        SearchResponse response = client().prepareSearch(DATELINE_IDX_NAME)
+            .setQuery(matchAllQuery())
+            .addAggregation(geoCentroid(aggName).field(SINGLE_VALUED_GEOSHAPE_FIELD_NAME))
+            .get();
+        assertSearchResponse(response);
+
+        GeoCentroid geoCentroid = response.getAggregations().get(aggName);
+        assertThat(geoCentroid, notNullValue());
+        assertThat(geoCentroid.getName(), equalTo(aggName));
+        GeoPoint centroid = geoCentroid.centroid();
+        assertThat(centroid.lat(), closeTo(singleShapeCentroid.lat(), GEOHASH_TOLERANCE));
+        assertThat(centroid.lon(), closeTo(singleShapeCentroid.lon(), GEOHASH_TOLERANCE));
+        assertEquals(5, geoCentroid.count());
+    }
+
     public void testSingleValueFieldGetProperty() throws Exception {
         SearchResponse response = client().prepareSearch(IDX_NAME)
                 .setQuery(matchAllQuery())
@@ -123,7 +139,7 @@ public class GeoCentroidIT extends AbstractGeoTestCase {
         GeoCentroid geoCentroid = global.getAggregations().get(aggName);
         assertThat(geoCentroid, notNullValue());
         assertThat(geoCentroid.getName(), equalTo(aggName));
-        assertThat((GeoCentroid) ((InternalAggregation)global).getProperty(aggName), sameInstance(geoCentroid));
+        assertThat(((InternalAggregation)global).getProperty(aggName), sameInstance(geoCentroid));
         GeoPoint centroid = geoCentroid.centroid();
         assertThat(centroid.lat(), closeTo(singleCentroid.lat(), GEOHASH_TOLERANCE));
         assertThat(centroid.lon(), closeTo(singleCentroid.lon(), GEOHASH_TOLERANCE));


### PR DESCRIPTION
This commit annotates geometries with centroid information
at index-time. Then each shapes centroid is used as input to
the geo_centroid aggregator so that it effectively calculates
the centroid of centroids of shapes within each bucket.

The centroid of each geo_shape field is calculated as the
centroid of all the points of all the shapes in the geometry
collection.

The centroid of each shape is calculated the same way geo_centroid
was -- using a kahan-summation to reduce precision loss.

relates to #37206 