### PR TITLE
[DOCS] Add missing icons to security HLRC APIs

### DIFF
--- a/docs/java-rest/high-level/security/authenticate.asciidoc
+++ b/docs/java-rest/high-level/security/authenticate.asciidoc
@@ -3,7 +3,7 @@
 :api: authenticate
 :response: AuthenticateResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Authenticate API
 

--- a/docs/java-rest/high-level/security/change-password.asciidoc
+++ b/docs/java-rest/high-level/security/change-password.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[java-rest-high-security-change-password]]
 === Change Password API
 

--- a/docs/java-rest/high-level/security/clear-realm-cache.asciidoc
+++ b/docs/java-rest/high-level/security/clear-realm-cache.asciidoc
@@ -4,7 +4,7 @@
 :request: ClearRealmCacheRequest
 :response: ClearRealmCacheResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Clear Realm Cache API
 

--- a/docs/java-rest/high-level/security/clear-roles-cache.asciidoc
+++ b/docs/java-rest/high-level/security/clear-roles-cache.asciidoc
@@ -4,7 +4,7 @@
 :request: ClearRolesCacheRequest
 :response: ClearRolesCacheResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Clear Roles Cache API
 

--- a/docs/java-rest/high-level/security/create-api-key.asciidoc
+++ b/docs/java-rest/high-level/security/create-api-key.asciidoc
@@ -3,7 +3,7 @@
 :request: CreateApiKeyRequest
 :response: CreateApiKeyResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Create API Key API
 

--- a/docs/java-rest/high-level/security/create-token.asciidoc
+++ b/docs/java-rest/high-level/security/create-token.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[java-rest-high-security-create-token]]
 === Create Token API
 

--- a/docs/java-rest/high-level/security/delegate-pki-authentication.asciidoc
+++ b/docs/java-rest/high-level/security/delegate-pki-authentication.asciidoc
@@ -3,7 +3,7 @@
 :request: DelegatePkiAuthenticationRequest
 :response: DelegatePkiAuthenticationResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Delegate PKI Authentication API
 

--- a/docs/java-rest/high-level/security/delete-privileges.asciidoc
+++ b/docs/java-rest/high-level/security/delete-privileges.asciidoc
@@ -3,7 +3,7 @@
 :request: DeletePrivilegesRequest
 :response: DeletePrivilegesResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Delete Privileges API
 

--- a/docs/java-rest/high-level/security/delete-role-mapping.asciidoc
+++ b/docs/java-rest/high-level/security/delete-role-mapping.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[java-rest-high-security-delete-role-mapping]]
 === Delete Role Mapping API
 

--- a/docs/java-rest/high-level/security/delete-role.asciidoc
+++ b/docs/java-rest/high-level/security/delete-role.asciidoc
@@ -3,7 +3,7 @@
 :request: DeleteRoleRequest
 :response: DeleteRoleResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Delete Role API
 

--- a/docs/java-rest/high-level/security/delete-user.asciidoc
+++ b/docs/java-rest/high-level/security/delete-user.asciidoc
@@ -3,7 +3,7 @@
 :request: DeleteUserRequest
 :response: DeleteUserResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Delete User API
 

--- a/docs/java-rest/high-level/security/disable-user.asciidoc
+++ b/docs/java-rest/high-level/security/disable-user.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[java-rest-high-security-disable-user]]
 === Disable User API
 

--- a/docs/java-rest/high-level/security/enable-user.asciidoc
+++ b/docs/java-rest/high-level/security/enable-user.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[java-rest-high-security-enable-user]]
 === Enable User API
 

--- a/docs/java-rest/high-level/security/get-api-key.asciidoc
+++ b/docs/java-rest/high-level/security/get-api-key.asciidoc
@@ -3,7 +3,7 @@
 :request: GetApiKeyRequest
 :response: GetApiKeyResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get API Key information API
 

--- a/docs/java-rest/high-level/security/get-builtin-privileges.asciidoc
+++ b/docs/java-rest/high-level/security/get-builtin-privileges.asciidoc
@@ -3,7 +3,7 @@
 :request: GetBuiltinPrivilegesRequest
 :response: GetBuiltinPrivilegesResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get Builtin Privileges API
 

