### PR TITLE
[DOCS] Reformats Field capabilities API

### DIFF
--- a/docs/reference/search/field-caps.asciidoc
+++ b/docs/reference/search/field-caps.asciidoc
@@ -5,7 +5,7 @@ Allows you to retrieve the capabilities of fields among multiple indices.
 
 [source,console]
 --------------------------------------------------
-GET _field_caps?fields=rating
+GET /_field_caps?fields=rating
 --------------------------------------------------
 
 

--- a/docs/reference/search/field-caps.asciidoc
+++ b/docs/reference/search/field-caps.asciidoc
@@ -1,16 +1,89 @@
 [[search-field-caps]]
 === Field Capabilities API
 
-The field capabilities API allows to retrieve the capabilities of fields among multiple indices.
-
-The field capabilities API by default executes on all indices:
+Allows you to retrieve the capabilities of fields among multiple indices.
 
 [source,console]
 --------------------------------------------------
 GET _field_caps?fields=rating
 --------------------------------------------------
 
-The request can also be restricted to specific indices:
+
+[[sample-api-request]]
+==== {api-request-title}
+
+`GET /_field_caps` +
+`POST /_field_caps` +
+`GET /<index>/_field_caps` +
+`POST /<index>/_field_caps`
+
+
+[[sample-api-desc]]
+==== {api-description-title}
+
+
+The Field Capabilities API returns the information about the capabilities of 
+fields among multiple indices.
+
+This API executes on all indices by default.
+
+
+[[sample-api-path-params]]
+==== {api-path-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+
+
+[[sample-api-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
++
+--
+Defaults to `open`.
+--
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=fields]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+
+`include_unmapped`::
+  (Optional, boolean) If `true`, unmapped fields are included in the response. 
+  Defaults to `false`.
+
+
+[[sample-api-response-body]]
+==== {api-response-body-title}
+  
+The field capabilities API returns the following information per field:
+
+
+`searchable`::
+  Whether this field is indexed for search on all indices.
+
+`aggregatable`::
+  Whether this field can be aggregated on all indices.
+
+`indices`::
+  The list of indices where this field has the same type, or null if all indices 
+  have the same type for the field.
+
+`non_searchable_indices`::
+  The list of indices where this field is not searchable, or null if all indices 
+  have the same definition for the field.
+
+`non_aggregatable_indices`::
+  The list of indices where this field is not aggregatable, or null if all 
+  indices have the same definition for the field.
+
+
+[[sample-api-example]]
+==== {api-examples-title}
+
+
+The request can be restricted to specific indices:
 
 [source,console]
 --------------------------------------------------
@@ -18,53 +91,18 @@ GET twitter/_field_caps?fields=rating
 --------------------------------------------------
 // TEST[setup:twitter]
 
-Supported request options:
 
-[horizontal]
-`fields`::  A list of fields to compute stats for. The field name supports wildcard notation. For example, using `text_*`
-            will cause all fields that match the expression to be returned.
-
-[float]
-==== Field Capabilities
-
-The field capabilities API returns the following information per field:
-
-[horizontal]
-`searchable`::
-
-Whether this field is indexed for search on all indices.
-
-`aggregatable`::
-
-Whether this field can be aggregated on all indices.
-
-`indices`::
-
-The list of indices where this field has the same type,
-or null if all indices have the same type for the field.
-
-`non_searchable_indices`::
-
-The list of indices where this field is not searchable,
-or null if all indices have the same definition for the field.
-
-`non_aggregatable_indices`::
-
-The list of indices where this field is not aggregatable,
-or null if all indices have the same definition for the field.
-
-
-[float]
-==== Response format
-
-Request:
+The next example API call requests information about the `rating` and the 
+`title` fields:
 
 [source,console]
 --------------------------------------------------
 GET _field_caps?fields=rating,title
 --------------------------------------------------
 
-[source,js]
+The API returns the following response:
+
+[source,console-result]
 --------------------------------------------------
 {
     "indices": ["index1", "index2", "index3", "index4", "index5"],
@@ -93,7 +131,6 @@ GET _field_caps?fields=rating,title
     }
 }
 --------------------------------------------------
-// NOTCONSOLE
 
 <1> The field `rating` is defined as a long in `index1` and `index2`
 and as a `keyword` in `index3` and `index4`.
@@ -101,8 +138,6 @@ and as a `keyword` in `index3` and `index4`.
 <3> The field `rating` is not searchable in `index4`.
 <4> The field `title` is defined as `text` in all indices.
 
-[float]
-==== Unmapped fields
 
 By default unmapped fields are ignored. You can include them in the response by
 adding a parameter called `include_unmapped` in the request:
@@ -115,7 +150,7 @@ GET _field_caps?fields=rating,title&include_unmapped
 In which case the response will contain an entry for each field that is present in
 some indices but not all:
 
-[source,js]
+[source,console-result]
 --------------------------------------------------
 {
     "indices": ["index1", "index2", "index3"],
@@ -154,7 +189,6 @@ some indices but not all:
     }
 }
 --------------------------------------------------
