### PR TITLE
[DOCS] Fix licensing information in Watcher documentation

### DIFF
--- a/x-pack/docs/en/watcher/actions.asciidoc
+++ b/x-pack/docs/en/watcher/actions.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[actions]]
 == Actions
 

--- a/x-pack/docs/en/watcher/actions/email.asciidoc
+++ b/x-pack/docs/en/watcher/actions/email.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[actions-email]]
 === Email Action
 

--- a/x-pack/docs/en/watcher/actions/index.asciidoc
+++ b/x-pack/docs/en/watcher/actions/index.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[actions-index]]
 === Index Action
 

--- a/x-pack/docs/en/watcher/actions/jira.asciidoc
+++ b/x-pack/docs/en/watcher/actions/jira.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[actions-jira]]
 === Jira Action
 

--- a/x-pack/docs/en/watcher/actions/logging.asciidoc
+++ b/x-pack/docs/en/watcher/actions/logging.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[actions-logging]]
 === Logging Action
 

--- a/x-pack/docs/en/watcher/actions/pagerduty.asciidoc
+++ b/x-pack/docs/en/watcher/actions/pagerduty.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[actions-pagerduty]]
 === PagerDuty Action
 

--- a/x-pack/docs/en/watcher/actions/slack.asciidoc
+++ b/x-pack/docs/en/watcher/actions/slack.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[actions-slack]]
 === Slack Action
 

--- a/x-pack/docs/en/watcher/actions/webhook.asciidoc
+++ b/x-pack/docs/en/watcher/actions/webhook.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[actions-webhook]]
 === Webhook Action
 

--- a/x-pack/docs/en/watcher/condition.asciidoc
+++ b/x-pack/docs/en/watcher/condition.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[condition]]
 == Conditions
 

--- a/x-pack/docs/en/watcher/condition/always.asciidoc
+++ b/x-pack/docs/en/watcher/condition/always.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[condition-always]]
 === Always Condition
 

--- a/x-pack/docs/en/watcher/condition/array-compare.asciidoc
+++ b/x-pack/docs/en/watcher/condition/array-compare.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[condition-array-compare]]
 === Array Compare Condition
 

--- a/x-pack/docs/en/watcher/condition/compare.asciidoc
+++ b/x-pack/docs/en/watcher/condition/compare.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[condition-compare]]
 === Compare Condition
 

--- a/x-pack/docs/en/watcher/condition/never.asciidoc
+++ b/x-pack/docs/en/watcher/condition/never.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[condition-never]]
 === Never Condition
 

--- a/x-pack/docs/en/watcher/condition/script.asciidoc
+++ b/x-pack/docs/en/watcher/condition/script.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[condition-script]]
 === Script Condition
 

--- a/x-pack/docs/en/watcher/customizing-watches.asciidoc
+++ b/x-pack/docs/en/watcher/customizing-watches.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[customizing-watches]]
 == Customizing Watches
 

--- a/x-pack/docs/en/watcher/encrypting-data.asciidoc
+++ b/x-pack/docs/en/watcher/encrypting-data.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[encrypting-data]]
 == Encrypting Sensitive Data in {watcher}
 

--- a/x-pack/docs/en/watcher/example-watches.asciidoc
+++ b/x-pack/docs/en/watcher/example-watches.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[example-watches]]
 == Example Watches
 The following examples show how to set up watches to:

--- a/x-pack/docs/en/watcher/example-watches/example-watch-clusterstatus.asciidoc
+++ b/x-pack/docs/en/watcher/example-watches/example-watch-clusterstatus.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[watch-cluster-status]]
 === Watching the Status of an Elasticsearch Cluster
 

--- a/x-pack/docs/en/watcher/example-watches/example-watch-meetupdata.asciidoc
+++ b/x-pack/docs/en/watcher/example-watches/example-watch-meetupdata.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[watching-meetup-data]]
 === Watching Event Data
 

--- a/x-pack/docs/en/watcher/example-watches/watching-time-series-data.asciidoc
+++ b/x-pack/docs/en/watcher/example-watches/watching-time-series-data.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[watching-time-series-data]]
 === Watching Time Series Data
 

--- a/x-pack/docs/en/watcher/getting-started.asciidoc
+++ b/x-pack/docs/en/watcher/getting-started.asciidoc
@@ -1,9 +1,10 @@
+[role="xpack"]
 [[watcher-getting-started]]
-== Getting Started with {watcher}
+== Getting started with {watcher}
 
-By default, when you install {es} and {kib}, {xpack} is installed and the 
-{watcher} is enabled. You cannot use {watcher} with the free basic license, but 
-you can try all of the {xpack} features with a <<license-management,trial license>>. 
+TIP: To complete these steps, you must obtain a license that includes the
+{alert-features}. For more information about Elastic license levels, see 
+https://www.elastic.co/subscriptions and <<license-management>>.
 
 [[watch-log-data]]
 To set up a watch to start sending alerts:

