### PR TITLE
SQL: Normalise ZoneId when deserialising

### DIFF
--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcTestUtils.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcTestUtils.java
@@ -10,6 +10,7 @@ import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.xpack.sql.action.BasicFormatter;
 import org.elasticsearch.xpack.sql.proto.ColumnInfo;
 import org.elasticsearch.xpack.sql.proto.StringUtils;
@@ -148,7 +149,7 @@ final class JdbcTestUtils {
     }
     
     static String of(long millis, String zoneId) {
-        return StringUtils.toString(ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneId.of(zoneId)));
+        return StringUtils.toString(Instant.ofEpochMilli(millis).atZone(DateUtils.of(zoneId)));
     }
 
     /**

--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetTestCase.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetTestCase.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.sql.jdbc.EsType;
@@ -1839,6 +1840,6 @@ public class ResultSetTestCase extends JdbcIntegrationTestCase {
     }
 
     private ZoneId getZoneFromOffset(Long randomLongDate) {
-        return ZoneId.of(ZoneId.of(timeZoneId).getRules().getOffset(Instant.ofEpochMilli(randomLongDate)).toString());
+        return ZoneId.of(DateUtils.of(timeZoneId).getRules().getOffset(Instant.ofEpochMilli(randomLongDate)).toString());
     }
 }

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/AbstractSqlQueryRequest.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/AbstractSqlQueryRequest.java
@@ -10,6 +10,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
@@ -76,7 +77,7 @@ public abstract class AbstractSqlQueryRequest extends AbstractSqlRequest impleme
         parser.declareString((request, mode) -> request.mode(Mode.fromString(mode)), MODE);
         parser.declareString((request, clientId) -> request.clientId(clientId), CLIENT_ID);
         parser.declareObjectArray(AbstractSqlQueryRequest::params, (p, c) -> SqlTypedParamValue.fromXContent(p), PARAMS);
-        parser.declareString((request, zoneId) -> request.zoneId(ZoneId.of(zoneId)), TIME_ZONE);
+        parser.declareString((request, zoneId) -> request.zoneId(DateUtils.of(zoneId)), TIME_ZONE);
         parser.declareInt(AbstractSqlQueryRequest::fetchSize, FETCH_SIZE);
         parser.declareString((request, timeout) -> request.requestTimeout(TimeValue.parseTimeValue(timeout, Protocol.REQUEST_TIMEOUT,
             "request_timeout")), REQUEST_TIMEOUT);

--- a/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlQueryRequestTests.java
+++ b/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlQueryRequestTests.java
@@ -31,7 +31,7 @@ import static org.elasticsearch.xpack.sql.proto.RequestInfo.CLIENT_IDS;
 
 public class SqlQueryRequestTests extends AbstractSerializingTestCase<SqlQueryRequest> {
 
-    public RequestInfo requestInfo;
+    private RequestInfo requestInfo;
 
     @Before
     public void setup() {
@@ -54,7 +54,7 @@ public class SqlQueryRequestTests extends AbstractSerializingTestCase<SqlQueryRe
     @Override
     protected SqlQueryRequest createTestInstance() {
         return new SqlQueryRequest(randomAlphaOfLength(10), randomParameters(), SqlTestUtils.randomFilterOrNull(random()),
-                randomZone(), between(1, Integer.MAX_VALUE), randomTV(),
+                SqlTestUtils.randomZone(), between(1, Integer.MAX_VALUE), randomTV(),
                 randomTV(), randomBoolean(), randomAlphaOfLength(10), requestInfo,
                 randomBoolean(), randomBoolean()
         );
@@ -105,12 +105,12 @@ public class SqlQueryRequestTests extends AbstractSerializingTestCase<SqlQueryRe
                 request -> request.requestInfo(randomValueOtherThan(request.requestInfo(), this::randomRequestInfo)),
                 request -> request.query(randomValueOtherThan(request.query(), () -> randomAlphaOfLength(5))),
                 request -> request.params(randomValueOtherThan(request.params(), this::randomParameters)),
-                request -> request.zoneId(randomValueOtherThan(request.zoneId(), ESTestCase::randomZone)),
+                request -> request.zoneId(randomValueOtherThan(request.zoneId(), SqlTestUtils::randomZone)),
                 request -> request.fetchSize(randomValueOtherThan(request.fetchSize(), () -> between(1, Integer.MAX_VALUE))),
                 request -> request.requestTimeout(randomValueOtherThan(request.requestTimeout(), this::randomTV)),
                 request -> request.filter(randomValueOtherThan(request.filter(),
                         () -> request.filter() == null ? randomFilter(random()) : randomFilterOrNull(random()))),
-                request -> request.columnar(randomValueOtherThan(request.columnar(), () -> randomBoolean())),
+                request -> request.columnar(randomValueOtherThan(request.columnar(), ESTestCase::randomBoolean)),
                 request -> request.cursor(randomValueOtherThan(request.cursor(), SqlQueryResponseTests::randomStringCursor))
         );
         SqlQueryRequest newRequest = new SqlQueryRequest(instance.query(), instance.params(), instance.filter(),

--- a/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlRequestParsersTests.java
+++ b/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlRequestParsersTests.java
@@ -117,7 +117,7 @@ public class SqlRequestParsersTests extends ESTestCase {
         List<SqlTypedParamValue> list = new ArrayList<>(1);
         list.add(new SqlTypedParamValue("whatever", 123));
         assertEquals(list, request.params());
-        assertEquals("UTC", request.zoneId().getId());
+        assertEquals("Z", request.zoneId().getId());
         assertEquals(TimeValue.parseTimeValue("5s", "request_timeout"), request.requestTimeout());
         assertEquals(TimeValue.parseTimeValue("10s", "page_timeout"), request.pageTimeout());
     }

--- a/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlTestUtils.java
+++ b/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlTestUtils.java
@@ -8,7 +8,9 @@ package org.elasticsearch.xpack.sql.action;
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
+import org.elasticsearch.test.ESTestCase;
 
+import java.time.ZoneId;
 import java.util.Random;
 
 public final class SqlTestUtils {
@@ -38,4 +40,7 @@ public final class SqlTestUtils {
                     .gt(random.nextInt());
     }
 
+    public static ZoneId randomZone() {
+        return ESTestCase.randomZone().normalized();
+    }
 }

--- a/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlTranslateRequestTests.java
+++ b/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlTranslateRequestTests.java
@@ -13,12 +13,10 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.AbstractSerializingTestCase;
-import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.proto.Mode;
 import org.elasticsearch.xpack.sql.proto.RequestInfo;
 import org.junit.Before;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.function.Consumer;
 
@@ -27,7 +25,7 @@ import static org.elasticsearch.xpack.sql.action.SqlTestUtils.randomFilterOrNull
 
 public class SqlTranslateRequestTests extends AbstractSerializingTestCase<SqlTranslateRequest> {
 
-    public Mode testMode;
+    private Mode testMode;
 
     @Before
     public void setup() {
@@ -37,7 +35,7 @@ public class SqlTranslateRequestTests extends AbstractSerializingTestCase<SqlTra
     @Override
     protected SqlTranslateRequest createTestInstance() {
         return new SqlTranslateRequest(randomAlphaOfLength(10), Collections.emptyList(), randomFilterOrNull(random()),
-                randomZone(), between(1, Integer.MAX_VALUE), randomTV(), randomTV(), new RequestInfo(testMode));
+                SqlTestUtils.randomZone(), between(1, Integer.MAX_VALUE), randomTV(), randomTV(), new RequestInfo(testMode));
     }
 
     @Override
@@ -67,11 +65,11 @@ public class SqlTranslateRequestTests extends AbstractSerializingTestCase<SqlTra
     }
 
     @Override
-    protected SqlTranslateRequest mutateInstance(SqlTranslateRequest instance) throws IOException {
+    protected SqlTranslateRequest mutateInstance(SqlTranslateRequest instance) {
         @SuppressWarnings("unchecked")
         Consumer<SqlTranslateRequest> mutator = randomFrom(
                 request -> request.query(randomValueOtherThan(request.query(), () -> randomAlphaOfLength(5))),
-                request -> request.zoneId(randomValueOtherThan(request.zoneId(), ESTestCase::randomZone)),
+                request -> request.zoneId(randomValueOtherThan(request.zoneId(), SqlTestUtils::randomZone)),
                 request -> request.fetchSize(randomValueOtherThan(request.fetchSize(), () -> between(1, Integer.MAX_VALUE))),
                 request -> request.requestTimeout(randomValueOtherThan(request.requestTimeout(), this::randomTV)),
                 request -> request.filter(randomValueOtherThan(request.filter(),

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFunction.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
+import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.xpack.sql.expression.Expression;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeProcessor.DateTimeExtractor;
 import org.elasticsearch.xpack.sql.expression.gen.processor.Processor;
@@ -30,7 +31,7 @@ public abstract class DateTimeFunction extends BaseDateTimeFunction {
     }
 
     public static Integer dateTimeChrono(ZonedDateTime dateTime, String tzId, String chronoName) {
-        ZonedDateTime zdt = dateTime.withZoneSameInstant(ZoneId.of(tzId));
+        ZonedDateTime zdt = dateTime.withZoneSameInstant(DateUtils.of(tzId));
         return dateTimeChrono(zdt, ChronoField.valueOf(chronoName));
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTruncProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTruncProcessor.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
 import org.elasticsearch.xpack.sql.common.io.SqlStreamInput;
 import org.elasticsearch.xpack.sql.expression.gen.processor.BinaryProcessor;
@@ -58,7 +59,7 @@ public class DateTruncProcessor extends BinaryProcessor {
      * Used in Painless scripting
      */
     public static Object process(Object source1, Object source2, String zoneId) {
-        return process(source1, source2, ZoneId.of(zoneId));
+        return process(source1, source2, DateUtils.of(zoneId));
     }
 
     static Object process(Object source1, Object source2, ZoneId zoneId) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/NamedDateTimeProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/NamedDateTimeProcessor.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.time.DateUtils;
 
 import java.io.IOException;
 import java.time.ZoneId;
