### PR TITLE
[DOCS] Change // CONSOLE comments to [source,console]

### DIFF
--- a/docs/reference/ingest/apis/enrich/delete-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/delete-enrich-policy.asciidoc
@@ -9,7 +9,7 @@
 Deletes an existing enrich policy and its enrich index.
 
 ////
-[source,js]
+[source,console]
 ----
 PUT /users
 
@@ -22,15 +22,13 @@ PUT /_enrich/policy/my-policy
     }
 }
 ----
-// CONSOLE
 // TESTSETUP
 ////
 
-[source,js]
+[source,console]
 --------------------------------------------------
 DELETE /_enrich/policy/my-policy
 --------------------------------------------------
-// CONSOLE
 
 
 [[delete-enrich-policy-api-request]]

--- a/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/execute-enrich-policy.asciidoc
@@ -10,7 +10,7 @@ Executes an existing enrich policy.
 
 ////
 
-[source,js]
+[source,console]
 ----
 PUT /users/_doc/1?refresh
 {
@@ -33,22 +33,19 @@ PUT /_enrich/policy/my-policy
     }
 }
 ----
-// CONSOLE
 // TESTSETUP
 ////
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /_enrich/policy/my-policy/_execute
 --------------------------------------------------
-// CONSOLE
 
 ////
-[source,js]
+[source,console]
 --------------------------------------------------
 DELETE /_enrich/policy/my-policy
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 ////
 

--- a/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
@@ -9,7 +9,7 @@
 Returns information about an enrich policy.
 
 ////
-[source,js]
+[source,console]
 ----
 PUT /users
 
@@ -31,14 +31,12 @@ PUT /_enrich/policy/other-policy
     }
 }
 ----
-// CONSOLE
 ////
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_enrich/policy/my-policy
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 
@@ -73,16 +71,15 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=enrich-policy]
 [[get-enrich-policy-api-single-ex]]
 ===== Get a single policy
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_enrich/policy/my-policy
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 The API returns the following response:
 
-[source,js]
+[source,console-result]
 --------------------------------------------------
 {
     "policies": [
@@ -103,22 +100,20 @@ The API returns the following response:
     ]
 }
 --------------------------------------------------
-// TESTRESPONSE
 
 
 [[get-enrich-policy-api-commas-ex]]
 ===== Get multiple policies
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_enrich/policy/my-policy,other-policy
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 The API returns the following response:
 
-[source,js]
+[source,console-result]
 --------------------------------------------------
 {
     "policies": [
@@ -153,22 +148,20 @@ The API returns the following response:
     ]
 }
 --------------------------------------------------
-// TESTRESPONSE
 
 
 [[get-enrich-policy-api-all-ex]]
 ===== Get all policies
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_enrich/policy
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 The API returns the following response:
 
-[source,js]
+[source,console-result]
 --------------------------------------------------
 {
     "policies": [
@@ -203,14 +196,12 @@ The API returns the following response:
     ]
 }
 --------------------------------------------------
-// TESTRESPONSE
 
 ////
-[source,js]
+[source,console]
 --------------------------------------------------
 DELETE /_enrich/policy/my-policy
 DELETE /_enrich/policy/other-policy
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 ////

--- a/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
@@ -9,14 +9,13 @@
 Creates an enrich policy.
 
 ////
-[source,js]
+[source,console]
 ----
 PUT /users
 ----
-// CONSOLE
 ////
 
-[source,js]
+[source,console]
 ----
 PUT /_enrich/policy/my-policy
 {
@@ -27,15 +26,13 @@ PUT /_enrich/policy/my-policy
     }
 }
 ----
-// CONSOLE
 // TEST[continued]
 
 ////
-[source,js]
+[source,console]
 --------------------------------------------------
 DELETE /_enrich/policy/my-policy
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 ////
 

--- a/docs/reference/ingest/enrich.asciidoc
+++ b/docs/reference/ingest/enrich.asciidoc
@@ -67,7 +67,7 @@ The following <<docs-index_,index API>> request creates the `users` source index
 containing user data.
 This request also indexes a new document to the `users` source index.
 
-[source,js]
+[source,console]
 ----
 PUT /users/_doc/1?refresh
 {
@@ -81,7 +81,6 @@ PUT /users/_doc/1?refresh
     "web": "mardy.asciidocsmith.com"
 }
 ----
-// CONSOLE
 
 You also can set up {beats-ref}/getting-started.html[{beats}],
 such as a {filebeat-ref}/filebeat-getting-started.html[{filebeat}],
@@ -99,7 +98,7 @@ to create an enrich policy.
 
 include::{docdir}/ingest/apis/enrich/put-enrich-policy.asciidoc[tag=enrich-policy-def]
 
-[source,js]
+[source,console]
 ----
 PUT /_enrich/policy/users-policy
 {
@@ -110,7 +109,6 @@ PUT /_enrich/policy/users-policy
     }
 }
 ----
-// CONSOLE
 // TEST[continued]
 
 
@@ -127,11 +125,10 @@ The following request executes the `users-policy` enrich policy.
 Because this API request performs several operations,
 it may take a while to return a response.
 
-[source,js]
+[source,console]
 ----
 POST /_enrich/policy/users-policy/_execute
 ----
-// CONSOLE
 // TEST[continued]
 
 
@@ -161,7 +158,7 @@ The following request adds a new pipeline, `user_lookup`.
 This pipeline includes an enrich processor
 that uses the `users-policy` enrich policy.
 
-[source,js]
+[source,console]
 ----
 PUT /_ingest/pipeline/user_lookup
 {
@@ -177,7 +174,6 @@ PUT /_ingest/pipeline/user_lookup
   ]
 }
 ----
-// CONSOLE
 // TEST[continued]
 
 You also can add other <<ingest-processors,processors>>
@@ -213,30 +209,28 @@ to index a document
 containing the `email` field,
 the `match_field` specified in the `users-policy` enrich policy.
 
-[source,js]
+[source,console]
 ----
 PUT /my_index/_doc/my_id?pipeline=user_lookup
 {
   "email": "mardy.brown@asciidocsmith.com"
 }
 ----
-// CONSOLE
 // TEST[continued]
 
 To verify the enrich processor matched 
 and appended the appropriate field data,
 use the <<docs-get,get>> API to view the indexed document.
 
-[source,js]
+[source,console]
 ----
 GET /my_index/_doc/my_id
 ----
-// CONSOLE
 // TEST[continued]
 
 The API returns the following response:
 
-[source,js]
+[source,console-result]
 ----
 {
   "found": true,
@@ -282,12 +276,11 @@ using your ingest pipeline.
 include::apis/enrich/put-enrich-policy.asciidoc[tag=update-enrich-policy]
 
 ////
-[source,js]
+[source,console]
 --------------------------------------------------
 DELETE /_ingest/pipeline/user_lookup
 
 DELETE /_enrich/policy/users-policy
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 ////


### PR DESCRIPTION
#46180 and #45937 replaced the magic comments used for Asciidoc snippets:

- `// CONSOLE` -> `[source,console]`
- `// TESTRESPONSE` -> `[source,console-result]`

This updates the examples in the Enrich docs to match.
There are no other substantive changes.

Will backport to enrich-7.x.