### PR TITLE
Disable local build cache in CI

### DIFF
--- a/.ci/init.gradle
+++ b/.ci/init.gradle
@@ -86,6 +86,10 @@ if (buildCacheUrl) {
             .getData();
     gradle.settingsEvaluated { settings ->
         settings.buildCache {
+            local {
+                // Disable the local build cache in CI since we use ephemeral workers and it incurs an IO penalty
+                enabled = false
+            }
             remote(HttpBuildCache) {
                 url = buildCacheUrl
                 push = buildCachePush


### PR DESCRIPTION
This change disables the local build cache when building in CI. Since we rely almost exclusively on ephemeral workers, there's little to no benefit of using the local cache. We do however pay a penalty by enabling it because it means that every cache miss results in a pack/store in the local cache, even for builds that don't push to the remote cache. The best example of this is the [BWC pull request builds](https://gradle-enterprise.elastic.co/scans/performance?failures.failureClassification=non_verification&list.offset=0&list.size=50&list.sortColumn=startTime&list.sortOrder=desc&performance.metric=buildCacheOverhead,buildCacheOverheadPack&performance.offset=534&search.buildToolType=gradle&search.buildToolType=maven&search.startTimeMax=1568055637758&search.startTimeMin=1567450837758&search.tags=elastic%2Belasticsearch%2Bpull-request-bwc&trends.section=overview&trends.timeResolution=day&viewer.tzOffset=-420) which have to pack up the entire BWC distribution whenever there's a cache miss.