### PR TITLE
Add migration tool checks for _field_names disabling

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -101,22 +101,22 @@ public class ClusterDeprecationChecks {
      * and will throw an error on new indices in 8.0
      */
     static DeprecationIssue checkTemplatesWithFieldNamesDisabled(ClusterState state) {
-        Set<String> templatesContainingFieldNamed = new HashSet<>();
+        Set<String> templatesContainingFieldNames = new HashSet<>();
         state.getMetaData().getTemplates().forEach((templateCursor) -> {
             String templateName = templateCursor.key;
             templateCursor.value.getMappings().forEach((mappingCursor) -> {
                 Map<String, Object> map = XContentHelper.convertToMap(mappingCursor.value.compressedReference(), false, XContentType.JSON)
                         .v2();
                 if (mapContainsFieldNamesDisabled(map)) {
-                    templatesContainingFieldNamed.add(templateName);
+                    templatesContainingFieldNames.add(templateName);
                 }
             });
         });
 
-        if (templatesContainingFieldNamed.isEmpty() == false) {
+        if (templatesContainingFieldNames.isEmpty() == false) {
             return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, "Index templates contain _field_names settings.",
                     "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html#fieldnames-enabling",
-                    "Index templates " + templatesContainingFieldNamed + " use the deprecated `enable` setting for the `"
+                    "Index templates " + templatesContainingFieldNames + " use the deprecated `enable` setting for the `"
                             + FieldNamesFieldMapper.NAME + "` field. Using this setting in new index mappings will throw an error "
                                     + "in the next major version and needs to be removed from existing mappings and templates.");
         }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -99,6 +99,7 @@ public class ClusterDeprecationChecks {
      * Check templates that use `_field_names` explicitly, which was deprecated in https://github.com/elastic/elasticsearch/pull/42854
      * and will throw an error on new indices in 8.0
      */
+    @SuppressWarnings("unchecked")
     static DeprecationIssue checkTemplatesWithFieldNamesDisabled(ClusterState state) {
         Set<String> templatesContainingFieldNames = new HashSet<>();
         state.getMetaData().getTemplates().forEach((templateCursor) -> {

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -120,7 +120,7 @@ public class ClusterDeprecationChecks {
         });
 
         if (templatesContainingFieldNames.isEmpty() == false) {
-            return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, "Index templates contain _field_names settings.",
+            return new DeprecationIssue(DeprecationIssue.Level.WARNING, "Index templates contain _field_names settings.",
                     "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html#fieldnames-enabling",
                     "Index templates " + templatesContainingFieldNames + " use the deprecated `enable` setting for the `"
                             + FieldNamesFieldMapper.NAME + "` field. Using this setting in new index mappings will throw an error "

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -35,7 +35,8 @@ public class DeprecationChecks {
         Collections.unmodifiableList(Arrays.asList(
             ClusterDeprecationChecks::checkUserAgentPipelines,
             ClusterDeprecationChecks::checkTemplatesWithTooManyFields,
-            ClusterDeprecationChecks::checkPollIntervalTooLow
+            ClusterDeprecationChecks::checkPollIntervalTooLow,
+            ClusterDeprecationChecks::checkTemplatesWithFieldNamesDisabled
         ));
 
 
@@ -51,7 +52,8 @@ public class DeprecationChecks {
             IndexDeprecationChecks::tooManyFieldsCheck,
             IndexDeprecationChecks::chainedMultiFieldsCheck,
             IndexDeprecationChecks::deprecatedDateTimeFormat,
-            IndexDeprecationChecks::translogRetentionSettingCheck
+            IndexDeprecationChecks::translogRetentionSettingCheck,
+            IndexDeprecationChecks::fieldNamesEnabling
         ));
 
     static List<BiFunction<DatafeedConfig, NamedXContentRegistry, DeprecationIssue>> ML_SETTINGS_CHECKS =

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -53,7 +53,7 @@ public class DeprecationChecks {
             IndexDeprecationChecks::chainedMultiFieldsCheck,
             IndexDeprecationChecks::deprecatedDateTimeFormat,
             IndexDeprecationChecks::translogRetentionSettingCheck,
-            IndexDeprecationChecks::fieldNamesEnabling
+            IndexDeprecationChecks::fieldNamesDisabledCheck
         ));
 
     static List<BiFunction<DatafeedConfig, NamedXContentRegistry, DeprecationIssue>> ML_SETTINGS_CHECKS =

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.deprecation;
 
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
+
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
@@ -183,6 +184,21 @@ public class IndexDeprecationChecks {
             }
         }
         return false;
+    }
+
+    /**
+     * warn about existing explicit "_field_names" enabled settings in existing mappings
+     */
+    static DeprecationIssue fieldNamesEnabling(IndexMetaData indexMetaData) {
+        MappingMetaData mapping = indexMetaData.mapping();
+        if ((mapping != null) && ClusterDeprecationChecks.mapContainsFieldNamesDisabled(mapping.getSourceAsMap())) {
+            return new DeprecationIssue(DeprecationIssue.Level.WARNING,
+                    "Index mapping contain explicit _field_names enabling settings.",
+                    "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html" +
+                            "#fieldnames-enabling",
+                    "The index mapping contains a deprecated `enabled` setting for `_field_names` that should be removed moving foward.");
+        }
+        return null;
     }
 
     private static final Set<String> TYPES_THAT_DONT_COUNT;

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecks.java
@@ -187,13 +187,13 @@ public class IndexDeprecationChecks {
     }
 
     /**
-     * warn about existing explicit "_field_names" enabled settings in existing mappings
+     * warn about existing explicit "_field_names" settings in existing mappings
      */
-    static DeprecationIssue fieldNamesEnabling(IndexMetaData indexMetaData) {
+    static DeprecationIssue fieldNamesDisabledCheck(IndexMetaData indexMetaData) {
         MappingMetaData mapping = indexMetaData.mapping();
         if ((mapping != null) && ClusterDeprecationChecks.mapContainsFieldNamesDisabled(mapping.getSourceAsMap())) {
             return new DeprecationIssue(DeprecationIssue.Level.WARNING,
-                    "Index mapping contain explicit _field_names enabling settings.",
+                    "Index mapping contains explicit `_field_names` enabling settings.",
                     "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html" +
                             "#fieldnames-enabling",
                     "The index mapping contains a deprecated `enabled` setting for `_field_names` that should be removed moving foward.");

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
@@ -224,7 +224,7 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
         if (expectIssue) {
             assertEquals(1, issues.size());
             DeprecationIssue issue = issues.get(0);
-            assertEquals(DeprecationIssue.Level.CRITICAL, issue.getLevel());
+            assertEquals(DeprecationIssue.Level.WARNING, issue.getLevel());
             assertEquals("https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html#fieldnames-enabling"
                     , issue.getUrl());
             assertEquals("Index templates contain _field_names settings.", issue.getMessage());

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.ingest.IngestService;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
@@ -156,6 +157,80 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
                 "which may cause queries which use automatic field expansion, such as query_string, simple_query_string, and multi_match " +
                 "to fail if fields are not explicitly specified in the query.");
         assertEquals(singletonList(expected), issues);
+    }
+
+    public void testTemplatesWithFieldNamesDisabled() throws IOException {
+        XContentBuilder goodMappingBuilder = jsonBuilder();
+        goodMappingBuilder.startObject();
+        {
+            goodMappingBuilder.startObject("_doc");
+            {
+                goodMappingBuilder.startObject("properties");
+                {
+                    addRandomFields(10, goodMappingBuilder);
+                }
+                goodMappingBuilder.endObject();
+            }
+            goodMappingBuilder.endObject();
+        }
+        goodMappingBuilder.endObject();
+        assertFieldNamesEnabledTemplate(goodMappingBuilder, false);
+
+        XContentBuilder badMappingWithTypeBuilder = jsonBuilder();
+        badMappingWithTypeBuilder.startObject();
+        {
+            badMappingWithTypeBuilder.startObject("_doc");
+            {
+                badMappingWithTypeBuilder.startObject(FieldNamesFieldMapper.NAME);
+                {
+                    badMappingWithTypeBuilder.field("enabled", randomBoolean());
+                }
+                badMappingWithTypeBuilder.endObject();
+            }
+            badMappingWithTypeBuilder.endObject();
+        }
+        badMappingWithTypeBuilder.endObject();
+        assertFieldNamesEnabledTemplate(badMappingWithTypeBuilder, true);
+
+        XContentBuilder badMappingWithoutTypeBuilder = jsonBuilder();
+        badMappingWithoutTypeBuilder.startObject();
+        {
+            badMappingWithoutTypeBuilder.startObject(FieldNamesFieldMapper.NAME);
+            {
+                badMappingWithoutTypeBuilder.field("enabled", randomBoolean());
+            }
+            badMappingWithoutTypeBuilder.endObject();
+        }
+        badMappingWithoutTypeBuilder.endObject();
+        assertFieldNamesEnabledTemplate(badMappingWithoutTypeBuilder, true);
+    }
+
+    private void assertFieldNamesEnabledTemplate(XContentBuilder templateBuilder, boolean expectIssue) throws IOException {
+        String badTemplateName = randomAlphaOfLength(5);
+        final ClusterState state = ClusterState.builder(new ClusterName(randomAlphaOfLength(5)))
+            .metaData(MetaData.builder()
+                .put(IndexTemplateMetaData.builder(badTemplateName)
+                    .patterns(Collections.singletonList(randomAlphaOfLength(5)))
+                    .putMapping("_doc", Strings.toString(templateBuilder))
+                    .build())
+                .build())
+            .build();
+
+        List<DeprecationIssue> issues = DeprecationChecks.filterChecks(CLUSTER_SETTINGS_CHECKS, c -> c.apply(state));
+        if (expectIssue) {
+            assertEquals(1, issues.size());
+            DeprecationIssue issue = issues.get(0);
+            assertEquals(DeprecationIssue.Level.CRITICAL, issue.getLevel());
+            assertEquals("https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html#fieldnames-enabling"
+                    , issue.getUrl());
+            assertEquals("Index templates contain _field_names settings.", issue.getMessage());
+            assertEquals("Index templates [" + badTemplateName + "] "
+                    + "use the deprecated `enable` setting for the `" + FieldNamesFieldMapper.NAME +
+                    "` field. Using this setting in new index mappings will throw an error in the next major version and " +
+                    "needs to be removed from existing mappings and templates.", issue.getDetails());
+        } else {
+            assertTrue(issues.isEmpty());
+        }
     }
 
     public void testPollIntervalTooLow() {

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
@@ -176,33 +176,22 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
         goodMappingBuilder.endObject();
         assertFieldNamesEnabledTemplate(goodMappingBuilder, false);
 
-        XContentBuilder badMappingWithTypeBuilder = jsonBuilder();
-        badMappingWithTypeBuilder.startObject();
+        XContentBuilder badMappingBuilder = jsonBuilder();
+        badMappingBuilder.startObject();
         {
-            badMappingWithTypeBuilder.startObject("_doc");
+            // we currently always store a type level internally
+            badMappingBuilder.startObject("_doc");
             {
-                badMappingWithTypeBuilder.startObject(FieldNamesFieldMapper.NAME);
+                badMappingBuilder.startObject(FieldNamesFieldMapper.NAME);
                 {
-                    badMappingWithTypeBuilder.field("enabled", randomBoolean());
+                    badMappingBuilder.field("enabled", randomBoolean());
                 }
-                badMappingWithTypeBuilder.endObject();
+                badMappingBuilder.endObject();
             }
-            badMappingWithTypeBuilder.endObject();
+            badMappingBuilder.endObject();
         }
-        badMappingWithTypeBuilder.endObject();
-        assertFieldNamesEnabledTemplate(badMappingWithTypeBuilder, true);
-
-        XContentBuilder badMappingWithoutTypeBuilder = jsonBuilder();
-        badMappingWithoutTypeBuilder.startObject();
-        {
-            badMappingWithoutTypeBuilder.startObject(FieldNamesFieldMapper.NAME);
-            {
-                badMappingWithoutTypeBuilder.field("enabled", randomBoolean());
-            }
-            badMappingWithoutTypeBuilder.endObject();
-        }
-        badMappingWithoutTypeBuilder.endObject();
-        assertFieldNamesEnabledTemplate(badMappingWithoutTypeBuilder, true);
+        badMappingBuilder.endObject();
+        assertFieldNamesEnabledTemplate(badMappingBuilder, true);
     }
 
     private void assertFieldNamesEnabledTemplate(XContentBuilder templateBuilder, boolean expectIssue) throws IOException {

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
@@ -192,6 +192,21 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
         }
         badMappingBuilder.endObject();
         assertFieldNamesEnabledTemplate(badMappingBuilder, true);
+
+        // however, there was a bug where mappings could be stored without a type (#45120)
+        // so we also should try to check these cases
+
+        XContentBuilder badMappingWithoutTypeBuilder = jsonBuilder();
+        badMappingWithoutTypeBuilder.startObject();
+        {
+            badMappingWithoutTypeBuilder.startObject(FieldNamesFieldMapper.NAME);
+            {
+                badMappingWithoutTypeBuilder.field("enabled", randomBoolean());
+            }
+            badMappingWithoutTypeBuilder.endObject();
+        }
+        badMappingWithoutTypeBuilder.endObject();
+        assertFieldNamesEnabledTemplate(badMappingWithoutTypeBuilder, true);
     }
 
     private void assertFieldNamesEnabledTemplate(XContentBuilder templateBuilder, boolean expectIssue) throws IOException {

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -11,10 +11,11 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.joda.JodaDeprecationPatterns;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
@@ -27,8 +28,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static java.util.Collections.singletonList;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.deprecation.DeprecationChecks.INDEX_SETTINGS_CHECKS;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 
 public class IndexDeprecationChecksTests extends ESTestCase {
@@ -161,6 +162,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             "The names of fields that contain chained multi-fields: [[type: _doc, field: invalid-field]]");
         assertEquals(singletonList(expected), issues);
     }
+
     public void testDefinedPatternsDoNotWarn() throws IOException {
         String simpleMapping = "{\n" +
             "\"properties\" : {\n" +
@@ -411,5 +413,31 @@ public class IndexDeprecationChecksTests extends ESTestCase {
         IndexMetaData indexMetaData = IndexMetaData.builder("test").settings(settings).numberOfShards(1).numberOfReplicas(0).build();
         List<DeprecationIssue> issues = DeprecationChecks.filterChecks(INDEX_SETTINGS_CHECKS, c -> c.apply(indexMetaData));
         assertThat(issues, empty());
+    }
+
+    public void testFieldNamesEnabling() throws IOException {
+        XContentBuilder xContent = XContentFactory.jsonBuilder().startObject()
+            .startObject(FieldNamesFieldMapper.NAME)
+                .field("enabled", randomBoolean())
+            .endObject()
+        .endObject();
+        String mapping = BytesReference.bytes(xContent).utf8ToString();
+
+        IndexMetaData simpleIndex = IndexMetaData.builder(randomAlphaOfLengthBetween(5, 10))
+                .settings(settings(
+                        VersionUtils.randomVersionBetween(random(), Version.V_7_0_0, Version.CURRENT)))
+                .numberOfShards(1)
+                .numberOfReplicas(0)
+                .putMapping("_doc", mapping).build();
+        List<DeprecationIssue> issues = DeprecationChecks.filterChecks(INDEX_SETTINGS_CHECKS, c -> c.apply(simpleIndex));
+        assertEquals(1, issues.size());
+
+        DeprecationIssue issue = issues.get(0);
+        assertEquals(DeprecationIssue.Level.WARNING, issue.getLevel());
+        assertEquals("https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html#fieldnames-enabling"
+                , issue.getUrl());
+        assertEquals("Index mapping contain explicit _field_names enabling settings.", issue.getMessage());
+        assertEquals("The index mapping contains a deprecated `enabled` setting for `_field_names` that should be removed moving foward.",
+                issue.getDetails());
     }
 }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -436,7 +436,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
         assertEquals(DeprecationIssue.Level.WARNING, issue.getLevel());
         assertEquals("https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html#fieldnames-enabling"
                 , issue.getUrl());
-        assertEquals("Index mapping contain explicit _field_names enabling settings.", issue.getMessage());
+        assertEquals("Index mapping contains explicit `_field_names` enabling settings.", issue.getMessage());
         assertEquals("The index mapping contains a deprecated `enabled` setting for `_field_names` that should be removed moving foward.",
                 issue.getDetails());
     }


### PR DESCRIPTION
This change adds a check to the migration tool that warns about the deprecated
"enabled" setting for the "_field_names" field on 7.x indices and issues a
critical error for templates containing this setting, since it has been removed
with 8.0.

Relates to #42854, #46681