### PR TITLE
[6.8] Fix class used to initialize logger in Watcher (#46467)

### DIFF
--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/execution/AsyncTriggerEventConsumer.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/execution/AsyncTriggerEventConsumer.java
@@ -5,8 +5,8 @@
  */
 package org.elasticsearch.xpack.watcher.execution;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.util.Supplier;
 import org.elasticsearch.xpack.core.watcher.trigger.TriggerEvent;
@@ -16,7 +16,7 @@ import java.util.function.Consumer;
 import static java.util.stream.StreamSupport.stream;
 
 public class AsyncTriggerEventConsumer implements Consumer<Iterable<TriggerEvent>> {
-    private static final Logger logger = LogManager.getLogger(SyncTriggerEventConsumer.class);
+    private static final Logger logger = LogManager.getLogger(AsyncTriggerEventConsumer.class);
     private final ExecutionService executionService;
 
     public AsyncTriggerEventConsumer(ExecutionService executionService) {


### PR DESCRIPTION
Backports the following commits to 6.8:
 - Fix class used to initialize logger in Watcher  (#46467)