### PR TITLE
[DOCS] Identify reloadable GCS repository plugin settings

### DIFF
--- a/docs/plugins/repository-gcs.asciidoc
+++ b/docs/plugins/repository-gcs.asciidoc
@@ -158,9 +158,9 @@ bin/elasticsearch-keystore add-file gcs.client.default.credentials_file /path/se
 The following are the available client settings. Those that must be stored in the keystore
 are marked as `Secure`.
 
-`credentials_file`::
+`credentials_file` ({ref}/secure-settings.html[Secure], {ref}/secure-settings.html#reloadable-secure-settings[reloadable])::
 
-    The service account file that is used to authenticate to the Google Cloud Storage service. (Secure)
+    The service account file that is used to authenticate to the Google Cloud Storage service.
 
 `endpoint`::
 

--- a/docs/reference/setup/secure-settings.asciidoc
+++ b/docs/reference/setup/secure-settings.asciidoc
@@ -124,4 +124,4 @@ of reloading after each modification.
 There are reloadable secure settings for:
 
 * {plugins}/discovery-ec2-usage.html#_configuring_ec2_discovery[The EC2 Discovery Plugin]
-
+* {plugins}/repository-gcs-client.html[The GCS repository plugin]


### PR DESCRIPTION
Related to #36112 and https://discuss.elastic.co/t/reloadable-secure-settings-elasticsearch/196127

This PR updates the list of settings for the GCS Repository Plugin (https://www.elastic.co/guide/en/elasticsearch/plugins/master/repository-gcs-client.html) such that the secure and reloadable settings are more clearly identified.

In particular, it follows the formatting for dynamic and secure settings in pages like https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-settings.html and https://www.elastic.co/guide/en/elasticsearch/reference/master/security-settings.html