### PR TITLE
Do not wait for the old notifications index (".ml-notifications") as it is no longer created.

### DIFF
--- a/x-pack/qa/src/main/java/org/elasticsearch/xpack/test/rest/XPackRestTestConstants.java
+++ b/x-pack/qa/src/main/java/org/elasticsearch/xpack/test/rest/XPackRestTestConstants.java
@@ -21,7 +21,6 @@ public final class XPackRestTestConstants {
 
     // ML constants:
     public static final String ML_META_INDEX_NAME = ".ml-meta";
-    public static final String AUDITOR_NOTIFICATIONS_INDEX_LEGACY = ".ml-notifications";
     public static final String AUDITOR_NOTIFICATIONS_INDEX = ".ml-notifications-000001";
     public static final String CONFIG_INDEX = ".ml-config";
     public static final String RESULTS_INDEX_PREFIX = ".ml-anomalies-";
@@ -30,7 +29,6 @@ public final class XPackRestTestConstants {
 
     public static final List<String> ML_POST_V660_TEMPLATES =
         List.of(
-            AUDITOR_NOTIFICATIONS_INDEX_LEGACY,
             AUDITOR_NOTIFICATIONS_INDEX,
             ML_META_INDEX_NAME,
             STATE_INDEX_PREFIX,


### PR DESCRIPTION
This PR aims at fixing unusually high execution times of BWC test suite.

Relates https://github.com/elastic/elasticsearch/issues/46590