### PR TITLE
update link for uptasticsearch

### DIFF
--- a/docs/community-clients/index.asciidoc
+++ b/docs/community-clients/index.asciidoc
@@ -155,7 +155,7 @@ Also see the {client}/python-api/current/index.html[official Elasticsearch Pytho
 * https://github.com/ropensci/elasticdsl[elasticdsl]:
   A high-level R DSL for Elasticsearch, wrapping the elastic R client.
   
-* https://github.com/UptakeOpenSource/uptasticsearch[uptasticsearch]:
+* https://github.com/uptake/uptasticsearch[uptasticsearch]:
   An R client tailored to data science workflows.
 
 [[ruby]]


### PR DESCRIPTION
Hello,

I'm the maintainer of `uptasticsearch`, data-science friendly R and Python clients for Elasticsearch. We recently changed the name or our space in GitHub (`/UptakeOpenSource` to `/uptake`). I hope you'll consider this PR to update the link to `uptasticsearch` in your documentation.

Thanks!