### PR TITLE
Bundle AdoptOpenJDK 13

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -1,8 +1,8 @@
 elasticsearch     = 8.0.0
 lucene            = 8.2.0
 
-bundled_jdk_vendor = openjdk
-bundled_jdk = 13+33@5b8a42f3905b406298b72d750b6919f6
+bundled_jdk_vendor = adoptopenjdk
+bundled_jdk = 13+33
 
 # optional dependencies
 spatial4j         = 0.7


### PR DESCRIPTION
This commit switches to use AdoptOpenJDK 13 for bundling the JDK, instead of Oracle OpenJDK 13.
