### PR TITLE
Validate index and cluster privilege names when creating a role

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequest.java
@@ -15,8 +15,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 import org.elasticsearch.xpack.core.security.authz.privilege.ApplicationPrivilege;
+import org.elasticsearch.xpack.core.security.authz.privilege.ClusterPrivilegeResolver;
 import org.elasticsearch.xpack.core.security.authz.privilege.ConfigurableClusterPrivilege;
 import org.elasticsearch.xpack.core.security.authz.privilege.ConfigurableClusterPrivileges;
+import org.elasticsearch.xpack.core.security.authz.privilege.IndexPrivilege;
 import org.elasticsearch.xpack.core.security.support.MetadataUtils;
 
 import java.io.IOException;
@@ -25,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
@@ -66,6 +69,24 @@ public class PutRoleRequest extends ActionRequest implements WriteRequest<PutRol
         ActionRequestValidationException validationException = null;
         if (name == null) {
             validationException = addValidationError("role name is missing", validationException);
+        }
+        if (clusterPrivileges != null) {
+            for (String cp : clusterPrivileges) {
+                try {
+                    ClusterPrivilegeResolver.resolve(cp);
+                } catch (IllegalArgumentException ile) {
+                    validationException = addValidationError(ile.getMessage(), validationException);
+                }
+            }
+        }
+        if (indicesPrivileges != null) {
+            for (RoleDescriptor.IndicesPrivileges idp : indicesPrivileges) {
+                try {
+                    IndexPrivilege.get(Set.of(idp.getPrivileges()));
+                } catch(IllegalArgumentException ile) {
+                    validationException = addValidationError(ile.getMessage(), validationException);
+                }
+            }
         }
         if(applicationPrivileges != null) {
             for (RoleDescriptor.ApplicationResourcePrivileges privilege : applicationPrivileges) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequest.java
@@ -83,7 +83,7 @@ public class PutRoleRequest extends ActionRequest implements WriteRequest<PutRol
             for (RoleDescriptor.IndicesPrivileges idp : indicesPrivileges) {
                 try {
                     IndexPrivilege.get(Set.of(idp.getPrivileges()));
-                } catch(IllegalArgumentException ile) {
+                } catch (IllegalArgumentException ile) {
                     validationException = addValidationError(ile.getMessage(), validationException);
                 }
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
@@ -164,7 +164,7 @@ public class ClusterPrivilegeResolver {
             "one of the predefined cluster privilege names [" +
             Strings.collectionToCommaDelimitedString(VALUES.keySet()) + "] or a pattern over one of the available " +
             "cluster actions";
-        logger.error(errorMessage);
+        logger.debug(errorMessage);
         throw new IllegalArgumentException(errorMessage);
 
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
@@ -160,11 +160,12 @@ public class ClusterPrivilegeResolver {
         if (fixedPrivilege != null) {
             return fixedPrivilege;
         }
-        logger.error("failed to resolve cluster privilege [" + name + "].");
-        throw new IllegalArgumentException("unknown cluster privilege [" + name + "]. a privilege must be either " +
+        String errorMessage = "unknown cluster privilege [" + name + "]. a privilege must be either " +
             "one of the predefined cluster privilege names [" +
             Strings.collectionToCommaDelimitedString(VALUES.keySet()) + "] or a pattern over one of the available " +
-            "cluster actions");
+            "cluster actions";
+        logger.error(errorMessage);
+        throw new IllegalArgumentException(errorMessage);
 
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.xpack.core.security.authz.privilege;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.admin.cluster.repositories.get.GetRepositoriesAction;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotAction;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsAction;
@@ -37,6 +39,8 @@ import java.util.stream.Stream;
  * Translates cluster privilege names into concrete implementations
  */
 public class ClusterPrivilegeResolver {
+    private static final Logger logger = LogManager.getLogger(ClusterPrivilegeResolver.class);
+
     // shared automatons
     private static final Set<String> ALL_SECURITY_PATTERN = Set.of("cluster:admin/xpack/security/*");
     private static final Set<String> MANAGE_SAML_PATTERN = Set.of("cluster:admin/xpack/security/saml/*",
@@ -156,6 +160,7 @@ public class ClusterPrivilegeResolver {
         if (fixedPrivilege != null) {
             return fixedPrivilege;
         }
+        logger.error("failed to resolve cluster privilege [" + name + "].");
         throw new IllegalArgumentException("unknown cluster privilege [" + name + "]. a privilege must be either " +
             "one of the predefined cluster privilege names [" +
             Strings.collectionToCommaDelimitedString(VALUES.keySet()) + "] or a pattern over one of the available " +

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
@@ -5,6 +5,8 @@
  */
 package org.elasticsearch.xpack.core.security.authz.privilege;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.automaton.Automaton;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsAction;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesAction;
@@ -38,6 +40,7 @@ import static org.elasticsearch.xpack.core.security.support.Automatons.patterns;
 import static org.elasticsearch.xpack.core.security.support.Automatons.unionAndMinimize;
 
 public final class IndexPrivilege extends Privilege {
+    private static final Logger logger = LogManager.getLogger(IndexPrivilege.class);
 
     private static final Automaton ALL_AUTOMATON = patterns("indices:*", "internal:transport/proxy/indices:*");
     private static final Automaton READ_AUTOMATON = patterns("indices:data/read/*");
@@ -139,6 +142,7 @@ public final class IndexPrivilege extends Privilege {
                 } else if (indexPrivilege != null) {
                     automata.add(indexPrivilege.automaton);
                 } else {
+                    logger.error("failed to resolve index privilege [" + part + "].");
                     throw new IllegalArgumentException("unknown index privilege [" + part + "]. a privilege must be either " +
                             "one of the predefined fixed indices privileges [" +
                             Strings.collectionToCommaDelimitedString(VALUES.entrySet()) + "] or a pattern over one of the available index" +

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
@@ -142,11 +142,12 @@ public final class IndexPrivilege extends Privilege {
                 } else if (indexPrivilege != null) {
                     automata.add(indexPrivilege.automaton);
                 } else {
-                    logger.error("failed to resolve index privilege [" + part + "].");
-                    throw new IllegalArgumentException("unknown index privilege [" + part + "]. a privilege must be either " +
-                            "one of the predefined fixed indices privileges [" +
-                            Strings.collectionToCommaDelimitedString(VALUES.entrySet()) + "] or a pattern over one of the available index" +
-                            " actions");
+                    String errorMessage = "unknown index privilege [" + part + "]. a privilege must be either " +
+                        "one of the predefined fixed indices privileges [" +
+                        Strings.collectionToCommaDelimitedString(VALUES.entrySet()) + "] or a pattern over one of the available index" +
+                        " actions";
+                    logger.error(errorMessage);
+                    throw new IllegalArgumentException(errorMessage);
                 }
             }
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
@@ -146,7 +146,7 @@ public final class IndexPrivilege extends Privilege {
                         "one of the predefined fixed indices privileges [" +
                         Strings.collectionToCommaDelimitedString(VALUES.entrySet()) + "] or a pattern over one of the available index" +
                         " actions";
-                    logger.error(errorMessage);
+                    logger.debug(errorMessage);
                     throw new IllegalArgumentException(errorMessage);
                 }
             }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequestTests.java
@@ -38,6 +38,42 @@ import static org.hamcrest.Matchers.nullValue;
 
 public class PutRoleRequestTests extends ESTestCase {
 
+    public void testValidationErrorWithUnknownClusterPrivilegeName() {
+        final PutRoleRequest request = new PutRoleRequest();
+        request.name(randomAlphaOfLengthBetween(4, 9));
+        String unknownClusterPrivilegeName = randomAlphaOfLengthBetween(7, 9);
+        request.cluster("manage_security", unknownClusterPrivilegeName);
+
+        // Fail
+        assertValidationError("unknown cluster privilege [" + unknownClusterPrivilegeName.toLowerCase(Locale.ROOT) + "]", request);
+    }
+
+    public void testValidationSuccessWithCorrectClusterPrivilegeName() {
+        final PutRoleRequest request = new PutRoleRequest();
+        request.name(randomAlphaOfLengthBetween(4, 9));
+        request.cluster("manage_security", "manage", "cluster:admin/xpack/security/*");
+        assertSuccessfulValidation(request);
+    }
+
+    public void testValidationErrorWithUnknownIndexPrivilegeName() {
+        final PutRoleRequest request = new PutRoleRequest();
+        request.name(randomAlphaOfLengthBetween(4, 9));
+        String unknownIndexPrivilegeName = randomAlphaOfLengthBetween(7, 9);
+        request.addIndex(new String[]{randomAlphaOfLength(5)}, new String[]{"index", unknownIndexPrivilegeName}, null,
+            null, null, randomBoolean());
+
+        // Fail
+        assertValidationError("unknown index privilege [" + unknownIndexPrivilegeName.toLowerCase(Locale.ROOT) + "]", request);
+    }
+
+    public void testValidationSuccessWithCorrectIndexPrivilegeName() {
+        final PutRoleRequest request = new PutRoleRequest();
+        request.name(randomAlphaOfLengthBetween(4, 9));
+        request.addIndex(new String[]{randomAlphaOfLength(5)}, new String[]{"index", "write", "indices:data/read"}, null,
+            null, null, randomBoolean());
+        assertSuccessfulValidation(request);
+    }
+
     public void testValidationOfApplicationPrivileges() {
         assertSuccessfulValidation(buildRequestWithApplicationPrivilege("app", new String[]{"read"}, new String[]{"*"}));
         assertSuccessfulValidation(buildRequestWithApplicationPrivilege("app", new String[]{"action:login"}, new String[]{"/"}));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequestTests.java
@@ -41,7 +41,7 @@ public class PutRoleRequestTests extends ESTestCase {
     public void testValidationErrorWithUnknownClusterPrivilegeName() {
         final PutRoleRequest request = new PutRoleRequest();
         request.name(randomAlphaOfLengthBetween(4, 9));
-        String unknownClusterPrivilegeName = randomAlphaOfLengthBetween(7, 9);
+        String unknownClusterPrivilegeName = "-unknown-";
         request.cluster("manage_security", unknownClusterPrivilegeName);
 
         // Fail
@@ -58,7 +58,7 @@ public class PutRoleRequestTests extends ESTestCase {
     public void testValidationErrorWithUnknownIndexPrivilegeName() {
         final PutRoleRequest request = new PutRoleRequest();
         request.name(randomAlphaOfLengthBetween(4, 9));
-        String unknownIndexPrivilegeName = randomAlphaOfLengthBetween(7, 9);
+        String unknownIndexPrivilegeName = "-unknown-";
         request.addIndex(new String[]{randomAlphaOfLength(5)}, new String[]{"index", unknownIndexPrivilegeName}, null,
             null, null, randomBoolean());
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequestTests.java
@@ -41,7 +41,7 @@ public class PutRoleRequestTests extends ESTestCase {
     public void testValidationErrorWithUnknownClusterPrivilegeName() {
         final PutRoleRequest request = new PutRoleRequest();
         request.name(randomAlphaOfLengthBetween(4, 9));
-        String unknownClusterPrivilegeName = "-unknown-";
+        String unknownClusterPrivilegeName = "unknown_" + randomAlphaOfLengthBetween(3,9);
         request.cluster("manage_security", unknownClusterPrivilegeName);
 
         // Fail
@@ -58,7 +58,7 @@ public class PutRoleRequestTests extends ESTestCase {
     public void testValidationErrorWithUnknownIndexPrivilegeName() {
         final PutRoleRequest request = new PutRoleRequest();
         request.name(randomAlphaOfLengthBetween(4, 9));
-        String unknownIndexPrivilegeName = "-unknown-";
+        String unknownIndexPrivilegeName = "unknown_" + randomAlphaOfLengthBetween(3,9);
         request.addIndex(new String[]{randomAlphaOfLength(5)}, new String[]{"index", unknownIndexPrivilegeName}, null,
             null, null, randomBoolean());
 


### PR DESCRIPTION
This commit adds validation so a role cannot be created with
invalid index or cluster privilege name.

Closes #29703
