### PR TITLE
Fix false positive out of sync warning in synced-flush

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
+++ b/server/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
@@ -387,7 +387,7 @@ public class SyncedFlushService implements IndexEventListener {
             if (preSyncedResponse.numDocs != numDocsOnPrimary &&
                 preSyncedResponse.numDocs != PreSyncedFlushResponse.UNKNOWN_NUM_DOCS &&
                 numDocsOnPrimary != PreSyncedFlushResponse.UNKNOWN_NUM_DOCS) {
-                logger.trace("{} can't to issue sync id [{}] for replica [{}] with num docs [{}]; num docs on primary [{}]",
+                logger.debug("{} can't issue sync id [{}] for replica [{}] with num docs [{}]; num docs on primary [{}]",
                     shardId, syncId, shard, preSyncedResponse.numDocs, numDocsOnPrimary);
                 results.put(shard, new ShardSyncedFlushResponse("ongoing indexing operations: " +
                     "num docs on replica [" + preSyncedResponse.numDocs + "]; num docs on primary [" + numDocsOnPrimary + "]"));

--- a/server/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
+++ b/server/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
@@ -387,9 +387,9 @@ public class SyncedFlushService implements IndexEventListener {
             if (preSyncedResponse.numDocs != numDocsOnPrimary &&
                 preSyncedResponse.numDocs != PreSyncedFlushResponse.UNKNOWN_NUM_DOCS &&
                 numDocsOnPrimary != PreSyncedFlushResponse.UNKNOWN_NUM_DOCS) {
-                logger.warn("{} can't to issue sync id [{}] for out of sync replica [{}] with num docs [{}]; num docs on primary [{}]",
+                logger.trace("{} can't to issue sync id [{}] for replica [{}] with num docs [{}]; num docs on primary [{}]",
                     shardId, syncId, shard, preSyncedResponse.numDocs, numDocsOnPrimary);
-                results.put(shard, new ShardSyncedFlushResponse("out of sync replica; " +
+                results.put(shard, new ShardSyncedFlushResponse("ongoing indexing operations: " +
                     "num docs on replica [" + preSyncedResponse.numDocs + "]; num docs on primary [" + numDocsOnPrimary + "]"));
                 countDownAndSendResponseIfDone(syncId, shards, shardId, totalShards, listener, countDown, results);
                 continue;

--- a/server/src/test/java/org/elasticsearch/indices/flush/FlushIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/flush/FlushIT.java
@@ -309,7 +309,7 @@ public class FlushIT extends ESIntegTestCase {
         assertThat(partialResult.totalShards(), equalTo(numberOfReplicas + 1));
         assertThat(partialResult.successfulShards(), equalTo(numberOfReplicas));
         assertThat(partialResult.shardResponses().get(outOfSyncReplica.routingEntry()).failureReason, equalTo(
-            "out of sync replica; num docs on replica [" + (numDocs + extraDocs) + "]; num docs on primary [" + numDocs + "]"));
+            "ongoing indexing operations: num docs on replica [" + (numDocs + extraDocs) + "]; num docs on primary [" + numDocs + "]"));
         // Index extra documents to all shards - synced-flush should be ok.
         for (IndexShard indexShard : indexShards) {
             // Do reindex documents to the out of sync replica to avoid trigger merges

--- a/server/src/test/java/org/elasticsearch/indices/flush/FlushIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/flush/FlushIT.java
@@ -20,13 +20,11 @@ package org.elasticsearch.indices.flush;
 
 import org.apache.lucene.index.Term;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.admin.indices.flush.FlushRequest;
 import org.elasticsearch.action.admin.indices.flush.FlushResponse;
 import org.elasticsearch.action.admin.indices.flush.SyncedFlushResponse;
 import org.elasticsearch.action.admin.indices.stats.IndexStats;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
-import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -40,11 +38,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.MockEngineFactoryPlugin;
 import org.elasticsearch.index.engine.Engine;
-import org.elasticsearch.index.engine.EngineConfig;
-import org.elasticsearch.index.engine.EngineException;
-import org.elasticsearch.index.engine.EngineFactory;
 import org.elasticsearch.index.engine.InternalEngine;
 import org.elasticsearch.index.engine.InternalEngineTests;
 import org.elasticsearch.index.mapper.ParsedDocument;
@@ -54,17 +48,12 @@ import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardTestCase;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.plugins.EnginePlugin;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -379,121 +368,5 @@ public class FlushIT extends ESIntegTestCase {
         final ShardsSyncedFlushResult forthSeal = SyncedFlushUtil.attemptSyncedFlush(logger, internalCluster(), shardId);
         assertThat(forthSeal.successfulShards(), equalTo(numberOfReplicas + 1));
         assertThat(forthSeal.syncId(), not(equalTo(thirdSeal.syncId())));
-    }
-
-    public void testFalsePositiveOutOfSync() throws Exception {
-        internalCluster().ensureAtLeastNumDataNodes(2);
-        assertAcked(
-            prepareCreate("test").setSettings(Settings.builder()
-                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
-                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1)).get()
-        );
-        ensureGreen("test");
-        final ShardId shardId = new ShardId(clusterService().state().metaData().index("test").getIndex(), 0);
-        final List<IndexShard> indexShards = internalCluster().nodesInclude("test").stream()
-            .map(node -> internalCluster().getInstance(IndicesService.class, node).getShardOrNull(shardId))
-            .collect(Collectors.toList());
-        CountDownLatch primaryIndexed = new CountDownLatch(1);
-        for (IndexShard shard : indexShards) {
-            TestEnginePlugin.TestInternalEngine engine = (TestEnginePlugin.TestInternalEngine) IndexShardTestCase.getEngine(shard);
-            if (shard.routingEntry().primary()) {
-                engine.eventListeners.add(new TestEnginePlugin.EventListener() {
-                    @Override
-                    public void afterIndexing(Engine.Index index) {
-                        primaryIndexed.countDown();
-                    }
-                });
-            } else {
-                engine.eventListeners.add(new TestEnginePlugin.EventListener() {
-                    final CountDownLatch flushLatch = new CountDownLatch(1);
-                    final CountDownLatch indexingLatch = new CountDownLatch(1);
-                    @Override
-                    public void beforeIndexing(Engine.Index index) {
-                        try {
-                            flushLatch.await();
-                        } catch (InterruptedException e) {
-                            throw new AssertionError(e);
-                        }
-                    }
-
-                    @Override
-                    public void afterIndexing(Engine.Index index) {
-                        indexingLatch.countDown();
-                    }
-
-                    @Override
-                    public void afterFlush() {
-                        flushLatch.countDown();
-                        try {
-                            indexingLatch.await();
-                        } catch (InterruptedException e) {
-                            throw new AssertionError(e);
-                        }
-                    }
-                });
-            }
-        }
-
-        Thread indexer = new Thread(() -> {
-            final IndexResponse indexResponse = client().prepareIndex("test", "1").setSource("{}", XContentType.JSON).get();
-            assertThat(indexResponse.getResult(), equalTo(DocWriteResponse.Result.CREATED));
-        });
-        indexer.start();
-        primaryIndexed.await();
-        final ShardsSyncedFlushResult syncedFlushResult = SyncedFlushUtil.attemptSyncedFlush(logger, internalCluster(), shardId);
-        assertThat(syncedFlushResult.successfulShards(), equalTo(1));
-        indexer.join();
-    }
-
-    public static class TestEnginePlugin extends Plugin implements EnginePlugin {
-        @Override
-        public Optional<EngineFactory> getEngineFactory(IndexSettings indexSettings) {
-            return Optional.of(TestInternalEngine::new);
-        }
-
-        interface EventListener {
-            default void beforeIndexing(Engine.Index index) {
-            }
-            default void afterIndexing(Engine.Index index) {
-            }
-            default void afterFlush() {
-            }
-        }
-
-        final static class TestInternalEngine extends InternalEngine {
-            final List<TestEnginePlugin.EventListener> eventListeners = new CopyOnWriteArrayList<>();
-
-            TestInternalEngine(EngineConfig engineConfig) {
-                super(engineConfig);
-            }
-
-            @Override
-            public IndexResult index(Index index) throws IOException {
-                final List<TestEnginePlugin.EventListener> listeners = this.eventListeners;
-                try {
-                    listeners.forEach(l -> l.beforeIndexing(index));
-                    return super.index(index);
-                } finally {
-                    listeners.forEach(l -> l.afterIndexing(index));
-                }
-            }
-
-            @Override
-            public CommitId flush(boolean force, boolean waitIfOngoing) throws EngineException {
-                try {
-                    return super.flush(force, waitIfOngoing);
-                } finally {
-                    eventListeners.forEach(TestEnginePlugin.EventListener::afterFlush);
-                }
-            }
-        }
-    }
-
-    @Override
-    protected Collection<Class<? extends Plugin>> getMockPlugins() {
-        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.getMockPlugins());
-        plugins.remove(MockEngineFactoryPlugin.class);
-        plugins.add(TestEnginePlugin.class);
-        return plugins;
     }
 }


### PR DESCRIPTION
Synced-flush consists of three steps: (1) force-flush on every active copy; (2) check for ongoing indexing operations; (3) seal copies if there's no change since step 1. If some indexing operations are completed on the primary but not replicas, then Lucene commits from step 1 on replicas won't be the same as the primary's. And step 2 would pass if it's executed when all pending operations are done. Once step 2 passes, we will incorrectly emit the "out of sync" warning message although nothing wrong here.

Perhaps we should remove the num docs check entirely from synced-flush. This check is no longer useful as we fixed the actual issue in https://github.com/elastic/elasticsearch/pull/30244.

Relates #28464
Relates #30244