@@ -34,7 +35,7 @@ public class NamedDateTimeProcessor extends BaseDateTimeProcessor {
         }
 
         public final String extract(ZonedDateTime millis, String tzId) {
-            return apply.apply(millis.withZoneSameInstant(ZoneId.of(tzId)));
+            return apply.apply(millis.withZoneSameInstant(DateUtils.of(tzId)));
         }
     }
     

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/NonIsoDateTimeProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/NonIsoDateTimeProcessor.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.time.DateUtils;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -52,7 +53,7 @@ public class NonIsoDateTimeProcessor extends BaseDateTimeProcessor {
         }
 
         public final Integer extract(ZonedDateTime millis, String tzId) {
-            return apply.apply(millis.withZoneSameInstant(ZoneId.of(tzId)));
+            return apply.apply(millis.withZoneSameInstant(DateUtils.of(tzId)));
         }
     }
     

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/QuarterProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/QuarterProcessor.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.time.DateUtils;
 
 import java.io.IOException;
 import java.time.ZoneId;
@@ -44,7 +45,7 @@ public class QuarterProcessor extends BaseDateTimeProcessor {
     }
     
     public static Integer quarter(ZonedDateTime dateTime, String tzId) {
-        return quarter(dateTime.withZoneSameInstant(ZoneId.of(tzId)));
+        return quarter(dateTime.withZoneSameInstant(DateUtils.of(tzId)));
     }
 
     static Integer quarter(ZonedDateTime zdt) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/TimeFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/TimeFunction.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