--- a/docs/java-rest/high-level/security/get-certificates.asciidoc
+++ b/docs/java-rest/high-level/security/get-certificates.asciidoc
@@ -4,7 +4,7 @@
 :response: GetSslCertificatesResponse
 --
 
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === SSL Certificate API
 

--- a/docs/java-rest/high-level/security/get-privileges.asciidoc
+++ b/docs/java-rest/high-level/security/get-privileges.asciidoc
@@ -4,7 +4,7 @@
 :request: GetPrivilegesRequest
 :response: GetPrivilegesResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get Privileges API
 

--- a/docs/java-rest/high-level/security/get-role-mappings.asciidoc
+++ b/docs/java-rest/high-level/security/get-role-mappings.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[java-rest-high-security-get-role-mappings]]
 === Get Role Mappings API
 

--- a/docs/java-rest/high-level/security/get-roles.asciidoc
+++ b/docs/java-rest/high-level/security/get-roles.asciidoc
@@ -4,7 +4,7 @@
 :request: GetRolesRequest
 :response: GetRolesResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get Roles API
 

--- a/docs/java-rest/high-level/security/get-user-privileges.asciidoc
+++ b/docs/java-rest/high-level/security/get-user-privileges.asciidoc
@@ -3,7 +3,7 @@
 :request: GetUserPrivilegesRequest
 :response: GetUserPrivilegesResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get User Privileges API
 

--- a/docs/java-rest/high-level/security/get-users.asciidoc
+++ b/docs/java-rest/high-level/security/get-users.asciidoc
@@ -4,7 +4,7 @@
 :request: GetUsersRequest
 :response: GetUsersResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get Users API
 

--- a/docs/java-rest/high-level/security/has-privileges.asciidoc
+++ b/docs/java-rest/high-level/security/has-privileges.asciidoc
@@ -3,7 +3,7 @@
 :request: HasPrivilegesRequest
 :response: HasPrivilegesResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Has Privileges API
 

--- a/docs/java-rest/high-level/security/invalidate-api-key.asciidoc
+++ b/docs/java-rest/high-level/security/invalidate-api-key.asciidoc
@@ -3,7 +3,7 @@
 :request: InvalidateApiKeyRequest
 :response: InvalidateApiKeyResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Invalidate API Key API
 

--- a/docs/java-rest/high-level/security/invalidate-token.asciidoc
+++ b/docs/java-rest/high-level/security/invalidate-token.asciidoc
@@ -3,7 +3,7 @@
 :request: InvalidateTokenRequest
 :response: InvalidateTokenResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Invalidate Token API
 

--- a/docs/java-rest/high-level/security/put-privileges.asciidoc
+++ b/docs/java-rest/high-level/security/put-privileges.asciidoc
@@ -3,7 +3,7 @@
 :request: PutPrivilegesRequest
 :response: PutPrivilegesResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Put Privileges API
 

--- a/docs/java-rest/high-level/security/put-role-mapping.asciidoc
+++ b/docs/java-rest/high-level/security/put-role-mapping.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[java-rest-high-security-put-role-mapping]]
 === Put Role Mapping API
 

--- a/docs/java-rest/high-level/security/put-role.asciidoc
+++ b/docs/java-rest/high-level/security/put-role.asciidoc
@@ -4,7 +4,7 @@
 :request: PutRoleRequest
 :response: PutRoleResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Put Role API
 

--- a/docs/java-rest/high-level/security/put-user.asciidoc
+++ b/docs/java-rest/high-level/security/put-user.asciidoc
@@ -3,7 +3,7 @@
 :request: PutUserRequest
 :response: PutUserResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Put User API
 

--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -396,6 +396,7 @@ include::rollup/search.asciidoc[]
 include::rollup/get_rollup_caps.asciidoc[]
 include::rollup/get_rollup_index_caps.asciidoc[]
 
+[role="xpack"]
 == Security APIs
 
 :upid: {mainid}-security


### PR DESCRIPTION
This PR adds the missing "role=xpack" attribute to the security APIs in the Java high level REST client documentation (https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/_security_apis.html)