### PR TITLE
Testfixtures allow a single service only

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixtureExtension.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixtureExtension.java
@@ -24,13 +24,13 @@ import org.gradle.api.Project;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
 public class TestFixtureExtension {
 
     private final Project project;
     final NamedDomainObjectContainer<Project> fixtures;
-    final Map<String, String> serviceUseByProject = new HashMap<>();
+    final Map<String, String> serviceToProjectUseMap = new HashMap<>();
 
     public TestFixtureExtension(Project project) {
         this.project = project;
@@ -42,19 +42,19 @@ public class TestFixtureExtension {
     }
 
     public void useFixture(String path) {
-        addFixtureProject(path, globalServiceUsedByProject());
-        serviceUseByProject.put(path, this.project.getPath());
+        addFixtureProject(path);
+        serviceToProjectUseMap.put(path, this.project.getPath());
     }
 
     public void useFixture(String path, String serviceName) {
-        Map<String, String> globalMap = globalServiceUsedByProject();
-        addFixtureProject(path, globalMap);
+        addFixtureProject(path);
         String key = getServiceNameKey(path, serviceName);
-        serviceUseByProject.put(key, this.project.getPath());
+        serviceToProjectUseMap.put(key, this.project.getPath());
 
-        if (globalMap.containsKey(key)) {
+        Optional<String> otherProject = this.findOtherProjectUsingService(key);
+        if (otherProject.isPresent()) {
             throw new GradleException(
-                "Projects " + globalMap.get(key) + " and " + this.project.getPath() + " both claim the "+ serviceName +
+                "Projects " + otherProject.get() + " and " + this.project.getPath() + " both claim the "+ serviceName +
                     " service defined in the docker-compose.yml of " + path + "This is not supported because it breaks " +
                     "running in parallel. Configure dedicated services for each project and use those instead."
             );
@@ -65,16 +65,18 @@ public class TestFixtureExtension {
         return fixtureProjectPath + "::" + serviceName;
     }
 
-    private Map<String, String> globalServiceUsedByProject() {
+    private Optional<String> findOtherProjectUsingService(String serviceName) {
         return this.project.getRootProject().getAllprojects().stream()
-                .filter(p -> p.equals(this.project) == false)
-                .filter(p -> p.getExtensions().findByType(TestFixtureExtension.class) != null)
-                .map(project -> project.getExtensions().getByType(TestFixtureExtension.class))
-                .flatMap(ext -> ext.serviceUseByProject.entrySet().stream())
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            .filter(p -> p.equals(this.project) == false)
+            .filter(p -> p.getExtensions().findByType(TestFixtureExtension.class) != null)
+            .map(project -> project.getExtensions().getByType(TestFixtureExtension.class))
+            .flatMap(ext -> ext.serviceToProjectUseMap.entrySet().stream())
+            .filter(entry -> entry.getKey().equals(serviceName))
+            .map(Map.Entry::getValue)
+            .findAny();
     }
 
-    private void addFixtureProject(String path, Map<String, String> globalMap) {
+    private void addFixtureProject(String path) {
         Project fixtureProject = this.project.findProject(path);
         if (fixtureProject == null) {
             throw new IllegalArgumentException("Could not find test fixture " + fixtureProject);
@@ -86,19 +88,19 @@ public class TestFixtureExtension {
         }
         fixtures.add(fixtureProject);
         // Check for exclusive access
-        if (globalMap.containsKey(path)) {
-            throw new GradleException("Projects " + globalMap.get(path) + " and " + this.project.getPath() + " both " +
+        Optional<String> otherProject = this.findOtherProjectUsingService(path);
+        if (otherProject.isPresent()) {
+            throw new GradleException("Projects " + otherProject.get() + " and " + this.project.getPath() + " both " +
                 "claim all services from " + path + ". This is not supported because it breaks running in parallel. " +
                 "Configure specific services in docker-compose.yml for each and add the service name to `useFixture`"
             );
-
         }
     }
 
-    boolean isServiceInUse(String serviceName, String fixtureProject) {
-        if (serviceUseByProject.containsKey(fixtureProject)) {
+    boolean isServiceRequired(String serviceName, String fixtureProject) {
+        if (serviceToProjectUseMap.containsKey(fixtureProject)) {
             return true;
         }
-        return serviceUseByProject.containsKey(getServiceNameKey(fixtureProject, serviceName));
+        return serviceToProjectUseMap.containsKey(getServiceNameKey(fixtureProject, serviceName));
     }
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixtureExtension.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixtureExtension.java
@@ -96,11 +96,6 @@ public class TestFixtureExtension {
     }
 
     boolean isServiceInUse(String serviceName, String fixtureProject) {
-        if (this.project.getPath().equals(fixtureProject)) {
-            // The fixture project is allowed to access all properties this is sometimes needed to generate additional
-            // resources in post process
-            return true;
-        }
         if (serviceUseByProject.containsKey(fixtureProject)) {
             return true;
         }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixtureExtension.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixtureExtension.java
@@ -49,7 +49,7 @@ public class TestFixtureExtension {
     public void useFixture(String path, String serviceName) {
         Map<String, String> globalMap = globalServiceUsedByProject();
         addFixtureProject(path, globalMap);
-        String key = path + "::" + serviceName;
+        String key = getServiceNameKey(path, serviceName);
         serviceUseByProject.put(key, this.project.getPath());
 
         if (globalMap.containsKey(key)) {
@@ -59,6 +59,10 @@ public class TestFixtureExtension {
                     "running in parallel. Configure dedicated services for each project and use those instead."
             );
         }
+    }
+
+    private String getServiceNameKey(String fixtureProjectPath, String serviceName) {
+        return fixtureProjectPath + "::" + serviceName;
     }
 
     private Map<String, String> globalServiceUsedByProject() {
@@ -91,5 +95,10 @@ public class TestFixtureExtension {
         }
     }
 
-
+    boolean isServiceInUse(String serviceName, String fixtureProject) {
+        if (serviceUseByProject.containsKey(fixtureProject)) {
+            return true;
+        }
+        return serviceUseByProject.containsKey(getServiceNameKey(fixtureProject, serviceName));
+    }
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixtureExtension.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixtureExtension.java
@@ -96,6 +96,11 @@ public class TestFixtureExtension {
     }
 
     boolean isServiceInUse(String serviceName, String fixtureProject) {
+        if (this.project.getPath().equals(fixtureProject)) {
+            // The fixture project is allowed to access all properties this is sometimes needed to generate additional
+            // resources in post process
+            return true;
+        }
         if (serviceUseByProject.containsKey(fixtureProject)) {
             return true;
         }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
@@ -165,7 +165,9 @@ public class TestFixturesPlugin implements Plugin<Project> {
         );
     }
 
-    private void configureServiceInfoForTask(Task task, Project fixtureProject, boolean enableFilter, BiConsumer<String, Integer> consumer) {
+    private void configureServiceInfoForTask(
+        Task task, Project fixtureProject, boolean enableFilter, BiConsumer<String, Integer> consumer
+    ) {
         // Configure ports for the tests as system properties.
         // We only know these at execution time so we need to do it in doFirst
         TestFixtureExtension extension = task.getProject().getExtensions().getByType(TestFixtureExtension.class);

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
@@ -104,6 +104,7 @@ public class TestFixturesPlugin implements Plugin<Project> {
                 configureServiceInfoForTask(
                     postProcessFixture,
                     project,
+                    false,
                     (name, port) -> postProcessFixture.getExtensions()
                         .getByType(ExtraPropertiesExtension.class).set(name, port)
                 );
@@ -142,6 +143,7 @@ public class TestFixturesPlugin implements Plugin<Project> {
                 configureServiceInfoForTask(
                     task,
                     fixtureProject,
+                    true,
                     (name, host) ->
                         task.getExtensions().getByType(SystemPropertyCommandLineArgumentProvider.class).systemProperty(name, host)
                 );
@@ -163,7 +165,7 @@ public class TestFixturesPlugin implements Plugin<Project> {
         );
     }
 
-    private void configureServiceInfoForTask(Task task, Project fixtureProject, BiConsumer<String, Integer> consumer) {
+    private void configureServiceInfoForTask(Task task, Project fixtureProject, boolean enableFilter, BiConsumer<String, Integer> consumer) {
         // Configure ports for the tests as system properties.
         // We only know these at execution time so we need to do it in doFirst
         TestFixtureExtension extension = task.getProject().getExtensions().getByType(TestFixtureExtension.class);
@@ -172,7 +174,9 @@ public class TestFixturesPlugin implements Plugin<Project> {
                          public void execute(Task theTask) {
                              fixtureProject.getExtensions().getByType(ComposeExtension.class).getServicesInfos()
                                  .entrySet().stream()
-                                 .filter(entry -> extension.isServiceInUse(entry.getKey(), fixtureProject.getPath()))
+                                 .filter(entry -> enableFilter == false||
+                                     extension.isServiceInUse(entry.getKey(), fixtureProject.getPath())
+                                 )
                                  .forEach(entry -> {
                                      String service = entry.getKey();
                                      ServiceInfo infos = entry.getValue();

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
@@ -58,9 +58,6 @@ public class TestFixturesPlugin implements Plugin<Project> {
         ext.set("testFixturesDir", testfixturesDir);
 
         if (project.file(DOCKER_COMPOSE_YML).exists()) {
-            // the project that defined a test fixture can also use it
-            extension.fixtures.add(project);
-
             Task buildFixture = project.getTasks().create("buildFixture");
             Task pullFixture = project.getTasks().create("pullFixture");
             Task preProcessFixture = project.getTasks().create("preProcessFixture");

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/TestFixturesPlugin.java
@@ -176,8 +176,8 @@ public class TestFixturesPlugin implements Plugin<Project> {
                          public void execute(Task theTask) {
                              fixtureProject.getExtensions().getByType(ComposeExtension.class).getServicesInfos()
                                  .entrySet().stream()
-                                 .filter(entry -> enableFilter == false||
-                                     extension.isServiceInUse(entry.getKey(), fixtureProject.getPath())
+                                 .filter(entry -> enableFilter == false ||
+                                     extension.isServiceRequired(entry.getKey(), fixtureProject.getPath())
                                  )
                                  .forEach(entry -> {
                                      String service = entry.getKey();

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -6,6 +6,8 @@ import org.elasticsearch.gradle.testfixtures.TestFixturesPlugin
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.test.fixtures'
 
+testFixtures.useFixture()
+
 configurations {
   dockerPlugins
   dockerSource

--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -37,7 +37,7 @@ versions << [
   'hadoop2': '2.8.1'
 ]
 
-testFixtures.useFixture ":test:fixtures:krb5kdc-fixture"
+testFixtures.useFixture ":test:fixtures:krb5kdc-fixture", "hdfs"
 
 configurations {
   hdfsFixture

--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -139,6 +139,9 @@ task thirdPartyTest(type: Test) {
 
 if (useFixture) {
   apply plugin: 'elasticsearch.test.fixtures'
+
+  testFixtures.useFixture()
+
   task writeDockerFile {
     File minioDockerfile = new File("${project.buildDir}/minio-docker/Dockerfile")
     outputs.file(minioDockerfile)

--- a/x-pack/qa/kerberos-tests/build.gradle
+++ b/x-pack/qa/kerberos-tests/build.gradle
@@ -1,13 +1,12 @@
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.nio.file.Files
 
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 apply plugin: 'elasticsearch.test.fixtures'
 
-testFixtures.useFixture ":test:fixtures:krb5kdc-fixture"
+testFixtures.useFixture ":test:fixtures:krb5kdc-fixture", "peppa"
 
 dependencies {
     testCompile project(':x-pack:plugin:core')

--- a/x-pack/qa/oidc-op-tests/build.gradle
+++ b/x-pack/qa/oidc-op-tests/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     }
     testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
 }
-testFixtures.useFixture ":x-pack:test:idp-fixture"
+testFixtures.useFixture ":x-pack:test:idp-fixture", "oidc-provider"
 
 String ephemeralPort;
 task setupPorts {

--- a/x-pack/qa/openldap-tests/build.gradle
+++ b/x-pack/qa/openldap-tests/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     }
 }
 
-testFixtures.useFixture ":x-pack:test:idp-fixture"
+testFixtures.useFixture ":x-pack:test:idp-fixture", "openldap"
 
 Project idpFixtureProject = xpackProject("test:idp-fixture")
 String outputDir = "${project.buildDir}/generated-resources/${project.name}"

--- a/x-pack/qa/third-party/active-directory/build.gradle
+++ b/x-pack/qa/third-party/active-directory/build.gradle
@@ -15,7 +15,7 @@ processTestResources {
 
 compileTestJava.options.compilerArgs << "-Xlint:-rawtypes,-unchecked"
 
-// we have to repeat these patterns because the security test resources are effectively in the src of this project
+// we have to repeat these patterns because the security test resources are effectively in the src of this p
 forbiddenPatterns {
   exclude '**/*.key'
   exclude '**/*.p12'

--- a/x-pack/snapshot-tool/qa/s3/build.gradle
+++ b/x-pack/snapshot-tool/qa/s3/build.gradle
@@ -50,6 +50,8 @@ task thirdPartyTest (type: Test) {
 if (useS3Fixture) {
     apply plugin: 'elasticsearch.test.fixtures'
 
+    testFixtures.useFixture()
+
     task writeDockerFile {
         File minioDockerfile = new File("${project.buildDir}/minio-docker/Dockerfile")
         outputs.file(minioDockerfile)


### PR DESCRIPTION
This PR  adds some restrictions around testfixtures to make sure the same service ( as defiend in `docker-compose.yml` ) is not shared between multiple projects. 
Sharing would break running with `--parallel`.

Projects can still share fixtures as long as each has it;s own service within. 
This is still useful to share some of the setup and configuration code of the fixture. 

Project now also have to specify a service name when calling `useCluster` to refer to a specific service. 
If this is not the case all services will be claimed and the fixture can't be shared. 
For this reason fixtures have to explicitly specify if they are using themselves ( fixture and  tests in the same project ).