### PR TITLE
[DOCS] Add missing icons to rollup HLRC APIs

### DIFF
--- a/docs/java-rest/high-level/rollup/delete_job.asciidoc
+++ b/docs/java-rest/high-level/rollup/delete_job.asciidoc
@@ -3,7 +3,7 @@
 :request: DeleteRollupJobRequest
 :response: DeleteRollupJobResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Delete Rollup Job API
 

--- a/docs/java-rest/high-level/rollup/get_job.asciidoc
+++ b/docs/java-rest/high-level/rollup/get_job.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[java-rest-high-x-pack-rollup-get-job]]
 === Get Rollup Job API
 

--- a/docs/java-rest/high-level/rollup/get_rollup_caps.asciidoc
+++ b/docs/java-rest/high-level/rollup/get_rollup_caps.asciidoc
@@ -3,7 +3,7 @@
 :request: GetRollupCapsRequest
 :response: GetRollupCapsResponse
 --
-
+[role="xpack"]
 [id="{upid}-x-pack-{api}"]
 === Get Rollup Capabilities API
 

--- a/docs/java-rest/high-level/rollup/get_rollup_index_caps.asciidoc
+++ b/docs/java-rest/high-level/rollup/get_rollup_index_caps.asciidoc
@@ -3,7 +3,7 @@
 :request: GetRollupIndexCapsRequest
 :response: GetRollupIndexCapsResponse
 --
-
+[role="xpack"]
 [id="{upid}-x-pack-{api}"]
 === Get Rollup Index Capabilities API
 

--- a/docs/java-rest/high-level/rollup/put_job.asciidoc
+++ b/docs/java-rest/high-level/rollup/put_job.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[java-rest-high-x-pack-rollup-put-job]]
 === Put Rollup Job API
 

--- a/docs/java-rest/high-level/rollup/search.asciidoc
+++ b/docs/java-rest/high-level/rollup/search.asciidoc
@@ -3,7 +3,7 @@
 :request: SearchRequest
 :response: SearchResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Rollup Search API
 

--- a/docs/java-rest/high-level/rollup/start_job.asciidoc
+++ b/docs/java-rest/high-level/rollup/start_job.asciidoc
@@ -3,7 +3,7 @@
 :request: StartRollupJobRequest
 :response: StartRollupJobResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Start Rollup Job API
 

--- a/docs/java-rest/high-level/rollup/stop_job.asciidoc
+++ b/docs/java-rest/high-level/rollup/stop_job.asciidoc
@@ -3,7 +3,7 @@
 :request: StopRollupJobRequest
 :response: StopRollupJobResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Stop Rollup Job API
 

--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -371,6 +371,7 @@ The Java High Level REST Client supports the following Migration APIs:
 
 include::migration/get-deprecation-info.asciidoc[]
 
+[role="xpack"]
 == Rollup APIs
 
 :upid: {mainid}-rollup


### PR DESCRIPTION
This PR adds the missing "role=xpack" attribute to the rollup APIs in the Java high level REST client documentation (https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/_rollup_apis.html)