### PR TITLE
Add a bwc smoke test

### DIFF
--- a/qa/smoke-test-bwc/build.gradle
+++ b/qa/smoke-test-bwc/build.gradle
@@ -1,0 +1,98 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.elasticsearch.gradle.Version
+import org.elasticsearch.gradle.testclusters.RestTestRunnerTask
+import org.elasticsearch.gradle.testclusters.TestDistribution
+
+apply plugin: 'elasticsearch.testclusters'
+apply plugin: 'elasticsearch.standalone-test'
+
+/**
+ * This projects tests that bwc versions can be started up.
+ *
+ * The goal is to test the build infrastructure that sets the test clusters up, not the versions as those won't change,
+ * but the build does have version dependent code and we want a quick way to verify that clusters still start up on al
+ * versions after making changes.
+ */
+
+tasks.register("bwcTest") {
+    description = 'Runs backwards compatibility tests.'
+    group = 'verification'
+}
+
+/**
+ * This is useful for making sure changes in master won't break when back-porting, but these
+ * WIL NOT RUN IN CI, since CI doesn't call `bwcTest`, the matrix calls the version specific bwc test
+ * but only does so for index compatible versions, so in CI the check will be spread out across version.
+ * As such keeping this list up to date is not mandatory.
+ * Note that adding unreleased versions that are not index compatible with the current branch here won't work,
+ * as the branch won't know about them ( you can't add the unreleased maintenance version )
+ */
+List<Version> additionalVersion = [
+        "6.0.0", "6.1.0", "6.2.0", "6.2.2", "6.2.3", "6.2.4",
+        "6.3.0", "6.4.0", "6.5.0", "6.6.0", "6.7.0", "6.8.0"
+].collect { Version.fromString(it)}
+
+(bwcVersions.indexCompatible + additionalVersion).each { Version bwcVersion ->
+    tasks.register("v${bwcVersion}#bwcTest")
+    // We don't use INTEG_TEST for bwc
+    (TestDistribution.values()
+            // The integ test distribution is currently not used for bwc
+            .minus(TestDistribution.INTEG_TEST)
+    ).each { TestDistribution distro ->
+        String baseName = "v${bwcVersion}-${distro}"
+
+        testClusters {
+            "${baseName}" {
+                numberOfNodes = 2
+                testDistribution = distro
+                version = bwcVersion.toString()
+                javaHome = project.file(project.ext.runtimeJavaHome)
+                if (distro == TestDistribution.DEFAULT) {
+                    setting 'xpack.security.enabled', 'false'
+                }
+            }
+        }
+
+        tasks.register("${baseName}#test", RestTestRunnerTask) {
+            useCluster testClusters."${baseName}"
+            mustRunAfter(precommit)
+            doFirst {
+                project.delete("${buildDir}/cluster/shared/repo/${baseName}")
+            }
+
+            systemProperty 'tests.cluster_version', bwcVersion.toString().minus("-SNAPSHOT")
+            systemProperty 'tests.cluster_distro', distro
+            nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",") }")
+            nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName() }")
+        }
+
+        if (project.bwc_tests_enabled) {
+            tasks.named("v${bwcVersion}#bwcTest").configure {
+                dependsOn "${baseName}#test"
+            }
+        }
+    }
+    tasks.named("bwcTest").configure {
+        dependsOn "v${bwcVersion}#bwcTest"
+    }
+}
+
+test.enabled = false

--- a/qa/smoke-test-bwc/src/test/java/org/elasticsearch/upgrades/VersionCheckIT.java
+++ b/qa/smoke-test-bwc/src/test/java/org/elasticsearch/upgrades/VersionCheckIT.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.upgrades;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.client.Request;
+
+import org.elasticsearch.test.rest.ESRestTestCase;
+
+import java.util.List;
+import java.util.Map;
+
+import java.util.stream.Collectors;
+
+
+public class VersionCheckIT extends ESRestTestCase {
+
+    private static final String EXPECTED_VERSION = System.getProperty("tests.cluster_version");
+    private static final String EXPECTED_DISTRO = System.getProperty("tests.cluster_distro");
+
+    @SuppressWarnings("unchecked")
+    public void testVersion() throws Exception {
+        assertNotNull("Tests expects the tests.cluster_version to be passed in", EXPECTED_VERSION);
+        assertNotNull("Tests expects the tests.cluster_distro to be passed in", EXPECTED_DISTRO);
+
+        Map<String, Object> response = entityAsMap(
+            client().performRequest(
+                new Request("GET", "/_nodes?pretty")
+            )
+        );
+        logger.info("_nodes: {}", response);
+        Map<String, Map<String, Object> > nodes = (Map<String, Map<String, Object>>) response.get("nodes");
+        for (Map.Entry<String, Map<String, Object>> entry : nodes.entrySet()) {
+            String version = entry.getValue().get("version").toString();
+            assertEquals(EXPECTED_VERSION, version);
+            logger.info("Version of {} is {}", entry.getKey(), version);
+
+            List<String> modules = ((List<Map<String, String>>) entry.getValue().get("modules")).stream()
+                .map(each -> each.get("name"))
+                .collect(Collectors.toList());
+
+            if (EXPECTED_DISTRO.equals("DEFAULT")) {
+                if (Version.fromString(EXPECTED_VERSION).before(Version.fromString("6.3.0"))) {
+                    List<String> plugins = ((List<Map<String, String>>) entry.getValue().get("plugins")).stream()
+                        .map(each -> each.get("name"))
+                        .collect(Collectors.toList());
+                    assertTrue(
+                        "Default distribution should have x-pack plugins. Is this really the \"default\" distribution ?",
+                        plugins.stream().anyMatch(plugin -> plugin.startsWith("x-pack"))
+                    );
+                } else {
+                    assertTrue(
+                        "Default distribution should have x-pack modules. Is this really the default distribution ?",
+                        modules.stream().anyMatch(module -> module.startsWith("x-pack"))
+                    );
+                }
+            } else if (EXPECTED_DISTRO.equals("OSS")) {
+                assertFalse(
+                    "The OOS distribution should not contain x-pack modules. Is this really the oss distribution ?",
+                    modules.stream().anyMatch(module -> module.startsWith("x-pack"))
+                );
+            } else if (EXPECTED_DISTRO.equals("INMTEG_TEST_ZIP")) {
+                if (modules.size() != 0) {
+                    fail("Integ test distribution should have no modules but it had: " + modules);
+                }
+            } else {
+                fail("Unknown distribution type");
+            }
+            modules.forEach((module) -> logger.info("module: {}", module));
+
+        }
+    }
+
+    @Override
+    public boolean preserveClusterUponCompletion() {
+        // Test is read only, no need to spend time cleaning up
+        return true;
+    }
+
+}


### PR DESCRIPTION
The tests verfies that all flavors and versions of the distributions can
be started and that testclsuters actually starts what we ask it to.

This tests changes from #46740 and some more.