### PR TITLE
[DOCS] Identify reloadable S3 repository plugin settings

### DIFF
--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -101,16 +101,16 @@ The following list contains the available client settings. Those that must be
 stored in the keystore are marked as "secure" and are *reloadable*; the other
 settings belong in the `elasticsearch.yml` file.
 
-`access_key` ({ref}/secure-settings.html[Secure])::
+`access_key` ({ref}/secure-settings.html[Secure], {ref}/secure-settings.html#reloadable-secure-settings[reloadable])::
 
     An S3 access key. If set, the `secret_key` setting must also be specified.
     If unset, the client will use the instance or container role instead.
 
-`secret_key` ({ref}/secure-settings.html[Secure])::
+`secret_key` ({ref}/secure-settings.html[Secure], {ref}/secure-settings.html#reloadable-secure-settings[reloadable])::
 
     An S3 secret key. If set, the `access_key` setting must also be specified.
 
-`session_token` ({ref}/secure-settings.html[Secure])::
+`session_token` ({ref}/secure-settings.html[Secure], {ref}/secure-settings.html#reloadable-secure-settings[reloadable])::
 
     An S3 session token. If set, the `access_key` and `secret_key` settings
     must also be specified.
@@ -137,11 +137,11 @@ settings belong in the `elasticsearch.yml` file.
 
     The port of a proxy to connect to S3 through.
 
-`proxy.username` ({ref}/secure-settings.html[Secure])::
+`proxy.username` ({ref}/secure-settings.html[Secure], {ref}/secure-settings.html#reloadable-secure-settings[reloadable])::
 
     The username to connect to the `proxy.host` with.
 
-`proxy.password` ({ref}/secure-settings.html[Secure])::
+`proxy.password` ({ref}/secure-settings.html[Secure], {ref}/secure-settings.html#reloadable-secure-settings[reloadable])::
 
     The password to connect to the `proxy.host` with.
 

--- a/docs/reference/setup/secure-settings.asciidoc
+++ b/docs/reference/setup/secure-settings.asciidoc
@@ -123,5 +123,5 @@ of reloading after each modification.
 
 There are reloadable secure settings for:
 
-* {plugins}/discovery-ec2-usage.html#_configuring_ec2_discovery[The EC2 Discovery Plugin]
-
+* {plugins}/discovery-ec2-usage.html#_configuring_ec2_discovery[The EC2 discovery plugin]
+* {plugins}/repository-s3-client.html[The S3 repository plugin]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/36112 and https://discuss.elastic.co/t/reloadable-secure-settings-elasticsearch/196127

This PR updates the list of settings for the S3 Repository Plugin (https://www.elastic.co/guide/en/elasticsearch/plugins/master/repository-s3-client.html) such that the secure and reloadable settings are more clearly identified.

In particular, it follows the formatting for dynamic and secure settings in pages like https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-settings.html and https://www.elastic.co/guide/en/elasticsearch/reference/master/security-settings.html
