### PR TITLE
[DOCS] Synchs Watcher API titles with better HLRC titles

### DIFF
--- a/docs/java-rest/high-level/watcher/ack-watch.asciidoc
+++ b/docs/java-rest/high-level/watcher/ack-watch.asciidoc
@@ -5,12 +5,12 @@
 --
 
 [id="{upid}-{api}"]
-=== Ack Watch API
+=== Ack watch API
 
 [id="{upid}-{api}-request"]
 ==== Execution
 
-{xpack-ref}/actions.html#actions-ack-throttle[Acknowledging a watch] enables you
+{stack-ov}/actions.html#actions-ack-throttle[Acknowledging a watch] enables you
 to manually throttle execution of a watch's actions. A watch can be acknowledged
 through the following request:
 

--- a/docs/java-rest/high-level/watcher/activate-watch.asciidoc
+++ b/docs/java-rest/high-level/watcher/activate-watch.asciidoc
@@ -5,7 +5,7 @@
 --
 
 [id="{upid}-{api}"]
-=== Activate Watch API
+=== Activate watch API
 
 [id="{upid}-{api}-request"]
 ==== Execution
@@ -29,7 +29,7 @@ include-tagged::{doc-tests-file}[{api}-response]
 <1> `watchStatus` contains status of the watch
 
 [id="{upid}-{api}-request-async"]
-==== Asynchronous Execution
+==== Asynchronous execution
 
 This request can be executed asynchronously:
 

--- a/docs/java-rest/high-level/watcher/deactivate-watch.asciidoc
+++ b/docs/java-rest/high-level/watcher/deactivate-watch.asciidoc
@@ -5,6 +5,6 @@
 :doc-tests-file: {doc-tests}/WatcherDocumentationIT.java
 --
 [[java-rest-high-watcher-deactivate-watch]]
-=== Deactivate Watch API
+=== Deactivate watch API
 
 include::../execution.asciidoc[]

--- a/docs/java-rest/high-level/watcher/delete-watch.asciidoc
+++ b/docs/java-rest/high-level/watcher/delete-watch.asciidoc
@@ -1,5 +1,5 @@
 [[java-rest-high-x-pack-watcher-delete-watch]]
-=== Delete Watch API
+=== Delete watch API
 
 [[java-rest-high-x-pack-watcher-delete-watch-execution]]
 ==== Execution
