### PR TITLE
BACKPORT 7.4 Do not rewrite aliases on remove-index from aliases requests (#46989)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
@@ -210,11 +210,15 @@ class IndicesAndAliasesResolver {
             } else {
                 resolvedIndicesBuilder.addLocal(aliasesRequest.aliases());
             }
-            // if no aliases are authorized, then fill in an expression that
-            // MetaData#findAliases evaluates to the empty alias list. You cannot put
-            // "nothing" (the empty list) explicitly because this is resolved by es core to
-            // _all
-            if (aliasesRequest.aliases().length == 0) {
+            /*
+             * If no aliases are authorized, then fill in an expression that MetaData#findAliases evaluates to an
+             * empty alias list. We can not put an empty list here because core resolves this as _all. For other
+             * request types, this replacement is not needed and can trigger issues when we rewrite the request
+             * on the coordinating node. For example, for a remove index request, if we did this replacement,
+             * the request would be rewritten to include "*","-*" and for a user that does not have permissions
+             * on "*", the master node would not authorize the request.
+             */
+            if (aliasesRequest.expandAliasesWildcards() && aliasesRequest.aliases().length == 0) {
                 aliasesRequest.replaceAliases(NO_INDICES_OR_ALIASES_ARRAY);
             }
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndexAliasesTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndexAliasesTests.java
@@ -37,6 +37,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
             ("test123".toCharArray())));
         return super.configUsers() +
             "create_only:" + usersPasswdHashed + "\n" +
+            "all_on_test:" + usersPasswdHashed + "\n" +
             "create_test_aliases_test:" + usersPasswdHashed + "\n" +
             "create_test_aliases_alias:" + usersPasswdHashed + "\n" +
             "create_test_aliases_test_alias:" + usersPasswdHashed + "\n" +
@@ -47,6 +48,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
     protected String configUsersRoles() {
         return super.configUsersRoles() +
                 "create_only:create_only\n" +
+                "all_on_test:all_on_test\n" +
                 "create_test_aliases_test:create_test_aliases_test\n" +
                 "create_test_aliases_alias:create_test_aliases_alias\n" +
                 "create_test_aliases_test_alias:create_test_aliases_test_alias\n" +
@@ -61,6 +63,10 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
                 "  indices:\n" +
                 "    - names: '*'\n" +
                 "      privileges: [ create_index ]\n" +
+                "all_on_test:\n" +
+                "  indices:\n" +
+                "    - names: 'test_*'\n" +
+                "      privileges: [ all ]\n" +
                 //role that has create index and manage_aliases on test_*, not enough to manage_aliases aliases outside of test_* namespace
                 "create_test_aliases_test:\n" +
                 "  indices:\n" +
@@ -89,23 +95,23 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
 
     @Before
     public void createBogusIndex() {
-        if (randomBoolean()) {
-            //randomly create an index with two aliases from user admin, to make sure it doesn't affect any of the test results
-            assertAcked(client().admin().indices().prepareCreate("index1").addAlias(new Alias("alias1")).addAlias(new Alias("alias2")));
-        }
+        //randomly create an index with two aliases from user admin, to make sure it doesn't affect any of the test results
+        assertAcked(client().admin().indices().prepareCreate("bogus_index_1").addAlias(new Alias("bogus_alias_1"))
+            .addAlias(new Alias("bogus_alias_2")));
     }
 
     public void testCreateIndexThenAliasesCreateOnlyPermission() {
         //user has create permission only: allows to create indices, manage_aliases is required to add/remove aliases
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("create_only",
                 new SecureString("test123".toCharArray())));
-        assertAcked(client().filterWithHeader(headers).admin().indices().prepareCreate("test_1").get());
+        final Client client = client().filterWithHeader(headers);
+        assertAcked(client.admin().indices().prepareCreate("test_1").get());
 
         assertThrowsAuthorizationException(
-                client().filterWithHeader(headers).admin().indices().prepareAliases().addAlias("test_1", "test_alias")::get,
+                client.admin().indices().prepareAliases().addAlias("test_1", "test_alias")::get,
                 IndicesAliasesAction.NAME, "create_only");
 
-        assertThrowsAuthorizationException(client().filterWithHeader(headers).admin().indices().prepareAliases()
+        assertThrowsAuthorizationException(client.admin().indices().prepareAliases()
                 .addAlias("test_*", "test_alias")::get, IndicesAliasesAction.NAME, "create_only");
     }
 
@@ -116,7 +122,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
                 new SecureString("test123".toCharArray())));
 
         assertThrowsAuthorizationException(
-                client().filterWithHeader(headers).admin().indices().prepareCreate("test_1").addAlias(new Alias("test_2"))::get,
+                client(headers).admin().indices().prepareCreate("test_1").addAlias(new Alias("test_2"))::get,
                 IndicesAliasesAction.NAME, "create_only");
     }
 
