### PR TITLE
[ML] fix two datafeed flush lockup bugs

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectCommunicator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectCommunicator.java
@@ -300,6 +300,7 @@ public class AutodetectCommunicator implements Closeable {
         }
 
         if (processKilled == false) {
+            LOGGER.debug("[{}] Initial flush completed, waiting until renormalizer is idle.", job.getId());
             // We also have to wait for the normalizer to become idle so that we block
             // clients from querying results in the middle of normalization.
             autodetectResultProcessor.waitUntilRenormalizerIsIdle();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectCommunicator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectCommunicator.java
@@ -284,7 +284,7 @@ public class AutodetectCommunicator implements Closeable {
     }
 
     @Nullable
-    FlushAcknowledgement waitFlushToCompletion(String flushId) throws InterruptedException {
+    FlushAcknowledgement waitFlushToCompletion(String flushId) throws Exception {
         LOGGER.debug("[{}] waiting for flush", job.getId());
 
         FlushAcknowledgement flushAcknowledgement;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
@@ -292,6 +292,7 @@ public class AutodetectResultProcessor {
             try {
                 bulkResultsPersister.executeRequest();
                 persister.commitResultWrites(jobId);
+                LOGGER.debug("[{}] Flush acknowledgement sent to listener for ID {}", jobId, flushAcknowledgement.getId());
             } catch (Exception e) {
                 LOGGER.error(
                     "[" + jobId + "] failed to bulk persist results and commit writes during flush acknowledgement for ID " +
@@ -300,7 +301,6 @@ public class AutodetectResultProcessor {
                 exception = e;
                 throw e;
             } finally {
-                LOGGER.debug("[{}] Flush acknowledgement sent to listener for ID {}", jobId, flushAcknowledgement.getId());
                 flushListener.acknowledgeFlush(flushAcknowledgement, exception);
             }
             // Interim results may have been produced by the flush,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/FlushListener.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/FlushListener.java
@@ -28,25 +28,29 @@ class FlushListener {
     });
 
     @Nullable
-    FlushAcknowledgement waitForFlush(String flushId, Duration timeout) throws InterruptedException {
+    FlushAcknowledgement waitForFlush(String flushId, Duration timeout) throws Exception {
         if (onClear.hasRun()) {
             return null;
         }
 
         FlushAcknowledgementHolder holder = awaitingFlushed.computeIfAbsent(flushId, (key) -> new FlushAcknowledgementHolder(flushId));
         if (holder.latch.await(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+            if (holder.flushException != null) {
+                throw holder.flushException;
+            }
             return holder.flushAcknowledgement;
         }
         return null;
     }
 
-    void acknowledgeFlush(FlushAcknowledgement flushAcknowledgement) {
+    void acknowledgeFlush(FlushAcknowledgement flushAcknowledgement, @Nullable Exception exception) {
         // acknowledgeFlush(...) could be called before waitForFlush(...)
         // a flush api call writes a flush command to the analytical process and then via a different thread the
         // result reader then reads whether the flush has been acked.
         String flushId = flushAcknowledgement.getId();
         FlushAcknowledgementHolder holder = awaitingFlushed.computeIfAbsent(flushId, (key) -> new FlushAcknowledgementHolder(flushId));
         holder.flushAcknowledgement = flushAcknowledgement;
+        holder.flushException = exception;
         holder.latch.countDown();
     }
 
@@ -62,6 +66,7 @@ class FlushListener {
 
         private final CountDownLatch latch;
         private volatile FlushAcknowledgement flushAcknowledgement;
+        private volatile Exception flushException;
 
         private FlushAcknowledgementHolder(String flushId) {
             this.flushAcknowledgement = new FlushAcknowledgement(flushId, null);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectCommunicatorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectCommunicatorTests.java
@@ -108,7 +108,7 @@ public class AutodetectCommunicatorTests extends ESTestCase {
         verifyNoMoreInteractions(process);
     }
 
-    public void testFlushJob() throws IOException, InterruptedException {
+    public void testFlushJob() throws Exception {
         AutodetectProcess process = mockAutodetectProcessWithOutputStream();
         when(process.isProcessAlive()).thenReturn(true);
         AutodetectResultProcessor processor = mock(AutodetectResultProcessor.class);
@@ -123,7 +123,7 @@ public class AutodetectCommunicatorTests extends ESTestCase {
         }
     }
 
-    public void testWaitForFlushReturnsIfParserFails() throws IOException, InterruptedException {
+    public void testWaitForFlushReturnsIfParserFails() throws Exception {
         AutodetectProcess process = mockAutodetectProcessWithOutputStream();
         when(process.isProcessAlive()).thenReturn(true);
         AutodetectResultProcessor processor = mock(AutodetectResultProcessor.class);
@@ -144,7 +144,7 @@ public class AutodetectCommunicatorTests extends ESTestCase {
         assertEquals("[foo] Unexpected death of autodetect: Mock process is dead", holder[0].getMessage());
     }
 
-    public void testFlushJob_givenFlushWaitReturnsTrueOnSecondCall() throws IOException, InterruptedException {
+    public void testFlushJob_givenFlushWaitReturnsTrueOnSecondCall() throws Exception {
         AutodetectProcess process = mockAutodetectProcessWithOutputStream();
         when(process.isProcessAlive()).thenReturn(true);
         AutodetectResultProcessor autodetectResultProcessor = Mockito.mock(AutodetectResultProcessor.class);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessorTests.java
@@ -220,7 +220,7 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         assertTrue(processorUnderTest.isDeleteInterimRequired());
 
         verify(persister).bulkPersisterBuilder(JOB_ID);
-        verify(flushListener).acknowledgeFlush(flushAcknowledgement);
+        verify(flushListener).acknowledgeFlush(flushAcknowledgement, null);
         verify(persister).commitResultWrites(JOB_ID);
         verify(bulkBuilder).executeRequest();
     }
@@ -242,7 +242,7 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         inOrder.verify(persister).persistCategoryDefinition(categoryDefinition);
         inOrder.verify(bulkBuilder).executeRequest();
         inOrder.verify(persister).commitResultWrites(JOB_ID);
-        inOrder.verify(flushListener).acknowledgeFlush(flushAcknowledgement);
+        inOrder.verify(flushListener).acknowledgeFlush(flushAcknowledgement, null);
     }
 
     public void testProcessResult_modelPlot() {
@@ -397,7 +397,7 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         verify(persister, times(2)).persistModelSnapshot(any(), eq(WriteRequest.RefreshPolicy.IMMEDIATE));
     }
 
-    public void testParsingErrorSetsFailed() throws InterruptedException {
+    public void testParsingErrorSetsFailed() throws Exception {
         @SuppressWarnings("unchecked")
         Iterator<AutodetectResult> iterator = mock(Iterator.class);
         when(iterator.hasNext()).thenThrow(new ElasticsearchParseException("this test throws"));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/FlushListenerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/FlushListenerTests.java
@@ -14,6 +14,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class FlushListenerTests extends ESTestCase {
@@ -27,13 +28,42 @@ public class FlushListenerTests extends ESTestCase {
                 flushAcknowledgementHolder.set(flushAcknowledgement);
             } catch (InterruptedException _ex) {
                 Thread.currentThread().interrupt();
+            } catch (Exception ex) {
+                fail("unexpected exception " + ex.getMessage());
             }
         }).start();
         assertBusy(() -> assertTrue(listener.awaitingFlushed.containsKey("_id")));
         assertNull(flushAcknowledgementHolder.get());
         FlushAcknowledgement flushAcknowledgement = new FlushAcknowledgement("_id", new Date(12345678L));
-        listener.acknowledgeFlush(flushAcknowledgement);
+        listener.acknowledgeFlush(flushAcknowledgement, null);
         assertBusy(() -> assertNotNull(flushAcknowledgementHolder.get()));
+        assertEquals(1, listener.awaitingFlushed.size());
+
+        listener.clear("_id");
+        assertEquals(0, listener.awaitingFlushed.size());
+    }
+
+    public void testAcknowledgeFlushFailure() throws Exception {
+        FlushListener listener = new FlushListener();
+        AtomicReference<Exception> flushExceptionHolder = new AtomicReference<>();
+        new Thread(() -> {
+            try {
+                listener.waitForFlush("_id", Duration.ofMillis(10000));
+                fail("Expected exception to throw.");
+            } catch (InterruptedException _ex) {
+                Thread.currentThread().interrupt();
+            } catch (Exception ex) {
+                flushExceptionHolder.set(ex);
+            }
+        }).start();
+        assertBusy(() -> assertTrue(listener.awaitingFlushed.containsKey("_id")));
+        assertNull(flushExceptionHolder.get());
+        FlushAcknowledgement flushAcknowledgement = new FlushAcknowledgement("_id", new Date(12345678L));
+        listener.acknowledgeFlush(flushAcknowledgement, new Exception("BOOM"));
+        assertBusy(() -> {
+            assertNotNull(flushExceptionHolder.get());
+            assertThat(flushExceptionHolder.get().getMessage(), equalTo("BOOM"));
+        });
         assertEquals(1, listener.awaitingFlushed.size());
 
         listener.clear("_id");
@@ -55,6 +85,8 @@ public class FlushListenerTests extends ESTestCase {
                     flushAcknowledgementHolder.set(flushAcknowledgement);
                 } catch (InterruptedException _ex) {
                     Thread.currentThread().interrupt();
+                } catch (Exception ex) {
+                    fail("unexpected exception " + ex.getMessage());
                 }
             }).start();
         }


### PR DESCRIPTION
There are two paths that could run into errors that could cause a wait for flush listener to never be called. 

1. Between the flush being acknowledged and the listener being notified, an exception is thrown. This would mean that the flush, which the native process believes it has acknowledged, was never actually acknowledged for the listener
2. The renormalizer throws an exception in `doRenormalizations` but more quantiles were added to the queue. This could create the following state:
   - Datafeed job is waiting for the flush to be acknowledged
   - flush acknowledgement is being blocked because we are waiting for `waitUntilIdle` on the normalizer
   - normalizer threw in `doRenormalizations`, and only the previously found quantile latch is counted down

This means no new data is being fed to the native process (flush lockup), so `doRenormalizations` is potentially never called again because new quantiles are not being made. This means that the latch that came in between `getLatestQuantilesWithLatchAndClear` and throwing the exception are never counted down.

I opted for keeping the "earliest" quantile in the queue, but with its latch triggered. The ONLY thing that polls the latches is `waitforidle`, and it will empty the latch queue as each gets tripped. Since I make sure the earliest quantile is tripped, it will essentially ONLY be used in `getEarliestQuantiles();` as the only next time that `doRenormalizations` will be called is when a NEW quantile and latch are added to the queues. 

I also added some debug level logging that may help diagnose flush lockups in the future.