### PR TITLE
[DOCS] [3 of 5] Change // CONSOLE comments to [source,console]

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
@@ -82,14 +82,13 @@ are no matches or only partial matches.
 
 The following example stops the `datafeed-total-requests` {dfeed}:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _ml/datafeeds/datafeed-total-requests/_stop
 {
   "timeout": "30s"
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:setup:server_metrics_startdf]
 
 When the {dfeed} stops, you receive the following results:

--- a/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
@@ -102,7 +102,7 @@ see <<ml-datafeed-resource>>.
 The following example updates the query for the `datafeed-total-requests`
 {dfeed} so that only log entries of error level are analyzed:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _ml/datafeeds/datafeed-total-requests/_update
 {
@@ -113,7 +113,6 @@ POST _ml/datafeeds/datafeed-total-requests/_update
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:setup:server_metrics_datafeed]
 
 When the {dfeed} is updated, you receive the full {dfeed} configuration with

--- a/docs/reference/ml/anomaly-detection/apis/update-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-filter.asciidoc
@@ -44,7 +44,7 @@ Updates the description of a filter, adds items, or removes items.
 You can change the description, add and remove items to the `safe_domains`
 filter as follows:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _ml/filters/safe_domains/_update
 {
@@ -53,7 +53,6 @@ POST _ml/filters/safe_domains/_update
   "remove_items": ["wikipedia.org"]
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:setup:ml_filter_safe_domains]
 
 The API returns the following results:

--- a/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
@@ -101,7 +101,7 @@ No other detector property can be updated.
 
 The following example updates the `total-requests` job:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _ml/anomaly_detectors/total-requests/_update
 {
@@ -125,7 +125,6 @@ POST _ml/anomaly_detectors/total-requests/_update
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:setup:server_metrics_job]
 
 When the {anomaly-job} is updated, you receive a summary of the job

--- a/docs/reference/ml/anomaly-detection/apis/update-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-snapshot.asciidoc
@@ -50,7 +50,7 @@ The following properties can be updated after the model snapshot is created:
 
 The following example updates the snapshot identified as `1491852978`:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST
 _ml/anomaly_detectors/it_ops_new_logs/model_snapshots/1491852978/_update
@@ -59,7 +59,6 @@ _ml/anomaly_detectors/it_ops_new_logs/model_snapshots/1491852978/_update
   "retain": true
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:todo]
 
 When the snapshot is updated, you receive the following results:

--- a/docs/reference/ml/anomaly-detection/apis/validate-detector.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/validate-detector.asciidoc
@@ -37,7 +37,7 @@ see <<ml-detectorconfig,detector configuration objects>>.
 
 The following example validates detector configuration information:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _ml/anomaly_detectors/_validate/detector
 {
@@ -46,7 +46,6 @@ POST _ml/anomaly_detectors/_validate/detector
   "by_field_name": "airline"
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:needs-licence]
 
 When the validation completes, you receive the following results:

--- a/docs/reference/ml/anomaly-detection/apis/validate-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/validate-job.asciidoc
@@ -37,7 +37,7 @@ see <<ml-job-resource>>.
 
 The following example validates job configuration information:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _ml/anomaly_detectors/_validate
 {
@@ -57,7 +57,6 @@ POST _ml/anomaly_detectors/_validate
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:needs-licence]
 
 When the validation is complete, you receive the following results:

--- a/docs/reference/ml/anomaly-detection/detector-custom-rules.asciidoc
+++ b/docs/reference/ml/anomaly-detection/detector-custom-rules.asciidoc
@@ -31,7 +31,7 @@ _filters_ in {ml}. Filters can be shared across {anomaly-jobs}.
 
 We create our filter using the {ref}/ml-put-filter.html[put filter API]:
 
-[source,js]
+[source,console]
 ----------------------------------
 PUT _ml/filters/safe_domains
 {
@@ -39,13 +39,12 @@ PUT _ml/filters/safe_domains
   "items": ["safe.com", "trusted.com"]
 }
 ----------------------------------
-// CONSOLE
 // TEST[skip:needs-licence]
 
 Now, we can create our {anomaly-job} specifying a scope that uses the
 `safe_domains`  filter for the `highest_registered_domain` field:
 
-[source,js]
+[source,console]
 ----------------------------------
 PUT _ml/anomaly_detectors/dns_exfiltration_with_rule
 {
@@ -71,21 +70,19 @@ PUT _ml/anomaly_detectors/dns_exfiltration_with_rule
   }
 }
 ----------------------------------
-// CONSOLE
 // TEST[skip:needs-licence]
 
 As time advances and we see more data and more results, we might encounter new 
 domains that we want to add in the filter. We can do that by using the 
 {ref}/ml-update-filter.html[update filter API]:
 
-[source,js]
+[source,console]
 ----------------------------------
 POST _ml/filters/safe_domains/_update
 {
   "add_items": ["another-safe.com"]
 }
 ----------------------------------
-// CONSOLE
 // TEST[skip:setup:ml_filter_safe_domains]
 
 Note that we can use any of the `partition_field_name`, `over_field_name`, or 
@@ -93,7 +90,7 @@ Note that we can use any of the `partition_field_name`, `over_field_name`, or
 
 In the following example we scope multiple fields:
 
-[source,js]
+[source,console]
 ----------------------------------
 PUT _ml/anomaly_detectors/scoping_multiple_fields
 {
@@ -125,7 +122,6 @@ PUT _ml/anomaly_detectors/scoping_multiple_fields
   }
 }
 ----------------------------------
-// CONSOLE
 // TEST[skip:needs-licence]
 
 Such a detector will skip results when the values of all 3 scoped fields
@@ -143,7 +139,7 @@ investigation.
 Let us now configure an {anomaly-job} with a rule that will skip results where
 CPU utilization is less than 0.20.
 
-[source,js]
+[source,console]
 ----------------------------------
 PUT _ml/anomaly_detectors/cpu_with_rule
 {
@@ -169,7 +165,6 @@ PUT _ml/anomaly_detectors/cpu_with_rule
   }
 }
 ----------------------------------
-// CONSOLE
 // TEST[skip:needs-licence]
 
 When there are multiple conditions they are combined with a logical `and`.
@@ -179,7 +174,7 @@ a rule with two conditions, one for each end of the desired range.
 Here is an example where a count detector will skip results when the count
 is greater than 30 and less than 50:
 
-[source,js]
+[source,console]
 ----------------------------------
 PUT _ml/anomaly_detectors/rule_with_range
 {
@@ -209,7 +204,6 @@ PUT _ml/anomaly_detectors/rule_with_range
   }
 }
 ----------------------------------
-// CONSOLE
 // TEST[skip:needs-licence]
 
 ==== Custom rules in the life-cycle of a job

--- a/docs/reference/ml/anomaly-detection/functions/count.asciidoc
+++ b/docs/reference/ml/anomaly-detection/functions/count.asciidoc
@@ -43,7 +43,7 @@ For more information about those properties,
 see {ref}/ml-job-resource.html#ml-detectorconfig[Detector configuration objects].
 
 .Example 1: Analyzing events with the count function
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _ml/anomaly_detectors/example1
 {
@@ -58,7 +58,6 @@ PUT _ml/anomaly_detectors/example1
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:needs-licence]
 
 This example is probably the simplest possible analysis. It identifies
@@ -70,7 +69,7 @@ event rate and detects when the event rate is unusual compared to its past
 behavior.
 
 .Example 2: Analyzing errors with the high_count function
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _ml/anomaly_detectors/example2
 {
@@ -87,7 +86,6 @@ PUT _ml/anomaly_detectors/example2
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:needs-licence]
 
 If you use this `high_count` function in a detector in your {anomaly-job}, it
@@ -96,7 +94,7 @@ unusually high count of error codes compared to other users.
 
 
 .Example 3: Analyzing status codes with the low_count function
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _ml/anomaly_detectors/example3
 {
@@ -112,7 +110,6 @@ PUT _ml/anomaly_detectors/example3
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:needs-licence]
 
 In this example, the function detects when the count of events for a
@@ -123,7 +120,7 @@ event rate for each status code and detects when a status code has an unusually
 low count compared to its past behavior.
 
 .Example 4: Analyzing aggregated data with the count function
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _ml/anomaly_detectors/example4
 {
@@ -139,7 +136,6 @@ PUT _ml/anomaly_detectors/example4
   }
 }  
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:needs-licence]
 
 If you are analyzing an aggregated `events_per_min` field, do not use a sum
@@ -188,7 +184,7 @@ The `non_zero_count` function models only the following data:
 ========================================
 
 .Example 5: Analyzing signatures with the high_non_zero_count function
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _ml/anomaly_detectors/example5
 {
@@ -204,7 +200,6 @@ PUT _ml/anomaly_detectors/example5
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:needs-licence]
 
 If you use this `high_non_zero_count` function in a detector in your
@@ -242,7 +237,7 @@ For more information about those properties,
 see {ref}/ml-job-resource.html#ml-detectorconfig[Detector configuration objects].
 
 .Example 6: Analyzing users with the distinct_count function
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _ml/anomaly_detectors/example6
 {
@@ -258,7 +253,6 @@ PUT _ml/anomaly_detectors/example6
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:needs-licence]
 
 This `distinct_count` function detects when a system has an unusual number
@@ -267,7 +261,7 @@ of logged in users. When you use this function in a detector in your
 distinct number of users is unusual compared to the past.
 
 .Example 7: Analyzing ports with the high_distinct_count function
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _ml/anomaly_detectors/example7
 {
@@ -284,7 +278,6 @@ PUT _ml/anomaly_detectors/example7
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:needs-licence]
 
 This example detects instances of port scanning. When you use this function in a

--- a/docs/reference/ml/anomaly-detection/functions/geo.asciidoc
+++ b/docs/reference/ml/anomaly-detection/functions/geo.asciidoc
@@ -29,7 +29,7 @@ For more information about those properties,
 see {ref}/ml-job-resource.html#ml-detectorconfig[Detector configuration objects].
 
 .Example 1: Analyzing transactions with the lat_long function
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _ml/anomaly_detectors/example1
 {
@@ -46,7 +46,6 @@ PUT _ml/anomaly_detectors/example1
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:needs-licence]
 
 If you use this `lat_long` function in a detector in your {anomaly-job}, it

--- a/docs/reference/ml/anomaly-detection/stopping-ml.asciidoc
+++ b/docs/reference/ml/anomaly-detection/stopping-ml.asciidoc
@@ -23,11 +23,10 @@ When you stop a {dfeed}, it ceases to retrieve data from {es}. You can stop a
 {ref}/ml-stop-datafeed.html[stop {dfeeds} API]. For example, the following
 request stops the `feed1` {dfeed}:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _ml/datafeeds/feed1/_stop
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:setup:server_metrics_startdf]
 
 NOTE: You must have `manage_ml`, or `manage` cluster privileges to stop {dfeeds}.
@@ -44,11 +43,10 @@ A {dfeed} can be started and stopped multiple times throughout its lifecycle.
 If you are upgrading your cluster, you can use the following request to stop all
 {dfeeds}:
 
-[source,js]
+[source,console]
 ----------------------------------
 POST _ml/datafeeds/_all/_stop
 ----------------------------------
-// CONSOLE
 // TEST[skip:needs-licence]
 
 [float]
@@ -64,11 +62,10 @@ You can close a job by using the
 {ref}/ml-close-job.html[close {anomaly-job} API]. For 
 example, the following request closes the `job1` job:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _ml/anomaly_detectors/job1/_close
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:setup:server_metrics_openjob]
 
 NOTE: You must have `manage_ml`, or `manage` cluster privileges to stop {dfeeds}.
@@ -84,9 +81,8 @@ lifecycle.
 If you are upgrading your cluster, you can use the following request to close
 all open {anomaly-jobs} on the cluster:
 
-[source,js]
+[source,console]
 ----------------------------------
 POST _ml/anomaly_detectors/_all/_close
 ----------------------------------
-// CONSOLE
 // TEST[skip:needs-licence]

--- a/docs/reference/ml/anomaly-detection/transforms.asciidoc
+++ b/docs/reference/ml/anomaly-detection/transforms.asciidoc
@@ -24,7 +24,7 @@ functions in one or more detectors.
 The following index APIs create and add content to an index that is used in
 subsequent examples:
 
-[source,js]
+[source,console]
 ----------------------------------
 PUT /my_index
 {
@@ -92,8 +92,8 @@ PUT /my_index/_doc/1
   }
 }
 ----------------------------------
-// CONSOLE
 // TEST[skip:SETUP]
+
 <1> In this example, string fields are mapped as `keyword` fields to support
 aggregation. If you want both a full text (`text`) and a keyword (`keyword`)
 version of the same field, use multi-fields. For more information, see
@@ -101,7 +101,7 @@ version of the same field, use multi-fields. For more information, see
 
 [[ml-configuring-transform1]]
 .Example 1: Adding two numerical fields
-[source,js]
+[source,console]
 ----------------------------------
 PUT _ml/anomaly_detectors/test1
 {
@@ -140,8 +140,8 @@ PUT _ml/datafeeds/datafeed-test1
   }
 }
 ----------------------------------
-// CONSOLE
 // TEST[skip:needs-licence]
+
 <1> A script field named `total_error_count` is referenced in the detector
 within the job.
 <2> The script field is defined in the {dfeed}.
@@ -157,11 +157,10 @@ For more information, see
 
 You can preview the contents of the {dfeed} by using the following API:
 
-[source,js]
+[source,console]
 ----------------------------------
 GET _ml/datafeeds/datafeed-test1/_preview
 ----------------------------------
-// CONSOLE
 // TEST[skip:continued]
 
 In this example, the API returns the following results, which contain a sum of
@@ -210,7 +209,7 @@ that convert your strings to upper or lowercase letters.
 
 [[ml-configuring-transform2]]
 .Example 2: Concatenating strings
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _ml/anomaly_detectors/test2
 {
@@ -251,8 +250,8 @@ PUT _ml/datafeeds/datafeed-test2
 
 GET _ml/datafeeds/datafeed-test2/_preview
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:needs-licence]
+
 <1> The script field has a rather generic name in this case, since it will
 be used for various tests in the subsequent examples.
 <2> The script field uses the plus (+) operator to concatenate strings.
@@ -272,7 +271,7 @@ and "SMITH  " have been concatenated and an underscore was added:
 
 [[ml-configuring-transform3]]
 .Example 3: Trimming strings
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _ml/datafeeds/datafeed-test2/_update
 {
@@ -288,8 +287,8 @@ POST _ml/datafeeds/datafeed-test2/_update
 
 GET _ml/datafeeds/datafeed-test2/_preview
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:continued]
+
 <1> This script field uses the `trim()` function to trim extra white space from a
 string.
 
@@ -308,7 +307,7 @@ has been trimmed to "SMITH":
 
 [[ml-configuring-transform4]]
 .Example 4: Converting strings to lowercase
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _ml/datafeeds/datafeed-test2/_update
 {
@@ -324,8 +323,8 @@ POST _ml/datafeeds/datafeed-test2/_update
 
 GET _ml/datafeeds/datafeed-test2/_preview
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:continued]
+
 <1> This script field uses the `toLowerCase` function to convert a string to all
 lowercase letters. Likewise, you can use the `toUpperCase{}` function to convert
 a string to uppercase letters.
@@ -345,7 +344,7 @@ has been converted to "joe":
 
 [[ml-configuring-transform5]]
 .Example 5: Converting strings to mixed case formats
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _ml/datafeeds/datafeed-test2/_update
 {
@@ -361,8 +360,8 @@ POST _ml/datafeeds/datafeed-test2/_update
 
 GET _ml/datafeeds/datafeed-test2/_preview
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:continued]
+
 <1> This script field is a more complicated example of case manipulation. It uses
 the `subString()` function to capitalize the first letter of a string and
 converts the remaining characters to lowercase.
@@ -382,7 +381,7 @@ has been converted to "Joe":
 
 [[ml-configuring-transform6]]
 .Example 6: Replacing tokens
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _ml/datafeeds/datafeed-test2/_update
 {
@@ -398,8 +397,8 @@ POST _ml/datafeeds/datafeed-test2/_update
 
 GET _ml/datafeeds/datafeed-test2/_preview
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:continued]
+
 <1> This script field uses regular expressions to replace white
 space with underscores.
 
@@ -418,7 +417,7 @@ The preview {dfeed} API returns the following results, which show that
 
 [[ml-configuring-transform7]]
 .Example 7: Regular expression matching and concatenation
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _ml/datafeeds/datafeed-test2/_update
 {
@@ -434,8 +433,8 @@ POST _ml/datafeeds/datafeed-test2/_update
 
 GET _ml/datafeeds/datafeed-test2/_preview
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:continued]
+
 <1> This script field looks for a specific regular expression pattern and emits the
 matched groups as a concatenated string. If no match is found, it emits an empty
 string.
@@ -455,7 +454,7 @@ The preview {dfeed} API returns the following results, which show that
 
 [[ml-configuring-transform8]]
 .Example 8: Splitting strings by domain name
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _ml/anomaly_detectors/test3
 {
@@ -499,7 +498,6 @@ PUT _ml/datafeeds/datafeed-test3
 
 GET _ml/datafeeds/datafeed-test3/_preview
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:needs-licence]
 
 If you have a single field that contains a well-formed DNS domain name, you can
@@ -527,7 +525,7 @@ The preview {dfeed} API returns the following results, which show that
 
 [[ml-configuring-transform9]]
 .Example 9: Transforming geo_point data
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _ml/anomaly_detectors/test4
 {
@@ -567,7 +565,6 @@ PUT _ml/datafeeds/datafeed-test4
 
 GET _ml/datafeeds/datafeed-test4/_preview
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:needs-licence]
 
 In {es}, location data can be stored in `geo_point` fields but this data type is

--- a/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
@@ -34,11 +34,10 @@ information, see {stack-ov}/security-privileges.html[Security privileges] and
 
 The following example deletes the `loganalytics` {dfanalytics-job}:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 DELETE _ml/data_frame/analytics/loganalytics
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:TBD]
 
 The API returns the following result:

--- a/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
@@ -28,7 +28,7 @@
     from the analysis.
   
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _ml/data_frame/analytics/loganalytics
 {
@@ -48,7 +48,6 @@ PUT _ml/data_frame/analytics/loganalytics
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:setup_logdata]
 
 `description`::

--- a/docs/reference/ml/df-analytics/apis/estimate-memory-usage-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/estimate-memory-usage-dfanalytics.asciidoc
@@ -54,7 +54,7 @@ Serves as an advice on how to set `model_memory_limit` when creating {dfanalytic
 [[ml-estimate-memory-usage-dfanalytics-example]]
 ==== {api-examples-title}
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _ml/data_frame/analytics/_estimate_memory_usage
 {
@@ -68,7 +68,6 @@ POST _ml/data_frame/analytics/_estimate_memory_usage
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:TBD]
 
 The API returns the following results:

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -74,7 +74,7 @@ packages together commonly used metrics for various analyses.
 [[ml-evaluate-dfanalytics-example]]
 ==== {api-examples-title}
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _ml/data_frame/_evaluate
 {
@@ -87,7 +87,6 @@ POST _ml/data_frame/_evaluate
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:TBD]
 
 The API returns the following results:

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -83,11 +83,10 @@ The API returns the following information:
 [[ml-get-dfanalytics-stats-example]]
 ==== {api-examples-title}
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET _ml/data_frame/analytics/loganalytics/_stats
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:TBD]
 
 The API returns the following results:

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
@@ -90,11 +90,10 @@ when there are no matches or only partial matches.
 The following example gets configuration information for the `loganalytics` 
 {dfanalytics-job}:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET _ml/data_frame/analytics/loganalytics
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:TBD]
 
 The API returns the following results:

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -124,7 +124,7 @@ and mappings.
 The following example creates the `loganalytics` {dfanalytics-job}, the analysis 
 type is `outlier_detection`:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _ml/data_frame/analytics/loganalytics
 {
@@ -141,7 +141,6 @@ PUT _ml/data_frame/analytics/loganalytics
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:setup_logdata]
 
 

--- a/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
@@ -46,11 +46,10 @@ and {stack-ov}/built-in-roles.html[Built-in roles].
 
 The following example starts the `loganalytics` {dfanalytics-job}:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _ml/data_frame/analytics/loganalytics/_start
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:setup:logdata_job]
 
 When the {dfanalytics-job} starts, you receive the following results:

--- a/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
@@ -68,11 +68,10 @@ stop all {dfanalytics-job} by using _all or by specifying * as the
 
 The following example stops the `loganalytics` {dfanalytics-job}:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _ml/data_frame/analytics/loganalytics/_stop
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:TBD]
 
 When the {dfanalytics-job} stops, you receive the following results:

--- a/docs/reference/modules/cluster/allocation_filtering.asciidoc
+++ b/docs/reference/modules/cluster/allocation_filtering.asciidoc
@@ -18,7 +18,7 @@ The most common use case for cluster-level shard allocation filtering is when
 you want to decommission a node. To move shards off of a node prior to shutting
 it down, you could create a filter that excludes the node by its IP address:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _cluster/settings
 {
@@ -27,7 +27,6 @@ PUT _cluster/settings
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 [float]
 [[cluster-routing-settings]]
@@ -57,7 +56,7 @@ The cluster allocation settings support the following built-in attributes:
 
 You can use wildcards when specifying attribute values, for example:
 
-[source,js]
+[source,console]
 ------------------------
 PUT _cluster/settings
 {
@@ -66,4 +65,3 @@ PUT _cluster/settings
   }
 }
 ------------------------
-// CONSOLE

--- a/docs/reference/modules/cluster/disk_allocator.asciidoc
+++ b/docs/reference/modules/cluster/disk_allocator.asciidoc
@@ -52,14 +52,13 @@ threshold).
 
 An example of resetting the read-only index block on the `twitter` index:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /twitter/_settings
 {
   "index.blocks.read_only_allow_delete": null
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 --
 
@@ -88,7 +87,7 @@ An example of updating the low watermark to at least 100 gigabytes free, a high
 watermark of at least 50 gigabytes free, and a flood stage watermark of 10
 gigabytes free, and updating the information about the cluster every minute:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _cluster/settings
 {
@@ -100,4 +99,3 @@ PUT _cluster/settings
   }
 }
 --------------------------------------------------
-// CONSOLE

--- a/docs/reference/modules/cluster/misc.asciidoc
+++ b/docs/reference/modules/cluster/misc.asciidoc
@@ -75,7 +75,7 @@ any key prefixed with `cluster.metadata.`.  For example, to store the email
 address of the administrator of a cluster under the key `cluster.metadata.administrator`,
 issue this request:
 
-[source,js]
+[source,console]
 -------------------------------
 PUT /_cluster/settings
 {
@@ -84,7 +84,6 @@ PUT /_cluster/settings
   }
 }
 -------------------------------
-// CONSOLE
 
 IMPORTANT: User-defined cluster metadata is not intended to store sensitive or
 confidential information. Any information stored in user-defined cluster
@@ -116,7 +115,7 @@ The settings which control logging can be updated dynamically with the
 `logger.` prefix.  For instance, to increase the logging level of the
 `indices.recovery` module to `DEBUG`, issue this request:
 
-[source,js]
+[source,console]
 -------------------------------
 PUT /_cluster/settings
 {
@@ -125,7 +124,6 @@ PUT /_cluster/settings
   }
 }
 -------------------------------
-// CONSOLE
 
 
 [[persistent-tasks-allocation]]

--- a/docs/reference/modules/cross-cluster-search.asciidoc
+++ b/docs/reference/modules/cross-cluster-search.asciidoc
@@ -21,7 +21,7 @@ To perform a {ccs}, you must have at least one remote cluster configured.
 The following <<cluster-update-settings,cluster update settings>> API request
 adds three remote clusters:`cluster_one`, `cluster_two`, and `cluster_three`.
 
-[source,js]
+[source,console]
 --------------------------------
 PUT _cluster/settings
 {
@@ -48,7 +48,6 @@ PUT _cluster/settings
   }
 }
 --------------------------------
-// CONSOLE
 // TEST[setup:host]
 // TEST[s/127.0.0.1:930\d+/\${transport_host}/]
 
@@ -59,7 +58,7 @@ PUT _cluster/settings
 The following <<search,search>> API request searches the
 `twitter` index on a single remote cluster, `cluster_one`.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /cluster_one:twitter/_search
 {
@@ -70,7 +69,6 @@ GET /cluster_one:twitter/_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 // TEST[setup:twitter]
 
@@ -132,7 +130,7 @@ three clusters:
 * Your local cluster
 * Two remote clusters, `cluster_one` and `cluster_two`
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /twitter,cluster_one:twitter,cluster_two:twitter/_search
 {
@@ -143,7 +141,6 @@ GET /twitter,cluster_one:twitter,cluster_two:twitter/_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 The API returns the following response:
@@ -235,7 +232,7 @@ To skip an unavailable cluster during a {ccs}, set the
 The following <<cluster-update-settings,cluster update settings>> API request
 changes `cluster_two`'s `skip_unavailable` setting to `true`.
 
-[source,js]
+[source,console]
 --------------------------------
 PUT _cluster/settings
 {
@@ -244,7 +241,6 @@ PUT _cluster/settings
   }
 }
 --------------------------------
-// CONSOLE
 // TEST[continued]
 
 If `cluster_two` is disconnected or unavailable during a {ccs}, {es} won't

--- a/docs/reference/modules/discovery/adding-removing-nodes.asciidoc
+++ b/docs/reference/modules/discovery/adding-removing-nodes.asciidoc
@@ -60,7 +60,7 @@ without affecting the cluster's master-level availability. A node can be added
 to the voting configuration exclusion list using the
 <<voting-config-exclusions>> API. For example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 # Add node to voting configuration exclusions list and wait for the system
 # to auto-reconfigure the node out of the voting configuration up to the
@@ -71,7 +71,6 @@ POST /_cluster/voting_config_exclusions/node_name
 # auto-reconfiguration up to one minute
 POST /_cluster/voting_config_exclusions/node_name?timeout=1m
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:this would break the test cluster if executed]
 
 The node that should be added to the exclusions list is specified using
@@ -104,11 +103,10 @@ reconfigure the voting configuration to remove that node and prevents it from
 returning to the voting configuration once it has removed. The current list of
 exclusions is stored in the cluster state and can be inspected as follows:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_cluster/state?filter_path=metadata.cluster_coordination.voting_config_exclusions
 --------------------------------------------------