+import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.xpack.sql.expression.Expression;
 import org.elasticsearch.xpack.sql.expression.Expressions;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeProcessor.DateTimeExtractor;
@@ -25,7 +26,7 @@ public abstract class TimeFunction extends DateTimeFunction {
     }
 
     public static Integer dateTimeChrono(OffsetTime time, String tzId, String chronoName) {
-        return dateTimeChrono(asTimeAtZone(time, ZoneId.of(tzId)), ChronoField.valueOf(chronoName));
+        return dateTimeChrono(asTimeAtZone(time, DateUtils.of(tzId)), ChronoField.valueOf(chronoName));
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/util/DateUtils.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/util/DateUtils.java
@@ -80,7 +80,7 @@ public final class DateUtils {
      * Creates a datetime from the millis since epoch then translates the date into the given timezone.
      */
     public static ZonedDateTime asDateTime(long millis, ZoneId id) {
-        return ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), id);
+        return Instant.ofEpochMilli(millis).atZone(id);
     }
 
     /**
@@ -148,6 +148,4 @@ public final class DateUtils {
         nano = nano - nano % (int) Math.pow(10, (9 - precision));
         return nano;
     }
-
-
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/AbstractSqlWireSerializingTestCase.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/AbstractSqlWireSerializingTestCase.java
@@ -49,6 +49,6 @@ public abstract class AbstractSqlWireSerializingTestCase<T extends Writeable> ex
      * e.g. in bwc serialization and in the extract() method
      */
     protected static ZoneId randomSafeZone() {
-        return randomValueOtherThanMany(zi -> zi.getId().startsWith("SystemV"), () -> randomZone());
+        return randomValueOtherThanMany(zi -> zi.getId().startsWith("SystemV"), TestUtils::randomZone);
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/TestUtils.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/TestUtils.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.sql;
 
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.proto.Mode;
 import org.elasticsearch.xpack.sql.proto.Protocol;
 import org.elasticsearch.xpack.sql.session.Configuration;
@@ -58,4 +59,7 @@ public class TestUtils {
                 randomBoolean());
     }
 
