### PR TITLE
[DOCS] Updates links to reporting content

### DIFF
--- a/x-pack/docs/en/watcher/actions/email.asciidoc
+++ b/x-pack/docs/en/watcher/actions/email.asciidoc
@@ -157,9 +157,9 @@ killed by firewalls or load balancers in-between.
 You can use the `reporting` attachment type in an `email` action to automatically
 generate a Kibana report and distribute it via email.
 
-include::{kib-repo-dir}/reporting/watch-example.asciidoc[]
+include::{kib-repo-dir}/user/reporting/watch-example.asciidoc[]
 
-include::{kib-repo-dir}/reporting/report-intervals.asciidoc[]
+include::{kib-repo-dir}/user/reporting/report-intervals.asciidoc[]
 
 For more information, see
 {kibana-ref}/automating-report-generation.html[Automating Report Generation].


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/45588

The elasticsearch/x-pack/docs/en/watcher/actions/email.asciidoc file includes kibana/docs/reporting/watch-example.asciidoc
 and kibana/docs/reporting/report-intervals.asciidoc files.  This PR updates email.asciidoc with the new location of those files.