### PR TITLE
Add audit messages for Data Frame Analytics

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
@@ -153,6 +153,7 @@ import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.xpack.core.ml.notifications.AuditorField;
 import org.junit.After;
 
 import java.io.IOException;
@@ -167,20 +168,20 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
 public class MachineLearningIT extends ESRestHighLevelClientTestCase {
@@ -1245,6 +1246,9 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
         assertThat(createdConfig.getAnalyzedFields(), equalTo(config.getAnalyzedFields()));
         assertThat(createdConfig.getModelMemoryLimit(), equalTo(ByteSizeValue.parseBytesSizeValue("1gb", "")));  // default value
         assertThat(createdConfig.getDescription(), equalTo("some description"));
+
+        assertThatAuditMessagesAreEqualTo(configId,
+            "Created analytics with analysis type [outlier detection]");
     }
 
     public void testPutDataFrameAnalyticsConfig_GivenRegression() throws Exception {
@@ -1280,6 +1284,9 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
         assertThat(createdConfig.getAnalyzedFields(), equalTo(config.getAnalyzedFields()));
         assertThat(createdConfig.getModelMemoryLimit(), equalTo(ByteSizeValue.parseBytesSizeValue("1gb", "")));  // default value
         assertThat(createdConfig.getDescription(), equalTo("this is a regression"));
+
+        assertThatAuditMessagesAreEqualTo(configId,
+            "Created analytics with analysis type [regression]");
     }
 
     public void testGetDataFrameAnalyticsConfig_SingleConfig() throws Exception {
@@ -1464,6 +1471,14 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
 
         // Verify that the destination index got created.
         assertTrue(highLevelClient().indices().exists(new GetIndexRequest(destIndex), RequestOptions.DEFAULT));
+
+        assertThatAuditMessagesAreEqualTo(configId,
+            "Created analytics with analysis type [outlier detection]",
+            "Estimated memory usage for this analytics to be [3kb]",
+            "Started analytics",
+            "Creating destination index [start-test-dest-index]",
+            "Finished reindexing to destination index [start-test-dest-index]",
+            "Finished analysis");
     }
 
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/43924")
@@ -1507,6 +1522,11 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
             machineLearningClient::stopDataFrameAnalytics, machineLearningClient::stopDataFrameAnalyticsAsync);
         assertTrue(stopDataFrameAnalyticsResponse.isStopped());
         assertThat(getAnalyticsState(configId), equalTo(DataFrameAnalyticsState.STOPPED));
+
+        assertThatAuditMessagesAreEqualTo(configId,
+            "Created analytics with analysis type [outlier detection]",
+            "Started analytics",
+            "Stopped analytics");
     }
 
     private DataFrameAnalyticsState getAnalyticsState(String configId) throws IOException {
@@ -1557,6 +1577,10 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
             new GetDataFrameAnalyticsRequest(configId + "*"),
             machineLearningClient::getDataFrameAnalytics, machineLearningClient::getDataFrameAnalyticsAsync);
         assertThat(getDataFrameAnalyticsResponse.getAnalytics(), hasSize(0));
