### PR TITLE
Correct default refresh policy for security APIs

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/security/CreateApiKeyRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/security/CreateApiKeyRequest.java
@@ -46,6 +46,7 @@ public final class CreateApiKeyRequest implements Validatable, ToXContentObject 
      * @param name name for the API key
      * @param roles list of {@link Role}s
      * @param expiration to specify expiration for the API key
+     * @param refreshPolicy refresh policy {@link RefreshPolicy} for the request, defaults to {@link RefreshPolicy#IMMEDIATE}
      */
     public CreateApiKeyRequest(String name, List<Role> roles, @Nullable TimeValue expiration, @Nullable final RefreshPolicy refreshPolicy) {
         if (Strings.hasText(name)) {
@@ -55,7 +56,7 @@ public final class CreateApiKeyRequest implements Validatable, ToXContentObject 
         }
         this.roles = Objects.requireNonNull(roles, "roles may not be null");
         this.expiration = expiration;
-        this.refreshPolicy = (refreshPolicy == null) ? RefreshPolicy.getDefault() : refreshPolicy;
+        this.refreshPolicy = (refreshPolicy == null) ? RefreshPolicy.IMMEDIATE : refreshPolicy;
     }
 
     public String getName() {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/security/DeletePrivilegesRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/security/DeletePrivilegesRequest.java
@@ -48,7 +48,7 @@ public final class DeletePrivilegesRequest implements Validatable {
      *
      * @param application   the name of the application for which the privileges will be deleted
      * @param privileges    the privileges to delete
-     * @param refreshPolicy the refresh policy {@link RefreshPolicy} for the request, defaults to {@link RefreshPolicy#getDefault()}
+     * @param refreshPolicy the refresh policy {@link RefreshPolicy} for the request, defaults to {@link RefreshPolicy#IMMEDIATE}
      */
     public DeletePrivilegesRequest(String application, String[] privileges, @Nullable RefreshPolicy refreshPolicy) {
         if (Strings.hasText(application) == false) {
@@ -59,7 +59,7 @@ public final class DeletePrivilegesRequest implements Validatable {
         }
         this.application = application;
         this.privileges = privileges;
-        this.refreshPolicy = (refreshPolicy == null) ? RefreshPolicy.getDefault() : refreshPolicy;
+        this.refreshPolicy = (refreshPolicy == null) ? RefreshPolicy.IMMEDIATE : refreshPolicy;
     }
 
     public String getApplication() {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/security/DeleteRoleMappingRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/security/DeleteRoleMappingRequest.java
@@ -37,14 +37,14 @@ public final class DeleteRoleMappingRequest implements Validatable {
      *
      * @param name role mapping name to be deleted
      * @param refreshPolicy refresh policy {@link RefreshPolicy} for the
-     * request, defaults to {@link RefreshPolicy#getDefault()}
+     * request, defaults to {@link RefreshPolicy#IMMEDIATE}
      */
     public DeleteRoleMappingRequest(final String name, @Nullable final RefreshPolicy refreshPolicy) {
         if (Strings.hasText(name) == false) {
             throw new IllegalArgumentException("role-mapping name is required");
         }
         this.name = name;
-        this.refreshPolicy = (refreshPolicy == null) ? RefreshPolicy.getDefault() : refreshPolicy;
+        this.refreshPolicy = (refreshPolicy == null) ? RefreshPolicy.IMMEDIATE : refreshPolicy;
     }
 
     public String getName() {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/security/PutRoleMappingRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/security/PutRoleMappingRequest.java
@@ -52,6 +52,17 @@ public final class PutRoleMappingRequest implements Validatable, ToXContentObjec
         this(name, enabled, roles, Collections.emptyList(), rules, metadata, refreshPolicy);
     }
 
+    /**
+     * Constructor to create request object to create or update a role mapping.
+     * @param name name for role mapping
+     * @param enabled mappings that have enabled set to {@code false} are ignored when role mapping is performed
+     * @param roles a list of roles that are granted to the users that match the role mapping rules
+     * @param templates a list of mustache templates that will be evaluated to determine the roles names that should granted to the
+     *                  users that match the role mapping rules
+     * @param rules the rules that determine which users should be matched by the mapping
+     * @param metadata metadata to be associated with role mapping
+     * @param refreshPolicy the refresh policy for the request. Defaults to {@link RefreshPolicy#IMMEDIATE}
+     */
     public PutRoleMappingRequest(final String name, final boolean enabled, final List<String> roles, final List<TemplateRoleName> templates,
                                  final RoleMapperExpression rules, @Nullable final Map<String, Object> metadata,
                                  @Nullable final RefreshPolicy refreshPolicy) {
@@ -70,7 +81,7 @@ public final class PutRoleMappingRequest implements Validatable, ToXContentObjec
         }
         this.rules = Objects.requireNonNull(rules, "role-mapping rules are missing");
         this.metadata = (metadata == null) ? Collections.emptyMap() : metadata;
-        this.refreshPolicy = (refreshPolicy == null) ? RefreshPolicy.getDefault() : refreshPolicy;
+        this.refreshPolicy = (refreshPolicy == null) ? RefreshPolicy.IMMEDIATE : refreshPolicy;
     }
 
     public String getName() {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/security/PutRoleRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/security/PutRoleRequest.java
@@ -36,9 +36,14 @@ public final class PutRoleRequest implements Validatable, ToXContentObject {
     private final Role role;
     private final RefreshPolicy refreshPolicy;
 
+    /**
+     * Constructor to create qequest object to create or update a role.
+     * @param role {@link Role} to be created or updated.
+     * @param refreshPolicy the refresh policy for the request. Defaults to {@link RefreshPolicy#IMMEDIATE}
+     */
     public PutRoleRequest(Role role, @Nullable final RefreshPolicy refreshPolicy) {
         this.role = Objects.requireNonNull(role);
-        this.refreshPolicy = (refreshPolicy == null) ? RefreshPolicy.getDefault() : refreshPolicy;
+        this.refreshPolicy = (refreshPolicy == null) ? RefreshPolicy.IMMEDIATE : refreshPolicy;
     }
 
     public Role getRole() {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/security/PutUserRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/security/PutUserRequest.java
@@ -105,7 +105,7 @@ public final class PutUserRequest implements Validatable, ToXContentObject {
      * @param passwordHash the hash of the password. Only one of "password" or "passwordHash" may be populated.
      *                     The other parameter must be {@code null}.
      * @param enabled true if the user is enabled and allowed to access elasticsearch
-     * @param refreshPolicy the refresh policy for the request.
+     * @param refreshPolicy the refresh policy for the request. Defaults to {@link RefreshPolicy#IMMEDIATE}
      */
     private PutUserRequest(User user, @Nullable char[] password, @Nullable char[] passwordHash, boolean enabled,
                            RefreshPolicy refreshPolicy) {
@@ -116,7 +116,7 @@ public final class PutUserRequest implements Validatable, ToXContentObject {
         this.password = password;
         this.passwordHash = passwordHash;
         this.enabled = enabled;
-        this.refreshPolicy = refreshPolicy == null ? RefreshPolicy.getDefault() : refreshPolicy;
+        this.refreshPolicy = refreshPolicy == null ? RefreshPolicy.IMMEDIATE : refreshPolicy;
     }
 
     public User getUser() {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/security/SetUserEnabledRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/security/SetUserEnabledRequest.java
@@ -32,10 +32,16 @@ public abstract class SetUserEnabledRequest implements Validatable {
     private final String username;
     private final RefreshPolicy refreshPolicy;
 
+    /**
+     * Constructor for creating request for enabling or disabling a built-in or native user
+     * @param enabled if set to {@code true} will enable a user else if set to {@code false} to disable a user
+     * @param username user name
+     * @param refreshPolicy the refresh policy for the request. Defaults to {@link RefreshPolicy#IMMEDIATE}
+     */
     SetUserEnabledRequest(boolean enabled, String username, RefreshPolicy refreshPolicy) {
         this.enabled = enabled;
         this.username = Objects.requireNonNull(username, "username is required");
-        this.refreshPolicy = refreshPolicy == null ? RefreshPolicy.getDefault() : refreshPolicy;
+        this.refreshPolicy = refreshPolicy == null ? RefreshPolicy.IMMEDIATE : refreshPolicy;
     }
 
     public boolean isEnabled() {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/security/DeleteRoleMappingRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/security/DeleteRoleMappingRequestTests.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class DeleteRoleMappingRequestTests extends ESTestCase {
 
@@ -68,5 +69,11 @@ public class DeleteRoleMappingRequestTests extends ESTestCase {
                     Collectors.toList());
             return new DeleteRoleMappingRequest(original.getName(), randomFrom(values));
         }
+    }
+
+    public void testBuildRequestDefaultsToImmediateRefreshPolicy() {
+        final String name = randomAlphaOfLength(5);
+        final DeleteRoleMappingRequest deleteRoleMappingRequest = new DeleteRoleMappingRequest(name, null);
+        assertThat(deleteRoleMappingRequest.getRefreshPolicy(), is(RefreshPolicy.IMMEDIATE));
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/security/PutRoleMappingRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/security/PutRoleMappingRequestTests.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class PutRoleMappingRequestTests extends ESTestCase {
 
@@ -240,4 +241,9 @@ public class PutRoleMappingRequestTests extends ESTestCase {
         }
     }
 
+    public void testBuildRequestDefaultsToImmediateRefreshPolicy() {
+        PutRoleMappingRequest putRoleMappingRequest = new PutRoleMappingRequest(randomAlphaOfLength(4), randomBoolean(),
+            Collections.singletonList("superuser"), Collections.emptyList(), FieldRoleMapperExpression.ofUsername("user"), null, null);
+        assertThat(putRoleMappingRequest.getRefreshPolicy(), is(RefreshPolicy.IMMEDIATE));
+    }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/security/PutRoleRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/security/PutRoleRequestTests.java
@@ -37,8 +37,8 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
 
 public class PutRoleRequestTests extends AbstractXContentTestCase<PutRoleRequest> {
 
@@ -84,4 +84,8 @@ public class PutRoleRequestTests extends AbstractXContentTestCase<PutRoleRequest
         return roleBuilder.build(); 
     }
 
+    public void testBuildRequestDefaultsToImmediateRefreshPolicy() {
+        final PutRoleRequest request = createTestInstance();
+        assertThat(request.getRefreshPolicy(), is(RefreshPolicy.IMMEDIATE));
+    }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/security/PutUserRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/security/PutUserRequestTests.java
@@ -98,4 +98,11 @@ public class PutUserRequestTests extends ESTestCase {
         assertThat(metadata.get("status"), is("active"));
     }
 
+    public void testBuildRequestDefaultsToImmediateRefreshPolicy() {
+        final User user = new User("hawkeye", Arrays.asList("kibana_user", "avengers"),
+            Collections.singletonMap("status", "active"), "Clinton Barton", null);
+        final char[] password = "f@rmb0y".toCharArray();
+        final PutUserRequest request = PutUserRequest.withPassword(user, password, true, null);
+        assertThat(request.getRefreshPolicy(), is(RefreshPolicy.IMMEDIATE));
+    }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/DeletePrivilegesRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/DeletePrivilegesRequestTests.java
@@ -8,14 +8,20 @@ package org.elasticsearch.xpack.core.security.action.privilege;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.client.security.PutUserRequest;
+import org.elasticsearch.client.security.RefreshPolicy;
+import org.elasticsearch.client.security.user.User;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -58,4 +64,8 @@ public class DeletePrivilegesRequestTests extends ESTestCase {
         }
     }
 
+    public void testBuildRequestDefaultsToImmediateRefreshPolicy() {
+        final DeletePrivilegesRequest request = new DeletePrivilegesRequest("app", new String[]{"all"});
+        assertThat(request.getRefreshPolicy(), is(RefreshPolicy.IMMEDIATE));
+    }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/DeletePrivilegesRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/privilege/DeletePrivilegesRequestTests.java
@@ -8,20 +8,14 @@ package org.elasticsearch.xpack.core.security.action.privilege;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.WriteRequest;
-import org.elasticsearch.client.security.PutUserRequest;
-import org.elasticsearch.client.security.RefreshPolicy;
-import org.elasticsearch.client.security.user.User;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -64,8 +58,4 @@ public class DeletePrivilegesRequestTests extends ESTestCase {
         }
     }
 
-    public void testBuildRequestDefaultsToImmediateRefreshPolicy() {
-        final DeletePrivilegesRequest request = new DeletePrivilegesRequest("app", new String[]{"all"});
-        assertThat(request.getRefreshPolicy(), is(RefreshPolicy.IMMEDIATE));
-    }
 }


### PR DESCRIPTION
The refresh policy for some of the APIs was inconsistent with
the default when invoked via Rest client. This commit sets
the refresh policy to make it consistent.