-// CONSOLE
 
 This list is limited in size by the `cluster.max_voting_config_exclusions` 
 setting, which defaults to `10`. See <<modules-discovery-settings>>. Since
@@ -123,7 +121,7 @@ down permanently, its exclusion can be removed after it is shut down and removed
 from the cluster. Exclusions can also be cleared if they were created in error
 or were only required temporarily:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 # Wait for all the nodes with voting configuration exclusions to be removed from
 # the cluster and then remove all the exclusions, allowing any node to return to
@@ -134,4 +132,3 @@ DELETE /_cluster/voting_config_exclusions
 # to return to the voting configuration in the future.
 DELETE /_cluster/voting_config_exclusions?wait_for_removal=false
 --------------------------------------------------
-// CONSOLE

--- a/docs/reference/modules/discovery/voting.asciidoc
+++ b/docs/reference/modules/discovery/voting.asciidoc
@@ -27,11 +27,10 @@ see <<modules-discovery-adding-removing-nodes>>.
 The current voting configuration is stored in the cluster state so you can
 inspect its current contents as follows:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_cluster/state?filter_path=metadata.cluster_coordination.last_committed_config
 --------------------------------------------------
-// CONSOLE
 
 NOTE: The current voting configuration is not necessarily the same as the set of
 all available master-eligible nodes in the cluster. Altering the voting

--- a/docs/reference/modules/indices/request_cache.asciidoc
+++ b/docs/reference/modules/indices/request_cache.asciidoc
@@ -40,11 +40,10 @@ evicted.
 
 The cache can be expired manually with the <<indices-clearcache,`clear-cache` API>>:
 
-[source,js]
+[source,console]
 ------------------------
 POST /kimchy,elasticsearch/_cache/clear?request=true
 ------------------------
-// CONSOLE
 // TEST[s/^/PUT kimchy\nPUT elasticsearch\n/]
 
 [float]
@@ -53,7 +52,7 @@ POST /kimchy,elasticsearch/_cache/clear?request=true
 The cache is enabled by default, but can be disabled when creating a new
 index as follows:
 
-[source,js]
+[source,console]
 -----------------------------
 PUT /my_index
 {
@@ -62,17 +61,15 @@ PUT /my_index
   }
 }
 -----------------------------
-// CONSOLE
 
 It can also be enabled or disabled dynamically on an existing index with the
 <<indices-update-settings,`update-settings`>> API:
 
-[source,js]
+[source,console]
 -----------------------------
 PUT /my_index/_settings
 { "index.requests.cache.enable": true }
 -----------------------------
-// CONSOLE
 // TEST[continued]
 
 
@@ -82,7 +79,7 @@ PUT /my_index/_settings
 The `request_cache` query-string parameter can be used to enable or disable
 caching on a *per-request* basis.  If set, it overrides the index-level setting:
 
-[source,js]
+[source,console]
 -----------------------------
 GET /my_index/_search?request_cache=true
 {
@@ -96,7 +93,6 @@ GET /my_index/_search?request_cache=true
   }
 }
 -----------------------------
-// CONSOLE
 // TEST[continued]
 
 IMPORTANT: If your query uses a script whose result is not deterministic (e.g.
@@ -140,16 +136,14 @@ setting is provided for completeness' sake only.
 The size of the cache (in bytes) and the number of evictions can be viewed
 by index, with the <<indices-stats,`indices-stats`>> API:
 
-[source,js]
+[source,console]
 ------------------------
 GET /_stats/request_cache?human
 ------------------------
-// CONSOLE
 
 or by node with the <<cluster-nodes-stats,`nodes-stats`>> API:
 
-[source,js]
+[source,console]
 ------------------------
 GET /_nodes/stats/indices/request_cache?human
 ------------------------
-// CONSOLE

--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -99,7 +99,7 @@ For more information about the optional transport settings, see
 If you use <<cluster-update-settings,cluster settings>>, the remote clusters
 are available on every node in the cluster. For example:
 
-[source,js]
+[source,console]
 --------------------------------
 PUT _cluster/settings
 {
@@ -129,14 +129,13 @@ PUT _cluster/settings
   }
 }
 --------------------------------
-// CONSOLE
 // TEST[setup:host]
 // TEST[s/127.0.0.1:9300/\${transport_host}/]
 
 You can dynamically update the compression and ping schedule settings. However,
 you must re-include seeds in the settings update request. For example:
 
-[source,js]
+[source,console]
 --------------------------------
 PUT _cluster/settings
 {
@@ -160,7 +159,6 @@ PUT _cluster/settings
   }
 }
 --------------------------------
-// CONSOLE
 // TEST[continued]
 
 NOTE: When the compression or ping schedule settings change, all the existing
@@ -169,7 +167,7 @@ fail.
 
 A remote cluster can be deleted from the cluster settings by setting its seeds and optional settings to `null` :
 
-[source,js]
+[source,console]
 --------------------------------
 PUT _cluster/settings
 {
@@ -188,8 +186,8 @@ PUT _cluster/settings
   }
 }
 --------------------------------
-// CONSOLE
 // TEST[continued]
+
 <1> `cluster_two` would be removed from the cluster settings, leaving
 `cluster_one` and `cluster_three` intact.
 

--- a/docs/reference/modules/snapshots.asciidoc
+++ b/docs/reference/modules/snapshots.asciidoc
@@ -91,7 +91,7 @@ be corrupted. While setting the repository to `readonly` on all but one of the
 clusters should work with multiple clusters differing by one major version, it
 is not a supported configuration.
 
-[source,js]
+[source,console]
 -----------------------------------
 PUT /_snapshot/my_backup
 {
@@ -101,16 +101,14 @@ PUT /_snapshot/my_backup
   }
 }
 -----------------------------------
-// CONSOLE
 // TESTSETUP
 
 To retrieve information about a registered repository, use a GET request:
 
-[source,js]
+[source,console]
 -----------------------------------
 GET /_snapshot/my_backup
 -----------------------------------
-// CONSOLE
 
 which returns:
 
@@ -132,28 +130,25 @@ specifying repository names. For example, the following request retrieves
 information about all of the snapshot repositories that start with `repo` or
 contain `backup`:
 
-[source,js]
+[source,console]
 -----------------------------------
 GET /_snapshot/repo*,*backup*
 -----------------------------------
-// CONSOLE
 
 To retrieve information about all registered snapshot repositories, omit the
 repository name or specify `_all`:
 
-[source,js]
+[source,console]
 -----------------------------------
 GET /_snapshot
 -----------------------------------
-// CONSOLE
 
 or
 
-[source,js]
+[source,console]
 -----------------------------------
 GET /_snapshot/_all
 -----------------------------------
-// CONSOLE
 
 [float]
 ===== Shared File System Repository
@@ -182,7 +177,7 @@ path.repo: ["\\\\MY_SERVER\\Snapshots"]
 After all nodes are restarted, the following command can be used to register the shared file system repository with
 the name `my_fs_backup`:
 
-[source,js]
+[source,console]
 -----------------------------------
 PUT /_snapshot/my_fs_backup
 {
@@ -193,13 +188,12 @@ PUT /_snapshot/my_fs_backup
     }
 }
 -----------------------------------
-// CONSOLE
 // TEST[skip:no access to absolute path]
 
 If the repository location is specified as a relative path this path will be resolved against the first path specified
 in `path.repo`:
 
-[source,js]
+[source,console]
 -----------------------------------
 PUT /_snapshot/my_fs_backup
 {
@@ -210,7 +204,6 @@ PUT /_snapshot/my_fs_backup
     }
 }
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 The following settings are supported:
@@ -277,7 +270,7 @@ When you restore a source only snapshot:
 When you create a source repository, you must specify the type and name of the delegate repository
 where the snapshots will be stored:
 
-[source,js]
+[source,console]
 -----------------------------------
 PUT _snapshot/my_src_only_repository
 {
@@ -288,7 +281,6 @@ PUT _snapshot/my_src_only_repository
   }
 }
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 [float]
@@ -307,7 +299,7 @@ When a repository is registered, it's immediately verified on all master and dat
 on all nodes currently present in the cluster. The `verify` parameter can be used to explicitly disable the repository
 verification when registering or updating a repository:
 
-[source,js]
+[source,console]
 -----------------------------------
 PUT /_snapshot/my_unverified_backup?verify=false
 {
@@ -317,16 +309,14 @@ PUT /_snapshot/my_unverified_backup?verify=false
   }
 }
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 The verification process can also be executed manually by running the following command:
 
-[source,js]
+[source,console]
 -----------------------------------
 POST /_snapshot/my_unverified_backup/_verify
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 It returns a list of nodes where repository was successfully verified or an error message if verification process failed.
@@ -339,11 +329,10 @@ process. This unreferenced data does in no way negatively impact the performance
 than necessary storage use. In order to clean up this unreferenced data, users can call the cleanup endpoint for a repository which will
 trigger a complete accounting of the repositories contents and subsequent deletion of all unreferenced data that was found.
 
-[source,js]
+[source,console]
 -----------------------------------
 POST /_snapshot/my_repository/_cleanup
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 The response to a cleanup request looks as follows:
@@ -374,11 +363,10 @@ A repository can contain multiple snapshots of the same cluster. Snapshots are i
 cluster. A snapshot with the name `snapshot_1` in the repository `my_backup` can be created by executing the following
 command:
 
-[source,js]
+[source,console]
 -----------------------------------
 PUT /_snapshot/my_backup/snapshot_1?wait_for_completion=true
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 The `wait_for_completion` parameter specifies whether or not the request should return immediately after snapshot
@@ -389,7 +377,7 @@ even minutes) for this command to return even if the `wait_for_completion` param
 By default a snapshot of all open and started indices in the cluster is created. This behavior can be changed by
 specifying the list of indices in the body of the snapshot request.
 
-[source,js]
+[source,console]
 -----------------------------------
 PUT /_snapshot/my_backup/snapshot_2?wait_for_completion=true
 {
@@ -402,7 +390,6 @@ PUT /_snapshot/my_backup/snapshot_2?wait_for_completion=true
   }
 }
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 The list of indices that should be included into the snapshot can be specified using the `indices` parameter that
@@ -421,12 +408,12 @@ new indices. Note that special characters need to be URI encoded.
 
 For example, creating a snapshot with the current day in the name, like `snapshot-2018.05.11`, can be achieved with
 the following command:
-[source,js]
+
+[source,console]
 -----------------------------------
 # PUT /_snapshot/my_backup/<snapshot-{now/d}>
 PUT /_snapshot/my_backup/%3Csnapshot-%7Bnow%2Fd%7D%3E
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 
@@ -452,11 +439,10 @@ filtering settings and rebalancing algorithm) once the snapshot is finished.
 
 Once a snapshot is created information about this snapshot can be obtained using the following command:
 
-[source,sh]
+[source,console]
 -----------------------------------
 GET /_snapshot/my_backup/snapshot_1
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 This command returns basic information about the snapshot including start and end time, version of
@@ -490,20 +476,18 @@ snapshot and the list of failures that occurred during the snapshot. The snapsho
 
 Similar as for repositories, information about multiple snapshots can be queried in one go, supporting wildcards as well:
 
-[source,sh]
+[source,console]
 -----------------------------------
 GET /_snapshot/my_backup/snapshot_*,some_other_snapshot
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 All snapshots currently stored in the repository can be listed using the following command:
 
-[source,sh]
+[source,console]
 -----------------------------------
 GET /_snapshot/my_backup/_all
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 The command fails if some of the snapshots are unavailable. The boolean parameter `ignore_unavailable` can be used to
@@ -519,31 +503,29 @@ such as status information, the number of snapshotted shards, etc.  The default
 value of the `verbose` parameter is `true`.
 
 It is also possible to retrieve snapshots from multiple repositories in one go, for example:
-[source,sh]
+
+[source,console]
 -----------------------------------
 GET /_snapshot/_all
 GET /_snapshot/my_backup,my_fs_backup
 GET /_snapshot/my*/snap*
 -----------------------------------
-// CONSOLE
 // TEST[skip:no my_fs_backup]
 
 A currently running snapshot can be retrieved using the following command:
 
-[source,sh]
+[source,console]
 -----------------------------------
 GET /_snapshot/my_backup/_current
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 A snapshot can be deleted from the repository using the following command:
 
-[source,sh]
+[source,console]
 -----------------------------------
 DELETE /_snapshot/my_backup/snapshot_2
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 When a snapshot is deleted from a repository, Elasticsearch deletes all files that are associated with the deleted
@@ -554,11 +536,10 @@ started by mistake.
 
 A repository can be unregistered using the following command:
 
-[source,sh]
+[source,console]
 -----------------------------------
 DELETE /_snapshot/my_backup
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 When a repository is unregistered, Elasticsearch only removes the reference to the location where the repository is storing
@@ -570,11 +551,10 @@ the snapshots. The snapshots themselves are left untouched and in place.
 
 A snapshot can be restored using the following command:
 
-[source,sh]
+[source,console]
 -----------------------------------
 POST /_snapshot/my_backup/snapshot_1/_restore
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 By default, all indices in the snapshot are restored, and the cluster state is
@@ -589,7 +569,7 @@ http://docs.oracle.com/javase/6/docs/api/java/util/regex/Matcher.html#appendRepl
 Set `include_aliases` to `false` to prevent aliases from being restored together
 with associated indices
 
-[source,js]
+[source,console]
 -----------------------------------
 POST /_snapshot/my_backup/snapshot_1/_restore
 {
@@ -600,7 +580,6 @@ POST /_snapshot/my_backup/snapshot_1/_restore
   "rename_replacement": "restored_index_$1"
 }
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 The restore operation can be performed on a functioning cluster. However, an
@@ -628,7 +607,7 @@ restored in this case and all missing shards will be recreated empty.
 Most of index settings can be overridden during the restore process. For example, the following command will restore
 the index `index_1` without creating any replicas while switching back to default refresh interval:
 
-[source,js]
+[source,console]
 -----------------------------------
 POST /_snapshot/my_backup/snapshot_1/_restore
 {
@@ -641,7 +620,6 @@ POST /_snapshot/my_backup/snapshot_1/_restore
   ]
 }
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 Please note, that some settings such as `index.number_of_shards` cannot be changed during restore operation.
@@ -673,31 +651,28 @@ the global cluster state.
 
 A list of currently running snapshots with their detailed status information can be obtained using the following command:
 
-[source,sh]
+[source,console]
 -----------------------------------
 GET /_snapshot/_status
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 In this format, the command will return information about all currently running snapshots. By specifying a repository name, it's possible
 to limit the results to a particular repository:
 
-[source,sh]
+[source,console]
 -----------------------------------
 GET /_snapshot/my_backup/_status
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 If both repository name and snapshot id are specified, this command will return detailed status information for the given snapshot even
 if it's not currently running:
 
-[source,sh]
+[source,console]
 -----------------------------------
 GET /_snapshot/my_backup/snapshot_1/_status
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 The output looks similar to the following:
@@ -749,11 +724,10 @@ in progress, there's also a `processed` section that contains information about 
 
 Multiple ids are also supported:
 
-[source,sh]
+[source,console]
 -----------------------------------
 GET /_snapshot/my_backup/snapshot_1,snapshot_2/_status
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 [float]
@@ -766,11 +740,10 @@ the simplest method that can be used to get notified about operation completion.
 
 The snapshot operation can be also monitored by periodic calls to the snapshot info:
 
-[source,sh]
+[source,console]
 -----------------------------------
 GET /_snapshot/my_backup/snapshot_1
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 Please note that snapshot info operation uses the same resources and thread pool as the snapshot operation. So,
@@ -779,11 +752,10 @@ for available resources before returning the result. On very large shards the wa
 
 To get more immediate and complete information about snapshots the snapshot status command can be used instead:
 
-[source,sh]
+[source,console]
 -----------------------------------
 GET /_snapshot/my_backup/snapshot_1/_status
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 While snapshot info method returns only basic information about the snapshot in progress, the snapshot status returns
@@ -809,11 +781,10 @@ running snapshot was executed by mistake, or takes unusually long, it can be ter
 The snapshot delete operation checks if the deleted snapshot is currently running and if it does, the delete operation stops
 that snapshot before deleting the snapshot data from the repository.
 
-[source,sh]
+[source,console]
 -----------------------------------
 DELETE /_snapshot/my_backup/snapshot_1
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 The restore operation uses the standard shard recovery mechanism. Therefore, any currently running restore operation can

--- a/docs/reference/modules/transport.asciidoc
+++ b/docs/reference/modules/transport.asciidoc
@@ -153,7 +153,7 @@ request was uncompressed--even when compression is enabled.
 The transport module has a dedicated tracer logger which, when activated, logs incoming and out going requests. The log can be dynamically activated
 by settings the level of the `org.elasticsearch.transport.TransportService.tracer` logger to `TRACE`:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _cluster/settings
 {
@@ -162,12 +162,11 @@ PUT _cluster/settings
    }
 }
 --------------------------------------------------
-// CONSOLE
 
 You can also control which actions will be traced, using a set of include and exclude wildcard patterns. By default every request will be traced
 except for fault detection pings:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _cluster/settings
 {
@@ -177,6 +176,3 @@ PUT _cluster/settings
    }
 }
 --------------------------------------------------
-// CONSOLE
-
-

--- a/docs/reference/monitoring/collecting-monitoring-data.asciidoc
+++ b/docs/reference/monitoring/collecting-monitoring-data.asciidoc
@@ -53,7 +53,7 @@ view the cluster settings and `manage` cluster privileges to change them.
 
 For example, use the following APIs to review and change this setting:
 
-[source,js]
+[source,console]
 ----------------------------------
 GET _cluster/settings
 
@@ -64,7 +64,6 @@ PUT _cluster/settings
   }
 }
 ----------------------------------
-// CONSOLE
 
 Alternatively, you can enable this setting in {kib}. In the side navigation, 
 click *Monitoring*. If data collection is disabled, you are prompted to turn it 

--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -28,7 +28,7 @@ production cluster. By default, it is is disabled (`false`).
 
 You can use the following APIs to review and change this setting:
 
-[source,js]
+[source,console]
 ----------------------------------
 GET _cluster/settings
 
@@ -38,8 +38,7 @@ PUT _cluster/settings
     "xpack.monitoring.collection.enabled": true
   }
 }
-----------------------------------
-// CONSOLE 
+---------------------------------- 
 
 If {es} {security-features} are enabled, you must have `monitor` cluster privileges to 
 view the cluster settings and `manage` cluster privileges to change them.
@@ -194,7 +193,7 @@ production cluster.
 
 You can use the following API to change this setting:
 
-[source,js]
+[source,console]
 ----------------------------------
 PUT _cluster/settings
 {
@@ -203,7 +202,6 @@ PUT _cluster/settings
   }
 }
 ----------------------------------
-// CONSOLE
 
 If {es} {security-features} are enabled, you must have `monitor` cluster
 privileges to  view the cluster settings and `manage` cluster privileges

--- a/docs/reference/monitoring/indices.asciidoc
+++ b/docs/reference/monitoring/indices.asciidoc
@@ -8,11 +8,10 @@ that store the monitoring data collected from a cluster.
 
 You can retrieve the templates through the `_template` API:
 
-[source,sh]
+[source,console]
 ----------------------------------
 GET /_template/.monitoring-*
 ----------------------------------
-// CONSOLE
 
 By default, the template configures one shard and one replica for the
 monitoring indices. To override the default settings, add your own template:
@@ -26,7 +25,7 @@ section.
 For example, the following template increases the number of shards to five
 and the number of replicas to two.
 
-[source,js]
+[source,console]
 ----------------------------------
 PUT /_template/custom_monitoring
 {
@@ -38,7 +37,6 @@ PUT /_template/custom_monitoring
     }
 }
 ----------------------------------
-// CONSOLE
 
 IMPORTANT: Only set the `number_of_shards` and `number_of_replicas` in the
 settings section. Overriding other monitoring template settings could cause

--- a/docs/reference/query-dsl/bool-query.asciidoc
+++ b/docs/reference/query-dsl/bool-query.asciidoc
@@ -32,7 +32,7 @@ The `bool` query takes a _more-matches-is-better_ approach, so the score from
 each matching `must` or `should` clause will be added together to provide the
 final `_score` for each document.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _search
 {
@@ -59,7 +59,6 @@ POST _search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 [[score-bool-filter]]
 ==== Scoring with `bool.filter`
@@ -72,7 +71,7 @@ all documents where the `status` field contains the term `active`.
 This first query assigns a score of `0` to all documents, as no scoring
 query has been specified:
 
-[source,js]
+[source,console]
 ---------------------------------
 GET _search
 {
@@ -87,12 +86,11 @@ GET _search
   }
 }
 ---------------------------------
-// CONSOLE
 
 This `bool` query has a `match_all` query, which assigns a score of `1.0` to
 all documents.
 
-[source,js]
+[source,console]
 ---------------------------------
 GET _search
 {
@@ -110,13 +108,12 @@ GET _search
   }
 }
 ---------------------------------
-// CONSOLE
 
 This `constant_score` query behaves in exactly the same way as the second example above.
 The `constant_score` query assigns a score of `1.0` to all documents matched
 by the filter.
 
-[source,js]
+[source,console]
 ---------------------------------
 GET _search
 {
@@ -131,7 +128,6 @@ GET _search
   }
 }
 ---------------------------------
-// CONSOLE
 
 ==== Using named queries to see which clauses matched
 

--- a/docs/reference/query-dsl/boosting-query.asciidoc
+++ b/docs/reference/query-dsl/boosting-query.asciidoc
@@ -14,7 +14,7 @@ excluding them from the search results.
 [[boosting-query-ex-request]]
 ==== Example request
 
-[source,js]
+[source,console]
 ----
 GET /_search
 {
@@ -35,7 +35,6 @@ GET /_search
     }
 }
 ----
-// CONSOLE
 
 [[boosting-top-level-params]]
 ==== Top-level parameters for `boosting`

--- a/docs/reference/query-dsl/constant-score-query.asciidoc
+++ b/docs/reference/query-dsl/constant-score-query.asciidoc
@@ -8,7 +8,7 @@ Wraps a <<query-dsl-bool-query, filter query>> and returns every matching
 document with a <<relevance-scores,relevance score>> equal to the `boost`
 parameter value.
 
-[source,js]
+[source,console]
 ----
 GET /_search
 {
@@ -22,7 +22,6 @@ GET /_search
     }
 }
 ----
-// CONSOLE
 
 [[constant-score-top-level-params]]
 ==== Top-level parameters for `constant_score`

--- a/docs/reference/query-dsl/dis-max-query.asciidoc
+++ b/docs/reference/query-dsl/dis-max-query.asciidoc
@@ -17,7 +17,7 @@ You can use the `dis_max` to search for a term in fields mapped with different
 [[query-dsl-dis-max-query-ex-request]]
 ==== Example request
 
-[source,js]
+[source,console]
 ----
 GET /_search
 {
@@ -32,7 +32,6 @@ GET /_search
     }
 }    
 ----
-// CONSOLE
 
 [[query-dsl-dis-max-query-top-level-params]]
 ==== Top-level parameters for `dis_max`

--- a/docs/reference/query-dsl/distance-feature-query.asciidoc
+++ b/docs/reference/query-dsl/distance-feature-query.asciidoc
@@ -33,7 +33,7 @@ following example.
 * `production_date`, a <<date, `date`>> field
 * `location`, a <<geo-point,`geo_point`>> field
 
-[source,js]
+[source,console]
 ----
 PUT /items
 {
@@ -52,14 +52,13 @@ PUT /items
   }
 }
 ----
-// CONSOLE
 // TESTSETUP
 --
 
 . Index several documents to this index.
 +
 --
-[source,js]
+[source,console]
 ----
 PUT /items/_doc/1?refresh
 {
@@ -83,7 +82,6 @@ PUT /items/_doc/3?refresh
   "location": [-71.3, 41.12]
 }
 ----
-// CONSOLE
 --
 
 
@@ -96,7 +94,7 @@ The following `bool` search returns documents with a `name` value of
 `chocolate`. The search also uses the `distance_feature` query to increase the
 relevance score of documents with a `production_date` value closer to `now`.
 
-[source,js]
+[source,console]
 ----
 GET /items/_search
 {
@@ -118,7 +116,6 @@ GET /items/_search
   }
 }
 ----
-// CONSOLE
 
 [[distance-feature-query-distance-ex]]
 ====== Boost documents based on location
@@ -126,7 +123,7 @@ The following `bool` search returns documents with a `name` value of
 `chocolate`. The search also uses the `distance_feature` query to increase the
 relevance score of documents with a `location` value closer to `[-71.3, 41.15]`.
 
-[source,js]
+[source,console]
 ----
 GET /items/_search
 {
@@ -148,7 +145,6 @@ GET /items/_search
   }
 }
 ----
-// CONSOLE
 
 
 [[distance-feature-top-level-params]]

--- a/docs/reference/query-dsl/exists-query.asciidoc
+++ b/docs/reference/query-dsl/exists-query.asciidoc
@@ -16,7 +16,7 @@ An indexed value may not exist for a document's field due to a variety of reason
 [[exists-query-ex-request]]
 ==== Example request
 
-[source,js]
+[source,console]
 ----
 GET /_search
 {
@@ -27,7 +27,6 @@ GET /_search
     }
 }
 ----
-// CONSOLE
 
 [[exists-query-top-level-params]]
 ==== Top-level parameters for `exists`
@@ -53,7 +52,7 @@ query.
 The following search returns documents that are missing an indexed value for
 the `user` field.
 
-[source,js]
+[source,console]
 ----
 GET /_search
 {
@@ -68,4 +67,3 @@ GET /_search
     }
 }
 ----
-// CONSOLE

--- a/docs/reference/query-dsl/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/function-score-query.asciidoc
@@ -15,7 +15,7 @@ by the query.
 
 `function_score` can be used with only one function like this:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -29,7 +29,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 <1> See <<score-functions>> for a list of supported functions.
@@ -38,7 +37,7 @@ Furthermore, several functions can be combined. In this case one can
 optionally choose to apply the function only if a document matches a
 given filtering query
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -65,7 +64,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 <1> Boost for the whole query.
@@ -135,7 +133,7 @@ the scoring of it optionally with a computation derived from other numeric
 field values in the doc using a script expression. Here is a
 simple sample:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -153,7 +151,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 NOTE: Scores produced by the `script_score` function must be non-negative,
