### PR TITLE
[DOCS] Adds missing icons to ML HLRC APIs

### DIFF
--- a/docs/java-rest/high-level/ml/close-job.asciidoc
+++ b/docs/java-rest/high-level/ml/close-job.asciidoc
@@ -3,6 +3,7 @@
 :request: CloseJobRequest
 :response: CloseJobResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Close {anomaly-job} API
 

--- a/docs/java-rest/high-level/ml/delete-calendar-event.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-calendar-event.asciidoc
@@ -3,6 +3,7 @@
 :request: DeleteCalendarEventRequest
 :response: AcknowledgedResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Delete calendar event API
 Removes a scheduled event from an existing {ml} calendar.

--- a/docs/java-rest/high-level/ml/delete-calendar-job.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-calendar-job.asciidoc
@@ -3,6 +3,7 @@
 :request: DeleteCalendarJobRequest
 :response: PutCalendarResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Delete {anomaly-jobs} from calendar API
 Removes {anomaly-jobs} from an existing {ml} calendar.

--- a/docs/java-rest/high-level/ml/delete-calendar.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-calendar.asciidoc
@@ -3,6 +3,7 @@
 :request: DeleteCalendarRequest
 :response: AcknowledgedResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Delete calendar API
 Delete a {ml} calendar.

--- a/docs/java-rest/high-level/ml/delete-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-data-frame-analytics.asciidoc
@@ -3,6 +3,7 @@
 :request: DeleteDataFrameAnalyticsRequest
 :response: AcknowledgedResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Delete Data Frame Analytics API
 

--- a/docs/java-rest/high-level/ml/delete-datafeed.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-datafeed.asciidoc
@@ -3,6 +3,7 @@
 :request: DeleteDatafeedRequest
 :response: AcknowledgedResponse
 --
+[role="xpack"]
 [id="{upid}-delete-datafeed"]
 === Delete datafeed API
 

--- a/docs/java-rest/high-level/ml/delete-expired-data.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-expired-data.asciidoc
@@ -4,6 +4,7 @@
 :request: DeleteExpiredRequest
 :response: DeleteExpiredResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Delete Expired Data API
 Delete expired {ml} data.

--- a/docs/java-rest/high-level/ml/delete-filter.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-filter.asciidoc
@@ -3,6 +3,7 @@
 :request: DeleteFilterRequest
 :response: AcknowledgedResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Delete Filter API
 Delete a {ml} filter.

--- a/docs/java-rest/high-level/ml/delete-forecast.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-forecast.asciidoc
@@ -3,6 +3,7 @@
 :request: DeleteForecastRequest
 :response: AcknowledgedResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Delete Forecast API
 

--- a/docs/java-rest/high-level/ml/delete-job.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-job.asciidoc
@@ -3,6 +3,7 @@
 :request: DeleteJobRequest
 :response: AcknowledgedResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Delete {anomaly-job} API
 

--- a/docs/java-rest/high-level/ml/delete-model-snapshot.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-model-snapshot.asciidoc
@@ -3,6 +3,7 @@
 :request: DeleteModelSnapshotRequest
 :response: AcknowledgedResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Delete Model Snapshot API
 

--- a/docs/java-rest/high-level/ml/estimate-memory-usage.asciidoc
+++ b/docs/java-rest/high-level/ml/estimate-memory-usage.asciidoc
@@ -3,6 +3,7 @@
 :request: PutDataFrameAnalyticsRequest
 :response: EstimateMemoryUsageResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Estimate memory usage API
 

--- a/docs/java-rest/high-level/ml/evaluate-data-frame.asciidoc
+++ b/docs/java-rest/high-level/ml/evaluate-data-frame.asciidoc
@@ -3,6 +3,7 @@
 :request: EvaluateDataFrameRequest
 :response: EvaluateDataFrameResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Evaluate Data Frame API
 

--- a/docs/java-rest/high-level/ml/find-file-structure.asciidoc
+++ b/docs/java-rest/high-level/ml/find-file-structure.asciidoc
@@ -3,6 +3,7 @@
 :request: FindFileStructureRequest
 :response: FindFileStructureResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Find File Structure API
 

