### PR TITLE
Deprecate the  "index.max_adjacency_matrix_filters" setting

### DIFF
--- a/docs/reference/aggregations/bucket/adjacency-matrix-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/adjacency-matrix-aggregation.asciidoc
@@ -109,4 +109,5 @@ where examining interactions _over time_ becomes important.
 
 ==== Limitations
 For N filters the matrix of buckets produced can be N²/2 and so there is a default maximum 
-imposed of 100 filters . This setting can be changed using the `index.max_adjacency_matrix_filters` index-level setting.
+imposed of 100 filters . This setting can be changed using the `index.max_adjacency_matrix_filters` index-level setting
+(note this setting is deprecated and will be removed in 8.0+).

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -823,16 +823,18 @@ public final class IndexSettings {
 
     /**
      * Returns the max number of filters in adjacency_matrix aggregation search requests
-     * @Deprecated This setting will be removed in 8.0
+     * @deprecated This setting will be removed in 8.0
      */
+    @Deprecated    
     public int getMaxAdjacencyMatrixFilters() {
         return this.maxAdjacencyMatrixFilters;
     }
 
     /**
      * @param maxAdjacencyFilters the max number of filters in adjacency_matrix aggregation search requests
-     * @Deprecated This setting will be removed in 8.0
+     * @deprecated This setting will be removed in 8.0
      */
+    @Deprecated    
     private void setMaxAdjacencyMatrixFilters(int maxAdjacencyFilters) {
         this.maxAdjacencyMatrixFilters = maxAdjacencyFilters;
     }

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -823,7 +823,7 @@ public final class IndexSettings {
 
     /**
      * Returns the max number of filters in adjacency_matrix aggregation search requests
-     * @deprecated This setting will be removed in 8.0
+     * @Deprecated This setting will be removed in 8.0
      */
     public int getMaxAdjacencyMatrixFilters() {
         return this.maxAdjacencyMatrixFilters;
@@ -831,7 +831,7 @@ public final class IndexSettings {
 
     /**
      * @param maxAdjacencyFilters the max number of filters in adjacency_matrix aggregation search requests
-     * @deprecated This setting will be removed in 8.0
+     * @Deprecated This setting will be removed in 8.0
      */
     private void setMaxAdjacencyMatrixFilters(int maxAdjacencyFilters) {
         this.maxAdjacencyMatrixFilters = maxAdjacencyFilters;

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -179,7 +179,7 @@ public final class IndexSettings {
      * N filters is (N*N)/2 so a limit of 100 filters is imposed by default.
      */
     public static final Setting<Integer> MAX_ADJACENCY_MATRIX_FILTERS_SETTING =
-        Setting.intSetting("index.max_adjacency_matrix_filters", 100, 2, Property.Dynamic, Property.IndexScope);
+        Setting.intSetting("index.max_adjacency_matrix_filters", 100, 2, Property.Dynamic, Property.IndexScope, Property.Deprecated);
     public static final TimeValue DEFAULT_REFRESH_INTERVAL = new TimeValue(1, TimeUnit.SECONDS);
     public static final Setting<TimeValue> INDEX_REFRESH_INTERVAL_SETTING =
         Setting.timeSetting("index.refresh_interval", DEFAULT_REFRESH_INTERVAL, new TimeValue(-1, TimeUnit.MILLISECONDS),
@@ -823,11 +823,16 @@ public final class IndexSettings {
 
     /**
      * Returns the max number of filters in adjacency_matrix aggregation search requests
+     * @deprecated This setting will be removed in 8.0
      */
     public int getMaxAdjacencyMatrixFilters() {
         return this.maxAdjacencyMatrixFilters;
     }
 
+    /**
+     * @param maxAdjacencyFilters the max number of filters in adjacency_matrix aggregation search requests
+     * @deprecated This setting will be removed in 8.0
+     */
     private void setMaxAdjacencyMatrixFilters(int maxAdjacencyFilters) {
         this.maxAdjacencyMatrixFilters = maxAdjacencyFilters;
     }

--- a/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
@@ -365,8 +365,8 @@ public class IndexSettingsTests extends ESTestCase {
         settings = new IndexSettings(metaData, Settings.EMPTY);
         assertEquals(IndexSettings.MAX_ADJACENCY_MATRIX_FILTERS_SETTING.get(Settings.EMPTY).intValue(),
                 settings.getMaxAdjacencyMatrixFilters());    
-        assertWarnings("[index.max_adjacency_matrix_filters] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                + "See the breaking changes documentation for the next major version.");
+        assertWarnings("[index.max_adjacency_matrix_filters] setting was deprecated in Elasticsearch and will be removed in a "
+                + "future release! See the breaking changes documentation for the next major version.");
     }
 
     public void testMaxRegexLengthSetting() {

--- a/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
@@ -364,7 +364,9 @@ public class IndexSettingsTests extends ESTestCase {
             .build());
         settings = new IndexSettings(metaData, Settings.EMPTY);
         assertEquals(IndexSettings.MAX_ADJACENCY_MATRIX_FILTERS_SETTING.get(Settings.EMPTY).intValue(),
-                settings.getMaxAdjacencyMatrixFilters());
+                settings.getMaxAdjacencyMatrixFilters());    
+        assertWarnings("[index.max_adjacency_matrix_filters] setting was deprecated in Elasticsearch and will be removed in a future release! "
+                + "See the breaking changes documentation for the next major version.");
     }
 
     public void testMaxRegexLengthSetting() {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregationBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregationBuilderTests.java
@@ -79,5 +79,7 @@ public class AdjacencyMatrixAggregationBuilderTests extends ESTestCase {
         AggregatorFactory factory = aggregationBuilder.doBuild(context, null, new AggregatorFactories.Builder());
         assertThat(factory instanceof AdjacencyMatrixAggregatorFactory, is(true));
         assertThat(factory.name(), equalTo("dummy"));
+        assertWarnings("[index.max_adjacency_matrix_filters] setting was deprecated in Elasticsearch and will be "
+                + "removed in a future release! See the breaking changes documentation for the next major version.");
     }
 }


### PR DESCRIPTION
Now that we have improved the efficiency of adjacency matrix agg in issue 46212 we no longer need this setting.

Related #46324 