### PR TITLE
[TEST] create larger cuckoo filters for tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/util/CuckooFilterTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/CuckooFilterTests.java
@@ -30,8 +30,8 @@ public class CuckooFilterTests extends AbstractWireSerializingTestCase<CuckooFil
 
     @Override
     protected CuckooFilter createTestInstance() {
-        CuckooFilter filter = new CuckooFilter(randomIntBetween(1, 100000),
-            ((float)randomIntBetween(1, 50)) / 100.0, Randomness.get());
+        CuckooFilter filter = new CuckooFilter(randomIntBetween(10000, 100000),
+            ((float)randomIntBetween(1, 20)) / 100.0, Randomness.get());
 
         int num = randomIntBetween(0, 10);
         for (int i = 0; i < num; i++) {
@@ -52,6 +52,15 @@ public class CuckooFilterTests extends AbstractWireSerializingTestCase<CuckooFil
         int num = randomIntBetween(1, 10);
         for (int i = 0; i < num; i++) {
             newInstance.add(hash(randomLong()));
+        }
+        int attempts = 0;
+        while (newInstance.getCount() == instance.getCount() && attempts < 100) {
+            newInstance.add(hash(randomLong()));
+            attempts += 1;
+        }
+        if (newInstance.equals(instance)) {
+            fail("Unable to mutate filter enough to generate a different version. " +
+                "Are capacity/precision defaults too low?");
         }
         return newInstance;
     }


### PR DESCRIPTION
The cuckoofilters could be randomly created with too small of capacity or precision, which means that they can only absorb a few values before collisions start to make all filters look identical.

This increases the size of filters we generate (capacity >> than the test cases) and lower fpp rate.  Also adds some more friendly error logging if we can't generate a unique instance, so that any future failures will be faster to debug.

Closes https://github.com/elastic/elasticsearch/issues/46443