--- a/docs/java-rest/high-level/ml/flush-job.asciidoc
+++ b/docs/java-rest/high-level/ml/flush-job.asciidoc
@@ -3,6 +3,7 @@
 :request: FlushJobRequest
 :response: FlushJobResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Flush Job API
 

--- a/docs/java-rest/high-level/ml/forecast-job.asciidoc
+++ b/docs/java-rest/high-level/ml/forecast-job.asciidoc
@@ -3,6 +3,7 @@
 :request: ForecastJobRequest
 :response: ForecastJobResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Forecast Job API
 

--- a/docs/java-rest/high-level/ml/get-buckets.asciidoc
+++ b/docs/java-rest/high-level/ml/get-buckets.asciidoc
@@ -3,6 +3,7 @@
 :request: GetBucketsRequest
 :response: GetBucketsResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get buckets API
 

--- a/docs/java-rest/high-level/ml/get-calendar-events.asciidoc
+++ b/docs/java-rest/high-level/ml/get-calendar-events.asciidoc
@@ -3,6 +3,7 @@
 :request: GetCalendarEventsRequest
 :response: GetCalendarEventsResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get calendar events API
 Retrieves a calendar's events.

--- a/docs/java-rest/high-level/ml/get-calendars.asciidoc
+++ b/docs/java-rest/high-level/ml/get-calendars.asciidoc
@@ -3,6 +3,7 @@
 :request: GetCalendarsRequest
 :response: GetCalendarsResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get calendars API
 Retrieves one or more calendar objects.

--- a/docs/java-rest/high-level/ml/get-categories.asciidoc
+++ b/docs/java-rest/high-level/ml/get-categories.asciidoc
@@ -3,6 +3,7 @@
 :request: GetCategoriesRequest
 :response: GetCategoriesResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get categories API
 

--- a/docs/java-rest/high-level/ml/get-data-frame-analytics-stats.asciidoc
+++ b/docs/java-rest/high-level/ml/get-data-frame-analytics-stats.asciidoc
@@ -3,6 +3,7 @@
 :request: GetDataFrameAnalyticsStatsRequest
 :response: GetDataFrameAnalyticsStatsResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get Data Frame Analytics Stats API
 

--- a/docs/java-rest/high-level/ml/get-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/get-data-frame-analytics.asciidoc
@@ -3,6 +3,7 @@
 :request: GetDataFrameAnalyticsRequest
 :response: GetDataFrameAnalyticsResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get Data Frame Analytics API
 

--- a/docs/java-rest/high-level/ml/get-datafeed-stats.asciidoc
+++ b/docs/java-rest/high-level/ml/get-datafeed-stats.asciidoc
@@ -3,6 +3,7 @@
 :request: GetDatafeedStatsRequest
 :response: GetDatafeedStatsResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get datafeed stats API
 

--- a/docs/java-rest/high-level/ml/get-datafeed.asciidoc
+++ b/docs/java-rest/high-level/ml/get-datafeed.asciidoc
@@ -3,6 +3,7 @@
 :request: GetDatafeedRequest
 :response: GetDatafeedResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get datafeed API
 

--- a/docs/java-rest/high-level/ml/get-filters.asciidoc
+++ b/docs/java-rest/high-level/ml/get-filters.asciidoc
@@ -3,6 +3,7 @@
 :request: GetFiltersRequest
 :response: GetFiltersResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get filters API
 

--- a/docs/java-rest/high-level/ml/get-influencers.asciidoc
+++ b/docs/java-rest/high-level/ml/get-influencers.asciidoc
@@ -3,6 +3,7 @@
 :request: GetInfluencersRequest
 :response: GetInfluencersResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get influencers API
 

--- a/docs/java-rest/high-level/ml/get-info.asciidoc
+++ b/docs/java-rest/high-level/ml/get-info.asciidoc
@@ -3,6 +3,7 @@
 :request: MlInfoRequest
 :response: MlInfoResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === ML get info API
 

