### PR TITLE
[DOCS] Correct several [source,console-result] snippets

### DIFF
--- a/docs/reference/aggregations/bucket/significantterms-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/significantterms-aggregation.asciidoc
@@ -17,7 +17,7 @@ that is significant and probably very relevant to their search. 5/10,000,000 vs 
 
 //////////////////////////
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT /reports
 {
@@ -52,7 +52,6 @@ POST /reports/_bulk?refresh
 {"force": "Metropolitan Police Service", "crime_type": "Robbery"}
 
 -------------------------------------------------
-// NOTCONSOLE
 // TESTSETUP
 
 //////////////////////////
@@ -82,7 +81,7 @@ GET /_search
 
 Response:
 
-[source,console]
+[source,console-result]
 --------------------------------------------------
 {
     ...

--- a/docs/reference/ilm/apis/explain.asciidoc
+++ b/docs/reference/ilm/apis/explain.asciidoc
@@ -96,7 +96,7 @@ GET my_index/_ilm/explain
 When management of the index is first taken over by ILM, `explain` shows
 that the index is managed and in the `new` phase:
 
-[source,console]
+[source,console-result]
 --------------------------------------------------
 {
   "indices": {

--- a/docs/reference/ilm/error-handling.asciidoc
+++ b/docs/reference/ilm/error-handling.asciidoc
@@ -64,7 +64,7 @@ GET /myindex/_ilm/explain
 
 Which returns the following information:
 
-[source,console]
+[source,console-result]
 --------------------------------------------------
 {
   "indices" : {


### PR DESCRIPTION
Fixes several test response snippets so they use the `[source,console-result]` language.