### PR TITLE
[DOCS] mention automatic cancellation in search docs

### DIFF
--- a/docs/reference/search.asciidoc
+++ b/docs/reference/search.asciidoc
@@ -125,11 +125,11 @@ Setting this value to `-1` resets the global search timeout to no timeout.
 [[global-search-cancellation]]
 === Search Cancellation
 
-Searches are automatically cancelled when the http connection used to perform
-the request is closed by the client. It is fundamental that the http client
-sending requests closes connections whenever requests time out or are aborted.
-Automatic cancellation relies on standard  <<task-cancellation,task cancellation>>
-mechanism.
+Searches can be cancelled using standard <<task-cancellation,task cancellation>>
+mechanism and are also automatically cancelled when the http connection used to
+perform the request is closed by the client. It is fundamental that the http
+client sending requests closes connections whenever requests time out or are
+aborted.
 
 [float]
 [[search-concurrency-and-parallelism]]

--- a/docs/reference/search.asciidoc
+++ b/docs/reference/search.asciidoc
@@ -125,9 +125,12 @@ Setting this value to `-1` resets the global search timeout to no timeout.
 [[global-search-cancellation]]
 === Search Cancellation
 
-Searches can be cancelled using standard <<task-cancellation,task cancellation>>
-mechanism. By default, a running search only checks if it is cancelled or
-not on segment boundaries, therefore the cancellation can be delayed by large
+Searches are automatically cancelled when the http connection that they came
+in from gets closed. It is fundamental that the http client sending requests
+closes connections whenever requests time out or are aborted. Automatic
+cancellation relies on standard  <<task-cancellation,task cancellation>>
+mechanism. By default, a running search only checks if it is cancelled or not
+on segment boundaries, therefore the cancellation can be delayed by large
 segments. The search cancellation responsiveness can be improved by setting
 the dynamic cluster-level setting `search.low_level_cancellation` to `true`.
 However, it comes with an additional overhead of more frequent cancellation

--- a/docs/reference/search.asciidoc
+++ b/docs/reference/search.asciidoc
@@ -125,17 +125,11 @@ Setting this value to `-1` resets the global search timeout to no timeout.
 [[global-search-cancellation]]
 === Search Cancellation
 
-Searches are automatically cancelled when the http connection that they came
-in from gets closed. It is fundamental that the http client sending requests
-closes connections whenever requests time out or are aborted. Automatic
-cancellation relies on standard  <<task-cancellation,task cancellation>>
-mechanism. By default, a running search only checks if it is cancelled or not
-on segment boundaries, therefore the cancellation can be delayed by large
-segments. The search cancellation responsiveness can be improved by setting
-the dynamic cluster-level setting `search.low_level_cancellation` to `true`.
-However, it comes with an additional overhead of more frequent cancellation
-checks that can be noticeable on large fast running search queries. Changing this
-setting only affects the searches that start after the change is made.
+Searches are automatically cancelled when the http connection used to perform
+the request is closed by the client. It is fundamental that the http client
+sending requests closes connections whenever requests time out or are aborted.
+Automatic cancellation relies on standard  <<task-cancellation,task cancellation>>
+mechanism.
 
 [float]
 [[search-concurrency-and-parallelism]]


### PR DESCRIPTION
Add a small note around automatic search cancellation which was missed as part of #43332

Relates to #43332