### PR TITLE
Workaround JDK-8213202 in SSLClientAuthTests

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLClientAuthTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLClientAuthTests.java
@@ -96,6 +96,10 @@ public class SSLClientAuthTests extends SecurityIntegTestCase {
         return builder
                 // invert the require auth settings
                 .put("xpack.security.transport.ssl.client_authentication", SSLClientAuth.NONE)
+                // Due to the TLSv1.3 bug with session resumption when client authentication is not
+                // used, we need to set the protocols since we disabled client auth for transport
+                // to avoid failures on pre 11.0.3 JDKs. See #getProtocols
+                .putList("xpack.security.transport.ssl.supported_protocols", getProtocols())
                 .put("xpack.security.http.ssl.enabled", true)
                 .put("xpack.security.http.ssl.client_authentication", SSLClientAuth.REQUIRED)
                 .build();


### PR DESCRIPTION
This change works around JDK-8213202, which is a bug related to TLSv1.3
session resumption before JDK 11.0.3 that occurs when there are
multiple concurrent sessions being established. Nodes connecting to
each other will trigger this bug when client authentication is
disabled, which is the case for SSLClientAuthTests.

Backport of #46680