### PR TITLE
[7.4][Transform] reuse mock client to avoid problems with thread context closed errors

### DIFF
--- a/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/checkpoint/DataFrameTransformCheckpointServiceNodeTests.java
+++ b/x-pack/plugin/data-frame/src/test/java/org/elasticsearch/xpack/dataframe/checkpoint/DataFrameTransformCheckpointServiceNodeTests.java
@@ -142,6 +142,7 @@ public class DataFrameTransformCheckpointServiceNodeTests extends DataFrameSingl
     @AfterClass
     public static void tearDownClient() {
         mockClientForCheckpointing.close();
+        mockClientForCheckpointing = null;
     }
 
     public void testCreateReadDeleteCheckpoint() throws InterruptedException {


### PR DESCRIPTION
backport of #46398

reuse mock client to avoid problems with threadcontext is already closed errors