### PR TITLE
Add temporary logging to help debug _cat/indices 404

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -42,6 +42,7 @@ import org.elasticsearch.common.Table;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -226,6 +227,11 @@ public class RestIndicesAction extends AbstractCatAction {
 
             @Override
             public void onFailure(final Exception e) {
+                // Temporary logging to help debug https://github.com/elastic/elasticsearch/issues/45652
+                // TODO: remove this when we understand why _cat/indices sometimes returns a 404
+                if (e instanceof IndexNotFoundException) {
+                    logger.info("_cat/indices returning index_not_found_exception", e);
+                }
                 listener.onFailure(e);
             }
         }, size);

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -230,7 +230,7 @@ public class RestIndicesAction extends AbstractCatAction {
                 // Temporary logging to help debug https://github.com/elastic/elasticsearch/issues/45652
                 // TODO: remove this when we understand why _cat/indices sometimes returns a 404
                 if (e instanceof IndexNotFoundException) {
-                    logger.info("_cat/indices returning index_not_found_exception", e);
+                    logger.debug("_cat/indices returning index_not_found_exception", e);
                 }
                 listener.onFailure(e);
             }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
@@ -55,6 +55,8 @@ testClusters.integTest {
     setting 'xpack.security.audit.enabled', 'false'
     setting 'xpack.license.self_generated.type', 'trial'
     setting 'xpack.ml.min_disk_space_off_heap', '200mb'
+    // TODO: remove when the cause of https://github.com/elastic/elasticsearch/issues/45652 is understood
+    setting 'logger.org.elasticsearch.rest.action.cat', 'DEBUG'
 
     keystore 'bootstrap.password', 'x-pack-test-password'
     keystore 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'


### PR DESCRIPTION
This logging is to help debug
https://github.com/elastic/elasticsearch/issues/45652
and will be removed once the cause is known.