### PR TITLE
[DOCS] Reformats ranking evaluation API

### DIFF
--- a/docs/reference/search/rank-eval.asciidoc
+++ b/docs/reference/search/rank-eval.asciidoc
@@ -46,7 +46,7 @@ needed:
 
 . A collection of documents you want to evaluate your query performance against, 
   usually one or more indices.
-. a collection of typical search requests that users enter into your system.
+. A collection of typical search requests that users enter into your system.
 . a set of document ratings that judge the documents relevance with respect to a 
   search request.
   

--- a/docs/reference/search/rank-eval.asciidoc
+++ b/docs/reference/search/rank-eval.asciidoc
@@ -156,7 +156,7 @@ have to be repeated all the time in the `requests` section this way. In typical
 search systems where user inputs usually get filled into a small set of query 
 templates, this helps making the evaluation request more succinct.
 
-[source,console]
+[source,js]
 --------------------------------
 GET /my_index/_rank_eval
 { 

--- a/docs/reference/search/rank-eval.asciidoc
+++ b/docs/reference/search/rank-eval.asciidoc
@@ -107,6 +107,8 @@ application, along with the document ratings for each particular search request.
 
 [source,console]
 -----------------------------
+GET /my_index/_rank_eval
+{
     "requests": [
         {
             "id": "amsterdam_query", <1>
@@ -129,6 +131,7 @@ application, along with the document ratings for each particular search request.
             ]
         }
     ]
+  }
 -----------------------------
 // NOTCONSOLE
 

--- a/docs/reference/search/rank-eval.asciidoc
+++ b/docs/reference/search/rank-eval.asciidoc
@@ -130,7 +130,7 @@ application, along with the document ratings for each particular search request.
         }
     ]
 -----------------------------
-// TEST[skip: TBD]
+// NOTCONSOLE
 
 <1> the search requests id, used to group result details later 
 <2> the query that is being evaluated

--- a/docs/reference/search/rank-eval.asciidoc
+++ b/docs/reference/search/rank-eval.asciidoc
@@ -47,7 +47,7 @@ needed:
 . A collection of documents you want to evaluate your query performance against, 
   usually one or more indices.
 . A collection of typical search requests that users enter into your system.
-. a set of document ratings that judge the documents relevance with respect to a 
+. A set of document ratings that judge the documents relevance with respect to a 
   search request.
   
 It is important to note that one set of document ratings is needed per test 

--- a/docs/reference/search/rank-eval.asciidoc
+++ b/docs/reference/search/rank-eval.asciidoc
@@ -86,7 +86,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
 In its most basic form, a request to the `_rank_eval` endpoint has two sections:
 
