### PR TITLE
Add a system property to ignore awareness attributes

### DIFF
--- a/docs/reference/modules/cluster/allocation_awareness.asciidoc
+++ b/docs/reference/modules/cluster/allocation_awareness.asciidoc
@@ -17,9 +17,12 @@ The allocation awareness settings can be configured in
 `elasticsearch.yml` and updated dynamically with the
 <<cluster-update-settings,cluster-update-settings>> API.
 
-{es} prefers using shards in the same location (with the same
-awareness attribute values) to process search or GET requests. Using local
-shards is usually faster than crossing rack or zone boundaries.
+By default {es} uses <<search-adaptive-replica,adaptive replica selection>>
+to route search or GET requests. However, with the presence of allocation awareness
+attributes {es} will prefer using shards in the same location (with the same
+awareness attribute values) to process these requests. This behavior can be
+disabled by specifying `export ES_JAVA_OPTS="-Des.search.ignore_awareness_attributes=true"`
+system property on every node that is part of the cluster.
 
 NOTE: The number of attribute values determines how many shard copies are
 allocated in each location. If the number of nodes in each location is

--- a/docs/reference/modules/cluster/allocation_awareness.asciidoc
+++ b/docs/reference/modules/cluster/allocation_awareness.asciidoc
@@ -21,7 +21,7 @@ By default {es} uses <<search-adaptive-replica,adaptive replica selection>>
 to route search or GET requests. However, with the presence of allocation awareness
 attributes {es} will prefer using shards in the same location (with the same
 awareness attribute values) to process these requests. This behavior can be
-disabled by specifying `export ES_JAVA_OPTS="-Des.search.ignore_awareness_attributes=true"`
+disabled by specifying `export ES_JAVA_OPTS="$ES_JAVA_OPTS -Des.search.ignore_awareness_attributes=true"`
 system property on every node that is part of the cluster.
 
 NOTE: The number of attribute values determines how many shard copies are

--- a/qa/evil-tests/src/test/java/org/elasticsearch/cluster/routing/EvilSystemPropertyTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/cluster/routing/EvilSystemPropertyTests.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.cluster.routing;
+
+import org.elasticsearch.common.SuppressForbidden;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class EvilSystemPropertyTests extends ESTestCase {
+
+    @SuppressForbidden(reason = "manipulates system properties for testing")
+    public void testDisableSearchAllocationAwareness() {
+        Settings indexSettings = Settings.builder()
+            .put("cluster.routing.allocation.awareness.attributes", "test")
+            .build();
+        OperationRouting routing = new OperationRouting(indexSettings,
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
+        assertThat(routing.getAwarenessAttributes().size(), equalTo(1));
+        assertThat(routing.getAwarenessAttributes().get(0), equalTo("test"));
+        System.setProperty("es.search.ignore_awareness_attributes", "true");
+        try {
+            routing = new OperationRouting(indexSettings,
+                new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
+            assertTrue(routing.getAwarenessAttributes().isEmpty());
+        } finally {
+            System.clearProperty("es.search.ignore_awareness_attributes");
+        }
+
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
@@ -24,7 +24,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.allocation.decider.AwarenessAllocationDecider;
-import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -50,7 +49,6 @@ public class OperationRouting {
     public static final Setting<Boolean> USE_ADAPTIVE_REPLICA_SELECTION_SETTING =
             Setting.boolSetting("cluster.routing.use_adaptive_replica_selection", true,
                     Setting.Property.Dynamic, Setting.Property.NodeScope);
-
 
     private List<String> awarenessAttributes;
     private boolean useAdaptiveReplicaSelection;


### PR DESCRIPTION
This is a follow up of #45735 for 7.x.
This change adds a system property called "es.routing.search_ignore_awareness_attributes" that when set to true will effectively ignore allocation awareness attributes when routing search and get requests. This is now the default in 8.x so this commit adds a way to opt-in to this new behavior in a minor version of 7.x.

Relates #45735