### PR TITLE
[DOCS] Fix calendar interval typos for date histo agg

### DIFF
--- a/docs/reference/aggregations/bucket/datehistogram-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/datehistogram-aggregation.asciidoc
@@ -58,7 +58,7 @@ seconds of the following minute in the specified timezone, compensating for any
 intervening leap seconds, so that the number of minutes and seconds past the
 hour is the same at the start and end.
 
-hours (`h`, `1h`) ::
+hour (`h`, `1h`) ::
 All hours begin at 00 minutes and 00 seconds.
 
 One hour (1h) is the interval between 00:00 minutes of the first hour and 00:00
@@ -67,7 +67,7 @@ intervening leap seconds, so that the number of minutes and seconds past the hou
 is the same at the start and end.
 
 
-days (`d`, `1d`) ::
+day (`d`, `1d`) ::
 All days begin at the earliest possible time, which is usually 00:00:00
 (midnight).
 


### PR DESCRIPTION
Fix calendar intervals values on version 7.3 (current) for days and hours, now `day` and `hour`.
When using `days` or `hours`, it throws:

```
{
  "error": {
    "root_cause": [
      {
        "type": "x_content_parse_exception",
        "reason": "[7:30] [date_histogram] failed to parse field [calendar_interval]"
      }
    ],
    "type": "x_content_parse_exception",
    "reason": "[7:30] [date_histogram] failed to parse field [calendar_interval]",
    "caused_by": {
      "type": "illegal_argument_exception",
      "reason": "The supplied interval [hours] could not be parsed as a calendar interval."
    }
  },
  "status": 400
}
```