--- a/docs/java-rest/high-level/ml/get-job-stats.asciidoc
+++ b/docs/java-rest/high-level/ml/get-job-stats.asciidoc
@@ -3,6 +3,7 @@
 :request: GetJobStatsRequest
 :response: GetJobStatsResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get {anomaly-job} stats API
 

--- a/docs/java-rest/high-level/ml/get-job.asciidoc
+++ b/docs/java-rest/high-level/ml/get-job.asciidoc
@@ -3,6 +3,7 @@
 :request: GetJobRequest
 :response: GetJobResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get {anomaly-jobs} API
 

--- a/docs/java-rest/high-level/ml/get-model-snapshots.asciidoc
+++ b/docs/java-rest/high-level/ml/get-model-snapshots.asciidoc
@@ -3,6 +3,7 @@
 :request: GetModelSnapshotsRequest
 :response: GetModelSnapshotsResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get model snapshots API
 

--- a/docs/java-rest/high-level/ml/get-overall-buckets.asciidoc
+++ b/docs/java-rest/high-level/ml/get-overall-buckets.asciidoc
@@ -3,6 +3,7 @@
 :request: GetOverallBucketsRequest
 :response: GetOverallBucketsResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get overall buckets API
 

--- a/docs/java-rest/high-level/ml/get-records.asciidoc
+++ b/docs/java-rest/high-level/ml/get-records.asciidoc
@@ -3,6 +3,7 @@
 :request: GetRecordsRequest
 :response: GetRecordsResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get records API
 

--- a/docs/java-rest/high-level/ml/open-job.asciidoc
+++ b/docs/java-rest/high-level/ml/open-job.asciidoc
@@ -3,6 +3,7 @@
 :request: OpenJobRequest
 :response: OpenJobResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Open {anomaly-job} API
 

--- a/docs/java-rest/high-level/ml/post-calendar-event.asciidoc
+++ b/docs/java-rest/high-level/ml/post-calendar-event.asciidoc
@@ -3,6 +3,7 @@
 :request: PostCalendarEventRequest
 :response: PostCalendarEventResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Post Calendar Event API
 Adds new ScheduledEvents to an existing {ml} calendar.

--- a/docs/java-rest/high-level/ml/post-data.asciidoc
+++ b/docs/java-rest/high-level/ml/post-data.asciidoc
@@ -3,6 +3,7 @@
 :request: PostDataRequest
 :response: PostDataResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Post Data API
 

--- a/docs/java-rest/high-level/ml/preview-datafeed.asciidoc
+++ b/docs/java-rest/high-level/ml/preview-datafeed.asciidoc
@@ -3,6 +3,7 @@
 :request: PreviewDatafeedRequest
 :response: PreviewDatafeedResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Preview Datafeed API
 

--- a/docs/java-rest/high-level/ml/put-calendar-job.asciidoc
+++ b/docs/java-rest/high-level/ml/put-calendar-job.asciidoc
@@ -3,6 +3,7 @@
 :request: PutCalendarJobRequest
 :response: PutCalendarResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Put {anomaly-jobs} in calendar API
 Adds {anomaly-jobs} jobs to an existing {ml} calendar.

--- a/docs/java-rest/high-level/ml/put-calendar.asciidoc
+++ b/docs/java-rest/high-level/ml/put-calendar.asciidoc
@@ -3,6 +3,7 @@
 :request: PutCalendarRequest
 :response: PutCalendarResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Put calendar API
 Creates a new {ml} calendar.

--- a/docs/java-rest/high-level/ml/put-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/put-data-frame-analytics.asciidoc
@@ -3,6 +3,7 @@
 :request: PutDataFrameAnalyticsRequest
 :response: PutDataFrameAnalyticsResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Put Data Frame Analytics API
 

