### PR TITLE
[HLRC] Send min_score as query string parameter to the count API

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -501,6 +501,9 @@ final class RequestConverters {
         if (countRequest.terminateAfter() != 0){
             params.withTerminateAfter(countRequest.terminateAfter());
         }
+        if (countRequest.minScore() != null){
+            params.putParam("min_score", String.valueOf(countRequest.minScore()));
+        }
         request.addParameters(params.asMap());
         request.setEntity(createEntity(countRequest.source(), REQUEST_BODY_CONTENT_TYPE));
         return request;

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/core/CountRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/core/CountRequest.java
@@ -44,6 +44,7 @@ public final class CountRequest extends ActionRequest implements IndicesRequest.
     private SearchSourceBuilder searchSourceBuilder;
     private IndicesOptions indicesOptions = DEFAULT_INDICES_OPTIONS;
     private int terminateAfter = SearchContext.DEFAULT_TERMINATE_AFTER;
+    private Float minScore;
 
     public CountRequest() {
         this.searchSourceBuilder = new SearchSourceBuilder();
@@ -158,11 +159,11 @@ public final class CountRequest extends ActionRequest implements IndicesRequest.
     }
 
     public Float minScore() {
-        return this.searchSourceBuilder.minScore();
+        return minScore;
     }
 
     public CountRequest minScore(Float minScore) {
-        this.searchSourceBuilder.minScore(minScore);
+        this.minScore = minScore;
         return this;
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
@@ -1191,9 +1191,13 @@ public class RequestConvertersTests extends ESTestCase {
             countRequest.preference(randomAlphaOfLengthBetween(3, 10));
             expectedParams.put("preference", countRequest.preference());
         }
-        if (randomBoolean()){
+        if (randomBoolean()) {
             countRequest.terminateAfter(randomIntBetween(0, Integer.MAX_VALUE));
             expectedParams.put("terminate_after", String.valueOf(countRequest.terminateAfter()));
+        }
+        if (randomBoolean()) {
+            countRequest.minScore((float) randomIntBetween(1, 10));
+            expectedParams.put("min_score", String.valueOf(countRequest.minScore()));
         }
     }
 


### PR DESCRIPTION
Prior to this commit min_score was sent as request body parameter
(via SearchSourceBuilder), which is not possible in the count api.

Similar to #46474