### PR TITLE
[DOCS] Remove `lowercase_terms` parm from `term` suggester docs

### DIFF
--- a/docs/reference/search/suggesters/term-suggest.asciidoc
+++ b/docs/reference/search/suggesters/term-suggest.asciidoc
@@ -53,9 +53,6 @@ doesn't take the query into account that is part of request.
 ===== Other term suggest options:
 
 [horizontal]
-`lowercase_terms`::
-    Lowercases the suggest text terms after text analysis.
-
 `max_edits`::
     The maximum edit distance candidate suggestions can
     have in order to be considered as a suggestion. Can only be a value


### PR DESCRIPTION
Removes the `lowercase_terms` parameter from the `term` suggester docs.

Based on tests and a review of the [code](https://github.com/elastic/elasticsearch/blob/master/server/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilder.java#L390), `lowercase_terms` is not a supported parameter.

Closes #46761.