-// NOTCONSOLE
 
 <1> The `rating` field is unmapped` in `index5`.
 <2> The `title` field is unmapped` in `index5`.

--- a/docs/reference/search/field-caps.asciidoc
+++ b/docs/reference/search/field-caps.asciidoc
@@ -58,7 +58,6 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 [[search-field-caps-api-response-body]]
 ==== {api-response-body-title}
   
-The field capabilities API returns the following information per field:
 
 
 `searchable`::

--- a/docs/reference/search/field-caps.asciidoc
+++ b/docs/reference/search/field-caps.asciidoc
@@ -9,32 +9,33 @@ GET _field_caps?fields=rating
 --------------------------------------------------
 
 
-[[sample-api-request]]
+[[search-field-caps-api-request]]
 ==== {api-request-title}
 
 `GET /_field_caps` 
+
 `POST /_field_caps` 
+
 `GET /<index>/_field_caps` 
+
 `POST /<index>/_field_caps`
 
 
-[[sample-api-desc]]
+[[search-field-caps-api-desc]]
 ==== {api-description-title}
 
 
-The Field Capabilities API returns the information about the capabilities of 
+The field capabilities API returns the information about the capabilities of 
 fields among multiple indices.
 
-This API executes on all indices by default.
 
-
-[[sample-api-path-params]]
+[[search-field-caps-api-path-params]]
 ==== {api-path-parms-title}
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
 
 
-[[sample-api-query-params]]
+[[search-field-caps-api-query-params]]
 ==== {api-query-parms-title}
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
@@ -54,7 +55,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
   Defaults to `false`.
 
 
-[[sample-api-response-body]]
+[[search-field-caps-api-response-body]]
 ==== {api-response-body-title}
   
 The field capabilities API returns the following information per field:
@@ -79,7 +80,7 @@ The field capabilities API returns the following information per field:
   indices have the same definition for the field.
 
 
-[[sample-api-example]]
+[[search-field-caps-api-example]]
 ==== {api-examples-title}
 
 
@@ -147,8 +148,8 @@ adding a parameter called `include_unmapped` in the request:
 GET _field_caps?fields=rating,title&include_unmapped
 --------------------------------------------------
 
-In which case the response will contain an entry for each field that is present in
-some indices but not all:
+In which case the response will contain an entry for each field that is present 
+in some indices but not all:
 
 [source,console-result]
 --------------------------------------------------

--- a/docs/reference/search/field-caps.asciidoc
+++ b/docs/reference/search/field-caps.asciidoc
@@ -131,6 +131,7 @@ The API returns the following response:
     }
 }
 --------------------------------------------------
+// TESTRESPONSE[skip:historically skipped]
 
 <1> The field `rating` is defined as a long in `index1` and `index2`
 and as a `keyword` in `index3` and `index4`.
@@ -189,6 +190,7 @@ in some indices but not all:
     }
 }
 --------------------------------------------------
+// TESTRESPONSE[skip:historically skipped
 
 <1> The `rating` field is unmapped` in `index5`.
 <2> The `title` field is unmapped` in `index5`.

--- a/docs/reference/search/field-caps.asciidoc
+++ b/docs/reference/search/field-caps.asciidoc
@@ -12,9 +12,9 @@ GET _field_caps?fields=rating
 [[sample-api-request]]
 ==== {api-request-title}
 
-`GET /_field_caps` +
-`POST /_field_caps` +
-`GET /<index>/_field_caps` +
+`GET /_field_caps` 
+`POST /_field_caps` 
+`GET /<index>/_field_caps` 
 `POST /<index>/_field_caps`
 
 

--- a/docs/reference/search/field-caps.asciidoc
+++ b/docs/reference/search/field-caps.asciidoc
@@ -190,7 +190,7 @@ in some indices but not all:
     }
 }
 --------------------------------------------------
-// TESTRESPONSE[skip:historically skipped
+// TESTRESPONSE[skip:historically skipped]
 
 <1> The `rating` field is unmapped` in `index5`.
 <2> The `title` field is unmapped` in `index5`.


### PR DESCRIPTION
Relates to elastic/docs#937 and https://github.com/elastic/elasticsearch/issues/45621.

This PR updates the field capabilities API to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc).

Resources:
* [Field capabilities API spec](https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/field_caps.json)
* [Field capabilities API doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-field-caps.html)