### PR TITLE
[7.x] [ML] testFullClusterRestart waiting for stable cluster (#46280)

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
@@ -113,6 +113,7 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
             logger.info("Restarting all nodes");
             internalCluster().fullRestart();
             logger.info("Restarted all nodes");
+            ensureStableClusterOnAllNodes(3);
         });
     }
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] testFullClusterRestart waiting for stable cluster  (#46280)