### PR TITLE
Enhance docs for create api keys created when role descriptor not specified

### DIFF
--- a/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
+++ b/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
@@ -49,11 +49,10 @@ The following parameters can be specified in the body of a POST or PUT request:
 `role_descriptors`::
 (Optional, array-of-role-descriptor) An array of role descriptors for this API
 key. This parameter is optional. When it is not specified or is an empty array,
-then the API key will have the permissions of the authenticated user. If you
-supply role descriptors, they must be a subset of the authenticated user's
-permissions. The structure of role descriptor is the same as the request for
-create role API. For more details, see
-<<security-api-roles,role management APIs>>.
+then the API key will have a _point in time snapshot of permissions of the 
+authenticated user_. If you supply role descriptors, they must be a subset of the
+authenticated user's permissions. The structure of role descriptor is the same as
+the request for create role API. For more details, see <<security-api-roles,role management APIs>>.
 
 `expiration`::
 (Optional, string) Expiration time for the API key. By default, API keys never

--- a/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
+++ b/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
@@ -50,9 +50,11 @@ The following parameters can be specified in the body of a POST or PUT request:
 (Optional, array-of-role-descriptor) An array of role descriptors for this API
 key. This parameter is optional. When it is not specified or is an empty array,
 then the API key will have a _point in time snapshot of permissions of the 
-authenticated user_. If you supply role descriptors, they must be a subset of the
-authenticated user's permissions. The structure of role descriptor is the same as
-the request for create role API. For more details, see <<security-api-roles,role management APIs>>.
+authenticated user_. If you supply role descriptors then the resultant permissions
+would be an intersection of API keys permissions and authenticated user's permissions
+thereby limiting the access scope for API keys.
+The structure of role descriptor is the same as the request for create role API.
+For more details, see <<security-api-roles,role management APIs>>.
 
 `expiration`::
 (Optional, string) Expiration time for the API key. By default, API keys never


### PR DESCRIPTION
This commit adds the documentation to point the user that when one
creates API keys with no role descriptor specified then that API
key will have a point in time snapshot of user permissions.

Closes#46876