### PR TITLE
[DOCS] Fixes data frame analytics job terminology in HLRC

### DIFF
--- a/docs/java-rest/high-level/ml/delete-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/delete-data-frame-analytics.asciidoc
@@ -5,25 +5,25 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Delete Data Frame Analytics API
+=== Delete {dfanalytics-jobs} API
 
-The Delete Data Frame Analytics API is used to delete an existing {dataframe-analytics-config}.
+Delete an existing {dfanalytics-job}.
 The API accepts a +{request}+ object as a request and returns a +{response}+.
 
 [id="{upid}-{api}-request"]
-==== Delete Data Frame Analytics Request
+==== Delete {dfanalytics-jobs} request
 
-A +{request}+ object requires a {dataframe-analytics-config} id.
+A +{request}+ object requires a {dfanalytics-job} ID.
 
 ["source","java",subs="attributes,callouts,macros"]
 ---------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 ---------------------------------------------------
-<1> Constructing a new request referencing an existing {dataframe-analytics-config}
+<1> Constructing a new request referencing an existing {dfanalytics-job}.
 
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
 ==== Response
 
-The returned +{response}+ object acknowledges the {dataframe-analytics-config} deletion.
+The returned +{response}+ object acknowledges the {dfanalytics-job} deletion.

--- a/docs/java-rest/high-level/ml/estimate-memory-usage.asciidoc
+++ b/docs/java-rest/high-level/ml/estimate-memory-usage.asciidoc
@@ -7,13 +7,13 @@
 [id="{upid}-{api}"]
 === Estimate memory usage API
 
-The Estimate memory usage API is used to estimate memory usage of {dfanalytics}.
+Estimates memory usage of {dfanalytics}.
 Estimation results can be used when deciding the appropriate value for `model_memory_limit` setting later on.
 
 The API accepts an +{request}+ object and returns an +{response}+.
 
 [id="{upid}-{api}-request"]
-==== Estimate memory usage Request
+==== Estimate memory usage request
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/ml/evaluate-data-frame.asciidoc
+++ b/docs/java-rest/high-level/ml/evaluate-data-frame.asciidoc
@@ -5,13 +5,13 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Evaluate Data Frame API
+=== Evaluate {dfanalytics} API
 
-The Evaluate Data Frame API is used to evaluate an ML algorithm that ran on a {dataframe}.
+Evaluates the {ml} algorithm that ran on a {dataframe}.
 The API accepts an +{request}+ object and returns an +{response}+.
 
 [id="{upid}-{api}-request"]
-==== Evaluate Data Frame Request
+==== Evaluate {dfanalytics} request
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/ml/get-data-frame-analytics-stats.asciidoc
+++ b/docs/java-rest/high-level/ml/get-data-frame-analytics-stats.asciidoc
@@ -5,29 +5,31 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Get Data Frame Analytics Stats API
+=== Get {dfanalytics-jobs} stats API
 
-The Get Data Frame Analytics Stats API is used to read the operational statistics of one or more {dataframe-analytics-config}s.
+Retrieves the operational statistics of one or more {dfanalytics-jobs}.
 The API accepts a +{request}+ object and returns a +{response}+.
 
 [id="{upid}-{api}-request"]
-==== Get Data Frame Analytics Stats Request
+==== Get {dfanalytics-jobs} stats request
 
-A +{request}+ requires either a {dataframe-analytics-config} id, a comma separated list of ids or
-the special wildcard `_all` to get the statistics for all {dataframe-analytics-config}s
+A +{request}+ requires either a {dfanalytics-job} ID, a comma-separated list of
+IDs, or the special wildcard `_all` to get the statistics for all
+{dfanalytics-jobs}.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
-<1> Constructing a new GET Stats request referencing an existing {dataframe-analytics-config}
+<1> Constructing a new GET stats request referencing an existing
+{dfanalytics-job}
 
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
 ==== Response
 
-The returned +{response}+ contains the requested {dataframe-analytics-config} statistics.
+The returned +{response}+ contains the requested {dfanalytics-job} statistics.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/ml/get-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/get-data-frame-analytics.asciidoc
@@ -5,29 +5,29 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Get Data Frame Analytics API
+=== Get {dfanalytics-jobs} API
 
