### PR TITLE
Add vector function changes to 7.4 migration docs.

### DIFF
--- a/docs/reference/migration/migrate_7_4.asciidoc
+++ b/docs/reference/migration/migrate_7_4.asciidoc
@@ -40,6 +40,12 @@ or sparse_vector) on which a vector function is executed, an error will
 be thrown.
 
 [discrete]
+==== Use float instead of double for query vectors
+Previously, vector functions like `cosineSimilarity` represented the query
+vector as an list of doubles. Now vector functions use floats, which matches
+how the stored document vectors are represented.
+
+[discrete]
 [[breaking_74_snapshots_changes]]
 === Snapshot and Restore changes
 


### PR DESCRIPTION
This note was accidentally omitted in the breaking change #46004.