### PR TITLE
[DOCS] Reformat enrich stats API

### DIFF
--- a/docs/reference/ingest/apis/enrich/enrich-stats.asciidoc
+++ b/docs/reference/ingest/apis/enrich/enrich-stats.asciidoc
@@ -3,24 +3,121 @@
 [[enrich-stats-api]]
 === Enrich stats API
 ++++
-<titleabbrev>Enrich stats API</titleabbrev>
+<titleabbrev>Enrich stats</titleabbrev>
 ++++
 
-Returns enrich coordinator stats and information about currently executing enrich policies.
+Returns <<coordinating-node,enrich coordinator>> statistics
+and information about enrich policies
+that are currently executing.
 
-[source,js]
---------------------------------------------------
+[source,console]
+----
 GET /_enrich/_stats
---------------------------------------------------
-// CONSOLE
-// TEST
+----
+
+
+[[enrich-stats-api-request]]
+==== {api-request-title}
+
+`GET /_enrich/_stats`
+
+
+[[enrich-stats-api-response-body]]
+==== {api-response-body-title}
+
+`executing_policies`::
++
+--
+(Array of objects)
+Objects containing information
+about each enrich policy
+that is currently executing.
+
+Returned parameters include:
+
+`name`::
+(String)
+Name of the enrich policy.
+
+`task`::
+(<<tasks,Task object>>)
+Object containing detailed information
+about the policy execution task.
+--
+
+`coordinator_stats`::
++
+--
+(Array of objects)
+Objects containing information
+about each <<coordinating-node,coordinating ingest node>>
+for configured enrich processors.
+
+Returned parameters include:
+
+`node_id`::
+(String)
+ID of the ingest node coordinating search requests
+for configured enrich processors.
+
+`queue_size`::
+(Integer)
+Number of search requests in the queue.
+
+`remote_requests_current`::
+(Integer)
+Current number of outstanding remote requests.
+
+`remote_requests_total`::
+(Integer)
+Number of outstanding remote requests executed
+since node startup.
++
+In most cases,
+a remote request includes multiple search requests.
+This depends on the number of search requests in the queue
+when the remote request is executed.
+
+`executed_searches_total`::
+(Integer)
+Number of search requests
+that enrich processors have executed
+since node startup.
+--
+
+
+[[enrich-stats-api-example]]
+==== {api-examples-title}
+
+
+[source,console]
+----
+GET /_enrich/_stats
+----
+//TEST[s/^/PUT \/_enrich\/policy\/my-policy\/_execute\/n/\
 
 The API returns the following response:
 
-[source,js]
---------------------------------------------------
+[source,console-result]
+----
 {
-    "executing_policies": [],
+    "executing_policies": [
+        {
+            "name": "my-policy",
+            "task": {
+                "id" : 124,
+                "type" : "direct",
+                "action" : "cluster:admin/xpack/enrich/execute",
+                "start_time_in_millis" : 1458585884904,
+                "running_time_in_nanos" : 47402,
+                "cancellable" : false,
+                "parent_task_id" : "oTUltX4IQMOUUVeiohTt8A:123",
+                "headers" : {
+                    "X-Opaque-Id" : "123456" 
+                }
+            },
+        }
+    ],
     "coordinator_stats": [
         {
             "node_id": "1sFM8cmSROZYhPxVsiWew",
@@ -31,22 +128,8 @@ The API returns the following response:
         }
     ]
 }
---------------------------------------------------
+----
+// TESTRESPONSE[s/"executing_policies": \[[^\]]*\]/"executing_policies": $body.$_path/]
 // TESTRESPONSE[s/"node_id": "1sFM8cmSROZYhPxVsiWew"/"node_id" : $body.coordinator_stats.0.node_id/]
 // TESTRESPONSE[s/"remote_requests_total": 0/"remote_requests_total" : $body.coordinator_stats.0.remote_requests_total/]
 // TESTRESPONSE[s/"executed_searches_total": 0/"executed_searches_total" : $body.coordinator_stats.0.executed_searches_total/]
-
-The top level `executing_policies` field includes an object for each policy that is currently executing.
-Each object contains the following fields:
-* `name` - The name of policy that is executing
-* `task` - A full blow task info object that is executing the policy.
-
-The top level `coordinator_stats` field includes an object for each ingest node with information about the coordinator.
-Each object contains the following fields:
-* `node_id`                     - The id of the ingest node that is coordinating search requests for configured `enrich` processors.
-* `queue_size`                  - The current number of search requests in the queue.
-* `remote_requests_current`     - The number of current outstanding remote requests.
-* `remote_requests_total`       - The total number of outstanding remote requests that have been executed since node startup.
-                                  Each remote request is likely to include multiple search requests. This depends on how much
-                                  search requests are in the queue at the time when the remote request is performed.
-* `executed_searches_total`     - The total number of search requests that `enrich` processors have executed since node startup.

--- a/docs/reference/ingest/apis/enrich/index.asciidoc
+++ b/docs/reference/ingest/apis/enrich/index.asciidoc
@@ -7,7 +7,7 @@ The following enrich APIs are available for managing enrich policies:
 * <<delete-enrich-policy-api>> to delete an enrich policy
 * <<get-enrich-policy-api>> to return information about an enrich policy
 * <<execute-enrich-policy-api>> to execute an enrich policy
-* <<enrich-stats-api>> to get enrich related stats
+* <<enrich-stats-api>> to get enrich-related stats
 
 
 include::put-enrich-policy.asciidoc[]


### PR DESCRIPTION
Updates the enrich stats API docs to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc).

Also updates the example response to include `executing_policies` output.

Will backport to `enrich-7.x`.