### PR TITLE
Minor improvement to the nested aggregation docs

### DIFF
--- a/docs/reference/aggregations/bucket/nested-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/nested-aggregation.asciidoc
@@ -25,7 +25,7 @@ PUT /products
 --------------------------------------------------
 <1> `resellers` is an array that holds nested documents.
 
-We are adding one example product with two resellers:
+The following request adds a product with two resellers:
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/aggregations/bucket/nested-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/nested-aggregation.asciidoc
@@ -8,14 +8,14 @@ price for the product. The mapping could look like:
 
 [source,console]
 --------------------------------------------------
-PUT /index
+PUT /products
 {
     "mappings": {
         "properties" : {
             "resellers" : { <1>
                 "type" : "nested",
                 "properties" : {
-                    "name" : { "type" : "text" },
+                    "reseller" : { "type" : "text" },
                     "price" : { "type" : "double" }
                 }
             }
@@ -23,14 +23,37 @@ PUT /index
     }
 }
 --------------------------------------------------
-// TESTSETUP
-<1> The `resellers` is an array that holds nested documents under the `product` object.
+<1> The `resellers` is an array that holds nested documents.
 
-The following aggregations will return the minimum price products can be purchased in:
+We are adding one example product with two resellers:
 
 [source,console]
 --------------------------------------------------
-GET /_search
+PUT /products/_doc/0
+{
+  "name": "LED TV", <1>
+  "resellers": [
+    {
+      "reseller": "companyA",
+      "price": 350
+    },
+    {
+      "reseller": "companyB",
+      "price": 500
+    }
+  ]
+}
+--------------------------------------------------
+// TEST[s/PUT \/products\/_doc\/0/PUT \/products\/_doc\/0\?refresh/]
+// TEST[continued]
+<1> We are using a dynamic mapping for the `name` attribute.
+
+
+The following aggregations will return the minimum price a product can be purchased for:
+
+[source,console]
+--------------------------------------------------
+GET /products/_search
 {
     "query" : {
         "match" : { "name" : "led tv" }
@@ -47,8 +70,8 @@ GET /_search
     }
 }
 --------------------------------------------------
-// TEST[s/GET \/_search/GET \/_search\?filter_path=aggregations/]
-// TEST[s/^/PUT index\/_doc\/0\?refresh\n{"name":"led", "resellers": [{"name": "foo", "price": 350.00}, {"name": "bar", "price": 500.00}]}\n/]
+// TEST[s/GET \/products\/_search/GET \/products\/_search\?filter_path=aggregations/]
+// TEST[continued]
 
 As you can see above, the nested aggregation requires the `path` of the nested documents within the top level documents.
 Then one can define any type of aggregation over these nested documents.
@@ -61,7 +84,7 @@ Response:
   ...
   "aggregations": {
     "resellers": {
-      "doc_count": 0,
+      "doc_count": 2,
       "min_price": {
         "value": 350
       }

--- a/docs/reference/aggregations/bucket/nested-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/nested-aggregation.asciidoc
@@ -49,7 +49,7 @@ PUT /products/_doc/0
 <1> We are using a dynamic mapping for the `name` attribute.
 
 
-The following aggregations will return the minimum price a product can be purchased for:
+The following request returns the minimum price a product can be purchased for:
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/aggregations/bucket/nested-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/nested-aggregation.asciidoc
@@ -23,7 +23,7 @@ PUT /products
     }
 }
 --------------------------------------------------
-<1> The `resellers` is an array that holds nested documents.
+<1> `resellers` is an array that holds nested documents.
 
 We are adding one example product with two resellers:
 


### PR DESCRIPTION
* The attributes name and resellers.name were rather confusing,
  especially since the first one was dynamically mapped and not shown
  in the documentation (you had to read the test to see it). This
  change introduces a unique name for the nested attribute and adds
  the example document to the documentation.
* Change the index name from "index" to something more speaking.

https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-nested-aggregation.html for reference. I'm not sure how far you normally backport those.