@@ -167,7 +164,7 @@ Scripts compilation is cached for faster execution. If the script has
 parameters that it needs to take into account, it is preferable to reuse the
 same script, and provide parameters to it:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -189,7 +186,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 Note that unlike the `custom_score` query, the
@@ -234,7 +230,7 @@ NOTE: It was possible to set a seed without setting a field, but this has been
 deprecated as this requires loading fielddata on the `_id` field which consumes
 a lot of memory.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -248,7 +244,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 [[function-field-value-factor]]
@@ -263,7 +258,7 @@ As an example, imagine you have a document indexed with a numeric `likes`
 field and wish to influence the score of a document with this field, an example
 doing so would look like:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -279,7 +274,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 Which will translate into the following formula for scoring:
@@ -375,7 +369,7 @@ this case. If your field is a date field, you can set `scale` and `offset` as
 days, weeks, and so on. Example:
 
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -393,8 +387,8 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
+
 <1> The date format of the origin depends on the <<mapping-date-format,`format`>> defined in
     your mapping. If you do not define the origin, the current time is used.
 <2> The `offset` and `decay` parameters are optional.
@@ -573,7 +567,7 @@ and for `location`:
 Suppose you want to multiply these two functions on the original score,
 the request would look like this:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -607,7 +601,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 Next, we show how the computed score looks like for each of the three
 possible decay functions.

--- a/docs/reference/query-dsl/fuzzy-query.asciidoc
+++ b/docs/reference/query-dsl/fuzzy-query.asciidoc
@@ -25,7 +25,7 @@ The query then returns exact matches for each expansion.
 [[fuzzy-query-ex-simple]]
 ===== Simple example
 
-[source,js]
+[source,console]
 ----
 GET /_search
 {
@@ -38,12 +38,11 @@ GET /_search
     }
 }
 ----
-// CONSOLE
 
 [[fuzzy-query-ex-advanced]]
 ===== Example using advanced parameters
 
-[source,js]
+[source,console]
 ----
 GET /_search
 {
@@ -61,7 +60,6 @@ GET /_search
     }
 }
 ----
-// CONSOLE
 
 [[fuzzy-query-top-level-params]]
 ==== Top-level parameters for `fuzzy`

