### PR TITLE
[DOCS] Fix typo in plugin description

### DIFF
--- a/plugins/analysis-icu/build.gradle
+++ b/plugins/analysis-icu/build.gradle
@@ -20,7 +20,7 @@ import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApis
  */
 
 esplugin {
-  description 'The ICU Analysis plugin integrates Lucene ICU module into elasticsearch, adding ICU relates analysis components.'
+  description 'The ICU Analysis plugin integrates Lucene ICU module into elasticsearch, adding ICU-related analysis components.'
   classname 'org.elasticsearch.plugin.analysis.icu.AnalysisICUPlugin'
 }
 


### PR DESCRIPTION
Updates description of the ICU Analysis plugin.

Re-opens #46220.