### PR TITLE
Fix MockAppender Error in Transport Tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -1127,7 +1127,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             assertBusy(appender::assertAllExpectationsMatched);
         } finally {
             Loggers.removeAppender(LogManager.getLogger("org.elasticsearch.transport.TransportService.tracer"), appender);
-            appender.stop();
+            // Not stopping the mock appender here to avoid logging an error about a stopped appender during a race from the transport
+            // service trying to log something while the appender is being removed
         }
     }
 


### PR DESCRIPTION
This test was previously fixed via https://github.com/elastic/elasticsearch/pull/42286 initially which made the below error incredibly unlikely (but not impossible as it turns out):

We can have an extremely rare race situation here:
A log call could happen concurrently to the appender
being removed and still pick up the appender and then
run into a stopped appender because the stop on the test
thread was executed before the appender was invoked
by the transport service.
I don't see a clean way of fixing this. We could technically
add some flag to the mock appender to "disable" it so it
doesn't forward any messages to log4j before removing it
but ... since the appender uses no resources I don't see the
value in that complication relative to just not calling `stop`.

Fixes #46307
