### PR TITLE
[DOCS] Reformats explain API

### DIFF
--- a/docs/reference/search/explain.asciidoc
+++ b/docs/reference/search/explain.asciidoc
@@ -7,6 +7,11 @@ query.
 [source,console]
 --------------------------------------------------
 GET /twitter/_explain/0
+{
+      "query" : {
+        "match" : { "message" : "elasticsearch" }
+      }
+}
 --------------------------------------------------
 // TEST[setup:twitter]
 

--- a/docs/reference/search/explain.asciidoc
+++ b/docs/reference/search/explain.asciidoc
@@ -19,7 +19,7 @@ GET /twitter/_explain/0
 [[sample-api-request]]
 ==== {api-request-title}
 
-`GET /<index>/_explain/<id>` +
+`GET /<index>/_explain/<id>`
 `POST /<index>/_explain/<id>`
 
 [[sample-api-desc]]

--- a/docs/reference/search/explain.asciidoc
+++ b/docs/reference/search/explain.asciidoc
@@ -1,16 +1,79 @@
 [[search-explain]]
 === Explain API
 
-The explain api computes a score explanation for a query and a specific
+Returns information about why a specific document matches (or doesn't match) a 
+query.
+
+[source,console]
+--------------------------------------------------
+GET /twitter/_explain/0
+--------------------------------------------------
+// TEST[setup:twitter]
+
+
+[[sample-api-request]]
+==== {api-request-title}
+
+`GET /<index>/_explain/<id>` +
+`POST /<index>/_explain/<id>`
+
+[[sample-api-desc]]
+==== {api-description-title}
+
+The explain API computes a score explanation for a query and a specific
 document. This can give useful feedback whether a document matches or
 didn't match a specific query.
 
 Note that a single index must be provided to the `index` parameter.
 
-[float]
-==== Usage
 
-Full query example:
+[[sample-api-path-params]]
+==== {api-path-parms-title}
+
+`id`::
+  (Required, integer) Defines the document ID.
+  
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+
+
+[[sample-api-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=analyzer]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=analyze_wildcard]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=default_operator]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=df]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=lenient]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=preference]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=search-q]
+
+`stored_fields`::
+  (Optional, string) A comma-separated list of stored fields to return in the 
+  response.
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index-routing]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=source]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=source_excludes]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=source_includes]
+
+
+[[sample-api-request-body]]
+==== {api-request-body-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=query]
+
+
+[[sample-api-example]]
+==== {api-examples-title}
 
 [source,console]
 --------------------------------------------------
@@ -23,7 +86,8 @@ GET /twitter/_explain/0
 --------------------------------------------------
 // TEST[setup:twitter]
 
-This will yield the following result:
+
+The API returns the following response:
 
 [source,console-result]
 --------------------------------------------------
@@ -99,9 +163,10 @@ This will yield the following result:
 }
 --------------------------------------------------
 
-There is also a simpler way of specifying the query via the `q`
-parameter. The specified `q` parameter value is then parsed as if the
-`query_string` query was used. Example usage of the `q` parameter in the
+
+There is also a simpler way of specifying the query via the `q` parameter. The 
+specified `q` parameter value is then parsed as if the `query_string` query was 
+used. Example usage of the `q` parameter in the
 explain api:
 
 [source,console]
@@ -110,54 +175,5 @@ GET /twitter/_explain/0?q=message:search
 --------------------------------------------------
 // TEST[setup:twitter]
 
-This will yield the same result as the previous request.
 
-[float]
-==== All parameters:
-
-[horizontal]
-`_source`::
-
-    Set to `true` to retrieve the `_source` of the document explained. You can also
-    retrieve part of the document by using `_source_includes` & `_source_excludes` (see <<get-source-filtering,Get API>> for more details)
-
-`stored_fields`::
-    Allows to control which stored fields to return as part of the
-    document explained.
-
-`routing`::
-    Controls the routing in the case the routing was used
-    during indexing.
-
-`parent`::
-    Same effect as setting the routing parameter.
-
-`preference`::
-    Controls on which shard the explain is executed.
-
-`source`::
-    Allows the data of the request to be put in the query
-    string of the url.
-
-`q`::
-    The query string (maps to the query_string query).
-
-`df`::
-    The default field to use when no field prefix is defined within
-    the query.
-
-`analyzer`::
-    The analyzer name to be used when analyzing the query
-    string. Defaults to the default search analyzer.
-
-`analyze_wildcard`::
-    Should wildcard and prefix queries be analyzed or
-    not. Defaults to false.
-
-`lenient`::
-    If set to true will cause format based failures (like
-    providing text to a numeric field) to be ignored. Defaults to false.
-
-`default_operator`::
-    The default operator to be used, can be AND or
-    OR. Defaults to OR.
+The API returns the same result as the previous request.

--- a/docs/reference/search/explain.asciidoc
+++ b/docs/reference/search/explain.asciidoc
@@ -172,7 +172,7 @@ The API returns the following response:
 There is also a simpler way of specifying the query via the `q` parameter. The 
 specified `q` parameter value is then parsed as if the `query_string` query was 
 used. Example usage of the `q` parameter in the
-explain api:
+explain API:
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/search/explain.asciidoc
+++ b/docs/reference/search/explain.asciidoc
@@ -29,16 +29,21 @@ The explain API computes a score explanation for a query and a specific
 document. This can give useful feedback whether a document matches or
 didn't match a specific query.
 
-Note that a single index must be provided to the `index` parameter.
-
 
 [[sample-api-path-params]]
 ==== {api-path-parms-title}
 
-`id`::
+`<id>`::
   (Required, integer) Defines the document ID.
   
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+`<index>`::
++
+--
+(Required, string)
+Index names used to limit the request.
+
+Only a single index name can be provided to this parameter.
+--
 
 
 [[sample-api-query-params]]


### PR DESCRIPTION
Relates to elastic/docs#937 and https://github.com/elastic/elasticsearch/issues/45621.

This PR updates the explain API to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc).

Resources:
* [Explain API spec](https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/explain.json)
* [Explain API doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-explain.html)