### PR TITLE
Change SLM stats format

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/slm/SnapshotLifecycleStats.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/slm/SnapshotLifecycleStats.java
@@ -74,7 +74,7 @@ public class SnapshotLifecycleStats implements ToXContentObject {
         PARSER.declareLong(ConstructingObjectParser.constructorArg(), RETENTION_FAILED);
         PARSER.declareLong(ConstructingObjectParser.constructorArg(), RETENTION_TIMED_OUT);
         PARSER.declareLong(ConstructingObjectParser.constructorArg(), RETENTION_TIME_MILLIS);
-        PARSER.declareNamedObjects(ConstructingObjectParser.constructorArg(), (p, c, n) -> SnapshotPolicyStats.parse(p, n), POLICY_STATS);
+        PARSER.declareObjectArray(ConstructingObjectParser.constructorArg(), SnapshotPolicyStats.PARSER, POLICY_STATS);
     }
 
     // Package visible for testing
@@ -178,22 +178,25 @@ public class SnapshotLifecycleStats implements ToXContentObject {
         private final long snapshotsDeleted;
         private final long snapshotDeleteFailures;
 
+        public static final ParseField POLICY_ID = new ParseField("policy");
         static final ParseField SNAPSHOTS_TAKEN = new ParseField("snapshots_taken");
         static final ParseField SNAPSHOTS_FAILED = new ParseField("snapshots_failed");
         static final ParseField SNAPSHOTS_DELETED = new ParseField("snapshots_deleted");
         static final ParseField SNAPSHOT_DELETION_FAILURES = new ParseField("snapshot_deletion_failures");
 
-        private static final ConstructingObjectParser<SnapshotPolicyStats, String> PARSER =
+        private static final ConstructingObjectParser<SnapshotPolicyStats, Void> PARSER =
             new ConstructingObjectParser<>("snapshot_policy_stats", true,
-                (a, id) -> {
-                    long taken = (long) a[0];
-                    long failed = (long) a[1];
-                    long deleted = (long) a[2];
-                    long deleteFailed = (long) a[3];
+                a -> {
+                    String id = (String) a[0];
+                    long taken = (long) a[1];
+                    long failed = (long) a[2];
+                    long deleted = (long) a[3];
+                    long deleteFailed = (long) a[4];
                     return new SnapshotPolicyStats(id, taken, failed, deleted, deleteFailed);
                 });
 
         static {
+            PARSER.declareString(ConstructingObjectParser.constructorArg(), POLICY_ID);
             PARSER.declareLong(ConstructingObjectParser.constructorArg(), SNAPSHOTS_TAKEN);
             PARSER.declareLong(ConstructingObjectParser.constructorArg(), SNAPSHOTS_FAILED);
             PARSER.declareLong(ConstructingObjectParser.constructorArg(), SNAPSHOTS_DELETED);
@@ -209,7 +212,11 @@ public class SnapshotLifecycleStats implements ToXContentObject {
         }
 
         public static SnapshotPolicyStats parse(XContentParser parser, String policyId) {
-            return PARSER.apply(parser, policyId);
+            return PARSER.apply(parser, null);
+        }
+
+        public String getPolicyId() {
+            return policyId;
         }
 
         public long getSnapshotsTaken() {

--- a/docs/reference/ilm/apis/slm-api.asciidoc
+++ b/docs/reference/ilm/apis/slm-api.asciidoc
@@ -142,6 +142,7 @@ The output looks similar to the following:
       "retention": {}
     },
     "stats": {
+      "policy": "daily-snapshots",
       "snapshots_taken": 0,
       "snapshots_failed": 0,
       "snapshots_deleted": 0,
@@ -231,6 +232,7 @@ Which, in this case shows an error because the index did not exist:
       "retention": {}
     },
     "stats": {
+      "policy": "daily-snapshots",
       "snapshots_taken": 0,
       "snapshots_failed": 1,
       "snapshots_deleted": 0,
@@ -319,6 +321,7 @@ Which now includes the successful snapshot information:
       "retention": {}
     },
     "stats": {
+      "policy": "daily-snapshots",
       "snapshots_taken": 1,
       "snapshots_failed": 1,
       "snapshots_deleted": 0,
@@ -371,14 +374,15 @@ Which returns a response similar to:
   "retention_timed_out": 0,
   "retention_deletion_time": "1.4s",
   "retention_deletion_time_millis": 1404,
-  "policy_metrics": {
-    "daily-snapshots": {
+  "policy_metrics": [
+    {
+      "policy": "daily-snapshots",
       "snapshots_taken": 1,
       "snapshots_failed": 1,
       "snapshots_deleted": 0,
       "snapshot_deletion_failures": 0
     }
-  },
+  ],
   "total_snapshots_taken": 1,
   "total_snapshots_failed": 1,
   "total_snapshots_deleted": 0,

--- a/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleRestIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleRestIT.java
@@ -41,6 +41,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.core.slm.history.SnapshotHistoryItem.CREATE_OPERATION;
@@ -134,7 +136,7 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
             assertHistoryIsPresent(policyName, true, repoId, CREATE_OPERATION);
 
             Map<String, Object> stats = getSLMStats();
-            Map<String, Object> policyStats = (Map<String, Object>) stats.get(SnapshotLifecycleStats.POLICY_STATS.getPreferredName());
+            Map<String, Object> policyStats = policyStatsAsMap(stats);
             Map<String, Object> policyIdStats = (Map<String, Object>) policyStats.get(policyName);
             int snapsTaken = (int) policyIdStats.get(SnapshotLifecycleStats.SnapshotPolicyStats.SNAPSHOTS_TAKEN.getPreferredName());
             int totalTaken = (int) stats.get(SnapshotLifecycleStats.TOTAL_TAKEN.getPreferredName());
@@ -183,7 +185,7 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
             assertHistoryIsPresent(policyName, false, repoName, CREATE_OPERATION);
 
             Map<String, Object> stats = getSLMStats();
-            Map<String, Object> policyStats = (Map<String, Object>) stats.get(SnapshotLifecycleStats.POLICY_STATS.getPreferredName());
+            Map<String, Object> policyStats = policyStatsAsMap(stats);
             Map<String, Object> policyIdStats = (Map<String, Object>) policyStats.get(policyName);
             int snapsFailed = (int) policyIdStats.get(SnapshotLifecycleStats.SnapshotPolicyStats.SNAPSHOTS_FAILED.getPreferredName());
             int totalFailed = (int) stats.get(SnapshotLifecycleStats.TOTAL_FAILED.getPreferredName());
@@ -232,7 +234,7 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
             }
 
             Map<String, Object> stats = getSLMStats();
-            Map<String, Object> policyStats = (Map<String, Object>) stats.get(SnapshotLifecycleStats.POLICY_STATS.getPreferredName());
+            Map<String, Object> policyStats = policyStatsAsMap(stats);
             Map<String, Object> policyIdStats = (Map<String, Object>) policyStats.get(policyName);
             int snapsTaken = (int) policyIdStats.get(SnapshotLifecycleStats.SnapshotPolicyStats.SNAPSHOTS_TAKEN.getPreferredName());
             int totalTaken = (int) stats.get(SnapshotLifecycleStats.TOTAL_TAKEN.getPreferredName());
@@ -304,7 +306,7 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
                 assertHistoryIsPresent(policyName, true, repoId, DELETE_OPERATION);
 
                 Map<String, Object> stats = getSLMStats();
-                Map<String, Object> policyStats = (Map<String, Object>) stats.get(SnapshotLifecycleStats.POLICY_STATS.getPreferredName());
+                Map<String, Object> policyStats = policyStatsAsMap(stats);
                 Map<String, Object> policyIdStats = (Map<String, Object>) policyStats.get(policyName);
                 int snapsTaken = (int) policyIdStats.get(SnapshotLifecycleStats.SnapshotPolicyStats.SNAPSHOTS_TAKEN.getPreferredName());
                 int snapsDeleted = (int) policyIdStats.get(SnapshotLifecycleStats.SnapshotPolicyStats.SNAPSHOTS_DELETED.getPreferredName());
@@ -487,5 +489,14 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
         final Request request = new Request("POST", "/" + index + "/_doc/" + id);
         request.setJsonEntity(Strings.toString(document));
         assertOK(client.performRequest(request));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> policyStatsAsMap(Map<String, Object> stats) {
+        return ((List<Map<String, Object>>) stats.get(SnapshotLifecycleStats.POLICY_STATS.getPreferredName()))
+            .stream()
+            .collect(Collectors.toMap(
+                m -> (String) m.get(SnapshotLifecycleStats.SnapshotPolicyStats.POLICY_ID.getPreferredName()),
+                Function.identity()));
     }
 }


### PR DESCRIPTION
Using arrays of objects with embedded IDs is preferred for new APIs over
using entity IDs as JSON keys.  This commit changes the SLM stats API to
use the preferred format.

Example of new `GET _slm/stats` response:
```
{
    "retention_runs": 0,
    "retention_failed": 0,
    "retention_timed_out": 0,
    "retention_deletion_time": "0s",
    "retention_deletion_time_millis": 0,
    "total_snapshots_taken": 1,
    "total_snapshots_failed": 0,
    "total_snapshots_deleted": 0,
    "total_snapshot_deletion_failures": 0,
    "policy_stats": [
        {
            "policy": "daily-snapshots",
            "snapshots_taken": 1,
            "snapshots_failed": 0,
            "snapshots_deleted": 0,
            "snapshot_deletion_failures": 0
        }
    ]
}
```

<details>
 <summary>vs. old format (collapsed)</summary>

```
{
    "retention_runs": 0,
    "retention_failed": 0,
    "retention_timed_out": 0,
    "retention_deletion_time": "0s",
    "retention_deletion_time_millis": 0,
    "total_snapshots_taken": 1,
    "total_snapshots_failed": 0,
    "total_snapshots_deleted": 0,
    "total_snapshot_deletion_failures": 0,
    "policy_stats": {
        "daily-snapshots": {
            "snapshots_taken": 1,
            "snapshots_failed": 0,
            "snapshots_deleted": 0,
            "snapshot_deletion_failures": 0
        }
    }
}
```

</details>

Relates https://github.com/elastic/elasticsearch/issues/43663