### PR TITLE
Repository plugin test cacheability fixes

### DIFF
--- a/modules/repository-url/build.gradle
+++ b/modules/repository-url/build.gradle
@@ -16,6 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+import org.elasticsearch.gradle.PropertyNormalization
 import org.elasticsearch.gradle.test.AntFixture
 
 esplugin {
@@ -42,7 +44,7 @@ integTest {
 }
 testClusters.integTest {
     // repositoryDir is used by a FS repository to create snapshots
-    setting 'path.repo', "${repositoryDir.absolutePath}"
+    setting 'path.repo', "${repositoryDir.absolutePath}", PropertyNormalization.IGNORE_VALUE
     // repositoryDir is used by two URL repositories to restore snapshots
-    setting 'repositories.url.allowed_urls', { "http://snapshot.test*,http://${urlFixture.addressAndPort}" }
+    setting 'repositories.url.allowed_urls', { "http://snapshot.test*,http://${urlFixture.addressAndPort}" }, PropertyNormalization.IGNORE_VALUE
 }

--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -75,6 +75,8 @@ normalization {
     runtimeClasspath {
         // ignore generated keytab files for the purposes of build avoidance
         ignore '*.keytab'
+        // ignore fixture ports file which is on the classpath primarily to pacify the security manager
+        ignore '*HdfsFixture/**'
     }
 }
 
@@ -153,15 +155,14 @@ for (String integTestTaskName : ['integTestHa', 'integTestSecure', 'integTestSec
                   .resolve("secureHaHdfsFixture")
                   .resolve("ports")
           nonInputProperties.systemProperty "test.hdfs-fixture.ports", path
-          classpath += files(path)
         } else {
           Path path = buildDir.toPath()
                   .resolve("fixtures")
                   .resolve("haHdfsFixture")
                   .resolve("ports")
           nonInputProperties.systemProperty "test.hdfs-fixture.ports", path
-          classpath += files(path)
         }
+        classpath += files("$buildDir/fixtures")
       }
 
       if (integTestTaskName.contains("Secure")) {


### PR DESCRIPTION
This PR fixes a couple of issues around cache misses for a few of our integration tests. In the end these come down to issues with us wiring in inputs that are dynamic, such as file paths, port numbers or fixture URLs that change from run to run.