### PR TITLE
Add node setting for disabling SLM (#46794)

### DIFF
--- a/docs/reference/ilm/apis/slm-api.asciidoc
+++ b/docs/reference/ilm/apis/slm-api.asciidoc
@@ -14,7 +14,9 @@ policies, a way to retrieve policies, and a way to delete unwanted policies, as
 well as a separate API for immediately invoking a snapshot based on a policy.
 
 Since SLM falls under the same category as ILM, it is stopped and started by
-using the <<start-stop-ilm,start and stop>> ILM APIs.
+using the <<start-stop-ilm,start and stop>> ILM APIs. It is, however, managed
+by a different enable setting. To disable SLM's functionality, set the cluster
+setting `xpack.slm.enabled` to `false` in elasticsearch.yml.
 
 [[slm-api-put]]
 === Put Snapshot Lifecycle Policy API

--- a/docs/reference/settings/ilm-settings.asciidoc
+++ b/docs/reference/settings/ilm-settings.asciidoc
@@ -2,6 +2,15 @@
 [[ilm-settings]]
 === {ilm-cap} settings
 
+These are the settings available for configuring Index Lifecycle Management
+
+==== Cluster level settings
+
+`xpack.ilm.enabled`::
+Whether ILM is enabled or disabled, setting this to `false` disables any
+ILM REST API endpoints and functionality. Defaults to `true`.
+
+==== Index level settings
 These index-level {ilm-init} settings are typically configured through index
 templates. For more information, see <<ilm-gs-create-policy>>.
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
@@ -92,6 +92,12 @@ public class XPackSettings {
     public static final Setting<Boolean> INDEX_LIFECYCLE_ENABLED = Setting.boolSetting("xpack.ilm.enabled", true,
         Setting.Property.NodeScope);
 
+    /**
+     * Setting for enabling or disabling the snapshot lifecycle extension. Defaults to true.
+     */
+    public static final Setting<Boolean> SNAPSHOT_LIFECYCLE_ENABLED = Setting.boolSetting("xpack.slm.enabled", true,
+        Setting.Property.NodeScope);
+
     /** Setting for enabling or disabling TLS. Defaults to false. */
     public static final Setting<Boolean> TRANSPORT_SSL_ENABLED = Setting.boolSetting("xpack.security.transport.ssl.enabled", false,
             Property.NodeScope);
@@ -255,6 +261,7 @@ public class XPackSettings {
         settings.add(ROLLUP_ENABLED);
         settings.add(PASSWORD_HASHING_ALGORITHM);
         settings.add(INDEX_LIFECYCLE_ENABLED);
+        settings.add(SNAPSHOT_LIFECYCLE_ENABLED);
         settings.add(DATA_FRAME_ENABLED);
         settings.add(FLATTENED_ENABLED);
         settings.add(VECTORS_ENABLED);


### PR DESCRIPTION
This adds the `xpack.slm.enabled` setting to allow disabling of SLM
functionality as well as its HTTP API endpoints.

Relates to #38461

Backport of #46794.
