### PR TITLE
[DOCS] Adds missing icons to Watcher HLRC APIs

### DIFF
--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -459,6 +459,7 @@ include::security/create-api-key.asciidoc[]
 include::security/get-api-key.asciidoc[]
 include::security/invalidate-api-key.asciidoc[]
 
+[role="xpack"]
 == Watcher APIs
 
 :upid: {mainid}-watcher

--- a/docs/java-rest/high-level/watcher/ack-watch.asciidoc
+++ b/docs/java-rest/high-level/watcher/ack-watch.asciidoc
@@ -4,6 +4,7 @@
 :response: AckWatchResponse
 --
 
+[role="xpack"]
 [id="{upid}-{api}"]
 === Ack watch API
 

--- a/docs/java-rest/high-level/watcher/activate-watch.asciidoc
+++ b/docs/java-rest/high-level/watcher/activate-watch.asciidoc
@@ -3,7 +3,7 @@
 :request: ActivateWatchRequest
 :response: ActivateWatchResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Activate watch API
 

--- a/docs/java-rest/high-level/watcher/deactivate-watch.asciidoc
+++ b/docs/java-rest/high-level/watcher/deactivate-watch.asciidoc
@@ -4,6 +4,7 @@
 :response: deactivateWatchResponse
 :doc-tests-file: {doc-tests}/WatcherDocumentationIT.java
 --
+[role="xpack"]
 [[java-rest-high-watcher-deactivate-watch]]
 === Deactivate watch API
 

--- a/docs/java-rest/high-level/watcher/delete-watch.asciidoc
+++ b/docs/java-rest/high-level/watcher/delete-watch.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[java-rest-high-x-pack-watcher-delete-watch]]
 === Delete watch API
 

--- a/docs/java-rest/high-level/watcher/execute-watch.asciidoc
+++ b/docs/java-rest/high-level/watcher/execute-watch.asciidoc
@@ -3,6 +3,7 @@
 :request: ExecuteWatchRequest
 :response: ExecuteWatchResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Execute watch API
 

--- a/docs/java-rest/high-level/watcher/get-watch.asciidoc
+++ b/docs/java-rest/high-level/watcher/get-watch.asciidoc
@@ -3,7 +3,7 @@
 :request: GetWatchRequest
 :response: GetWatchResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get watch API
 

--- a/docs/java-rest/high-level/watcher/put-watch.asciidoc
+++ b/docs/java-rest/high-level/watcher/put-watch.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[java-rest-high-x-pack-watcher-put-watch]]
 === Put watch API
 

--- a/docs/java-rest/high-level/watcher/start-watch-service.asciidoc
+++ b/docs/java-rest/high-level/watcher/start-watch-service.asciidoc
@@ -3,6 +3,7 @@
 :request: StartWatchServiceRequest
 :response: StartWatchServiceResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Start watch service API
 

--- a/docs/java-rest/high-level/watcher/stop-watch-service.asciidoc
+++ b/docs/java-rest/high-level/watcher/stop-watch-service.asciidoc
@@ -3,6 +3,7 @@
 :request: StopWatchServiceRequest
 :response: StopWatchServiceResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Stop watch service API
 

--- a/docs/java-rest/high-level/watcher/watcher-stats.asciidoc
+++ b/docs/java-rest/high-level/watcher/watcher-stats.asciidoc
@@ -3,6 +3,7 @@
 :request: WatcherStatsRequest
 :response: WatcherStatsResponse
 --
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get Watcher stats API
 

--- a/x-pack/docs/en/watcher/actions.asciidoc
+++ b/x-pack/docs/en/watcher/actions.asciidoc
@@ -190,7 +190,7 @@ of a watch during its execution:
 
 image::images/action-throttling.jpg[align="center"]
 
-
+[role="xpack"]
 [[action-foreach]]
 === Running an action for each element in an array
 
@@ -236,6 +236,7 @@ PUT _watcher/watch/log_event_watch
 
 <1> The logging statement will be executed for each of the returned search hits.
 
+[role="xpack"]
 [[action-conditions]]
 === Adding conditions to actions
 


### PR DESCRIPTION
This PR adds the missing "role=xpack" attribute to the Watcher APIs in the Java high level REST client documentation (https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/_watcher_apis.html)