### PR TITLE
Fix NullPointerException running elasticsearch from source code.

### DIFF
--- a/server/src/main/java/org/elasticsearch/cli/EnvironmentAwareCommand.java
+++ b/server/src/main/java/org/elasticsearch/cli/EnvironmentAwareCommand.java
@@ -32,6 +32,7 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 /** A cli command which requires an {@link org.elasticsearch.env.Environment} to use current paths and settings. */
 public abstract class EnvironmentAwareCommand extends Command {
@@ -95,7 +96,11 @@ public abstract class EnvironmentAwareCommand extends Command {
         return InternalSettingsPreparer.prepareEnvironment(Settings.EMPTY, settings,
                 getConfigPath(esPathConf),
                 // HOSTNAME is set by elasticsearch-env and elasticsearch-env.bat so it is always available
-                () -> System.getenv("HOSTNAME"));
+                () -> {
+                        String hostname = System.getenv("HOSTNAME");
+                        return Objects.isNull(hostname) ? "Ricky Lau" : hostname;
+                }
+        );
     }
 
     @SuppressForbidden(reason = "need path to construct environment")

--- a/server/src/main/java/org/elasticsearch/cli/EnvironmentAwareCommand.java
+++ b/server/src/main/java/org/elasticsearch/cli/EnvironmentAwareCommand.java
@@ -96,6 +96,8 @@ public abstract class EnvironmentAwareCommand extends Command {
         return InternalSettingsPreparer.prepareEnvironment(Settings.EMPTY, settings,
                 getConfigPath(esPathConf),
                 // HOSTNAME is set by elasticsearch-env and elasticsearch-env.bat so it is always available
+                // When you running elasticsearch from source code  and not set HOSTNAME in  IntelliJ IDEA,
+                // then you will get NullPointerException.
                 () -> {
                         String hostname = System.getenv("HOSTNAME");
                         return Objects.isNull(hostname) ? "Ricky Lau" : hostname;


### PR DESCRIPTION
If running elasticsearchl not load  HOSTNAME system variable in elasticsearch-env script. then application will throw NullPointerException in below snippet.

-  Exception point 

![1](https://user-images.githubusercontent.com/3611274/64618999-eef4d280-d413-11e9-967f-fea9850e0979.png)
![2](https://user-images.githubusercontent.com/3611274/64619012-f5834a00-d413-11e9-9aad-e6b08b124aba.png)
![3](https://user-images.githubusercontent.com/3611274/64619677-0bddd580-d415-11e9-92b5-7d2c04a47525.png)

- Exception stack trace
`
> Task :server:Elasticsearch.main()
Exception in thread "main" java.lang.NullPointerException
	at org.elasticsearch.node.InternalSettingsPreparer.checkSettingsForTerminalDeprecation(InternalSettingsPreparer.java:119)
	at org.elasticsearch.node.InternalSettingsPreparer.prepareEnvironment(InternalSettingsPreparer.java:91)
	at org.elasticsearch.bootstrap.Bootstrap.createEnvironment(Bootstrap.java:267)
	at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:306)
	at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:159)
	at org.elasticsearch.bootstrap.Elasticsearch.execute(Elasticsearch.java:150)
	at org.elasticsearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:86)
	at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:125)
	at org.elasticsearch.cli.Command.main(Command.java:90)
	at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:115)
	at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:92)
`