### PR TITLE
Add resolution rule to allow resolving all deps

### DIFF
--- a/x-pack/plugin/sql/qa/build.gradle
+++ b/x-pack/plugin/sql/qa/build.gradle
@@ -57,6 +57,10 @@ subprojects {
   configurations.testRuntimeClasspath {
     resolutionStrategy.force "org.slf4j:slf4j-api:1.7.25"
   }
+  configurations.testRuntime {
+    // This is also required to make resolveAllDependencies work
+    resolutionStrategy.force "org.slf4j:slf4j-api:1.7.25"
+  }
   dependencies {
     
     /* Since we're a standalone rest test we actually get transitive


### PR DESCRIPTION
Since the `resolveAllDependencies` task resolves all the congfigurations
it can find, this was not caught by our testing, but it's required to be
configuraed specifically.

We should probably cut-over to the new configurations at some point to
avoid problems like this.

Closes elastic/infra#14580