### PR TITLE
Disable BWC for SLM retention backport

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,8 +176,8 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
-final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = false
+final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/46509" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")


### PR DESCRIPTION
SLM retention was merged in #46407 and will be backported in #46506.
This disables BWC tests until both the backport and the version change
in #46509 are merged.