+
+        assertThatAuditMessagesAreEqualTo(configId,
+            "Created analytics with analysis type [outlier detection]",
+            "Deleted analytics");
     }
 
     public void testDeleteDataFrameAnalyticsConfig_ConfigNotFound() {
@@ -1782,6 +1806,27 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
 
     private void createIndex(String indexName, XContentBuilder mapping) throws IOException {
         highLevelClient().indices().create(new CreateIndexRequest(indexName).mapping(mapping), RequestOptions.DEFAULT);
+    }
+
+    private static void assertThatAuditMessagesAreEqualTo(String configId, String... expectedAuditMessages) throws Exception {
+        // Make sure we wrote to the audit
+        // Since calls to write the AbstractAuditor are sent and forgot (async) we could have returned from the start,
+        // finished the job (as this is a very short analytics job), all without the audit being fully written.
+        assertBusy(() -> assertTrue(indexExists(AuditorField.NOTIFICATIONS_INDEX)));
+        assertBusy(() -> assertThat(fetchAllAuditMessages(configId), equalTo(List.of(expectedAuditMessages))));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> fetchAllAuditMessages(String dataFrameAnalyticsId) throws Exception {
+        assertOK(client().performRequest(new Request("POST", AuditorField.NOTIFICATIONS_INDEX + "/_refresh")));
+        Request request = new Request("GET", AuditorField.NOTIFICATIONS_INDEX + "/_search?sort=timestamp");
+        request.setJsonEntity("{\"query\":{\"term\":{\"job_id\":\"" + dataFrameAnalyticsId + "\"}}}");
+        Map<String, Object> response = entityAsMap(client().performRequest(request));
+        List<Map<String, Object>> hitList = ((List<Map<String, Object>>) ((Map<String, Object>) response.get("hits")).get("hits"));
+        return hitList
+            .stream()
+            .map(hit -> (String) ((Map<String, Object>) hit.get("_source")).get("message"))
+            .collect(Collectors.toList());
     }
 
     public void testEstimateMemoryUsage() throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
@@ -14,6 +14,13 @@ import java.util.Map;
 public interface DataFrameAnalysis extends ToXContentObject, NamedWriteable {
 
     /**
+     * @return Name of this analysis that can be presented to the user
+     */
+    default String getUserFriendlyName() {
+        return getWriteableName().replace('_', ' ');
+    }
+
+    /**
      * @return The analysis parameters as a map
      */
     Map<String, Object> getParams();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
@@ -14,13 +14,6 @@ import java.util.Map;
 public interface DataFrameAnalysis extends ToXContentObject, NamedWriteable {
 
     /**
-     * @return Name of this analysis that can be presented to the user
-     */
-    default String getUserFriendlyName() {
-        return getWriteableName().replace('_', ' ');
-    }
-
-    /**
      * @return The analysis parameters as a map
      */
     Map<String, Object> getParams();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -56,6 +56,20 @@ public final class Messages {
     public static final String DATA_FRAME_ANALYTICS_BAD_QUERY_FORMAT = "Data Frame Analytics config query is not parsable";
     public static final String DATA_FRAME_ANALYTICS_BAD_FIELD_FILTER = "No field [{0}] could be detected";
 
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_CREATED = "Created analytics with analysis type [{0}]";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_STARTED = "Started analytics";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_STOPPED = "Stopped analytics";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_DELETED = "Deleted analytics";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_ALREADY_STARTED = "Cannot start analytics because it has already been started";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_START_TIMEOUT = "Starting analytics timed out after [{0}]";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_CANCELED = "Canceled analytics";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_UPDATED_STATE = "Successfully updated analytics task state to [{0}]";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_ESTIMATED_MEMORY_USAGE = "Estimated memory usage for this analytics to be [{0}]";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_CREATING_DEST_INDEX = "Creating destination index [{0}]";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_REUSING_DEST_INDEX = "Using existing destination index [{0}]";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_FINISHED_REINDEXING = "Finished reindexing to destination index [{0}]";
+    public static final String DATA_FRAME_ANALYTICS_AUDIT_FINISHED_ANALYSIS = "Finished analysis";
+
     public static final String FILTER_CANNOT_DELETE = "Cannot delete filter [{0}] currently used by jobs {1}";
     public static final String FILTER_CONTAINS_TOO_MANY_ITEMS = "Filter [{0}] contains too many items; up to [{1}] items are allowed";
     public static final String FILTER_NOT_FOUND = "No filter with id [{0}] exists";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -60,9 +60,6 @@ public final class Messages {
     public static final String DATA_FRAME_ANALYTICS_AUDIT_STARTED = "Started analytics";
     public static final String DATA_FRAME_ANALYTICS_AUDIT_STOPPED = "Stopped analytics";
     public static final String DATA_FRAME_ANALYTICS_AUDIT_DELETED = "Deleted analytics";
-    public static final String DATA_FRAME_ANALYTICS_AUDIT_ALREADY_STARTED = "Cannot start analytics because it has already been started";
-    public static final String DATA_FRAME_ANALYTICS_AUDIT_START_TIMEOUT = "Starting analytics timed out after [{0}]";
-    public static final String DATA_FRAME_ANALYTICS_AUDIT_CANCELED = "Canceled analytics";
     public static final String DATA_FRAME_ANALYTICS_AUDIT_UPDATED_STATE = "Successfully updated analytics task state to [{0}]";
     public static final String DATA_FRAME_ANALYTICS_AUDIT_ESTIMATED_MEMORY_USAGE = "Estimated memory usage for this analytics to be [{0}]";
     public static final String DATA_FRAME_ANALYTICS_AUDIT_CREATING_DEST_INDEX = "Creating destination index [{0}]";

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
@@ -102,6 +102,13 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
 
         assertProgress(jobId, 100, 100, 100, 100);
         assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertThatAuditMessagesMatch(jobId,
+            "Created analytics with analysis type [regression]",
+            "Estimated memory usage for this analytics to be",
+            "Started analytics",
+            "Creating destination index [regression_single_numeric_feature_and_mixed_data_set_source_index_results]",
+            "Finished reindexing to destination index [regression_single_numeric_feature_and_mixed_data_set_source_index_results]",
+            "Finished analysis");
     }
 
     public void testWithOnlyTrainingRowsAndTrainingPercentIsHundred() throws Exception {
@@ -161,6 +168,13 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
 
         assertProgress(jobId, 100, 100, 100, 100);
         assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertThatAuditMessagesMatch(jobId,
+            "Created analytics with analysis type [regression]",
+            "Estimated memory usage for this analytics to be",
+            "Started analytics",
+            "Creating destination index [regression_only_training_data_and_training_percent_is_hundred_source_index_results]",
+            "Finished reindexing to destination index [regression_only_training_data_and_training_percent_is_hundred_source_index_results]",
+            "Finished analysis");
     }
 
     public void testWithOnlyTrainingRowsAndTrainingPercentIsFifty() throws Exception {
@@ -230,5 +244,12 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
 
         assertProgress(jobId, 100, 100, 100, 100);
         assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertThatAuditMessagesMatch(jobId,
+            "Created analytics with analysis type [regression]",
+            "Estimated memory usage for this analytics to be",
+            "Started analytics",
+            "Creating destination index [regression_only_training_data_and_training_percent_is_fifty_source_index_results]",
+            "Finished reindexing to destination index [regression_only_training_data_and_training_percent_is_fifty_source_index_results]",
+            "Finished analysis");
     }
 }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
@@ -115,6 +115,13 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
 
         assertProgress(id, 100, 100, 100, 100);
         assertThat(searchStoredProgress(id).getHits().getTotalHits().value, equalTo(1L));
+        assertThatAuditMessagesMatch(id,
+            "Created analytics with analysis type [outlier_detection]",
+            "Estimated memory usage for this analytics to be",
+            "Started analytics",
+            "Creating destination index [test-outlier-detection-with-few-docs-results]",
+            "Finished reindexing to destination index [test-outlier-detection-with-few-docs-results]",
+            "Finished analysis");
     }
 
     public void testOutlierDetectionWithEnoughDocumentsToScroll() throws Exception {
@@ -162,6 +169,13 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
 
         assertProgress(id, 100, 100, 100, 100);
         assertThat(searchStoredProgress(id).getHits().getTotalHits().value, equalTo(1L));
+        assertThatAuditMessagesMatch(id,
+            "Created analytics with analysis type [outlier_detection]",
+            "Estimated memory usage for this analytics to be",
+            "Started analytics",
+            "Creating destination index [test-outlier-detection-with-enough-docs-to-scroll-results]",
+            "Finished reindexing to destination index [test-outlier-detection-with-enough-docs-to-scroll-results]",
+            "Finished analysis");
     }
 
     public void testOutlierDetectionWithMoreFieldsThanDocValueFieldLimit() throws Exception {
@@ -234,9 +248,16 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
 
         assertProgress(id, 100, 100, 100, 100);
         assertThat(searchStoredProgress(id).getHits().getTotalHits().value, equalTo(1L));
+        assertThatAuditMessagesMatch(id,
+            "Created analytics with analysis type [outlier_detection]",
+            "Estimated memory usage for this analytics to be",
+            "Started analytics",
+            "Creating destination index [test-outlier-detection-with-more-fields-than-docvalue-limit-results]",
+            "Finished reindexing to destination index [test-outlier-detection-with-more-fields-than-docvalue-limit-results]",
+            "Finished analysis");
     }
 
-    public void testStopOutlierDetectionWithEnoughDocumentsToScroll() {
+    public void testStopOutlierDetectionWithEnoughDocumentsToScroll() throws Exception {
         String sourceIndex = "test-stop-outlier-detection-with-enough-docs-to-scroll";
 
         client().admin().indices().prepareCreate(sourceIndex)
@@ -284,6 +305,13 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
         } else {
             logger.debug("We stopped during reindexing: [{}] < [{}]", searchResponse.getHits().getTotalHits().value, docCount);
         }
+
+        assertThatAuditMessagesMatch(id,
+            "Created analytics with analysis type [outlier_detection]",
+            "Estimated memory usage for this analytics to be",
+            "Started analytics",
+            "Creating destination index [test-stop-outlier-detection-with-enough-docs-to-scroll-results]",
+            "Stopped analytics");
     }
 
     public void testOutlierDetectionWithMultipleSourceIndices() throws Exception {
@@ -338,6 +366,13 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
 
         assertProgress(id, 100, 100, 100, 100);
         assertThat(searchStoredProgress(id).getHits().getTotalHits().value, equalTo(1L));
+        assertThatAuditMessagesMatch(id,
+            "Created analytics with analysis type [outlier_detection]",
+            "Estimated memory usage for this analytics to be",
+            "Started analytics",
+            "Creating destination index [test-outlier-detection-with-multiple-source-indices-results]",
+            "Finished reindexing to destination index [test-outlier-detection-with-multiple-source-indices-results]",
+            "Finished analysis");
     }
 
     public void testOutlierDetectionWithPreExistingDestIndex() throws Exception {
@@ -388,9 +423,16 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
 
         assertProgress(id, 100, 100, 100, 100);
         assertThat(searchStoredProgress(id).getHits().getTotalHits().value, equalTo(1L));
+        assertThatAuditMessagesMatch(id,
+            "Created analytics with analysis type [outlier_detection]",
+            "Estimated memory usage for this analytics to be",
+            "Started analytics",
+            "Using existing destination index [test-outlier-detection-with-pre-existing-dest-index-results]",
+            "Finished reindexing to destination index [test-outlier-detection-with-pre-existing-dest-index-results]",
+            "Finished analysis");
     }
 
-    public void testModelMemoryLimitLowerThanEstimatedMemoryUsage() {
+    public void testModelMemoryLimitLowerThanEstimatedMemoryUsage() throws Exception {
         String sourceIndex = "test-model-memory-limit";
 
         client().admin().indices().prepareCreate(sourceIndex)
@@ -429,5 +471,9 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
             exception.getMessage(),
             startsWith("Cannot start because the configured model memory limit [" + modelMemoryLimit +
                 "] is lower than the expected memory usage"));
+
+        assertThatAuditMessagesMatch(id,
+            "Created analytics with analysis type [outlier_detection]",
+            "Estimated memory usage for this analytics to be");
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -370,6 +370,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
     private final SetOnce<AutodetectProcessManager> autodetectProcessManager = new SetOnce<>();
     private final SetOnce<DatafeedManager> datafeedManager = new SetOnce<>();
     private final SetOnce<DataFrameAnalyticsManager> dataFrameAnalyticsManager = new SetOnce<>();
+    private final SetOnce<DataFrameAnalyticsAuditor> dataFrameAnalyticsAuditor = new SetOnce<>();
     private final SetOnce<MlMemoryTracker> memoryTracker = new SetOnce<>();
 
     public MachineLearning(Settings settings, Path configPath) {
@@ -473,6 +474,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
 
         AnomalyDetectionAuditor anomalyDetectionAuditor = new AnomalyDetectionAuditor(client, clusterService.getNodeName());
         DataFrameAnalyticsAuditor dataFrameAnalyticsAuditor = new DataFrameAnalyticsAuditor(client, clusterService.getNodeName());
+        this.dataFrameAnalyticsAuditor.set(dataFrameAnalyticsAuditor);
         JobResultsProvider jobResultsProvider = new JobResultsProvider(client, settings);
         JobResultsPersister jobResultsPersister = new JobResultsPersister(client);
         JobDataCountsPersister jobDataCountsPersister = new JobDataCountsPersister(client);
@@ -562,8 +564,8 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                 threadPool.generic(), threadPool.executor(MachineLearning.JOB_COMMS_THREAD_POOL_NAME), memoryEstimationProcessFactory);
         DataFrameAnalyticsConfigProvider dataFrameAnalyticsConfigProvider = new DataFrameAnalyticsConfigProvider(client);
         assert client instanceof NodeClient;
-        DataFrameAnalyticsManager dataFrameAnalyticsManager = new DataFrameAnalyticsManager((NodeClient) client,
-            dataFrameAnalyticsConfigProvider, analyticsProcessManager);
+        DataFrameAnalyticsManager dataFrameAnalyticsManager = new DataFrameAnalyticsManager(
+            (NodeClient) client, dataFrameAnalyticsConfigProvider, analyticsProcessManager, dataFrameAnalyticsAuditor);
         this.dataFrameAnalyticsManager.set(dataFrameAnalyticsManager);
 
         // Components shared by anomaly detection and data frame analytics
@@ -618,7 +620,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                     memoryTracker.get(), client),
                 new TransportStartDatafeedAction.StartDatafeedPersistentTasksExecutor(datafeedManager.get()),
                 new TransportStartDataFrameAnalyticsAction.TaskExecutor(settings, client, clusterService, dataFrameAnalyticsManager.get(),
-                    memoryTracker.get())
+                    dataFrameAnalyticsAuditor.get(), memoryTracker.get())
         );
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
@@ -46,6 +46,7 @@ import org.elasticsearch.xpack.core.security.authz.permission.ResourcePrivileges
 import org.elasticsearch.xpack.core.security.support.Exceptions;
 import org.elasticsearch.xpack.ml.dataframe.SourceDestValidator;
 import org.elasticsearch.xpack.ml.dataframe.persistence.DataFrameAnalyticsConfigProvider;
+import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -64,6 +65,7 @@ public class TransportPutDataFrameAnalyticsAction
     private final Client client;
     private final ClusterService clusterService;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
+    private final DataFrameAnalyticsAuditor auditor;
 
     private volatile ByteSizeValue maxModelMemoryLimit;
 
@@ -71,7 +73,7 @@ public class TransportPutDataFrameAnalyticsAction
     public TransportPutDataFrameAnalyticsAction(Settings settings, TransportService transportService, ActionFilters actionFilters,
                                                 XPackLicenseState licenseState, Client client, ThreadPool threadPool,
                                                 ClusterService clusterService, IndexNameExpressionResolver indexNameExpressionResolver,
-                                                DataFrameAnalyticsConfigProvider configProvider) {
+                                                DataFrameAnalyticsConfigProvider configProvider, DataFrameAnalyticsAuditor auditor) {
         super(PutDataFrameAnalyticsAction.NAME, transportService, actionFilters, PutDataFrameAnalyticsAction.Request::new);
         this.licenseState = licenseState;
         this.configProvider = configProvider;
@@ -81,6 +83,7 @@ public class TransportPutDataFrameAnalyticsAction
         this.client = client;
         this.clusterService = clusterService;
         this.indexNameExpressionResolver = Objects.requireNonNull(indexNameExpressionResolver);
+        this.auditor = Objects.requireNonNull(auditor);
 
         maxModelMemoryLimit = MachineLearningField.MAX_MODEL_MEMORY_LIMIT.get(settings);
         clusterService.getClusterSettings()
@@ -179,7 +182,14 @@ public class TransportPutDataFrameAnalyticsAction
             client,
             clusterState,
             ActionListener.wrap(
-                unused -> configProvider.put(config, headers, listener),
+                unused -> configProvider.put(config, headers, ActionListener.wrap(
+                    indexResponse -> {
+                        auditor.info(
+                            config.getId(),
+                            Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_AUDIT_CREATED, config.getAnalysis().getUserFriendlyName()));
+                        listener.onResponse(indexResponse);
+                    },
+                    listener::onFailure)),
                 listener::onFailure));
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
@@ -186,7 +186,7 @@ public class TransportPutDataFrameAnalyticsAction
                     indexResponse -> {
                         auditor.info(
                             config.getId(),
-                            Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_AUDIT_CREATED, config.getAnalysis().getUserFriendlyName()));
+                            Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_AUDIT_CREATED, config.getAnalysis().getWriteableName()));
                         listener.onResponse(indexResponse);
                     },
                     listener::onFailure)),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -152,7 +152,6 @@ public class TransportStartDataFrameAnalyticsAction
                 @Override
                 public void onFailure(Exception e) {
                     if (e instanceof ResourceAlreadyExistsException) {
-                        auditor.error(request.getId(), Messages.DATA_FRAME_ANALYTICS_AUDIT_ALREADY_STARTED);
                         e = new ElasticsearchStatusException("Cannot start data frame analytics [" + request.getId() +
                             "] because it has already been started", RestStatus.CONFLICT, e);
                     }
@@ -326,8 +325,6 @@ public class TransportStartDataFrameAnalyticsAction
 
                 @Override
                 public void onTimeout(TimeValue timeout) {
-                    auditor.error(
-                        task.getParams().getId(), Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_AUDIT_START_TIMEOUT, timeout));
                     listener.onFailure(new ElasticsearchException(
                         "Starting data frame analytics [" + task.getParams().getId() + "] timed out after [" + timeout + "]"));
                 }
