### PR TITLE
Work around error building deb on Windows

### DIFF
--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -58,7 +58,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath 'com.netflix.nebula:gradle-ospackage-plugin:7.4.2'
+    classpath 'com.netflix.nebula:gradle-ospackage-plugin:4.7.1'
   }
 }
 
@@ -363,7 +363,7 @@ Closure commonRpmConfig(boolean oss, boolean jdk) {
     prefix '/usr'
     packager 'Elasticsearch'
     version = project.version.replace('-', '_')
-    release = ''
+    release = '1'
     os 'LINUX'
     distribution 'Elasticsearch'
     vendor 'Elasticsearch'

--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -58,7 +58,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath 'com.netflix.nebula:gradle-ospackage-plugin:4.7.1'
+    classpath 'com.netflix.nebula:gradle-ospackage-plugin:7.4.2'
   }
 }
 
@@ -407,6 +407,9 @@ subprojects {
     'default' buildDist
   }
 
+  if (! (dpkgExists() || rpmExists())) {
+    return;
+  }
   // sanity checks if packages can be extracted
   final File extractionDir = new File(buildDir, 'extracted')
   File packageExtractionDir
@@ -423,6 +426,7 @@ subprojects {
       extractionDir.mkdirs()
     }
   }
+
   check.dependsOn checkExtraction
   if (project.name.contains('deb')) {
     checkExtraction {

--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -407,167 +407,168 @@ subprojects {
     'default' buildDist
   }
 
-  if (! (dpkgExists() || rpmExists())) {
-    return;
-  }
-  // sanity checks if packages can be extracted
-  final File extractionDir = new File(buildDir, 'extracted')
-  File packageExtractionDir
-  if (project.name.contains('deb')) {
-    packageExtractionDir = new File(extractionDir, 'deb-extracted')
-  } else {
-    assert project.name.contains('rpm')
-    packageExtractionDir = new File(extractionDir, 'rpm-extracted')
-  }
-  task checkExtraction(type: LoggedExec) {
-    dependsOn buildDist
-    doFirst {
-      project.delete(extractionDir)
-      extractionDir.mkdirs()
-    }
-  }
+  if (dpkgExists() || rpmExists()) {
 
-  check.dependsOn checkExtraction
-  if (project.name.contains('deb')) {
-    checkExtraction {
-      onlyIf dpkgExists
-      commandLine 'dpkg-deb', '-x', "${-> buildDist.outputs.files.filter(debFilter).singleFile}", packageExtractionDir
+    // sanity checks if packages can be extracted
+    final File extractionDir = new File(buildDir, 'extracted')
+    File packageExtractionDir
+    if (project.name.contains('deb')) {
+      packageExtractionDir = new File(extractionDir, 'deb-extracted')
+    } else {
+      assert project.name.contains('rpm')
+      packageExtractionDir = new File(extractionDir, 'rpm-extracted')
     }
-  } else {
-    assert project.name.contains('rpm')
-    checkExtraction {
-      onlyIf rpmExists
-      final File rpmDatabase = new File(extractionDir, 'rpm-database')
-      commandLine 'rpm',
-          '--badreloc',
-          '--nodeps',
-          '--noscripts',
-          '--notriggers',
-          '--dbpath',
-          rpmDatabase,
-          '--relocate',
-          "/=${packageExtractionDir}",
-          '-i',
-          "${-> buildDist.outputs.files.singleFile}"
-    }
-  }
-
-  task checkLicense {
-    dependsOn buildDist, checkExtraction
-  }
-  check.dependsOn checkLicense
-  if (project.name.contains('deb')) {
-    checkLicense {
-      onlyIf dpkgExists
-      doLast {
-        Path copyrightPath
-        String expectedLicense
-        String licenseFilename
-        if (project.name.contains('oss-')) {
-          copyrightPath = packageExtractionDir.toPath().resolve("usr/share/doc/elasticsearch-oss/copyright")
-          expectedLicense = "ASL-2.0"
-          licenseFilename = "APACHE-LICENSE-2.0.txt"
-        } else {
-          copyrightPath = packageExtractionDir.toPath().resolve("usr/share/doc/elasticsearch/copyright")
-          expectedLicense = "Elastic-License"
-          licenseFilename = "ELASTIC-LICENSE.txt"
-        }
-        final List<String> header = Arrays.asList("Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/",
-                "Copyright: Elasticsearch B.V. <info@elastic.co>",
-                "License: " + expectedLicense)
-        final List<String> licenseLines = Files.readAllLines(rootDir.toPath().resolve("licenses/" + licenseFilename))
-        final List<String> expectedLines = header + licenseLines.collect { " " + it }
-        assertLinesInFile(copyrightPath, expectedLines)
+    task checkExtraction(type: LoggedExec) {
+      dependsOn buildDist
+      doFirst {
+        project.delete(extractionDir)
+        extractionDir.mkdirs()
       }
     }
-  } else {
-    assert project.name.contains('rpm')
-    checkLicense {
-      onlyIf rpmExists
-      doLast {
-        String licenseFilename
-        if (project.name.contains('oss-')) {
-          licenseFilename = "APACHE-LICENSE-2.0.txt"
-        } else {
-          licenseFilename = "ELASTIC-LICENSE.txt"
-        }
-        final List<String> licenseLines = Files.readAllLines(rootDir.toPath().resolve("licenses/" + licenseFilename))
-        final Path licensePath = packageExtractionDir.toPath().resolve("usr/share/elasticsearch/LICENSE.txt")
-        assertLinesInFile(licensePath, licenseLines)
+
+    check.dependsOn checkExtraction
+    if (project.name.contains('deb')) {
+      checkExtraction {
+        onlyIf dpkgExists
+        commandLine 'dpkg-deb', '-x', "${-> buildDist.outputs.files.filter(debFilter).singleFile}", packageExtractionDir
+      }
+    } else {
+      assert project.name.contains('rpm')
+      checkExtraction {
+        onlyIf rpmExists
+        final File rpmDatabase = new File(extractionDir, 'rpm-database')
+        commandLine 'rpm',
+                '--badreloc',
+                '--nodeps',
+                '--noscripts',
+                '--notriggers',
+                '--dbpath',
+                rpmDatabase,
+                '--relocate',
+                "/=${packageExtractionDir}",
+                '-i',
+                "${-> buildDist.outputs.files.singleFile}"
       }
     }
-  }
 
-  task checkNotice {
-    dependsOn buildDist, checkExtraction
-    onlyIf { (project.name.contains('deb') && dpkgExists.call(it)) || (project.name.contains('rpm') && rpmExists.call(it)) }
-    doLast {
-      final List<String> noticeLines = Arrays.asList("Elasticsearch", "Copyright 2009-2018 Elasticsearch")
-      final Path noticePath = packageExtractionDir.toPath().resolve("usr/share/elasticsearch/NOTICE.txt")
-      assertLinesInFile(noticePath, noticeLines)
+    task checkLicense {
+      dependsOn buildDist, checkExtraction
     }
-  }
-  check.dependsOn checkNotice
-
-  task checkLicenseMetadata(type: LoggedExec) {
-    dependsOn buildDist, checkExtraction
-  }
-  check.dependsOn checkLicenseMetadata
-  if (project.name.contains('deb')) {
-    checkLicenseMetadata { LoggedExec exec ->
-      onlyIf dpkgExists
-      final ByteArrayOutputStream output = new ByteArrayOutputStream()
-      exec.commandLine 'dpkg-deb', '--info', "${ -> buildDist.outputs.files.filter(debFilter).singleFile}"
-      exec.standardOutput = output
-      doLast {
-        String expectedLicense
-        if (project.name.contains('oss-')) {
-          expectedLicense = "ASL-2.0"
-        } else {
-          expectedLicense = "Elastic-License"
+    check.dependsOn checkLicense
+    if (project.name.contains('deb')) {
+      checkLicense {
+        onlyIf dpkgExists
+        doLast {
+          Path copyrightPath
+          String expectedLicense
+          String licenseFilename
+          if (project.name.contains('oss-')) {
+            copyrightPath = packageExtractionDir.toPath().resolve("usr/share/doc/elasticsearch-oss/copyright")
+            expectedLicense = "ASL-2.0"
+            licenseFilename = "APACHE-LICENSE-2.0.txt"
+          } else {
+            copyrightPath = packageExtractionDir.toPath().resolve("usr/share/doc/elasticsearch/copyright")
+            expectedLicense = "Elastic-License"
+            licenseFilename = "ELASTIC-LICENSE.txt"
+          }
+          final List<String> header = Arrays.asList("Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/",
+                  "Copyright: Elasticsearch B.V. <info@elastic.co>",
+                  "License: " + expectedLicense)
+          final List<String> licenseLines = Files.readAllLines(rootDir.toPath().resolve("licenses/" + licenseFilename))
+          final List<String> expectedLines = header + licenseLines.collect { " " + it }
+          assertLinesInFile(copyrightPath, expectedLines)
         }
-        final Pattern pattern = Pattern.compile("\\s*License: (.+)")
-        final String info = output.toString('UTF-8')
-        final String[] actualLines = info.split("\n")
-        int count = 0
-        for (final String actualLine : actualLines) {
-          final Matcher matcher = pattern.matcher(actualLine)
-          if (matcher.matches()) {
-            count++
-            final String actualLicense = matcher.group(1)
-            if (expectedLicense != actualLicense) {
-              throw new GradleException("expected license [${expectedLicense} for package info but found [${actualLicense}]")
+      }
+    } else {
+      assert project.name.contains('rpm')
+      checkLicense {
+        onlyIf rpmExists
+        doLast {
+          String licenseFilename
+          if (project.name.contains('oss-')) {
+            licenseFilename = "APACHE-LICENSE-2.0.txt"
+          } else {
+            licenseFilename = "ELASTIC-LICENSE.txt"
+          }
+          final List<String> licenseLines = Files.readAllLines(rootDir.toPath().resolve("licenses/" + licenseFilename))
+          final Path licensePath = packageExtractionDir.toPath().resolve("usr/share/elasticsearch/LICENSE.txt")
+          assertLinesInFile(licensePath, licenseLines)
+        }
+      }
+    }
+
+    task checkNotice {
+      dependsOn buildDist, checkExtraction
+      onlyIf {
+        (project.name.contains('deb') && dpkgExists.call(it)) || (project.name.contains('rpm') && rpmExists.call(it))
+      }
+      doLast {
+        final List<String> noticeLines = Arrays.asList("Elasticsearch", "Copyright 2009-2018 Elasticsearch")
+        final Path noticePath = packageExtractionDir.toPath().resolve("usr/share/elasticsearch/NOTICE.txt")
+        assertLinesInFile(noticePath, noticeLines)
+      }
+    }
+    check.dependsOn checkNotice
+
+    task checkLicenseMetadata(type: LoggedExec) {
+      dependsOn buildDist, checkExtraction
+    }
+    check.dependsOn checkLicenseMetadata
+    if (project.name.contains('deb')) {
+      checkLicenseMetadata { LoggedExec exec ->
+        onlyIf dpkgExists
+        final ByteArrayOutputStream output = new ByteArrayOutputStream()
+        exec.commandLine 'dpkg-deb', '--info', "${-> buildDist.outputs.files.filter(debFilter).singleFile}"
+        exec.standardOutput = output
+        doLast {
+          String expectedLicense
+          if (project.name.contains('oss-')) {
+            expectedLicense = "ASL-2.0"
+          } else {
+            expectedLicense = "Elastic-License"
+          }
+          final Pattern pattern = Pattern.compile("\\s*License: (.+)")
+          final String info = output.toString('UTF-8')
+          final String[] actualLines = info.split("\n")
+          int count = 0
+          for (final String actualLine : actualLines) {
+            final Matcher matcher = pattern.matcher(actualLine)
+            if (matcher.matches()) {
+              count++
+              final String actualLicense = matcher.group(1)
+              if (expectedLicense != actualLicense) {
+                throw new GradleException("expected license [${expectedLicense} for package info but found [${actualLicense}]")
+              }
             }
           }
-        }
-        if (count == 0) {
-          throw new GradleException("expected license [${expectedLicense}] for package info but found none in:\n${info}")
-        }
-        if (count > 1) {
-          throw new GradleException("expected a single license for package info but found [${count}] in:\n${info}")
+          if (count == 0) {
+            throw new GradleException("expected license [${expectedLicense}] for package info but found none in:\n${info}")
+          }
+          if (count > 1) {
+            throw new GradleException("expected a single license for package info but found [${count}] in:\n${info}")
+          }
         }
       }
-    }
-  } else {
-    assert project.name.contains('rpm')
-    checkLicenseMetadata { LoggedExec exec ->
-      onlyIf rpmExists
-      final ByteArrayOutputStream output = new ByteArrayOutputStream()
-      exec.commandLine 'rpm', '-qp', '--queryformat', '%{License}', "${-> buildDist.outputs.files.singleFile}"
-      exec.standardOutput = output
-      doLast {
-        String license = output.toString('UTF-8')
-        String expectedLicense
-        if (project.name.contains('oss-')) {
-          expectedLicense = "ASL 2.0"
-        } else {
-          expectedLicense = "Elastic License"
-        }
-        if (license != expectedLicense) {
-          throw new GradleException("expected license [${expectedLicense}] for [${-> buildDist.outputs.files.singleFile}] but was [${license}]")
+    } else {
+      assert project.name.contains('rpm')
+      checkLicenseMetadata { LoggedExec exec ->
+        onlyIf rpmExists
+        final ByteArrayOutputStream output = new ByteArrayOutputStream()
+        exec.commandLine 'rpm', '-qp', '--queryformat', '%{License}', "${-> buildDist.outputs.files.singleFile}"
+        exec.standardOutput = output
+        doLast {
+          String license = output.toString('UTF-8')
+          String expectedLicense
+          if (project.name.contains('oss-')) {
+            expectedLicense = "ASL 2.0"
+          } else {
+            expectedLicense = "Elastic License"
+          }
+          if (license != expectedLicense) {
+            throw new GradleException("expected license [${expectedLicense}] for [${-> buildDist.outputs.files.singleFile}] but was [${license}]")
+          }
         }
       }
     }
   }
-
 }

--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -363,7 +363,7 @@ Closure commonRpmConfig(boolean oss, boolean jdk) {
     prefix '/usr'
     packager 'Elasticsearch'
     version = project.version.replace('-', '_')
-    release = '1'
+    release = ''
     os 'LINUX'
     distribution 'Elasticsearch'
     vendor 'Elasticsearch'


### PR DESCRIPTION
Relates to  #47007 . the `gradle-ospackage-plugin` plugin doesn't
properly support symlink on windows.

This PR changes the way we configure tasks to prevent building these
packages as part of a windows check.


