### PR TITLE
[DOCS] shard allocation filtering add more support attributes

### DIFF
--- a/docs/reference/index-modules/allocation/filtering.asciidoc
+++ b/docs/reference/index-modules/allocation/filtering.asciidoc
@@ -96,12 +96,12 @@ PUT test/_settings
 The index allocation settings support the following built-in attributes:
 
 [horizontal]
-`_name`::       Match nodes by node names
+`_name`::       Match nodes by node name
 `_host_ip`::    Match nodes by host IP address (IP associated with hostname)
 `_publish_ip`:: Match nodes by publish IP address
 `_ip`::         Match either `_host_ip` or `_publish_ip`
 `_host`::       Match nodes by hostname
-`_id`::         Match nodes by node ids
+`_id`::         Match nodes by node id
 
 You can use wildcards when specifying attribute values, for example:
 

--- a/docs/reference/index-modules/allocation/filtering.asciidoc
+++ b/docs/reference/index-modules/allocation/filtering.asciidoc
@@ -7,7 +7,7 @@ a particular index. These per-index filters are applied in conjunction with
 <<allocation-awareness, allocation awareness>>.
 
 Shard allocation filters can be based on custom node attributes or the built-in
-`_name`, `host_ip`, `publish_ip`, `_ip`, and `_host` attributes.
+`_name`, `_host_ip`, `_publish_ip`, `_ip`, `_host` and `_id` attributes.
 <<index-lifecycle-management, Index lifecycle management>> uses filters based
 on custom node attributes to determine how to reallocate shards when moving
 between phases.
@@ -96,11 +96,12 @@ PUT test/_settings
 The index allocation settings support the following built-in attributes:
 
 [horizontal]
-`_name`::       Match nodes by node name
+`_name`::       Match nodes by node names
 `_host_ip`::    Match nodes by host IP address (IP associated with hostname)
 `_publish_ip`:: Match nodes by publish IP address
 `_ip`::         Match either `_host_ip` or `_publish_ip`
 `_host`::       Match nodes by hostname
+`_id`::         Match nodes by node ids
 
 You can use wildcards when specifying attribute values, for example:
 

--- a/docs/reference/modules/cluster/allocation_filtering.asciidoc
+++ b/docs/reference/modules/cluster/allocation_filtering.asciidoc
@@ -50,12 +50,12 @@ PUT _cluster/settings
 The cluster allocation settings support the following built-in attributes:
 
 [horizontal]
-`_name`::       Match nodes by node names
+`_name`::       Match nodes by node name
 `_host_ip`::    Match nodes by host IP address (IP associated with hostname)
 `_publish_ip`:: Match nodes by publish IP address
-`_ip`::         Match nodes by IP addresses (the IP address associated with the hostname)
-`_host`::       Match nodes by hostnames
-`_id`::         Match nodes by node ids
+`_ip`::         Match either `_host_ip` or `_publish_ip`
+`_host`::       Match nodes by hostname
+`_id`::         Match nodes by node id
 
 
 

--- a/docs/reference/modules/cluster/allocation_filtering.asciidoc
+++ b/docs/reference/modules/cluster/allocation_filtering.asciidoc
@@ -7,7 +7,7 @@ conjunction with <<shard-allocation-filtering, per-index allocation filtering>>
 and <<allocation-awareness, allocation awareness>>.
 
 Shard allocation filters can be based on custom node attributes or the built-in
-`_name`, `_ip`, and `_host` attributes.
+`_name`, `_host_ip`, `_publish_ip`, `_ip`, `_host` and `_id` attributes.
 
 The `cluster.routing.allocation` settings are dynamic, enabling live indices to
 be moved from one set of nodes to another. Shards are only relocated if it is
@@ -50,9 +50,14 @@ PUT _cluster/settings
 The cluster allocation settings support the following built-in attributes:
 
 [horizontal]
-`_name`::   Match nodes by node names
-`_ip`::     Match nodes by IP addresses (the IP address associated with the hostname)
-`_host`::   Match nodes by hostnames
+`_name`::       Match nodes by node names
+`_host_ip`::    Match nodes by host IP address (IP associated with hostname)
+`_publish_ip`:: Match nodes by publish IP address
+`_ip`::         Match nodes by IP addresses (the IP address associated with the hostname)
+`_host`::       Match nodes by hostnames
+`_id`::         Match nodes by node ids
+
+
 
 You can use wildcards when specifying attribute values, for example:
 


### PR DESCRIPTION
Both Index-level and Cluster-level share the same filtering attributes.

 add `_id` attributes description in [Index-level shard allocation filtering](https://www.elastic.co/guide/en/elasticsearch/reference/master/shard-allocation-filtering.html)  and full attributes description in [Cluster-level shard allocation filtering](https://www.elastic.co/guide/en/elasticsearch/reference/master/allocation-filtering.html)