### PR TITLE
Fix testHistoryRetention (#46799)

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -863,7 +863,8 @@ public class IndexRecoveryIT extends ESIntegTestCase {
         final String indexName = "test";
         client().admin().indices().prepareCreate(indexName).setSettings(Settings.builder()
             .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
-            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 2)).get();
+            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 2)
+            .put(IndexSettings.FILE_BASED_RECOVERY_THRESHOLD_SETTING.getKey(), 1.0)).get();
         ensureGreen(indexName);
 
         // Perform some replicated operations so the replica isn't simply empty, because ops-based recovery isn't better in that case


### PR DESCRIPTION
Suppress the reasonable-history check in this test to guarantee we're always getting ops based recovery even after a background sync.

Closes #45953

Co-Authored-By: David Turner <david.turner@elastic.co>

backport of #46799 