### PR TITLE
[DOCS]Changes failed transforms limitation

### DIFF
--- a/docs/reference/transform/limitations.asciidoc
+++ b/docs/reference/transform/limitations.asciidoc
@@ -198,9 +198,6 @@ failure and re-starting.
 When using the API to delete a failed {transform}, first stop it using 
 `_stop?force=true`, then delete it.
 
-If starting a failed {transform}, after the root cause has been 
-resolved, the `_start?force=true` parameter must be specified.
-
 [float]
 [[df-availability-limitations]]
 === {cdataframes-cap} may give incorrect results if documents are not yet available to search


### PR DESCRIPTION
This PR fine-tunes the limitation around failed transforms: refers to `stop?force` parameter and removes the reference of `start?force`.

The PR replicates the changes that https://github.com/elastic/stack-docs/pull/499 contains. I close that PR in the Stack Docs repo.

Related issue: https://github.com/elastic/ml-team/issues/187#issuecomment-529352714