### PR TITLE
[DOCS] Replace "// CONSOLE" comments with [source,console]

### DIFF
--- a/docs/reference/ilm/apis/slm-api.asciidoc
+++ b/docs/reference/ilm/apis/slm-api.asciidoc
@@ -353,11 +353,10 @@ retrieved by using the following API:
 
 ==== Example
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_slm/stats
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 Which returns a response similar to:

--- a/docs/reference/indices/templates.asciidoc
+++ b/docs/reference/indices/templates.asciidoc
@@ -248,4 +248,3 @@ The API returns the following response:
   }	
 }	
 --------------------------------------------------	
-// TESTRESPONSE

--- a/docs/reference/mapping/fields/field-names-field.asciidoc
+++ b/docs/reference/mapping/fields/field-names-field.asciidoc
@@ -33,5 +33,4 @@ PUT tweets
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[warning:Index [tweets] uses the deprecated `enabled` setting for `_field_names`. Disabling _field_names is not necessary because it no longer carries a large index overhead. Support for this setting will be removed in a future major version. Please remove it from your mappings and templates.]

--- a/docs/reference/sql/language/data-types.asciidoc
+++ b/docs/reference/sql/language/data-types.asciidoc
@@ -102,7 +102,7 @@ To do that, it will search for the first `keyword` that it can find that is _not
 
 Consider the following `string` mapping:
 
-[source, js]
+[source,js]
 ----
 {
     "first_name" : {

--- a/docs/reference/transform/ecommerce-example.asciidoc
+++ b/docs/reference/transform/ecommerce-example.asciidoc
@@ -83,7 +83,7 @@ If you want to use more complex queries, you can create your {dataframe} from a
 If you prefer, you can use the
 {ref}/preview-data-frame-transform.html[preview {dataframe-transforms} API]:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _data_frame/transforms/_preview
 {
@@ -130,7 +130,6 @@ POST _data_frame/transforms/_preview
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:set up sample data]
 --
 
@@ -159,7 +158,7 @@ If you prefer, you can use the
 {ref}/put-data-frame-transform.html[create {dataframe-transforms} API]. For
 example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT _data_frame/transforms/ecommerce-customer-transform
 {
@@ -213,7 +212,6 @@ PUT _data_frame/transforms/ecommerce-customer-transform
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:setup kibana sample data]
 --
 
@@ -236,11 +234,10 @@ Alternatively, you can use the
 {ref}/stop-data-frame-transform.html[stop {dataframe-transforms}] APIs. For
 example:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _data_frame/transforms/ecommerce-customer-transform/_start
 --------------------------------------------------
-// CONSOLE
 // TEST[skip:setup kibana sample data]
 
 --

--- a/x-pack/docs/en/rest-api/security/role-mapping-resources.asciidoc
+++ b/x-pack/docs/en/rest-api/security/role-mapping-resources.asciidoc
@@ -80,7 +80,7 @@ if _at least one_ of the member values matches. For example, the following rule
 matches any user who is a member of the `admin` group, regardless of any
 other groups they belong to:
 
-[source, js]
+[source,js]
 ------------------------------------------------------------
 { "field" : { "groups" : "admin" } }
 ------------------------------------------------------------

--- a/x-pack/docs/en/security/authentication/user-cache.asciidoc
+++ b/x-pack/docs/en/security/authentication/user-cache.asciidoc
@@ -22,7 +22,7 @@ You can use the {ref}/security-api-clear-cache.html[clear cache API] to force
 the eviction of cached users . For example, the following request evicts all
 users from the `ad1` realm:
 
-[source, js]
+[source,js]
 ------------------------------------------------------------
 $ curl -XPOST 'http://localhost:9200/_security/realm/ad1/_clear_cache'
 ------------------------------------------------------------
@@ -30,7 +30,7 @@ $ curl -XPOST 'http://localhost:9200/_security/realm/ad1/_clear_cache'
 To clear the cache for multiple realms, specify the realms as a comma-separated
 list:
 
-[source, js]
+[source,js]
 ------------------------------------------------------------
 $ curl -XPOST 'http://localhost:9200/_security/realm/ad1,ad2/_clear_cache'
 ------------------------------------------------------------


### PR DESCRIPTION
#46180 and #45937 replaced the magic comments used for Asciidoc snippets:

- `// CONSOLE` -> `[source,console]`
- `// TESTRESPONSE` -> `[source,console-result]`

This updates the examples in the docs to match.
