### PR TITLE
Remove trailing comma from nodes lists

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/NodeRemovalClusterStateTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/NodeRemovalClusterStateTaskExecutor.java
@@ -56,7 +56,7 @@ public class NodeRemovalClusterStateTaskExecutor implements ClusterStateTaskExec
 
         @Override
         public String toString() {
-            return node + " " + reason;
+            return node + " reason: " + reason;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -41,6 +42,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -517,39 +519,17 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
                 if (summary.length() > 0) {
                     summary.append(", ");
                 }
-                summary.append("removed {");
-                boolean first = true;
-                for (DiscoveryNode node : removedNodes()) {
-                    if (first) {
-                        first = false;
-                    } else {
-                        summary.append(',');
-                    }
-                    summary.append(node);
-                }
-                summary.append("}");
+                summary.append("removed {").append(Strings.collectionToCommaDelimitedString(removedNodes())).append('}');
             }
             if (added()) {
-                // don't print if there is one added, and it is us
-                if (!(addedNodes().size() == 1 && addedNodes().get(0).getId().equals(localNodeId))) {
+                final String addedNodesExceptLocalNode = addedNodes().stream()
+                    .filter(node -> node.getId().equals(localNodeId) == false).map(DiscoveryNode::toString)
+                    .collect(Collectors.joining(","));
+                if (addedNodesExceptLocalNode.length() > 0) {
                     if (summary.length() > 0) {
                         summary.append(", ");
                     }
-                    summary.append("added {");
-                    boolean first = true;
-                    for (DiscoveryNode node : addedNodes()) {
-                        if (node.getId().equals(localNodeId) == false) {
-                            // don't print ourself
-
-                            if (first) {
-                                first = false;
-                            } else {
-                                summary.append(',');
-                            }
-                            summary.append(node);
-                        }
-                    }
-                    summary.append("}");
+                    summary.append("added {").append(addedNodesExceptLocalNode).append('}');
                 }
             }
             return summary.toString();

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -518,8 +518,14 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
                     summary.append(", ");
                 }
                 summary.append("removed {");
+                boolean first = true;
                 for (DiscoveryNode node : removedNodes()) {
-                    summary.append(node).append(',');
+                    if (first) {
+                        first = false;
+                    } else {
+                        summary.append(',');
+                    }
+                    summary.append(node);
                 }
                 summary.append("}");
             }
@@ -530,10 +536,17 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
                         summary.append(", ");
                     }
                     summary.append("added {");
