### PR TITLE
[DOCS] Bump docs version from 6.8.2 to 6.8.3

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -1,4 +1,4 @@
-:version:               6.8.2
+:version:               6.8.3
 :major-version:         6.x
 :lucene_version:        7.7.0
 :lucene_version_path:   7_7_0


### PR DESCRIPTION
Increments the :version: attribute for the 6.8.3 release.