@@ -124,15 +130,16 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
         //user has create permission only: allows to create indices, manage_aliases is required to add/remove aliases
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("create_only",
                 new SecureString("test123".toCharArray())));
+        final Client client = client().filterWithHeader(headers);
 
         assertThrowsAuthorizationException(
-                client().filterWithHeader(headers).admin().indices().prepareAliases().removeAlias("test_1", "alias_1")::get,
+                client.admin().indices().prepareAliases().removeAlias("test_1", "alias_1")::get,
                 IndicesAliasesAction.NAME, "create_only");
 
-        assertThrowsAuthorizationException(client().filterWithHeader(headers).admin().indices().prepareAliases()
+        assertThrowsAuthorizationException(client.admin().indices().prepareAliases()
                 .removeAlias("test_1", "alias_*")::get, IndicesAliasesAction.NAME, "create_only");
 
-        assertThrowsAuthorizationException(client().filterWithHeader(headers).admin().indices().prepareAliases()
+        assertThrowsAuthorizationException(client.admin().indices().prepareAliases()
                 .removeAlias("test_1", "_all")::get, IndicesAliasesAction.NAME, "create_only");
     }
 
@@ -140,24 +147,25 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
         //user has create permission only: allows to create indices, manage_aliases is required to retrieve aliases though
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("create_only",
                 new SecureString("test123".toCharArray())));
+        final Client client = client().filterWithHeader(headers);
 
