### PR TITLE
[DOCS] Adds missing icons to Graph HLRC APIs

### DIFF
--- a/docs/java-rest/high-level/graph/explore.asciidoc
+++ b/docs/java-rest/high-level/graph/explore.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[java-rest-high-x-pack-graph-explore]]
 === X-Pack Graph explore API
 

--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -488,6 +488,7 @@ include::watcher/activate-watch.asciidoc[]
 include::watcher/execute-watch.asciidoc[]
 include::watcher/watcher-stats.asciidoc[]
 
+[role="xpack"]
 == Graph APIs
 
 The Java High Level REST Client supports the following Graph APIs:


### PR DESCRIPTION
This PR adds the missing "role=xpack" attribute to the Graph APIs in the Java high level REST client documentation ( https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/_graph_apis.html)