### PR TITLE
Ensure rest api specs are always copied before using test classpath

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
@@ -127,8 +127,8 @@ class RestIntegTestTask extends DefaultTask {
         }
 
         // copy the rest spec/tests onto the test classpath
-        Task copyRestSpec = createCopyRestSpecTask()
-        runner.classpath += copyRestSpec.outputs.files
+        Copy copyRestSpec = createCopyRestSpecTask()
+        project.sourceSets.test.output.builtBy(copyRestSpec)
 
         // this must run after all projects have been configured, so we know any project
         // references can be accessed as a fully configured
@@ -227,12 +227,6 @@ class RestIntegTestTask extends DefaultTask {
 
     }
 
-    /**
-     * Creates a task (if necessary) to copy the rest spec files.
-     *
-     * @param project The project to add the copy task to
-     * @param includePackagedTests true if the packaged tests should be copied, false otherwise
-     */
     Copy createCopyRestSpecTask() {
         Boilerplate.maybeCreate(project.configurations, 'restSpec') {
             project.dependencies.add(
@@ -244,7 +238,7 @@ class RestIntegTestTask extends DefaultTask {
 
         return Boilerplate.maybeCreate(project.tasks, 'copyRestSpec', Copy) { Copy copy ->
             copy.dependsOn project.configurations.restSpec
-            copy.into "${project.buildDir}/rest-spec"
+            copy.into(project.sourceSets.test.output.resourcesDir)
             copy.from({ project.zipTree(project.configurations.restSpec.singleFile) }) {
                 includeEmptyDirs = false
                 include 'rest-api-spec/**'

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
@@ -22,6 +22,7 @@ import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.testclusters.ElasticsearchCluster
 import org.elasticsearch.gradle.testclusters.RestTestRunnerTask
 import org.elasticsearch.gradle.testclusters.TestClustersPlugin
+import org.elasticsearch.gradle.tool.Boilerplate
 import org.elasticsearch.gradle.tool.ClasspathUtils
 import org.gradle.api.DefaultTask
 import org.gradle.api.Task
@@ -38,6 +39,7 @@ import org.gradle.plugins.ide.idea.IdeaPlugin
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.util.stream.Stream
+
 /**
  * A wrapper task around setting up a cluster and running rest tests.
  */
@@ -81,9 +83,9 @@ class RestIntegTestTask extends DefaultTask {
             }
             if (usesTestclusters == true) {
                 ElasticsearchCluster cluster = project.testClusters."${name}"
-                runner.nonInputProperties.systemProperty('tests.rest.cluster', "${-> cluster.allHttpSocketURI.join(",") }")
-                runner.nonInputProperties.systemProperty('tests.cluster', "${-> cluster.transportPortURI }")
-                runner.nonInputProperties.systemProperty('tests.clustername', "${-> cluster.getName() }")
+                runner.nonInputProperties.systemProperty('tests.rest.cluster', "${-> cluster.allHttpSocketURI.join(",")}")
+                runner.nonInputProperties.systemProperty('tests.cluster', "${-> cluster.transportPortURI}")
+                runner.nonInputProperties.systemProperty('tests.clustername', "${-> cluster.getName()}")
             } else {
                 // we pass all nodes to the rest cluster to allow the clients to round-robin between them
                 // this is more realistic than just talking to a single node
@@ -125,8 +127,8 @@ class RestIntegTestTask extends DefaultTask {
 
         // copy the rest spec/tests into the test resources
         Task copyRestSpec = createCopyRestSpecTask()
-        runner.dependsOn(copyRestSpec)
-        
+        runner.classpath += copyRestSpec.outputs.files
+
         // this must run after all projects have been configured, so we know any project
         // references can be accessed as a fully configured
         project.gradle.projectsEvaluated {
@@ -150,8 +152,8 @@ class RestIntegTestTask extends DefaultTask {
     }
 
     @Option(
-        option = "debug-jvm",
-        description = "Enable debugging configuration, to allow attaching a debugger to elasticsearch."
+            option = "debug-jvm",
+            description = "Enable debugging configuration, to allow attaching a debugger to elasticsearch."
     )
     public void setDebug(boolean enabled) {
         clusterConfig.debug = enabled;
@@ -166,7 +168,7 @@ class RestIntegTestTask extends DefaultTask {
         runner.dependsOn(dependencies)
         for (Object dependency : dependencies) {
             if (dependency instanceof Fixture) {
-                runner.finalizedBy(((Fixture)dependency).getStopTask())
+                runner.finalizedBy(((Fixture) dependency).getStopTask())
             }
         }
         return this
@@ -177,7 +179,7 @@ class RestIntegTestTask extends DefaultTask {
         runner.setDependsOn(dependencies)
         for (Object dependency : dependencies) {
             if (dependency instanceof Fixture) {
-                runner.finalizedBy(((Fixture)dependency).getStopTask())
+                runner.finalizedBy(((Fixture) dependency).getStopTask())
             }
         }
     }
@@ -231,43 +233,33 @@ class RestIntegTestTask extends DefaultTask {
      * @param includePackagedTests true if the packaged tests should be copied, false otherwise
      */
     Task createCopyRestSpecTask() {
-        project.configurations {
-            restSpec
+        Boilerplate.maybeCreate(project.configurations, 'restSpec') {
+            project.dependencies.add(
+                    'restSpec',
+                    ClasspathUtils.isElasticsearchProject() ? project.project(':rest-api-spec') :
+                            "org.elasticsearch:rest-api-spec:${VersionProperties.elasticsearch}"
+            )
         }
-        project.dependencies {
-            restSpec ClasspathUtils.isElasticsearchProject() ? project.project(':rest-api-spec') :
-                    "org.elasticsearch:rest-api-spec:${VersionProperties.elasticsearch}"
-        }
-        Task copyRestSpec = project.tasks.findByName('copyRestSpec')
-        if (copyRestSpec != null) {
-            return copyRestSpec
-        }
-        Map copyRestSpecProps = [
-                name     : 'copyRestSpec',
-                type     : Copy,
-                dependsOn: [project.configurations.restSpec, 'processTestResources']
-        ]
-        copyRestSpec = project.tasks.create(copyRestSpecProps) {
-            into project.sourceSets.test.output.resourcesDir
-        }
-        project.afterEvaluate {
-            copyRestSpec.from({ project.zipTree(project.configurations.restSpec.singleFile) }) {
+
+        return Boilerplate.maybeCreate(project.tasks, 'copyRestSpec', Copy) { Copy copy ->
+            copy.dependsOn project.configurations.restSpec
+            copy.into "${project.buildDir}/rest-spec"
+            copy.from({ project.zipTree(project.configurations.restSpec.singleFile) }) {
                 include 'rest-api-spec/api/**'
                 if (includePackaged) {
                     include 'rest-api-spec/test/**'
                 }
             }
-        }
-        if (project.plugins.hasPlugin(IdeaPlugin)) {
-            project.idea {
-                module {
-                    if (scopes.TEST != null) {
-                        scopes.TEST.plus.add(project.configurations.restSpec)
+
+            if (project.plugins.hasPlugin(IdeaPlugin)) {
+                project.idea {
+                    module {
+                        if (scopes.TEST != null) {
+                            scopes.TEST.plus.add(project.configurations.restSpec)
+                        }
                     }
                 }
             }
         }
-        return copyRestSpec
     }
-
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/tool/Boilerplate.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/tool/Boilerplate.java
@@ -20,6 +20,7 @@ package org.elasticsearch.gradle.tool;
 
 import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.PolymorphicDomainObjectContainer;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
@@ -46,6 +47,16 @@ public abstract class Boilerplate {
         return Optional.ofNullable(collection.findByName(name))
             .orElseGet(() -> {
                 T result = collection.create(name);
+                action.execute(result);
+                return result;
+            });
+
+    }
+
+    public static <T> T maybeCreate(PolymorphicDomainObjectContainer<T> collection, String name, Class<T> type, Action<T> action) {
+        return Optional.ofNullable(collection.findByName(name))
+            .orElseGet(() -> {
+                T result = collection.create(name, type);
                 action.execute(result);
                 return result;
             });


### PR DESCRIPTION
This PR fixes an issue with odd cache misses for tasks that track the test runtime classpath as an input, such as checkstyle. Essentially, if the `copyRestSpec` task happens to run before checkstyle, then it would be included as an input, if it ran after, it wouldn't. This means that the hashes for a task like checkstyle would be different for the same inputs (git checkout) simply due to the inherit randomness of task execution order.

I initially started down the path of separating the `copyRestSpec` task such that it had it's own output directory but that rabbit hole got deeper and deeper as x-pack and other projects define their own specs which have to be aggregated. Due to the way our tests search for these on the classpath that was going to turn into more of a refactoring that I wanted just to fix this cache miss issue so for now we just say that the rest specs are a dependency of the `test` sourceset output. This does mean that you'll have to copy the specs to run unit tests, but I'm not sure any of the projects in question even have any unit tests so this is likely a non-issue.