### PR TITLE
Use composition instead of inheritance for extending Gradle plugins

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/DocsTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/DocsTestPlugin.groovy
@@ -21,19 +21,21 @@ package org.elasticsearch.gradle.doc
 import org.elasticsearch.gradle.OS
 import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
-import org.elasticsearch.gradle.test.RestTestPlugin
+import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+
 /**
  * Sets up tests for documentation.
  */
-public class DocsTestPlugin extends RestTestPlugin {
+class DocsTestPlugin implements Plugin<Project> {
 
     @Override
-    public void apply(Project project) {
+    void apply(Project project) {
         project.pluginManager.apply('elasticsearch.testclusters')
         project.pluginManager.apply('elasticsearch.standalone-rest-test')
-        super.apply(project)
+        project.pluginManager.apply('elasticsearch.rest-test')
+
         String distribution = System.getProperty('tests.distribution', 'default')
         // The distribution can be configured with -Dtests.distribution on the command line
         project.testClusters.integTest.testDistribution = distribution.toUpperCase()


### PR DESCRIPTION
Adding capabilities to, or extending Gradle plugins should be done through plugin composition instead of inheritance. There are a few reasons for this:

1. Gradle will ensure that plugin logic is only applied once to a single project if done via the correct APIs but this guarantee goes away when we do things like call `super()`.

2. Build scans will breakdown details per-plugin when individually applied. However, when extending plugins through inheritance all metrics will be attributed to the super-class plugin.

3. APIs like `withPlugin` and `hasPlugin` won't work through the inheritance method since the parent plugin is never actually being "applied". 