### PR TITLE
[TEST] Rename data-frames to transform in docs test cleanup

### DIFF
--- a/docs/src/test/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
+++ b/docs/src/test/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
@@ -101,7 +101,7 @@ public class DocsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     @After
     public void cleanup() throws Exception {
-        if (isMachineLearningTest() || isDataFrameTest()) {
+        if (isMachineLearningTest() || isTransformTest()) {
             ESRestTestCase.waitForPendingTasks(adminClient());
         }
     }
@@ -111,9 +111,9 @@ public class DocsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
         return testName != null && (testName.contains("/ml/") || testName.contains("\\ml\\"));
     }
 
-    protected boolean isDataFrameTest() {
+    protected boolean isTransformTest() {
         String testName = getTestName();
-        return testName != null && (testName.contains("/data-frames/") || testName.contains("\\data-frames\\"));
+        return testName != null && (testName.contains("/transform/") || testName.contains("\\transform\\"));
     }
 
     /**


### PR DESCRIPTION
The renaming of the tests in #46760 caused the
cleanup between tests to be skipped.

Fixes #43271
Fixes #47012