--- a/docs/reference/query-dsl/geo-bounding-box-query.asciidoc
+++ b/docs/reference/query-dsl/geo-bounding-box-query.asciidoc
@@ -7,7 +7,7 @@
 A query allowing to filter hits based on a point location using a
 bounding box. Assuming the following indexed document:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /my_locations
 {
@@ -34,13 +34,12 @@ PUT /my_locations/_doc/1
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TESTSETUP
 
 Then the following simple query can be executed with a
 `geo_bounding_box` filter:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET my_locations/_search
 {
@@ -67,7 +66,6 @@ GET my_locations/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 [float]
 ==== Query Options
@@ -95,7 +93,7 @@ representations of the geo point, the filter can accept it as well:
 [float]
 ===== Lat Lon As Properties
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET my_locations/_search
 {
@@ -122,7 +120,6 @@ GET my_locations/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 [float]
 ===== Lat Lon As Array
@@ -130,7 +127,7 @@ GET my_locations/_search
 Format in `[lon, lat]`, note, the order of lon/lat here in order to
 conform with http://geojson.org/[GeoJSON].
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET my_locations/_search
 {
@@ -151,14 +148,13 @@ GET my_locations/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 [float]
 ===== Lat Lon As String
 
 Format in `lat,lon`.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET my_locations/_search
 {
@@ -179,12 +175,11 @@ GET my_locations/_search
 }
 }
 --------------------------------------------------
-// CONSOLE
 
 [float]
 ===== Bounding Box as Well-Known Text (WKT)
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET my_locations/_search
 {
@@ -204,12 +199,11 @@ GET my_locations/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 [float]
 ===== Geohash
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET my_locations/_search
 {
@@ -230,7 +224,6 @@ GET my_locations/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 
 When geohashes are used to specify the bounding the edges of the
@@ -244,7 +237,7 @@ In order to specify a bounding box that would match entire area of a
 geohash the geohash can be specified in both `top_left` and
 `bottom_right` parameters:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET my_locations/_search
 {
@@ -258,7 +251,6 @@ GET my_locations/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 In this example, the geohash `dr` will produce the bounding box
 query with the top left corner at `45.0,-78.75` and the bottom right
@@ -274,7 +266,7 @@ are supported. Instead of setting the values pairwise, one can use
 the simple names `top`, `left`, `bottom` and `right` to set the
 values separately.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET my_locations/_search
 {
@@ -297,7 +289,6 @@ GET my_locations/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 
 [float]
@@ -324,7 +315,7 @@ that the `geo_point` type must have lat and lon indexed in this case).
 Note, when using the indexed option, multi locations per document field
 are not supported. Here is an example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET my_locations/_search
 {
@@ -352,7 +343,6 @@ GET my_locations/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 [float]
 ==== Ignore Unmapped

--- a/docs/reference/query-dsl/geo-distance-query.asciidoc
+++ b/docs/reference/query-dsl/geo-distance-query.asciidoc
@@ -8,7 +8,7 @@ Filters documents that include only hits that exists within a specific
 distance from a geo point. Assuming the following mapping and indexed
 document:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /my_locations
 {
@@ -35,14 +35,13 @@ PUT /my_locations/_doc/1
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TESTSETUP
 
 
 Then the following simple query can be executed with a `geo_distance`
 filter:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /my_locations/_search
 {
@@ -64,7 +63,6 @@ GET /my_locations/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 [float]
 ==== Accepted Formats
@@ -75,7 +73,7 @@ representations of the geo point, the filter can accept it as well:
 [float]
 ===== Lat Lon As Properties
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /my_locations/_search
 {
@@ -97,7 +95,6 @@ GET /my_locations/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 [float]
 ===== Lat Lon As Array
@@ -105,7 +102,7 @@ GET /my_locations/_search
 Format in `[lon, lat]`, note, the order of lon/lat here in order to
 conform with http://geojson.org/[GeoJSON].
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /my_locations/_search
 {
@@ -124,7 +121,6 @@ GET /my_locations/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 
 [float]
@@ -132,7 +128,7 @@ GET /my_locations/_search
 
 Format in `lat,lon`.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /my_locations/_search
 {
@@ -151,12 +147,11 @@ GET /my_locations/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 [float]
 ===== Geohash
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /my_locations/_search
 {
@@ -175,7 +170,6 @@ GET /my_locations/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 [float]
 ==== Options

--- a/docs/reference/query-dsl/geo-polygon-query.asciidoc
+++ b/docs/reference/query-dsl/geo-polygon-query.asciidoc
@@ -7,7 +7,7 @@
 A query returning hits that only fall within a polygon of
 points. Here is an example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -31,7 +31,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 [float]
 ==== Query Options
@@ -57,7 +56,7 @@ Format as `[lon, lat]`
 Note: the order of lon/lat here must
 conform with http://geojson.org/[GeoJSON].
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -81,14 +80,13 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 [float]
 ===== Lat Lon as String
 
 Format in `lat,lon`.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -112,12 +110,11 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 [float]
 ===== Geohash
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -141,7 +138,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 [float]
 ==== geo_point Type

--- a/docs/reference/query-dsl/geo-shape-query.asciidoc
+++ b/docs/reference/query-dsl/geo-shape-query.asciidoc
@@ -25,7 +25,7 @@ http://www.geojson.org[GeoJSON] to represent shapes.
 
 Given the following index:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /example
 {
@@ -47,13 +47,12 @@ POST /example/_doc?refresh
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TESTSETUP
 
 The following query will find the point using the Elasticsearch's
 `envelope` GeoJSON extension:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /example/_search
 {
@@ -77,7 +76,6 @@ GET /example/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 ==== Pre-Indexed Shape
 
@@ -98,7 +96,7 @@ Defaults to 'shape'.
 The following is an example of using the Filter with a pre-indexed
 shape:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /shapes
 {
@@ -138,7 +136,6 @@ GET /example/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 ==== Spatial Relations
 

--- a/docs/reference/query-dsl/has-child-query.asciidoc
+++ b/docs/reference/query-dsl/has-child-query.asciidoc
@@ -27,7 +27,7 @@ the `has_child` query, use it as rarely as possible.
 To use the `has_child` query, your index must include a <<parent-join,join>>
 field mapping. For example:
 
-[source,js]
+[source,console]
 ----
 PUT /my_index
 {
@@ -44,13 +44,12 @@ PUT /my_index
 }
 
 ----
-// CONSOLE
 // TESTSETUP
 
 [[has-child-query-ex-query]]
 ===== Example query
 
-[source,js]
+[source,console]
 ----
 GET /_search
 {
@@ -67,7 +66,6 @@ GET /_search
     }
 }
 ----
-// CONSOLE
 
 [[has-child-top-level-params]]
 ==== Top-level parameters for `has_child`
@@ -139,7 +137,7 @@ If you need to sort returned documents by a field in their child documents, use
 a `function_score` query and sort by `_score`. For example, the following query
 sorts returned documents by the `click_count` field of their child documents.
 
-[source,js]
+[source,console]
 ----
 GET /_search
 {
@@ -158,4 +156,3 @@ GET /_search
     }
 }
 ----
-// CONSOLE

--- a/docs/reference/query-dsl/has-parent-query.asciidoc
+++ b/docs/reference/query-dsl/has-parent-query.asciidoc
@@ -23,7 +23,7 @@ Each `has_parent` query in a search can increase query time significantly.
 To use the `has_parent` query, your index must include a <<parent-join,join>>
 field mapping. For example:
 
-[source,js]
+[source,console]
 ----
 PUT /my-index
 {
@@ -43,13 +43,12 @@ PUT /my-index
 }
 
 ----
-// CONSOLE
 // TESTSETUP
 
 [[has-parent-query-ex-query]]
 ===== Example query
 
-[source,js]
+[source,console]
 ----
 GET /my-index/_search
 {
@@ -67,7 +66,6 @@ GET /my-index/_search
     }
 }
 ----
-// CONSOLE
 
 [[has-parent-top-level-params]]
 ==== Top-level parameters for `has_parent`
@@ -120,7 +118,7 @@ If you need to sort returned documents by a field in their parent documents, use
 a `function_score` query and sort by `_score`. For example, the following query
 sorts returned documents by the `view_count` field of their parent documents.
 
-[source,js]
+[source,console]
 ----
 GET /_search
 {
@@ -139,4 +137,3 @@ GET /_search
     }
 }
 ----
-// CONSOLE

--- a/docs/reference/query-dsl/ids-query.asciidoc
+++ b/docs/reference/query-dsl/ids-query.asciidoc
@@ -9,7 +9,7 @@ the <<mapping-id-field,`_id`>> field.
 
 ==== Example request
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -20,7 +20,6 @@ GET /_search
     }
 }    
 --------------------------------------------------
-// CONSOLE
 
 [[ids-query-top-level-parameters]]
 ==== Top-level parameters for `ids`

--- a/docs/reference/query-dsl/intervals-query.asciidoc
+++ b/docs/reference/query-dsl/intervals-query.asciidoc
@@ -24,7 +24,7 @@ favorite food` immediately followed by `hot water` or `cold porridge` in the
 This search would match a `my_text` value of `my favorite food is cold
 porridge` but not `when it's cold my favorite food is porridge`.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _search
 {
@@ -56,7 +56,6 @@ POST _search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 [[intervals-top-level-params]]
 ==== Top-level parameters for `intervals`
@@ -273,7 +272,7 @@ The following search includes a `filter` rule. It returns documents that have
 the words `hot` and `porridge` within 10 positions of each other, without the
 word `salty` in between:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _search
 {
@@ -296,7 +295,6 @@ POST _search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 [[interval-script-filter]]
 ===== Script filters
@@ -305,7 +303,7 @@ You can use a script to filter intervals based on their start position, end
 position, and internal gap count. The following `filter` script uses the
 `interval` variable with the `start`, `end`, and `gaps` methods:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _search
 {
@@ -325,7 +323,6 @@ POST _search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 
 [[interval-minimization]]
@@ -337,7 +334,7 @@ when using `max_gaps` restrictions or filters. For example, take the
 following query, searching for `salty` contained within the phrase `hot
 porridge`:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _search
 {
@@ -359,7 +356,6 @@ POST _search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 This query does *not* match a document containing the phrase `hot porridge is
 salty porridge`, because the intervals returned by the match query for `hot
@@ -373,7 +369,7 @@ cause surprises when used in combination with `max_gaps`. Consider the
 following query, searching for `the` immediately followed by `big` or `big bad`,
 immediately followed by `wolf`:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _search
 {
@@ -398,7 +394,6 @@ POST _search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 Counter-intuitively, this query does *not* match the document `the big bad
 wolf`, because the `any_of` rule in the middle only produces intervals
@@ -407,7 +402,7 @@ starting at the same position, and so being minimized away. In these cases,
 it's better to rewrite the query so that all of the options are explicitly
 laid out at the top level:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _search
 {
@@ -431,4 +426,3 @@ POST _search
   }
 }
 --------------------------------------------------
-// CONSOLE

--- a/docs/reference/query-dsl/match-all-query.asciidoc
+++ b/docs/reference/query-dsl/match-all-query.asciidoc
@@ -7,7 +7,7 @@
 The most simple query, which matches all documents, giving them all a `_score`
 of `1.0`.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 { 
@@ -16,11 +16,10 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 The `_score` can be changed with the `boost` parameter:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -29,7 +28,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 [[query-dsl-match-none-query]]
 [float]
@@ -37,7 +35,7 @@ GET /_search
 
 This is the inverse of the `match_all` query, which matches no documents.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -46,4 +44,3 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE

--- a/docs/reference/query-dsl/match-bool-prefix-query.asciidoc
+++ b/docs/reference/query-dsl/match-bool-prefix-query.asciidoc
@@ -9,7 +9,7 @@ A `match_bool_prefix` query analyzes its input and constructs a
 is used in a `term` query. The last term is used in a `prefix` query. A
 `match_bool_prefix` query such as
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -20,12 +20,11 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 where analysis produces the terms `quick`, `brown`, and `f` is similar to the
 following `bool` query
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -40,7 +39,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 An important difference between the `match_bool_prefix` query and
 <<query-dsl-match-query-phrase-prefix,`match_phrase_prefix`>> is that the
@@ -57,7 +55,7 @@ By default, `match_bool_prefix` queries' input text will be analyzed using the
 analyzer from the queried field's mapping. A different search analyzer can be
 configured with the `analyzer` parameter
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -71,7 +69,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 `match_bool_prefix` queries support the
 <<query-dsl-minimum-should-match,`minimum_should_match`>> and `operator`

--- a/docs/reference/query-dsl/match-phrase-prefix-query.asciidoc
+++ b/docs/reference/query-dsl/match-phrase-prefix-query.asciidoc
@@ -18,7 +18,7 @@ The following search returns documents that contain phrases beginning with
 This search would match a `message` value of `quick brown fox` or `two quick
 brown ferrets` but not `the fox is quick and brown`.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -31,7 +31,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 
 [[match-phrase-prefix-top-level-params]]

--- a/docs/reference/query-dsl/match-phrase-query.asciidoc
+++ b/docs/reference/query-dsl/match-phrase-query.asciidoc
@@ -7,7 +7,7 @@
 The `match_phrase` query analyzes the text and creates a `phrase` query
 out of the analyzed text. For example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -18,7 +18,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 A phrase query matches terms up to a configurable `slop`
 (which defaults to 0) in any order. Transposed terms have a slop of 2.
@@ -27,7 +26,7 @@ The `analyzer` can be set to control which analyzer will perform the
 analysis process on the text. It defaults to the field explicit mapping
 definition, or the default search analyzer, for example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -41,6 +40,5 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 This query also accepts `zero_terms_query`, as explained in <<query-dsl-match-query, `match` query>>.

--- a/docs/reference/query-dsl/match-query.asciidoc
+++ b/docs/reference/query-dsl/match-query.asciidoc
@@ -14,7 +14,7 @@ including options for fuzzy matching.
 [[match-query-ex-request]]
 ==== Example request
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -27,7 +27,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 
 [[match-top-level-params]]
@@ -147,7 +146,7 @@ See <<query-dsl-match-query-zero>> for an example.
 You can simplify the match query syntax by combining the `<field>` and `query`
 parameters. For example:
 
-[source,js]
+[source,console]
 ----
 GET /_search
 {
@@ -158,7 +157,6 @@ GET /_search
     }
 }
 ----
-// CONSOLE
 
 [[query-dsl-match-query-boolean]]
 ===== How the match query works
@@ -173,7 +171,7 @@ parameter.
 
 Here is an example with the `operator` parameter:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -187,7 +185,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 The `analyzer` can be set to control which analyzer will perform the
 analysis process on the text. It defaults to the field explicit mapping
@@ -218,7 +215,7 @@ analysis process produces multiple tokens at the same position. Under the hood
 these terms are expanded to a special synonym query that blends term frequencies,
 which does not support fuzzy expansion.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -232,7 +229,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 [[query-dsl-match-query-zero]]
 ===== Zero terms query
@@ -241,7 +237,7 @@ does, the default behavior is to match no documents at all. In order to
 change that the `zero_terms_query` option can be used, which accepts
 `none` (default) and `all` which corresponds to a `match_all` query.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -256,7 +252,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 [[query-dsl-match-query-synonyms]]
 ===== Synonyms
@@ -269,7 +264,7 @@ For example, the following synonym: `"ny, new york" would produce:`
 
 It is also possible to match multi terms synonyms with conjunctions instead:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -283,7 +278,6 @@ GET /_search
    }
 }
 --------------------------------------------------
-// CONSOLE
 
 The example above creates a boolean query:
 

--- a/docs/reference/query-dsl/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/mlt-query.asciidoc
@@ -15,7 +15,7 @@ provided piece of text. Here, we are asking for all movies that have some text
 similar to "Once upon a time" in their "title" and in their "description"
 fields, limiting the number of selected terms to 12.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -29,13 +29,12 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 A more complicated use case consists of mixing texts with documents already
 existing in the index. In this case, the syntax to specify a document is
 similar to the one used in the <<docs-multi-get,Multi GET API>>.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -59,13 +58,12 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 Finally, users can mix some texts, a chosen set of documents but also provide
 documents not necessarily present in the index. To provide documents not
 present in the index, the syntax is similar to <<docs-termvectors-artificial-doc,artificial documents>>.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -94,7 +92,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 ==== How it Works
 
@@ -120,7 +117,7 @@ we can explicitly store their `term_vector` at index time. We can still
 perform MLT on the "description" and "tags" fields, as `_source` is enabled by
 default, but there will be no speed up on analysis for these fields.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /imdb
 {
@@ -147,7 +144,6 @@ PUT /imdb
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 ==== Parameters
 

--- a/docs/reference/query-dsl/multi-match-query.asciidoc
+++ b/docs/reference/query-dsl/multi-match-query.asciidoc
@@ -7,7 +7,7 @@
 The `multi_match` query builds on the <<query-dsl-match-query,`match` query>>
 to allow multi-field queries:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -19,7 +19,7 @@ GET /_search
   }
 }
 --------------------------------------------------
-// CONSOLE
+
 <1> The query string.
 <2> The fields to be queried.
 
@@ -29,7 +29,7 @@ GET /_search
 
 Fields can be specified with wildcards, eg:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -41,12 +41,12 @@ GET /_search
   }
 }
 --------------------------------------------------
-// CONSOLE
+
 <1> Query the `title`, `first_name` and `last_name` fields.
 
 Individual fields can be boosted with the caret (`^`) notation:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -58,7 +58,6 @@ GET /_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 <1> The `subject` field is three times as important as the `message` field.
 
@@ -110,7 +109,7 @@ The `best_fields` type generates a <<query-dsl-match-query,`match` query>> for
 each field and wraps them in a <<query-dsl-dis-max-query,`dis_max`>> query, to
 find the single best matching field.  For instance, this query:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -124,11 +123,10 @@ GET /_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 would be executed as:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -143,7 +141,6 @@ GET /_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 Normally the `best_fields` type uses the score of the *single* best matching
 field, but if `tie_breaker` is specified, then it calculates the score as
@@ -169,7 +166,7 @@ which is probably not what you want.
 
 Take this query for example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -183,7 +180,6 @@ GET /_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 <1> All terms must be present.
 
@@ -212,7 +208,7 @@ to push the most similar results to the top of the list.
 
 This query:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -225,11 +221,10 @@ GET /_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 would be executed as:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -244,7 +239,6 @@ GET /_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 The score from each `match` clause is added together, then divided by the
 number of `match` clauses.
@@ -260,7 +254,8 @@ but they use a `match_phrase` or `match_phrase_prefix` query instead of a
 `match` query.
 
 This query:
-[source,js]
+
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -273,11 +268,10 @@ GET /_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 would be executed as:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -291,7 +285,6 @@ GET /_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 Also, accepts `analyzer`, <<mapping-boost,`boost`>>, `lenient` and `zero_terms_query` as explained
 in <<query-dsl-match-query>>, as well as `slop` which is explained in <<query-dsl-match-query-phrase>>.
@@ -344,7 +337,7 @@ big field.
 
 A query like:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -358,7 +351,6 @@ GET /_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 is executed as:
 
@@ -404,7 +396,7 @@ For instance, if we have a `first` and `last` field which have
 the same analyzer, plus a `first.edge` and `last.edge` which
 both use an `edge_ngram` analyzer, this query:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -420,7 +412,6 @@ GET /_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 would be executed as:
 
@@ -443,7 +434,7 @@ You can easily rewrite this query yourself as two separate `cross_fields`
 queries combined with a `bool` query, and apply the `minimum_should_match`
 parameter to just one of them:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -470,7 +461,6 @@ GET /_search
   }
 }
 --------------------------------------------------
-// CONSOLE 
 
 <1> Either `will` or `smith` must be present in either of the `first`
     or `last` fields
@@ -478,7 +468,7 @@ GET /_search
 You can force all fields into the same group by specifying the `analyzer`
 parameter in the query.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -492,7 +482,6 @@ GET /_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 <1> Use the `standard` analyzer for all fields.
 
@@ -531,7 +520,7 @@ The `bool_prefix` type's scoring behaves like <<type-most-fields>>, but using a
 <<query-dsl-match-bool-prefix-query,`match_bool_prefix` query>> instead of a
 `match` query.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -544,7 +533,6 @@ GET /_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 The `analyzer`, `boost`, `operator`, `minimum_should_match`, `lenient`,
 `zero_terms_query`, and `auto_generate_synonyms_phrase_query` parameters as

--- a/docs/reference/query-dsl/nested-query.asciidoc
+++ b/docs/reference/query-dsl/nested-query.asciidoc
@@ -19,7 +19,7 @@ the root parent document.
 To use the `nested` query, your index must include a <<nested,nested>> field
 mapping. For example:
 
-[source,js]
+[source,console]
 ----
 PUT /my_index
 {
@@ -33,13 +33,12 @@ PUT /my_index
 }
 
 ----
-// CONSOLE
 // TESTSETUP
 
 [[nested-query-ex-query]]
 ===== Example query
 
-[source,js]
+[source,console]
 ----
 GET /my_index/_search
 {
@@ -59,7 +58,6 @@ GET /my_index/_search
     }
 }
 ----
-// CONSOLE
 
 [[nested-top-level-params]]
 ==== Top-level parameters for `nested`

--- a/docs/reference/query-dsl/parent-id-query.asciidoc
+++ b/docs/reference/query-dsl/parent-id-query.asciidoc
@@ -20,7 +20,7 @@ the following example.
 . Create an index with a <<parent-join,join>> field mapping.
 +
 --
-[source,js]
+[source,console]
 ----
 PUT /my-index
 {
@@ -37,14 +37,13 @@ PUT /my-index
 }
 
 ----
-// CONSOLE
 // TESTSETUP
 --
 
 . Index a parent document with an ID of `1`.
 +
 --
-[source,js]
+[source,console]
 ----
 PUT /my-index/_doc/1?refresh
 {
@@ -52,13 +51,12 @@ PUT /my-index/_doc/1?refresh
   "my-join-field": "my-parent"
 }
 ----
-// CONSOLE
 --
 
 . Index a child document of the parent document.
 +
 --
-[source,js]
+[source,console]
 ----
 PUT /my-index/_doc/2?routing=1&refresh
 {
@@ -69,7 +67,6 @@ PUT /my-index/_doc/2?routing=1&refresh
   }
 }
 ----
-// CONSOLE
 --
 
 [[parent-id-query-ex-query]]
@@ -78,7 +75,7 @@ PUT /my-index/_doc/2?routing=1&refresh
 The following search returns child documents for a parent document with an ID of
 `1`.
 
-[source,js]
+[source,console]
 ----
 GET /my-index/_search
 {
@@ -90,7 +87,6 @@ GET /my-index/_search
   }
 }
 ----
-// CONSOLE
 
 [[parent-id-top-level-params]]
 ==== Top-level parameters for `parent_id`

--- a/docs/reference/query-dsl/percolate-query.asciidoc
+++ b/docs/reference/query-dsl/percolate-query.asciidoc
@@ -14,7 +14,7 @@ to match with the stored queries.
 
 Create an index with two fields:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /my-index
 {
@@ -30,7 +30,6 @@ PUT /my-index
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 The `message` field is the field used to preprocess the document defined in
 the `percolator` query before it gets indexed into a temporary index.
@@ -43,7 +42,7 @@ used later on to match documents defined on the `percolate` query.
 
 Register a query in the percolator:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /my-index/_doc/1?refresh
 {
@@ -54,12 +53,11 @@ PUT /my-index/_doc/1?refresh
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 Match a document to the registered percolator queries:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /my-index/_search
 {
@@ -73,7 +71,6 @@ GET /my-index/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 The above request will yield the following response:
@@ -158,7 +155,7 @@ In that case the `document` parameter can be substituted with the following para
 In case you are not interested in the score, better performance can be expected by wrapping
 the percolator query in a `bool` query's filter clause or in a `constant_score` query:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /my-index/_search
 {
@@ -176,7 +173,6 @@ GET /my-index/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 At index time terms are extracted from the percolator query and the percolator
@@ -199,7 +195,7 @@ The `_percolator_document_slot` field that is being returned with each matched p
 multiple documents simultaneously. It indicates which documents matched with a particular percolator query. The numbers
 correlate with the slot in the `documents` array specified in the `percolate` query.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /my-index/_search
 {
@@ -224,7 +220,6 @@ GET /my-index/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 <1> The documents array contains 4 documents that are going to be percolated at the same time.
@@ -286,14 +281,13 @@ Based on the previous example.
 
 Index the document we want to percolate:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /my-index/_doc/2
 {
   "message" : "A new bonsai tree in the office"
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 Index response:
 
@@ -317,7 +311,7 @@ Index response:
 
 Percolating an existing document, using the index response as basis to build to new search request:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /my-index/_search
 {
@@ -331,7 +325,6 @@ GET /my-index/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 <1> The version is optional, but useful in certain cases. We can ensure that we are trying to percolate
@@ -354,7 +347,7 @@ This example is based on the mapping of the first example.
 
 Save a query:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /my-index/_doc/3?refresh
 {
@@ -365,12 +358,11 @@ PUT /my-index/_doc/3?refresh
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 Save another query:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /my-index/_doc/4?refresh
 {
@@ -381,12 +373,11 @@ PUT /my-index/_doc/4?refresh
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 Execute a search request with the `percolate` query and highlighting enabled:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /my-index/_search
 {
@@ -405,7 +396,6 @@ GET /my-index/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 This will yield the following response.
@@ -483,7 +473,7 @@ the document defined in the `percolate` query.
 
 When percolating multiple documents at the same time like the request below then the highlight response is different:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /my-index/_search
 {
@@ -513,7 +503,6 @@ GET /my-index/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 The slightly different response:
@@ -577,7 +566,7 @@ The slightly different response:
 
 It is possible to specify multiple `percolate` queries in a single search request:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /my-index/_search
 {
@@ -607,7 +596,6 @@ GET /my-index/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 <1> The `name` parameter will be used to identify which percolator document slots belong to what `percolate` query.
@@ -683,7 +671,7 @@ or the unsupported query is the only query in the percolator document).  These q
 can be found by running the following search:
 
 
-[source,js]
+[source,console]
 ---------------------------------------------------
 GET /_search
 {
@@ -694,7 +682,6 @@ GET /_search
   }
 }
 ---------------------------------------------------
-// CONSOLE
 
 NOTE: The above example assumes that there is a `query` field of type
 `percolator` in the mappings.

--- a/docs/reference/query-dsl/pinned-query.asciidoc
+++ b/docs/reference/query-dsl/pinned-query.asciidoc
@@ -10,7 +10,7 @@ the <<mapping-id-field,`_id`>> field.
 
 ==== Example request
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -26,7 +26,6 @@ GET /_search
     }
 }    
 --------------------------------------------------
-// CONSOLE
 
 [[pinned-query-top-level-parameters]]
 ==== Top-level parameters for `pinned`

--- a/docs/reference/query-dsl/prefix-query.asciidoc
+++ b/docs/reference/query-dsl/prefix-query.asciidoc
@@ -12,7 +12,7 @@ Returns documents that contain a specific prefix in a provided field.
 The following search returns documents where the `user` field contains a term
 that begins with `ki`.
 
-[source,js]
+[source,console]
 ----
 GET /_search
 {
@@ -25,7 +25,6 @@ GET /_search
     }
 }
 ----
-// CONSOLE
 
 [[prefix-query-top-level-params]]
 ==== Top-level parameters for `prefix`
@@ -50,7 +49,7 @@ information, see the <<query-dsl-multi-term-rewrite, `rewrite` parameter>>.
 You can simplify the `prefix` query syntax by combining the `<field>` and
 `value` parameters. For example:
 
-[source,js]
+[source,console]
 ----
 GET /_search
 {
@@ -59,7 +58,6 @@ GET /_search
     }
 }
 ----
-// CONSOLE
 
 [[prefix-query-index-prefixes]]
 ===== Speed up prefix queries

--- a/docs/reference/query-dsl/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/query-string-query.asciidoc
@@ -38,7 +38,7 @@ city) OR (big apple)` into two parts: `new york city` and `big apple`. The
 before returning matching documents. Because the query syntax does not use
 whitespace as an operator, `new york city` is passed as-is to the analyzer.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -50,7 +50,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 [[query-string-top-level-params]]
 ==== Top-level parameters for `query_string`
@@ -252,7 +251,7 @@ field1:query_term OR field2:query_term | ...
 
 For example, the following query
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -264,12 +263,11 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 matches the same words as
 
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -280,13 +278,12 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 Since several queries are generated from the individual search terms,
 combining them is automatically done using a `dis_max` query with a `tie_breaker`.
 For example (the `name` is boosted by 5 using `^5` notation):
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -299,14 +296,13 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 Simple wildcard can also be used to search "within" specific inner
 elements of the document. For example, if we have a `city` object with
 several fields (or inner object with fields) in it, we can automatically
 search on all "city" fields:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -318,13 +314,12 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 Another option is to provide the wildcard fields search in the query
 string itself (properly escaping the `*` sign), for example:
 `city.\*:something`:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -335,7 +330,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 NOTE: Since `\` (backslash) is a special character in json strings, it needs to
 be escaped, hence the two backslashes in the above `query_string`.
@@ -344,7 +338,7 @@ The fields parameter can also include pattern based field names,
 allowing to automatically expand to the relevant fields (dynamically
 introduced fields included). For example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -356,7 +350,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 [[query-string-multi-field-parms]]
 ====== Additional parameters for multiple field searches
@@ -411,7 +404,7 @@ For example, the following synonym: `ny, new york` would produce:
 
 It is also possible to match multi terms synonyms with conjunctions instead:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -424,7 +417,6 @@ GET /_search
    }
 }
 --------------------------------------------------
-// CONSOLE
 
 The example above creates a boolean query:
 
@@ -440,7 +432,7 @@ The `query_string` splits the query around each operator to create a boolean
 query for the entire input. You can use `minimum_should_match` to control how
 many "should" clauses in the resulting query should match.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -455,7 +447,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 The example above creates a boolean query:
 
@@ -467,7 +458,7 @@ in the single field `title`.
 [[query-string-min-should-match-multi]]
 ===== How `minimum_should_match` works for multiple fields
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -483,7 +474,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 The example above creates a boolean query:
 
@@ -492,7 +482,7 @@ The example above creates a boolean query:
 that matches documents with the disjunction max over the fields `title` and
 `content`. Here the `minimum_should_match` parameter can't be applied.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -508,7 +498,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 Adding explicit operators forces each term to be considered as a separate clause.
 
@@ -525,7 +514,7 @@ them made of the disjunction max over the fields for each term.
 A `cross_fields` value in the `type` field indicates fields with the same
 analyzer are grouped together when the input is analyzed.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -542,7 +531,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 The example above creates a boolean query:
 

--- a/docs/reference/query-dsl/query_filter_context.asciidoc
+++ b/docs/reference/query-dsl/query_filter_context.asciidoc
@@ -58,7 +58,7 @@ conditions are met:
 * The `status` field contains the exact word `published`.
 * The `publish_date` field contains a date from 1 Jan 2015 onwards.
 
-[source,js]
+[source,console]
 ------------------------------------
 GET /_search
 {
@@ -76,7 +76,7 @@ GET /_search
   }
 }
 ------------------------------------
-// CONSOLE
+
 <1> The `query` parameter indicates query context.
 <2> The `bool` and two `match` clauses are used in query context,
     which means that they are used to score how well each document

--- a/docs/reference/query-dsl/range-query.asciidoc
+++ b/docs/reference/query-dsl/range-query.asciidoc
@@ -12,7 +12,7 @@ Returns documents that contain terms within a provided range.
 The following search returns documents where the `age` field contains a term
 between `10` and `20`.
 
-[source,js]
+[source,console]
 ----
 GET _search
 {
@@ -27,7 +27,6 @@ GET _search
     }
 }
 ----
-// CONSOLE 
 
 [[range-query-top-level-params]]
 ==== Top-level parameters for `range`
@@ -149,7 +148,7 @@ When the `<field>` parameter is a <<date,`date`>> field datatype, you can use
 For example, the following search returns documents where the `timestamp` field
 contains a date between today and yesterday.
 
-[source,js]
+[source,console]
 ----
 GET _search
 {
@@ -163,7 +162,6 @@ GET _search
     }
 }
 ----
-// CONSOLE
 
 
 [[range-query-date-math-rounding]]
@@ -212,7 +210,7 @@ the entire month.
 You can use the `time_zone` parameter to convert `date` values to UTC using a
 UTC offset. For example:
 
-[source,js]
+[source,console]
 ----
 GET _search
 {
@@ -227,7 +225,7 @@ GET _search
     }
 }
 ----
-// CONSOLE
+
 <1> Indicates that `date` values use a UTC offset of `+01:00`.
 <2> With a UTC offset of `+01:00`, {es} converts this date to
 `2014-12-31T23:00:00 UTC`.

--- a/docs/reference/query-dsl/rank-feature-query.asciidoc
+++ b/docs/reference/query-dsl/rank-feature-query.asciidoc
@@ -53,7 +53,7 @@ to relevance, indicated by a `positive_score_impact` value of `false`.
 - `topics`, a <<rank-features,`rank_features`>> field which contains a list of
 topics and a measure of how well each document is connected to this topic
 
-[source,js]
+[source,console]
 ----
 PUT /test
 {
@@ -73,13 +73,12 @@ PUT /test
   }
 }
 ----
-// CONSOLE
 // TESTSETUP
 
 
 Index several documents to the `test` index.
 
-[source,js]
+[source,console]
 ----
 PUT /test/_doc/1?refresh
 {
@@ -118,7 +117,6 @@ PUT /test/_doc/3?refresh
   }
 }
 ----
-// CONSOLE
 
 [[rank-feature-query-ex-query]]
 ===== Example query
@@ -126,7 +124,7 @@ PUT /test/_doc/3?refresh
 The following query searches for `2016` and boosts relevance scores based or
 `pagerank`, `url_length`, and the `sports` topic.
 
-[source,js]
+[source,console]
 ----
 GET /test/_search 
 {
@@ -162,7 +160,6 @@ GET /test/_search
   }
 }
 ----
-// CONSOLE
 
 
 [[rank-feature-top-level-params]]
@@ -232,7 +229,7 @@ than `0.5` otherwise. Scores are always `(0,1)`.
 If the rank feature has a negative score impact then the function will be
 computed as `pivot / (S + pivot)`, which decreases when `S` increases.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /test/_search
 {
@@ -246,14 +243,13 @@ GET /test/_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 If a `pivot` value is not provided, {es} computes a default value equal to the
 approximate geometric mean of all rank feature values in the index. We recommend
 using this default value if you haven't had the opportunity to train a good
 pivot value.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /test/_search
 {
@@ -265,7 +261,6 @@ GET /test/_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 [[rank-feature-query-logarithm]]
 ===== Logarithm
@@ -275,7 +270,7 @@ scaling factor. Scores are unbounded.
 
 This function only supports rank features that have a positive score impact.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /test/_search
 {
@@ -289,7 +284,6 @@ GET /test/_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 [[rank-feature-query-sigmoid]]
 ===== Sigmoid
@@ -302,7 +296,7 @@ The `exponent` must be positive and is typically in `[0.5, 1]`. A
 good value should be computed via training. If you don't have the opportunity to
 do so, we recommend you use the `saturation` function instead.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /test/_search
 {
@@ -317,4 +311,3 @@ GET /test/_search
   }
 }
 --------------------------------------------------
-// CONSOLE

--- a/docs/reference/query-dsl/regexp-query.asciidoc
+++ b/docs/reference/query-dsl/regexp-query.asciidoc
@@ -19,7 +19,7 @@ that begins with `k` and ends with `y`. The `.*` operators match any
 characters of any length, including no characters. Matching
 terms can include `ky`, `kay`, and `kimchy`.
 
-[source,js]
+[source,console]
 ----
 GET /_search
 {
@@ -35,7 +35,6 @@ GET /_search
     }
 }
 ----
-// CONSOLE
 
 
 [[regexp-top-level-params]]

--- a/docs/reference/query-dsl/script-query.asciidoc
+++ b/docs/reference/query-dsl/script-query.asciidoc
@@ -11,7 +11,7 @@ Filters documents based on a provided <<modules-scripting-using,script>>. The
 [[script-query-ex-request]]
 ==== Example request
 
-[source,js]
+[source,console]
 ----
 GET /_search
 {
@@ -29,7 +29,6 @@ GET /_search
     }
 }
 ----
-// CONSOLE
 
 
 [[script-top-level-params]]
@@ -49,7 +48,7 @@ Like <<query-filter-context,filters>>, scripts are cached for faster execution.
 If you frequently change the arguments of a script, we recommend you store them
 in the script's `params` parameter. For example:
 
-[source,js]
+[source,console]
 ----
 GET /_search
 {
@@ -70,4 +69,3 @@ GET /_search
     }
 }
 ----
-// CONSOLE

--- a/docs/reference/query-dsl/script-score-query.asciidoc
+++ b/docs/reference/query-dsl/script-score-query.asciidoc
@@ -14,7 +14,7 @@ The `script_score` query is useful if, for example, a scoring function is expens
 ==== Example request
 The following `script_score` query assigns each returned document a score equal to the `likes` field value divided by `10`.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -30,7 +30,6 @@ GET /_search
      }
 }
 --------------------------------------------------
-// CONSOLE
 
 
 [[script-score-top-level-params]]

--- a/docs/reference/query-dsl/shape-query.asciidoc
+++ b/docs/reference/query-dsl/shape-query.asciidoc
@@ -24,7 +24,7 @@ https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry[Well Kn
 
 Given the following index:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /example
 {
@@ -46,13 +46,12 @@ POST /example/_doc?refresh
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TESTSETUP
 
 The following query will find the point using the Elasticsearch's
 `envelope` GeoJSON extension:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /example/_search
 {
@@ -69,7 +68,6 @@ GET /example/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 ==== Pre-Indexed Shape
 
@@ -90,7 +88,7 @@ Defaults to 'shape'.
 The following is an example of using the Filter with a pre-indexed
 shape:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /shapes
 {
@@ -126,7 +124,6 @@ GET /example/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 ==== Spatial Relations
 

--- a/docs/reference/query-dsl/simple-query-string-query.asciidoc
+++ b/docs/reference/query-dsl/simple-query-string-query.asciidoc
@@ -20,7 +20,7 @@ parts of the query string.
 [[simple-query-string-query-ex-request]]
 ==== Example request
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -33,7 +33,6 @@ GET /_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 
 [[simple-query-string-top-level-params]]
@@ -153,7 +152,7 @@ To use one of these characters literally, escape it with a preceding backslash
 The behavior of these operators may differ depending on the `default_operator`
 value. For example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -165,7 +164,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 This search is intended to only return documents containing `foo` or `bar` that
 also do **not** contain `baz`. However because of a `default_operator` of `OR`,
@@ -182,7 +180,7 @@ To explicitly enable only specific operators, use a `|` separator. For example,
 a `flags` value of `OR|AND|PREFIX` disables all operators except `OR`, `AND`,
 and `PREFIX`.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -194,7 +192,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 [[supported-flags-values]]
 ====== Valid values
@@ -247,7 +244,7 @@ Enables whitespace as split characters.
 
 Fields can be specified with wildcards, eg:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -259,12 +256,12 @@ GET /_search
   }
 }
 --------------------------------------------------
-// CONSOLE
+
 <1> Query the `title`, `first_name` and `last_name` fields.
 
 Individual fields can be boosted with the caret (`^`) notation:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -276,7 +273,6 @@ GET /_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 <1> The `subject` field is three times as important as the `message` field.
 
@@ -291,7 +287,7 @@ For example, the following synonym: `"ny, new york" would produce:`
 
 It is also possible to match multi terms synonyms with conjunctions instead:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -303,7 +299,6 @@ GET /_search
    }
 }
 --------------------------------------------------
-// CONSOLE
 
 The example above creates a boolean query:
 

--- a/docs/reference/query-dsl/span-field-masking-query.asciidoc
+++ b/docs/reference/query-dsl/span-field-masking-query.asciidoc
@@ -12,7 +12,7 @@ Span field masking query is invaluable in conjunction with *multi-fields* when s
 
 Example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -41,6 +41,5 @@ GET /_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 Note: as span field masking query returns the masked field, scoring will be done using the norms of the field name supplied. This may lead to unexpected scoring behaviour.

--- a/docs/reference/query-dsl/span-first-query.asciidoc
+++ b/docs/reference/query-dsl/span-first-query.asciidoc
@@ -7,7 +7,7 @@
 Matches spans near the beginning of a field. The span first query maps
 to Lucene `SpanFirstQuery`. Here is an example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -21,7 +21,6 @@ GET /_search
     }
 }    
 --------------------------------------------------
-// CONSOLE
 
 The `match` clause can be any other span type query. The `end` controls
 the maximum end position permitted in a match.

--- a/docs/reference/query-dsl/span-multi-term-query.asciidoc
+++ b/docs/reference/query-dsl/span-multi-term-query.asciidoc
@@ -8,7 +8,7 @@ The `span_multi` query allows you to wrap a `multi term query` (one of wildcard,
 fuzzy, prefix, range or regexp query) as a `span query`, so
 it can be nested. Example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -21,11 +21,10 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 A boost can also be associated with the query:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -38,7 +37,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 WARNING: `span_multi` queries will hit too many clauses failure if the number of terms that match the query exceeds the
 boolean query limit (defaults to 1024).To avoid an unbounded expansion you can set the <<query-dsl-multi-term-rewrite,

--- a/docs/reference/query-dsl/span-near-query.asciidoc
+++ b/docs/reference/query-dsl/span-near-query.asciidoc
@@ -9,7 +9,7 @@ maximum number of intervening unmatched positions, as well as whether
 matches are required to be in-order. The span near query maps to Lucene
 `SpanNearQuery`. Here is an example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -26,7 +26,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 The `clauses` element is a list of one or more other span type queries
 and the `slop` controls the maximum number of intervening unmatched

--- a/docs/reference/query-dsl/span-not-query.asciidoc
+++ b/docs/reference/query-dsl/span-not-query.asciidoc
@@ -9,7 +9,7 @@ within x tokens before (controlled by the parameter `pre`) or y tokens
 after (controlled by the parameter `post`) another SpanQuery. The span not
 query maps to Lucene `SpanNotQuery`. Here is an example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -32,7 +32,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 The `include` and `exclude` clauses can be any span type query. The
 `include` clause is the span query whose matches are filtered, and the

--- a/docs/reference/query-dsl/span-or-query.asciidoc
+++ b/docs/reference/query-dsl/span-or-query.asciidoc
@@ -7,7 +7,7 @@
 Matches the union of its span clauses. The span or query maps to Lucene
 `SpanOrQuery`. Here is an example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -22,6 +22,5 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 The `clauses` element is a list of one or more other span type queries.

--- a/docs/reference/query-dsl/span-term-query.asciidoc
+++ b/docs/reference/query-dsl/span-term-query.asciidoc
@@ -7,7 +7,7 @@
 Matches spans containing a term. The span term query maps to Lucene
 `SpanTermQuery`. Here is an example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -16,11 +16,10 @@ GET /_search
     }
 }    
 --------------------------------------------------
-// CONSOLE
 
 A boost can also be associated with the query:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -29,11 +28,10 @@ GET /_search
     }
 }    
 --------------------------------------------------
-// CONSOLE
 
 Or :
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -42,4 +40,3 @@ GET /_search
     }
 }    
 --------------------------------------------------
-// CONSOLE

--- a/docs/reference/query-dsl/span-within-query.asciidoc
+++ b/docs/reference/query-dsl/span-within-query.asciidoc
@@ -7,7 +7,7 @@
 Returns matches which are enclosed inside another span query. The span within
 query maps to Lucene `SpanWithinQuery`. Here is an example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -30,7 +30,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 The `big` and `little` clauses can be any span type query. Matching
 spans from `little` that are enclosed within `big` are returned.

--- a/docs/reference/query-dsl/term-query.asciidoc
+++ b/docs/reference/query-dsl/term-query.asciidoc
@@ -24,7 +24,7 @@ instead.
 [[term-query-ex-request]]
 ==== Example request
 
-[source,js]
+[source,console]
 ----
 GET /_search
 {
@@ -38,7 +38,6 @@ GET /_search
     }
 }
 ----
-// CONSOLE
 
 [[term-top-level-params]]
 ==== Top-level parameters for `term`
@@ -91,7 +90,7 @@ To see the difference in search results, try the following example.
 +
 --
 
-[source,js]
+[source,console]
 ----
 PUT my_index
 {
@@ -102,7 +101,6 @@ PUT my_index
     }
 }
 ----
-// CONSOLE
 
 --
 
@@ -111,14 +109,13 @@ field.
 +
 --
 
-[source,js]
+[source,console]
 ----
 PUT my_index/_doc/1
 {
   "full_text":   "Quick Brown Foxes!"
 }
 ----
-// CONSOLE
 // TEST[continued]
 
 Because `full_text` is a `text` field, {es} changes `Quick Brown Foxes!` to
@@ -131,7 +128,7 @@ field. Include the `pretty` parameter so the response is more readable.
 +
 --
 
-[source,js]
+[source,console]
 ----
 GET my_index/_search?pretty
 {
@@ -142,7 +139,6 @@ GET my_index/_search?pretty
   }
 }
 ----
-// CONSOLE
 // TEST[continued]
 
 Because the `full_text` field no longer contains the *exact* term `Quick Brown
@@ -157,16 +153,15 @@ field.
 
 ////
 
-[source,js]
+[source,console]
 ----
 POST my_index/_refresh
 ----
-// CONSOLE
 // TEST[continued]
 
 ////
 
-[source,js]
+[source,console]
 ----
 GET my_index/_search?pretty
 {
@@ -177,7 +172,6 @@ GET my_index/_search?pretty
   }
 }
 ----
-// CONSOLE
 // TEST[continued]
 
 Unlike the `term` query, the `match` query analyzes your provided search term,

--- a/docs/reference/query-dsl/terms-query.asciidoc
+++ b/docs/reference/query-dsl/terms-query.asciidoc
@@ -15,7 +15,7 @@ except you can search for multiple values.
 The following search returns documents where the `user` field contains `kimchy`
 or `elasticsearch`.
 
-[source,js]
+[source,console]
 ----
 GET /_search
 {
@@ -27,7 +27,6 @@ GET /_search
     }
 }
 ----
-// CONSOLE
 
 [[terms-top-level-params]]
 ==== Top-level parameters for `terms`
@@ -124,7 +123,7 @@ To see how terms lookup works, try the following example.
 +
 --
 
-[source,js]
+[source,console]
 ----
 PUT my_index
 {
@@ -135,7 +134,6 @@ PUT my_index
     }
 }
 ----
-// CONSOLE
 --
 
 . Index a document with an ID of 1 and values of `["blue", "green"]` in the
@@ -143,14 +141,13 @@ PUT my_index
 +
 --
 
-[source,js]
+[source,console]
 ----
 PUT my_index/_doc/1
 {
   "color":   ["blue", "green"]
 }
 ----
-// CONSOLE
 // TEST[continued]
 --
 
@@ -159,14 +156,13 @@ field.
 +
 --
 
-[source,js]
+[source,console]
 ----
 PUT my_index/_doc/2
 {
   "color":   "blue"
 }
 ----
-// CONSOLE
 // TEST[continued]
 --
 
@@ -178,16 +174,15 @@ parameter so the response is more readable.
 
 ////
 
-[source,js]
+[source,console]
 ----
 POST my_index/_refresh
 ----
-// CONSOLE
 // TEST[continued]
 
 ////
 
-[source,js]
+[source,console]
 ----
 GET my_index/_search?pretty
 {
@@ -202,7 +197,6 @@ GET my_index/_search?pretty
   }
 }
 ----
-// CONSOLE
 // TEST[continued]
 
 Because document 2 and document 1 both contain `blue` as a value in the `color`

--- a/docs/reference/query-dsl/terms-set-query.asciidoc
+++ b/docs/reference/query-dsl/terms-set-query.asciidoc
@@ -45,7 +45,7 @@ programming languages known by the job candidate.
 * `required_matches`, a <<number, numeric>> `long` field. This field contains
 the number of matching terms required to return a document.
 
-[source,js]
+[source,console]
 ----
 PUT /job-candidates
 {
@@ -64,7 +64,6 @@ PUT /job-candidates
     }
 }
 ----
-// CONSOLE
 // TESTSETUP
 
 --
@@ -82,7 +81,7 @@ PUT /job-candidates
 Include the `?refresh` parameter so the document is immediately available for
 search.
 
-[source,js]
+[source,console]
 ----
 PUT /job-candidates/_doc/1?refresh
 {
@@ -91,7 +90,6 @@ PUT /job-candidates/_doc/1?refresh
     "required_matches": 2
 }
 ----
-// CONSOLE
 
 --
 
@@ -105,7 +103,7 @@ PUT /job-candidates/_doc/1?refresh
 
 * `2` in the `required_matches` field.
 
-[source,js]
+[source,console]
 ----
 PUT /job-candidates/_doc/2?refresh
 {
@@ -114,7 +112,6 @@ PUT /job-candidates/_doc/2?refresh
     "required_matches": 2
 }
 ----
-// CONSOLE
 
 --
 
@@ -135,7 +132,7 @@ The `minimum_should_match_field` is `required_matches`. This means the
 number of matching terms required is `2`, the value of the `required_matches`
 field.
 
-[source,js]
+[source,console]
 ----
 GET /job-candidates/_search
 {
@@ -149,7 +146,6 @@ GET /job-candidates/_search
     }
 }
 ----
-// CONSOLE
 
 [[terms-set-top-level-params]]
 ==== Top-level parameters for `terms_set`
@@ -214,7 +210,7 @@ number of terms provided in the `terms` field.
 * The required number of terms to match is `2`, the value of the
 `required_matches` field.
 
-[source,js]
+[source,console]
 ----
 GET /job-candidates/_search
 {
@@ -231,4 +227,3 @@ GET /job-candidates/_search
     }
 }
 ----
-// CONSOLE

--- a/docs/reference/query-dsl/wildcard-query.asciidoc
+++ b/docs/reference/query-dsl/wildcard-query.asciidoc
@@ -17,7 +17,7 @@ The following search returns documents where the `user` field contains a term
 that begins with `ki` and ends with `y`. These matching terms can include `kiy`,
 `kity`, or `kimchy`.
 
-[source,js]
+[source,console]
 ----
 GET /_search
 {
@@ -32,7 +32,6 @@ GET /_search
     }
 }
 ----
-// CONSOLE
 
 [[wildcard-top-level-params]]
 ==== Top-level parameters for `wildcard`

--- a/docs/reference/query-dsl/wrapper-query.asciidoc
+++ b/docs/reference/query-dsl/wrapper-query.asciidoc
@@ -6,7 +6,7 @@
 
 A query that accepts any other query as base64 encoded string.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -17,7 +17,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 <1> Base64 encoded string:  `{"term" : { "user" : "Kimchy" }}`
 

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -404,7 +404,7 @@ GET _search
 move the query and filter to the `must` and `filter` parameters in the `bool`
 query:
 
-[source,js]
+[source,console]
 -------------------------
 GET _search
 {
@@ -424,7 +424,6 @@ GET _search
   }
 }
 -------------------------
-// CONSOLE
 
 [role="exclude",id="query-dsl-or-query"]
 === Or query

--- a/docs/reference/rest-api/info.asciidoc
+++ b/docs/reference/rest-api/info.asciidoc
@@ -41,11 +41,10 @@ The information provided by this API includes:
 
 The following example queries the info API:
 
-[source,js]
+[source,console]
 ------------------------------------------------------------
 GET /_xpack
 ------------------------------------------------------------
-// CONSOLE
 
 Example response:
 [source,js]
@@ -145,16 +144,14 @@ Example response:
 
 The following example only returns the build and features information:
 
-[source,js]
+[source,console]
 ------------------------------------------------------------
 GET /_xpack?categories=build,features
 ------------------------------------------------------------
-// CONSOLE
 
 The following example removes the descriptions from the response:
 
-[source,js]
+[source,console]
 ------------------------------------------------------------
 GET /_xpack?human=false
 ------------------------------------------------------------
-// CONSOLE

--- a/docs/reference/rollup/apis/delete-job.asciidoc
+++ b/docs/reference/rollup/apis/delete-job.asciidoc
@@ -76,11 +76,10 @@ POST my_rollup_index/_delete_by_query
 
 If we have a rollup job named `sensor`, it can be deleted with:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 DELETE _rollup/job/sensor
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:sensor_rollup_job]
 
 Which will return the response:

--- a/docs/reference/rollup/apis/get-job.asciidoc
+++ b/docs/reference/rollup/apis/get-job.asciidoc
@@ -79,11 +79,10 @@ state is set, the job will remove itself from the cluster.
 If we have already created a rollup job named `sensor`, the details about the
 job can be retrieved with:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET _rollup/job/sensor
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:sensor_rollup_job]
 
 The API yields the following response:
@@ -153,7 +152,7 @@ The API yields the following response:
 The `jobs` array contains a single job (`id: sensor`) since we requested a single job in the endpoint's URL. 
 If we add another job, we can see how multi-job responses are handled:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _rollup/job/sensor2 <1>
 {
@@ -185,7 +184,6 @@ PUT _rollup/job/sensor2 <1>
 
 GET _rollup/job/_all <2>
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:sensor_rollup_job]
 <1> We create a second job with name `sensor2`
 <2> Then request all jobs by using `_all` in the GetJobs API

--- a/docs/reference/rollup/apis/put-job.asciidoc
+++ b/docs/reference/rollup/apis/put-job.asciidoc
@@ -70,7 +70,7 @@ For more details about the job configuration, see <<rollup-job-config>>.
 The following example creates a {rollup-job} named "sensor", targeting the
 "sensor-*" index pattern:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _rollup/job/sensor
 {
@@ -100,7 +100,6 @@ PUT _rollup/job/sensor
     ]
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:sensor_index]
 
 When the job is created, you receive the following results:

--- a/docs/reference/rollup/apis/rollup-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-caps.asciidoc
@@ -51,7 +51,7 @@ Imagine we have an index named `sensor-1` full of raw data.  We know that the da
 will be a `sensor-2`, `sensor-3`, etc.  Let's create a Rollup job that targets the index pattern `sensor-*` to accommodate
 this future scaling:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _rollup/job/sensor
 {
@@ -81,16 +81,14 @@ PUT _rollup/job/sensor
     ]
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:sensor_index]
 
 We can then retrieve the rollup capabilities of that index pattern (`sensor-*`) via the following command:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET _rollup/data/sensor-*
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 Which will yield the following response:
@@ -155,20 +153,18 @@ configurations available.
 
 We could also retrieve the same information with a request to `_all`:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET _rollup/data/_all
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 But note that if we use the concrete index name (`sensor-1`), we'll retrieve no rollup capabilities:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET _rollup/data/sensor-1
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 [source,console-result]

--- a/docs/reference/rollup/apis/rollup-index-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-index-caps.asciidoc
@@ -42,7 +42,7 @@ For more information, see
 Imagine we have an index named `sensor-1` full of raw data.  We know that the data will grow over time, so there
 will be a `sensor-2`, `sensor-3`, etc.  Let's create a Rollup job, which stores it's data in `sensor_rollup`:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _rollup/job/sensor
 {
@@ -72,17 +72,15 @@ PUT _rollup/job/sensor
     ]
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:sensor_index]
 
 If at a later date, we'd like to determine what jobs and capabilities were stored in the `sensor_rollup` index, we can use the Get Rollup
 Index API:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /sensor_rollup/_rollup/data
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 Note how we are requesting the concrete rollup index name (`sensor_rollup`) as the first part of the URL.
@@ -150,10 +148,9 @@ configurations available.
 
 Like other APIs that interact with indices, you can specify index patterns instead of explicit indices:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /*_rollup/_rollup/data
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 

--- a/docs/reference/rollup/apis/rollup-job-config.asciidoc
+++ b/docs/reference/rollup/apis/rollup-job-config.asciidoc
@@ -13,7 +13,7 @@ should be grouped on, and what metrics to collect for each group.
 
 A full job configuration might look like this:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _rollup/job/sensor
 {
@@ -47,7 +47,6 @@ PUT _rollup/job/sensor
     ]
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:sensor_index]
 
 ==== Logistical Details

--- a/docs/reference/rollup/apis/rollup-search.asciidoc
+++ b/docs/reference/rollup/apis/rollup-search.asciidoc
@@ -51,7 +51,7 @@ omitted entirely.
 
 Imagine we have an index named `sensor-1` full of raw data, and we have created a rollup job with the following configuration:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _rollup/job/sensor
 {
@@ -81,14 +81,13 @@ PUT _rollup/job/sensor
     ]
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:sensor_index]
 
 This rolls up the `sensor-*` pattern and stores the results in `sensor_rollup`.  To search this rolled up data, we
 need to use the `_rollup_search` endpoint.  However, you'll notice that we can use regular query DSL to search the
 rolled-up data:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /sensor_rollup/_rollup_search
 {
@@ -102,7 +101,6 @@ GET /sensor_rollup/_rollup_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:sensor_prefab_data]
 // TEST[s/_rollup_search/_rollup_search?filter_path=took,timed_out,terminated_early,_shards,hits,aggregations/]
 
@@ -141,7 +139,7 @@ Rollup searches are limited to functionality that was configured in the rollup j
 the average temperature because `avg` was not one of the configured metrics for the `temperature` field.  If we try
 to execute that search:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET sensor_rollup/_rollup_search
 {
@@ -155,7 +153,6 @@ GET sensor_rollup/_rollup_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 // TEST[catch:/illegal_argument_exception/]
 
@@ -185,7 +182,7 @@ The Rollup Search API has the capability to search across both "live", non-rollu
 data.  This is done by simply adding the live indices to the URI:
 
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET sensor-1,sensor_rollup/_rollup_search <1>
 {
@@ -199,7 +196,6 @@ GET sensor-1,sensor_rollup/_rollup_search <1>
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 // TEST[s/_rollup_search/_rollup_search?filter_path=took,timed_out,terminated_early,_shards,hits,aggregations/]
 <1> Note the URI now searches `sensor-1` and `sensor_rollup` at the same time

--- a/docs/reference/rollup/apis/start-job.asciidoc
+++ b/docs/reference/rollup/apis/start-job.asciidoc
@@ -47,11 +47,10 @@ to start a job that is already started, nothing happens.
 
 If we have already created a {rollup-job} named `sensor`, it can be started with:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _rollup/job/sensor/_start
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:sensor_rollup_job]
 
 Which will return the response:

--- a/docs/reference/rollup/apis/stop-job.asciidoc
+++ b/docs/reference/rollup/apis/stop-job.asciidoc
@@ -72,11 +72,10 @@ the indexer has fully stopped. This is accomplished with the
 `wait_for_completion` query parameter, and optionally a `timeout`:
 
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _rollup/job/sensor/_stop?wait_for_completion=true&timeout=10s
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:sensor_started_rollup_job]
 
 The parameter blocks the API call from returning until either the job has moved

--- a/docs/reference/rollup/rollup-getting-started.asciidoc
+++ b/docs/reference/rollup/rollup-getting-started.asciidoc
@@ -28,7 +28,7 @@ look like this:
 We'd like to rollup these documents into hourly summaries, which will allow us to generate reports and dashboards with any time interval
 one hour or greater.  A rollup job might look like this:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _rollup/job/sensor
 {
@@ -57,7 +57,6 @@ PUT _rollup/job/sensor
     ]
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:sensor_index]
 
 We give the job the ID of "sensor" (in the url: `PUT _rollup/job/sensor`), and tell it to rollup the index pattern `"sensor-*"`.
@@ -111,11 +110,10 @@ you to stop them later as a way to temporarily pause, without deleting the confi
 
 To start the job, execute this command:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _rollup/job/sensor/_start
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:sensor_rollup_job]
 
 [float]
@@ -126,7 +124,7 @@ so that you can use the same Query DSL syntax that you are accustomed to... it j
 
 For example, take this query:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /sensor_rollup/_rollup_search
 {
@@ -140,7 +138,6 @@ GET /sensor_rollup/_rollup_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:sensor_prefab_data]
 
 It's a simple aggregation that calculates the maximum of the `temperature` field.  But you'll notice that is is being sent to the `sensor_rollup`
@@ -184,7 +181,7 @@ is nearly identical to normal DSL, making it easy to integrate into dashboards a
 
 Finally, we can use those grouping fields we defined to construct a more complicated query:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /sensor_rollup/_rollup_search
 {
@@ -218,7 +215,6 @@ GET /sensor_rollup/_rollup_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:sensor_prefab_data]
 
 Which returns a corresponding response:

--- a/docs/reference/rollup/rollup-search-limitations.asciidoc
+++ b/docs/reference/rollup/rollup-search-limitations.asciidoc
@@ -41,7 +41,7 @@ rollup job to store metrics about the `price` field, you won't be able to use th
 For example, the `temperature` field in the following query has been stored in a rollup job... but not with an `avg` metric.  Which means
 the usage of `avg` here is not allowed:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET sensor_rollup/_rollup_search
 {
@@ -55,7 +55,6 @@ GET sensor_rollup/_rollup_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:sensor_prefab_data]
 // TEST[catch:/illegal_argument_exception/]
 

--- a/docs/reference/scripting/engine.asciidoc
+++ b/docs/reference/scripting/engine.asciidoc
@@ -24,7 +24,7 @@ You can execute the script by specifying its `lang` as `expert_scripts`, and the
 of the script as the script source:
 
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST /_search
 {
@@ -53,5 +53,4 @@ POST /_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:we don't have an expert script plugin installed to test this]

--- a/docs/reference/scripting/fields.asciidoc
+++ b/docs/reference/scripting/fields.asciidoc
@@ -42,7 +42,7 @@ Here's an example of using a script in a
 <<query-dsl-function-score-query,`function_score` query>> to alter the
 relevance `_score` of each document:
 
-[source,js]
+[source,console]
 -------------------------------------
 PUT my_index/_doc/1?refresh
 {
@@ -75,7 +75,6 @@ GET my_index/_search
   }
 }
 -------------------------------------
-// CONSOLE
 
 
 [float]
@@ -87,7 +86,7 @@ script is to use the `doc['field_name']` syntax, which retrieves the field
 value from <<doc-values,doc values>>. Doc values are a columnar field value
 store, enabled by default on all fields except for <<text,analyzed `text` fields>>.
 
-[source,js]
+[source,console]
 -------------------------------
 PUT my_index/_doc/1?refresh
 {
@@ -109,7 +108,6 @@ GET my_index/_search
   }
 }
 -------------------------------
-// CONSOLE
 
 Doc-values can only return "simple" field values like numbers, dates, geo-
 points, terms, etc, or arrays of these values if the field is multi-valued.
@@ -170,7 +168,7 @@ doc values.
 
 For instance:
 
-[source,js]
+[source,console]
 -------------------------------
 PUT my_index
 {
@@ -216,7 +214,7 @@ GET my_index/_search
   }
 }
 -------------------------------
-// CONSOLE
+
 <1> The `title` field is not stored and so cannot be used with the `_fields[]` syntax.
 <2> The `title` field can still be accessed from the `_source`.
 

--- a/docs/reference/scripting/using.asciidoc
+++ b/docs/reference/scripting/using.asciidoc
@@ -20,7 +20,7 @@ the same pattern:
 For example, the following script is used in a search request to return a
 <<request-body-search-script-fields, scripted field>>:
 
-[source,js]
+[source,console]
 -------------------------------------
 PUT my_index/_doc/1
 {
@@ -42,7 +42,6 @@ GET my_index/_search
   }
 }
 -------------------------------------
-// CONSOLE
 
 [float]
 === Script parameters
@@ -144,7 +143,7 @@ The following are examples of using a stored script that lives at
 
 First, create the script called `calculate-score` in the cluster state:
 
-[source,js]
+[source,console]
 -----------------------------------
 POST _scripts/calculate-score
 {
@@ -154,20 +153,18 @@ POST _scripts/calculate-score
   }
 }
 -----------------------------------
-// CONSOLE
 
 This same script can be retrieved with:
 
-[source,js]
+[source,console]
 -----------------------------------
 GET _scripts/calculate-score
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 Stored scripts can be used by specifying the `id` parameters as follows:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET _search
 {
@@ -183,16 +180,14 @@ GET _search
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 And deleted with:
 
-[source,js]
+[source,console]
 -----------------------------------
 DELETE _scripts/calculate-score
 -----------------------------------
-// CONSOLE
 // TEST[continued]
 
 [float]

--- a/docs/reference/search.asciidoc
+++ b/docs/reference/search.asciidoc
@@ -14,7 +14,7 @@ Which shards will be searched on can also be controlled by providing the
 `routing` parameter. For example, when indexing tweets, the routing value can be
 the user name:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST /twitter/_doc?routing=kimchy
 {
@@ -23,13 +23,12 @@ POST /twitter/_doc?routing=kimchy
     "message" : "trying out Elasticsearch"
 }
 --------------------------------------------------
-// CONSOLE
 
 In such a case, if we want to search only on the tweets for a specific
 user, we can specify it as the routing, resulting in the search hitting
 only the relevant shard:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST /twitter/_search?routing=kimchy
 {
@@ -47,7 +46,6 @@ POST /twitter/_search?routing=kimchy
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 The routing parameter can be multi valued represented as a comma
@@ -70,7 +68,7 @@ based on a number of criteria:
 This can be turned off by changing the dynamic cluster setting
 `cluster.routing.use_adaptive_replica_selection` from `true` to `false`:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /_cluster/settings
 {
@@ -79,7 +77,6 @@ PUT /_cluster/settings
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 If adaptive replica selection is turned off, searches are sent to the
 index/indices shards in a round robin fashion between all copies of the data
@@ -95,7 +92,7 @@ statistics aggregation per group. It can later be retrieved using the
 specifically. For example, here is a search body request that associate
 the request with two different groups:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST /_search
 {
@@ -105,7 +102,6 @@ POST /_search
     "stats" : ["group1", "group2"]
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 [float]

--- a/docs/reference/search/explain.asciidoc
+++ b/docs/reference/search/explain.asciidoc
@@ -12,7 +12,7 @@ Note that a single index must be provided to the `index` parameter.
 
 Full query example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /twitter/_explain/0
 {
@@ -21,7 +21,6 @@ GET /twitter/_explain/0
       }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 This will yield the following result:
@@ -105,11 +104,10 @@ parameter. The specified `q` parameter value is then parsed as if the
 `query_string` query was used. Example usage of the `q` parameter in the
 explain api:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /twitter/_explain/0?q=message:search
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 This will yield the same result as the previous request.

--- a/docs/reference/search/field-caps.asciidoc
+++ b/docs/reference/search/field-caps.asciidoc
@@ -5,19 +5,17 @@ The field capabilities API allows to retrieve the capabilities of fields among m
 
 The field capabilities API by default executes on all indices:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET _field_caps?fields=rating
 --------------------------------------------------
-// CONSOLE
 
 The request can also be restricted to specific indices:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET twitter/_field_caps?fields=rating
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 Supported request options:
@@ -61,11 +59,10 @@ or null if all indices have the same definition for the field.
 
 Request:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET _field_caps?fields=rating,title
 --------------------------------------------------
-// CONSOLE
 
 [source,js]
 --------------------------------------------------
@@ -110,11 +107,10 @@ and as a `keyword` in `index3` and `index4`.
 By default unmapped fields are ignored. You can include them in the response by
 adding a parameter called `include_unmapped` in the request:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET _field_caps?fields=rating,title&include_unmapped
 --------------------------------------------------
-// CONSOLE
 
 In which case the response will contain an entry for each field that is present in
 some indices but not all:

--- a/docs/reference/search/multi-search.asciidoc
+++ b/docs/reference/search/multi-search.asciidoc
@@ -123,7 +123,7 @@ The endpoint allows to also search against an index/indices in the URI itself,
 in which case it will be used as the default unless explicitly defined otherwise
 in the header. For example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET twitter/_msearch
 {}
@@ -133,7 +133,6 @@ GET twitter/_msearch
 {"index" : "twitter2"}
 {"query" : {"match_all" : {}}}
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 The above will execute the search against the `twitter` index for all the
@@ -157,7 +156,7 @@ Much like described in <<search-template>> for the _search resource, _msearch
 also provides support for templates. Submit them like follows for inline 
 templates:
 
-[source,js]
+[source,console]
 -----------------------------------------------
 GET _msearch/template
 {"index" : "twitter"}
@@ -165,13 +164,12 @@ GET _msearch/template
 {"index" : "twitter"}
 { "source" : "{ \"query\": { \"match_{{template}}\": {} } }", "params": { "template": "all" } }
 -----------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 
 You can also create search templates:
 
-[source,js]
+[source,console]
 ------------------------------------------
 POST /_scripts/my_template_1
 {
@@ -187,11 +185,10 @@ POST /_scripts/my_template_1
     }
 }
 ------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 
-[source,js]
+[source,console]
 ------------------------------------------
 POST /_scripts/my_template_2
 {
@@ -207,12 +204,11 @@ POST /_scripts/my_template_2
     }
 }
 ------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 You can use search templates in a _msearch:
 
-[source,js]
+[source,console]
 -----------------------------------------------
 GET _msearch/template
 {"index" : "main"}
@@ -220,7 +216,6 @@ GET _msearch/template
 {"index" : "main"}
 { "id": "my_template_2", "params": { "field": "user", "value": "test" } }
 -----------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 

--- a/docs/reference/search/profile.asciidoc
+++ b/docs/reference/search/profile.asciidoc
@@ -18,7 +18,7 @@ many shards. Pretty-printing the response is recommended to help understand the 
 
 Any `_search` request can be profiled by adding a top-level `profile` parameter:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /twitter/_search
 {
@@ -28,7 +28,6 @@ GET /twitter/_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 <1> Setting the top-level `profile` parameter to `true` will enable profiling
@@ -505,7 +504,7 @@ value is cumulative and contains the total time for all queries being rewritten.
 
 To demonstrate a slightly more complex query and the associated results, we can profile the following query:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /twitter/_search
 {
@@ -541,7 +540,6 @@ GET /twitter/_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[s/_search/_search\?filter_path=profile.shards.id,profile.shards.searches,profile.shards.aggregations/]
 // TEST[continued]
 
@@ -704,7 +702,7 @@ The `aggregations` section contains detailed timing of the aggregation tree exec
 The overall structure of this aggregation tree will resemble your original Elasticsearch request.  Let's
 execute the previous query again and look at the aggregation profile this time:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /twitter/_search
 {
@@ -740,7 +738,6 @@ GET /twitter/_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[s/_search/_search\?filter_path=profile.shards.aggregations/]
 // TEST[continued]
 

--- a/docs/reference/search/rank-eval.asciidoc
+++ b/docs/reference/search/rank-eval.asciidoc
@@ -147,7 +147,7 @@ Documents in the collection need to be rated either as relevant or irrelevant wi
 P@k does not take into account where in the top k results the relevant documents occur, so a ranking of ten results that 
 contains one relevant result in position 10 is equally good as a ranking of ten results that contains one relevant result in position 1.
 
-[source,js]
+[source,console]
 --------------------------------
 GET /twitter/_rank_eval
 {
@@ -166,7 +166,6 @@ GET /twitter/_rank_eval
    }
 }
 --------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 The `precision` metric takes the following optional parameters
@@ -190,7 +189,7 @@ first relevant document. For example finding the first relevant result
 in position 3 means the reciprocal rank is 1/3. The reciprocal rank for each query
 is averaged across all queries in the test suite to give the https://en.wikipedia.org/wiki/Mean_reciprocal_rank[mean reciprocal rank].
 
-[source,js]
+[source,console]
 --------------------------------
 GET /twitter/_rank_eval
 {
@@ -208,7 +207,6 @@ GET /twitter/_rank_eval
     }
 }
 --------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 The `mean_reciprocal_rank` metric takes the following optional parameters
@@ -229,7 +227,7 @@ In contrast to the two metrics above, https://en.wikipedia.org/wiki/Discounted_c
 
 The assumption is that highly relevant documents are more useful for the user when appearing at the top of the result list. Therefore, the DCG formula reduces the contribution that high ratings for documents on lower search ranks have on the overall DCG metric.
 
-[source,js]
+[source,console]
 --------------------------------
 GET /twitter/_rank_eval
 {
@@ -247,7 +245,6 @@ GET /twitter/_rank_eval
     }
 }
 --------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 The `dcg` metric takes the following optional parameters:
@@ -278,7 +275,7 @@ even more so if there are some relevant (but maybe less relevant) documents prec
 In this way, the ERR metric discounts documents which are shown after very relevant documents. This introduces 
 a notion of dependency in the ordering of relevant documents that e.g. Precision or DCG don't account for.
 
-[source,js]
+[source,console]
 --------------------------------
 GET /twitter/_rank_eval
 {
@@ -296,7 +293,6 @@ GET /twitter/_rank_eval
     }
 }
 --------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 The `expected_reciprocal_rank` metric takes the following parameters:

--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -3,7 +3,7 @@
 
 Specifies search criteria as request body parameters.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /twitter/_search
 {
@@ -12,7 +12,6 @@ GET /twitter/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 
@@ -89,7 +88,7 @@ all clients support GET with body, POST is allowed as well.
 [[search-request-body-api-example]]
 ==== {api-examples-title}
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /twitter/_search
 {
@@ -98,7 +97,6 @@ GET /twitter/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 
@@ -155,11 +153,10 @@ interested in the search results. Also we can set `terminate_after` to `1`
 to indicate that the query execution can be terminated whenever the first
 matching document was found (per shard).
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search?q=message:number&size=0&terminate_after=1
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 

--- a/docs/reference/search/request/collapse.asciidoc
+++ b/docs/reference/search/request/collapse.asciidoc
@@ -5,7 +5,7 @@ Allows to collapse search results based on field values.
 The collapsing is done by selecting only the top sorted document per collapse key.
 For instance the query below retrieves the best tweet for each user and sorts them by number of likes.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /twitter/_search
 {
@@ -21,8 +21,8 @@ GET /twitter/_search
     "from": 10 <3>
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
+
 <1> collapse the result set using the "user" field
 <2> sort the top docs by number of likes
 <3> define the offset of the first collapsed result
@@ -39,7 +39,7 @@ NOTE: The collapsing is applied to the top hits only and does not affect aggrega
 
 It is also possible to expand each collapsed top hits with the `inner_hits` option.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /twitter/_search
 {
@@ -60,8 +60,8 @@ GET /twitter/_search
     "sort": ["likes"]
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
+
 <1> collapse the result set using the "user" field
 <2> the name used for the inner hit section in the response
 <3> the number of inner_hits to retrieve per collapse key
@@ -73,7 +73,7 @@ See <<request-body-search-inner-hits, inner hits>> for the complete list of supp
 It is also possible to request multiple `inner_hits` for each collapsed hit.  This can be useful when you want to get
 multiple representations of the collapsed hits.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /twitter/_search
 {
@@ -100,8 +100,8 @@ GET /twitter/_search
     "sort": ["likes"]
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
+
 <1> collapse the result set using the "user" field
 <2> return the three most liked tweets for the user
 <3> return the three most recent tweets for the user

--- a/docs/reference/search/request/docvalue-fields.asciidoc
+++ b/docs/reference/search/request/docvalue-fields.asciidoc
@@ -4,7 +4,7 @@
 Allows to return the <<doc-values,doc value>> representation of a field for each hit, for
 example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -23,7 +23,7 @@ GET /_search
     ]
 }
 --------------------------------------------------
-// CONSOLE
+
 <1> the name of the field
 <2> an object notation is supported as well
 <3> the object notation allows to specify a custom format
@@ -32,7 +32,7 @@ Doc value fields can work on fields that have doc-values enabled, regardless of 
 
 `*` can be used as a wild card, for example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -47,7 +47,7 @@ GET /_search
     ]
 }
 --------------------------------------------------
-// CONSOLE
+
 <1> Match all fields ending with `field`
 <2> Format to be applied to all matching fields.
 

--- a/docs/reference/search/request/explain.asciidoc
+++ b/docs/reference/search/request/explain.asciidoc
@@ -3,7 +3,7 @@
 
 Enables explanation for each hit on how its score was computed.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -13,4 +13,3 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE

--- a/docs/reference/search/request/from-size.asciidoc
+++ b/docs/reference/search/request/from-size.asciidoc
@@ -10,7 +10,7 @@ Though `from` and `size` can be set as request parameters, they can also
 be set within the search body. `from` defaults to `0`, and `size`
 defaults to `10`.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -20,7 +20,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 
 Note that `from` + `size` can not be more than the `index.max_result_window`

--- a/docs/reference/search/request/highlighting.asciidoc
+++ b/docs/reference/search/request/highlighting.asciidoc
@@ -20,7 +20,7 @@ For example, to get highlights for the `content` field in each search hit
 using the default highlighter, include a `highlight` object in
 the request body that specifies the `content` field:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -34,7 +34,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 {es} supports three highlighters: `unified`, `plain`, and `fvh` (fast vector
@@ -276,7 +275,7 @@ type:: The highlighter to use: `unified`, `plain`, or `fvh`. Defaults to
 You can specify highlighter settings globally and selectively override them for
 individual fields.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -295,7 +294,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 [float]
@@ -307,7 +305,7 @@ when highlighting. For example, the following query includes both the search
 query and rescore query in the `highlight_query`. Without the `highlight_query`,
 highlighting would only take the search query into account.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -365,7 +363,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 [float]
@@ -376,7 +373,7 @@ The `type` field allows to force a specific highlighter type.
 The allowed values are: `unified`, `plain` and `fvh`.
 The following is an example that forces the use of the plain highlighter:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -390,7 +387,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 [[configure-tags]]
@@ -401,7 +397,7 @@ By default, the highlighting will wrap highlighted text in `<em>` and
 `</em>`. This can be controlled by setting `pre_tags` and `post_tags`,
 for example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -417,13 +413,12 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 When using the fast vector highlighter, you can specify additional tags and the
 "importance" is ordered.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -439,12 +434,11 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 You can also use the built-in `styled` tag schema:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -459,7 +453,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 [float]
@@ -469,7 +462,7 @@ GET /_search
 Forces the highlighting to highlight fields based on the source even if fields
 are stored separately. Defaults to `false`.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -483,7 +476,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 
@@ -494,7 +486,7 @@ GET /_search
 By default, only fields that contains a query match are highlighted. Set
 `require_field_match` to `false` to highlight all fields.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -509,7 +501,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 [[matched-fields]]
@@ -528,7 +519,7 @@ the matches are combined is loaded so only that field would benefit from having
 In the following examples, `comment` is analyzed by the `english`
 analyzer and `comment.plain` is analyzed by the `standard` analyzer.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -549,7 +540,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 The above matches both "run with scissors" and "running with scissors"
@@ -558,7 +548,7 @@ phrases appear in a large document then "running with scissors" is
 sorted above "run with scissors" in the fragments list because there
 are more matches in that fragment.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -579,14 +569,13 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 The above highlights "run" as well as "running" and "scissors" but
 still sorts "running with scissors" above "run with scissors" because
 the plain match ("running") is boosted.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -607,7 +596,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 The above query wouldn't highlight "run" or "scissor" but shows that
@@ -656,7 +644,7 @@ Elasticsearch highlights the fields in the order that they are sent, but per the
 JSON spec, objects are unordered.  If you need to be explicit about the order
 in which fields are highlighted specify the `fields` as an array:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -668,7 +656,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 None of the highlighters built into Elasticsearch care about the order that the
@@ -686,7 +673,7 @@ in characters (defaults to `100`), and the maximum number of fragments
 to return (defaults to `5`).
 For example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -700,13 +687,12 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 On top of this it is possible to specify that highlighted fragments need
 to be sorted by score:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -721,7 +707,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 If the `number_of_fragments` value is set to `0` then no fragments are
@@ -730,7 +715,7 @@ course it is highlighted. This can be very handy if short texts (like
 document title or address) need to be highlighted but no fragmentation
 is required. Note that `fragment_size` is ignored in this case.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -745,7 +730,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 When using `fvh` one can use `fragment_offset`
@@ -757,7 +741,7 @@ beginning of the field by setting `no_match_size` (default `0`) to the length
 of the text that you want returned. The actual length may be shorter or longer than
 specified as it tries to break on a word boundary.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -775,7 +759,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 [float]
@@ -785,7 +768,7 @@ GET /_search
 Here is an example of setting the `comment` field in the index mapping to
 allow for highlighting using the postings:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /example
 {
@@ -799,12 +782,11 @@ PUT /example
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 Here is an example of setting the `comment` field to allow for
 highlighting using the `term_vectors` (this will cause the index to be bigger):
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /example
 {
@@ -818,7 +800,6 @@ PUT /example
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 [float]
 [[specify-fragmenter]]
@@ -827,7 +808,7 @@ PUT /example
 When using the `plain` highlighter, you can choose between the `simple` and
 `span` fragmenters:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET twitter/_search
 {
@@ -846,7 +827,6 @@ GET twitter/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 Response:
@@ -886,7 +866,7 @@ Response:
 --------------------------------------------------
 // TESTRESPONSE[s/\.\.\./"took": $body.took,"timed_out": false,"_shards": $body._shards,/]
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET twitter/_search
 {
@@ -905,7 +885,6 @@ GET twitter/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 Response:

--- a/docs/reference/search/request/index-boost.asciidoc
+++ b/docs/reference/search/request/index-boost.asciidoc
@@ -7,7 +7,7 @@ one index matter more than hits coming from another index (think social
 graph where each user has an index).
 
 deprecated[5.2.0, This format is deprecated. Please use array format instead.]
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -17,12 +17,11 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:index_boost warning:Object format in indices_boost is deprecated, please use array format instead]
 
 You can also specify it as an array to control the order of boosts.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -32,7 +31,6 @@ GET /_search
     ]
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 This is important when you use aliases or wildcard expression.

--- a/docs/reference/search/request/inner-hits.asciidoc
+++ b/docs/reference/search/request/inner-hits.asciidoc
@@ -83,7 +83,7 @@ Inner hits also supports the following per document features:
 
 The nested `inner_hits` can be used to include nested inner objects as inner hits to a search hit.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT test
 {
@@ -124,7 +124,6 @@ POST test/_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 <1> The inner hit definition in the nested query. No other options need to be defined.
 
@@ -207,7 +206,7 @@ has an impact on the time it takes to execute the entire search request, especia
 are set higher than the default. To avoid the relatively expensive source extraction for nested inner hits, one can disable
 including the source and solely rely on doc values fields. Like this:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT test
 {
@@ -253,7 +252,6 @@ POST test/_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 ////
 
@@ -321,7 +319,7 @@ If a mapping has multiple levels of hierarchical nested object fields each level
 For example if there is a `comments` nested field that contains a `votes` nested field and votes should directly be returned
 with the root hits then the following path can be defined:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT test
 {
@@ -374,7 +372,6 @@ POST test/_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 Which would look like:
 
@@ -441,7 +438,7 @@ This indirect referencing is only supported for nested inner hits.
 
 The parent/child `inner_hits` can be used to include parent or child:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT test
 {
@@ -487,7 +484,6 @@ POST test/_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 <1> The inner hit definition like in the nested example.
 

--- a/docs/reference/search/request/min-score.asciidoc
+++ b/docs/reference/search/request/min-score.asciidoc
@@ -4,7 +4,7 @@
 Exclude documents which have a `_score` less than the minimum specified
 in `min_score`:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -14,7 +14,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 Note, most times, this does not make much sense, but is provided for
 advanced use cases.

--- a/docs/reference/search/request/named-queries-and-filters.asciidoc
+++ b/docs/reference/search/request/named-queries-and-filters.asciidoc
@@ -3,7 +3,7 @@
 
 Each filter and query can accept a `_name` in its top level definition.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -23,7 +23,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 The search response will include for each hit the `matched_queries` it matched on. The tagging of queries and filters
 only make sense for the `bool` query.

--- a/docs/reference/search/request/post-filter.asciidoc
+++ b/docs/reference/search/request/post-filter.asciidoc
@@ -7,7 +7,7 @@ best explained by example:
 
 Imagine that you are selling shirts that have the following properties:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /shirts
 {
@@ -27,7 +27,6 @@ PUT /shirts/_doc/1?refresh
     "model": "slim"
 }
 --------------------------------------------------
-// CONSOLE
 // TESTSETUP
 
 
@@ -37,7 +36,7 @@ Imagine a user has specified two filters:
 Gucci in the search results.  Normally you would do this with a 
 <<query-dsl-bool-query,`bool` query>>:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /shirts/_search 
 {
@@ -51,7 +50,6 @@ GET /shirts/_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 However, you would also like to use _faceted navigation_ to display a list of
 other options that the user could click on.  Perhaps you have a `model` field
@@ -61,7 +59,7 @@ that would allow the user to limit their search results to red Gucci
 This can be done with a 
 <<search-aggregations-bucket-terms-aggregation,`terms` aggregation>>:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /shirts/_search 
 {
@@ -80,7 +78,7 @@ GET /shirts/_search
   }
 }
 --------------------------------------------------
-// CONSOLE
+
 <1> Returns the most popular models of red shirts by Gucci.
 
 But perhaps you would also like to tell the user how many Gucci shirts are
@@ -92,7 +90,7 @@ Instead, you want to include shirts of all colors during aggregation, then
 apply the `colors` filter only to the search results.  This is the purpose of
 the `post_filter`:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /shirts/_search
 {
@@ -123,7 +121,7 @@ GET /shirts/_search
   }
 }
 --------------------------------------------------
-// CONSOLE
+
 <1> The main query now finds all shirts by Gucci, regardless of color.
 <2> The `colors` agg returns popular colors for shirts by Gucci.
 <3> The `color_red` agg limits the `models` sub-aggregation 

--- a/docs/reference/search/request/preference.asciidoc
+++ b/docs/reference/search/request/preference.asciidoc
@@ -55,7 +55,7 @@ Custom (string) value::
 
 For instance, use the user's session ID `xyzabc123` as follows:
 
-[source,js]
+[source,console]
 ------------------------------------------------
 GET /_search?preference=xyzabc123
 {
@@ -66,7 +66,6 @@ GET /_search?preference=xyzabc123
     }
 }
 ------------------------------------------------
-// CONSOLE
 
 This can be an effective strategy to increase usage of e.g. the request cache for
 unique users running similar searches repeatedly by always hitting the same cache, while

--- a/docs/reference/search/request/query.asciidoc
+++ b/docs/reference/search/request/query.asciidoc
@@ -4,7 +4,7 @@
 The query element within the search request body allows to define a
 query using the <<query-dsl,Query DSL>>.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -13,4 +13,3 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE

--- a/docs/reference/search/request/rescore.asciidoc
+++ b/docs/reference/search/request/rescore.asciidoc
@@ -39,7 +39,7 @@ respectively. Both default to `1`.
 
 For example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST /_search
 {
@@ -68,7 +68,6 @@ POST /_search
    }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 The way the scores are combined can be controlled with the `score_mode`:
@@ -87,7 +86,7 @@ for <<query-dsl-function-score-query,`function query`>> rescores.
 
 It is also possible to execute multiple rescores in sequence:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST /_search
 {
@@ -130,7 +129,6 @@ POST /_search
    } ]
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 The first one gets the results of the query then the second one gets the

--- a/docs/reference/search/request/script-fields.asciidoc
+++ b/docs/reference/search/request/script-fields.asciidoc
@@ -4,7 +4,7 @@
 Allows to return a <<modules-scripting,script
 evaluation>> (based on different fields) for each hit, for example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -30,7 +30,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:sales]
 
 Script fields can work on fields that are not stored (`price` in
@@ -41,7 +40,7 @@ Script fields can also access the actual `_source` document and
 extract specific elements to be returned from it by using `params['_source']`.
 Here is an example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
     {
@@ -55,7 +54,6 @@ GET /_search
         }
     }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 Note the `_source` keyword here to navigate the json-like model.

--- a/docs/reference/search/request/scroll.asciidoc
+++ b/docs/reference/search/request/scroll.asciidoc
@@ -36,7 +36,7 @@ In order to use scrolling, the initial search request should specify the
 `scroll` parameter in the query string, which tells Elasticsearch how long it
 should keep the ``search context'' alive (see <<scroll-search-context>>), eg `?scroll=1m`.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST /twitter/_search?scroll=1m
 {
@@ -48,14 +48,13 @@ POST /twitter/_search?scroll=1m
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 The result from the above request includes a `_scroll_id`, which should
 be passed to the `scroll` API in order to retrieve the next batch of
 results.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST /_search/scroll <1>
 {
@@ -63,7 +62,6 @@ POST /_search/scroll <1>
     "scroll_id" : "DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ==" <3>
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued s/DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ==/$body._scroll_id/]
 
 <1> `GET` or `POST` can be used and the URL should not include the `index`
@@ -88,7 +86,7 @@ NOTE: Scroll requests have optimizations that make them faster when the sort
 order is `_doc`. If you want to iterate over all documents regardless of the
 order, this is the most efficient option:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search?scroll=1m
 {
@@ -97,7 +95,6 @@ GET /_search?scroll=1m
   ]
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 [[scroll-search-context]]
@@ -142,11 +139,10 @@ maximum number of open scrolls is 500. This limit can be updated with the
 You can check how many search contexts are open with the
 <<cluster-nodes-stats,nodes stats API>>:
 
-[source,js]
+[source,console]
 ---------------------------------------
 GET /_nodes/stats/indices/search
 ---------------------------------------
-// CONSOLE
 
 ===== Clear scroll API
 
@@ -156,19 +152,18 @@ exceeded. However keeping scrolls open has a cost, as discussed in the
 cleared as soon as the scroll is not being used anymore using the
 `clear-scroll` API:
 
-[source,js]
+[source,console]
 ---------------------------------------
 DELETE /_search/scroll
 {
     "scroll_id" : "DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ=="
 }
 ---------------------------------------
-// CONSOLE
 // TEST[catch:missing]
 
 Multiple scroll IDs can be passed as array:
 
-[source,js]
+[source,console]
 ---------------------------------------
 DELETE /_search/scroll
 {
@@ -178,25 +173,22 @@ DELETE /_search/scroll
     ]
 }
 ---------------------------------------
-// CONSOLE
 // TEST[catch:missing]
 
 All search contexts can be cleared with the `_all` parameter:
 
-[source,js]
+[source,console]
 ---------------------------------------
 DELETE /_search/scroll/_all
 ---------------------------------------
-// CONSOLE
 
 The `scroll_id` can also be passed as a query string parameter or in the request body.
 Multiple scroll IDs can be passed as comma separated values:
 
-[source,js]
+[source,console]
 ---------------------------------------
 DELETE /_search/scroll/DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ==,DnF1ZXJ5VGhlbkZldGNoBQAAAAAAAAABFmtSWWRRWUJrU2o2ZExpSGJCVmQxYUEAAAAAAAAAAxZrUllkUVlCa1NqNmRMaUhiQlZkMWFBAAAAAAAAAAIWa1JZZFFZQmtTajZkTGlIYkJWZDFhQQAAAAAAAAAFFmtSWWRRWUJrU2o2ZExpSGJCVmQxYUEAAAAAAAAABBZrUllkUVlCa1NqNmRMaUhiQlZkMWFB
 ---------------------------------------
-// CONSOLE
 // TEST[catch:missing]
 
 [[sliced-scroll]]
@@ -205,7 +197,7 @@ DELETE /_search/scroll/DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMN
 For scroll queries that return a lot of documents it is possible to split the scroll in multiple slices which
 can be consumed independently:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /twitter/_search?scroll=1m
 {
@@ -232,7 +224,6 @@ GET /twitter/_search?scroll=1m
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:big_twitter]
 
 <1> The id of the slice
@@ -268,7 +259,7 @@ slice gets deterministic results.
 
     * The cardinality of the field should be high. This ensures that each slice gets approximately the same amount of documents.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /twitter/_search?scroll=1m
 {
@@ -284,7 +275,6 @@ GET /twitter/_search?scroll=1m
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:big_twitter]
 
 For append only time-based indices, the `timestamp` field can be used safely.

--- a/docs/reference/search/request/search-after.asciidoc
+++ b/docs/reference/search/request/search-after.asciidoc
@@ -9,7 +9,8 @@ The `search_after` parameter circumvents this problem by providing a live cursor
 The idea is to use the results from the previous page to help the retrieval of the next page.
 
 Suppose that the query to retrieve the first page looks like this:
-[source,js]
+
+[source,console]
 --------------------------------------------------
 GET twitter/_search
 {
@@ -25,7 +26,6 @@ GET twitter/_search
     ]
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 // TEST[s/"tie_breaker_id": "asc"/"tie_breaker_id": {"unmapped_type": "keyword"}/]
 
@@ -53,7 +53,7 @@ These `sort values` can be used in conjunction with the `search_after` parameter
 document in the result list.
 For instance we can use the `sort values` of the last document and pass it to `search_after` to retrieve the next page of results:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET twitter/_search
 {
@@ -70,7 +70,6 @@ GET twitter/_search
     ]
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 // TEST[s/"tie_breaker_id": "asc"/"tie_breaker_id": {"unmapped_type": "keyword"}/]
 

--- a/docs/reference/search/request/search-type.asciidoc
+++ b/docs/reference/search/request/search-type.asciidoc
@@ -50,11 +50,10 @@ During the second phase, the coordinating node requests the document
 content (and highlighted snippets, if any) from *only the relevant
 shards*.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET twitter/_search?search_type=query_then_fetch
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 NOTE: This is the default setting, if you do not specify a `search_type`
@@ -69,9 +68,8 @@ Same as "Query Then Fetch", except for an initial scatter phase which
 goes and computes the distributed term frequencies for more accurate
 scoring.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET twitter/_search?search_type=dfs_query_then_fetch
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]

--- a/docs/reference/search/request/seq-no.asciidoc
+++ b/docs/reference/search/request/seq-no.asciidoc
@@ -4,7 +4,7 @@
 Returns the sequence number and primary term of the last modification to each search hit.
 See <<optimistic-concurrency-control>> for more details.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -14,4 +14,3 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE

--- a/docs/reference/search/request/sort.asciidoc
+++ b/docs/reference/search/request/sort.asciidoc
@@ -7,7 +7,7 @@ field name for `_score` to sort by score, and `_doc` to sort by index order.
 
 Assuming the following index mapping:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /my_index
 {
@@ -25,9 +25,8 @@ PUT /my_index
     }
 }
 --------------------------------------------------
-// CONSOLE
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /my_index/_search
 {
@@ -43,7 +42,6 @@ GET /my_index/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 NOTE: `_doc` has no real use-case besides being the most efficient sort order.
@@ -92,7 +90,7 @@ In the example below the field price has multiple prices per document.
 In this case the result hits will be sorted by price ascending based on
 the average price per document.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /my_index/_doc/1?refresh
 {
@@ -110,7 +108,6 @@ POST /_search
    ]
 }
 --------------------------------------------------
-// CONSOLE
 
 ===== Sorting numeric fields
 
@@ -122,7 +119,7 @@ indices.
 
 Consider for instance these two indices:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /index_double
 {
@@ -133,9 +130,8 @@ PUT /index_double
     }
 }
 --------------------------------------------------
-// CONSOLE
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /index_long
 {
@@ -146,7 +142,6 @@ PUT /index_long
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 Since `field` is mapped as a `double` in the first index and as a `long`
@@ -155,7 +150,7 @@ that query both indices by default. However you can force the type to one
 or the other with the `numeric_type` option in order to force a specific
 type for all indices:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST /index_long,index_double/_search
 {
@@ -168,7 +163,6 @@ POST /index_long,index_double/_search
    ]
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 In the example above, values for the `index_long` index are casted to
@@ -183,7 +177,7 @@ This option can also be used to convert a `date` field that uses millisecond
 resolution to a `date_nanos` field with nanosecond resolution.
 Consider for instance these two indices:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /index_double
 {
@@ -194,9 +188,8 @@ PUT /index_double
     }
 }
 --------------------------------------------------
-// CONSOLE
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /index_long
 {
@@ -207,7 +200,6 @@ PUT /index_long
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 Values in these indices are stored with different resolutions so sorting on these
@@ -216,7 +208,7 @@ With the `numeric_type` type option it is possible to set a single resolution fo
 the sort, setting to `date` will convert the `date_nanos` to the millisecond resolution
 while `date_nanos` will convert the values in the `date` field to the nanoseconds resolution:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST /index_long,index_double/_search
 {
@@ -229,7 +221,6 @@ POST /index_long,index_double/_search
    ]
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 [WARNING]
@@ -268,7 +259,7 @@ a `nested` context.
 In the below example `offer` is a field of type `nested`.
 The nested `path` needs to be specified; otherwise, Elasticsearch doesn't know on what nested level sort values need to be captured.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST /_search
 {
@@ -291,12 +282,11 @@ POST /_search
     ]
 }
 --------------------------------------------------
-// CONSOLE
 
 In the below example `parent` and `child` fields are of type `nested`.
 The `nested.path` needs to be specified at each level; otherwise, Elasticsearch doesn't know on what nested level sort values need to be captured.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST /_search
 {
@@ -338,7 +328,6 @@ POST /_search
    ]
 }
 --------------------------------------------------
-// CONSOLE
 
 Nested sorting is also supported when sorting by
 scripts and sorting by geo distance.
@@ -353,7 +342,7 @@ The default is `_last`.
 
 For example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -365,7 +354,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 NOTE: If a nested inner object doesn't match with
 the `nested.filter` then a missing value is used.
@@ -378,7 +366,7 @@ fields that have no mapping and not sort by them. The value of this
 parameter is used to determine what sort values to emit. Here is an
 example of how it can be used:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -390,7 +378,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 If any of the indices that are queried doesn't have a mapping for `price`
 then Elasticsearch will handle it as if there was a mapping of type
@@ -401,7 +388,7 @@ then Elasticsearch will handle it as if there was a mapping of type
 
 Allow to sort by `_geo_distance`. Here is an example, assuming `pin.location` is a field of type `geo_point`:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -422,7 +409,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 
 
@@ -455,7 +441,7 @@ The following formats are supported in providing the coordinates:
 
 ====== Lat Lon as Properties
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -476,13 +462,12 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 ====== Lat Lon as String
 
 Format in `lat,lon`.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -500,11 +485,10 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 ====== Geohash
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -522,14 +506,13 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 ====== Lat Lon as Array
 
 Format in `[lon, lat]`, note, the order of lon/lat here in order to
 conform with http://geojson.org/[GeoJSON].
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -547,14 +530,13 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 
 ===== Multiple reference points
 
 Multiple geo points can be passed as an array containing any `geo_point` format, for example
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -572,7 +554,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 and so forth.
 
@@ -584,7 +565,7 @@ The final distance for a document will then be `min`/`max`/`avg` (defined via `m
 
 Allow to sort based on custom scripts, here is an example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -606,7 +587,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 
 ===== Track Scores
@@ -614,7 +594,7 @@ GET /_search
 When sorting on a field, scores are not computed. By setting
 `track_scores` to true, scores will still be computed and tracked.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -629,7 +609,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 ===== Memory Considerations
 

--- a/docs/reference/search/request/source-filtering.asciidoc
+++ b/docs/reference/search/request/source-filtering.asciidoc
@@ -11,7 +11,7 @@ You can turn off `_source` retrieval by using the `_source` parameter:
 
 To disable `_source` retrieval set to `false`:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -21,13 +21,12 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 The `_source` also accepts one or more wildcard patterns to control what parts of the `_source` should be returned:
 
 For example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -37,11 +36,10 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 Or
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -51,7 +49,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 Finally, for complete control, you can specify both `includes` and `excludes`
 patterns. If `includes` is not empty, then only fields that match one of the
@@ -59,7 +56,7 @@ patterns in `includes` but none of the patterns in `excludes` are provided in
 `_source`. If `includes` is empty, then all fields are provided in `_source`,
 except for those that match a pattern in `excludes`.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -72,4 +69,3 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE

--- a/docs/reference/search/request/stored-fields.asciidoc
+++ b/docs/reference/search/request/stored-fields.asciidoc
@@ -9,7 +9,7 @@ subsets of the original source document to be returned.
 Allows to selectively load specific stored fields for each document represented
 by a search hit.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -19,14 +19,13 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 `*` can be used to load all stored fields from the document.
 
 An empty array will cause only the `_id` and `_type` for each hit to be
 returned, for example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -36,7 +35,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 If the requested fields are not stored (`store` mapping set to `false`), they will be ignored.
 
@@ -58,7 +56,7 @@ must be used within an <<request-body-search-inner-hits, `inner_hits`>> block.
 
 To disable the stored fields (and metadata fields) entirely use: `_none_`:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -68,7 +66,6 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 NOTE: <<request-body-search-source-filtering,`_source`>> and <<request-body-search-version, `version`>> parameters cannot be activated if `_none_` is used.
 

--- a/docs/reference/search/request/track-total-hits.asciidoc
+++ b/docs/reference/search/request/track-total-hits.asciidoc
@@ -19,7 +19,7 @@ should be interpreted. A value of `"gte"` means that the `"total.value"` is a
 lower bound of the total hits that match the query and a value of `"eq"` indicates
 that `"total.value"` is the accurate count.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET twitter/_search
 {
@@ -32,7 +32,6 @@ GET twitter/_search
 }
 --------------------------------------------------
 // TEST[setup:twitter]
-// CONSOLE
 
 \... returns:
 
@@ -65,7 +64,7 @@ It is also possible to set `track_total_hits` to an integer.
 For instance the following query will accurately track the total hit count that match
 the query up to 100 documents:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET twitter/_search
 {
@@ -77,7 +76,6 @@ GET twitter/_search
      }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 The `hits.total.relation` in the response will indicate if the
@@ -140,7 +138,7 @@ will indicate that the returned value is a lower bound:
 If you don't need to track the total number of hits at all you can improve query
 times by setting this option to `false`:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET twitter/_search
 {
@@ -152,7 +150,6 @@ GET twitter/_search
      }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 \... returns:

--- a/docs/reference/search/request/version.asciidoc
+++ b/docs/reference/search/request/version.asciidoc
@@ -3,7 +3,7 @@
 
 Returns a version for each search hit.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_search
 {
@@ -13,4 +13,3 @@ GET /_search
     }
 }
 --------------------------------------------------
-// CONSOLE

--- a/docs/reference/search/search-shards.asciidoc
+++ b/docs/reference/search/search-shards.asciidoc
@@ -3,11 +3,10 @@
 
 Returns the indices and shards that a search request would be executed against.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /twitter/_search_shards
 --------------------------------------------------
-// CONSOLE
 // TEST[s/^/PUT twitter\n{"settings":{"index.number_of_shards":5}}\n/]
 
 
@@ -55,11 +54,10 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=routing]
 [[search-shards-api-example]]
 ==== {api-examples-title}
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /twitter/_search_shards
 --------------------------------------------------
-// CONSOLE
 // TEST[s/^/PUT twitter\n{"settings":{"index.number_of_shards":5}}\n/]
 
 The API returns the following result:
@@ -140,11 +138,10 @@ The API returns the following result:
 
 Specifying the same request, this time with a routing value:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /twitter/_search_shards?routing=foo,bar
 --------------------------------------------------
-// CONSOLE
 // TEST[s/^/PUT twitter\n{"settings":{"index.number_of_shards":5}}\n/]
 
 The API returns the following result:

--- a/docs/reference/search/search-template.asciidoc
+++ b/docs/reference/search/search-template.asciidoc
@@ -3,7 +3,7 @@
 
 Allows you to use the mustache language to pre render search requests.
 
-[source,js]
+[source,console]
 ------------------------------------------
 GET _search/template
 {
@@ -18,7 +18,6 @@ GET _search/template
     }
 }
 ------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 [[search-template-api-request]]
@@ -107,7 +106,7 @@ The API request body must contain the search definition template and its paramet
 
 You can store a search template using the stored scripts API.
 
-[source,js]
+[source,console]
 ------------------------------------------
 POST _scripts/<templateid>
 {
@@ -123,7 +122,6 @@ POST _scripts/<templateid>
     }
 }
 ------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 //////////////////////////
@@ -143,11 +141,10 @@ created:
 
 The template can be retrieved by calling
 
-[source,js]
+[source,console]
 ------------------------------------------
 GET _scripts/<templateid>
 ------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 The API returns the following result:
@@ -170,11 +167,10 @@ The API returns the following result:
 
 This template can be deleted by calling
 
-[source,js]
+[source,console]
 ------------------------------------------
 DELETE _scripts/<templateid>
 ------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 
@@ -183,7 +179,7 @@ DELETE _scripts/<templateid>
 
 To use a stored template at search time send the following request:
 
-[source,js]
+[source,console]
 ------------------------------------------
 GET _search/template
 {
@@ -193,7 +189,6 @@ GET _search/template
     }
 }
 ------------------------------------------
-// CONSOLE
 // TEST[catch:missing]
 <1> Name of the stored template script.
 
@@ -204,7 +199,7 @@ GET _search/template
 A template can be rendered in a response with given parameters by using the 
 following request:
 
-[source,js]
+[source,console]
 ------------------------------------------
 GET _render/template
 {
@@ -216,7 +211,6 @@ GET _render/template
   }
 }
 ------------------------------------------
-// CONSOLE
 
 
 The API returns the rendered template:
@@ -258,7 +252,7 @@ GET _render/template/<template_name>
 
 You can use the `explain` parameter when running a template:
 
-[source,js]
+[source,console]
 ------------------------------------------
 GET _search/template
 {
@@ -269,7 +263,6 @@ GET _search/template
   "explain": true
 }
 ------------------------------------------
-// CONSOLE
 // TEST[catch:missing]
 
 
@@ -278,7 +271,7 @@ GET _search/template
 
 You can use the `profile` parameter when running a template:
 
-[source,js]
+[source,console]
 ------------------------------------------
 GET _search/template
 {
@@ -289,14 +282,13 @@ GET _search/template
   "profile": true
 }
 ------------------------------------------
-// CONSOLE
 // TEST[catch:missing]
 
 
 [[search-template-query-string-single]]
 ===== Filling in a query string with a single value
 
-[source,js]
+[source,console]
 ------------------------------------------
 GET _search/template
 {
@@ -312,7 +304,6 @@ GET _search/template
     }
 }
 ------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 [[search-template-converting-to-json]]
@@ -321,7 +312,7 @@ GET _search/template
 The `{{#toJson}}parameter{{/toJson}}` function can be used to convert parameters
 like maps and array to their JSON representation:
 
-[source,js]
+[source,console]
 ------------------------------------------
 GET _search/template
 {
@@ -333,7 +324,6 @@ GET _search/template
   }
 }
 ------------------------------------------
-// CONSOLE
 
 which is rendered as:
 
@@ -354,7 +344,7 @@ which is rendered as:
 
 A more complex example substitutes an array of JSON objects:
 
-[source,js]
+[source,console]
 ------------------------------------------
 GET _search/template
 {
@@ -367,7 +357,6 @@ GET _search/template
    }
 }
 ------------------------------------------
-// CONSOLE
 
 which is rendered as:
 
@@ -400,7 +389,7 @@ which is rendered as:
 The `{{#join}}array{{/join}}` function can be used to concatenate the
 values of an array as a comma delimited string:
 
-[source,js]
+[source,console]
 ------------------------------------------
 GET _search/template
 {
@@ -416,7 +405,6 @@ GET _search/template
   }
 }
 ------------------------------------------
-// CONSOLE
 
 which is rendered as:
 
@@ -434,7 +422,7 @@ which is rendered as:
 
 The function also accepts a custom delimiter:
 
-[source,js]
+[source,console]
 ------------------------------------------
 GET _search/template
 {
@@ -458,7 +446,6 @@ GET _search/template
   }
 }
 ------------------------------------------
-// CONSOLE
 
 which is rendered as:
 
@@ -624,7 +611,7 @@ http://www.w3.org/TR/html4/[HTML specification].
 
 As an example, it is useful to encode a URL:
 
-[source,js]
+[source,console]
 ------------------------------------------
 GET _render/template
 {
@@ -641,7 +628,6 @@ GET _render/template
     }
 }
 ------------------------------------------
-// CONSOLE
 
 
 The previous query will be rendered as:

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -3,11 +3,10 @@
 
 Returns search hits that match the query defined in the request.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /twitter/_search?q=user:kimchy
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 
@@ -225,28 +224,25 @@ All search APIs can be applied across multiple indices with support for
 the <<multi-index,multi index syntax>>. For
 example, we can search on all documents within the twitter index:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /twitter/_search?q=user:kimchy
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 We can also search all documents with a certain tag across several indices
 (for example, when there is one index per user):
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /kimchy,elasticsearch/_search?q=tag:wow
 --------------------------------------------------
-// CONSOLE
 // TEST[s/^/PUT kimchy\nPUT elasticsearch\n/]
 
 Or we can search across all available indices using `_all`:
 
-[source,js]
+[source,console]
 ---------------------------------------------------
 GET /_all/_search?q=tag:wow
 ---------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]

--- a/docs/reference/search/suggesters.asciidoc
+++ b/docs/reference/search/suggesters.asciidoc
@@ -12,7 +12,7 @@ NOTE: `_suggest` endpoint has been deprecated in favour of using suggest via
 `_search` endpoint. In 5.0, the `_search` endpoint has been optimized for
 suggest only search requests.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST twitter/_search
 {
@@ -31,7 +31,6 @@ POST twitter/_search
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 Several suggestions can be specified per request. Each suggestion is
@@ -39,7 +38,7 @@ identified with an arbitrary name. In the example below two suggestions
 are requested. Both `my-suggest-1` and `my-suggest-2` suggestions use
 the `term` suggester, but have a different `text`.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _search
 {
@@ -59,7 +58,6 @@ POST _search
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 The below suggest response example includes the suggestion response for
@@ -115,7 +113,7 @@ To avoid repetition of the suggest text, it is possible to define a
 global text. In the example below the suggest text is defined globally
 and applies to the `my-suggest-1` and `my-suggest-2` suggestions.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _search
 {
@@ -134,7 +132,6 @@ POST _search
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 The suggest text can in the above example also be specified as
 suggestion specific option. The suggest text specified on suggestion

--- a/docs/reference/search/suggesters/completion-suggest.asciidoc
+++ b/docs/reference/search/suggesters/completion-suggest.asciidoc
@@ -24,7 +24,7 @@ but are costly to build and are stored in-memory.
 To use this feature, specify a special mapping for this field,
 which indexes the field values for fast completions.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT music
 {
@@ -40,7 +40,6 @@ PUT music
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TESTSETUP
 
 Mapping supports the following parameters:
@@ -81,7 +80,7 @@ You index suggestions like any other field. A suggestion is made of an
 text to be matched by a suggestion query and the `weight` determines how
 the suggestions will be scored. Indexing a suggestion is as follows:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT music/_doc/1?refresh
 {
@@ -91,7 +90,6 @@ PUT music/_doc/1?refresh
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST
 
 The following parameters are supported:
@@ -108,7 +106,7 @@ The following parameters are supported:
 
 You can index multiple suggestions for a document as follows:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT music/_doc/1?refresh
 {
@@ -124,20 +122,18 @@ PUT music/_doc/1?refresh
     ]
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 You can use the following shorthand form. Note that you can not specify
 a weight with suggestion(s) in the shorthand form.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT music/_doc/1?refresh
 {
   "suggest" : [ "Nevermind", "Nirvana" ]
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 [[querying]]
@@ -148,7 +144,7 @@ type as `completion`. Suggestions are near real-time, which means
 new suggestions can be made visible by <<indices-refresh,refresh>> and
 documents once deleted are never shown. This request:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST music/_search?pretty
 {
@@ -162,7 +158,6 @@ POST music/_search?pretty
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 <1> Prefix used to search for suggestions
@@ -218,7 +213,7 @@ using <<request-body-search-source-filtering, source filtering>> to minimize
 `_source` size. Note that the _suggest endpoint doesn't support source
 filtering but using suggest on the `_search` endpoint does:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST music/_search
 {
@@ -234,7 +229,6 @@ POST music/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 <1> Filter the source to return only the `suggest` field
@@ -310,7 +304,7 @@ Queries can return duplicate suggestions coming from different documents.
 It is possible to modify this behavior by setting `skip_duplicates` to true.
 When set, this option filters out documents with duplicate suggestions from the result.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST music/_search?pretty
 {
@@ -325,7 +319,6 @@ POST music/_search?pretty
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 WARNING: When set to true, this option can slow down search because more suggestions
 need to be visited to find the top N.
@@ -336,7 +329,7 @@ need to be visited to find the top N.
 The completion suggester also supports fuzzy queries -- this means
 you can have a typo in your search and still get results back.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST music/_search?pretty
 {
@@ -353,7 +346,6 @@ POST music/_search?pretty
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 Suggestions that share the longest prefix to the query `prefix` will
 be scored higher.
@@ -395,7 +387,7 @@ NOTE: If you want to stick with the default values, but
 The completion suggester also supports regex queries meaning
 you can express a prefix as a regular expression
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST music/_search?pretty
 {
@@ -409,7 +401,6 @@ POST music/_search?pretty
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 The regex query can take specific regex parameters.
 The following parameters are supported:

--- a/docs/reference/search/suggesters/context-suggest.asciidoc
+++ b/docs/reference/search/suggesters/context-suggest.asciidoc
@@ -21,7 +21,7 @@ NOTE: The maximum allowed number of completion field context mappings is 10.
 The following defines types, each with two context mappings for a completion
 field:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT place
 {
@@ -71,8 +71,8 @@ PUT place_path_category
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TESTSETUP
+
 <1> Defines a `category` context named 'place_type' where the categories must be
     sent with the suggestions.
 <2> Defines a `geo` context named 'location' where the categories must be sent
@@ -96,7 +96,7 @@ The mappings are set up like the `place_type` fields above. If `path` is defined
 then the categories are read from that path in the document, otherwise they must
 be sent in the suggest field like this:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT place/_doc/1
 {
@@ -108,13 +108,13 @@ PUT place/_doc/1
     }
 }
 --------------------------------------------------
-// CONSOLE
+
 <1> These suggestions will be associated with 'cafe' and 'food' category.
 
 If the mapping had a `path` then the following index request would be enough to
 add the categories:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT place_path_category/_doc/1
 {
@@ -122,7 +122,7 @@ PUT place_path_category/_doc/1
     "cat": ["cafe", "food"] <1>
 }
 --------------------------------------------------
-// CONSOLE
+
 <1> These suggestions will be associated with 'cafe' and 'food' category.
 
 NOTE: If context mapping references another field and the categories
@@ -136,7 +136,7 @@ of categories.
 Suggestions can be filtered by one or more categories. The following
 filters suggestions by multiple categories:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST place/_search?pretty
 {
@@ -154,7 +154,6 @@ POST place/_search?pretty
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 NOTE: If multiple categories or category contexts are set on the query
@@ -165,7 +164,7 @@ Suggestions with certain categories can be boosted higher than others.
 The following filters suggestions by categories and additionally boosts
 suggestions associated with some categories:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST place/_search?pretty
 {
@@ -186,8 +185,8 @@ POST place/_search?pretty
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
+
 <1> The context query filter suggestions associated with
     categories 'cafe' and 'restaurants' and boosts the
     suggestions associated with 'restaurants' by a
@@ -250,7 +249,7 @@ document via the `path` parameter, similar to `category` contexts. Associating m
 with a suggestion, will index the suggestion for every geo location. The following indexes a suggestion
 with two geo location contexts:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT place/_doc/1
 {
@@ -271,7 +270,6 @@ PUT place/_doc/1
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 [float]
 ====== Geo location Query
@@ -280,7 +278,7 @@ Suggestions can be filtered and boosted with respect to how close they are to on
 more geo points. The following filters suggestions that fall within the area represented by
 the encoded geohash of a geo point:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST place/_search
 {
@@ -301,7 +299,6 @@ POST place/_search
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 NOTE: When a location with a lower precision at query time is specified, all suggestions
@@ -314,7 +311,7 @@ if they contain at least one of the provided context values.
 Suggestions that are within an area represented by a geohash can also be boosted higher
 than others, as shown by the following:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST place/_search?pretty
 {
@@ -345,8 +342,8 @@ POST place/_search?pretty
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
+
 <1> The context query filters for suggestions that fall under
     the geo location represented by a geohash of '(43.662, -79.380)'
     with a precision of '2' and boosts suggestions

--- a/x-pack/docs/en/rest-api/watcher/ack-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/ack-watch.asciidoc
@@ -58,7 +58,7 @@ status from a watch execution.
 
 To demonstrate let's create a new watch:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _watcher/watch/my_watch
 {
@@ -89,17 +89,15 @@ PUT _watcher/watch/my_watch
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TESTSETUP
 
 The current status of a watch and the state of its actions is returned with the
 watch definition when you call the <<watcher-api-get-watch, Get Watch API>>:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET _watcher/watch/my_watch
 --------------------------------------------------
-// CONSOLE
 
 The action state of a newly-created watch is `awaits_successful_execution`:
 
@@ -134,7 +132,7 @@ When the watch executes and the condition matches, the value of the `ack.state`
 changes to `ackable`. Let's force execution of the watch and fetch it again to
 check the status:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _watcher/watch/my_watch/_execute
 {
@@ -143,7 +141,6 @@ POST _watcher/watch/my_watch/_execute
 
 GET _watcher/watch/my_watch
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 and the action is now in `ackable` state:
@@ -191,12 +188,11 @@ and the action is now in `ackable` state:
 
 Now we can acknowledge it:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _watcher/watch/my_watch/_ack/test_index
 GET _watcher/watch/my_watch
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 [source,js]
@@ -247,21 +243,19 @@ condition of the watch is not met (the condition evaluates to `false`).
 You can acknowledge multiple actions by assigning the `actions` parameter a
 comma-separated list of action ids:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _watcher/watch/my_watch/_ack/action1,action2
 --------------------------------------------------
-// CONSOLE
 
 To acknowledge all of the actions of a watch, simply omit the `actions`
 parameter:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _watcher/watch/my_watch/_ack
 --------------------------------------------------
 // TEST[s/^/POST _watcher\/watch\/my_watch\/_execute\n{ "record_execution" : true }\n/]
-// CONSOLE
 
 
 The response looks like a get watch response, but only contains the status:

--- a/x-pack/docs/en/rest-api/watcher/activate-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/activate-watch.asciidoc
@@ -47,11 +47,10 @@ information, see {stack-ov}/security-privileges.html[Security privileges].
 The status of an inactive watch is returned with the watch definition when you
 call the <<watcher-api-get-watch,get watch API>>:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET _watcher/watch/my_watch
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:my_inactive_watch]
 
 [source,js]
@@ -80,11 +79,10 @@ GET _watcher/watch/my_watch
 
 You can activate the watch by executing the following API call:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _watcher/watch/my_watch/_activate
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:my_inactive_watch]
 
 The new state of the watch is returned as part of its overall status:

--- a/x-pack/docs/en/rest-api/watcher/deactivate-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/deactivate-watch.asciidoc
@@ -47,11 +47,10 @@ information, see {stack-ov}/security-privileges.html[Security privileges].
 The status of an active watch is returned with the watch definition when you
 call the <<watcher-api-get-watch,get watch API>>:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET _watcher/watch/my_watch
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:my_active_watch]
 
 [source,js]
@@ -80,11 +79,10 @@ GET _watcher/watch/my_watch
 
 You can deactivate the watch by executing the following API call:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _watcher/watch/my_watch/_deactivate
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:my_active_watch]
 
 The new state of the watch is returned as part of its overall status:

--- a/x-pack/docs/en/rest-api/watcher/delete-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/delete-watch.asciidoc
@@ -56,11 +56,10 @@ IMPORTANT:  Deleting a watch must be done via this API only. Do not delete the
 
 The following example deletes a watch with the `my-watch` id:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 DELETE _watcher/watch/my_watch
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:my_active_watch]
 
 Response:

--- a/x-pack/docs/en/rest-api/watcher/execute-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/execute-watch.asciidoc
@@ -144,16 +144,15 @@ the watch.
 
 The following example executes the `my_watch` watch:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _watcher/watch/my_watch/_execute
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:my_active_watch]
 
 The following example shows a comprehensive example of executing the `my-watch` watch:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _watcher/watch/my_watch/_execute
 {
@@ -171,8 +170,8 @@ POST _watcher/watch/my_watch/_execute
   "record_execution" : true <5>
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:my_active_watch]
+
 <1> The triggered and schedule times are provided.
 <2> The input as defined by the watch is ignored and instead the provided input
     is used as the execution payload.
@@ -296,7 +295,7 @@ This is an example of the output:
 You can set a different execution mode for every action by associating the mode
 name with the action id:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _watcher/watch/my_watch/_execute
 {
@@ -306,13 +305,12 @@ POST _watcher/watch/my_watch/_execute
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:my_active_watch]
 
 You can also associate a single execution mode with all the actions in the watch
 using `_all` as the action id:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _watcher/watch/my_watch/_execute
 {
@@ -321,12 +319,11 @@ POST _watcher/watch/my_watch/_execute
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:my_active_watch]
 
 The following example shows how to execute a watch inline:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _watcher/watch/_execute
 {
@@ -357,13 +354,12 @@ POST _watcher/watch/_execute
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 All other settings for this API still apply when inlining a watch. In the
 following snippet, while the inline watch defines a `compare` condition,
 during the execution this condition will be ignored:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _watcher/watch/_execute
 {
@@ -395,4 +391,3 @@ POST _watcher/watch/_execute
   }
 }
 --------------------------------------------------
-// CONSOLE

--- a/x-pack/docs/en/rest-api/watcher/get-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/get-watch.asciidoc
@@ -45,11 +45,10 @@ this API. For more information, see
 
 The following example gets a watch with `my-watch` id:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET _watcher/watch/my_watch
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:my_active_watch]
 
 Response:

--- a/x-pack/docs/en/rest-api/watcher/put-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/put-watch.asciidoc
@@ -113,7 +113,7 @@ characteristics:
 * The watch condition checks if any search hits where found.
 * When found, the watch action sends an email to an administrator.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _watcher/watch/my-watch
 {
@@ -161,7 +161,6 @@ PUT _watcher/watch/my-watch
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 When you add a watch you can also define its initial
 {stack-ov}/how-watcher-works.html#watch-active-state[active state]. You do that

--- a/x-pack/docs/en/rest-api/watcher/start.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/start.asciidoc
@@ -39,11 +39,10 @@ information, see {stack-ov}/security-privileges.html[Security privileges].
 [[watcher-api-start-example]]
 ==== {api-examples-title}
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _watcher/_start
 --------------------------------------------------
-// CONSOLE
 
 {watcher} returns the following response if the request is successful:
 

--- a/x-pack/docs/en/rest-api/watcher/stats.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/stats.asciidoc
@@ -80,11 +80,10 @@ the `metric` parameter.
 
 The following example calls the `stats` API to retrieve basic metrics:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET _watcher/stats
 --------------------------------------------------
-// CONSOLE
 
 A successful call returns a JSON structure similar to the following example:
 
@@ -109,19 +108,17 @@ number of concurrent executing watches.
 The following example specifies the `metric` option as a query string argument
 and will include the basic metrics and metrics about the current executing watches:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET _watcher/stats?metric=current_watches
 --------------------------------------------------
-// CONSOLE
 
 The following example specifies the `metric` option as part of the url path:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET _watcher/stats/current_watches
 --------------------------------------------------
-// CONSOLE
 
 The following snippet shows an example of a successful JSON response that
 captures a watch in execution:
@@ -162,11 +159,10 @@ captures a watch in execution:
 The following example specifies the `queued_watches` metric option and includes
 both the basic metrics and the queued watches:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET _watcher/stats/queued_watches
 --------------------------------------------------
-// CONSOLE
 
 An example of a successful JSON response that captures a watch in execution:
 

--- a/x-pack/docs/en/rest-api/watcher/stop.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/stop.asciidoc
@@ -39,11 +39,10 @@ information, see {stack-ov}/security-privileges.html[Security privileges].
 [[watcher-api-stop-example]]
 ==== {api-examples-title}
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _watcher/_stop
 --------------------------------------------------
-// CONSOLE
 
 {watcher} returns the following response if the request is successful:
 

--- a/x-pack/docs/en/security/auditing/output-logfile.asciidoc
+++ b/x-pack/docs/en/security/auditing/output-logfile.asciidoc
@@ -23,7 +23,7 @@ Alternatively, use the
 {ref}/cluster-update-settings.html[cluster update settings API] to dynamically
 configure the logger:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /_cluster/settings
 {
@@ -32,7 +32,6 @@ PUT /_cluster/settings
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 NOTE: If you overwrite the `log4j2.properties` and do not specify appenders for
 any of the audit trails, audit events are forwarded to the root appender, which

--- a/x-pack/docs/en/security/authentication/configuring-active-directory-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-active-directory-realm.asciidoc
@@ -184,7 +184,8 @@ Directory `admins` group to both the `monitoring` and `user` roles, maps the
 role.
 
 Configured via the role-mapping API:
-[source,js]
+
+[source,console]
 --------------------------------------------------
 PUT /_security/role_mapping/admins
 {
@@ -195,10 +196,10 @@ PUT /_security/role_mapping/admins
   "enabled": true
 }
 --------------------------------------------------
-// CONSOLE
+
 <1> The Active Directory distinguished name (DN) of the `admins` group.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /_security/role_mapping/basic_users
 {
@@ -214,7 +215,7 @@ PUT /_security/role_mapping/basic_users
   "enabled": true
 }
 --------------------------------------------------
-// CONSOLE
+
 <1> The Active Directory distinguished name (DN) of the `users` group.
 <2> The Active Directory distinguished name (DN) of the user `John Doe`.
 

--- a/x-pack/docs/en/security/authentication/configuring-kerberos-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-kerberos-realm.asciidoc
@@ -151,7 +151,7 @@ users by their `username` field.
 The following example uses the role mapping API to map `user@REALM` to the roles 
 `monitoring` and `user`:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST /_security/role_mapping/kerbrolemapping
 {
@@ -162,7 +162,6 @@ POST /_security/role_mapping/kerbrolemapping
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 In case you want to support Kerberos cross realm authentication you may 
 need to map roles based on the Kerberos realm name. For such scenarios 

--- a/x-pack/docs/en/security/authentication/configuring-ldap-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-ldap-realm.asciidoc
@@ -145,7 +145,8 @@ names. For example, the following mapping configuration maps the LDAP
 `users` group to the `user` role.
 
 Configured via the role-mapping API:
-[source,js]
+
+[source,console]
 --------------------------------------------------
 PUT /_security/role_mapping/admins
 {
@@ -156,10 +157,10 @@ PUT /_security/role_mapping/admins
   "enabled": true
 }
 --------------------------------------------------
-// CONSOLE
+
 <1> The LDAP distinguished name (DN) of the `admins` group.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /_security/role_mapping/basic_users
 {
@@ -170,7 +171,7 @@ PUT /_security/role_mapping/basic_users
   "enabled": true
 }
 --------------------------------------------------
-// CONSOLE
+
 <1> The LDAP distinguished name (DN) of the `users` group.
 
 Or, alternatively, configured via the role-mapping file:

--- a/x-pack/docs/en/security/authentication/configuring-pki-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-pki-realm.asciidoc
@@ -169,7 +169,8 @@ For example, the following mapping configuration maps `John Doe` to the
 `user` role:
 
 Using the role-mapping API:
-[source,js]
+
+[source,console]
 --------------------------------------------------
 PUT /_security/role_mapping/users
 {
@@ -180,7 +181,7 @@ PUT /_security/role_mapping/users
   "enabled": true
 }
 --------------------------------------------------
-// CONSOLE
+
 <1> The distinguished name (DN) of a PKI user.
 
 Or, alternatively, configured inside a role-mapping file. The file's path
@@ -267,7 +268,7 @@ the following role mapping rule will assign the `role_for_pki1_direct` role to
 all users that have been authenticated directly by the `pki1` realm, by
 connecting to {es} instead of going through {kib}:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /_security/role_mapping/direct_pki_only
 {
@@ -287,7 +288,7 @@ PUT /_security/role_mapping/direct_pki_only
   "enabled": true
 }
 --------------------------------------------------
-// CONSOLE
+
 <1> only when this metadata field is set (it is *not* `null`) the user has been
 authenticated in the delegation scenario.
 

--- a/x-pack/docs/en/security/authentication/oidc-guide.asciidoc
+++ b/x-pack/docs/en/security/authentication/oidc-guide.asciidoc
@@ -422,7 +422,7 @@ to grant roles to users authenticating via OpenID Connect.
 This is an example of a simple role mapping that grants the `kibana_user` role
 to any user who authenticates against the `oidc1` OpenID Connect realm:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /_security/role_mapping/oidc-kibana
 {
@@ -433,8 +433,6 @@ PUT /_security/role_mapping/oidc-kibana
   }
 }
 --------------------------------------------------
-// CONSOLE
-// TEST
 
 
 The user properties that are mapped via the realm configuration are used to process
@@ -459,7 +457,7 @@ as per the example below.
 This mapping grants the {es} `finance_data` role, to any users who authenticate
 via the `oidc1` realm with the `finance-team` group membership.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /_security/role_mapping/oidc-finance
 {
@@ -471,8 +469,6 @@ PUT /_security/role_mapping/oidc-finance
   ] }
 }
 --------------------------------------------------
-// CONSOLE
-// TEST
 
 If your users also exist in a repository that can be directly accessed by {es}
 (such as an LDAP directory) then you can use
@@ -599,17 +595,16 @@ that gives them the `manage_oidc` cluster privilege. The use of the `manage_toke
 cluster privilege will be necessary after the authentication takes place, so that the
 the user can maintain access or be subsequently logged out.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST /_security/role/facilitator-role
 {
   "cluster" : ["manage_oidc", "manage_token"]
 }
 --------------------------------------------------
-// CONSOLE
 
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST /_security/user/facilitator
 {
@@ -617,7 +612,6 @@ POST /_security/user/facilitator
   "roles"    : [ "facilitator-role"]
 }
 --------------------------------------------------
-// CONSOLE
 
 
 ==== Handling the authentication flow
@@ -629,14 +623,13 @@ authenticate a user with OpenID Connect:
 OpenID Connect realm in the {es} configuration in the request body. See the
 {ref}/security-api-oidc-prepare-authentication.html[OIDC Prepare Authentication API] for more details
 +
-[source,js]
+[source,console]
 --------------------------------------------------
 POST /_security/oidc/prepare
 {
   "realm" : "oidc1"
 }
 --------------------------------------------------
-// CONSOLE
 +
 . Handle the response to `/_security/oidc/prepare`. The response from {es} will contain 3 parameters:
   `redirect`, `state`, `nonce`. The custom web application would need to store the values for `state`
@@ -653,7 +646,7 @@ POST /_security/oidc/prepare
   used for handling this, but this parameter is optional.
   See {ref}/security-api-oidc-authenticate.html[OIDC Authenticate API] for more details
 +
-[source,js]
+[source,console]
 -----------------------------------------------------------------------
 POST /_security/oidc/authenticate
 {
@@ -663,7 +656,6 @@ POST /_security/oidc/authenticate
   "realm" : "oidc1"
 }
 -----------------------------------------------------------------------
-// CONSOLE
 // TEST[catch:unauthorized]
 +
 Elasticsearch will validate this and if all is correct will respond with an access token that can be used
@@ -672,7 +664,7 @@ Elasticsearch will validate this and if all is correct will respond with an acce
 . At some point, if necessary, the custom web application can log the user out by using the
   {ref}/security-api-oidc-logout.html[OIDC Logout API] passing the access token and refresh token as parameters. For example:
 +
-[source,js]
+[source,console]
 --------------------------------------------------
 POST /_security/oidc/logout
 {
@@ -680,7 +672,6 @@ POST /_security/oidc/logout
   "refresh_token": "vLBPvmAB6KvwvJZr27cS"
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[catch:unauthorized]
 +
 If the realm is configured accordingly, this may result in a response with a `redirect` parameter indicating where

--- a/x-pack/docs/en/security/authentication/saml-guide.asciidoc
+++ b/x-pack/docs/en/security/authentication/saml-guide.asciidoc
@@ -639,7 +639,7 @@ to grant roles to users authenticating via SAML.
 This is an example of a simple role mapping that grants the `kibana_user` role
 to any user who authenticates against the `saml1` realm:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /_security/role_mapping/saml-kibana
 {
@@ -650,8 +650,6 @@ PUT /_security/role_mapping/saml-kibana
   }
 }
 --------------------------------------------------
-// CONSOLE
-// TEST
 
 
 The attributes that are mapped via the realm configuration are used to process
@@ -676,7 +674,7 @@ below.
 This mapping grants the {es} `finance_data` role, to any users who authenticate
 via the `saml1` realm with the `finance-team` group.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /_security/role_mapping/saml-finance
 {
@@ -688,8 +686,6 @@ PUT /_security/role_mapping/saml-finance
   ] }
 }
 --------------------------------------------------
-// CONSOLE
-// TEST
 
 If your users also exist in a repository that can be directly accessed by {es}
 (such as an LDAP directory) then you can use

--- a/x-pack/docs/en/security/authorization/alias-privileges.asciidoc
+++ b/x-pack/docs/en/security/authorization/alias-privileges.asciidoc
@@ -25,11 +25,10 @@ points to it called `current_year`, and a user with the following role:
 
 The user attempts to retrieve a document from `current_year`:
 
-[source,shell]
+[source,console]
 -------------------------------------------------------------------------------
 GET /current_year/event/1
 -------------------------------------------------------------------------------
-// CONSOLE
 // TEST[s/^/PUT 2015\n{"aliases": {"current_year": {}}}\nPUT 2015\/event\/1\n{}\n/]
 
 The above request gets rejected, although the user has `read` privilege on the
@@ -52,7 +51,7 @@ Unlike creating indices, which requires the `create_index` privilege, adding,
 removing and retrieving aliases requires the `manage` permission. Aliases can be
 added to an index directly as part of the index creation:
 
-[source,shell]
+[source,console]
 -------------------------------------------------------------------------------
 PUT /2015
 {
@@ -61,11 +60,10 @@ PUT /2015
     }
 }
 -------------------------------------------------------------------------------
-// CONSOLE
 
 or via the dedicated aliases api if the index already exists:
 
-[source,shell]
+[source,console]
 -------------------------------------------------------------------------------
 POST /_aliases
 {
@@ -74,7 +72,6 @@ POST /_aliases
     ]
 }
 -------------------------------------------------------------------------------
-// CONSOLE
 // TEST[s/^/PUT 2015\n/]
 
 The above requests both require the `manage` privilege on the alias name as well

--- a/x-pack/docs/en/security/authorization/managing-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/managing-roles.asciidoc
@@ -144,7 +144,8 @@ no effect, and will not grant any actions in the
 ==== Example
 
 The following snippet shows an example definition of a `clicks_admin` role:
-[source,js]
+
+[source,console]
 -----------
 POST /_security/role/clicks_admin
 {
@@ -162,7 +163,6 @@ POST /_security/role/clicks_admin
   ]
 }
 -----------
-// CONSOLE
 
 Based on the above definition, users owning the `clicks_admin` role can:
 

--- a/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
@@ -96,7 +96,8 @@ user:
 <3> The distinguished name of an LDAP or Active Directory user.
 
 You can use the role-mapping API to define equivalent mappings as follows:
-[source,js]
+
+[source,console]
 --------------------------------------------------
 PUT /_security/role_mapping/admins
 {
@@ -105,9 +106,8 @@ PUT /_security/role_mapping/admins
   "enabled": true
 }
 --------------------------------------------------
-// CONSOLE
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /_security/role_mapping/basic_users
 {
@@ -119,7 +119,6 @@ PUT /_security/role_mapping/basic_users
   "enabled": true
 }
 --------------------------------------------------
-// CONSOLE
 
 [float]
 [[pki-role-mapping]]
@@ -140,7 +139,7 @@ user:
 
 The following example creates equivalent mappings using the API:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /_security/role_mapping/admin_user
 {
@@ -149,9 +148,8 @@ PUT /_security/role_mapping/admin_user
   "enabled": true
 }
 --------------------------------------------------
-// CONSOLE
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /_security/role_mapping/basic_user
 {
@@ -160,4 +158,3 @@ PUT /_security/role_mapping/basic_user
   "enabled": true
 }
 --------------------------------------------------
-// CONSOLE

--- a/x-pack/docs/en/security/authorization/role-templates.asciidoc
+++ b/x-pack/docs/en/security/authorization/role-templates.asciidoc
@@ -12,7 +12,7 @@ authenticated user through the `_user` parameter.
 For example, the following role query uses a template to insert the username
 of the current authenticated user:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST /_security/role/example1
 {
@@ -31,7 +31,6 @@ POST /_security/role/example1
   ]
 }
 --------------------------------------------------
-// CONSOLE
 
 You can access the following information through the `_user` variable:
 
@@ -49,7 +48,7 @@ You can also access custom user metadata. For example, if you maintain a
 `group_id` in your user metadata, you can apply document level security
 based on the `group.id` field in your documents:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST /_security/role/example2
 {
@@ -68,4 +67,3 @@ POST /_security/role/example2
   ]
 }
 --------------------------------------------------
-// CONSOLE

--- a/x-pack/docs/en/security/ccs-clients-integrations/cross-cluster.asciidoc
+++ b/x-pack/docs/en/security/ccs-clients-integrations/cross-cluster.asciidoc
@@ -45,7 +45,7 @@ For more information about the `xpack.security.enabled` setting, see
   to the local cluster:
 +
 --
-[source,js]
+[source,console]
 -----------------------------------------------------------
 PUT _cluster/settings
 {
@@ -63,7 +63,6 @@ PUT _cluster/settings
   }
 }
 -----------------------------------------------------------
-// CONSOLE
 --
 
 * On the local cluster, ensure that users are assigned to (at least) one role
@@ -78,7 +77,7 @@ to search any index starting with `logs-` in cluster `two` from cluster `one`.
 First, enable cluster `one` to perform cross cluster search on remote cluster
 `two` by running the following request as the superuser on cluster `one`:
 
-[source,js]
+[source,console]
 -----------------------------------------------------------
 PUT _cluster/settings
 {
@@ -87,25 +86,23 @@ PUT _cluster/settings
   }
 }
 -----------------------------------------------------------
-// CONSOLE
 
 Next, set up a role called `cluster_two_logs` on both cluster `one` and
 cluster `two`.
 
 On cluster `one`, this role does not need any special privileges:
 
-[source,js]
+[source,console]
 -----------------------------------------------------------
 POST /_security/role/cluster_two_logs
 {
 }
 -----------------------------------------------------------
-// CONSOLE
 
 On cluster `two`, this role allows the user to query local indices called
 `logs-` from a remote cluster:
 
-[source,js]
+[source,console]
 -----------------------------------------------------------
 POST /_security/role/cluster_two_logs
 {
@@ -123,11 +120,10 @@ POST /_security/role/cluster_two_logs
   ]
 }
 -----------------------------------------------------------
-// CONSOLE
 
 Finally, create a user on cluster `one` and apply the `cluster_two_logs` role:
 
-[source,js]
+[source,console]
 -----------------------------------------------------------
 POST /_security/user/alice
 {
@@ -138,12 +134,11 @@ POST /_security/user/alice
   "enabled": true
 }
 -----------------------------------------------------------
-// CONSOLE
 
 With all of the above setup, the user `alice` is able to search indices in
 cluster `two` as follows:
 
-[source,js]
+[source,console]
 -----------------------------------------------------------
 GET two:logs-2017.04/_search <1>
 {
@@ -152,7 +147,6 @@ GET two:logs-2017.04/_search <1>
   }
 }
 -----------------------------------------------------------
-// CONSOLE
 // TEST[skip:todo]
 //TBD: Is there a missing description of the <1> callout above?
 

--- a/x-pack/docs/en/security/using-ip-filtering.asciidoc
+++ b/x-pack/docs/en/security/using-ip-filtering.asciidoc
@@ -114,7 +114,7 @@ based hosting, it is very hard to know the IP addresses upfront when provisionin
 a machine. Instead of changing the configuration file and restarting the node,
 you can use the _Cluster Update Settings API_. For example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /_cluster/settings
 {
@@ -123,11 +123,10 @@ PUT /_cluster/settings
     }
 }
 --------------------------------------------------
-// CONSOLE
 
 You can also dynamically disable filtering completely:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /_cluster/settings
 {
@@ -136,7 +135,6 @@ PUT /_cluster/settings
     }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 NOTE: In order to avoid locking yourself out of the cluster, the default bound

--- a/x-pack/docs/en/watcher/actions.asciidoc
+++ b/x-pack/docs/en/watcher/actions.asciidoc
@@ -44,7 +44,7 @@ time frame (`now - throttling period`).
 The following snippet shows a watch for the scenario described above - associating
 a throttle period with the `email_administrator` action:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _watcher/watch/error_logs_alert
 {
@@ -90,7 +90,7 @@ PUT _watcher/watch/error_logs_alert
   }
 }
 --------------------------------------------------
-// CONSOLE
+
 <1> There will be at least 15 minutes between subsequent `email_administrator`
 		action executions.
 <2> See <<actions-email, Email Action>> for more information.
@@ -99,7 +99,7 @@ You can also define a throttle period at the watch level. The watch-level
 throttle period serves as the default throttle period for all of the actions
 defined in the watch:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _watcher/watch/log_event_watch
 {
@@ -149,7 +149,6 @@ PUT _watcher/watch/log_event_watch
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 <1> There will be at least 15 minutes between subsequent action executions
 		(applies to both `email_administrator` and `notify_pager` actions)
@@ -175,11 +174,10 @@ When that happens, the action's state changes to `awaits_successful_execution`.
 To acknowledge an action, you use the
 {ref}/watcher-api-ack-watch.html[Ack Watch API]:
 
-[source,js]
+[source,console]
 ----------------------------------------------------------------------
 POST _watcher/watch/<id>/_ack/<action_ids>
 ----------------------------------------------------------------------
-// CONSOLE
 // TEST[skip:https://github.com/elastic/x-plugins/issues/2513]
 
 Where `<id>` is the id of the watch and `<action_ids>` is a comma-separated list
@@ -203,7 +201,7 @@ field to limit the maximum amount of runs that each watch executes. If this limi
 is reached, the execution is gracefully stopped. If not set, this field defaults 
 to one hundred.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _watcher/watch/log_event_watch
 {
@@ -234,7 +232,6 @@ PUT _watcher/watch/log_event_watch
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 <1> The logging statement will be executed for each of the returned search hits.
 
@@ -248,7 +245,7 @@ on a their respective conditions. The following watch would always send an email
 hits are found from the input search, but only trigger the `notify_pager` action when
 there are more than 5 hits in the search result.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _watcher/watch/log_event_watch
 {
@@ -300,7 +297,6 @@ PUT _watcher/watch/log_event_watch
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 <1> A `condition` that only applies to the `notify_pager` action, which
     restricts its execution to when the condition succeeds (at least 5 hits in this case).

--- a/x-pack/docs/en/watcher/example-watches/example-watch-clusterstatus.asciidoc
+++ b/x-pack/docs/en/watcher/example-watches/example-watch-clusterstatus.asciidoc
@@ -22,7 +22,7 @@ The watch <<input, input>> gets the data that you want to evaluate.
 The simplest way to define a schedule is to specify an interval. For example,
 the following schedule runs every 10 seconds:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _watcher/watch/cluster_health_watch
 {
@@ -31,7 +31,7 @@ PUT _watcher/watch/cluster_health_watch
   }
 }
 --------------------------------------------------
-// CONSOLE
+
 <1> Schedules are typically configured to run less frequently. This example sets
     the interval to 10 seconds to you can easily see the watches being triggered.
     Since this watch runs so frequently, don't forget to <<health-delete, delete the watch>>
@@ -40,17 +40,16 @@ PUT _watcher/watch/cluster_health_watch
 To get the status of your cluster, you can call the Elasticsearch
 {ref}//cluster-health.html[cluster health] API:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET _cluster/health?pretty
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 To load the health status into your watch, you simply add an
 <<input-http, HTTP input>> that calls the cluster health API:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _watcher/watch/cluster_health_watch
 {
@@ -68,11 +67,10 @@ PUT _watcher/watch/cluster_health_watch
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 If you're using Security, then you'll also need to supply some authentication credentials as part of the watch configuration:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _watcher/watch/cluster_health_watch
 {
@@ -96,7 +94,6 @@ PUT _watcher/watch/cluster_health_watch
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 It would be a good idea to create a user with the minimum privileges required for use with such a watch configuration.
 
@@ -109,7 +106,7 @@ as part of the `watch_record` each time the watch executes.
 For example, the following request retrieves the last ten watch records from
 the watch history:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET .watcher-history*/_search
 {
@@ -118,7 +115,6 @@ GET .watcher-history*/_search
   ]
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 [float]
@@ -132,7 +128,7 @@ status.
 
 For example, you could add a condition to check to see if the status is RED.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _watcher/watch/cluster_health_watch
 {
@@ -155,7 +151,7 @@ PUT _watcher/watch/cluster_health_watch
   }
 }
 --------------------------------------------------
