### PR TITLE
[7.x][ML] Avoid marking data frame analytics task completed twice (#4…

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTask.java
@@ -96,7 +96,12 @@ public class DataFrameAnalyticsTask extends AllocatedPersistentTask implements S
 
     @Override
     public void markAsCompleted() {
-        persistProgress(() -> super.markAsCompleted());
+        // It is possible that the stop API has been called in the meantime and that
+        // may also cause this method to be called. We check whether we have already
+        // been marked completed to avoid doing it twice.
+        if (isCompleted() == false) {
+            persistProgress(() -> super.markAsCompleted());
+        }
     }
 
     @Override


### PR DESCRIPTION
…6721)

When the stop API is called while the task is running there is
a chance the task gets marked completed twice. This may cause
undesired side effects, like indexing the progress document a second
time after the stop API has returned (the cause for #46705).

This commit adds a check that the task has not been completed before
proceeding to mark it so. In addition, when we update the task's state
we could get some warnings that the task was missing if the stop API
has been called in the meantime. We now check the errors are
`ResourceNotFoundException` and ignore them if so.

Closes #46705

Backports #46721
