### PR TITLE
[6.8] [ML] fix two datafeed flush lockup bugs (#46982)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectCommunicator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectCommunicator.java
@@ -282,7 +282,7 @@ public class AutodetectCommunicator implements Closeable {
     }
 
     @Nullable
-    FlushAcknowledgement waitFlushToCompletion(String flushId) throws InterruptedException {
+    FlushAcknowledgement waitFlushToCompletion(String flushId) throws Exception {
         LOGGER.debug("[{}] waiting for flush", job.getId());
 
         FlushAcknowledgement flushAcknowledgement;
@@ -298,6 +298,7 @@ public class AutodetectCommunicator implements Closeable {
         }
 
         if (processKilled == false) {
+            LOGGER.debug("[{}] Initial flush completed, waiting until renormalizer is idle.", job.getId());
             // We also have to wait for the normalizer to become idle so that we block
             // clients from querying results in the middle of normalization.
             autoDetectResultProcessor.waitUntilRenormalizerIsIdle();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutoDetectResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutoDetectResultProcessor.java
@@ -296,7 +296,7 @@ public class AutoDetectResultProcessor {
             // Commit previous writes here, effectively continuing
             // the flush from the C++ autodetect process right
             // through to the data store
-						Exception exception = null;
+            Exception exception = null;
             try {
                 context.bulkResultsPersister.executeRequest();
                 persister.commitResultWrites(context.jobId);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutoDetectResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutoDetectResultProcessor.java
@@ -296,9 +296,21 @@ public class AutoDetectResultProcessor {
             // Commit previous writes here, effectively continuing
             // the flush from the C++ autodetect process right
             // through to the data store
-            context.bulkResultsPersister.executeRequest();
-            persister.commitResultWrites(context.jobId);
-            flushListener.acknowledgeFlush(flushAcknowledgement);
+						Exception exception = null;
+            try {
+                context.bulkResultsPersister.executeRequest();
+                persister.commitResultWrites(context.jobId);
+                LOGGER.debug("[{}] Flush acknowledgement sent to listener for ID {}", context.jobId, flushAcknowledgement.getId());
+            } catch (Exception e) {
+                LOGGER.error(
+                    "[" + context.jobId + "] failed to bulk persist results and commit writes during flush acknowledgement for ID " +
+                        flushAcknowledgement.getId(),
+                    e);
+                exception = e;
+                throw e;
+            } finally {
+                flushListener.acknowledgeFlush(flushAcknowledgement, exception);
+            }
             // Interim results may have been produced by the flush,
             // which need to be
             // deleted when the next finalized results come through
@@ -512,7 +524,7 @@ public class AutoDetectResultProcessor {
      * @return The {@link FlushAcknowledgement} if the flush has completed or the parsing finished; {@code null} if the timeout expired
      */
     @Nullable
-    public FlushAcknowledgement waitForFlushAcknowledgement(String flushId, Duration timeout) throws InterruptedException {
+    public FlushAcknowledgement waitForFlushAcknowledgement(String flushId, Duration timeout) throws Exception {
         return failed ? null : flushListener.waitForFlush(flushId, timeout);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/FlushListener.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/FlushListener.java
@@ -28,25 +28,29 @@ class FlushListener {
     });
 
     @Nullable
-    FlushAcknowledgement waitForFlush(String flushId, Duration timeout) throws InterruptedException {
+    FlushAcknowledgement waitForFlush(String flushId, Duration timeout) throws Exception {
         if (onClear.hasRun()) {
             return null;
         }
 
         FlushAcknowledgementHolder holder = awaitingFlushed.computeIfAbsent(flushId, (key) -> new FlushAcknowledgementHolder(flushId));
         if (holder.latch.await(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+            if (holder.flushException != null) {
+                throw holder.flushException;
+            }
             return holder.flushAcknowledgement;
         }
         return null;
     }
 
-    void acknowledgeFlush(FlushAcknowledgement flushAcknowledgement) {
+    void acknowledgeFlush(FlushAcknowledgement flushAcknowledgement, @Nullable Exception exception) {
         // acknowledgeFlush(...) could be called before waitForFlush(...)
         // a flush api call writes a flush command to the analytical process and then via a different thread the
         // result reader then reads whether the flush has been acked.
         String flushId = flushAcknowledgement.getId();
         FlushAcknowledgementHolder holder = awaitingFlushed.computeIfAbsent(flushId, (key) -> new FlushAcknowledgementHolder(flushId));
         holder.flushAcknowledgement = flushAcknowledgement;
+        holder.flushException = exception;
         holder.latch.countDown();
     }
 
@@ -62,6 +66,7 @@ class FlushListener {
 
         private final CountDownLatch latch;
         private volatile FlushAcknowledgement flushAcknowledgement;
+        private volatile Exception flushException;
 
         private FlushAcknowledgementHolder(String flushId) {
             this.flushAcknowledgement = new FlushAcknowledgement(flushId, null);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectCommunicatorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectCommunicatorTests.java
@@ -108,7 +108,7 @@ public class AutodetectCommunicatorTests extends ESTestCase {
         verifyNoMoreInteractions(process);
     }
 
-    public void testFlushJob() throws IOException, InterruptedException {
+    public void testFlushJob() throws Exception {
         AutodetectProcess process = mockAutodetectProcessWithOutputStream();
         when(process.isProcessAlive()).thenReturn(true);
         AutoDetectResultProcessor processor = mock(AutoDetectResultProcessor.class);
@@ -123,7 +123,7 @@ public class AutodetectCommunicatorTests extends ESTestCase {
         }
     }
 
-    public void testWaitForFlushReturnsIfParserFails() throws IOException, InterruptedException {
+    public void testWaitForFlushReturnsIfParserFails() throws Exception {
         AutodetectProcess process = mockAutodetectProcessWithOutputStream();
         when(process.isProcessAlive()).thenReturn(true);
         AutoDetectResultProcessor processor = mock(AutoDetectResultProcessor.class);
@@ -144,7 +144,7 @@ public class AutodetectCommunicatorTests extends ESTestCase {
         assertEquals("[foo] Unexpected death of autodetect: Mock process is dead", holder[0].getMessage());
     }
 
-    public void testFlushJob_givenFlushWaitReturnsTrueOnSecondCall() throws IOException, InterruptedException {
+    public void testFlushJob_givenFlushWaitReturnsTrueOnSecondCall() throws Exception {
         AutodetectProcess process = mockAutodetectProcessWithOutputStream();
         when(process.isProcessAlive()).thenReturn(true);
         AutoDetectResultProcessor autoDetectResultProcessor = Mockito.mock(AutoDetectResultProcessor.class);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutoDetectResultProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutoDetectResultProcessorTests.java
@@ -223,7 +223,7 @@ public class AutoDetectResultProcessorTests extends ESTestCase {
         when(result.getFlushAcknowledgement()).thenReturn(flushAcknowledgement);
         processorUnderTest.processResult(context, result);
 
-        verify(flushListener, times(1)).acknowledgeFlush(flushAcknowledgement);
+        verify(flushListener, times(1)).acknowledgeFlush(flushAcknowledgement, null);
         verify(persister, times(1)).commitResultWrites(JOB_ID);
         verify(bulkBuilder, times(1)).executeRequest();
         verifyNoMoreInteractions(persister);
@@ -248,7 +248,7 @@ public class AutoDetectResultProcessorTests extends ESTestCase {
         inOrder.verify(persister, times(1)).persistCategoryDefinition(categoryDefinition);
         inOrder.verify(bulkBuilder, times(1)).executeRequest();
         inOrder.verify(persister, times(1)).commitResultWrites(JOB_ID);
-        inOrder.verify(flushListener, times(1)).acknowledgeFlush(flushAcknowledgement);
+        inOrder.verify(flushListener, times(1)).acknowledgeFlush(flushAcknowledgement, null);
         verifyNoMoreInteractions(persister);
         assertTrue(context.deleteInterimRequired);
     }
@@ -496,7 +496,7 @@ public class AutoDetectResultProcessorTests extends ESTestCase {
         verify(persister, times(2)).persistModelSnapshot(any(), eq(WriteRequest.RefreshPolicy.IMMEDIATE));
     }
 
-    public void testParsingErrorSetsFailed() throws InterruptedException {
+    public void testParsingErrorSetsFailed() throws Exception {
         @SuppressWarnings("unchecked")
         Iterator<AutodetectResult> iterator = mock(Iterator.class);
         when(iterator.hasNext()).thenThrow(new ElasticsearchParseException("this test throws"));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/FlushListenerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/FlushListenerTests.java
@@ -14,6 +14,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class FlushListenerTests extends ESTestCase {
@@ -27,13 +28,42 @@ public class FlushListenerTests extends ESTestCase {
                 flushAcknowledgementHolder.set(flushAcknowledgement);
             } catch (InterruptedException _ex) {
                 Thread.currentThread().interrupt();
+            } catch (Exception ex) {
+                fail("unexpected exception " + ex.getMessage());
             }
         }).start();
         assertBusy(() -> assertTrue(listener.awaitingFlushed.containsKey("_id")));
         assertNull(flushAcknowledgementHolder.get());
         FlushAcknowledgement flushAcknowledgement = new FlushAcknowledgement("_id", new Date(12345678L));
-        listener.acknowledgeFlush(flushAcknowledgement);
+        listener.acknowledgeFlush(flushAcknowledgement, null);
         assertBusy(() -> assertNotNull(flushAcknowledgementHolder.get()));
+        assertEquals(1, listener.awaitingFlushed.size());
+
+        listener.clear("_id");
+        assertEquals(0, listener.awaitingFlushed.size());
+    }
+
+    public void testAcknowledgeFlushFailure() throws Exception {
+        FlushListener listener = new FlushListener();
+        AtomicReference<Exception> flushExceptionHolder = new AtomicReference<>();
+        new Thread(() -> {
+            try {
+                listener.waitForFlush("_id", Duration.ofMillis(10000));
+                fail("Expected exception to throw.");
+            } catch (InterruptedException _ex) {
+                Thread.currentThread().interrupt();
+            } catch (Exception ex) {
+                flushExceptionHolder.set(ex);
+            }
+        }).start();
+        assertBusy(() -> assertTrue(listener.awaitingFlushed.containsKey("_id")));
+        assertNull(flushExceptionHolder.get());
+        FlushAcknowledgement flushAcknowledgement = new FlushAcknowledgement("_id", new Date(12345678L));
+        listener.acknowledgeFlush(flushAcknowledgement, new Exception("BOOM"));
+        assertBusy(() -> {
+            assertNotNull(flushExceptionHolder.get());
+            assertThat(flushExceptionHolder.get().getMessage(), equalTo("BOOM"));
+        });
         assertEquals(1, listener.awaitingFlushed.size());
 
         listener.clear("_id");
@@ -55,6 +85,8 @@ public class FlushListenerTests extends ESTestCase {
                     flushAcknowledgementHolder.set(flushAcknowledgement);
                 } catch (InterruptedException _ex) {
                     Thread.currentThread().interrupt();
+                } catch (Exception ex) {
+                    fail("unexpected exception " + ex.getMessage());
                 }
             }).start();
         }


### PR DESCRIPTION
Backports the following commits to 6.8:
 - [ML] fix two datafeed flush lockup bugs  (#46982)