### PR TITLE
[DOCS] Adds missing icons to CCR HLRC APIs

### DIFF
--- a/docs/java-rest/high-level/ccr/delete_auto_follow_pattern.asciidoc
+++ b/docs/java-rest/high-level/ccr/delete_auto_follow_pattern.asciidoc
@@ -3,7 +3,7 @@
 :request: DeleteAutoFollowPatternRequest
 :response: AcknowledgedResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Delete Auto Follow Pattern API
 

--- a/docs/java-rest/high-level/ccr/forget_follower.asciidoc
+++ b/docs/java-rest/high-level/ccr/forget_follower.asciidoc
@@ -3,7 +3,7 @@
 :request: ForgetFollowerRequest
 :response: BroadcastResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Forget Follower API
 

--- a/docs/java-rest/high-level/ccr/get_auto_follow_pattern.asciidoc
+++ b/docs/java-rest/high-level/ccr/get_auto_follow_pattern.asciidoc
@@ -3,7 +3,7 @@
 :request: GetAutoFollowPatternRequest
 :response: GetAutoFollowPatternResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get Auto Follow Pattern API
 

--- a/docs/java-rest/high-level/ccr/get_follow_info.asciidoc
+++ b/docs/java-rest/high-level/ccr/get_follow_info.asciidoc
@@ -3,7 +3,7 @@
 :request: FollowInfoRequest
 :response: FollowInfoResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get Follow Info API
 

--- a/docs/java-rest/high-level/ccr/get_follow_stats.asciidoc
+++ b/docs/java-rest/high-level/ccr/get_follow_stats.asciidoc
@@ -3,7 +3,7 @@
 :request: FollowStatsRequest
 :response: FollowStatsResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get Follow Stats API
 

--- a/docs/java-rest/high-level/ccr/get_stats.asciidoc
+++ b/docs/java-rest/high-level/ccr/get_stats.asciidoc
@@ -3,7 +3,7 @@
 :request: CcrStatsRequest
 :response: CcrStatsResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get CCR Stats API
 

--- a/docs/java-rest/high-level/ccr/pause_follow.asciidoc
+++ b/docs/java-rest/high-level/ccr/pause_follow.asciidoc
@@ -3,7 +3,7 @@
 :request: PauseFollowRequest
 :response: AcknowledgedResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Pause Follow API
 

--- a/docs/java-rest/high-level/ccr/put_auto_follow_pattern.asciidoc
+++ b/docs/java-rest/high-level/ccr/put_auto_follow_pattern.asciidoc
@@ -3,7 +3,7 @@
 :request: PutAutoFollowPatternRequest
 :response: AcknowledgedResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Put Auto Follow Pattern API
 

--- a/docs/java-rest/high-level/ccr/put_follow.asciidoc
+++ b/docs/java-rest/high-level/ccr/put_follow.asciidoc
@@ -3,7 +3,7 @@
 :request: PutFollowRequest
 :response: PutFollowResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Put Follow API
 

--- a/docs/java-rest/high-level/ccr/resume_follow.asciidoc
+++ b/docs/java-rest/high-level/ccr/resume_follow.asciidoc
@@ -3,7 +3,7 @@
 :request: ResumeFollowRequest
 :response: AcknowledgedResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Resume Follow API
 

--- a/docs/java-rest/high-level/ccr/unfollow.asciidoc
+++ b/docs/java-rest/high-level/ccr/unfollow.asciidoc
@@ -3,7 +3,7 @@
 :request: UnfollowRequest
 :response: AcknowledgedResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Unfollow API
 

--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -508,6 +508,7 @@ don't leak into the rest of the documentation.
 :upid!:
 --
 
+[role="xpack"]
 == CCR APIs
 
 :upid: {mainid}-ccr


### PR DESCRIPTION
This PR adds the missing "role=xpack" attribute to the CCR APIs in the Java high level REST client documentation ( https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/_ccr_apis.html)