### PR TITLE
[DOCS] Adds outlier detection params to the data frame analytics resources

### DIFF
--- a/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
@@ -133,7 +133,7 @@ An {oldetection} configuration object has the following properties:
   
 `outlier_fraction`::
   (double) Sets the proportion of the data set that is assumed to be outlying prior to 
-  {oldetection}. For example, 0.05 means, it is assumed that 5% of values are real outliers 
+  {oldetection}. For example, 0.05 means it is assumed that 5% of values are real outliers 
   and 95% are inliers.
   
 `standardize_columns`::

--- a/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
@@ -132,7 +132,7 @@ An {oldetection} configuration object has the following properties:
   confident that the value you choose is appropriate for the data set.
   
 `outlier_fraction`::
-  (double) Sets the proportion of data set that is assumed to be outlying prior to 
+  (double) Sets the proportion of the data set that is assumed to be outlying prior to 
   {oldetection}. For example, 0.05 means, it is assumed that 5% of values are real outliers 
   and 95% are inliers.
   

--- a/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
@@ -130,7 +130,7 @@ An {oldetection} configuration object has the following properties:
   not set, the system will dynamically detect an appropriate value.
   
 `outlier_fraction`::
-  (double) Sets the proportion of data that is assumed to be outlier prior to the 
+  (double) Sets the proportion of data set that is assumed to be outlying prior to 
   {oldetection}. For example, 0.05 means, it is assumed that 5% of values are real outliers 
   and 95% are inliers.
   

--- a/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
@@ -131,7 +131,7 @@ An {oldetection} configuration object has the following properties:
   
 `outlier_fraction`::
   (double) Sets the proportion of data that is assumed to be outlier prior to the 
-  {oldetection}. For example, 0.05 mean you think 5% of values are real outliers 
+  {oldetection}. For example, 0.05 means, it is assumed that 5% of values are real outliers 
   and 95% are inliers.
   
 `standardize_columns`::

--- a/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
@@ -130,7 +130,7 @@ An {oldetection} configuration object has the following properties:
   not set, the system will dynamically detect an appropriate value.
   
 `outlier_fraction`::
-  (double) Sets the proportion of data you assume that is outlier prior to the 
+  (double) Sets the proportion of data that is assumed to be outlier prior to the 
   {oldetection}. For example, 0.05 mean you think 5% of values are real outliers 
   and 95% are inliers.
   

--- a/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
@@ -109,10 +109,13 @@ other types will be added, for example `regression`.
 
 An {oldetection} configuration object has the following properties:
 
-`n_neighbors`::
-  (integer) Defines the value for how many nearest neighbors each method of 
-  {oldetection} will use to calculate its {olscore}. When the value is 
-  not set, the system will dynamically detect an appropriate value.
+`compute_feature_influence`::
+  (boolean) If `true`, the feature influence calculation is enabled. Defaults to 
+  `true`.
+  
+`feature_influence_threshold`:: 
+  (double) The minimum {olscore} that a document needs to have in order to 
+  calculate its {fiscore}. Value range: 0-1 (`0.1` by default).
 
 `method`::
   (string) Sets the method that {oldetection} uses. If the method is not set 
@@ -120,8 +123,18 @@ An {oldetection} configuration object has the following properties:
   combines their individual {olscores} to obtain the overall {olscore}. We 
   recommend to use the ensemble method. Available methods are `lof`, `ldof`, 
   `distance_kth_nn`, `distance_knn`.
-
-`feature_influence_threshold`:: 
-  (double) The minimum {olscore} that a document needs to have in order to 
-  calculate its {fiscore}. 
-  Value range: 0-1 (`0.1` by default).
+  
+`n_neighbors`::
+  (integer) Defines the value for how many nearest neighbors each method of 
+  {oldetection} will use to calculate its {olscore}. When the value is 
+  not set, the system will dynamically detect an appropriate value.
+  
+`outlier_fraction`::
+  (double) Sets the proportion of data you assume that is outlier prior to the 
+  {oldetection}. For example, 0.05 mean you think 5% of values are real outliers 
+  and 95% are inliers.
+  
+`standardize_columns`::
+  (boolean) If `true`, then the following operation is performed on the columns 
+  before computing outlier scores: (x_i - mean(x_i)) / sd(x_i). Defaults to 
+  `true`.

--- a/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
@@ -126,8 +126,10 @@ An {oldetection} configuration object has the following properties:
   
 `n_neighbors`::
   (integer) Defines the value for how many nearest neighbors each method of 
-  {oldetection} will use to calculate its {olscore}. When the value is 
-  not set, the system will dynamically detect an appropriate value.
+  {oldetection} will use to calculate its {olscore}. When the value is not set, 
+  different values will be used for different ensemble members. This helps 
+  improve diversity in the ensemble. Therefore, only override this if you are 
+  confident that the value you choose is appropriate for the data set.
   
 `outlier_fraction`::
   (double) Sets the proportion of data set that is assumed to be outlying prior to 

--- a/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
@@ -139,4 +139,5 @@ An {oldetection} configuration object has the following properties:
 `standardize_columns`::
   (boolean) If `true`, then the following operation is performed on the columns 
   before computing outlier scores: (x_i - mean(x_i)) / sd(x_i). Defaults to 
-  `true`.
+  `true`. For more information, see 
+  https://en.wikipedia.org/wiki/Feature_scaling#Standardization_(Z-score_Normalization)[this wiki page about standardization].


### PR DESCRIPTION
This PR adds `compute_feature_influence`, `outlier_fraction`, and `standardize_columns` to the outlier detection parameters.