### PR TITLE
[DOCS] Adds missing icons to ILM HLRC APIs

### DIFF
--- a/docs/java-rest/high-level/ilm/delete_lifecycle_policy.asciidoc
+++ b/docs/java-rest/high-level/ilm/delete_lifecycle_policy.asciidoc
@@ -3,7 +3,7 @@
 :request: DeleteLifecyclePolicyRequest
 :response: AcknowledgedResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Delete Lifecycle Policy API
 

--- a/docs/java-rest/high-level/ilm/delete_snapshot_lifecycle_policy.asciidoc
+++ b/docs/java-rest/high-level/ilm/delete_snapshot_lifecycle_policy.asciidoc
@@ -3,7 +3,7 @@
 :request: DeleteSnapshotLifecyclePolicyRequest
 :response: AcknowledgedResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Delete Snapshot Lifecycle Policy API
 

--- a/docs/java-rest/high-level/ilm/execute_snapshot_lifecycle_policy.asciidoc
+++ b/docs/java-rest/high-level/ilm/execute_snapshot_lifecycle_policy.asciidoc
@@ -3,7 +3,7 @@
 :request: ExecuteSnapshotLifecyclePolicyRequest
 :response: ExecuteSnapshotLifecyclePolicyResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Execute Snapshot Lifecycle Policy API
 

--- a/docs/java-rest/high-level/ilm/explain_lifecycle.asciidoc
+++ b/docs/java-rest/high-level/ilm/explain_lifecycle.asciidoc
@@ -3,7 +3,7 @@
 :request: ExplainLifecycleRequest
 :response: ExplainLifecycleResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Explain Lifecycle API
 

--- a/docs/java-rest/high-level/ilm/get_lifecycle_policy.asciidoc
+++ b/docs/java-rest/high-level/ilm/get_lifecycle_policy.asciidoc
@@ -3,7 +3,7 @@
 :request: GetLifecyclePolicyRequest
 :response: GetLifecyclePolicyResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get Lifecycle Policy API
 

--- a/docs/java-rest/high-level/ilm/get_snapshot_lifecycle_policy.asciidoc
+++ b/docs/java-rest/high-level/ilm/get_snapshot_lifecycle_policy.asciidoc
@@ -3,7 +3,7 @@
 :request: GetSnapshotLifecyclePolicyRequest
 :response: GetSnapshotLifecyclePolicyResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get Snapshot Lifecycle Policy API
 

--- a/docs/java-rest/high-level/ilm/get_snapshot_lifecycle_stats.asciidoc
+++ b/docs/java-rest/high-level/ilm/get_snapshot_lifecycle_stats.asciidoc
@@ -3,7 +3,7 @@
 :request: GetSnapshotLifecycleStatsRequest
 :response: GetSnapshotLifecycleStatsResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Get Snapshot Lifecycle Stats API
 

--- a/docs/java-rest/high-level/ilm/lifecycle_management_status.asciidoc
+++ b/docs/java-rest/high-level/ilm/lifecycle_management_status.asciidoc
@@ -3,7 +3,7 @@
 :request: LifecycleManagementStatusRequest
 :response: AcknowledgedResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Index Lifecycle Management Status API
 

--- a/docs/java-rest/high-level/ilm/put_lifecycle_policy.asciidoc
+++ b/docs/java-rest/high-level/ilm/put_lifecycle_policy.asciidoc
@@ -3,7 +3,7 @@
 :request: PutLifecyclePolicyRequest
 :response: AcknowledgedResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Put Lifecycle Policy API
 

--- a/docs/java-rest/high-level/ilm/put_snapshot_lifecycle_policy.asciidoc
+++ b/docs/java-rest/high-level/ilm/put_snapshot_lifecycle_policy.asciidoc
@@ -3,7 +3,7 @@
 :request: PutSnapshotLifecyclePolicyRequest
 :response: AcknowledgedResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Put Snapshot Lifecycle Policy API
 

--- a/docs/java-rest/high-level/ilm/remove_lifecycle_policy_from_index.asciidoc
+++ b/docs/java-rest/high-level/ilm/remove_lifecycle_policy_from_index.asciidoc
@@ -3,7 +3,7 @@
 :request: RemoveIndexLifecyclePolicyRequest
 :response: AcknowledgedResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Remove Policy from Index API
 

--- a/docs/java-rest/high-level/ilm/retry_lifecycle_policy.asciidoc
+++ b/docs/java-rest/high-level/ilm/retry_lifecycle_policy.asciidoc
@@ -3,7 +3,7 @@
 :request: RetryLifecyclePolicyRequest
 :response: AcknowledgedResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Retry Lifecycle Policy API
 

--- a/docs/java-rest/high-level/ilm/start_lifecycle_management.asciidoc
+++ b/docs/java-rest/high-level/ilm/start_lifecycle_management.asciidoc
@@ -3,7 +3,7 @@
 :request: StartILMRequest
 :response: AcknowledgedResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Start Index Lifecycle Management API
 

--- a/docs/java-rest/high-level/ilm/stop_lifecycle_management.asciidoc
+++ b/docs/java-rest/high-level/ilm/stop_lifecycle_management.asciidoc
@@ -3,7 +3,7 @@
 :request: StopILMRequest
 :response: AcknowledgedResponse
 --
-
+[role="xpack"]
 [id="{upid}-{api}"]
 === Stop Index Lifecycle Management API
 

--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -539,6 +539,7 @@ include::ccr/get_stats.asciidoc[]
 include::ccr/get_follow_stats.asciidoc[]
 include::ccr/get_follow_info.asciidoc[]
 
+[role="xpack"]
 == Index Lifecycle Management APIs
 
 :upid: {mainid}-ilm


### PR DESCRIPTION
This PR adds the missing "role=xpack" attribute to the index lifecycle management APIs in the Java high level REST client documentation ( https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/_index_lifecycle_management_apis.html)