+                    boolean first = true;
                     for (DiscoveryNode node : addedNodes()) {
-                        if (!node.getId().equals(localNodeId)) {
+                        if (node.getId().equals(localNodeId) == false) {
                             // don't print ourself
-                            summary.append(node).append(',');
+
+                            if (first) {
+                                first = false;
+                            } else {
+                                summary.append(',');
+                            }
+                            summary.append(node);
                         }
                     }
                     summary.append("}");

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -526,6 +526,7 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
                     .filter(node -> node.getId().equals(localNodeId) == false).map(DiscoveryNode::toString)
                     .collect(Collectors.joining(","));
                 if (addedNodesExceptLocalNode.length() > 0) {
+                    // ignore ourselves when reporting on nodes being added
                     if (summary.length() > 0) {
                         summary.append(", ");
                     }

--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -234,10 +234,10 @@ public class MasterService extends AbstractLifecycleComponent {
                 // new cluster state, notify all listeners
                 final DiscoveryNodes.Delta nodesDelta = clusterChangedEvent.nodesDelta();
                 if (nodesDelta.hasChanges() && logger.isInfoEnabled()) {
-                    String nodeSummary = nodesDelta.shortSummary();
-                    if (nodeSummary.length() > 0) {
-                        logger.info("{}, term: {}, version: {}, reason: {}",
-                            summary, newClusterState.term(), newClusterState.version(), nodeSummary);
+                    String nodesDeltaSummary = nodesDelta.shortSummary();
+                    if (nodesDeltaSummary.length() > 0) {
+                        logger.info("{}, term: {}, version: {}, delta: {}",
+                            summary, newClusterState.term(), newClusterState.version(), nodesDeltaSummary);
                     }
                 }
 

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
@@ -191,7 +191,6 @@ public class DiscoveryNodesTests extends ESTestCase {
         assertThat(nodes0.delta(nodes02Local).shortSummary(), oneOf(
             "removed {" + discoveryNodes.get(1) + "," + discoveryNodes.get(2) + "}",
             "removed {" + discoveryNodes.get(2) + "," + discoveryNodes.get(1) + "}"));
-
     }
 
     public void testDeltas() {

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
@@ -44,6 +44,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.oneOf;
 
 public class DiscoveryNodesTests extends ESTestCase {
 
@@ -161,6 +162,24 @@ public class DiscoveryNodesTests extends ESTestCase {
         final List<DiscoveryNode> sortedNodes = new ArrayList<>(returnedNodes);
         Collections.sort(sortedNodes, Comparator.comparing(n -> n.isMasterNode() == false));
         assertEquals(sortedNodes, returnedNodes);
+    }
+
+    public void testDeltaListsMultipleNodes() {
+        final List<DiscoveryNode> discoveryNodes = randomNodes(3);
+
+        final DiscoveryNodes nodes0 = DiscoveryNodes.builder().add(discoveryNodes.get(0)).build();
+        final DiscoveryNodes nodes01 = DiscoveryNodes.builder(nodes0).add(discoveryNodes.get(1)).build();
+        final DiscoveryNodes nodes012 = DiscoveryNodes.builder(nodes01).add(discoveryNodes.get(2)).build();
+
+        assertThat(nodes01.delta(nodes0).shortSummary(), equalTo("added {" + discoveryNodes.get(1) + "}"));
+        assertThat(nodes012.delta(nodes0).shortSummary(), oneOf(
+            "added {" + discoveryNodes.get(1) + "," + discoveryNodes.get(2) + "}",
+            "added {" + discoveryNodes.get(2) + "," + discoveryNodes.get(1) + "}"));
+
+        assertThat(nodes0.delta(nodes01).shortSummary(), equalTo("removed {" + discoveryNodes.get(1) + "}"));
+        assertThat(nodes0.delta(nodes012).shortSummary(), oneOf(
+            "removed {" + discoveryNodes.get(1) + "," + discoveryNodes.get(2) + "}",
+            "removed {" + discoveryNodes.get(2) + "," + discoveryNodes.get(1) + "}"));
     }
 
     public void testDeltas() {

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
@@ -180,6 +180,18 @@ public class DiscoveryNodesTests extends ESTestCase {
         assertThat(nodes0.delta(nodes012).shortSummary(), oneOf(
             "removed {" + discoveryNodes.get(1) + "," + discoveryNodes.get(2) + "}",
             "removed {" + discoveryNodes.get(2) + "," + discoveryNodes.get(1) + "}"));
+
+        final DiscoveryNodes nodes01Local = DiscoveryNodes.builder(nodes01).localNodeId(discoveryNodes.get(1).getId()).build();
+        final DiscoveryNodes nodes02Local = DiscoveryNodes.builder(nodes012).localNodeId(discoveryNodes.get(1).getId()).build();
+
+        assertThat(nodes01Local.delta(nodes0).shortSummary(), equalTo(""));
+        assertThat(nodes02Local.delta(nodes0).shortSummary(), equalTo("added {" + discoveryNodes.get(2) + "}"));
+
+        assertThat(nodes0.delta(nodes01Local).shortSummary(), equalTo("removed {" + discoveryNodes.get(1) + "}"));
+        assertThat(nodes0.delta(nodes02Local).shortSummary(), oneOf(
+            "removed {" + discoveryNodes.get(1) + "," + discoveryNodes.get(2) + "}",
+            "removed {" + discoveryNodes.get(2) + "," + discoveryNodes.get(1) + "}"));
+
     }
 
     public void testDeltas() {


### PR DESCRIPTION
Today when the membership of the cluster changes we log messages that describe
the change like this:

    added {{node-1}{OPdaTIGmSxaEXXOyg3o96w}{127.0.0.1}{127.0.0.1:9301}{di},}

The trailing comma suggests there is some missing string that might contain
extra information, but in fact it's an artefact of how these messages are
constructed. This commit removes the trailing comma from these lists.