### PR TITLE
Fix usage of randomIntBetween() in testWriteBlobWithRetries

### DIFF
--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
@@ -206,7 +206,7 @@ public class S3BlobContainerRetriesTests extends ESTestCase {
 
                 if (randomBoolean()) {
                     if (randomBoolean()) {
-                        Streams.readFully(exchange.getRequestBody(), new byte[randomIntBetween(1, bytes.length - 1)]);
+                        Streams.readFully(exchange.getRequestBody(), new byte[randomIntBetween(1, Math.max(1, bytes.length - 1))]);
                     } else {
                         Streams.readFully(exchange.getRequestBody());
                         exchange.sendResponseHeaders(randomFrom(HttpStatus.SC_INTERNAL_SERVER_ERROR, HttpStatus.SC_BAD_GATEWAY,


### PR DESCRIPTION
This commit fixes the usage of `randomIntBetween()` in the test `testWriteBlobWithRetries`, when the test generates a random array of a single byte.

CI failure: https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+7.4+multijob+fast+part1/40/console