### PR TITLE
SQL: [TESTS] Enhance leniency of ResultSet datetime tests

### DIFF
--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcTestUtils.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcTestUtils.java
@@ -148,7 +148,7 @@ final class JdbcTestUtils {
     }
     
     static String of(long millis, String zoneId) {
-        return StringUtils.toString(ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneId.of(zoneId)));
+        return StringUtils.toString(Instant.ofEpochMilli(millis).atZone(ZoneId.of(zoneId)));
     }
 
     /**

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/AbstractSqlQueryRequest.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/AbstractSqlQueryRequest.java
@@ -76,7 +76,7 @@ public abstract class AbstractSqlQueryRequest extends AbstractSqlRequest impleme
         parser.declareString((request, mode) -> request.mode(Mode.fromString(mode)), MODE);
         parser.declareString((request, clientId) -> request.clientId(clientId), CLIENT_ID);
         parser.declareObjectArray(AbstractSqlQueryRequest::params, (p, c) -> SqlTypedParamValue.fromXContent(p), PARAMS);
-        parser.declareString((request, zoneId) -> request.zoneId(ZoneId.of(zoneId)), TIME_ZONE);
+        parser.declareString((request, zoneId) -> request.zoneId(ZoneId.of(zoneId).normalized()), TIME_ZONE);
         parser.declareInt(AbstractSqlQueryRequest::fetchSize, FETCH_SIZE);
         parser.declareString((request, timeout) -> request.requestTimeout(TimeValue.parseTimeValue(timeout, Protocol.REQUEST_TIMEOUT,
             "request_timeout")), REQUEST_TIMEOUT);

--- a/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlQueryRequestTests.java
+++ b/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlQueryRequestTests.java
@@ -31,7 +31,7 @@ import static org.elasticsearch.xpack.sql.proto.RequestInfo.CLIENT_IDS;
 
 public class SqlQueryRequestTests extends AbstractSerializingTestCase<SqlQueryRequest> {
 
-    public RequestInfo requestInfo;
+    private RequestInfo requestInfo;
 
     @Before
     public void setup() {
@@ -54,7 +54,7 @@ public class SqlQueryRequestTests extends AbstractSerializingTestCase<SqlQueryRe
     @Override
     protected SqlQueryRequest createTestInstance() {
         return new SqlQueryRequest(randomAlphaOfLength(10), randomParameters(), SqlTestUtils.randomFilterOrNull(random()),
-                randomZone(), between(1, Integer.MAX_VALUE), randomTV(),
+                randomZone().normalized(), between(1, Integer.MAX_VALUE), randomTV(),
                 randomTV(), randomBoolean(), randomAlphaOfLength(10), requestInfo,
                 randomBoolean(), randomBoolean()
         );
@@ -105,12 +105,12 @@ public class SqlQueryRequestTests extends AbstractSerializingTestCase<SqlQueryRe
                 request -> request.requestInfo(randomValueOtherThan(request.requestInfo(), this::randomRequestInfo)),
                 request -> request.query(randomValueOtherThan(request.query(), () -> randomAlphaOfLength(5))),
                 request -> request.params(randomValueOtherThan(request.params(), this::randomParameters)),
-                request -> request.zoneId(randomValueOtherThan(request.zoneId(), ESTestCase::randomZone)),
+                request -> request.zoneId(randomValueOtherThan(request.zoneId(), () -> randomZone().normalized())),
                 request -> request.fetchSize(randomValueOtherThan(request.fetchSize(), () -> between(1, Integer.MAX_VALUE))),
                 request -> request.requestTimeout(randomValueOtherThan(request.requestTimeout(), this::randomTV)),
                 request -> request.filter(randomValueOtherThan(request.filter(),
                         () -> request.filter() == null ? randomFilter(random()) : randomFilterOrNull(random()))),
-                request -> request.columnar(randomValueOtherThan(request.columnar(), () -> randomBoolean())),
+                request -> request.columnar(randomValueOtherThan(request.columnar(), ESTestCase::randomBoolean)),
                 request -> request.cursor(randomValueOtherThan(request.cursor(), SqlQueryResponseTests::randomStringCursor))
         );
         SqlQueryRequest newRequest = new SqlQueryRequest(instance.query(), instance.params(), instance.filter(),

--- a/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlRequestParsersTests.java
+++ b/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlRequestParsersTests.java
@@ -117,7 +117,7 @@ public class SqlRequestParsersTests extends ESTestCase {
         List<SqlTypedParamValue> list = new ArrayList<>(1);
         list.add(new SqlTypedParamValue("whatever", 123));
         assertEquals(list, request.params());
-        assertEquals("UTC", request.zoneId().getId());
+        assertEquals("Z", request.zoneId().getId());
         assertEquals(TimeValue.parseTimeValue("5s", "request_timeout"), request.requestTimeout());
         assertEquals(TimeValue.parseTimeValue("10s", "page_timeout"), request.pageTimeout());
     }

--- a/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlTranslateRequestTests.java
+++ b/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlTranslateRequestTests.java
@@ -13,12 +13,10 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.AbstractSerializingTestCase;
-import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.proto.Mode;
 import org.elasticsearch.xpack.sql.proto.RequestInfo;
 import org.junit.Before;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.function.Consumer;
 
@@ -27,7 +25,7 @@ import static org.elasticsearch.xpack.sql.action.SqlTestUtils.randomFilterOrNull
 
 public class SqlTranslateRequestTests extends AbstractSerializingTestCase<SqlTranslateRequest> {
 
-    public Mode testMode;
+    private Mode testMode;
 
     @Before
     public void setup() {
@@ -37,7 +35,7 @@ public class SqlTranslateRequestTests extends AbstractSerializingTestCase<SqlTra
     @Override
     protected SqlTranslateRequest createTestInstance() {
         return new SqlTranslateRequest(randomAlphaOfLength(10), Collections.emptyList(), randomFilterOrNull(random()),
-                randomZone(), between(1, Integer.MAX_VALUE), randomTV(), randomTV(), new RequestInfo(testMode));
+                randomZone().normalized(), between(1, Integer.MAX_VALUE), randomTV(), randomTV(), new RequestInfo(testMode));
     }
 
     @Override
@@ -67,11 +65,11 @@ public class SqlTranslateRequestTests extends AbstractSerializingTestCase<SqlTra
     }
 
     @Override
-    protected SqlTranslateRequest mutateInstance(SqlTranslateRequest instance) throws IOException {
+    protected SqlTranslateRequest mutateInstance(SqlTranslateRequest instance) {
         @SuppressWarnings("unchecked")
         Consumer<SqlTranslateRequest> mutator = randomFrom(
                 request -> request.query(randomValueOtherThan(request.query(), () -> randomAlphaOfLength(5))),
-                request -> request.zoneId(randomValueOtherThan(request.zoneId(), ESTestCase::randomZone)),
+                request -> request.zoneId(randomValueOtherThan(request.zoneId(), () -> randomZone().normalized())),
                 request -> request.fetchSize(randomValueOtherThan(request.fetchSize(), () -> between(1, Integer.MAX_VALUE))),
                 request -> request.requestTimeout(randomValueOtherThan(request.requestTimeout(), this::randomTV)),
                 request -> request.filter(randomValueOtherThan(request.filter(),

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/util/DateUtils.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/util/DateUtils.java
@@ -80,7 +80,7 @@ public final class DateUtils {
      * Creates a datetime from the millis since epoch then translates the date into the given timezone.
      */
     public static ZonedDateTime asDateTime(long millis, ZoneId id) {
-        return ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), id);
+        return Instant.ofEpochMilli(millis).atZone(id);
     }
 
     /**


### PR DESCRIPTION
Tests on ResultSet that attempt to get a datetime object as an
inappropriate type (e.g.: boolean, float, etc.) isn't necessary to
assert the exact timestamp that is printed in the exception message.
There are other tests that verify the valid get of a datetime object
as date, timestamp or time.

Need to point that the main issue for the CI failure during the assertion
of such an exception message is the difference in tzdata for certain
timezones like `Africa/Sao_Tome` between JDK versions. JDK 13 has the
updated data but for example JDK 12 has been fixed in the latest builds.

Moreover, use `normalized()` when deserializing the SqlRequest to be
consistent with what is done when creating a ZoneId object out of the
TIMEZONE client parameter.

Relates to https://github.com/elastic/infra/issues/14773
