### PR TITLE
Enable Gradle build cache on all rest integ tests

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/RestTestRunnerTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/RestTestRunnerTask.java
@@ -5,9 +5,8 @@ import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.testing.Test;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
-
-import static org.elasticsearch.gradle.testclusters.TestDistribution.INTEG_TEST;
 
 /**
  * Customized version of Gradle {@link Test} task which tracks a collection of {@link ElasticsearchCluster} as a task input. We must do this
@@ -20,9 +19,17 @@ public class RestTestRunnerTask extends Test implements TestClustersAware {
     private Collection<ElasticsearchCluster> clusters = new HashSet<>();
 
     public RestTestRunnerTask() {
-        super();
-        this.getOutputs().doNotCacheIf("Build cache is only enabled for tests against clusters using the 'integ-test' distribution",
-            task -> clusters.stream().flatMap(c -> c.getNodes().stream()).anyMatch(n -> n.getTestDistribution() != INTEG_TEST));
+        this.getOutputs().doNotCacheIf("Caching disabled for this task since it uses a cluster shared by other tasks",
+            /*
+             * Look for any other tasks which use the same cluster as this task. Since tests often have side effects for the cluster they
+             * execute against, this state can cause issues when trying to cache tests results of tasks that share a cluster. To avoid any
+             * undesired behavior we simply disable the cache if we detect that this task uses a cluster shared between multiple tasks.
+             */
+            t -> getProject().getTasks().withType(RestTestRunnerTask.class)
+                .stream()
+                .filter(task -> task != this)
+                .anyMatch(task -> Collections.disjoint(task.getClusters(), getClusters()) == false)
+        );
     }
 
     @Override


### PR DESCRIPTION
This PR removes the restriction that rest integration tests can only be cached when targeting the `integ-test` distribution. Now all rest tests, including those using the default distribution can be cached. For many tests this required no changes, and one major motivation for this was to make docs-only changes run only the `:docs` project tests. That said, some of the more complex BWC tests, that involve multiple clusters, or upgrading cluster node between test suite runs requires some additional refactoring:

1. We need to track the actual distribution being used as an input. To support BWC testing, we added the ability to configure a cluster with multiple distribution version, then added some APIs to upgrade the whole cluster, or individual nodes to the next configured version. We didn't however track which version the node was _currently_ on as an input. This has now changed. Simply, when we snapshot the collection of files for the distribution, we no longer use _all_ distributions, but only the one currently in use. This means that as we upgrade cluster nodes, the inputs for the next test task will be different, respecting the fact that the test task is testing a cluster in a particular _state_ so we need to consider that state during input snapshotting.

2. Because cluster _state_ is part of the test task inputs, the cluster needs to be placed into the target state _before_ test task execution. Before we were performing the upgrade in a `doFirst()`, which is no longer possible since the upgrade would not be reflected in the task inputs. Instead we refactored the upgrade into it's own task which runs regardless of whether tests will be cached or not. This is necessary to ensure that inputs are always the same for test tasks between runs, w/ or w/o caching. This also mean that upgrades needed to be lenient, meaning they could be done on a non-started node, since if tests are cached, we avoid starting a cluster, but we still want to bump the version in the input model, so caching works as intended.

3. These multi-stage tests assume that all stage tests will run. Caching one stage will often cause subsequent stage tests to fail because they rely on setup or tasks performed in previous stages. For this reason we need to ensure that these tests are cached _atomically_. In practice, this should always be the case, as the same inputs should result in cache hits for all test tasks. There is the potential for unexpected results here though, such as an unintended modification to the inputs of just a single test task, or one of the test task outputs being evicted from the cache. In such a scenario we've added a check that will cause the build to fail eagerly, rather than with odd test results. For local builds this would mostly be resolved using `--rerun-tasks`. For CI builds it depends on what caused the partial cache hit, but in any case we want to be alerted so we can manually intervene, mostly likely by manually evicting the outlier artifacts from the remote cache.