### PR TITLE
[DOCS] Remove cat request from Index Segments API requests

### DIFF
--- a/docs/reference/indices/segments.asciidoc
+++ b/docs/reference/indices/segments.asciidoc
@@ -21,8 +21,6 @@ GET /twitter/_segments
 
 `GET /_segments`
 
-`GET /_cat/segments/<index>`
-
 
 [[index-segments-api-path-params]]
 ==== {api-path-parms-title}


### PR DESCRIPTION
Removes a cat API request format from the index segment API request formats.