### PR TITLE
[DOCS] Remove support for `// CONSOLE` magic comment

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
@@ -202,12 +202,15 @@ public class RestTestsFromSnippetsTask extends SnippetsTask {
                 previousTest = snippet
                 return
             }
-            if (snippet.testResponse || snippet.language == 'console-result') {
+            if (snippet.language == 'console-result') {
                 response(snippet)
                 return
             }
-            if (snippet.test || snippet.console ||
-                    snippet.language == 'console') {
+            if ((snippet.language == 'js') && (snippet.console)) {
+                throw new InvalidUserDataException(
+                        "$snippet: Use `[source,console]` instead of `// CONSOLE`.")
+            }
+            if (snippet.test || snippet.language == 'console') {
                 test(snippet)
                 previousTest = snippet
                 return

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
@@ -202,7 +202,7 @@ public class RestTestsFromSnippetsTask extends SnippetsTask {
                 previousTest = snippet
                 return
             }
-            if (snippet.language == 'console-result') {
+            if (snippet.testResponse || snippet.language == 'console-result') {
                 response(snippet)
                 return
             }


### PR DESCRIPTION
elastic/elasticsearch#46180 added support for the `[source,console]`
language for snippets which should be tested.

This removes support for the `// CONSOLE` magic comment,
which serve a similar purpose.

Snippets that include the `// CONSOLE` magic comment will return an exception.