### PR TITLE
Add node setting for disabling SLM (#46794)

### DIFF
--- a/docs/reference/ilm/apis/slm-api.asciidoc
+++ b/docs/reference/ilm/apis/slm-api.asciidoc
@@ -14,7 +14,9 @@ policies, a way to retrieve policies, and a way to delete unwanted policies, as
 well as a separate API for immediately invoking a snapshot based on a policy.
 
 Since SLM falls under the same category as ILM, it is stopped and started by
-using the <<start-stop-ilm,start and stop>> ILM APIs.
+using the <<start-stop-ilm,start and stop>> ILM APIs. It is, however, managed
+by a different enable setting. To disable SLM's functionality, set the cluster
+setting `xpack.slm.enabled` to `false` in elasticsearch.yml.
 
 [[slm-api-put]]
 === Put Snapshot Lifecycle Policy API

--- a/docs/reference/settings/ilm-settings.asciidoc
+++ b/docs/reference/settings/ilm-settings.asciidoc
@@ -2,6 +2,15 @@
 [[ilm-settings]]
 === {ilm-cap} settings
 
+These are the settings available for configuring Index Lifecycle Management
+
+==== Cluster level settings
+
+`xpack.ilm.enabled`::
+Whether ILM is enabled or disabled, setting this to `false` disables any
+ILM REST API endpoints and functionality. Defaults to `true`.
+
+==== Index level settings
 These index-level {ilm-init} settings are typically configured through index
 templates. For more information, see <<ilm-gs-create-policy>>.
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
@@ -92,6 +92,12 @@ public class XPackSettings {
     public static final Setting<Boolean> INDEX_LIFECYCLE_ENABLED = Setting.boolSetting("xpack.ilm.enabled", true,
         Setting.Property.NodeScope);
 
+    /**
+     * Setting for enabling or disabling the snapshot lifecycle extension. Defaults to true.
+     */
+    public static final Setting<Boolean> SNAPSHOT_LIFECYCLE_ENABLED = Setting.boolSetting("xpack.slm.enabled", true,
+        Setting.Property.NodeScope);
+
     /** Setting for enabling or disabling TLS. Defaults to false. */
     public static final Setting<Boolean> TRANSPORT_SSL_ENABLED = Setting.boolSetting("xpack.security.transport.ssl.enabled", false,
             Property.NodeScope);
@@ -255,6 +261,7 @@ public class XPackSettings {
         settings.add(ROLLUP_ENABLED);
         settings.add(PASSWORD_HASHING_ALGORITHM);
         settings.add(INDEX_LIFECYCLE_ENABLED);
+        settings.add(SNAPSHOT_LIFECYCLE_ENABLED);
         settings.add(DATA_FRAME_ENABLED);
         settings.add(FLATTENED_ENABLED);
         settings.add(VECTORS_ENABLED);

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
@@ -108,7 +108,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 
-import static java.util.Collections.emptyList;
 import static org.elasticsearch.xpack.core.ClientHelper.INDEX_LIFECYCLE_ORIGIN;
 
 public class IndexLifecycle extends Plugin implements ActionPlugin {
@@ -116,12 +115,14 @@ public class IndexLifecycle extends Plugin implements ActionPlugin {
     private final SetOnce<SnapshotLifecycleService> snapshotLifecycleService = new SetOnce<>();
     private final SetOnce<SnapshotHistoryStore> snapshotHistoryStore = new SetOnce<>();
     private Settings settings;
-    private boolean enabled;
+    private boolean ilmEnabled;
+    private boolean slmEnabled;
     private boolean transportClientMode;
 
     public IndexLifecycle(Settings settings) {
         this.settings = settings;
-        this.enabled = XPackSettings.INDEX_LIFECYCLE_ENABLED.get(settings);
+        this.ilmEnabled = XPackSettings.INDEX_LIFECYCLE_ENABLED.get(settings);
+        this.slmEnabled = XPackSettings.SNAPSHOT_LIFECYCLE_ENABLED.get(settings);
         this.transportClientMode = XPackPlugin.transportClientMode(settings);
     }
 
@@ -157,18 +158,25 @@ public class IndexLifecycle extends Plugin implements ActionPlugin {
                                                ResourceWatcherService resourceWatcherService, ScriptService scriptService,
                                                NamedXContentRegistry xContentRegistry, Environment environment,
                                                NodeEnvironment nodeEnvironment, NamedWriteableRegistry namedWriteableRegistry) {
-        if (enabled == false || transportClientMode) {
-            return emptyList();
+        if (transportClientMode) {
+            return Collections.emptyList();
         }
-        indexLifecycleInitialisationService.set(new IndexLifecycleService(settings, client, clusterService, threadPool,
+        final List<Object> components = new ArrayList<>();
+        if (ilmEnabled) {
+            indexLifecycleInitialisationService.set(new IndexLifecycleService(settings, client, clusterService, threadPool,
                 getClock(), System::currentTimeMillis, xContentRegistry));
-        SnapshotLifecycleTemplateRegistry templateRegistry = new SnapshotLifecycleTemplateRegistry(settings, clusterService, threadPool,
-            client, xContentRegistry);
-        snapshotHistoryStore.set(new SnapshotHistoryStore(settings, new OriginSettingClient(client, INDEX_LIFECYCLE_ORIGIN), clusterService
-        ));
-        snapshotLifecycleService.set(new SnapshotLifecycleService(settings,
-            () -> new SnapshotLifecycleTask(client, clusterService, snapshotHistoryStore.get()), clusterService, getClock()));
-        return Arrays.asList(indexLifecycleInitialisationService.get(), snapshotLifecycleService.get(), snapshotHistoryStore.get());
+            components.add(indexLifecycleInitialisationService.get());
+        }
+        if (slmEnabled) {
+            SnapshotLifecycleTemplateRegistry templateRegistry = new SnapshotLifecycleTemplateRegistry(settings, clusterService, threadPool,
+                client, xContentRegistry);
+            snapshotHistoryStore.set(new SnapshotHistoryStore(settings, new OriginSettingClient(client, INDEX_LIFECYCLE_ORIGIN),
+                clusterService));
+            snapshotLifecycleService.set(new SnapshotLifecycleService(settings,
+                () -> new SnapshotLifecycleTask(client, clusterService, snapshotHistoryStore.get()), clusterService, getClock()));
+            components.addAll(Arrays.asList(snapshotLifecycleService.get(), snapshotHistoryStore.get()));
+        }
+        return components;
     }
 
     @Override
@@ -204,10 +212,9 @@ public class IndexLifecycle extends Plugin implements ActionPlugin {
     public List<RestHandler> getRestHandlers(Settings settings, RestController restController, ClusterSettings clusterSettings,
             IndexScopedSettings indexScopedSettings, SettingsFilter settingsFilter, IndexNameExpressionResolver indexNameExpressionResolver,
             Supplier<DiscoveryNodes> nodesInCluster) {
-        if (enabled == false) {
-            return emptyList();
-        }
-        return Arrays.asList(
+        List<RestHandler> handlers = new ArrayList<>();
+        if (ilmEnabled) {
+            handlers.addAll(Arrays.asList(
                 new RestPutLifecycleAction(restController),
                 new RestGetLifecycleAction(restController),
                 new RestDeleteLifecycleAction(restController),
@@ -217,21 +224,25 @@ public class IndexLifecycle extends Plugin implements ActionPlugin {
                 new RestRetryAction(restController),
                 new RestStopAction(restController),
                 new RestStartILMAction(restController),
-                new RestGetStatusAction(restController),
-                // Snapshot lifecycle actions
+                new RestGetStatusAction(restController)
+            ));
+        }
+        if (slmEnabled) {
+            handlers.addAll(Arrays.asList(
                 new RestPutSnapshotLifecycleAction(restController),
                 new RestDeleteSnapshotLifecycleAction(restController),
                 new RestGetSnapshotLifecycleAction(restController),
                 new RestExecuteSnapshotLifecycleAction(restController)
-            );
+            ));
+        }
+        return handlers;
     }
 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
-        if (enabled == false) {
-            return emptyList();
-        }
-        return Arrays.asList(
+        List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> actions = new ArrayList<>();
+        if (ilmEnabled) {
+            actions.addAll(Arrays.asList(
                 new ActionHandler<>(PutLifecycleAction.INSTANCE, TransportPutLifecycleAction.class),
                 new ActionHandler<>(GetLifecycleAction.INSTANCE, TransportGetLifecycleAction.class),
                 new ActionHandler<>(DeleteLifecycleAction.INSTANCE, TransportDeleteLifecycleAction.class),
@@ -241,12 +252,18 @@ public class IndexLifecycle extends Plugin implements ActionPlugin {
                 new ActionHandler<>(RetryAction.INSTANCE, TransportRetryAction.class),
                 new ActionHandler<>(StartILMAction.INSTANCE, TransportStartILMAction.class),
                 new ActionHandler<>(StopILMAction.INSTANCE, TransportStopILMAction.class),
-                new ActionHandler<>(GetStatusAction.INSTANCE, TransportGetStatusAction.class),
-                // Snapshot lifecycle actions
+                new ActionHandler<>(GetStatusAction.INSTANCE, TransportGetStatusAction.class)
+            ));
+        }
+        if (slmEnabled) {
+            actions.addAll(Arrays.asList(
                 new ActionHandler<>(PutSnapshotLifecycleAction.INSTANCE, TransportPutSnapshotLifecycleAction.class),
                 new ActionHandler<>(DeleteSnapshotLifecycleAction.INSTANCE, TransportDeleteSnapshotLifecycleAction.class),
                 new ActionHandler<>(GetSnapshotLifecycleAction.INSTANCE, TransportGetSnapshotLifecycleAction.class),
-                new ActionHandler<>(ExecuteSnapshotLifecycleAction.INSTANCE, TransportExecuteSnapshotLifecycleAction.class));
+                new ActionHandler<>(ExecuteSnapshotLifecycleAction.INSTANCE, TransportExecuteSnapshotLifecycleAction.class)
+            ));
+        }
+        return actions;
     }
 
     @Override


### PR DESCRIPTION
This adds the `xpack.slm.enabled` setting to allow disabling of SLM
functionality as well as its HTTP API endpoints.

Relates to #38461

Backport of #46794.