### PR TITLE
[7.4] Disallow persisting any documents when datafeed is isolated (#46485)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJob.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJob.java
@@ -97,6 +97,7 @@ class DatafeedJob {
 
     void isolate() {
         isIsolated = true;
+        timingStatsReporter.disallowPersisting();
     }
 
     boolean isIsolated() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporterTests.java
@@ -132,6 +132,15 @@ public class DatafeedTimingStatsReporterTests extends ESTestCase {
         verifyNoMoreInteractions(timingStatsPersister);
     }
 
+    public void testDisallowPersisting() {
+        DatafeedTimingStatsReporter reporter = createReporter(createDatafeedTimingStats(JOB_ID, 0, 0, 0.0));
+        reporter.disallowPersisting();
+        // This call would normally trigger persisting but because of the "disallowPersisting" call above it will not.
+        reporter.reportSearchDuration(ONE_SECOND);
+
+        verifyZeroInteractions(timingStatsPersister);
+    }
+
     public void testTimingStatsDifferSignificantly() {
         assertThat(
             DatafeedTimingStatsReporter.differSignificantly(


### PR DESCRIPTION
Backports the following commits to 7.4:
 - Disallow persisting any documents when datafeed is isolated  (#46485)