### PR TITLE
Improve LeaderCheck rejection messages

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
@@ -62,7 +62,7 @@ public class LeaderChecker {
 
     private static final Logger logger = LogManager.getLogger(LeaderChecker.class);
 
-    public static final String LEADER_CHECK_ACTION_NAME = "internal:coordination/fault_detection/leader_check";
+    static final String LEADER_CHECK_ACTION_NAME = "internal:coordination/fault_detection/leader_check";
 
     // the time between checks sent to the leader
     public static final Setting<TimeValue> LEADER_CHECK_INTERVAL_SETTING =
@@ -88,7 +88,7 @@ public class LeaderChecker {
 
     private volatile DiscoveryNodes discoveryNodes;
 
-    public LeaderChecker(final Settings settings, final TransportService transportService, final Consumer<Exception> onLeaderFailure) {
+    LeaderChecker(final Settings settings, final TransportService transportService, final Consumer<Exception> onLeaderFailure) {
         leaderCheckInterval = LEADER_CHECK_INTERVAL_SETTING.get(settings);
         leaderCheckTimeout = LEADER_CHECK_TIMEOUT_SETTING.get(settings);
         leaderCheckRetryCount = LEADER_CHECK_RETRY_COUNT_SETTING.get(settings);
@@ -119,7 +119,7 @@ public class LeaderChecker {
      *
      * @param leader the node to be checked as leader, or null if checks should be disabled
      */
-    public void updateLeader(@Nullable final DiscoveryNode leader) {
+    void updateLeader(@Nullable final DiscoveryNode leader) {
         assert transportService.getLocalNode().equals(leader) == false;
         final CheckScheduler checkScheduler;
         if (leader != null) {
@@ -139,12 +139,8 @@ public class LeaderChecker {
     /**
      * Update the "known" discovery nodes. Should be called on the leader before a new cluster state is published to reflect the new
      * publication targets, and also called if a leader becomes a non-leader.
-     * TODO if heartbeats can make nodes become followers then this needs to be called before a heartbeat is sent to a new node too.
-     * <p>
-     * isLocalNodeElectedMaster() should reflect whether this node is a leader, and nodeExists()
-     * should indicate whether nodes are known publication targets or not.
      */
-    public void setCurrentNodes(DiscoveryNodes discoveryNodes) {
+    void setCurrentNodes(DiscoveryNodes discoveryNodes) {
         logger.trace("setCurrentNodes: {}", discoveryNodes);
         this.discoveryNodes = discoveryNodes;
     }
@@ -159,11 +155,13 @@ public class LeaderChecker {
         assert discoveryNodes != null;
 
         if (discoveryNodes.isLocalNodeElectedMaster() == false) {
-            logger.debug("non-master handling {}", request);
-            throw new CoordinationStateRejectedException("non-leader rejecting leader check");
+            logger.debug("rejecting leader check on non-master {}", request);
+            throw new CoordinationStateRejectedException(
+                "rejecting leader check from [" + request.getSender() + "] since this node is not the master");
         } else if (discoveryNodes.nodeExists(request.getSender()) == false) {
-            logger.debug("leader check from unknown node: {}", request);
-            throw new CoordinationStateRejectedException("leader check from unknown node");
+            logger.debug("rejecting leader check from removed node: {}", request);
+            throw new CoordinationStateRejectedException(
+                "rejecting leader check since [" + request.getSender() + "] has been removed from the cluster");
         } else {
             logger.trace("handling {}", request);
         }
@@ -303,15 +301,15 @@ public class LeaderChecker {
         }
     }
 
-    public static class LeaderCheckRequest extends TransportRequest {
+    static class LeaderCheckRequest extends TransportRequest {
 
         private final DiscoveryNode sender;
 
-        public LeaderCheckRequest(final DiscoveryNode sender) {
+        LeaderCheckRequest(final DiscoveryNode sender) {
             this.sender = sender;
         }
 
-        public LeaderCheckRequest(final StreamInput in) throws IOException {
+        LeaderCheckRequest(final StreamInput in) throws IOException {
             super(in);
             sender = new DiscoveryNode(in);
         }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
@@ -157,7 +157,7 @@ public class LeaderChecker {
         if (discoveryNodes.isLocalNodeElectedMaster() == false) {
             logger.debug("rejecting leader check on non-master {}", request);
             throw new CoordinationStateRejectedException(
-                "rejecting leader check from [" + request.getSender() + "] since this node is not the master");
+                "rejecting leader check from [" + request.getSender() + "] sent to a node that is not the master");
         } else if (discoveryNodes.nodeExists(request.getSender()) == false) {
             logger.debug("rejecting leader check from removed node: {}", request);
             throw new CoordinationStateRejectedException(

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
@@ -157,7 +157,7 @@ public class LeaderChecker {
         if (discoveryNodes.isLocalNodeElectedMaster() == false) {
             logger.debug("rejecting leader check on non-master {}", request);
             throw new CoordinationStateRejectedException(
-                "rejecting leader check from [" + request.getSender() + "] sent to a node that is not the master");
+                "rejecting leader check from [" + request.getSender() + "] sent to a node that is no longer the master");
         } else if (discoveryNodes.nodeExists(request.getSender()) == false) {
             logger.debug("rejecting leader check from removed node: {}", request);
             throw new CoordinationStateRejectedException(

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/LeaderCheckerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/LeaderCheckerTests.java
@@ -56,9 +56,11 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.matchesRegex;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
 
 public class LeaderCheckerTests extends ESTestCase {
 
@@ -220,7 +222,7 @@ public class LeaderCheckerTests extends ESTestCase {
                     return;
                 }
                 assertThat(action, equalTo(LEADER_CHECK_ACTION_NAME));
-                assertTrue(node.equals(leader));
+                assertEquals(node, leader);
                 final Response response = responseHolder[0];
 
                 deterministicTaskQueue.scheduleNow(new Runnable() {
@@ -340,7 +342,7 @@ public class LeaderCheckerTests extends ESTestCase {
             assertFalse(handler.successfulResponseReceived);
             assertThat(handler.transportException.getRootCause(), instanceOf(CoordinationStateRejectedException.class));
             CoordinationStateRejectedException cause = (CoordinationStateRejectedException) handler.transportException.getRootCause();
-            assertThat(cause.getMessage(), equalTo("leader check from unknown node"));
+            assertThat(cause.getMessage(), is("rejecting leader check since [" + otherNode + "] has been removed from the cluster"));
         }
 
         {
@@ -364,7 +366,7 @@ public class LeaderCheckerTests extends ESTestCase {
             assertFalse(handler.successfulResponseReceived);
             assertThat(handler.transportException.getRootCause(), instanceOf(CoordinationStateRejectedException.class));
             CoordinationStateRejectedException cause = (CoordinationStateRejectedException) handler.transportException.getRootCause();
-            assertThat(cause.getMessage(), equalTo("non-leader rejecting leader check"));
+            assertThat(cause.getMessage(), is("rejecting leader check from [" + otherNode + "] sent to a node that is not the master"));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/LeaderCheckerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/LeaderCheckerTests.java
@@ -56,11 +56,9 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.matchesRegex;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertEquals;
 
 public class LeaderCheckerTests extends ESTestCase {
 
@@ -342,7 +340,7 @@ public class LeaderCheckerTests extends ESTestCase {
             assertFalse(handler.successfulResponseReceived);
             assertThat(handler.transportException.getRootCause(), instanceOf(CoordinationStateRejectedException.class));
             CoordinationStateRejectedException cause = (CoordinationStateRejectedException) handler.transportException.getRootCause();
-            assertThat(cause.getMessage(), is("rejecting leader check since [" + otherNode + "] has been removed from the cluster"));
+            assertThat(cause.getMessage(), equalTo("rejecting leader check since [" + otherNode + "] has been removed from the cluster"));
         }
 
         {
@@ -366,7 +364,8 @@ public class LeaderCheckerTests extends ESTestCase {
             assertFalse(handler.successfulResponseReceived);
             assertThat(handler.transportException.getRootCause(), instanceOf(CoordinationStateRejectedException.class));
             CoordinationStateRejectedException cause = (CoordinationStateRejectedException) handler.transportException.getRootCause();
-            assertThat(cause.getMessage(), is("rejecting leader check from [" + otherNode + "] sent to a node that is not the master"));
+            assertThat(cause.getMessage(),
+                equalTo("rejecting leader check from [" + otherNode + "] sent to a node that is no longer the master"));
         }
     }
 
@@ -399,7 +398,7 @@ public class LeaderCheckerTests extends ESTestCase {
     public void testLeaderCheckRequestEqualsHashcodeSerialization() {
         LeaderCheckRequest request = new LeaderCheckRequest(
             new DiscoveryNode(randomAlphaOfLength(10), buildNewFakeTransportAddress(), Version.CURRENT));
-        // Note: the explicit cast of the CopyFunction is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
+        //noinspection RedundantCast since it is needed for some IDEs (specifically Eclipse 4.8.0) to infer the right type
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(request,
                 (CopyFunction<LeaderCheckRequest>) rq -> copyWriteable(rq, writableRegistry(), LeaderCheckRequest::new),
             rq -> new LeaderCheckRequest(new DiscoveryNode(randomAlphaOfLength(10), buildNewFakeTransportAddress(), Version.CURRENT)));


### PR DESCRIPTION
Today the `LeaderChecker` rejects checks from nodes that are not in the current
cluster with the exception message `leader check from unknown node` which
offers no information about why the node is unknown. In fact the node must have
been in the cluster in the recent past, so it might help guide the user to a
more useful log message if we describe it as a `removed node` instead of an
`unknown node`. This commit changes the exception message like this, and also
tidies up a few other loose ends in the `LeaderChecker`.