### PR TITLE
Fix SymbolicLinkPreservingTarIT on windows

### DIFF
--- a/buildSrc/src/test/java/org/elasticsearch/gradle/tar/SymbolicLinkPreservingTarIT.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/tar/SymbolicLinkPreservingTarIT.java
@@ -19,6 +19,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 public class SymbolicLinkPreservingTarIT extends GradleIntegrationTestCase {
@@ -92,18 +93,27 @@ public class SymbolicLinkPreservingTarIT extends GradleIntegrationTestCase {
                     fileEntry = true;
                 } else if (entry.getName().equals("real-folder/link-to-file")) {
                     assertTrue(entry.isSymbolicLink());
-                    assertThat(entry.getLinkName(), equalTo("./file"));
+                    assertThat(
+                        entry.getLinkName(),
+                        anyOf(equalTo("./file"), equalTo(".\\file"))
+                    );
                     linkToFileEntry = true;
                 } else if (entry.getName().equals("link-in-folder/")) {
                     assertTrue(entry.isDirectory());
                     linkInFolderEntry = true;
                 } else if (entry.getName().equals("link-in-folder/link-to-file")) {
                     assertTrue(entry.isSymbolicLink());
-                    assertThat(entry.getLinkName(), equalTo("../real-folder/file"));
+                    assertThat(
+                        entry.getLinkName(),
+                        anyOf(equalTo("../real-folder/file"), equalTo("..\\real-folder\\file"))
+                    );
                     linkInFolderLinkToFileEntry = true;
                 } else if (entry.getName().equals("link-to-real-folder")) {
                     assertTrue(entry.isSymbolicLink());
-                    assertThat(entry.getLinkName(), equalTo("./real-folder"));
+                    assertThat(
+                        entry.getLinkName(),
+                        anyOf(equalTo("./real-folder"), equalTo(".\\real-folder"))
+                    );
                     linkToRealFolderEntry = true;
                 } else {
                     throw new GradleException("unexpected entry [" + entry.getName() + "]");


### PR DESCRIPTION
Broken path comparison on windows:
 https://scans.gradle.com/s/7y3zl23orfp7w/tests/nr3ff3qzwqzsw-xfh7lvi5orvq4
With the fix:
 https://gradle-enterprise.elastic.co/s/4dcc2nv3haaqw