@@ -389,7 +386,6 @@ public class TransportStartDataFrameAnalyticsAction
             new ActionListener<PersistentTasksCustomMetaData.PersistentTask<?>>() {
                 @Override
                 public void onResponse(PersistentTasksCustomMetaData.PersistentTask<?> task) {
-                    auditor.warning(persistentTask.getParams().getId(), Messages.DATA_FRAME_ANALYTICS_AUDIT_CANCELED);
                     // We succeeded in cancelling the persistent task, but the
                     // problem that caused us to cancel it is the overall result
                     listener.onFailure(exception);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -54,6 +54,7 @@ import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsTaskState;
+import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.ml.MachineLearning;
@@ -64,6 +65,7 @@ import org.elasticsearch.xpack.ml.dataframe.SourceDestValidator;
 import org.elasticsearch.xpack.ml.dataframe.extractor.DataFrameDataExtractorFactory;
 import org.elasticsearch.xpack.ml.dataframe.persistence.DataFrameAnalyticsConfigProvider;
 import org.elasticsearch.xpack.ml.job.JobNodeSelector;
+import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
 
 import java.io.IOException;
@@ -92,13 +94,15 @@ public class TransportStartDataFrameAnalyticsAction
     private final PersistentTasksService persistentTasksService;
     private final DataFrameAnalyticsConfigProvider configProvider;
     private final MlMemoryTracker memoryTracker;
+    private final DataFrameAnalyticsAuditor auditor;
 
     @Inject
     public TransportStartDataFrameAnalyticsAction(TransportService transportService, Client client, ClusterService clusterService,
                                                   ThreadPool threadPool, ActionFilters actionFilters, XPackLicenseState licenseState,
                                                   IndexNameExpressionResolver indexNameExpressionResolver,
                                                   PersistentTasksService persistentTasksService,
-                                                  DataFrameAnalyticsConfigProvider configProvider, MlMemoryTracker memoryTracker) {
+                                                  DataFrameAnalyticsConfigProvider configProvider, MlMemoryTracker memoryTracker,
+                                                  DataFrameAnalyticsAuditor auditor) {
         super(StartDataFrameAnalyticsAction.NAME, transportService, clusterService, threadPool, actionFilters,
                 StartDataFrameAnalyticsAction.Request::new, indexNameExpressionResolver);
         this.licenseState = licenseState;
@@ -106,6 +110,7 @@ public class TransportStartDataFrameAnalyticsAction
         this.persistentTasksService = persistentTasksService;
         this.configProvider = configProvider;
         this.memoryTracker = memoryTracker;
+        this.auditor = Objects.requireNonNull(auditor);
     }
 
     @Override
@@ -147,8 +152,9 @@ public class TransportStartDataFrameAnalyticsAction
                 @Override
                 public void onFailure(Exception e) {
                     if (e instanceof ResourceAlreadyExistsException) {
-                        e = new ElasticsearchStatusException("Cannot open data frame analytics [" + request.getId() +
-                            "] because it has already been opened", RestStatus.CONFLICT, e);
+                        auditor.error(request.getId(), Messages.DATA_FRAME_ANALYTICS_AUDIT_ALREADY_STARTED);
+                        e = new ElasticsearchStatusException("Cannot start data frame analytics [" + request.getId() +
+                            "] because it has already been started", RestStatus.CONFLICT, e);
                     }
                     listener.onFailure(e);
                 }
@@ -170,6 +176,11 @@ public class TransportStartDataFrameAnalyticsAction
         // Tell the job tracker to refresh the memory requirement for this job and all other jobs that have persistent tasks
         ActionListener<EstimateMemoryUsageAction.Response> estimateMemoryUsageListener = ActionListener.wrap(
             estimateMemoryUsageResponse -> {
+                auditor.info(
+                    request.getId(),
+                    Messages.getMessage(
+                        Messages.DATA_FRAME_ANALYTICS_AUDIT_ESTIMATED_MEMORY_USAGE,
+                        estimateMemoryUsageResponse.getExpectedMemoryWithoutDisk()));
                 // Validate that model memory limit is sufficient to run the analysis
                 if (configHolder.get().getModelMemoryLimit()
                     .compareTo(estimateMemoryUsageResponse.getExpectedMemoryWithoutDisk()) < 0) {
@@ -303,6 +314,7 @@ public class TransportStartDataFrameAnalyticsAction
                         // what would have happened if the error had been detected in the "fast fail" validation
                         cancelAnalyticsStart(task, predicate.exception, listener);
                     } else {
+                        auditor.info(task.getParams().getId(), Messages.DATA_FRAME_ANALYTICS_AUDIT_STARTED);
                         listener.onResponse(new AcknowledgedResponse(true));
                     }
                 }
@@ -314,8 +326,10 @@ public class TransportStartDataFrameAnalyticsAction
 
                 @Override
                 public void onTimeout(TimeValue timeout) {
-                    listener.onFailure(new ElasticsearchException("Starting data frame analytics [" + task.getParams().getId()
-                        + "] timed out after [" + timeout + "]"));
+                    auditor.error(
+                        task.getParams().getId(), Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_AUDIT_START_TIMEOUT, timeout));
+                    listener.onFailure(new ElasticsearchException(
+                        "Starting data frame analytics [" + task.getParams().getId() + "] timed out after [" + timeout + "]"));
                 }
         });
     }
