### PR TITLE
Update bundled JDK to JDK 13

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -1,8 +1,8 @@
 elasticsearch     = 8.0.0
 lucene            = 8.2.0
 
-bundled_jdk_vendor = adoptopenjdk
-bundled_jdk = 12.0.2+10
+bundled_jdk_vendor = openjdk
+bundled_jdk = 13+33@5b8a42f3905b406298b72d750b6919f6
 
 # optional dependencies
 spatial4j         = 0.7


### PR DESCRIPTION
With the next minor release of Elasticsearch we will drop support for JDK 12 and bump to JDK 13. While we want to use AdoptOpenJDK as the bundled JDK, we are waiting for a release there. This commit moves to OpenJDK 13 for now, and we will move to AdoptOpenJDK 13 as soon as its available. Since macOS Catalina is delayed until October, we have some time to update this.
