### PR TITLE
Updating upgrade.asciidoc

### DIFF
--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -5,10 +5,10 @@
 --
 {es} can usually be upgraded using a <<rolling-upgrades,Rolling upgrade>>
 process so upgrading does not interrupt service. Rolling upgrades are supported:
-
+  
 * Between minor versions
-* From 5.6 to 6.7
-* From 6.7 to {version}
+* From 5.6 to 6.8
+* From 6.8 to {version}
 
 The following table shows the recommended upgrade paths to {version}.
 


### PR DESCRIPTION
The [Rolling Upgrades](https://www.elastic.co/guide/en/elasticsearch/reference/7.0/rolling-upgrades.html) doc says that you can upgrade from 6.8 to 7.0.1 and the [Upgrade Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/7.0/setup-upgrade.html) doc says that you can from 6.7 to 7.0.1. So I updated the version number.