### PR TITLE
Update SLM Retention serialization versions

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleMetadata.java
@@ -79,8 +79,7 @@ public class SnapshotLifecycleMetadata implements MetaData.Custom {
     public SnapshotLifecycleMetadata(StreamInput in) throws IOException {
         this.snapshotConfigurations = in.readMap(StreamInput::readString, SnapshotLifecyclePolicyMetadata::new);
         this.operationMode = in.readEnum(OperationMode.class);
-        // TODO: version qualify this with the correct version (7.5) once available
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_5_0)) {
             this.slmStats = new SnapshotLifecycleStats(in);
         } else {
             this.slmStats = new SnapshotLifecycleStats();
@@ -123,8 +122,7 @@ public class SnapshotLifecycleMetadata implements MetaData.Custom {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeMap(this.snapshotConfigurations, StreamOutput::writeString, (out1, value) -> value.writeTo(out1));
         out.writeEnum(this.operationMode);
-        // TODO: version qualify this with the correct version (7.5) once available
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_5_0)) {
             this.slmStats.writeTo(out);
         }
     }
@@ -179,8 +177,7 @@ public class SnapshotLifecycleMetadata implements MetaData.Custom {
                 SnapshotLifecyclePolicyMetadata::new,
                 SnapshotLifecycleMetadataDiff::readLifecyclePolicyDiffFrom);
             this.operationMode = in.readEnum(OperationMode.class);
-            // TODO: version qualify this with the correct version (7.5) once available
-            if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            if (in.getVersion().onOrAfter(Version.V_7_5_0)) {
                 this.slmStats = new SnapshotLifecycleStats(in);
             } else {
                 this.slmStats = new SnapshotLifecycleStats();
@@ -203,8 +200,7 @@ public class SnapshotLifecycleMetadata implements MetaData.Custom {
         public void writeTo(StreamOutput out) throws IOException {
             lifecycles.writeTo(out);
             out.writeEnum(this.operationMode);
-            // TODO: version qualify this with the correct version (7.5) once available
-            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            if (out.getVersion().onOrAfter(Version.V_7_5_0)) {
                 this.slmStats.writeTo(out);
             }
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicy.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.core.slm;
 
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -102,7 +103,11 @@ public class SnapshotLifecyclePolicy extends AbstractDiffable<SnapshotLifecycleP
         this.schedule = in.readString();
         this.repository = in.readString();
         this.configuration = in.readMap();
-        this.retentionPolicy = in.readOptionalWriteable(SnapshotRetentionConfiguration::new);
+        if (in.getVersion().onOrAfter(Version.V_7_5_0)) {
+            this.retentionPolicy = in.readOptionalWriteable(SnapshotRetentionConfiguration::new);
+        } else {
+            this.retentionPolicy = SnapshotRetentionConfiguration.EMPTY;
+        }
     }
 
     public String getId() {
@@ -270,7 +275,9 @@ public class SnapshotLifecyclePolicy extends AbstractDiffable<SnapshotLifecycleP
         out.writeString(this.schedule);
         out.writeString(this.repository);
         out.writeMap(this.configuration);
-        out.writeOptionalWriteable(this.retentionPolicy);
+        if (out.getVersion().onOrAfter(Version.V_7_5_0)) {
+            out.writeOptionalWriteable(this.retentionPolicy);
+        }
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicyItem.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicyItem.java
@@ -64,7 +64,7 @@ public class SnapshotLifecyclePolicyItem implements ToXContentFragment, Writeabl
         this.lastSuccess = in.readOptionalWriteable(SnapshotInvocationRecord::new);
         this.lastFailure = in.readOptionalWriteable(SnapshotInvocationRecord::new);
         this.snapshotInProgress = in.readOptionalWriteable(SnapshotInProgress::new);
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_5_0)) {
             this.policyStats = new SnapshotLifecycleStats.SnapshotPolicyStats(in);
         } else {
             this.policyStats = new SnapshotLifecycleStats.SnapshotPolicyStats(this.policy.getId());
@@ -122,7 +122,7 @@ public class SnapshotLifecyclePolicyItem implements ToXContentFragment, Writeabl
         out.writeOptionalWriteable(lastSuccess);
         out.writeOptionalWriteable(lastFailure);
         out.writeOptionalWriteable(snapshotInProgress);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_5_0)) {
             this.policyStats.writeTo(out);
         }
     }


### PR DESCRIPTION
With #46506 backporting SLM retention, this updates master's version
guards for SLM retention.

Relates to #43663
