### PR TITLE
Fixed slm.get_stats.json documentation url

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_stats.json
@@ -1,7 +1,7 @@
 {
   "slm.get_stats":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-get-stats.html"
     },
     "stability":"stable",
     "url":{


### PR DESCRIPTION
As titled.
Related: https://github.com/elastic/elasticsearch/pull/46407
This should also be backported to `7.x`