### PR TITLE
[DOCS] Term dict memory usage is a 7.3.0 enhancement, not 7.2.0

### DIFF
--- a/docs/reference/release-notes/7.2.asciidoc
+++ b/docs/reference/release-notes/7.2.asciidoc
@@ -236,7 +236,6 @@ Docs Infrastructure::
 * Docs: Simplifying setup by using module configuration variant syntax {pull}40879[#40879]
 
 Engine::
-* Use reader attributes to control term dict memory useage {pull}42838[#42838] (issue: {issue}38390[#38390])
 * Simplify initialization of max_seq_no of updates {pull}41161[#41161] (issues: {issue}33842[#33842], {issue}40249[#40249])
 * Adjust init map size of user data of index commit {pull}40965[#40965]
 * Don't mark shard as refreshPending on stats fetching {pull}40458[#40458] (issues: {issue}33835[#33835], {issue}33847[#33847])

--- a/docs/reference/release-notes/7.3.asciidoc
+++ b/docs/reference/release-notes/7.3.asciidoc
@@ -263,6 +263,7 @@ Distributed::
 * Improve Close Index Response {pull}39687[#39687] (issue: {issue}33888[#33888])
 
 Engine::
+* Use reader attributes to control term dict memory useage {pull}42838[#42838] (issue: {issue}38390[#38390])
 * Remove sort by primary term when reading soft-deletes {pull}43845[#43845]
 * Refresh translog stats after translog trimming in NoOpEngine {pull}43825[#43825] (issue: {issue}43156[#43156])
 * Expose translog stats in ReadOnlyEngine {pull}43752[#43752]


### PR DESCRIPTION


Closes #46635