-// CONSOLE
+
 <1> Schedules are typically configured to run less frequently. This example sets
     the interval to 10 seconds to you can easily see the watches being triggered.
 
@@ -164,7 +160,7 @@ as part of the `watch_record` each time the watch executes.
 
 To check to see if the condition was met, you can run the following query.
 
-[source,js]
+[source,console]
 ------------------------------------------------------
 GET .watcher-history*/_search?pretty
 {
@@ -173,7 +169,6 @@ GET .watcher-history*/_search?pretty
   }
 }
 ------------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 [float]
@@ -189,7 +184,7 @@ Elasticsearch index or log when the watch condition is met.
 For example, you could add an action to index the cluster status information
 when the status is RED.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _watcher/watch/cluster_health_watch
 {
@@ -221,7 +216,6 @@ PUT _watcher/watch/cluster_health_watch
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 For {watcher} to send email, you must configure an email account in your
 `elasticsearch.yml` configuration file and restart Elasticsearch. To add an email
@@ -256,7 +250,7 @@ NOTE:   If you have advanced security options enabled for your email account,
 You can check the watch history or the `status_index` to see that the action was
 performed.
 
-[source,js]
+[source,console]
 -------------------------------------------------------
 GET .watcher-history*/_search?pretty
 {
@@ -265,7 +259,6 @@ GET .watcher-history*/_search?pretty
   }
 }
 -------------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 [float]
