### PR TITLE
[DOCS] Correct definition for `allow_no_indices` parameter

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -12,10 +12,13 @@ end::aliases[]
 
 tag::allow-no-indices[]
 `allow_no_indices`::
-(Optional, boolean) If `true`, the request returns an error if a wildcard
-expression or `_all` value retrieves only missing or closed indices. This
-parameter also applies to <<indices-aliases,index aliases>> that point to a
-missing or closed index.
+(Optional, boolean) If `true`,
+the request does *not* return an error
+if a wildcard expression
+or `_all` value retrieves only missing or closed indices.
++
+This parameter also applies to <<indices-aliases,index aliases>>
+that point to a missing or closed index.
 end::allow-no-indices[]
 
 tag::analyzer[]


### PR DESCRIPTION
Corrects the parameter definition for `allow_no_indices`.

Based on feedback from https://github.com/elastic/elasticsearch/pull/45699#discussion_r321750062