-The Get Data Frame Analytics API is used to get one or more {dataframe-analytics-config}s.
+Retrieves one or more {dfanalytics-jobs}.
 The API accepts a +{request}+ object and returns a +{response}+.
 
 [id="{upid}-{api}-request"]
-==== Get Data Frame Analytics Request
+==== Get {dfanalytics-jobs} request
 
-A +{request}+ requires either a {dataframe-analytics-config} id, a comma separated list of ids or
-the special wildcard `_all` to get all {dataframe-analytics-config}s.
+A +{request}+ requires either a {dfanalytics-job} ID, a comma-separated list of
+IDs, or the special wildcard `_all` to get all {dfanalytics-jobs}.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 --------------------------------------------------
-<1> Constructing a new GET request referencing an existing {dataframe-analytics-config}
+<1> Constructing a new GET request referencing an existing {dfanalytics-job}
 
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
 ==== Response
 
-The returned +{response}+ contains the requested {dataframe-analytics-config}s.
+The returned +{response}+ contains the requested {dfanalytics-jobs}.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/ml/put-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/put-data-frame-analytics.asciidoc
@@ -5,13 +5,13 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Put {dfanalytics} API
+=== Put {dfanalytics-jobs} API
 
-The Put {dfanalytics} API is used to create a new {dataframe-analytics-config}.
+Creates a new {dfanalytics-job}.
 The API accepts a +{request}+ object as a request and returns a +{response}+.
 
 [id="{upid}-{api}-request"]
-==== Put {dfanalytics} request
+==== Put {dfanalytics-jobs} request
 
 A +{request}+ requires the following argument:
 
@@ -31,7 +31,7 @@ configuration and contains the following arguments:
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-config]
 --------------------------------------------------
-<1> The {dataframe-analytics-config} id
+<1> The {dfanalytics-job} ID
 <2> The source index and query from which to gather data
 <3> The destination index
 <4> The analysis to be performed
@@ -129,7 +129,7 @@ include::../execution.asciidoc[]
 [id="{upid}-{api}-response"]
 ==== Response
 
-The returned +{response}+ contains the newly created {dataframe-analytics-config}.
+The returned +{response}+ contains the newly created {dfanalytics-job}.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/ml/start-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/start-data-frame-analytics.asciidoc
@@ -5,21 +5,21 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Start {dfanalytics} API
+=== Start {dfanalytics-jobs} API
 
-The start {dfanalytics} API is used to start an existing {dataframe-analytics-config}.
+Starts an existing {dfanalytics-job}.
 It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Start {dfanalytics} Request
+==== Start {dfanalytics-job} request
 
-A +{request}+ object requires a {dataframe-analytics-config} id.
+A +{request}+ object requires a {dfanalytics-job} ID.
 
 ["source","java",subs="attributes,callouts,macros"]
 ---------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 ---------------------------------------------------
-<1> Constructing a new start request referencing an existing {dataframe-analytics-config}
+<1> Constructing a new start request referencing an existing {dfanalytics-job}
 
 include::../execution.asciidoc[]
 

--- a/docs/java-rest/high-level/ml/stop-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/stop-data-frame-analytics.asciidoc
@@ -5,21 +5,21 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Stop {dfanalytics} API
+=== Stop {dfanalytics-jobs} API
 
-The stop {dfanalytics} API is used to stop a running {dataframe-analytics-config}.
+Stops a running {dfanalytics-job}.
 It accepts a +{request}+ object and responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Stop {dfanalytics} Request
+==== Stop {dfanalytics-jobs} request
 
-A +{request}+ object requires a {dataframe-analytics-config} id.
+A +{request}+ object requires a {dfanalytics-job} ID.
 
 ["source","java",subs="attributes,callouts,macros"]
 ---------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request]
 ---------------------------------------------------
-<1> Constructing a new stop request referencing an existing {dataframe-analytics-config}
+<1> Constructing a new stop request referencing an existing {dfanalytics-job}
 <2> Optionally used to stop a failed task
 
 include::../execution.asciidoc[]


### PR DESCRIPTION
This PR addresses a mismatch between the terminology used for data frame analytics APIs in the Elasticsearch API reference and the Java high-level REST client.  In particular, the former refers to data frame analytics jobs whereas the latter refers to data frame analytics configs.

For example: https://www.elastic.co/guide/en/elasticsearch/reference/master/get-dfanalytics.html and https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/java-rest-high-x-pack-ml-get-data-frame-analytics.html