+    public static ZoneId randomZone() {
+        return ESTestCase.randomZone().normalized();
+    }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/ScrollCursorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/ScrollCursorTests.java
@@ -9,6 +9,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.xpack.sql.AbstractSqlWireSerializingTestCase;
+import org.elasticsearch.xpack.sql.TestUtils;
 import org.elasticsearch.xpack.sql.execution.search.extractor.ComputingExtractorTests;
 import org.elasticsearch.xpack.sql.execution.search.extractor.ConstantExtractorTests;
 import org.elasticsearch.xpack.sql.execution.search.extractor.HitExtractor;
@@ -68,6 +69,6 @@ public class ScrollCursorTests extends AbstractSqlWireSerializingTestCase<Scroll
         if (randomBoolean()) {
             return super.copyInstance(instance, version);
         }
-        return (ScrollCursor) Cursors.decodeFromString(Cursors.encodeToString(instance, randomZone()));
+        return (ScrollCursor) Cursors.decodeFromString(Cursors.encodeToString(instance, TestUtils.randomZone()));
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/CompositeKeyExtractorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/CompositeKeyExtractorTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Buck
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.AbstractSqlWireSerializingTestCase;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
+import org.elasticsearch.xpack.sql.TestUtils;
 import org.elasticsearch.xpack.sql.querydsl.container.GroupByRef.Property;
 import org.elasticsearch.xpack.sql.util.DateUtils;
 
@@ -59,7 +60,7 @@ public class CompositeKeyExtractorTests extends AbstractSqlWireSerializingTestCa
     public void testExtractBucketCount() {
         Bucket bucket = new TestBucket(emptyMap(), randomLong(), new Aggregations(emptyList()));
         CompositeKeyExtractor extractor = new CompositeKeyExtractor(randomAlphaOfLength(16), Property.COUNT,
-                randomZone(), false);
+                TestUtils.randomZone(), false);
         assertEquals(bucket.getDocCount(), extractor.extract(bucket));
     }
 
