### PR TITLE
Relax ReindexIT test timeouts

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ReindexIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ReindexIT.java
@@ -292,7 +292,7 @@ public class ReindexIT extends ESRestHighLevelClientTestCase {
             assertThat(response.getTasks().get(0).getStatus(), instanceOf(RawTaskStatus.class));
             assertEquals(Float.toString(requestsPerSecond),
                 ((RawTaskStatus) response.getTasks().get(0).getStatus()).toMap().get("requests_per_second").toString());
-            taskFinished.await(2, TimeUnit.SECONDS);
+            assertTrue(taskFinished.await(10, TimeUnit.SECONDS));
 
             // any rethrottling after the update-by-query is done performed with the same taskId should result in a failure
             response = execute(new RethrottleRequest(taskIdToRethrottle, requestsPerSecond),
@@ -423,7 +423,7 @@ public class ReindexIT extends ESRestHighLevelClientTestCase {
             assertThat(response.getTasks().get(0).getStatus(), instanceOf(RawTaskStatus.class));
             assertEquals(Float.toString(requestsPerSecond),
                 ((RawTaskStatus) response.getTasks().get(0).getStatus()).toMap().get("requests_per_second").toString());
-            taskFinished.await(2, TimeUnit.SECONDS);
+            assertTrue(taskFinished.await(10, TimeUnit.SECONDS));
 
             // any rethrottling after the delete-by-query is done performed with the same taskId should result in a failure
             response = execute(new RethrottleRequest(taskIdToRethrottle, requestsPerSecond),


### PR DESCRIPTION
A couple of tests used 2 second timeout, which was prone to failure,
increased to 10 seconds.

Closes #46301
