### PR TITLE
Favor java.vendor.version over java.vendor

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GenerateGlobalBuildInfoTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GenerateGlobalBuildInfoTask.java
@@ -120,9 +120,9 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
 
     @TaskAction
     public void generate() {
-        String javaVendor = System.getProperty("java.vendor");
+        String javaVendorVersion = System.getProperty("java.vendor.version", System.getProperty("java.vendor"));
         String gradleJavaVersion = System.getProperty("java.version");
-        String gradleJavaVersionDetails = javaVendor + " " + gradleJavaVersion + " [" + System.getProperty("java.vm.name")
+        String gradleJavaVersionDetails = javaVendorVersion + " " + gradleJavaVersion + " [" + System.getProperty("java.vm.name")
             + " " + System.getProperty("java.vm.version") + "]";
 
         String compilerJavaVersionDetails = gradleJavaVersionDetails;
@@ -231,8 +231,10 @@ public class GenerateGlobalBuildInfoTask extends DefaultTask {
      */
     private String findJavaVersionDetails(File javaHome) {
         String versionInfoScript = "print(" +
-            "java.lang.System.getProperty(\"java.vendor\") + \" \" + java.lang.System.getProperty(\"java.version\") + " +
-            "\" [\" + java.lang.System.getProperty(\"java.vm.name\") + \" \" + java.lang.System.getProperty(\"java.vm.version\") + \"]\");";
+            "java.lang.System.getProperty(\"java.vendor.version\", java.lang.System.getProperty(\"java.vendor\")) + \" \" + " +
+            "java.lang.System.getProperty(\"java.version\") + \" [\" + " +
+            "java.lang.System.getProperty(\"java.vm.name\") + \" \" + " +
+            "java.lang.System.getProperty(\"java.vm.version\") + \"]\");";
         return runJavaAsScript(javaHome, versionInfoScript).trim();
     }
 


### PR DESCRIPTION
In some cases (for example some AdoptOpenJDK builds), the java.vendor is mistakenly populated as "Oracle Corporation" while the real value is under "java.vendor.version". Since "java.vendor.version" is mandatory since JDK 10, this commit changes to use "java.vendor.version" as the favored system property to find the JVM vendor, and we fallback to "java.vendor" if this is not populated (as happens in some Oracle builds). Ugh.

Relates AdoptOpenJDK/openjdk-build#465