--- a/x-pack/docs/en/watcher/gs-index.asciidoc
+++ b/x-pack/docs/en/watcher/gs-index.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[xpack-alerting]]
 = Alerting on Cluster and Index Events
 

--- a/x-pack/docs/en/watcher/how-watcher-works.asciidoc
+++ b/x-pack/docs/en/watcher/how-watcher-works.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[how-watcher-works]]
 == How {watcher} Works
 

--- a/x-pack/docs/en/watcher/index.asciidoc
+++ b/x-pack/docs/en/watcher/index.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[xpack-alerting]]
 = Alerting on cluster and index events
 

--- a/x-pack/docs/en/watcher/input.asciidoc
+++ b/x-pack/docs/en/watcher/input.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[input]]
 == Inputs
 

--- a/x-pack/docs/en/watcher/input/chain.asciidoc
+++ b/x-pack/docs/en/watcher/input/chain.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[input-chain]]
 === Chain Input
 

--- a/x-pack/docs/en/watcher/input/http.asciidoc
+++ b/x-pack/docs/en/watcher/input/http.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[input-http]]
 === HTTP Input
 

--- a/x-pack/docs/en/watcher/input/search.asciidoc
+++ b/x-pack/docs/en/watcher/input/search.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[input-search]]
 === Search Input
 

--- a/x-pack/docs/en/watcher/input/simple.asciidoc
+++ b/x-pack/docs/en/watcher/input/simple.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[input-simple]]
 === Simple Input
 

--- a/x-pack/docs/en/watcher/managing-watches.asciidoc
+++ b/x-pack/docs/en/watcher/managing-watches.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[managing-watches]]
 == Managing Watches
 

--- a/x-pack/docs/en/watcher/release-notes.asciidoc
+++ b/x-pack/docs/en/watcher/release-notes.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[watcher-release-notes]]
 == Watcher Release Notes (Pre-5.0)
 

--- a/x-pack/docs/en/watcher/transform.asciidoc
+++ b/x-pack/docs/en/watcher/transform.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[transform]]
 == Transforms
 

--- a/x-pack/docs/en/watcher/transform/chain.asciidoc
+++ b/x-pack/docs/en/watcher/transform/chain.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[transform-chain]]
 === Chain Transform
 

--- a/x-pack/docs/en/watcher/transform/script.asciidoc
+++ b/x-pack/docs/en/watcher/transform/script.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[transform-script]]
 === Script Transform
 

--- a/x-pack/docs/en/watcher/transform/search.asciidoc
+++ b/x-pack/docs/en/watcher/transform/search.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[transform-search]]
 === Search Transform
 

--- a/x-pack/docs/en/watcher/trigger.asciidoc
+++ b/x-pack/docs/en/watcher/trigger.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[trigger]]
 == Triggers
 

--- a/x-pack/docs/en/watcher/trigger/schedule.asciidoc
+++ b/x-pack/docs/en/watcher/trigger/schedule.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[trigger-schedule]]
 === Schedule Trigger
 

--- a/x-pack/docs/en/watcher/trigger/schedule/cron.asciidoc
+++ b/x-pack/docs/en/watcher/trigger/schedule/cron.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[schedule-cron]]
 ==== `cron` schedule
 

--- a/x-pack/docs/en/watcher/trigger/schedule/daily.asciidoc
+++ b/x-pack/docs/en/watcher/trigger/schedule/daily.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[schedule-daily]]
 ==== Daily Schedule
 

--- a/x-pack/docs/en/watcher/trigger/schedule/hourly.asciidoc
+++ b/x-pack/docs/en/watcher/trigger/schedule/hourly.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[schedule-hourly]]
 ==== Hourly Schedule
 

--- a/x-pack/docs/en/watcher/trigger/schedule/interval.asciidoc
+++ b/x-pack/docs/en/watcher/trigger/schedule/interval.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[schedule-interval]]
 ==== Interval Schedule
 

--- a/x-pack/docs/en/watcher/trigger/schedule/monthly.asciidoc
+++ b/x-pack/docs/en/watcher/trigger/schedule/monthly.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[schedule-monthly]]
 ==== Monthly Schedule
 

--- a/x-pack/docs/en/watcher/trigger/schedule/weekly.asciidoc
+++ b/x-pack/docs/en/watcher/trigger/schedule/weekly.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[schedule-weekly]]
 ==== Weekly Schedule
 

--- a/x-pack/docs/en/watcher/trigger/schedule/yearly.asciidoc
+++ b/x-pack/docs/en/watcher/trigger/schedule/yearly.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[schedule-yearly]]
 ==== Yearly Schedule
 


### PR DESCRIPTION
This PR fixes the licensing information in the first paragraph of https://www.elastic.co/guide/en/elastic-stack-overview/current/watcher-getting-started.html

It also adds missing xpack role attributes to the other documentation source files in that directory.