### PR TITLE
Rename Painless node SSource to SClass

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Compiler.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Compiler.java
@@ -22,7 +22,7 @@ package org.elasticsearch.painless;
 import org.elasticsearch.bootstrap.BootstrapInfo;
 import org.elasticsearch.painless.antlr.Walker;
 import org.elasticsearch.painless.lookup.PainlessLookup;
-import org.elasticsearch.painless.node.SSource;
+import org.elasticsearch.painless.node.SClass;
 import org.elasticsearch.painless.spi.Whitelist;
 import org.objectweb.asm.util.Printer;
 
@@ -45,7 +45,7 @@ import static org.elasticsearch.painless.WriterConstants.CLASS_NAME;
 /**
  * The Compiler is the entry point for generating a Painless script.  The compiler will receive a Painless
  * tree based on the type of input passed in (currently only ANTLR).  Two passes will then be run over the tree,
- * one for analysis and another to generate the actual byte code using ASM using the root of the tree {@link SSource}.
+ * one for analysis and another to generate the actual byte code using ASM using the root of the tree {@link SClass}.
  */
 final class Compiler {
 
@@ -209,7 +209,7 @@ final class Compiler {
      */
     Constructor<?> compile(Loader loader, Set<String> extractedVariables, String name, String source, CompilerSettings settings) {
         ScriptClassInfo scriptClassInfo = new ScriptClassInfo(painlessLookup, scriptClass);
-        SSource root = Walker.buildPainlessTree(scriptClassInfo, name, source, settings, painlessLookup, null);
+        SClass root = Walker.buildPainlessTree(scriptClassInfo, name, source, settings, painlessLookup, null);
         root.extractVariables(extractedVariables);
         root.storeSettings(settings);
         root.analyze(painlessLookup);
@@ -240,7 +240,7 @@ final class Compiler {
      */
     byte[] compile(String name, String source, CompilerSettings settings, Printer debugStream) {
         ScriptClassInfo scriptClassInfo = new ScriptClassInfo(painlessLookup, scriptClass);
-        SSource root = Walker.buildPainlessTree(scriptClassInfo, name, source, settings, painlessLookup,
+        SClass root = Walker.buildPainlessTree(scriptClassInfo, name, source, settings, painlessLookup,
                 debugStream);
         root.extractVariables(new HashSet<>());
         root.storeSettings(settings);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/Walker.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/Walker.java
@@ -152,7 +152,7 @@ import org.elasticsearch.painless.node.SFunction;
 import org.elasticsearch.painless.node.SIf;
 import org.elasticsearch.painless.node.SIfElse;
 import org.elasticsearch.painless.node.SReturn;
-import org.elasticsearch.painless.node.SSource;
+import org.elasticsearch.painless.node.SClass;
 import org.elasticsearch.painless.node.SThrow;
 import org.elasticsearch.painless.node.STry;
 import org.elasticsearch.painless.node.SWhile;
@@ -166,14 +166,14 @@ import java.util.List;
  */
 public final class Walker extends PainlessParserBaseVisitor<ANode> {
 
-    public static SSource buildPainlessTree(ScriptClassInfo mainMethod, String sourceName,
+    public static SClass buildPainlessTree(ScriptClassInfo mainMethod, String sourceName,
                                             String sourceText, CompilerSettings settings, PainlessLookup painlessLookup,
                                             Printer debugStream) {
         return new Walker(mainMethod, sourceName, sourceText, settings, painlessLookup, debugStream).source;
     }
 
     private final ScriptClassInfo scriptClassInfo;
-    private final SSource source;
+    private final SClass source;
     private final CompilerSettings settings;
     private final Printer debugStream;
     private final String sourceName;
@@ -188,7 +188,7 @@ public final class Walker extends PainlessParserBaseVisitor<ANode> {
         this.sourceName = Location.computeSourceName(sourceName);
         this.sourceText = sourceText;
         this.painlessLookup = painlessLookup;
-        this.source = (SSource)visit(buildAntlrTree(sourceText));
+        this.source = (SClass)visit(buildAntlrTree(sourceText));
     }
 
     private SourceContext buildAntlrTree(String source) {
@@ -245,7 +245,7 @@ public final class Walker extends PainlessParserBaseVisitor<ANode> {
             statements.add((AStatement)visit(statement));
         }
 
-        return new SSource(scriptClassInfo, sourceName, sourceText, debugStream, location(ctx), functions, statements);
+        return new SClass(scriptClassInfo, sourceName, sourceText, debugStream, location(ctx), functions, statements);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/AStatement.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/AStatement.java
@@ -29,7 +29,7 @@ import org.objectweb.asm.Label;
 public abstract class AStatement extends ANode {
 
     /**
-     * Set to true when the final statement in an {@link SSource} is reached.
+     * Set to true when the final statement in an {@link SClass} is reached.
      * Used to determine whether or not an auto-return is necessary.
      */
     boolean lastSource = false;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SClass.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SClass.java
@@ -78,7 +78,7 @@ import static org.elasticsearch.painless.WriterConstants.STRING_TYPE;
 /**
  * The root of all Painless trees.  Contains a series of statements.
  */
-public final class SSource extends AStatement {
+public final class SClass extends AStatement {
 
     private final ScriptClassInfo scriptClassInfo;
     private final String name;
@@ -94,7 +94,7 @@ public final class SSource extends AStatement {
     private final List<org.objectweb.asm.commons.Method> getMethods;
     private byte[] bytes;
 
-    public SSource(ScriptClassInfo scriptClassInfo, String name, String sourceText, Printer debugStream,
+    public SClass(ScriptClassInfo scriptClassInfo, String name, String sourceText, Printer debugStream,
             Location location, List<SFunction> functions, List<AStatement> statements) {
         super(location);
         this.scriptClassInfo = Objects.requireNonNull(scriptClassInfo);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/package-info.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/package-info.java
@@ -88,7 +88,7 @@
  * {@link org.elasticsearch.painless.node.SIf} - Represents an if block.
  * {@link org.elasticsearch.painless.node.SIfElse} - Represents an if/else block.
  * {@link org.elasticsearch.painless.node.SReturn} - Represents a return statement.
- * {@link org.elasticsearch.painless.node.SSource} - The root of all Painless trees.  Contains a series of statements.
+ * {@link org.elasticsearch.painless.node.SClass} - The root of all Painless trees.  Contains a series of statements.
  * {@link org.elasticsearch.painless.node.SSubEachArray} - Represents a for-each loop for arrays.
  * {@link org.elasticsearch.painless.node.SSubEachIterable} - Represents a for-each loop for iterables.
  * {@link org.elasticsearch.painless.node.SThrow} - Represents a throw statement.
@@ -98,7 +98,7 @@
  * Note that internal nodes are generated during the analysis phase by modifying the tree on-the-fly
  * for clarity of development and convenience during the writing phase.
  * <p>
- * All Painless trees must start with an SSource node at the root.  Each node has a constructor that requires
+ * All Painless trees must start with an SClass node at the root.  Each node has a constructor that requires
  * all of its values and children be passed in at the time of instantiation.  This means that Painless trees
  * are build bottom-up; however, this helps enforce tree structure correctness and fits naturally with a
  * standard recursive-descent parser.

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/node/NodeToStringTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/node/NodeToStringTests.java
@@ -53,7 +53,7 @@ public class NodeToStringTests extends ESTestCase {
 
     public void testEAssignment() {
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SDeclBlock (SDeclaration def i))\n"
               + "  (SExpression (EAssignment (EVariable i) = (ENumeric 2)))\n"
               + "  (SReturn (EVariable i)))",
@@ -62,7 +62,7 @@ public class NodeToStringTests extends ESTestCase {
               + "return i");
         for (String operator : new String[] {"+", "-", "*", "/", "%", "&", "^", "|", "<<", ">>", ">>>"}) {
             assertToString(
-                    "(SSource\n"
+                    "(SClass\n"
                   + "  (SDeclBlock (SDeclaration def i (ENumeric 1)))\n"
                   + "  (SExpression (EAssignment (EVariable i) " + operator + "= (ENumeric 2)))\n"
                   + "  (SReturn (EVariable i)))",
@@ -72,31 +72,31 @@ public class NodeToStringTests extends ESTestCase {
         }
         // Compound
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SDeclBlock (SDeclaration def i))\n"
               + "  (SReturn (EAssignment (EVariable i) = (ENumeric 2))))",
                 "def i;\n"
               + "return i = 2");
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SDeclBlock (SDeclaration def i))\n"
               + "  (SReturn (EAssignment (EVariable i) ++ post)))",
                 "def i;\n"
               + "return i++");
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SDeclBlock (SDeclaration def i))\n"
               + "  (SReturn (EAssignment (EVariable i) ++ pre)))",
                 "def i;\n"
               + "return ++i");
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SDeclBlock (SDeclaration def i))\n"
               + "  (SReturn (EAssignment (EVariable i) -- post)))",
                 "def i;\n"
               + "return i--");
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SDeclBlock (SDeclaration def i))\n"
               + "  (SReturn (EAssignment (EVariable i) -- pre)))",
                 "def i;\n"
@@ -104,34 +104,34 @@ public class NodeToStringTests extends ESTestCase {
     }
 
     public void testEBinary() {
-        assertToString(     "(SSource (SReturn (EBinary (ENumeric 1) * (ENumeric 1))))", "return 1 * 1");
-        assertToString(     "(SSource (SReturn (EBinary (ENumeric 1) / (ENumeric 1))))", "return 1 / 1");
-        assertToString(     "(SSource (SReturn (EBinary (ENumeric 1) % (ENumeric 1))))", "return 1 % 1");
-        assertToString(     "(SSource (SReturn (EBinary (ENumeric 1) + (ENumeric 1))))", "return 1 + 1");
-        assertToString(     "(SSource (SReturn (EBinary (ENumeric 1) - (ENumeric 1))))", "return 1 - 1");
-        assertToString( "(SSource (SReturn (EBinary (EString 'asb') =~ (ERegex /cat/))))", "return 'asb' =~ /cat/");
-        assertToString("(SSource (SReturn (EBinary (EString 'asb') ==~ (ERegex /cat/))))", "return 'asb' ==~ /cat/");
-        assertToString(    "(SSource (SReturn (EBinary (ENumeric 1) << (ENumeric 1))))", "return 1 << 1");
-        assertToString(    "(SSource (SReturn (EBinary (ENumeric 1) >> (ENumeric 1))))", "return 1 >> 1");
-        assertToString(   "(SSource (SReturn (EBinary (ENumeric 1) >>> (ENumeric 1))))", "return 1 >>> 1");
-        assertToString(     "(SSource (SReturn (EBinary (ENumeric 1) & (ENumeric 1))))", "return 1 & 1");
-        assertToString(     "(SSource (SReturn (EBinary (ENumeric 1) ^ (ENumeric 1))))", "return 1 ^ 1");
-        assertToString(     "(SSource (SReturn (EBinary (ENumeric 1) | (ENumeric 1))))", "return 1 | 1");
+        assertToString(     "(SClass (SReturn (EBinary (ENumeric 1) * (ENumeric 1))))", "return 1 * 1");
+        assertToString(     "(SClass (SReturn (EBinary (ENumeric 1) / (ENumeric 1))))", "return 1 / 1");
+        assertToString(     "(SClass (SReturn (EBinary (ENumeric 1) % (ENumeric 1))))", "return 1 % 1");
+        assertToString(     "(SClass (SReturn (EBinary (ENumeric 1) + (ENumeric 1))))", "return 1 + 1");
+        assertToString(     "(SClass (SReturn (EBinary (ENumeric 1) - (ENumeric 1))))", "return 1 - 1");
+        assertToString( "(SClass (SReturn (EBinary (EString 'asb') =~ (ERegex /cat/))))", "return 'asb' =~ /cat/");
+        assertToString("(SClass (SReturn (EBinary (EString 'asb') ==~ (ERegex /cat/))))", "return 'asb' ==~ /cat/");
+        assertToString(    "(SClass (SReturn (EBinary (ENumeric 1) << (ENumeric 1))))", "return 1 << 1");
+        assertToString(    "(SClass (SReturn (EBinary (ENumeric 1) >> (ENumeric 1))))", "return 1 >> 1");
+        assertToString(   "(SClass (SReturn (EBinary (ENumeric 1) >>> (ENumeric 1))))", "return 1 >>> 1");
+        assertToString(     "(SClass (SReturn (EBinary (ENumeric 1) & (ENumeric 1))))", "return 1 & 1");
+        assertToString(     "(SClass (SReturn (EBinary (ENumeric 1) ^ (ENumeric 1))))", "return 1 ^ 1");
+        assertToString(     "(SClass (SReturn (EBinary (ENumeric 1) | (ENumeric 1))))", "return 1 | 1");
     }
 
     public void testEBool() {
-        assertToString("(SSource (SReturn (EBool (EBoolean true) && (EBoolean false))))", "return true && false");
-        assertToString("(SSource (SReturn (EBool (EBoolean true) || (EBoolean false))))", "return true || false");
+        assertToString("(SClass (SReturn (EBool (EBoolean true) && (EBoolean false))))", "return true && false");
+        assertToString("(SClass (SReturn (EBool (EBoolean true) || (EBoolean false))))", "return true || false");
     }
 
     public void testEBoolean() {
-        assertToString("(SSource (SReturn (EBoolean true)))",  "return true");
-        assertToString("(SSource (SReturn (EBoolean false)))", "return false");
+        assertToString("(SClass (SReturn (EBoolean true)))",  "return true");
+        assertToString("(SClass (SReturn (EBoolean false)))", "return false");
     }
 
     public void testECallLocal() {
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SFunction def a\n"
               + "    (SReturn (EBoolean true)))\n"
               + "  (SReturn (ECallLocal a)))",
@@ -140,7 +140,7 @@ public class NodeToStringTests extends ESTestCase {
               + "}\n"
               + "return a()");
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SFunction def a (Args (Pair int i) (Pair int j))\n"
               + "    (SReturn (EBoolean true)))\n"
               + "  (SReturn (ECallLocal a (Args (ENumeric 1) (ENumeric 2)))))",
@@ -152,7 +152,7 @@ public class NodeToStringTests extends ESTestCase {
 
     public void testECapturingFunctionRef() {
         assertToString(
-                  "(SSource\n"
+                  "(SClass\n"
                 + "  (SDeclBlock (SDeclaration Integer x (PCallInvoke (EStatic Integer) valueOf (Args (ENumeric 5)))))\n"
                 + "  (SReturn (PCallInvoke (PCallInvoke (EStatic Optional) empty) orElseGet (Args (ECapturingFunctionRef x toString)))))",
                   "Integer x = Integer.valueOf(5);\n"
@@ -173,18 +173,18 @@ public class NodeToStringTests extends ESTestCase {
     }
 
     public void testEComp() {
-        assertToString(  "(SSource (SReturn (EComp (PField (EVariable params) a) < (ENumeric 10))))", "return params.a < 10");
-        assertToString( "(SSource (SReturn (EComp (PField (EVariable params) a) <= (ENumeric 10))))", "return params.a <= 10");
-        assertToString(  "(SSource (SReturn (EComp (PField (EVariable params) a) > (ENumeric 10))))", "return params.a > 10");
-        assertToString( "(SSource (SReturn (EComp (PField (EVariable params) a) >= (ENumeric 10))))", "return params.a >= 10");
-        assertToString( "(SSource (SReturn (EComp (PField (EVariable params) a) == (ENumeric 10))))", "return params.a == 10");
-        assertToString("(SSource (SReturn (EComp (PField (EVariable params) a) === (ENumeric 10))))", "return params.a === 10");
-        assertToString( "(SSource (SReturn (EComp (PField (EVariable params) a) != (ENumeric 10))))", "return params.a != 10");
-        assertToString("(SSource (SReturn (EComp (PField (EVariable params) a) !== (ENumeric 10))))", "return params.a !== 10");
+        assertToString(  "(SClass (SReturn (EComp (PField (EVariable params) a) < (ENumeric 10))))", "return params.a < 10");
+        assertToString( "(SClass (SReturn (EComp (PField (EVariable params) a) <= (ENumeric 10))))", "return params.a <= 10");
+        assertToString(  "(SClass (SReturn (EComp (PField (EVariable params) a) > (ENumeric 10))))", "return params.a > 10");
+        assertToString( "(SClass (SReturn (EComp (PField (EVariable params) a) >= (ENumeric 10))))", "return params.a >= 10");
+        assertToString( "(SClass (SReturn (EComp (PField (EVariable params) a) == (ENumeric 10))))", "return params.a == 10");
+        assertToString("(SClass (SReturn (EComp (PField (EVariable params) a) === (ENumeric 10))))", "return params.a === 10");
+        assertToString( "(SClass (SReturn (EComp (PField (EVariable params) a) != (ENumeric 10))))", "return params.a != 10");
+        assertToString("(SClass (SReturn (EComp (PField (EVariable params) a) !== (ENumeric 10))))", "return params.a !== 10");
     }
 
     public void testEConditional() {
-        assertToString("(SSource (SReturn (EConditional (PField (EVariable params) a) (ENumeric 1) (ENumeric 6))))",
+        assertToString("(SClass (SReturn (EConditional (PField (EVariable params) a) (ENumeric 1) (ENumeric 6))))",
                 "return params.a ? 1 : 6");
     }
 
@@ -196,68 +196,68 @@ public class NodeToStringTests extends ESTestCase {
     }
 
     public void testEDecimal() {
-        assertToString("(SSource (SReturn (EDecimal 1.0)))", "return 1.0");
-        assertToString("(SSource (SReturn (EDecimal 14.121d)))", "return 14.121d");
-        assertToString("(SSource (SReturn (EDecimal 2234.1f)))", "return 2234.1f");
-        assertToString("(SSource (SReturn (EDecimal 14.121D)))", "return 14.121D");
-        assertToString("(SSource (SReturn (EDecimal 1234.1F)))", "return 1234.1F");
+        assertToString("(SClass (SReturn (EDecimal 1.0)))", "return 1.0");
+        assertToString("(SClass (SReturn (EDecimal 14.121d)))", "return 14.121d");
+        assertToString("(SClass (SReturn (EDecimal 2234.1f)))", "return 2234.1f");
+        assertToString("(SClass (SReturn (EDecimal 14.121D)))", "return 14.121D");
+        assertToString("(SClass (SReturn (EDecimal 1234.1F)))", "return 1234.1F");
     }
 
     public void testEElvis() {
-        assertToString("(SSource (SReturn (EElvis (PField (EVariable params) a) (ENumeric 1))))", "return params.a ?: 1");
+        assertToString("(SClass (SReturn (EElvis (PField (EVariable params) a) (ENumeric 1))))", "return params.a ?: 1");
     }
 
     public void testEExplicit() {
-        assertToString("(SSource (SReturn (EExplicit byte (PField (EVariable params) a))))", "return (byte)(params.a)");
+        assertToString("(SClass (SReturn (EExplicit byte (PField (EVariable params) a))))", "return (byte)(params.a)");
     }
 
     public void testEFunctionRef() {
         assertToString(
-                "(SSource (SReturn "
+                "(SClass (SReturn "
                         + "(PCallInvoke (PCallInvoke (EStatic Optional) empty) orElseGet (Args (EFunctionRef Optional empty)))))",
                 "return Optional.empty().orElseGet(Optional::empty)");
     }
 
     public void testEInstanceOf() {
-        assertToString("(SSource (SReturn (EInstanceof (ENewObj Object) Object)))", "return new Object() instanceof Object");
-        assertToString("(SSource (SReturn (EInstanceof (ENumeric 12) double)))", "return 12 instanceof double");
+        assertToString("(SClass (SReturn (EInstanceof (ENewObj Object) Object)))", "return new Object() instanceof Object");
+        assertToString("(SClass (SReturn (EInstanceof (ENumeric 12) double)))", "return 12 instanceof double");
     }
 
     public void testELambda() {
         assertToString(
-                  "(SSource (SReturn (PCallInvoke (PCallInvoke (EStatic Optional) empty) orElseGet (Args "
+                  "(SClass (SReturn (PCallInvoke (PCallInvoke (EStatic Optional) empty) orElseGet (Args "
                 + "(ELambda (SReturn (ENumeric 1)))))))",
                   "return Optional.empty().orElseGet(() -> {\n"
                 + "  return 1\n"
                 + "})");
         assertToString(
-                  "(SSource (SReturn (PCallInvoke (PCallInvoke (EStatic Optional) empty) orElseGet (Args "
+                  "(SClass (SReturn (PCallInvoke (PCallInvoke (EStatic Optional) empty) orElseGet (Args "
                 + "(ELambda (SReturn (ENumeric 1)))))))",
                   "return Optional.empty().orElseGet(() -> 1)");
         assertToString(
-                  "(SSource (SReturn (PCallInvoke (PCallInvoke (PCallInvoke (EListInit (ENumeric 1) (ENumeric 2) (ENumeric 3)) stream) "
+                  "(SClass (SReturn (PCallInvoke (PCallInvoke (PCallInvoke (EListInit (ENumeric 1) (ENumeric 2) (ENumeric 3)) stream) "
                 + "mapToInt (Args (ELambda (Pair def x)\n"
                 + "  (SReturn (EBinary (EVariable x) + (ENumeric 1)))))) sum)))",
                   "return [1, 2, 3].stream().mapToInt((def x) -> {\n"
                 + "  return x + 1\n"
                 + "}).sum()");
         assertToString(
-                  "(SSource (SReturn (PCallInvoke (PCallInvoke (PCallInvoke (EListInit (ENumeric 1) (ENumeric 2) (ENumeric 3)) stream) "
+                  "(SClass (SReturn (PCallInvoke (PCallInvoke (PCallInvoke (EListInit (ENumeric 1) (ENumeric 2) (ENumeric 3)) stream) "
                 + "mapToInt (Args (ELambda (Pair null x)\n"
                 + "  (SReturn (EBinary (EVariable x) + (ENumeric 1)))))) sum)))",
                   "return [1, 2, 3].stream().mapToInt(x -> x + 1).sum()");
         assertToString(
-                  "(SSource (SReturn (PCallInvoke (EListInit (EString 'a') (EString 'b')) sort (Args (ELambda (Pair def a) (Pair def b)\n"
+                  "(SClass (SReturn (PCallInvoke (EListInit (EString 'a') (EString 'b')) sort (Args (ELambda (Pair def a) (Pair def b)\n"
                 + "  (SReturn (EBinary (PCallInvoke (EVariable a) length) - (PCallInvoke (EVariable b) length))))))))",
                   "return ['a', 'b'].sort((def a, def b) -> {\n"
                 + "  return a.length() - b.length()\n"
                 + "})");
         assertToString(
-                  "(SSource (SReturn (PCallInvoke (EListInit (EString 'a') (EString 'b')) sort (Args (ELambda (Pair null a) (Pair null b)\n"
+                  "(SClass (SReturn (PCallInvoke (EListInit (EString 'a') (EString 'b')) sort (Args (ELambda (Pair null a) (Pair null b)\n"
                 + "  (SReturn (EBinary (PCallInvoke (EVariable a) length) - (PCallInvoke (EVariable b) length))))))))",
                   "return ['a', 'b'].sort((a, b) -> a.length() - b.length())");
         assertToString(
-                "(SSource (SReturn (PCallInvoke (EListInit (EString 'a') (EString 'b')) sort (Args (ELambda (Pair def a) (Pair def b)\n"
+                "(SClass (SReturn (PCallInvoke (EListInit (EString 'a') (EString 'b')) sort (Args (ELambda (Pair def a) (Pair def b)\n"
               + "  (SIf (EComp (EVariable a) < (EVariable b)) (SBlock "
                   + "(SReturn (EBinary (PCallInvoke (EVariable a) length) - (PCallInvoke (EVariable b) length)))))\n"
               + "  (SReturn (ENumeric 1)))))))",
@@ -270,85 +270,85 @@ public class NodeToStringTests extends ESTestCase {
     }
 
     public void testEListInit() {
-        assertToString("(SSource (SReturn (EListInit (ENumeric 1) (ENumeric 2) (EString 'cat') (EString 'dog') (ENewObj Object))))",
+        assertToString("(SClass (SReturn (EListInit (ENumeric 1) (ENumeric 2) (EString 'cat') (EString 'dog') (ENewObj Object))))",
                 "return [1, 2, 'cat', 'dog', new Object()]");
-        assertToString("(SSource (SReturn (EListInit)))", "return []");
+        assertToString("(SClass (SReturn (EListInit)))", "return []");
     }
 
     public void testEMapInit() {
-        assertToString("(SSource (SReturn (EMapInit "
+        assertToString("(SClass (SReturn (EMapInit "
                     + "(Pair (EString 'a') (ENumeric 1)) "
                     + "(Pair (EString 'b') (ENumeric 3)) "
                     + "(Pair (ENumeric 12) (ENewObj Object)))))",
                 "return ['a': 1, 'b': 3, 12: new Object()]");
-        assertToString("(SSource (SReturn (EMapInit)))", "return [:]");
+        assertToString("(SClass (SReturn (EMapInit)))", "return [:]");
     }
 
     public void testENewArray() {
-        assertToString("(SSource (SReturn (ENewArray int[] dims (Args (ENumeric 10)))))", "return new int[10]");
-        assertToString("(SSource (SReturn (ENewArray int[][][] dims (Args (ENumeric 10) (ENumeric 4) (ENumeric 5)))))",
+        assertToString("(SClass (SReturn (ENewArray int[] dims (Args (ENumeric 10)))))", "return new int[10]");
+        assertToString("(SClass (SReturn (ENewArray int[][][] dims (Args (ENumeric 10) (ENumeric 4) (ENumeric 5)))))",
                 "return new int[10][4][5]");
-        assertToString("(SSource (SReturn (ENewArray int[] init (Args (ENumeric 1) (ENumeric 2) (ENumeric 3)))))",
+        assertToString("(SClass (SReturn (ENewArray int[] init (Args (ENumeric 1) (ENumeric 2) (ENumeric 3)))))",
                 "return new int[] {1, 2, 3}");
-        assertToString("(SSource (SReturn (ENewArray def[] init (Args (ENumeric 1) (ENumeric 2) (EString 'bird')))))",
+        assertToString("(SClass (SReturn (ENewArray def[] init (Args (ENumeric 1) (ENumeric 2) (EString 'bird')))))",
                 "return new def[] {1, 2, 'bird'}");
     }
 
     public void testENewObj() {
-        assertToString("(SSource (SReturn (ENewObj Object)))", "return new Object()");
-        assertToString("(SSource (SReturn (ENewObj DateTimeException (Args (EString 'test')))))", "return new DateTimeException('test')");
+        assertToString("(SClass (SReturn (ENewObj Object)))", "return new Object()");
+        assertToString("(SClass (SReturn (ENewObj DateTimeException (Args (EString 'test')))))", "return new DateTimeException('test')");
     }
 
     public void testENull() {
-        assertToString("(SSource (SReturn (ENull)))", "return null");
+        assertToString("(SClass (SReturn (ENull)))", "return null");
     }
 
     public void testENumeric() {
-        assertToString("(SSource (SReturn (ENumeric 1)))", "return 1");
-        assertToString("(SSource (SReturn (ENumeric 114121d)))", "return 114121d");
-        assertToString("(SSource (SReturn (ENumeric 114134f)))", "return 114134f");
-        assertToString("(SSource (SReturn (ENumeric 114121D)))", "return 114121D");
-        assertToString("(SSource (SReturn (ENumeric 111234F)))", "return 111234F");
-        assertToString("(SSource (SReturn (ENumeric 774121l)))", "return 774121l");
-        assertToString("(SSource (SReturn (ENumeric 881234L)))", "return 881234L");
+        assertToString("(SClass (SReturn (ENumeric 1)))", "return 1");
+        assertToString("(SClass (SReturn (ENumeric 114121d)))", "return 114121d");
+        assertToString("(SClass (SReturn (ENumeric 114134f)))", "return 114134f");
+        assertToString("(SClass (SReturn (ENumeric 114121D)))", "return 114121D");
+        assertToString("(SClass (SReturn (ENumeric 111234F)))", "return 111234F");
+        assertToString("(SClass (SReturn (ENumeric 774121l)))", "return 774121l");
+        assertToString("(SClass (SReturn (ENumeric 881234L)))", "return 881234L");
 
-        assertToString("(SSource (SReturn (ENumeric 1 16)))", "return 0x1");
-        assertToString("(SSource (SReturn (ENumeric 774121l 16)))", "return 0x774121l");
-        assertToString("(SSource (SReturn (ENumeric 881234L 16)))", "return 0x881234L");
+        assertToString("(SClass (SReturn (ENumeric 1 16)))", "return 0x1");
+        assertToString("(SClass (SReturn (ENumeric 774121l 16)))", "return 0x774121l");
+        assertToString("(SClass (SReturn (ENumeric 881234L 16)))", "return 0x881234L");
 
-        assertToString("(SSource (SReturn (ENumeric 1 8)))", "return 01");
-        assertToString("(SSource (SReturn (ENumeric 774121l 8)))", "return 0774121l");
-        assertToString("(SSource (SReturn (ENumeric 441234L 8)))", "return 0441234L");
+        assertToString("(SClass (SReturn (ENumeric 1 8)))", "return 01");
+        assertToString("(SClass (SReturn (ENumeric 774121l 8)))", "return 0774121l");
+        assertToString("(SClass (SReturn (ENumeric 441234L 8)))", "return 0441234L");
     }
 
     public void testERegex() {
-        assertToString("(SSource (SReturn (ERegex /foo/)))", "return /foo/");
-        assertToString("(SSource (SReturn (ERegex /foo/ cix)))", "return /foo/cix");
-        assertToString("(SSource (SReturn (ERegex /foo/ cix)))", "return /foo/xci");
+        assertToString("(SClass (SReturn (ERegex /foo/)))", "return /foo/");
+        assertToString("(SClass (SReturn (ERegex /foo/ cix)))", "return /foo/cix");
+        assertToString("(SClass (SReturn (ERegex /foo/ cix)))", "return /foo/xci");
     }
 
     public void testEStatic() {
-        assertToString("(SSource (SReturn (PCallInvoke (EStatic Optional) empty)))", "return Optional.empty()");
+        assertToString("(SClass (SReturn (PCallInvoke (EStatic Optional) empty)))", "return Optional.empty()");
     }
 
     public void testEString() {
-        assertToString("(SSource (SReturn (EString 'foo')))", "return 'foo'");
-        assertToString("(SSource (SReturn (EString ' oo')))", "return ' oo'");
-        assertToString("(SSource (SReturn (EString 'fo ')))", "return 'fo '");
-        assertToString("(SSource (SReturn (EString ' o ')))", "return ' o '");
+        assertToString("(SClass (SReturn (EString 'foo')))", "return 'foo'");
+        assertToString("(SClass (SReturn (EString ' oo')))", "return ' oo'");
+        assertToString("(SClass (SReturn (EString 'fo ')))", "return 'fo '");
+        assertToString("(SClass (SReturn (EString ' o ')))", "return ' o '");
     }
 
     public void testEUnary() {
-        assertToString("(SSource (SReturn (EUnary ! (EBoolean true))))", "return !true");
-        assertToString("(SSource (SReturn (EUnary ~ (ENumeric 1))))", "return ~1");
-        assertToString("(SSource (SReturn (EUnary + (ENumeric 1))))", "return +1");
-        assertToString("(SSource (SReturn (EUnary - (ENumeric 1))))", "return -(1)");
+        assertToString("(SClass (SReturn (EUnary ! (EBoolean true))))", "return !true");
+        assertToString("(SClass (SReturn (EUnary ~ (ENumeric 1))))", "return ~1");
+        assertToString("(SClass (SReturn (EUnary + (ENumeric 1))))", "return +1");
+        assertToString("(SClass (SReturn (EUnary - (ENumeric 1))))", "return -(1)");
     }
 
     public void testEVariable() {
-        assertToString("(SSource (SReturn (EVariable params)))", "return params");
+        assertToString("(SClass (SReturn (EVariable params)))", "return params");
         assertToString(
-                  "(SSource\n"
+                  "(SClass\n"
                 + "  (SDeclBlock (SDeclaration def a (ENumeric 1)))\n"
                 + "  (SReturn (EVariable a)))",
                   "def a = 1;\n"
@@ -356,29 +356,29 @@ public class NodeToStringTests extends ESTestCase {
     }
 
     public void testPBrace() {
-        assertToString("(SSource (SReturn (PBrace (PField (EVariable params) a) (ENumeric 10))))", "return params.a[10]");
-        assertToString("(SSource (SReturn (PBrace (EVariable params) (EString 'a'))))", "return params['a']");
+        assertToString("(SClass (SReturn (PBrace (PField (EVariable params) a) (ENumeric 10))))", "return params.a[10]");
+        assertToString("(SClass (SReturn (PBrace (EVariable params) (EString 'a'))))", "return params['a']");
     }
 
     public void testPCallInvoke() {
-        assertToString("(SSource (SReturn (PCallInvoke (EStatic Optional) empty)))", "return Optional.empty()");
-        assertToString("(SSource (SReturn (PCallInvoke (EStatic Optional) of (Args (ENumeric 1)))))", "return Optional.of(1)");
-        assertToString("(SSource (SReturn (PCallInvoke (EStatic Objects) equals (Args (ENumeric 1) (ENumeric 2)))))",
+        assertToString("(SClass (SReturn (PCallInvoke (EStatic Optional) empty)))", "return Optional.empty()");
+        assertToString("(SClass (SReturn (PCallInvoke (EStatic Optional) of (Args (ENumeric 1)))))", "return Optional.of(1)");
+        assertToString("(SClass (SReturn (PCallInvoke (EStatic Objects) equals (Args (ENumeric 1) (ENumeric 2)))))",
                 "return Objects.equals(1, 2)");
-        assertToString("(SSource (SReturn (PCallInvoke (EVariable params) equals (Args (ENumeric 1)))))", "return params.equals(1)");
+        assertToString("(SClass (SReturn (PCallInvoke (EVariable params) equals (Args (ENumeric 1)))))", "return params.equals(1)");
     }
 
     public void testPField() {
-        assertToString("(SSource (SReturn (PField (EVariable params) a)))", "return params.a");
-        assertToString("(SSource (SReturn (PField nullSafe (EVariable params) a)))", "return params?.a");
+        assertToString("(SClass (SReturn (PField (EVariable params) a)))", "return params.a");
+        assertToString("(SClass (SReturn (PField nullSafe (EVariable params) a)))", "return params?.a");
         assertToString(
-                  "(SSource\n"
+                  "(SClass\n"
                 + "  (SDeclBlock (SDeclaration int[] a (ENewArray int[] dims (Args (ENumeric 10)))))\n"
                 + "  (SReturn (PField (EVariable a) length)))",
                   "int[] a = new int[10];\n"
                 + "return a.length");
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SDeclBlock (SDeclaration org.elasticsearch.painless.FeatureTestObject a"
               + " (ENewObj org.elasticsearch.painless.FeatureTestObject)))\n"
               + "  (SExpression (EAssignment (PField (EVariable a) x) = (ENumeric 10)))\n"
@@ -510,7 +510,7 @@ public class NodeToStringTests extends ESTestCase {
 
     public void testSBreak() {
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SDeclBlock (SDeclaration int itr (ENumeric 2)))\n"
               + "  (SDeclBlock (SDeclaration int a (ENumeric 1)))\n"
               + "  (SDeclBlock (SDeclaration int b (ENumeric 1)))\n"
@@ -538,7 +538,7 @@ public class NodeToStringTests extends ESTestCase {
 
     public void testSContinue() {
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SDeclBlock (SDeclaration int itr (ENumeric 2)))\n"
               + "  (SDeclBlock (SDeclaration int a (ENumeric 1)))\n"
               + "  (SDeclBlock (SDeclaration int b (ENumeric 1)))\n"
@@ -566,7 +566,7 @@ public class NodeToStringTests extends ESTestCase {
 
     public void testSDeclBlock() {
         assertToString(
-                  "(SSource\n"
+                  "(SClass\n"
                 + "  (SDeclBlock (SDeclaration def a))\n"
                 + "  (SExpression (EAssignment (EVariable a) = (ENumeric 10)))\n"
                 + "  (SReturn (EVariable a)))",
@@ -574,13 +574,13 @@ public class NodeToStringTests extends ESTestCase {
                 + "a = 10;\n"
                 + "return a");
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SDeclBlock (SDeclaration def a (ENumeric 10)))\n"
               + "  (SReturn (EVariable a)))",
                 "def a = 10;\n"
               + "return a");
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SDeclBlock\n"
               + "    (SDeclaration def a)\n"
               + "    (SDeclaration def b)\n"
@@ -589,7 +589,7 @@ public class NodeToStringTests extends ESTestCase {
                 "def a, b, c;\n"
               + "return a");
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SDeclBlock\n"
               + "    (SDeclaration def a (ENumeric 10))\n"
               + "    (SDeclaration def b (ENumeric 20))\n"
@@ -598,7 +598,7 @@ public class NodeToStringTests extends ESTestCase {
                 "def a = 10, b = 20, c = 100;\n"
               + "return a");
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SDeclBlock\n"
               + "    (SDeclaration def a (ENumeric 10))\n"
               + "    (SDeclaration def b)\n"
@@ -607,7 +607,7 @@ public class NodeToStringTests extends ESTestCase {
                 "def a = 10, b, c = 100;\n"
               + "return a");
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SIf (PField (EVariable params) a) (SBlock\n"
               + "    (SDeclBlock\n"
               + "      (SDeclaration def a (ENumeric 10))\n"
@@ -624,7 +624,7 @@ public class NodeToStringTests extends ESTestCase {
 
     public void testSDo() {
         assertToString(
-                  "(SSource\n"
+                  "(SClass\n"
                 + "  (SDeclBlock (SDeclaration int itr (ENumeric 2)))\n"
                 + "  (SDeclBlock (SDeclaration int a (ENumeric 1)))\n"
                 + "  (SDeclBlock (SDeclaration int b (ENumeric 1)))\n"
@@ -648,7 +648,7 @@ public class NodeToStringTests extends ESTestCase {
 
     public void testSEach() {
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SDeclBlock (SDeclaration int l (ENumeric 0)))\n"
               + "  (SEach String s (EListInit (EString 'cat') (EString 'dog') (EString 'chicken')) (SBlock "
                   + "(SExpression (EAssignment (EVariable l) += (PCallInvoke (EVariable s) length)))))\n"
@@ -659,7 +659,7 @@ public class NodeToStringTests extends ESTestCase {
                 + "}\n"
                 + "return l");
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SDeclBlock (SDeclaration int l (ENumeric 0)))\n"
               + "  (SEach String s (EListInit (EString 'cat') (EString 'dog') (EString 'chicken')) (SBlock\n"
               + "    (SDeclBlock (SDeclaration String s2 (EBinary (EString 'dire ') + (EVariable s))))\n"
@@ -675,7 +675,7 @@ public class NodeToStringTests extends ESTestCase {
 
     public void testSFor() {
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SDeclBlock (SDeclaration int sum (ENumeric 0)))\n"
               + "  (SFor\n"
               + "    (SDeclBlock (SDeclaration int i (ENumeric 0)))\n"
@@ -689,7 +689,7 @@ public class NodeToStringTests extends ESTestCase {
                 + "}\n"
                 + "return sum");
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SDeclBlock (SDeclaration int sum (ENumeric 0)))\n"
               + "  (SFor\n"
               + "    (SDeclBlock (SDeclaration int i (ENumeric 0)))\n"
@@ -712,12 +712,12 @@ public class NodeToStringTests extends ESTestCase {
 
     public void testSIf() {
         assertToString(
-                "(SSource (SIf (PField (EVariable param) a) (SBlock (SReturn (EBoolean true)))))",
+                "(SClass (SIf (PField (EVariable param) a) (SBlock (SReturn (EBoolean true)))))",
                   "if (param.a) {\n"
                 + "  return true\n"
                 +"}");
         assertToString(
-                "(SSource (SIf (PField (EVariable param) a) (SBlock\n"
+                "(SClass (SIf (PField (EVariable param) a) (SBlock\n"
               + "  (SIf (PField (EVariable param) b) (SBlock (SReturn (EBoolean true))))\n"
               + "  (SReturn (EBoolean false)))))",
                 "if (param.a) {\n"
@@ -730,7 +730,7 @@ public class NodeToStringTests extends ESTestCase {
 
     public void testSIfElse() {
         assertToString(
-                  "(SSource (SIfElse (PField (EVariable param) a)\n"
+                  "(SClass (SIfElse (PField (EVariable param) a)\n"
                 + "  (SBlock (SReturn (EBoolean true)))\n"
                 + "  (SBlock (SReturn (EBoolean false)))))",
                   "if (param.a) {\n"
@@ -739,7 +739,7 @@ public class NodeToStringTests extends ESTestCase {
                 + "  return false\n"
                 + "}");
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SDeclBlock (SDeclaration int i (ENumeric 0)))\n"
               + "  (SIfElse (PField (EVariable param) a)\n"
               + "    (SBlock (SIfElse (PField (EVariable param) b)\n"
@@ -783,12 +783,12 @@ public class NodeToStringTests extends ESTestCase {
     }
 
     public void testSThrow() {
-        assertToString("(SSource (SThrow (ENewObj RuntimeException)))", "throw new RuntimeException()");
+        assertToString("(SClass (SThrow (ENewObj RuntimeException)))", "throw new RuntimeException()");
     }
 
     public void testSWhile() {
         assertToString(
-                  "(SSource\n"
+                  "(SClass\n"
                 + "  (SDeclBlock (SDeclaration int i (ENumeric 0)))\n"
                 + "  (SWhile (EComp (EVariable i) < (ENumeric 10)) (SBlock (SExpression (EAssignment (EVariable i) ++ post))))\n"
                 + "  (SReturn (EVariable i)))",
@@ -801,7 +801,7 @@ public class NodeToStringTests extends ESTestCase {
 
     public void testSFunction() {
         assertToString(
-                  "(SSource\n"
+                  "(SClass\n"
                 + "  (SFunction def a\n"
                 + "    (SReturn (EBoolean true)))\n"
                 + "  (SReturn (EBoolean true)))",
@@ -810,7 +810,7 @@ public class NodeToStringTests extends ESTestCase {
                 + "}\n"
                 + "return true");
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SFunction def a (Args (Pair int i) (Pair int j))\n"
               + "    (SReturn (EBoolean true)))\n"
               + "  (SReturn (EBoolean true)))",
@@ -819,7 +819,7 @@ public class NodeToStringTests extends ESTestCase {
               + "}\n"
               + "return true");
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SFunction def a (Args (Pair int i) (Pair int j))\n"
               + "    (SIf (EComp (EVariable i) < (EVariable j)) (SBlock (SReturn (EBoolean true))))\n"
               + "    (SDeclBlock (SDeclaration int k (EBinary (EVariable i) + (EVariable j))))\n"
@@ -834,7 +834,7 @@ public class NodeToStringTests extends ESTestCase {
               + "}\n"
               + "return true");
         assertToString(
-                "(SSource\n"
+                "(SClass\n"
               + "  (SFunction def a\n"
               + "    (SReturn (EBoolean true)))\n"
               + "  (SFunction def b\n"
@@ -851,7 +851,7 @@ public class NodeToStringTests extends ESTestCase {
 
     public void testSTryAndSCatch() {
         assertToString(
-                  "(SSource (STry (SBlock (SReturn (ENumeric 1)))\n"
+                  "(SClass (STry (SBlock (SReturn (ENumeric 1)))\n"
                 + "  (SCatch Exception e (SBlock (SReturn (ENumeric 2))))))",
                   "try {\n"
                 + "  return 1\n"
@@ -859,7 +859,7 @@ public class NodeToStringTests extends ESTestCase {
                 + "  return 2\n"
                 + "}");
         assertToString(
-                "(SSource (STry (SBlock\n"
+                "(SClass (STry (SBlock\n"
               + "  (SDeclBlock (SDeclaration int i (ENumeric 1)))\n"
               + "  (SReturn (ENumeric 1)))\n"
               + "  (SCatch Exception e (SBlock (SReturn (ENumeric 2))))))",
@@ -870,7 +870,7 @@ public class NodeToStringTests extends ESTestCase {
               + "  return 2\n"
               + "}");
         assertToString(
-                "(SSource (STry (SBlock (SReturn (ENumeric 1)))\n"
+                "(SClass (STry (SBlock (SReturn (ENumeric 1)))\n"
               + "  (SCatch Exception e (SBlock\n"
               + "    (SDeclBlock (SDeclaration int i (ENumeric 1)))\n"
               + "    (SReturn (ENumeric 2))))))",
@@ -881,7 +881,7 @@ public class NodeToStringTests extends ESTestCase {
               + "  return 2\n"
               + "}");
         assertToString(
-                "(SSource (STry (SBlock (SReturn (ENumeric 1)))\n"
+                "(SClass (STry (SBlock (SReturn (ENumeric 1)))\n"
               + "  (SCatch NullPointerException e (SBlock (SReturn (ENumeric 2))))\n"
               + "  (SCatch Exception e (SBlock (SReturn (ENumeric 3))))))",
                 "try {\n"
@@ -905,7 +905,7 @@ public class NodeToStringTests extends ESTestCase {
         assertEquals(expected, walk(code).toString());
     }
 
-    private SSource walk(String code) {
+    private SClass walk(String code) {
         ScriptClassInfo scriptClassInfo = new ScriptClassInfo(painlessLookup, PainlessTestScript.class);
         CompilerSettings compilerSettings = new CompilerSettings();
         compilerSettings.setRegexesEnabled(true);


### PR DESCRIPTION
Mechanical renaming of SSource node to SClass to better align with the names of what other nodes generate.