### PR TITLE
[DOCS] Add missing icons to transform HLRC APIs

### DIFF
--- a/docs/java-rest/high-level/dataframe/delete_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/delete_data_frame.asciidoc
@@ -3,6 +3,7 @@
 :request: DeleteDataFrameTransformRequest
 :response: AcknowledgedResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Delete {dataframe-transform} API
 

--- a/docs/java-rest/high-level/dataframe/get_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/get_data_frame.asciidoc
@@ -3,6 +3,7 @@
 :request: GetDataFrameTransformRequest
 :response: GetDataFrameTransformResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get {dataframe-transform} API
 

--- a/docs/java-rest/high-level/dataframe/get_data_frame_stats.asciidoc
+++ b/docs/java-rest/high-level/dataframe/get_data_frame_stats.asciidoc
@@ -3,6 +3,7 @@
 :request: GetDataFrameTransformStatsRequest
 :response: GetDataFrameTransformStatsResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get {dataframe-transform} stats API
 

--- a/docs/java-rest/high-level/dataframe/preview_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/preview_data_frame.asciidoc
@@ -3,6 +3,7 @@
 :request: PreviewDataFrameTransformRequest
 :response: PreviewDataFrameTransformResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Preview {dataframe-transform} API
 

--- a/docs/java-rest/high-level/dataframe/put_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/put_data_frame.asciidoc
@@ -3,6 +3,7 @@
 :request: PutDataFrameTransformRequest
 :response: AcknowledgedResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Put {dataframe-transform} API
 

--- a/docs/java-rest/high-level/dataframe/start_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/start_data_frame.asciidoc
@@ -3,6 +3,7 @@
 :request: StartDataFrameTransformRequest
 :response: StartDataFrameTransformResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Start {dataframe-transform} API
 

--- a/docs/java-rest/high-level/dataframe/stop_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/stop_data_frame.asciidoc
@@ -3,6 +3,7 @@
 :request: StopDataFrameTransformRequest
 :response: StopDataFrameTransformResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Stop {dataframe-transform} API
 

--- a/docs/java-rest/high-level/dataframe/update_data_frame.asciidoc
+++ b/docs/java-rest/high-level/dataframe/update_data_frame.asciidoc
@@ -3,6 +3,7 @@
 :request: UpdateDataFrameTransformRequest
 :response: UpdateDataFrameTransformResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Update {dataframe-transform} API
 

--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -250,6 +250,7 @@ include::licensing/start-basic.asciidoc[]
 include::licensing/get-trial-status.asciidoc[]
 include::licensing/get-basic-status.asciidoc[]
 
+[role="xpack"]
 == Machine Learning APIs
 :upid: {mainid}-x-pack-ml
 :doc-tests-file: {doc-tests}/MlClientDocumentationIT.java
@@ -568,6 +569,7 @@ include::ilm/lifecycle_management_status.asciidoc[]
 include::ilm/retry_lifecycle_policy.asciidoc[]
 include::ilm/remove_lifecycle_policy_from_index.asciidoc[]
 
+[role="xpack"]
 [[_data_frame_transform_apis]]
 == {dataframe-transform-cap} APIs
 


### PR DESCRIPTION
This PR adds the missing "role=xpack" attribute to the transform APIs in the Java high level REST client documentation (https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/_data_frame_transform_apis.html)