### PR TITLE
Remove types from _source endpoint

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestGetSourceAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestGetSourceAction.java
@@ -19,14 +19,12 @@
 
 package org.elasticsearch.rest.action.document;
 
-import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -50,15 +48,9 @@ import static org.elasticsearch.rest.RestStatus.OK;
  */
 public class RestGetSourceAction extends BaseRestHandler {
 
-    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(RestGetSourceAction.class));
-    static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Specifying types in get_source and exist_source"
-            + "requests is deprecated.";
-
     public RestGetSourceAction(final RestController controller) {
         controller.registerHandler(GET, "/{index}/_source/{id}", this);
         controller.registerHandler(HEAD, "/{index}/_source/{id}", this);
-        controller.registerHandler(GET, "/{index}/{type}/{id}/_source", this);
-        controller.registerHandler(HEAD, "/{index}/{type}/{id}/_source", this);
     }
 
     @Override


### PR DESCRIPTION
Most of the work here was done in #46587, and now it only remains to 
remove the typed endpoints.