### PR TITLE
[DOCS] Add redirect for SLM API docs

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -834,3 +834,7 @@ See <<ccs-works>>.
 [role="exclude",id="administer-elasticsearch"]
 === Administering {es}
 See <<high-availability>>.
+
+[role="exclude",id="slm-api"]
+=== Snapshot lifecycle management API
+See <<snapshot-lifecycle-management-api>>.

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_stats.json
@@ -1,7 +1,7 @@
 {
   "slm.get_stats":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-get-stats.html"
     },
     "stability":"stable",
     "url":{


### PR DESCRIPTION
### Changes

- Updates link for `slm.get_stats.json`.
- Adds a redirect for the removed `slm-api` anchor.