### PR TITLE
max_children exist only in top level nested sort

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
@@ -52,7 +52,6 @@ import org.elasticsearch.index.query.GeoValidationMethod;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.QueryShardContext;
-import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
 
@@ -64,6 +63,7 @@ import java.util.Locale;
 import java.util.Objects;
 
 import static org.elasticsearch.search.sort.FieldSortBuilder.validateMissingNestedPath;
+import static org.elasticsearch.search.sort.FieldSortBuilder.validateMaxChildrenExistOnlyInTopLevelNestedSort;
 import static org.elasticsearch.search.sort.NestedSortBuilder.NESTED_FIELD;
 
 /**
@@ -536,10 +536,7 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
 
         Nested nested = null;
         if (nestedSort != null) {
-            if (nestedSort.getNestedSort() != null && nestedSort.getMaxChildren() != Integer.MAX_VALUE)  {
-                throw new QueryShardException(context,
-                    "max_children is only supported on last level of nested sort");
-            }
+            validateMaxChildrenExistOnlyInTopLevelNestedSort(context, nestedSort);
             nested = resolveNested(context, nestedSort);
         } else {
             validateMissingNestedPath(context, fieldName);

--- a/server/src/main/java/org/elasticsearch/search/sort/ScriptSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/ScriptSortBuilder.java
@@ -58,6 +58,7 @@ import java.util.Locale;
 import java.util.Objects;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.search.sort.FieldSortBuilder.validateMaxChildrenExistOnlyInTopLevelNestedSort;
 import static org.elasticsearch.search.sort.NestedSortBuilder.NESTED_FIELD;
 
 /**
@@ -242,10 +243,7 @@ public class ScriptSortBuilder extends SortBuilder<ScriptSortBuilder> {
 
         Nested nested = null;
         if (nestedSort != null) {
-            if (nestedSort.getNestedSort() != null && nestedSort.getMaxChildren() != Integer.MAX_VALUE)  {
-                throw new QueryShardException(context,
-                    "max_children is only supported on last level of nested sort");
-            }
+            validateMaxChildrenExistOnlyInTopLevelNestedSort(context, nestedSort);
             nested = resolveNested(context, nestedSort);
         }
 

--- a/server/src/test/java/org/elasticsearch/search/sort/FieldSortIT.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/FieldSortIT.java
@@ -1421,6 +1421,20 @@ public class FieldSortIT extends ESIntegTestCase {
                                                             .endObject()
                                                         .endObject()
                                                     .endObject()
+                                                    .startObject("bar")
+                                                        .field("type", "nested")
+                                                        .startObject("properties")
+                                                            .startObject("foo")
+                                                                .field("type", "text")
+                                                                .field("fielddata", true)
+                                                                .startObject("fields")
+                                                                    .startObject("sub")
+                                                                        .field("type", "keyword")
+                                                                    .endObject()
+                                                                .endObject()
+                                                            .endObject()
+                                                        .endObject()
+                                                    .endObject()
                                                 .endObject()
                                             .endObject()
                                         .endObject()
@@ -1472,6 +1486,22 @@ public class FieldSortIT extends ESIntegTestCase {
         assertThat(hits[1].getSortValues().length, is(1));
         assertThat(hits[0].getSortValues()[0], is("bar"));
         assertThat(hits[1].getSortValues()[0], is("abc"));
+
+        try {
+            client().prepareSearch()
+                .setQuery(matchAllQuery())
+                .addSort(SortBuilders
+                    .fieldSort("nested.bar.foo")
+                    .setNestedSort(new NestedSortBuilder("nested")
+                        .setNestedSort(new NestedSortBuilder("nested.bar")
+                            .setMaxChildren(1)))
+                    .order(SortOrder.DESC))
+                .get();
+        } catch (SearchPhaseExecutionException e) {
+            for (ShardSearchFailure shardSearchFailure : e.shardFailures()) {
+                assertThat(shardSearchFailure.toString(), containsString("[max_children is only supported on top level of nested sort]"));
+            }
+        }
 
         // We sort on nested sub field
         searchResponse = client().prepareSearch()


### PR DESCRIPTION
**FIX**
related with (https://github.com/elastic/elasticsearch/pull/33587#discussion_r222654589)

If we have query like that;
```javascript
GET /products/_search
{
  "sort": [
    {
      "variants.listings.price": {
        "order": "desc",
        "nested": {
          "path": "variants",
          "nested": {
            "max_children": 1,
            "path": "variants.listings"
          }
        }
      }
    }
  ]
}
``` 

Elastic going to ignore max_children=1, cause we passed top level nested sort object in here (example flow);
https://github.com/elastic/elasticsearch/blob/3f18cf74ac3e86907a0c73e53374dafa233d6268/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java#L334-L340

https://github.com/elastic/elasticsearch/blob/3f18cf74ac3e86907a0c73e53374dafa233d6268/server/src/main/java/org/elasticsearch/search/sort/SortBuilder.java#L173-L186

https://github.com/elastic/elasticsearch/blob/3f18cf74ac3e86907a0c73e53374dafa233d6268/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/FloatValuesComparatorSource.java#L69-L74

So i think we must use max_children on top level nested sort or we need to pass last level nested sort.

In this PR, I allow to max_children on top level nested sort.