### PR TITLE
[DOCS] Add index alias definition to glossary

### DIFF
--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -96,6 +96,20 @@ An index is a logical namespace which maps to one or more
 <<glossary-primary-shard,primary shards>> and can have zero or more
 <<glossary-replica-shard,replica shards>>.
 
+[[glossary-index-alias]] index alias ::
++
+--
+// tag::index-alias-def[]
+An index alias is a secondary name
+used to refer to one or more existing indices.
+
+Most {es} APIs accept an index alias
+in place of an index name.
+// end::index-alias-def[]
+
+See <<indices-add-alias>>.
+--
+
 [[glossary-leader-index]] leader index ::  
   
 Leader indices are the source indices for <<glossary-ccr,{ccr}>>. They exist

--- a/docs/reference/indices/add-alias.asciidoc
+++ b/docs/reference/indices/add-alias.asciidoc
@@ -6,7 +6,7 @@
 
 Creates or updates an index alias.
 
-include::alias-exists.asciidoc[tag=index-alias-def]
+include::{docdir}/glossary.asciidoc[tag=index-alias-def]
 
 [source,js]
 ----

--- a/docs/reference/indices/alias-exists.asciidoc
+++ b/docs/reference/indices/alias-exists.asciidoc
@@ -6,14 +6,7 @@
 
 Checks if an index alias exists.
 
-//tag::index-alias-def[]
-An index alias is a secondary name
-used to refer to one or more existing indices.
-//end::index-alias-def[]
-
-The returned HTTP status code indicates whether the index alias exists or not.
-A `404` means it does not exist,
-and `200` means it does.
+include::{docdir}/glossary.asciidoc[tag=index-alias-def]
 
 [source,js]
 ----

--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -6,7 +6,7 @@
 
 Adds or removes index aliases.
 
-include::alias-exists.asciidoc[tag=index-alias-def]
+include::{docdir}/glossary.asciidoc[tag=index-alias-def]
 
 [source,js]
 ----

--- a/docs/reference/indices/delete-alias.asciidoc
+++ b/docs/reference/indices/delete-alias.asciidoc
@@ -6,7 +6,7 @@
 
 Deletes an existing index alias.
 
-include::alias-exists.asciidoc[tag=index-alias-def]
+include::{docdir}/glossary.asciidoc[tag=index-alias-def]
 
 [source,js]
 ----

--- a/docs/reference/indices/get-alias.asciidoc
+++ b/docs/reference/indices/get-alias.asciidoc
@@ -6,7 +6,7 @@
 
 Returns information about one or more index aliases.
 
-include::alias-exists.asciidoc[tag=index-alias-def]
+include::{docdir}/glossary.asciidoc[tag=index-alias-def]
 
 [source,js]
 ----


### PR DESCRIPTION
- Moves the `index alias` definition from the index alias exists API docs to the glossary.
- Updates any references to the index alias def tagged region
- Removes a HTTP status code paragraph from the  index alias exists API docs. HTTP status codes are covered later in the page so this paragraph is redundant.

Relates to #46098.

