### PR TITLE
Split `_source` into a schema and a data field.

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentGenerator.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentGenerator.java
@@ -151,6 +151,14 @@ public interface XContentGenerator extends Closeable, Flushable {
                     case DOUBLE:
                         writeNumber(parser.doubleValue());
                         break;
+                    case BIG_INTEGER:
+                        writeNumber((BigInteger) parser.numberValue());
+                        break;
+                    case BIG_DECIMAL:
+                        writeNumber((BigDecimal) parser.numberValue());
+                        break;
+                    default:
+                        throw new UnsupportedOperationException();
                 }
                 break;
             case VALUE_BOOLEAN:

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
@@ -122,6 +122,9 @@ public interface XContentParser extends Closeable {
 
     XContentType contentType();
 
+    /**
+     * Return the next {@link Token} or {@code null} if the content is exhausted.
+     */
     Token nextToken() throws IOException;
 
     void skipChildren() throws IOException;

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
@@ -397,4 +397,36 @@ public abstract class AbstractXContentParser implements XContentParser {
     public DeprecationHandler getDeprecationHandler() {
         return deprecationHandler;
     }
+
+    @Override
+    public Object objectText() throws IOException {
+        Token currentToken = currentToken();
+        if (currentToken == Token.VALUE_STRING) {
+            return text();
+        } else if (currentToken == Token.VALUE_NUMBER) {
+            return numberValue();
+        } else if (currentToken == Token.VALUE_BOOLEAN) {
+            return booleanValue();
+        } else if (currentToken == Token.VALUE_NULL) {
+            return null;
+        } else {
+            return text();
+        }
+    }
+
+    @Override
+    public Object objectBytes() throws IOException {
+        Token currentToken = currentToken();
+        if (currentToken == Token.VALUE_STRING) {
+            return text();
+        } else if (currentToken == Token.VALUE_NUMBER) {
+            return numberValue();
+        } else if (currentToken == Token.VALUE_BOOLEAN) {
+            return booleanValue();
+        } else if (currentToken == Token.VALUE_NULL) {
+            return null;
+        } else {
+            return charBuffer();
+        }
+    }
 }

--- a/server/src/main/java/org/elasticsearch/common/xcontent/support/SplitXContentSchemaData.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/support/SplitXContentSchemaData.java
@@ -270,8 +270,8 @@ public final class SplitXContentSchemaData {
                     }
                 } else {
                     double asDouble = asBigDecimal.doubleValue();
-                    // TODO: Is there a better way?
-                    if (asBigDecimal.toString().equals(Double.toString(asDouble))) {
+                    // TODO: make it faster
+                    if (asBigDecimal.equals(new BigDecimal(Double.toString(asDouble)))) {
                         return asDouble;
                     } else {
                         return asBigDecimal;

--- a/server/src/main/java/org/elasticsearch/common/xcontent/support/SplitXContentSchemaData.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/support/SplitXContentSchemaData.java
@@ -1,0 +1,358 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.xcontent.support;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentLocation;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentParser.Token;
+import org.elasticsearch.common.xcontent.XContentType;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.CharBuffer;
+
+/**
+ * Utility class to split and merge the schema and data of a JSON document.
+ * This is typically useful to improve compression, especially in the case that
+ * multiple documents share similar schemas.
+ */
+public final class SplitXContentSchemaData {
+
+    private static final int MAX_LONG_CHAR_COUNT = Long.toString(Long.MAX_VALUE).length();
+    private static final BigInteger MAX_LONG_AS_BIG_INTEGER = BigInteger.valueOf(Long.MAX_VALUE);
+    private static final BigInteger MIN_LONG_AS_BIG_INTEGER = BigInteger.valueOf(Long.MIN_VALUE);
+
+    private SplitXContentSchemaData() {}
+
+    /**
+     * Split the schema and the data of the current object that the parser is
+     * positioned on into two separate streams.
+     * @param parser parser of the object to split, must be positioned on a START_OBJECT
+     * @param schema where to write the schema of the object, including field names
+     * @param data   where to write the data of the object
+     */
+    public static void splitXContent(XContentParser parser, StreamOutput schema, StreamOutput data) throws IOException {
+        if (parser.currentToken() != Token.START_OBJECT) {
+            throw new IllegalArgumentException("The provided parser must be positioned on a START_OBJECT, but got " + parser.currentToken());
+        }
+
+        schema.write('{');
+        int level = 1;
+        for (Token token = parser.nextToken(); level > 0; token = parser.nextToken()) {
+            switch (token) {
+            case START_OBJECT:
+                schema.write('{');
+                level++;
+                break;
+            case END_OBJECT:
+                schema.write('}');
+                level--;
+                break;
+            case START_ARRAY:
+                schema.write('[');
+                break;
+            case END_ARRAY:
+                schema.write(']');
+                break;
+            case FIELD_NAME:
+                schema.write('F');
+                schema.writeString(parser.currentName());
+                break;
+            case VALUE_STRING:
+                schema.write('S');
+                data.writeString(parser.text());
+                break;
+            case VALUE_NUMBER:
+                schema.write('N');
+                data.writeString(parser.text());
+                break;
+            case VALUE_BOOLEAN:
+                schema.write('B');
+                data.writeString(parser.text());
+                break;
+            case VALUE_NULL:
+                schema.write('\0');
+                break;
+            case VALUE_EMBEDDED_OBJECT:
+                schema.write('E');
+                data.writeByteArray(parser.binaryValue());
+                break;
+            default:
+                throw new UnsupportedOperationException();
+            }
+        }
+    }
+
+    /**
+     * Merge back the schema and data of an XContent object. Note that calling
+     * {@link Closeable#close} in the parser doesn't close the input streams.
+     *
+     * @param schema input stream containing the schema of the object
+     * @param data   input stream containing the data of the object
+     * @return a parser for the object
+     */
+    public static XContentParser mergeXContent(StreamInput schema, StreamInput data) {
+        return new AbstractXContentParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION) {
+
+            private Token token;
+            private String fieldName;
+            private String stringValue;
+            private byte[] binaryValue;
+            private boolean closed;
+
+            @Override
+            public XContentType contentType() {
+                return XContentType.JSON;
+            }
+
+            @Override
+            public Token nextToken() throws IOException {
+                token = readToken();
+                if (token != null) {
+                    switch (token) {
+                    case FIELD_NAME:
+                        fieldName = schema.readString();
+                        stringValue = null;
+                        binaryValue = null;
+                        break;
+                    case VALUE_STRING:
+                    case VALUE_NUMBER:
+                    case VALUE_BOOLEAN:
+                        stringValue = data.readString();
+                        binaryValue = null;
+                        break;
+                    case VALUE_EMBEDDED_OBJECT:
+                        stringValue = null;
+                        binaryValue = data.readByteArray();
+                        break;
+                    default:
+                        stringValue = null;
+                        binaryValue = null;
+                        break;
+                    }
+                }
+                return token;
+            }
+
+            private Token readToken() throws IOException {
+                final int b = schema.read();
+                switch (b) {
+                case -1:
+                    return null;
+                case '{':
+                    return Token.START_OBJECT;
+                case '}':
+                    return Token.END_OBJECT;
+                case '[':
+                    return Token.START_ARRAY;
+                case ']':
+                    return Token.END_ARRAY;
+                case 'F':
+                    return Token.FIELD_NAME;
+                case 'S':
+                    return Token.VALUE_STRING;
+                case '\0':
+                    return Token.VALUE_NULL;
+                case 'N':
+                    return Token.VALUE_NUMBER;
+                case 'B':
+                    return Token.VALUE_BOOLEAN;
+                case 'E':
+                    return Token.VALUE_EMBEDDED_OBJECT;
+                default:
+                    throw new IOException("Data is corrupt, unexpected token: " + b);
+                }
+            }
+
+            @Override
+            public void skipChildren() throws IOException {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Token currentToken() {
+                return token;
+            }
+
+            @Override
+            public String currentName() throws IOException {
+                return fieldName;
+            }
+
+            @Override
+            public String text() throws IOException {
+                if (binaryValue != null || stringValue == null) {
+                    throw new IllegalStateException();
+                }
+                return stringValue;
+            }
+
+            @Override
+            public CharBuffer charBuffer() throws IOException {
+                if (binaryValue != null || stringValue == null) {
+                    throw new IllegalStateException();
+                }
+                return CharBuffer.wrap(stringValue);
+            }
+
+            @Override
+            public boolean hasTextCharacters() {
+                return false;
+            }
+
+            @Override
+            public char[] textCharacters() throws IOException {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public int textLength() throws IOException {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public int textOffset() throws IOException {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Number numberValue() throws IOException {
+                if (binaryValue != null || stringValue == null) {
+                    throw new IllegalStateException();
+                }
+
+                // Fast path for integers
+                if (stringValue.length() < MAX_LONG_CHAR_COUNT) {
+                    boolean integer = true;
+                    for (int i = 0; i < stringValue.length(); ++i) {
+                        char c = stringValue.charAt(i);
+                        if ((c < '0' || c > '9') && (i > 0 || c != '-')) {
+                            integer = false;
+                            break;
+                        }
+                    }
+
+                    if (integer) {
+                        return Long.parseLong(stringValue);
+                    }
+                }
+
+                BigDecimal asBigDecimal = new BigDecimal(stringValue);
+                if (asBigDecimal.stripTrailingZeros().scale() <= 0) { // whole number
+                    BigInteger asBigInteger = asBigDecimal.toBigIntegerExact();
+                    if (asBigInteger.compareTo(MIN_LONG_AS_BIG_INTEGER) >= 0 && asBigInteger.compareTo(MAX_LONG_AS_BIG_INTEGER) <= 0) {
+                        return asBigInteger.longValue();
+                    } else {
+                        return asBigInteger;
+                    }
+                } else {
+                    double asDouble = asBigDecimal.doubleValue();
+                    // TODO: Is there a better way?
+                    if (asBigDecimal.toString().equals(Double.toString(asDouble))) {
+                        return asDouble;
+                    } else {
+                        return asBigDecimal;
+                    }
+                }
+            }
+
+            @Override
+            public NumberType numberType() throws IOException {
+                Number number = numberValue();
+                if (number instanceof Long) {
+                    return NumberType.LONG;
+                } else if (number instanceof Double) {
+                    return NumberType.DOUBLE;
+                } else if (number instanceof BigInteger) {
+                    return NumberType.BIG_INTEGER;
+                } else if (number instanceof BigDecimal) {
+                    return NumberType.BIG_DECIMAL;
+                } else {
+                    throw new IllegalStateException();
+                }
+            }
+
+            @Override
+            public byte[] binaryValue() throws IOException {
+                if (binaryValue == null || stringValue != null) {
+                    throw new IllegalStateException();
+                }
+                return binaryValue;
+            }
+
+            @Override
+            public XContentLocation getTokenLocation() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            protected boolean doBooleanValue() throws IOException {
+                if (binaryValue != null || stringValue == null) {
+                    throw new IllegalStateException();
+                }
+                return Boolean.valueOf(stringValue);
+            }
+
+            @Override
+            protected short doShortValue() throws IOException {
+                return (short) doLongValue();
+            }
+
+            @Override
+            protected int doIntValue() throws IOException {
+                return (int) doLongValue();
+            }
+
+            @Override
+            protected long doLongValue() throws IOException {
+                return numberValue().longValue();
+            }
+
+            @Override
+            protected float doFloatValue() throws IOException {
+                return (float) doDoubleValue();
+            }
+
+            @Override
+            protected double doDoubleValue() throws IOException {
+                return numberValue().doubleValue();
+            }
+
+            @Override
+            public void close() throws IOException {
+                // no-op
+                closed = true;
+            }
+
+            @Override
+            public boolean isClosed() {
+                return closed;
+            }
+
+        };
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
@@ -38,7 +38,6 @@ import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
-import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.translog.Translog;
 
@@ -231,9 +230,10 @@ final class LuceneChangesSnapshot implements Translog.Snapshot {
             return null;
         }
         final long version = parallelArray.version[docIndex];
-        final String sourceField = parallelArray.hasRecoverySource[docIndex] ? SourceFieldMapper.RECOVERY_SOURCE_NAME :
-            SourceFieldMapper.NAME;
-        final FieldsVisitor fields = new FieldsVisitor(true, sourceField);
+        final FieldsVisitor.LoadSource loadSource = parallelArray.hasRecoverySource[docIndex]
+                ? FieldsVisitor.LoadSource.RECOVERY_SOURCE
+                : FieldsVisitor.LoadSource.YES;
+        final FieldsVisitor fields = new FieldsVisitor(loadSource);
         leaf.reader().document(segmentDocID, fields);
         fields.postProcess(mapperService);
 

--- a/server/src/main/java/org/elasticsearch/index/fieldvisitor/CustomFieldsVisitor.java
+++ b/server/src/main/java/org/elasticsearch/index/fieldvisitor/CustomFieldsVisitor.java
@@ -33,7 +33,7 @@ public class CustomFieldsVisitor extends FieldsVisitor {
 
     private final Set<String> fields;
 
-    public CustomFieldsVisitor(Set<String> fields, boolean loadSource) {
+    public CustomFieldsVisitor(Set<String> fields, LoadSource loadSource) {
         super(loadSource);
         this.fields = fields;
     }

--- a/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -39,6 +39,7 @@ import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.fieldvisitor.CustomFieldsVisitor;
 import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
+import org.elasticsearch.index.fieldvisitor.FieldsVisitor.LoadSource;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.Mapper;
@@ -251,9 +252,9 @@ public final class ShardGetService extends AbstractIndexShardComponent {
 
     private static FieldsVisitor buildFieldsVisitors(String[] fields, FetchSourceContext fetchSourceContext) {
         if (fields == null || fields.length == 0) {
-            return fetchSourceContext.fetchSource() ? new FieldsVisitor(true) : null;
+            return fetchSourceContext.fetchSource() ? new FieldsVisitor(LoadSource.YES) : null;
         }
 
-        return new CustomFieldsVisitor(Sets.newHashSet(fields), fetchSourceContext.fetchSource());
+        return new CustomFieldsVisitor(Sets.newHashSet(fields), fetchSourceContext.fetchSource() ? LoadSource.YES : LoadSource.NO);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightUtils.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightUtils.java
@@ -22,6 +22,7 @@ import org.apache.lucene.search.highlight.DefaultEncoder;
 import org.apache.lucene.search.highlight.Encoder;
 import org.apache.lucene.search.highlight.SimpleHTMLEncoder;
 import org.elasticsearch.index.fieldvisitor.CustomFieldsVisitor;
+import org.elasticsearch.index.fieldvisitor.FieldsVisitor.LoadSource;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.internal.SearchContext;
@@ -54,7 +55,7 @@ public final class HighlightUtils {
         boolean forceSource = searchContext.highlight().forceSource(field);
         List<Object> textsToHighlight;
         if (!forceSource && fieldType.stored()) {
-            CustomFieldsVisitor fieldVisitor = new CustomFieldsVisitor(singleton(fieldType.name()), false);
+            CustomFieldsVisitor fieldVisitor = new CustomFieldsVisitor(singleton(fieldType.name()), LoadSource.NO);
             hitContext.reader().document(hitContext.docId(), fieldVisitor);
             textsToHighlight = fieldVisitor.fields().get(fieldType.name());
             if (textsToHighlight == null) {

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
+import org.elasticsearch.index.fieldvisitor.FieldsVisitor.LoadSource;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 
 import java.util.Collection;
@@ -65,7 +66,7 @@ public class SourceLookup implements Map {
             return source;
         }
         try {
-            FieldsVisitor sourceFieldVisitor = new FieldsVisitor(true);
+            FieldsVisitor sourceFieldVisitor = new FieldsVisitor(LoadSource.YES);
             reader.document(docId, sourceFieldVisitor);
             BytesReference source = sourceFieldVisitor.source();
             if (source == null) {

--- a/server/src/test/java/org/elasticsearch/common/xcontent/support/SplitXContentSchemaDataTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/support/SplitXContentSchemaDataTests.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.xcontent.support;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentGenerator;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentParser.Token;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+public class SplitXContentSchemaDataTests extends ESTestCase {
+
+    public void testEmptyObject() throws IOException {
+        doRoundtrip("{}");
+    }
+
+    public void testString() throws IOException {
+        doRoundtrip("{\"foo\":\"bar\"}");
+    }
+
+    public void testLong() throws IOException {
+        doRoundtrip("{\"foo\":42}");
+    }
+
+    public void testDouble() throws IOException {
+        doRoundtrip("{\"foo\":4.2}");
+    }
+
+    public void testNegativeLong() throws IOException {
+        doRoundtrip("{\"foo\":-42}");
+    }
+
+    public void testNegativeDouble() throws IOException {
+        doRoundtrip("{\"foo\":-4.2}");
+    }
+
+    public void testNull() throws IOException {
+        doRoundtrip("{\"foo\":null}");
+    }
+
+    public void testInnerObject() throws IOException {
+        doRoundtrip("{\"foo\":{\"bar\":\"baz\"}}");
+    }
+
+    public void testArray() throws IOException {
+        doRoundtrip("{\"foo\":[\"bar\",42]}");
+    }
+
+    public void testInnerArray() throws IOException {
+        doRoundtrip("{\"foo\":[[\"bar\"],[42]]}");
+    }
+
+    public void testBigInteger() throws IOException {
+        doRoundtrip("{\"foo\":99999999999999999999999999999}");
+    }
+
+    public void testBigDecimal() throws IOException {
+        doRoundtrip("{\"foo\":4.0000000000000000000000000002}");
+    }
+
+    private void doRoundtrip(String json) throws IOException {
+        XContentParser parser = XContentType.JSON.xContent().createParser(
+                NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, new StringReader(json));
+        assertEquals(Token.START_OBJECT, parser.nextToken());
+        BytesStreamOutput schema = new BytesStreamOutput();
+        BytesStreamOutput data = new BytesStreamOutput();
+        SplitXContentSchemaData.splitXContent(parser, schema, data);
+        XContentParser mergedParser = SplitXContentSchemaData.mergeXContent(schema.bytes().streamInput(), data.bytes().streamInput());
+        BytesStreamOutput merged = new BytesStreamOutput();
+        assertEquals(Token.START_OBJECT, mergedParser.nextToken());
+        try (XContentGenerator generator = XContentType.JSON.xContent().createGenerator(merged)) {
+            generator.copyCurrentStructure(mergedParser);
+        }
+        String reconstructed = merged.bytes().utf8ToString();
+        assertEquals(json, reconstructed);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -109,6 +109,7 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.codec.CodecService;
 import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
+import org.elasticsearch.index.fieldvisitor.FieldsVisitor.LoadSource;
 import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.Mapper.BuilderContext;
@@ -2235,7 +2236,7 @@ public class InternalEngineTests extends EngineTestCase {
                 for (int op = 0; op < opsPerThread; op++) {
                     try (Engine.GetResult get = engine.get(new Engine.Get(true, false,
                         doc.type(), doc.id(), uidTerm), searcherFactory)) {
-                        FieldsVisitor visitor = new FieldsVisitor(true);
+                        FieldsVisitor visitor = new FieldsVisitor(LoadSource.YES);
                         get.docIdAndVersion().reader.document(get.docIdAndVersion().docId, visitor);
                         List<String> values = new ArrayList<>(Strings.commaDelimitedListToSet(visitor.source().utf8ToString()));
                         String removed = op % 3 == 0 && values.size() > 0 ? values.remove(0) : null;
@@ -2278,7 +2279,7 @@ public class InternalEngineTests extends EngineTestCase {
 
         try (Engine.GetResult get = engine.get(new Engine.Get(true, false,
                 doc.type(), doc.id(), uidTerm), searcherFactory)) {
-            FieldsVisitor visitor = new FieldsVisitor(true);
+            FieldsVisitor visitor = new FieldsVisitor(LoadSource.YES);
             get.docIdAndVersion().reader.document(get.docIdAndVersion().docId, visitor);
             List<String> values = Arrays.asList(Strings.commaDelimitedListToStringArray(visitor.source().utf8ToString()));
             assertThat(currentValues, equalTo(new HashSet<>(values)));

--- a/server/src/test/java/org/elasticsearch/index/mapper/SourceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/SourceFieldMapperTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.common.xcontent.support.SplitXContentSchemaData;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
@@ -87,9 +88,12 @@ public class SourceFieldMapperTests extends ESSingleNodeTestCase {
             .endObject()),
             XContentType.JSON));
 
-        IndexableField sourceField = doc.rootDoc().getField("_source");
+        IndexableField sourceSchema = doc.rootDoc().getField("_source_schema");
+        IndexableField sourceData = doc.rootDoc().getField("_source_data");
         Map<String, Object> sourceAsMap;
-        try (XContentParser parser = createParser(JsonXContent.jsonXContent, new BytesArray(sourceField.binaryValue()))) {
+        try (XContentParser parser = SplitXContentSchemaData.mergeXContent(
+                new BytesArray(sourceSchema.binaryValue()).streamInput(),
+                new BytesArray(sourceData.binaryValue()).streamInput())) {
             sourceAsMap = parser.map();
         }
         assertThat(sourceAsMap.containsKey("path1"), equalTo(true));
@@ -111,9 +115,12 @@ public class SourceFieldMapperTests extends ESSingleNodeTestCase {
             .endObject()),
             XContentType.JSON));
 
-        IndexableField sourceField = doc.rootDoc().getField("_source");
+        IndexableField sourceSchema = doc.rootDoc().getField("_source_schema");
+        IndexableField sourceData = doc.rootDoc().getField("_source_data");
         Map<String, Object> sourceAsMap;
-        try (XContentParser parser = createParser(JsonXContent.jsonXContent, new BytesArray(sourceField.binaryValue()))) {
+        try (XContentParser parser = SplitXContentSchemaData.mergeXContent(
+                new BytesArray(sourceSchema.binaryValue()).streamInput(),
+                new BytesArray(sourceData.binaryValue()).streamInput())) {
             sourceAsMap = parser.map();
         }
         assertThat(sourceAsMap.containsKey("path1"), equalTo(false));

--- a/server/src/test/java/org/elasticsearch/index/mapper/StoredNumericValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/StoredNumericValuesTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.fieldvisitor.CustomFieldsVisitor;
+import org.elasticsearch.index.fieldvisitor.FieldsVisitor.LoadSource;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
@@ -87,7 +88,7 @@ public class StoredNumericValuesTests extends ESSingleNodeTestCase {
 
         Set<String> fieldNames = Sets.newHashSet("field1", "field2", "field3", "field4", "field5",
             "field6", "field7", "field8", "field9", "field10");
-        CustomFieldsVisitor fieldsVisitor = new CustomFieldsVisitor(fieldNames, false);
+        CustomFieldsVisitor fieldsVisitor = new CustomFieldsVisitor(fieldNames, LoadSource.NO);
         searcher.doc(0, fieldsVisitor);
 
         fieldsVisitor.postProcess(mapperService);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/SourceOnlySnapshotShardTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/SourceOnlySnapshotShardTests.java
@@ -44,6 +44,7 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineException;
 import org.elasticsearch.index.engine.InternalEngineFactory;
 import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
+import org.elasticsearch.index.fieldvisitor.FieldsVisitor.LoadSource;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.SourceToParse;
@@ -293,7 +294,7 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
         try {
             recoverShardFromStore(targetShard);
             String index = targetShard.shardId().getIndexName();
-            FieldsVisitor rootFieldsVisitor = new FieldsVisitor(true);
+            FieldsVisitor rootFieldsVisitor = new FieldsVisitor(LoadSource.YES);
             for (LeafReaderContext ctx : reader.leaves()) {
                 LeafReader leafReader = ctx.reader();
                 Bits liveDocs = leafReader.getLiveDocs();


### PR DESCRIPTION
The fact that `_source` interleaves schema (structure and field names) and data
(field values) tends to hurt compression. If we split both in separate Lucene
stored fields, then the expectation is that in the common case the schema field
would be the same, or almost the same for every document and would compress
very efficiently. For instance, the cost of a back reference with LZ4 is 3 bytes
at a minimum so it is more efficient to have a single reference for a long
string than many back references of short strings.

The change doesn't pass all tests but it should be good enough for
experimentation purposes.

I played with one shard of the geonames dataset to see what the impact of this
change would be on the size of the file that holds Lucene's stored fields (only
`_id` and `_source` in that case).

| index.codec       | master | patch |
| ----------------- | ------ | ----- |
| BEST_SPEED        | 28MB   | 23MB  |
| BEST_COMPRESSION  | 17MB   | 16MB  |

This dataset has text fields that have lots of repetition already, and the
schema is not exactly the same for all documents so it is not a best-case
scenario for this patch. I believe the difference would be higher for
CSV-style data with many numeric fields.

I'm mostly opening this for discussion at this stage. The main downside of
this approach is that it requires more processing of the `_source` at
index-time, which can slow down indexing. One thing worth noting is that
parsing the `_source` is a significant index-time overhead and we
discussed in the past having a more efficient bulk API that would allow users
to pass the schema and data separately so that we could look up field mappers
only once for the entire per-shard bulk request and then field them with data
for all documents. If this feels going too far, another thing worth mentioning
is that the splitting of the `_source` could also be done via an ILM action so
that it wouldn't hurt indexing speed.