### PR TITLE
Ensure no ongoing peer recovery in translog yaml test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/20_translog.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/20_translog.yml
@@ -9,6 +9,7 @@
   - do:
       cluster.health:
         wait_for_no_initializing_shards: true
+        wait_for_events: languid
   - do:
       indices.stats:
         metric: [ translog ]


### PR DESCRIPTION
We leave replicas unassigned until we [reroute](https://github.com/elastic/elasticsearch/blob/50fde6cfaade7b70cd5e51605f3506f9fa1f7c6a/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java#L600) after the primary shard starts. If a cluster health request with `wait_for_no_initializing_shards` is executed before the reroute, it will return immediately although there will be some initializing replicas. Peer recoveries of those shards can prevent translog on the primary from trimming.

We add `wait_for_events` to the cluster health request so that it will execute after the reroute.

Closes #46425