### PR TITLE
Use a literal block in the field data docs.

### DIFF
--- a/docs/reference/mapping/params/fielddata.asciidoc
+++ b/docs/reference/mapping/params/fielddata.asciidoc
@@ -31,12 +31,10 @@ why fielddata is disabled by default.
 If you try to sort, aggregate, or access values from a script on a `text`
 field, you will see this exception:
 
-[quote]
---
+[literal]
 Fielddata is disabled on text fields by default.  Set `fielddata=true` on
 [`your_field_name`] in order to load  fielddata in memory by uninverting the
 inverted index. Note that this can however use significant memory.
---
 
 [[before-enabling-fielddata]]
 ==== Before enabling fielddata


### PR DESCRIPTION
Currently we use `quote`, which renders a bit strangely on the website:

<img width="770" alt="Screen Shot 2019-09-06 at 4 49 17 PM" src="https://user-images.githubusercontent.com/7461306/64466793-b4fc9700-d0c8-11e9-873c-d5b8f0bed7ac.png">
