### PR TITLE
Clarify error message on keystore write permissions

### DIFF
--- a/qa/evil-tests/src/test/java/org/elasticsearch/common/settings/EvilKeyStoreWrapperTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/common/settings/EvilKeyStoreWrapperTests.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.settings;
+
+import org.apache.lucene.util.Constants;
+import org.elasticsearch.cli.ExitCodes;
+import org.elasticsearch.cli.UserException;
+import org.elasticsearch.test.ESTestCase;
+
+import java.nio.file.AccessDeniedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Locale;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class EvilKeyStoreWrapperTests extends ESTestCase {
+
+    public void testWritePermissions() throws Exception {
+        assumeFalse("requires POSIX file permissions", Constants.WINDOWS);
+        final Path configDir = createTempDir();
+        PosixFileAttributeView attrs = Files.getFileAttributeView(configDir, PosixFileAttributeView.class);
+        if (attrs != null) {
+            // don't rely on umask: ensure the keystore has minimal permissions
+            attrs.setPermissions(PosixFilePermissions.fromString("r--r-----"));
+        }
+        try {
+            final KeyStoreWrapper wrapper = KeyStoreWrapper.create();
+            final UserException e = expectThrows(UserException.class, () -> wrapper.save(configDir, new char[0]));
+            final String expected = String.format(
+                Locale.ROOT,
+                "unable to create temporary keystore at [%s], write permissions required for [%s] or run [elasticsearch-keystore upgrade]",
+                configDir.resolve("elasticsearch.keystore.tmp"),
+                configDir);
+            assertThat(e, hasToString(containsString(expected)));
+            assertThat(e.exitCode, equalTo(ExitCodes.CONFIG));
+            assertThat(e.getCause(), instanceOf(AccessDeniedException.class));
+        } finally {
+            // so the test framework can cleanup
+            attrs.setPermissions(PosixFilePermissions.fromString("rw-rw----"));
+        }
+    }
+
+}

--- a/qa/evil-tests/src/test/java/org/elasticsearch/common/settings/EvilKeyStoreWrapperTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/common/settings/EvilKeyStoreWrapperTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.common.settings;
 
 import org.apache.lucene.util.Constants;
+import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.cli.ExitCodes;
 import org.elasticsearch.cli.UserException;
 import org.elasticsearch.test.ESTestCase;
@@ -36,6 +37,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.instanceOf;
 
+@LuceneTestCase.SuppressFileSystems("ExtrasFS")
 public class EvilKeyStoreWrapperTests extends ESTestCase {
 
     public void testWritePermissions() throws Exception {

--- a/server/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
@@ -502,10 +502,10 @@ public class KeyStoreWrapper implements SecureSettings {
 
         } catch (final AccessDeniedException e) {
             final String message = String.format(
-                    Locale.ROOT,
-                    "unable to create temporary keystore at [%s], write permissions required for [%s] or run [elasticsearch-keystore upgrade]",
-                    configDir.resolve(tmpFile),
-                    configDir);
+                Locale.ROOT,
+                "unable to create temporary keystore at [%s], write permissions required for [%s] or run [elasticsearch-keystore upgrade]",
+                configDir.resolve(tmpFile),
+                configDir);
             throw new UserException(ExitCodes.CONFIG, message, e);
         }
 

--- a/server/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
@@ -503,8 +503,9 @@ public class KeyStoreWrapper implements SecureSettings {
         } catch (final AccessDeniedException e) {
             final String message = String.format(
                     Locale.ROOT,
-                    "unable to create temporary keystore at [%s], please check filesystem permissions",
-                    configDir.resolve(tmpFile));
+                    "unable to create temporary keystore at [%s], write permissions required for [%s] or run [elasticsearch-keystore upgrade]",
+                    configDir.resolve(tmpFile),
+                    configDir);
             throw new UserException(ExitCodes.CONFIG, message, e);
         }
 


### PR DESCRIPTION
When the Elasticsearch process does not have write permissions to upgrade the Elasticsearch keystore, we bail with an error message that indicates there is a filesystem permissions problem. This commit  clarifies that error message by pointing out the directory where write permissions are required, or that the user can also run the elasticsearch-keystore upgrade command manually before starting the Elasticsearch process. In this case, the upgrade would not be needed at runtime, so the permissions would not be needed then.