@@ -278,9 +271,8 @@ indefinitely.
 
 To remove the watch, use the {ref}/watcher-api-delete-watch.html[DELETE watch API]:
 
-[source,js]
+[source,console]
 -------------------------------------------------------
 DELETE _watcher/watch/cluster_health_watch
 -------------------------------------------------------
-// CONSOLE
 // TEST[continued]

--- a/x-pack/docs/en/watcher/example-watches/example-watch-meetupdata.asciidoc
+++ b/x-pack/docs/en/watcher/example-watches/example-watch-meetupdata.asciidoc
@@ -192,7 +192,8 @@ NOTE: To enable Watcher to send emails, you must configure an email account in `
 
 
 The complete watch looks like this:
-[source,js]
+
+[source,console]
 --------------------------------------------------
 PUT _watcher/watch/meetup
 {
@@ -288,7 +289,6 @@ PUT _watcher/watch/meetup
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 <1> The email body can include Mustache templates to reference data in the watch payload. By default,it will be <<email-html-sanitization, sanitized>> to block dangerous content.
 <2> Replace the `from` address with the email address you configured in `elasticsearch.yml`.
@@ -298,9 +298,8 @@ PUT _watcher/watch/meetup
 Now that you've created your watch, you can use the
 {ref}/watcher-api-execute-watch.html[`_execute` API] to run it without waiting for the schedule to trigger execution:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _watcher/watch/meetup/_execute
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]

--- a/x-pack/docs/en/watcher/example-watches/watching-time-series-data.asciidoc
+++ b/x-pack/docs/en/watcher/example-watches/watching-time-series-data.asciidoc
@@ -155,7 +155,7 @@ specify which one you want to send the email with. For more information, see
 
 The complete watch looks like this:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _watcher/watch/rss_watch
 {
@@ -203,8 +203,8 @@ PUT _watcher/watch/rss_watch
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[s/"id" : "threshold_hits"/"source": "return ctx.payload.hits.total.value > params.threshold"/]
+
 <1> Replace `username@example.org` with your email address to receive
     notifications.
 
@@ -213,7 +213,7 @@ PUT _watcher/watch/rss_watch
 To execute a watch immediately (without waiting for the schedule to trigger),
 use the {ref}/watcher-api-execute-watch.html[`_execute` API]:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _watcher/watch/rss_watch/_execute
 {
@@ -224,6 +224,5 @@ POST _watcher/watch/rss_watch/_execute
   "record_execution" : true
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 =================================================

--- a/x-pack/docs/en/watcher/getting-started.asciidoc
+++ b/x-pack/docs/en/watcher/getting-started.asciidoc
@@ -26,7 +26,7 @@ watch, you could use an {xpack-ref}/trigger-schedule.html#schedule-interval[inte
 {xpack-ref}/input-search.html[search] input. For example, the following Watch searches
 the `logs` index for errors every 10 seconds:
 
-[source,js]
+[source,console]
 ------------------------------------------------------------
 PUT _watcher/watch/log_error_watch
 {
@@ -47,7 +47,7 @@ PUT _watcher/watch/log_error_watch
   }
 }
 ------------------------------------------------------------
-// CONSOLE
+
 <1> Schedules are typically configured to run less frequently. This example sets
     the interval to 10 seconds so you can easily see the watches being triggered.
     Since this watch runs so frequently, don't forget to <<log-delete, delete the watch>>
@@ -60,7 +60,7 @@ into the watch payload.
 For example, the following request retrieves the last ten watch executions (watch
 records) from the watch history:
 
-[source,js]
+[source,console]
 ------------------------------------------------------------
 GET .watcher-history*/_search?pretty
 {
@@ -69,7 +69,6 @@ GET .watcher-history*/_search?pretty
   ]
 }
 ------------------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 [float]
@@ -84,7 +83,7 @@ found.
 For example, the following compare condition simply checks to see if the
 search input returned any hits.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _watcher/watch/log_error_watch
 {
@@ -106,7 +105,7 @@ PUT _watcher/watch/log_error_watch
   }
 }
 --------------------------------------------------
-// CONSOLE
+
 <1> The {xpack-ref}/condition-compare.html[compare] condition lets you easily compare against
     values in the execution context.
 
@@ -114,7 +113,7 @@ For this compare condition to evaluate to `true`, you need to add an event
 to the `logs` index that contains an error. For example, the following request
 adds a 404 error to the `logs` index:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST logs/event
 {
@@ -124,7 +123,6 @@ POST logs/event
     "message" : "Error: File not found"
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 Once you add this event, the next time the watch executes its condition will
@@ -132,7 +130,7 @@ evaluate to `true`. The condition result is recorded as part of the
 `watch_record` each time the watch executes, so you can verify whether or
 not the condition was met by searching the watch history:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET .watcher-history*/_search?pretty
 {
@@ -146,7 +144,6 @@ GET .watcher-history*/_search?pretty
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 [float]
@@ -163,7 +160,7 @@ Elasticsearch log files.
 For example, the following action writes a message to the Elasticsearch
 log when an error is detected.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _watcher/watch/log_error_watch
 {
@@ -192,7 +189,6 @@ PUT _watcher/watch/log_error_watch
   }
 }
 --------------------------------------------------
-// CONSOLE
 
 [float]
 [[log-delete]]
@@ -205,11 +201,10 @@ log file.
 
 To remove the watch, use the {ref}/watcher-api-delete-watch.html[DELETE watch API]:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 DELETE _watcher/watch/log_error_watch
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 [float]

--- a/x-pack/docs/en/watcher/how-watcher-works.asciidoc
+++ b/x-pack/docs/en/watcher/how-watcher-works.asciidoc
@@ -46,7 +46,7 @@ For example, the following snippet shows a
 {ref}/watcher-api-put-watch.html[Put Watch] request that defines a watch that
 looks for log error events:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _watcher/watch/log_errors
 {
@@ -110,7 +110,7 @@ PUT _watcher/watch/log_errors
   }
 }
 --------------------------------------------------
-// CONSOLE
+
 <1> Metadata  - You can attach optional static metadata to a watch.
 <2> Trigger   - This schedule trigger executes the watch every 5 minutes.
 <3> Input     - This input searches for errors in the `log-events` index and
@@ -152,14 +152,13 @@ dedicated watcher nodes by using shard allocation filtering.
 You could configure nodes with a dedicated `node.attr.role: watcher` property and
 then configure the `.watches` index like this:
 
-[source,js]
+[source,console]
 ------------------------
 PUT .watches/_settings
 {
   "index.routing.allocation.include.role": "watcher"
 }
 ------------------------
-// CONSOLE
 // TEST[skip:indexes don't assign]
 
 When the {watcher} service is stopped, the scheduler stops with it. Trigger

--- a/x-pack/docs/en/watcher/managing-watches.asciidoc
+++ b/x-pack/docs/en/watcher/managing-watches.asciidoc
@@ -25,12 +25,11 @@ IMPORTANT:	You can only perform read actions on the `.watches` index. You must
 
 For example, the following returns the first 100 watches:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET .watches/_search
 {
   "size" : 100
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:my_active_watch]

--- a/x-pack/docs/en/watcher/troubleshooting.asciidoc
+++ b/x-pack/docs/en/watcher/troubleshooting.asciidoc
@@ -14,11 +14,10 @@ If you get the _Dynamic Mapping is Disabled_ error when you try to add a watch,
 verify that the index mappings for the `.watches` index are available. You can
 do that by submitting the following request:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET .watches/_mapping
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:my_active_watch]
 
 If the index mappings are missing, follow these steps to restore the correct
@@ -30,11 +29,10 @@ mappings:
 . Delete the `.watches` index:
 +
 --
-[source,js]
+[source,console]
 --------------------------------------------------
 DELETE .watches
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:index deletion]
 --
 . Disable direct access to the `.watches` index:


### PR DESCRIPTION
Third chunk of a work effort to replace `// CONSOLE` comments.

I can break this up into smaller diffs if wanted.

Relates to #46189.