### PR TITLE
Fix snapshot_restore_exception in Docs Tests

### DIFF
--- a/docs/reference/indices/recovery.asciidoc
+++ b/docs/reference/indices/recovery.asciidoc
@@ -32,6 +32,7 @@ PUT /_snapshot/my_repository
 
 # snapshot the index
 PUT /_snapshot/my_repository/snap_1?wait_for_completion=true
+{"indices": "index1"}
 
 # delete the index
 DELETE index1


### PR DESCRIPTION
We should only snapshot the index we're going to
restore in the next step. Otherwise, we will
potentially not get the correct response or
fail restoring outright due to internal indices
getting created concurrently when running against
the x-pack distribution.

Closes #46844
