### PR TITLE
[DOCS] Adds force query parameter to the stop API parms

### DIFF
--- a/docs/reference/data-frames/apis/stop-transform.asciidoc
+++ b/docs/reference/data-frames/apis/stop-transform.asciidoc
@@ -72,7 +72,7 @@ are no matches or only partial matches.
 --
 
 `force`::
-  (Optional, boolean) If `true`, resets the state of a failed {transform} back to 
+  (Optional, boolean) If `true`, resets the state of a failed {transform} to 
   started. It is required to do in order to delete or restart the job (after 
   resolving root cause of the original issue).
 

--- a/docs/reference/data-frames/apis/stop-transform.asciidoc
+++ b/docs/reference/data-frames/apis/stop-transform.asciidoc
@@ -73,7 +73,7 @@ are no matches or only partial matches.
 
 `force`::
   (Optional, boolean) If `true`, resets the state of a failed {transform} to 
-  started. It is required to do in order to delete or restart the job (after 
+  stopped. It is required to do in order to delete or restart the job (after 
   resolving root cause of the original issue).
 
 `timeout`::

--- a/docs/reference/data-frames/apis/stop-transform.asciidoc
+++ b/docs/reference/data-frames/apis/stop-transform.asciidoc
@@ -72,9 +72,9 @@ are no matches or only partial matches.
 --
 
 `force`::
-  (Optional, boolean) If `true`, resets the state of a failed job back to 
-  started. It is required to do in order to delete or restart the job (after 
-  resolving root cause of the original issue).
+  (Optional, boolean) Set to `true` to stop a failed {transform} or to 
+  forcefully stop a {transform} that did not respond to the initial stop 
+  request.
 
 `timeout`::
   (Optional, time value) If `wait_for_completion=true`, the API blocks for (at
@@ -99,12 +99,11 @@ are no matches or only partial matches.
 [[stop-data-frame-transform-example]]
 ==== {api-examples-title}
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _data_frame/transforms/ecommerce_transform/_stop
 --------------------------------------------------
 // CONSOLE
-// TEST[skip:set up kibana samples]
 
 When the {dataframe-transform} stops, you receive the following results:
 

--- a/docs/reference/data-frames/apis/stop-transform.asciidoc
+++ b/docs/reference/data-frames/apis/stop-transform.asciidoc
@@ -30,6 +30,7 @@ beta[]
 see {stack-ov}/security-privileges.html[Security privileges] and
 {stack-ov}/built-in-roles.html[Built-in roles].
 
+
 [[stop-data-frame-transform-desc]]
 ==== {api-description-title}
 
@@ -38,6 +39,7 @@ comma-separated list of {dataframe-transforms} or a wildcard expression.
 All {dataframe-transforms} can be stopped by using `_all` or `*` as the
 `<data_frame_transform_id>`.
 
+
 [[stop-data-frame-transform-path-parms]]
 ==== {api-path-parms-title}
 
@@ -45,6 +47,7 @@ All {dataframe-transforms} can be stopped by using `_all` or `*` as the
   (Required, string) Identifier for the {dataframe-transform}. This identifier
   can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and
   underscores. It must start and end with alphanumeric characters.
+
 
 [[stop-data-frame-transform-query-parms]]
 ==== {api-query-parms-title}
@@ -67,6 +70,11 @@ that match `test-id1*`.
 If this parameter is `false`, the request returns a `404` status code when there
 are no matches or only partial matches.
 --
+
+`force`::
+  (Optional, boolean) If `true`, resets the state of a failed job back to 
+  started. It is required to do in order to delete or restart the job (after 
+  resolving root cause of the original issue).
 
 `timeout`::
   (Optional, time value) If `wait_for_completion=true`, the API blocks for (at

--- a/docs/reference/data-frames/apis/stop-transform.asciidoc
+++ b/docs/reference/data-frames/apis/stop-transform.asciidoc
@@ -72,7 +72,7 @@ are no matches or only partial matches.
 --
 
 `force`::
-  (Optional, boolean) If `true`, resets the state of a failed job back to 
+  (Optional, boolean) If `true`, resets the state of a failed {transform} back to 
   started. It is required to do in order to delete or restart the job (after 
   resolving root cause of the original issue).
 


### PR DESCRIPTION
This PR adds `force` query parameter to the parameter pool of the stop transform API.

Related issue: https://github.com/elastic/ml-team/issues/187#issuecomment-529352714