### PR TITLE
[DOCS] Fixes link to Kibana security

### DIFF
--- a/x-pack/docs/en/security/ccs-clients-integrations/cross-cluster.asciidoc
+++ b/x-pack/docs/en/security/ccs-clients-integrations/cross-cluster.asciidoc
@@ -150,4 +150,4 @@ GET two:logs-2017.04/_search <1>
 // TEST[skip:todo]
 //TBD: Is there a missing description of the <1> callout above?
 
-include::{kib-repo-dir}/security/cross-cluster-kibana.asciidoc[]
+include::{kib-repo-dir}/user/security/cross-cluster-kibana.asciidoc[]


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/45555

This PR fixes a link between elasticsearch/x-pack/docs/en/security/ccs-clients-integrations/cross-cluster.asciidoc and kibana/docs/security/cross-cluster-kibana.asciidoc, since the latter file has moved to kibana/docs/user/security...
