### PR TITLE
Re-enable BWC tests after SLM retention backport

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,8 +176,8 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
-final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/46509" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = true
+final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")


### PR DESCRIPTION
Now that #46506 and #46509 have been merged, BWC tests can be re-enabled.
