### PR TITLE
[DOCS] Fix sample code for minhash

### DIFF
--- a/docs/reference/analysis/tokenfilters/minhash-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/minhash-tokenfilter.asciidoc
@@ -123,8 +123,8 @@ POST /index1
   },
   "mappings": {
     "properties": {
-      "text": {
-        "fingerprint": "text",
+      "fingerprint": {
+        "type": "text",
         "analyzer": "my_analyzer"
       }
     }


### PR DESCRIPTION
Fixes an error in the minhash token filter example.

@dschneiter already made this change on 7.3. This ports that change to other supported branches.