-        assertThrowsAuthorizationException(client().filterWithHeader(headers).admin().indices().prepareGetAliases("test_1")
+        assertThrowsAuthorizationException(client.admin().indices().prepareGetAliases("test_1")
                 .setIndices("test_1").setIndicesOptions(IndicesOptions.strictExpand())::get, GetAliasesAction.NAME, "create_only");
 
-        assertThrowsAuthorizationException(client().filterWithHeader(headers)
+        assertThrowsAuthorizationException(client
                 .admin().indices().prepareGetAliases("_all")
                 .setIndices("test_1").setIndicesOptions(IndicesOptions.strictExpand())::get, GetAliasesAction.NAME, "create_only");
 
-        assertThrowsAuthorizationException(client().filterWithHeader(headers).admin().indices()
+        assertThrowsAuthorizationException(client.admin().indices()
                 .prepareGetAliases().setIndices("test_1").setIndicesOptions(IndicesOptions.strictExpand())::get,
                 GetAliasesAction.NAME, "create_only");
 
-        assertThrowsAuthorizationException(client().filterWithHeader(headers).admin().indices().prepareGetAliases("test_alias")
+        assertThrowsAuthorizationException(client.admin().indices().prepareGetAliases("test_alias")
                 .setIndices("test_*").setIndicesOptions(IndicesOptions.strictExpand())::get, GetAliasesAction.NAME, "create_only");
 
         //this throws exception no matter what the indices options are because the aliases part cannot be resolved to any alias
         //and there is no way to "allow_no_aliases" like we can do with indices.
-        assertThrowsAuthorizationException(client().filterWithHeader(headers).admin().indices().prepareGetAliases()::get,
+        assertThrowsAuthorizationException(client.admin().indices().prepareGetAliases()::get,
                 GetAliasesAction.NAME, "create_only");
     }
 
@@ -165,23 +173,30 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
         //user has create permission only: allows to create indices, manage_aliases is required to retrieve aliases though
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("create_only",
                 new SecureString("test123".toCharArray())));
+        final Client client = client().filterWithHeader(headers);
 
-        assertThrowsAuthorizationException(client().filterWithHeader(headers).admin().indices().prepareGetAliases("test_1")
+        assertThrowsAuthorizationException(client.admin().indices().prepareGetAliases("test_1")
                 .setIndices("test_1").setIndicesOptions(IndicesOptions.lenientExpandOpen())::get, GetAliasesAction.NAME, "create_only");
 
-        assertThrowsAuthorizationException(client().filterWithHeader(headers).admin().indices().prepareGetAliases("_all")
+        assertThrowsAuthorizationException(client.admin().indices().prepareGetAliases("_all")
                 .setIndices("test_1").setIndicesOptions(IndicesOptions.lenientExpandOpen())::get, GetAliasesAction.NAME, "create_only");
 
-        assertThrowsAuthorizationException(client().filterWithHeader(headers).admin().indices().prepareGetAliases().setIndices("test_1")
+        assertThrowsAuthorizationException(client.admin().indices().prepareGetAliases("alias*")::get, GetAliasesAction.NAME, "create_only");
+
+        assertThrowsAuthorizationException(client.admin().indices().prepareGetAliases().setIndices("test_1")
                 .setIndicesOptions(IndicesOptions.lenientExpandOpen())::get, GetAliasesAction.NAME, "create_only");
 
         assertThrowsAuthorizationException(
-                client().filterWithHeader(headers).admin().indices().prepareGetAliases("test_alias")
+                client.admin().indices().prepareGetAliases("test_alias")
+                .setIndices("test_*").setIndicesOptions(IndicesOptions.lenientExpandOpen())::get, GetAliasesAction.NAME, "create_only");
+
+        assertThrowsAuthorizationException(
+            client.admin().indices().prepareGetAliases()
                 .setIndices("test_*").setIndicesOptions(IndicesOptions.lenientExpandOpen())::get, GetAliasesAction.NAME, "create_only");
 
         //this throws exception no matter what the indices options are because the aliases part cannot be resolved to any alias
         //and there is no way to "allow_no_aliases" like we can do with indices.
-        assertThrowsAuthorizationException(client().filterWithHeader(headers).admin().indices()
+        assertThrowsAuthorizationException(client.admin().indices()
                 .prepareGetAliases().setIndicesOptions(IndicesOptions.lenientExpandOpen())::get, GetAliasesAction.NAME, "create_only");
     }
 
@@ -190,17 +205,18 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
         // indices
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
                 basicAuthHeaderValue("create_test_aliases_test", new SecureString("test123".toCharArray())));
+        final Client client = client().filterWithHeader(headers);
 
-        assertAcked(client().filterWithHeader(headers).admin().indices().prepareCreate("test_1").get());
-
-        //ok: user has manage_aliases on test_*
-        assertAcked(client().filterWithHeader(headers).admin().indices().prepareAliases().addAlias("test_1", "test_alias").get());
+        assertAcked(client.admin().indices().prepareCreate("test_1").get());
 
         //ok: user has manage_aliases on test_*
-        assertAcked(client().filterWithHeader(headers).admin().indices().prepareAliases().addAlias("test_*", "test_alias_2").get());
+        assertAcked(client.admin().indices().prepareAliases().addAlias("test_1", "test_alias").get());
+
+        //ok: user has manage_aliases on test_*
+        assertAcked(client.admin().indices().prepareAliases().addAlias("test_*", "test_alias_2").get());
 
         //fails: user doesn't have manage_aliases on alias_1
-        assertThrowsAuthorizationException(client().filterWithHeader(headers).admin().indices().prepareAliases()
+        assertThrowsAuthorizationException(client.admin().indices().prepareAliases()
                 .addAlias("test_1", "alias_1").addAlias("test_1", "test_alias")::get,
                 IndicesAliasesAction.NAME, "create_test_aliases_test");
     }
@@ -211,10 +227,12 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
         //ok: user has manage_aliases on test_*
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("create_test_aliases_test",
                 new SecureString("test123".toCharArray())));
-        assertAcked(client().filterWithHeader(headers).admin().indices().prepareCreate("test_1").addAlias(new Alias("test_alias")).get());
+        final Client client = client(headers);
+
+        assertAcked(client.admin().indices().prepareCreate("test_1").addAlias(new Alias("test_alias")).get());
 
         //fails: user doesn't have manage_aliases on alias_1
-        assertThrowsAuthorizationException(client().filterWithHeader(headers).admin().indices().prepareCreate("test_2")
+        assertThrowsAuthorizationException(client.admin().indices().prepareCreate("test_2")
                 .addAlias(new Alias("test_alias")).addAlias(new Alias("alias_2"))::get,
                 IndicesAliasesAction.NAME, "create_test_aliases_test");
     }
@@ -225,38 +243,49 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
         //ok: user has manage_aliases on test_*
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("create_test_aliases_test",
                 new SecureString("test123".toCharArray())));
+        final Client client = client(headers);
 
-        assertAcked(client().filterWithHeader(headers).admin().indices().prepareCreate("test_1").addAlias(new Alias("test_alias_1"))
+        assertAcked(client.admin().indices().prepareCreate("test_1").addAlias(new Alias("test_alias_1"))
                 .addAlias(new Alias("test_alias_2"))
                 .addAlias(new Alias("test_alias_3")).addAlias(new Alias("test_alias_4")).get());
         //ok: user has manage_aliases on test_*
-        assertAcked(client().filterWithHeader(headers).admin().indices().prepareAliases().removeAlias("test_1", "test_alias_1").get());
+        assertAcked(client.admin().indices().prepareAliases().removeAlias("test_1", "test_alias_1").get());
         //ok: user has manage_aliases on test_*
-        assertAcked(client().filterWithHeader(headers).admin().indices().prepareAliases().removeAlias("test_*", "test_alias_2").get());
+        assertAcked(client.admin().indices().prepareAliases().removeAlias("test_*", "test_alias_2").get());
         //ok: user has manage_aliases on test_*
-        assertAcked(client().filterWithHeader(headers).admin().indices().prepareAliases().removeAlias("test_1", "test_alias_*").get());
+        assertAcked(client.admin().indices().prepareAliases().removeAlias("test_1", "test_alias_*").get());
 
         {
             //fails: all aliases have been deleted, no existing aliases match test_alias_*
             AliasesNotFoundException exception = expectThrows(AliasesNotFoundException.class,
-                client().filterWithHeader(headers).admin().indices().prepareAliases().removeAlias("test_1", "test_alias_*")::get);
+                client.admin().indices().prepareAliases().removeAlias("test_1", "test_alias_*")::get);
             assertThat(exception.getMessage(), equalTo("aliases [test_alias_*] missing"));
         }
 
         {
             //fails: all aliases have been deleted, no existing aliases match _all
             AliasesNotFoundException exception = expectThrows(AliasesNotFoundException.class,
-                client().filterWithHeader(headers).admin().indices().prepareAliases().removeAlias("test_1", "_all")::get);
+                client.admin().indices().prepareAliases().removeAlias("test_1", "_all")::get);
             assertThat(exception.getMessage(), equalTo("aliases [_all] missing"));
         }
 
+        // add unauthorized aliases
+        if (randomBoolean()) {
+            assertAcked(client().admin().indices().prepareAliases().addAlias("test_1", "alias_1").get());
+        }
+        assertAcked(client().admin().indices().prepareAliases().addAlias("test_1", "alias_2").get());
+
         //fails: user doesn't have manage_aliases on alias_1
-        assertThrowsAuthorizationException(client().filterWithHeader(headers).admin().indices().prepareAliases()
+        assertThrowsAuthorizationException(client.admin().indices().prepareAliases()
                 .removeAlias("test_1", "alias_1")::get, IndicesAliasesAction.NAME, "create_test_aliases_test");
 
         //fails: user doesn't have manage_aliases on alias_1
-        assertThrowsAuthorizationException(client().filterWithHeader(headers).admin().indices().prepareAliases()
+        assertThrowsAuthorizationException(client.admin().indices().prepareAliases()
                 .removeAlias("test_1", new String[]{"_all", "alias_1"})::get, IndicesAliasesAction.NAME, "create_test_aliases_test");
+
+        AliasesNotFoundException exception = expectThrows(AliasesNotFoundException.class,
+            client.admin().indices().prepareAliases().removeAlias("test_1", "*")::get);
+        assertThat(exception.getMessage(), equalTo("aliases [*] missing"));
     }
 
     public void testGetAliasesCreateAndAliasesPermission() {
@@ -264,7 +293,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
         // indices
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
                 basicAuthHeaderValue("create_test_aliases_test", new SecureString("test123".toCharArray())));
-        final Client client = client().filterWithHeader(headers);
+        final Client client = client(headers);
         assertAcked(client.admin().indices().prepareCreate("test_1").addAlias(new Alias("test_alias")).get());
 
         //ok: user has manage_aliases on test_*
@@ -315,7 +344,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
     public void testCreateIndexThenAliasesCreateAndAliasesPermission2() {
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
                 basicAuthHeaderValue("create_test_aliases_alias", new SecureString("test123".toCharArray())));
-        final Client client = client().filterWithHeader(headers);
+        final Client client = client(headers);
 
         //user has create permission on test_* and manage_aliases permission on alias_*. manage_aliases is required to add/remove aliases
         // on both aliases and indices
@@ -339,7 +368,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
                 basicAuthHeaderValue("create_test_aliases_alias", new
                 SecureString("test123".toCharArray())));
-        final Client client = client().filterWithHeader(headers);
+        final Client client = client(headers);
 
         //user has create permission on test_* and manage_aliases permission on alias_*. manage_aliases is required to add/remove aliases
         // on both aliases and indices
@@ -352,7 +381,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
     public void testDeleteAliasesCreateAndAliasesPermission2() {
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
                 basicAuthHeaderValue("create_test_aliases_alias", new SecureString("test123".toCharArray())));
-        final Client client = client().filterWithHeader(headers);
+        final Client client = client(headers);
 
         //user has create permission on test_* and manage_aliases permission on alias_*. manage_aliases is required to add/remove aliases
         // on both aliases and indices
@@ -368,7 +397,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
     public void testGetAliasesCreateAndAliasesPermission2() {
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
                 basicAuthHeaderValue("create_test_aliases_alias", new SecureString("test123".toCharArray())));
-        final Client client = client().filterWithHeader(headers);
+        final Client client = client(headers);
 
         //user has create permission on test_* and manage_aliases permission on alias_*. manage_aliases is required to retrieve aliases
         // on both aliases and indices
@@ -413,7 +442,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
     public void testCreateIndexThenAliasesCreateAndAliasesPermission3() {
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
                 basicAuthHeaderValue("create_test_aliases_test_alias", new SecureString("test123".toCharArray())));
-        final Client client = client().filterWithHeader(headers);
+        final Client client = client(headers);
 
         //user has create permission on test_* and manage_aliases permission on test_*,alias_*. All good.
         assertAcked(client.admin().indices().prepareCreate("test_1"));
@@ -428,7 +457,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
     public void testCreateIndexAndAliasesCreateAndAliasesPermission3() {
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
                 basicAuthHeaderValue("create_test_aliases_test_alias", new SecureString("test123".toCharArray())));
-        final Client client = client().filterWithHeader(headers);
+        final Client client = client(headers);
 
         //user has create permission on test_* and manage_aliases permission on test_*,alias_*. All good.
         assertAcked(client.admin().indices().prepareCreate("test_1").addAlias(new Alias("test_alias")));
@@ -439,7 +468,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
     public void testDeleteAliasesCreateAndAliasesPermission3() {
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
                 basicAuthHeaderValue("create_test_aliases_test_alias", new SecureString("test123".toCharArray())));
-        final Client client = client().filterWithHeader(headers);
+        final Client client = client(headers);
 
         //user has create permission on test_* and manage_aliases permission on test_*,alias_*. All good.
         assertAcked(client.admin().indices().prepareCreate("test_1").addAlias(new Alias("test_alias")).addAlias(new Alias("alias_1"))
@@ -462,7 +491,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
     public void testGetAliasesCreateAndAliasesPermission3() {
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
                 basicAuthHeaderValue("create_test_aliases_test_alias", new SecureString("test123".toCharArray())));
-        final Client client = client().filterWithHeader(headers);
+        final Client client = client(headers);
 
         //user has create permission on test_* and manage_aliases permission on test_*,alias_*. All good.
         assertAcked(client.admin().indices().prepareCreate("test_1").addAlias(new Alias("test_alias")).addAlias(new Alias("alias_1")));
@@ -503,7 +532,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
     public void testGetAliasesAliasesOnlyPermissionStrict() {
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
                 basicAuthHeaderValue("aliases_only", new SecureString("test123".toCharArray())));
-        final Client client = client().filterWithHeader(headers);
+        final Client client = client(headers);
         //user has manage_aliases only permissions on both alias_* and test_*
 
         //security plugin lets it through, but es core intercepts it due to strict indices options and throws index not found
@@ -523,7 +552,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
     public void testGetAliasesAliasesOnlyPermissionIgnoreUnavailable() {
         Map<String, String> headers = Collections.singletonMap(BASIC_AUTH_HEADER,
                 basicAuthHeaderValue("aliases_only", new SecureString("test123".toCharArray())));
-        final Client client = client().filterWithHeader(headers);
+        final Client client = client(headers);
         //user has manage_aliases only permissions on both alias_* and test_*
 
         //ok: manage_aliases on both test_* and alias_*
@@ -540,6 +569,37 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
         getAliasesResponse = client.admin().indices().prepareGetAliases("alias_1").addIndices("non_authorized")
                 .setIndicesOptions(IndicesOptions.lenientExpandOpen()).get();
         assertEquals(0, getAliasesResponse.getAliases().size());
+    }
+
+    public void testRemoveIndex() {
+        final Map<String, String> headers = Collections.singletonMap(
+            BASIC_AUTH_HEADER,
+            basicAuthHeaderValue("all_on_test", new SecureString("test123".toCharArray())));
+        final Client client = client(headers);
+
+        assertAcked(client.admin().indices().prepareCreate("test_delete_1").get());
+        assertAcked(client.admin().indices().prepareCreate("test_1").addAlias(new Alias("test_alias_1")));
+
+        assertAcked(client.admin().indices().prepareAliases().removeIndex("test_delete_*").get());
+        assertAliases(client.admin().indices().prepareGetAliases().setAliases("*"), "test_1", "test_alias_1");
+
+        // test that the remove index wildcard expacnds only to authorized indices
+        assertAcked(client.admin().indices().prepareAliases().removeIndex("*").get());
+        GetAliasesResponse getAliasesResponse = client.admin().indices().prepareGetAliases().setAliases("*").get();
+        assertThat(getAliasesResponse.getAliases().size(), equalTo(0));
+        assertAliases(client().admin().indices().prepareGetAliases().setAliases("*"), "bogus_index_1", "bogus_alias_1", "bogus_alias_2");
+    }
+
+    private static Client client(final Map<String, String> headers) {
+        // it should not matter what client we send the request to, but let's pin all requests to a specific node
+        final Client client;
+        if (internalCluster().numDataAndMasterNodes() == 1 || randomBoolean()) {
+            client = client(internalCluster().getMasterName()).filterWithHeader(headers);
+        } else {
+            client = client(randomValueOtherThan(internalCluster().getMasterName(), () -> randomFrom(internalCluster().getNodeNames())))
+                .filterWithHeader(headers);
+        }
+        return client;
     }
 
     private static void assertAliases(GetAliasesRequestBuilder getAliasesRequestBuilder, String index, String... aliases) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
@@ -83,6 +83,7 @@ import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -777,14 +778,24 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         assertThat(request.getAliasActions().get(1).aliases(), arrayContainingInAnyOrder("foofoobar", "foobarfoo", "explicit"));
     }
 
-    public void testResolveAliasesWildcardsIndicesAliasesRequestDeleteActionsNoAuthorizedIndices() {
+    public void testResolveAliasesWildcardsIndicesAliasesRequestRemoveAliasActionsNoAuthorizedIndices() {
         IndicesAliasesRequest request = new IndicesAliasesRequest();
         request.addAliasAction(AliasActions.remove().index("foo*").alias("foo*"));
-        //no authorized aliases match bar*, hence aliases are replaced with no-aliases-expression for that action
         request.addAliasAction(AliasActions.remove().index("*bar").alias("bar*"));
         resolveIndices(request, buildAuthorizedIndices(user, IndicesAliasesAction.NAME));
         assertThat(request.getAliasActions().get(0).aliases(), arrayContainingInAnyOrder("foofoobar", "foobarfoo"));
-        assertThat(request.getAliasActions().get(1).aliases(), arrayContaining(IndicesAndAliasesResolver.NO_INDICES_OR_ALIASES_ARRAY));
+        assertThat(request.getAliasActions().get(1).aliases(), arrayContaining("*", "-*"));
+    }
+
+    public void testResolveAliasesWildcardsIndicesAliasesRequestRemoveIndexActions() {
+        IndicesAliasesRequest request = new IndicesAliasesRequest();
+        request.addAliasAction(AliasActions.removeIndex().index("foo*"));
+        request.addAliasAction(AliasActions.removeIndex().index("*bar"));
+        resolveIndices(request, buildAuthorizedIndices(user, IndicesAliasesAction.NAME));
+        assertThat(request.getAliasActions().get(0).indices(), arrayContainingInAnyOrder("foofoo"));
+        assertThat(request.getAliasActions().get(0).aliases(), emptyArray());
+        assertThat(request.getAliasActions().get(1).indices(), arrayContainingInAnyOrder("bar"));
+        assertThat(request.getAliasActions().get(1).aliases(), emptyArray());
     }
 
     public void testResolveWildcardsIndicesAliasesRequestAddAndDeleteActions() {


### PR DESCRIPTION
Backport of #46989

When we rewrite alias requests, after filtering down to only those that
the user is authorized to see, it can be that there are no aliases
remaining in the request. However, core Elasticsearch interprets this as
_all so the user would see more than they are authorized for. To address
this, we previously rewrote all such requests to have aliases `"*"`,
`"-*"`, which would be interpreted when aliases are resolved as
nome. Yet, this is only needed for get aliases requests and we were
applying it to all alias requests, including remove index requests. If
such a request was sent to a coordinating node that is not the master
node, the request would be rewritten to include `"*"` and `"-*"`, and
then the master would authorize the user for these. If the user had
limited permissions, the request would fail, even if they were
authorized on the index that the remove index action was over. This
commit addresses this by ~only~ rewriting get aliases and remove
aliases request types but not for the remove index.

Co-authored-by: Albert Zaharovits <albert.zaharovits@elastic.co>
Co-authored-by: Tim Vernum <tim@adjective.org>