### PR TITLE
[ML][Transform] Use field_caps API for mapping deduction

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_start_stop.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_frame/transforms_start_stop.yml
@@ -5,6 +5,9 @@ setup:
         body:
           mappings:
             properties:
+              time_alias:
+                type: alias
+                path: time
               time:
                 type: date
               airline:
@@ -322,3 +325,27 @@ teardown:
   - do:
       data_frame.delete_data_frame_transform:
         transform_id: "airline-transform-stop-all"
+---
+"Test start/stop with field alias":
+  - do:
+      data_frame.put_data_frame_transform:
+        transform_id: "airline_via_field_alias"
+        body: >
+          {
+            "source": {"index": "airline-data"},
+            "dest": {"index": "airline-data-time-alias"},
+            "pivot": {
+              "group_by": {"time": {"date_histogram": {"field": "time_alias", "calendar_interval": "1m"}}},
+              "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+            }
+          }
+  - do:
+      data_frame.start_data_frame_transform:
+        transform_id: "airline_via_field_alias"
+  - match: { acknowledged: true }
+
+  - do:
+      indices.get_mapping:
+        index: airline-data-time-alias
+  - match: { airline-data-time-alias.mappings.properties.time.type: date }
+  - match: { airline-data-time-alias.mappings.properties.avg_response.type: double }


### PR DESCRIPTION
Getting the mapping directly causes some problems, and is more complicated than just using the field caps API.

This updates `SchemaUtil` to use the field caps API instead of getting the raw mapping of the source indices. 

closes https://github.com/elastic/elasticsearch/issues/46694