### PR TITLE
[DOCS] Correct anchors and title for Update index settings API docs

### DIFF
--- a/docs/reference/indices/update-settings.asciidoc
+++ b/docs/reference/indices/update-settings.asciidoc
@@ -53,7 +53,7 @@ Defaults to `false`.
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 
-[[update-index-settings-api-query-params]]
+[[update-index-settings-api-request-body]]
 ==== {api-request-body-title}
 
 `settings`::

--- a/docs/reference/indices/update-settings.asciidoc
+++ b/docs/reference/indices/update-settings.asciidoc
@@ -53,14 +53,14 @@ Defaults to `false`.
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 
-[[sample-api-query-params]]
-==== {api-query-parms-title}
+[[update-index-settings-api-query-params]]
+==== {api-request-body-title}
 
 `settings`::
 (Optional, <<index-modules-settings,index setting object>>) Configuration
 options for the index. See <<index-modules-settings>>.
 
-[[sample-api-example]]
+[[update-index-settings-api-example]]
 ==== {api-examples-title}
 
 [[reset-index-setting]]


### PR DESCRIPTION
Fixes a few copy/paste errors in the Update index settings API docs.