--- a/docs/java-rest/high-level/ml/put-datafeed.asciidoc
+++ b/docs/java-rest/high-level/ml/put-datafeed.asciidoc
@@ -3,6 +3,7 @@
 :request: PutDatafeedRequest
 :response: PutDatafeedResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Put datafeed API
 

--- a/docs/java-rest/high-level/ml/put-filter.asciidoc
+++ b/docs/java-rest/high-level/ml/put-filter.asciidoc
@@ -3,6 +3,7 @@
 :request: PutFilterRequest
 :response: PutFilterResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Put Filter API
 

--- a/docs/java-rest/high-level/ml/put-job.asciidoc
+++ b/docs/java-rest/high-level/ml/put-job.asciidoc
@@ -3,6 +3,7 @@
 :request: PutJobRequest
 :response: PutJobResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Put {anomaly-job} API
 

--- a/docs/java-rest/high-level/ml/revert-model-snapshot.asciidoc
+++ b/docs/java-rest/high-level/ml/revert-model-snapshot.asciidoc
@@ -3,6 +3,8 @@
 :request: RevertModelSnapshotRequest
 :response: RevertModelSnapshotResponse
 --
+[role="xpack"]
+
 [id="{upid}-{api}"]
 === Revert Model Snapshot API
 

--- a/docs/java-rest/high-level/ml/set-upgrade-mode.asciidoc
+++ b/docs/java-rest/high-level/ml/set-upgrade-mode.asciidoc
@@ -3,6 +3,7 @@
 :request: SetUpgradeModeRequest
 :response: AcknowledgedResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Set Upgrade Mode API
 

--- a/docs/java-rest/high-level/ml/start-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/start-data-frame-analytics.asciidoc
@@ -3,6 +3,7 @@
 :request: StartDataFrameAnalyticsRequest
 :response: AcknowledgedResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Start Data Frame Analytics API
 

--- a/docs/java-rest/high-level/ml/start-datafeed.asciidoc
+++ b/docs/java-rest/high-level/ml/start-datafeed.asciidoc
@@ -3,6 +3,7 @@
 :request: StartDatafeedRequest
 :response: StartDatafeedResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Start datafeed API
 

--- a/docs/java-rest/high-level/ml/stop-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/stop-data-frame-analytics.asciidoc
@@ -3,6 +3,7 @@
 :request: StopDataFrameAnalyticsRequest
 :response: StopDataFrameAnalyticsResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Stop Data Frame Analytics API
 

--- a/docs/java-rest/high-level/ml/stop-datafeed.asciidoc
+++ b/docs/java-rest/high-level/ml/stop-datafeed.asciidoc
@@ -3,6 +3,7 @@
 :request: StopDatafeedRequest
 :response: StopDatafeedResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Stop Datafeed API
 

--- a/docs/java-rest/high-level/ml/update-datafeed.asciidoc
+++ b/docs/java-rest/high-level/ml/update-datafeed.asciidoc
@@ -3,6 +3,7 @@
 :request: UpdateDatafeedRequest
 :response: PutDatafeedResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Update datafeed API
 

--- a/docs/java-rest/high-level/ml/update-filter.asciidoc
+++ b/docs/java-rest/high-level/ml/update-filter.asciidoc
@@ -3,6 +3,7 @@
 :request: UpdateFilterRequest
 :response: PutFilterResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Update filter API
 

--- a/docs/java-rest/high-level/ml/update-job.asciidoc
+++ b/docs/java-rest/high-level/ml/update-job.asciidoc
@@ -3,6 +3,7 @@
 :request: UpdateJobRequest
 :response: PutJobResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Update {anomaly-job} API
 

--- a/docs/java-rest/high-level/ml/update-model-snapshot.asciidoc
+++ b/docs/java-rest/high-level/ml/update-model-snapshot.asciidoc
@@ -3,6 +3,7 @@
 :request: UpdateModelSnapshotRequest
 :response: UpdateModelSnapshotResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Update model snapshot API
 


### PR DESCRIPTION
This PR adds the missing "role=xpack" attribute to the machine learning APIs in the Java high level REST client documentation (https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/_machine_learning_apis.html)