@@ -80,7 +81,8 @@ public class CompositeKeyExtractorTests extends AbstractSqlWireSerializingTestCa
     }
 
     public void testExtractIncorrectDateKey() {
-        CompositeKeyExtractor extractor = new CompositeKeyExtractor(randomAlphaOfLength(16), Property.VALUE, randomZone(), true);
+        CompositeKeyExtractor extractor = new CompositeKeyExtractor(randomAlphaOfLength(16), Property.VALUE,
+            TestUtils.randomZone(), true);
 
         Object value = new Object();
         Bucket bucket = new TestBucket(singletonMap(extractor.key(), value), randomLong(), new Aggregations(emptyList()));

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/FieldHitExtractorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/FieldHitExtractorTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.AbstractSqlWireSerializingTestCase;
 import org.elasticsearch.xpack.sql.SqlException;
+import org.elasticsearch.xpack.sql.TestUtils;
 import org.elasticsearch.xpack.sql.expression.function.scalar.geo.GeoShape;
 import org.elasticsearch.xpack.sql.type.DataType;
 import org.elasticsearch.xpack.sql.util.DateUtils;
@@ -42,7 +43,7 @@ public class FieldHitExtractorTests extends AbstractSqlWireSerializingTestCase<F
     public static FieldHitExtractor randomFieldHitExtractor() {
         String hitName = randomAlphaOfLength(5);
         String name = randomAlphaOfLength(5) + "." + hitName;
-        return new FieldHitExtractor(name, null, null, randomZone(), randomBoolean(), hitName, false);
+        return new FieldHitExtractor(name, null, null, TestUtils.randomZone(), randomBoolean(), hitName, false);
     }
 
     @Override
@@ -158,7 +159,7 @@ public class FieldHitExtractorTests extends AbstractSqlWireSerializingTestCase<F
     }
 
     public void testGetDate() {
-        ZoneId zoneId = randomZone();
+        ZoneId zoneId = TestUtils.randomZone();
         long millis = 1526467911780L;
         List<Object> documentFieldValues = Collections.singletonList(Long.toString(millis));
         SearchHit hit = new SearchHit(1);

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/MetricAggExtractorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/MetricAggExtractorTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Buck
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.AbstractSqlWireSerializingTestCase;
 import org.elasticsearch.xpack.sql.SqlException;
+import org.elasticsearch.xpack.sql.TestUtils;
 import org.elasticsearch.xpack.sql.util.DateUtils;
 
 import java.io.IOException;
@@ -26,7 +27,7 @@ public class MetricAggExtractorTests extends AbstractSqlWireSerializingTestCase<
 
     public static MetricAggExtractor randomMetricAggExtractor() {
         return new MetricAggExtractor(randomAlphaOfLength(16), randomAlphaOfLength(16), randomAlphaOfLength(16),
-            randomZone(), randomBoolean());
+            TestUtils.randomZone(), randomBoolean());
     }
 
     public static MetricAggExtractor randomMetricAggExtractor(ZoneId zoneId) {
@@ -75,7 +76,7 @@ public class MetricAggExtractorTests extends AbstractSqlWireSerializingTestCase<
     }
 
     public void testSingleValuePropertyDate() {
-        ZoneId zoneId = randomZone();
+        ZoneId zoneId = TestUtils.randomZone();
         MetricAggExtractor extractor = new MetricAggExtractor("my_date_field", "property", "innerKey", zoneId, true);
 
         double value = randomDouble();
@@ -94,7 +95,7 @@ public class MetricAggExtractorTests extends AbstractSqlWireSerializingTestCase<
     }
 
     public void testSingleValueInnerKeyDate() {
-        ZoneId zoneId = randomZone();
+        ZoneId zoneId = TestUtils.randomZone();
         MetricAggExtractor extractor = new MetricAggExtractor("field", "property", "innerKey", zoneId, true);
 
         double innerValue = randomDouble();
@@ -114,7 +115,7 @@ public class MetricAggExtractorTests extends AbstractSqlWireSerializingTestCase<
     }
 
     public void testMultiValuePropertyDate() {
-        ZoneId zoneId = randomZone();
+        ZoneId zoneId = TestUtils.randomZone();
         MetricAggExtractor extractor = new MetricAggExtractor("field", "property", "innerKey", zoneId, true);
 
         double value = randomDouble();

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/TopHitsAggExtractorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/TopHitsAggExtractorTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.search.aggregations.metrics.InternalTopHits;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.AbstractSqlWireSerializingTestCase;
 import org.elasticsearch.xpack.sql.SqlException;
+import org.elasticsearch.xpack.sql.TestUtils;
 import org.elasticsearch.xpack.sql.type.DataType;
 import org.elasticsearch.xpack.sql.util.DateUtils;
 
@@ -31,7 +32,7 @@ import static org.elasticsearch.xpack.sql.util.DateUtils.UTC;
 public class TopHitsAggExtractorTests extends AbstractSqlWireSerializingTestCase<TopHitsAggExtractor> {
 
     public static TopHitsAggExtractor randomTopHitsAggExtractor() {
-        return new TopHitsAggExtractor(randomAlphaOfLength(16), randomFrom(DataType.values()), randomZone());
+        return new TopHitsAggExtractor(randomAlphaOfLength(16), randomFrom(DataType.values()), TestUtils.randomZone());
     }
 
     @Override
@@ -83,7 +84,7 @@ public class TopHitsAggExtractorTests extends AbstractSqlWireSerializingTestCase
     }
 
     public void testExtractDateValue() {
-        ZoneId zoneId = randomZone();
+        ZoneId zoneId = TestUtils.randomZone();
         TopHitsAggExtractor extractor = new TopHitsAggExtractor("topHitsAgg", DataType.DATETIME, zoneId);
 
         long value = 123456789L;

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/FunctionRegistryTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/FunctionRegistryTests.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.sql.expression.function;
 
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
+import org.elasticsearch.xpack.sql.TestUtils;
 import org.elasticsearch.xpack.sql.expression.Expression;
 import org.elasticsearch.xpack.sql.expression.function.scalar.ScalarFunction;
 import org.elasticsearch.xpack.sql.expression.gen.pipeline.Pipe;
@@ -103,7 +104,7 @@ public class FunctionRegistryTests extends ESTestCase {
     public void testDateTimeFunction() {
         boolean urIsExtract = randomBoolean();
         UnresolvedFunction ur = uf(urIsExtract ? EXTRACT : STANDARD, mock(Expression.class));
-        ZoneId providedTimeZone = randomZone().normalized();
+        ZoneId providedTimeZone = TestUtils.randomZone();
         Configuration providedConfiguration = randomConfiguration(providedTimeZone);
         FunctionRegistry r = new FunctionRegistry(def(DummyFunction.class, (Source l, Expression e, ZoneId zi) -> {
                     assertEquals(providedTimeZone, zi);

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/FunctionTestUtils.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/FunctionTestUtils.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.sql.expression.function.scalar;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.sql.TestUtils;
 import org.elasticsearch.xpack.sql.expression.Literal;
 
 import java.time.Instant;
@@ -31,7 +32,7 @@ public final class FunctionTestUtils {
     }
 
     public static Literal randomDatetimeLiteral() {
-        return l(ZonedDateTime.ofInstant(Instant.ofEpochMilli(ESTestCase.randomLong()), ESTestCase.randomZone()));
+        return l(ZonedDateTime.ofInstant(Instant.ofEpochMilli(ESTestCase.randomLong()), TestUtils.randomZone()));
     }
 
     public static class Combinations implements Iterable<BitSet> {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentDateTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/CurrentDateTests.java
@@ -35,7 +35,7 @@ public class CurrentDateTests extends AbstractNodeTestCase<CurrentDate, Expressi
     protected CurrentDate mutate(CurrentDate instance) {
         ZonedDateTime now = instance.configuration().now();
         ZoneId mutatedZoneId = randomValueOtherThanMany(o -> Objects.equals(now.getOffset(), o.getRules().getOffset(now.toInstant())),
-                () -> randomZone());
+            TestUtils::randomZone);
         return new CurrentDate(instance.source(), TestUtils.randomConfiguration(mutatedZoneId));
     }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeProcessorTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.xpack.sql.AbstractSqlWireSerializingTestCase;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
+import org.elasticsearch.xpack.sql.TestUtils;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeProcessor.DateTimeExtractor;
 
 import java.time.OffsetTime;
@@ -20,7 +21,7 @@ import static org.hamcrest.Matchers.startsWith;
 public class DateTimeProcessorTests extends AbstractSqlWireSerializingTestCase<DateTimeProcessor> {
 
     public static DateTimeProcessor randomDateTimeProcessor() {
-        return new DateTimeProcessor(randomFrom(DateTimeExtractor.values()), randomZone());
+        return new DateTimeProcessor(randomFrom(DateTimeExtractor.values()), TestUtils.randomZone());
     }
 
     @Override
@@ -41,7 +42,7 @@ public class DateTimeProcessorTests extends AbstractSqlWireSerializingTestCase<D
     @Override
     protected DateTimeProcessor mutateInstance(DateTimeProcessor instance) {
         DateTimeExtractor replaced = randomValueOtherThan(instance.extractor(), () -> randomFrom(DateTimeExtractor.values()));
-        return new DateTimeProcessor(replaced, randomZone());
+        return new DateTimeProcessor(replaced, TestUtils.randomZone());
     }
 
     public void testApply_withTimezoneUTC() {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTruncPipeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTruncPipeTests.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.sql.TestUtils;
 import org.elasticsearch.xpack.sql.expression.Expression;
 import org.elasticsearch.xpack.sql.expression.function.scalar.FunctionTestUtils;
 import org.elasticsearch.xpack.sql.expression.gen.pipeline.BinaryPipe;
@@ -41,7 +42,7 @@ public class DateTruncPipeTests extends AbstractNodeTestCase<DateTruncPipe, Pipe
                 randomSource(),
                 randomStringLiteral(),
                 randomStringLiteral(),
-                randomZone())
+                TestUtils.randomZone())
                 .makePipe();
     }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTruncProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTruncProcessorTests.java
@@ -10,6 +10,7 @@ import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.AbstractSqlWireSerializingTestCase;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
+import org.elasticsearch.xpack.sql.TestUtils;
 import org.elasticsearch.xpack.sql.expression.Literal;
 import org.elasticsearch.xpack.sql.expression.gen.processor.ConstantProcessor;
 import org.elasticsearch.xpack.sql.tree.Source;
@@ -30,7 +31,7 @@ public class DateTruncProcessorTests extends AbstractSqlWireSerializingTestCase<
         return new DateTruncProcessor(
             new ConstantProcessor(randomRealisticUnicodeOfLengthBetween(0, 128)),
             new ConstantProcessor(ZonedDateTime.now()),
-            randomZone());
+            TestUtils.randomZone());
     }
 
     @Override
@@ -53,34 +54,35 @@ public class DateTruncProcessorTests extends AbstractSqlWireSerializingTestCase<
         return new DateTruncProcessor(
             new ConstantProcessor(ESTestCase.randomRealisticUnicodeOfLength(128)),
             new ConstantProcessor(ZonedDateTime.now()),
-            randomValueOtherThan(instance.zoneId(), ESTestCase::randomZone));
+            randomValueOtherThan(instance.zoneId(), TestUtils::randomZone));
     }
 
     public void testInvalidInputs() {
-        SqlIllegalArgumentException siae = expectThrows(SqlIllegalArgumentException.class,
-                () -> new DateTrunc(Source.EMPTY, l(5), randomDatetimeLiteral(), randomZone()).makePipe().asProcessor().process(null));
+        SqlIllegalArgumentException siae = expectThrows(SqlIllegalArgumentException.class, () -> new DateTrunc(
+            Source.EMPTY, l(5), randomDatetimeLiteral(), TestUtils.randomZone()).makePipe().asProcessor().process(null));
         assertEquals("A string is required; received [5]", siae.getMessage());
 
-        siae = expectThrows(SqlIllegalArgumentException.class,
-            () -> new DateTrunc(Source.EMPTY, l("days"), l("foo"), randomZone()).makePipe().asProcessor().process(null));
+        siae = expectThrows(SqlIllegalArgumentException.class, () -> new DateTrunc(
+            Source.EMPTY, l("days"), l("foo"), TestUtils.randomZone()).makePipe().asProcessor().process(null));
         assertEquals("A datetime/date is required; received [foo]", siae.getMessage());
 
-        siae = expectThrows(SqlIllegalArgumentException.class,
-            () -> new DateTrunc(Source.EMPTY, l("invalid"), randomDatetimeLiteral(), randomZone()).makePipe().asProcessor().process(null));
+        siae = expectThrows(SqlIllegalArgumentException.class, () -> new DateTrunc(
+            Source.EMPTY, l("invalid"), randomDatetimeLiteral(), TestUtils.randomZone()).makePipe().asProcessor().process(null));
         assertEquals("A value of [MILLENNIUM, CENTURY, DECADE, YEAR, QUARTER, MONTH, WEEK, DAY, HOUR, MINUTE, " +
             "SECOND, MILLISECOND, MICROSECOND, NANOSECOND] or their aliases is required; received [invalid]",
             siae.getMessage());
 
-        siae = expectThrows(SqlIllegalArgumentException.class,
-            () -> new DateTrunc(Source.EMPTY, l("dacede"), randomDatetimeLiteral(), randomZone()).makePipe().asProcessor().process(null));
+        siae = expectThrows(SqlIllegalArgumentException.class, () -> new DateTrunc(
+            Source.EMPTY, l("dacede"), randomDatetimeLiteral(), TestUtils.randomZone()).makePipe().asProcessor().process(null));
         assertEquals("Received value [dacede] is not valid date part for truncation; did you mean [decade, decades]?",
              siae.getMessage());
     }
 
     public void testWithNulls() {
-        assertNull(new DateTrunc(Source.EMPTY, NULL, randomDatetimeLiteral(), randomZone()).makePipe().asProcessor().process(null));
-        assertNull(new DateTrunc(Source.EMPTY, l("days"), NULL, randomZone()).makePipe().asProcessor().process(null));
-        assertNull(new DateTrunc(Source.EMPTY, NULL, NULL, randomZone()).makePipe().asProcessor().process(null));
+        assertNull(new DateTrunc(Source.EMPTY, NULL, randomDatetimeLiteral(),
+            TestUtils.randomZone()).makePipe().asProcessor().process(null));
+        assertNull(new DateTrunc(Source.EMPTY, l("days"), NULL, TestUtils.randomZone()).makePipe().asProcessor().process(null));
+        assertNull(new DateTrunc(Source.EMPTY, NULL, NULL, TestUtils.randomZone()).makePipe().asProcessor().process(null));
     }
 
     public void testTruncation() {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/TimeProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/TimeProcessorTests.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.xpack.sql.AbstractSqlWireSerializingTestCase;
+import org.elasticsearch.xpack.sql.TestUtils;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeProcessor.DateTimeExtractor;
 
 import java.time.ZoneId;
@@ -17,7 +18,7 @@ import static org.elasticsearch.xpack.sql.util.DateUtils.UTC;
 public class TimeProcessorTests extends AbstractSqlWireSerializingTestCase<TimeProcessor> {
 
     public static TimeProcessor randomTimeProcessor() {
-        return new TimeProcessor(randomFrom(DateTimeExtractor.values()), randomZone());
+        return new TimeProcessor(randomFrom(DateTimeExtractor.values()), TestUtils.randomZone());
     }
 
     @Override
@@ -38,7 +39,7 @@ public class TimeProcessorTests extends AbstractSqlWireSerializingTestCase<TimeP
     @Override
     protected TimeProcessor mutateInstance(TimeProcessor instance) {
         DateTimeExtractor replaced = randomValueOtherThan(instance.extractor(), () -> randomFrom(DateTimeExtractor.values()));
-        return new TimeProcessor(replaced, randomZone());
+        return new TimeProcessor(replaced, TestUtils.randomZone());
     }
 
     public void testApply_withTimeZoneUTC() {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerTests.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.sql.optimizer;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.sql.TestUtils;
 import org.elasticsearch.xpack.sql.analysis.analyzer.Analyzer.PruneSubqueryAliases;
 import org.elasticsearch.xpack.sql.analysis.index.EsIndex;
 import org.elasticsearch.xpack.sql.expression.Alias;
@@ -439,7 +440,7 @@ public class OptimizerTests extends ESTestCase {
     public void testGenericNullableExpression() {
         FoldNull rule = new FoldNull();
         // date-time
-        assertNullLiteral(rule.rule(new DayName(EMPTY, NULL, randomZone())));
+        assertNullLiteral(rule.rule(new DayName(EMPTY, NULL, TestUtils.randomZone())));
         // math function
         assertNullLiteral(rule.rule(new Cos(EMPTY, NULL)));
         // string function

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plugin/CursorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plugin/CursorTests.java
@@ -104,11 +104,11 @@ public class CursorTests extends ESTestCase {
 
     public void testVersionHandling() {
         Cursor cursor = randomNonEmptyCursor();
-        assertEquals(cursor, Cursors.decodeFromString(Cursors.encodeToString(cursor, randomZone())));
+        assertEquals(cursor, Cursors.decodeFromString(Cursors.encodeToString(cursor, TestUtils.randomZone())));
 
         Version nextMinorVersion = Version.fromId(Version.CURRENT.id + 10000);
 
-        String encodedWithWrongVersion = CursorsTestUtil.encodeToString(cursor, nextMinorVersion, randomZone());
+        String encodedWithWrongVersion = CursorsTestUtil.encodeToString(cursor, nextMinorVersion, TestUtils.randomZone());
         SqlException exception = expectThrows(SqlException.class, () -> Cursors.decodeFromString(encodedWithWrongVersion));
 
         assertEquals(LoggerMessageFormat.format("Unsupported cursor version [{}], expected [{}]", nextMinorVersion, Version.CURRENT),

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/session/ListCursorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/session/ListCursorTests.java
@@ -9,6 +9,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.sql.TestUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -57,6 +58,6 @@ public class ListCursorTests extends AbstractWireSerializingTestCase<ListCursor>
         if (randomBoolean()) {
             return super.copyInstance(instance, version);
         }
-        return (ListCursor) Cursors.decodeFromString(Cursors.encodeToString(instance, randomZone()));
+        return (ListCursor) Cursors.decodeFromString(Cursors.encodeToString(instance, TestUtils.randomZone()));
     }
 }


### PR DESCRIPTION
Moreover, use `normalized()` when deserialising the ZoneID (e.g.: from SqlRequest)
to be consistent with what is done when creating a ZoneId object out of the
TIMEZONE client parameter.
