### PR TITLE
Correcting documentation

### DIFF
--- a/docs/reference/query-dsl/range-query.asciidoc
+++ b/docs/reference/query-dsl/range-query.asciidoc
@@ -175,7 +175,7 @@ GET _search
 --
 Rounds up to the lastest millisecond.
 
-For example, `2014-11-18||/M` rounds up to `2014-11-30T23:59:59.999`, including
+For example, `2014-11-18||/M` rounds up to `2014-11-30T23:59:59.999`, excluding
 the entire month.
 --
 
@@ -184,7 +184,7 @@ the entire month.
 --
 Rounds down to the first millisecond.
 
-For example, `2014-11-18||/M` rounds down to `2014-11-01`, excluding
+For example, `2014-11-18||/M` rounds down to `2014-11-01`, including
 the entire month.
 --
 


### PR DESCRIPTION
 date > `2014-11-18||/M` rounds up to `2014-11-30T23:59:59.999` is excluding the month, not including. 
date > `2014-11-18||/M` rounds down to `2014-11-01` is including the entire month.