-[source,console]
+[source,js]
 -----------------------------
 GET /my_index/_rank_eval
 {

--- a/docs/reference/search/rank-eval.asciidoc
+++ b/docs/reference/search/rank-eval.asciidoc
@@ -64,8 +64,9 @@ generation in your application.
 [[search-rank-eval-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
-
+`<index>`::
+ (Required, string) Comma-separated list or wildcard expression of index names
+ used to limit the request.
 
 [[search-rank-eval-api-query-params]]
 ==== {api-query-parms-title}

--- a/docs/reference/search/rank-eval.asciidoc
+++ b/docs/reference/search/rank-eval.asciidoc
@@ -44,7 +44,7 @@ other types of queries.
 In order to get started with search quality evaluation, three basic things are 
 needed:
 
-. a collection of documents you want to evaluate your query performance against, 
+. A collection of documents you want to evaluate your query performance against, 
   usually one or more indices.
 . a collection of typical search requests that users enter into your system.
 . a set of document ratings that judge the documents relevance with respect to a 

--- a/docs/reference/search/rank-eval.asciidoc
+++ b/docs/reference/search/rank-eval.asciidoc
@@ -3,39 +3,90 @@
 
 experimental["The ranking evaluation API is experimental and may be changed or removed completely in a future release, as well as change in non-backwards compatible ways on minor versions updates. Elastic will take a best effort approach to fix any issues, but experimental features are not subject to the support SLA of official GA features."]
 
-The ranking evaluation API allows to evaluate the quality of ranked search
+Allows you to evaluate the quality of ranked search results over a set of 
+typical search queries.
+
+
+[[search-rank-eval-api-request]]
+==== {api-request-title}
+
+`GET /<index>/_rank_eval`
+
+`POST /<index>/_rank_eval`
+
+
+[[search-rank-eval-api-desc]]
+==== {api-description-title}
+
+The ranking evaluation API allows you to evaluate the quality of ranked search 
 results over a set of typical search queries. Given this set of queries and a
 list of manually rated documents, the `_rank_eval` endpoint calculates and
 returns typical information retrieval metrics like _mean reciprocal rank_,
 _precision_ or _discounted cumulative gain_.
 
-[float]
-==== Overview
+Search quality evaluation starts with looking at the users of your search 
+application, and the things that they are searching for. Users have a specific 
+_information need_, for example they are looking for gift in a web shop or want 
+to book a flight for their next holiday. They usually enter some search terms 
+into a search box or some other web form. All of this information, together with 
+meta information about the user (for example the browser, location, earlier 
+preferences and so on) then gets translated into a query to the underlying 
+search system.
 
-Search quality evaluation starts with looking at the users of your search application, and the things that they are searching for.
-Users have a specific _information need_, e.g. they are looking for gift in a web shop or want to book a flight for their next holiday.
-They usually enter some search terms into a search box or some other web form.
-All of this information, together with meta information about the user (e.g. the browser, location, earlier preferences etc...) then gets translated into a query to the underlying search system.
+The challenge for search engineers is to tweak this translation process from 
+user entries to a concrete query in such a way, that the search results contain 
+the most relevant information with respect to the users information need. This 
+can only be done if the search result quality is evaluated constantly across a 
+representative test suite of typical user queries, so that improvements in the 
+rankings for one particular query doesn't negatively effect the ranking for 
+other types of queries.
 
-The challenge for search engineers is to tweak this translation process from user entries to a concrete query in such a way, that the search results contain the most relevant information with respect to the users information need.
-This can only be done if the search result quality is evaluated constantly across a representative test suite of typical user queries, so that improvements in the rankings for one particular query doesn't negatively effect the ranking for other types of queries.
+In order to get started with search quality evaluation, three basic things are 
+needed:
 
-In order to get started with search quality evaluation, three basic things are needed:
+. a collection of documents you want to evaluate your query performance against, 
+  usually one or more indices.
+. a collection of typical search requests that users enter into your system.
+. a set of document ratings that judge the documents relevance with respect to a 
+  search request.
+  
+It is important to note that one set of document ratings is needed per test 
+query, and that the relevance judgements are based on the information need of 
+the user that entered the query.
 
-. a collection of documents you want to evaluate your query performance against, usually one or more indices
-. a collection of typical search requests that users enter into your system
-. a set of document ratings that judge the documents relevance with respect to a search request+
-  It is important to note that one set of document ratings is needed per test query, and that
-  the relevance judgements are based on the information need of the user that entered the query.
+The ranking evaluation API provides a convenient way to use this information in 
+a ranking evaluation request to calculate different search evaluation metrics. 
+This gives a first estimation of your overall search quality and give you a 
+measurement to optimize against when fine-tuning various aspect of the query 
+generation in your application.
 
-The ranking evaluation API provides a convenient way to use this information in a ranking evaluation request to calculate different search evaluation metrics. This gives a first estimation of your overall search quality and give you a measurement to optimize against when fine-tuning various aspect of the query generation in your application. 
 
-[float]
-==== Ranking evaluation request structure
+[[search-rank-eval-api-path-params]]
+==== {api-path-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+
+
+[[search-rank-eval-api-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
++
+--
+Defaults to `open`.
+--
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+
+
+[[search-rank-eval-api-example]]
+==== {api-examples-title}
 
 In its most basic form, a request to the `_rank_eval` endpoint has two sections:
 
-[source,js]
+[source,console]
 -----------------------------
 GET /my_index/_rank_eval
 {
@@ -51,9 +102,10 @@ GET /my_index/_rank_eval
 <2> definition of the evaluation metric to calculate
 <3> a specific metric and its parameters
 
-The request section contains several search requests typical to your application, along with the document ratings for each particular search request, e.g.
+The request section contains several search requests typical to your 
+application, along with the document ratings for each particular search request.
 
-[source,js]
+[source,console]
 -----------------------------
     "requests": [
         {
@@ -82,17 +134,26 @@ The request section contains several search requests typical to your application
 
 <1> the search requests id, used to group result details later 
 <2> the query that is being evaluated
-<3> a list of document ratings, each entry containing the documents `_index` and `_id` together with
-the rating of the documents relevance with regards to this search request
+<3> a list of document ratings, each entry containing the documents `_index` and 
+`_id` together with the rating of the documents relevance with regards to this 
+search request
 
-A document `rating` can be any integer value that expresses the relevance of the document on a user defined scale. For some of the metrics, just giving a binary rating (e.g. `0` for irrelevant and `1` for relevant) will be sufficient, other metrics can use a more fine grained scale.
+A document `rating` can be any integer value that expresses the relevance of the 
+document on a user defined scale. For some of the metrics, just giving a binary 
+rating (for example `0` for irrelevant and `1` for relevant) will be sufficient, 
+other metrics can use a more fine grained scale.
 
-[float]
-==== Template based ranking evaluation
 
-As an alternative to having to provide a single query per test request, it is possible to specify query templates in the evaluation request and later refer to them. Queries with similar structure that only differ in their parameters don't have to be repeated all the time in the `requests` section this way. In typical search systems where user inputs usually get filled into a small set of query templates, this helps making the evaluation request more succinct.
+===== Template based ranking evaluation
 
-[source,js]
+As an alternative to having to provide a single query per test request, it is 
+possible to specify query templates in the evaluation request and later refer to 
+them. Queries with similar structure that only differ in their parameters don't 
+have to be repeated all the time in the `requests` section this way. In typical 
+search systems where user inputs usually get filled into a small set of query 
+templates, this helps making the evaluation request more succinct.
+
+[source,console]
 --------------------------------
 GET /my_index/_rank_eval
 { 
@@ -129,23 +190,30 @@ GET /my_index/_rank_eval
 <3> a reference to a previously defined template
 <4> the parameters to use to fill the template
 
-[float]
-==== Available evaluation metrics
 
-The `metric` section determines which of the available evaluation metrics is going to be used.
-Currently, the following metrics are supported:
+===== Available evaluation metrics
+
+The `metric` section determines which of the available evaluation metrics is 
+going to be used. The following metrics are supported:
 
 [float]
 [[k-precision]]
 ===== Precision at K (P@k)
 
-This metric measures the number of relevant results in the top k search results. Its a form of the well known https://en.wikipedia.org/wiki/Information_retrieval#Precision[Precision] metric that only looks at the top k documents. It is the fraction of relevant documents in those first k
-search. A precision at 10 (P@10) value of 0.6 then means six out of the 10 top hits are relevant with respect to the users information need.
+This metric measures the number of relevant results in the top k search results. 
+Its a form of the well known 
+https://en.wikipedia.org/wiki/Information_retrieval#Precision[Precision] metric 
+that only looks at the top k documents. It is the fraction of relevant documents 
+in those first k search. A precision at 10 (P@10) value of 0.6 then means six 
+out of the 10 top hits are relevant with respect to the users information need.
 
-P@k works well as a simple evaluation metric that has the benefit of being easy to understand and explain.
-Documents in the collection need to be rated either as relevant or irrelevant with respect to the current query. 
-P@k does not take into account where in the top k results the relevant documents occur, so a ranking of ten results that 
-contains one relevant result in position 10 is equally good as a ranking of ten results that contains one relevant result in position 1.
+P@k works well as a simple evaluation metric that has the benefit of being easy 
+to understand and explain. Documents in the collection need to be rated either 
+as relevant or irrelevant with respect to the current query. P@k does not take 
+into account where in the top k results the relevant documents occur, so a 
+ranking of ten results that contains one relevant result in position 10 is 
+equally good as a ranking of ten results that contains one relevant result in 
+position 1.
 
 [source,console]
 --------------------------------
@@ -181,13 +249,15 @@ in the query. Defaults to 10.
 If set to 'true', unlabeled documents are ignored and neither count as relevant or irrelevant. Set to 'false' (the default), they are treated as irrelevant.
 |=======================================================================
 
+
 [float]
 ===== Mean reciprocal rank
 
-For every query in the test suite, this metric calculates the reciprocal of the rank of the
-first relevant document. For example finding the first relevant result
-in position 3 means the reciprocal rank is 1/3. The reciprocal rank for each query
-is averaged across all queries in the test suite to give the https://en.wikipedia.org/wiki/Mean_reciprocal_rank[mean reciprocal rank].
+For every query in the test suite, this metric calculates the reciprocal of the 
+rank of the first relevant document. For example finding the first relevant 
+result in position 3 means the reciprocal rank is 1/3. The reciprocal rank for 
+each query is averaged across all queries in the test suite to give the 
+https://en.wikipedia.org/wiki/Mean_reciprocal_rank[mean reciprocal rank].
 
 [source,console]
 --------------------------------
@@ -220,12 +290,18 @@ in the query. Defaults to 10.
 "relevant". Defaults to `1`.
 |=======================================================================
 
+
 [float]
 ===== Discounted cumulative gain (DCG)
 
-In contrast to the two metrics above, https://en.wikipedia.org/wiki/Discounted_cumulative_gain[discounted cumulative gain] takes both, the rank and the rating of the search results, into account.
+In contrast to the two metrics above, 
+https://en.wikipedia.org/wiki/Discounted_cumulative_gain[discounted cumulative gain] 
+takes both, the rank and the rating of the search results, into account.
 
-The assumption is that highly relevant documents are more useful for the user when appearing at the top of the result list. Therefore, the DCG formula reduces the contribution that high ratings for documents on lower search ranks have on the overall DCG metric.
+The assumption is that highly relevant documents are more useful for the user 
+when appearing at the top of the result list. Therefore, the DCG formula reduces 
+the contribution that high ratings for documents on lower search ranks have on 
+the overall DCG metric.
 
 [source,console]
 --------------------------------
@@ -257,23 +333,31 @@ in the query. Defaults to 10.
 |`normalize` | If set to `true`, this metric will calculate the https://en.wikipedia.org/wiki/Discounted_cumulative_gain#Normalized_DCG[Normalized DCG].
 |=======================================================================
 
+
 [float]
 ===== Expected Reciprocal Rank (ERR)
 
-Expected Reciprocal Rank (ERR) is an extension of the classical reciprocal rank for the graded relevance case
-(Olivier Chapelle, Donald Metzler, Ya Zhang, and Pierre Grinspan. 2009. http://olivier.chapelle.cc/pub/err.pdf[Expected reciprocal rank for graded relevance].)
+Expected Reciprocal Rank (ERR) is an extension of the classical reciprocal rank 
+for the graded relevance case (Olivier Chapelle, Donald Metzler, Ya Zhang, and 
+Pierre Grinspan. 2009. 
+http://olivier.chapelle.cc/pub/err.pdf[Expected reciprocal rank for graded relevance].)
 
-It is based on the assumption of a cascade model of search, in which a user scans through ranked search
-results in order and stops at the first document that satisfies the information need. For this reason, it
-is a good metric for question answering and navigation queries, but less so for survey oriented information 
-needs where the user is interested in finding many relevant documents in the top k results.
+It is based on the assumption of a cascade model of search, in which a user 
+scans through ranked search results in order and stops at the first document 
+that satisfies the information need. For this reason, it is a good metric for 
+question answering and navigation queries, but less so for survey oriented 
+information needs where the user is interested in finding many relevant 
+documents in the top k results.
 
-The metric models the expectation of the reciprocal of the position at which a user stops reading through
-the result list. This means that relevant document in top ranking positions will contribute much to the
-overall score. However, the same document will contribute much less to the score if it appears in a lower rank,
-even more so if there are some relevant (but maybe less relevant) documents preceding it. 
-In this way, the ERR metric discounts documents which are shown after very relevant documents. This introduces 
-a notion of dependency in the ordering of relevant documents that e.g. Precision or DCG don't account for.
+The metric models the expectation of the reciprocal of the position at which a 
+user stops reading through the result list. This means that relevant document in 
+top ranking positions will contribute much to the overall score. However, the 
+same document will contribute much less to the score if it appears in a lower 
+rank, even more so if there are some relevant (but maybe less relevant) 
+documents preceding it. In this way, the ERR metric discounts documents which 
+are shown after very relevant documents. This introduces a notion of dependency 
+in the ordering of relevant documents that e.g. Precision or DCG don't account 
+for.
 
 [source,console]
 --------------------------------
@@ -306,12 +390,13 @@ relevance judgments.
 in the query. Defaults to 10.
 |=======================================================================
 
-[float]
-==== Response format
 
-The response of the `_rank_eval` endpoint contains the overall calculated result for the defined quality metric, 
-a `details` section with a breakdown of results for each query in the test suite and an optional `failures` section
-that shows potential errors of individual queries. The response has the following format:
+===== Response format
+
+The response of the `_rank_eval` endpoint contains the overall calculated result 
+for the defined quality metric, a `details` section with a breakdown of results 
+for each query in the test suite and an optional `failures` section that shows 
+potential errors of individual queries. The response has the following format:
 
 [source,js]
 --------------------------------

--- a/docs/reference/search/rank-eval.asciidoc
+++ b/docs/reference/search/rank-eval.asciidoc
@@ -130,7 +130,7 @@ application, along with the document ratings for each particular search request.
         }
     ]
 -----------------------------
-// NOTCONSOLE
+// TEST[skip: TBD]
 
 <1> the search requests id, used to group result details later 
 <2> the query that is being evaluated

--- a/docs/reference/search/rank-eval.asciidoc
+++ b/docs/reference/search/rank-eval.asciidoc
@@ -105,7 +105,7 @@ GET /my_index/_rank_eval
 The request section contains several search requests typical to your 
 application, along with the document ratings for each particular search request.
 
-[source,console]
+[source,js]
 -----------------------------
 GET /my_index/_rank_eval
 {


### PR DESCRIPTION
Relates to elastic/docs#937 and https://github.com/elastic/elasticsearch/issues/45621.

This PR updates the ranking evaluation API to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc).


Resources:
* [Ranking eval API spec](https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/rank_eval.json)
* [Ranking eval API doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-rank-eval.html)