@@ -26,7 +26,7 @@ include-tagged::{doc-tests}/WatcherDocumentationIT.java[x-pack-put-watch-respons
 <3> `_version` returns the version of the deleted watch
 
 [[java-rest-high-x-pack-watcher-delete-watch-async]]
-==== Asynchronous Execution
+==== Asynchronous execution
 
 This request can be executed asynchronously:
 

--- a/docs/java-rest/high-level/watcher/execute-watch.asciidoc
+++ b/docs/java-rest/high-level/watcher/execute-watch.asciidoc
@@ -4,7 +4,7 @@
 :response: ExecuteWatchResponse
 --
 [id="{upid}-{api}"]
-=== Execute Watch API
+=== Execute watch API
 
 The execute watch API allows clients to immediately execute a watch, either
 one that has been previously added via the
@@ -27,7 +27,7 @@ include-tagged::{doc-tests-file}[x-pack-execute-watch-by-id]
 <6> Enable debug mode
 
 [id="{upid}-{api}-response-by-id"]
-==== Execute by id Response
+==== Execute by id response
 
 The returned `Response` contains details of the execution:
 

--- a/docs/java-rest/high-level/watcher/get-watch.asciidoc
+++ b/docs/java-rest/high-level/watcher/get-watch.asciidoc
@@ -5,7 +5,7 @@
 --
 
 [id="{upid}-{api}"]
-=== Get Watch API
+=== Get watch API
 
 [id="{upid}-{api}-request"]
 ==== Execution

--- a/docs/java-rest/high-level/watcher/put-watch.asciidoc
+++ b/docs/java-rest/high-level/watcher/put-watch.asciidoc
@@ -1,5 +1,5 @@
 [[java-rest-high-x-pack-watcher-put-watch]]
-=== Put Watch API
+=== Put watch API
 
 [[java-rest-high-x-pack-watcher-put-watch-execution]]
 ==== Execution
@@ -28,7 +28,7 @@ include-tagged::{doc-tests}/WatcherDocumentationIT.java[x-pack-put-watch-respons
 <3> `_version` returns the newly created version
 
 [[java-rest-high-x-pack-watcher-put-watch-async]]
-==== Asynchronous Execution
+==== Asynchronous execution
 
 This request can be executed asynchronously:
 

--- a/docs/java-rest/high-level/watcher/start-watch-service.asciidoc
+++ b/docs/java-rest/high-level/watcher/start-watch-service.asciidoc
@@ -4,7 +4,7 @@
 :response: StartWatchServiceResponse
 --
 [id="{upid}-{api}"]
-=== Start Watch Service API
+=== Start watch service API
 
 [id="{upid}-{api}-request"]
 ==== Execution

--- a/docs/java-rest/high-level/watcher/stop-watch-service.asciidoc
+++ b/docs/java-rest/high-level/watcher/stop-watch-service.asciidoc
@@ -4,7 +4,7 @@
 :response: StopWatchServiceResponse
 --
 [id="{upid}-{api}"]
-=== Stop Watch Service API
+=== Stop watch service API
 
 [[java-rest-high-watcher-stop-watch-service-execution]]
 ==== Execution

--- a/docs/java-rest/high-level/watcher/watcher-stats.asciidoc
+++ b/docs/java-rest/high-level/watcher/watcher-stats.asciidoc
@@ -4,7 +4,7 @@
 :response: WatcherStatsResponse
 --
 [id="{upid}-{api}"]
-=== Watcher Stats API
+=== Get Watcher stats API
 
 [id="{upid}-{api}-request"]
 ==== Execution

--- a/x-pack/docs/en/rest-api/watcher.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher.asciidoc
@@ -13,13 +13,22 @@
 * <<watcher-api-stop>>
 * <<watcher-api-start>>
 
-include::watcher/put-watch.asciidoc[]
-include::watcher/get-watch.asciidoc[]
-include::watcher/delete-watch.asciidoc[]
-include::watcher/execute-watch.asciidoc[]
+//ACK
 include::watcher/ack-watch.asciidoc[]
+//ACTIVATE
 include::watcher/activate-watch.asciidoc[]
+//DEACTIVATE
 include::watcher/deactivate-watch.asciidoc[]
+//DELETE
+include::watcher/delete-watch.asciidoc[]
+//EXECUTE
+include::watcher/execute-watch.asciidoc[]
+//GET
+include::watcher/get-watch.asciidoc[]
 include::watcher/stats.asciidoc[]
-include::watcher/stop.asciidoc[]
+//PUT
+include::watcher/put-watch.asciidoc[]
+//START
 include::watcher/start.asciidoc[]
+//STOP
+include::watcher/stop.asciidoc[]

--- a/x-pack/docs/en/rest-api/watcher/start.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/start.asciidoc
@@ -1,8 +1,9 @@
 [role="xpack"]
 [[watcher-api-start]]
-=== Start API
+=== Start {watcher} API
+[subs="attributes"]
 ++++
-<titleabbrev>Start</titleabbrev>
+<titleabbrev>Start {watcher}</titleabbrev>
 ++++
 
 The `start` API starts the {watcher} service if the service is not already

--- a/x-pack/docs/en/rest-api/watcher/start.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/start.asciidoc
@@ -1,13 +1,11 @@
 [role="xpack"]
 [[watcher-api-start]]
-=== Start {watcher} API
-[subs="attributes"]
+=== Start watch service API
 ++++
-<titleabbrev>Start {watcher}</titleabbrev>
+<titleabbrev>Start watch service</titleabbrev>
 ++++
 
-The `start` API starts the {watcher} service if the service is not already
-running.
+Starts the {watcher} service if it is not already running.
 
 [float]
 ==== Request

--- a/x-pack/docs/en/rest-api/watcher/stats.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/stats.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Get {watcher} stats</titleabbrev>
 ++++
 
-The `stats` API returns the current {watcher} metrics.
+Retrieves the current {watcher} metrics.
 
 [float]
 ==== Request

--- a/x-pack/docs/en/rest-api/watcher/stats.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/stats.asciidoc
@@ -1,8 +1,9 @@
 [role="xpack"]
 [[watcher-api-stats]]
-=== Stats API
+=== Get {watcher} stats API
+[subs="attributes"]
 ++++
-<titleabbrev>Stats</titleabbrev>
+<titleabbrev>Get {watcher} stats</titleabbrev>
 ++++
 
 The `stats` API returns the current {watcher} metrics.

--- a/x-pack/docs/en/rest-api/watcher/stop.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/stop.asciidoc
@@ -1,12 +1,11 @@
 [role="xpack"]
 [[watcher-api-stop]]
-=== Stop {watcher} API
-[subs="attributes"]
+=== Stop watch service API
 ++++
-<titleabbrev>Stop {watcher}</titleabbrev>
+<titleabbrev>Stop watch service</titleabbrev>
 ++++
 
-The `stop` API stops the {watcher} service if the service is running.
+Stops the {watcher} service if it is running.
 
 [float]
 ==== Request

--- a/x-pack/docs/en/rest-api/watcher/stop.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/stop.asciidoc
@@ -1,8 +1,9 @@
 [role="xpack"]
 [[watcher-api-stop]]
-=== Stop API
+=== Stop {watcher} API
+[subs="attributes"]
 ++++
-<titleabbrev>Stop</titleabbrev>
+<titleabbrev>Stop {watcher}</titleabbrev>
 ++++
 
 The `stop` API stops the {watcher} service if the service is running.


### PR DESCRIPTION
Three Watcher APIs in the Elasticsearch Reference have slightly vague titles: start, stop, and stats.

![image](https://user-images.githubusercontent.com/26471269/64271399-19193280-cef2-11e9-9d33-d3fff179605f.png)

Their titles are better in the high level rest client documentation (for example, https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/java-rest-high-watcher-start-watch-service.html):

![image](https://user-images.githubusercontent.com/26471269/64271544-567dc000-cef2-11e9-88df-d93a76523a37.png)

It also sorts the order of the APIs to reflect the changed titles.



