### PR TITLE
Remove custom assignment listener

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/ReindexJobState.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/ReindexJobState.java
@@ -102,9 +102,8 @@ public class ReindexJobState implements Task.Status, PersistentTaskState {
 
     public enum Status {
         STARTED,
-        FAILED_TO_READ_FROM_REINDEX_INDEX,
         ASSIGNMENT_FAILED,
-        FAILED_TO_WRITE_TO_REINDEX_INDEX,
+        SET_DONE_FAILED,
         DONE
     }
 }


### PR DESCRIPTION
Currently the ReindexTaskStateUpdater currently uses a custom listener
type to propogate error statuses during assignment. This is not really
necessary. We can use a generic assignment failed status and use the
exception message and logging to indicate assignment issues.

Relates to #42612.