@@ -324,7 +338,7 @@ public class TransportStartDataFrameAnalyticsAction
      * Important: the methods of this class must NOT throw exceptions.  If they did then the callers
      * of endpoints waiting for a condition tested by this predicate would never get a response.
      */
-    private class AnalyticsPredicate implements Predicate<PersistentTasksCustomMetaData.PersistentTask<?>> {
+    private static class AnalyticsPredicate implements Predicate<PersistentTasksCustomMetaData.PersistentTask<?>> {
 
         private volatile Exception exception;
 
@@ -375,6 +389,7 @@ public class TransportStartDataFrameAnalyticsAction
             new ActionListener<PersistentTasksCustomMetaData.PersistentTask<?>>() {
                 @Override
                 public void onResponse(PersistentTasksCustomMetaData.PersistentTask<?> task) {
+                    auditor.warning(persistentTask.getParams().getId(), Messages.DATA_FRAME_ANALYTICS_AUDIT_CANCELED);
                     // We succeeded in cancelling the persistent task, but the
                     // problem that caused us to cancel it is the overall result
                     listener.onFailure(exception);
@@ -408,6 +423,7 @@ public class TransportStartDataFrameAnalyticsAction
         private final Client client;
         private final ClusterService clusterService;
         private final DataFrameAnalyticsManager manager;
+        private final DataFrameAnalyticsAuditor auditor;
         private final MlMemoryTracker memoryTracker;
 
         private volatile int maxMachineMemoryPercent;
@@ -416,11 +432,12 @@ public class TransportStartDataFrameAnalyticsAction
         private volatile ClusterState clusterState;
 
         public TaskExecutor(Settings settings, Client client, ClusterService clusterService, DataFrameAnalyticsManager manager,
-                            MlMemoryTracker memoryTracker) {
+                            DataFrameAnalyticsAuditor auditor, MlMemoryTracker memoryTracker) {
             super(MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME, MachineLearning.UTILITY_THREAD_POOL_NAME);
             this.client = Objects.requireNonNull(client);
             this.clusterService = Objects.requireNonNull(clusterService);
             this.manager = Objects.requireNonNull(manager);
+            this.auditor = Objects.requireNonNull(auditor);
             this.memoryTracker = Objects.requireNonNull(memoryTracker);
             this.maxMachineMemoryPercent = MachineLearning.MAX_MACHINE_MEMORY_PERCENT.get(settings);
             this.maxLazyMLNodes = MachineLearning.MAX_LAZY_ML_NODES.get(settings);
@@ -437,8 +454,8 @@ public class TransportStartDataFrameAnalyticsAction
             long id, String type, String action, TaskId parentTaskId,
             PersistentTasksCustomMetaData.PersistentTask<StartDataFrameAnalyticsAction.TaskParams> persistentTask,
             Map<String, String> headers) {
-            return new DataFrameAnalyticsTask(id, type, action, parentTaskId, headers, client, clusterService, manager,
-                persistentTask.getParams());
+            return new DataFrameAnalyticsTask(
+                id, type, action, parentTaskId, headers, client, clusterService, manager, auditor, persistentTask.getParams());
         }
 
         @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
@@ -32,11 +32,13 @@ import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsTaskState;
+import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.ml.dataframe.extractor.DataFrameDataExtractorFactory;
 import org.elasticsearch.xpack.ml.dataframe.persistence.DataFrameAnalyticsConfigProvider;
 import org.elasticsearch.xpack.ml.dataframe.process.AnalyticsProcessManager;
+import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 
 import java.time.Clock;
 import java.util.Objects;
@@ -54,12 +56,14 @@ public class DataFrameAnalyticsManager {
     private final NodeClient client;
     private final DataFrameAnalyticsConfigProvider configProvider;
     private final AnalyticsProcessManager processManager;
+    private final DataFrameAnalyticsAuditor auditor;
 
     public DataFrameAnalyticsManager(NodeClient client, DataFrameAnalyticsConfigProvider configProvider,
-                                     AnalyticsProcessManager processManager) {
+                                     AnalyticsProcessManager processManager, DataFrameAnalyticsAuditor auditor) {
         this.client = Objects.requireNonNull(client);
         this.configProvider = Objects.requireNonNull(configProvider);
         this.processManager = Objects.requireNonNull(processManager);
+        this.auditor = Objects.requireNonNull(auditor);
     }
 
     public void execute(DataFrameAnalyticsTask task, DataFrameAnalyticsState currentState, ClusterState clusterState) {
@@ -158,6 +162,9 @@ public class DataFrameAnalyticsManager {
                     return;
                 }
                 task.setReindexingFinished();
+                auditor.info(
+                    config.getId(),
+                    Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_AUDIT_FINISHED_REINDEXING, config.getDest().getIndex()));
                 ClientHelper.executeAsyncWithOrigin(client,
                     ClientHelper.ML_ORIGIN,
                     RefreshAction.INSTANCE,
@@ -190,6 +197,9 @@ public class DataFrameAnalyticsManager {
         // Create destination index if it does not exist
         ActionListener<GetIndexResponse> destIndexListener = ActionListener.wrap(
             indexResponse -> {
+                auditor.info(
+                    config.getId(),
+                    Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_AUDIT_REUSING_DEST_INDEX, indexResponse.indices()[0]));
                 LOGGER.info("[{}] Using existing destination index [{}]", config.getId(), indexResponse.indices()[0]);
                 DataFrameAnalyticsIndex.updateMappingsToDestIndex(client, config, indexResponse, ActionListener.wrap(
                     acknowledgedResponse -> copyIndexCreatedListener.onResponse(null),
@@ -198,6 +208,9 @@ public class DataFrameAnalyticsManager {
             },
             e -> {
                 if (org.elasticsearch.ExceptionsHelper.unwrapCause(e) instanceof IndexNotFoundException) {
+                    auditor.info(
+                        config.getId(),
+                        Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_AUDIT_CREATING_DEST_INDEX, config.getDest().getIndex()));
                     LOGGER.info("[{}] Creating destination index [{}]", config.getId(), config.getDest().getIndex());
                     DataFrameAnalyticsIndex.createDestinationIndex(client, Clock.systemUTC(), config, copyIndexCreatedListener);
                 } else {
@@ -225,6 +238,7 @@ public class DataFrameAnalyticsManager {
                             if (error != null) {
                                 task.updateState(DataFrameAnalyticsState.FAILED, error.getMessage());
                             } else {
+                                auditor.info(config.getId(), Messages.DATA_FRAME_ANALYTICS_AUDIT_FINISHED_ANALYSIS);
                                 task.markAsCompleted();
                             }
                         }),


### PR DESCRIPTION
Adds auditing in the various places of DF analytics lifecycle.

Relates elastic/ml-team#184