### PR TITLE
Adjusting the location of the _cat/indices debug

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -126,6 +126,11 @@ public class RestIndicesAction extends AbstractCatAction {
 
                 @Override
                 public void onFailure(final Exception e) {
+                    // Temporary logging to help debug https://github.com/elastic/elasticsearch/issues/45652
+                    // TODO: remove this when we understand why _cat/indices sometimes returns a 404
+                    if (e instanceof IndexNotFoundException) {
+                        logger.debug("_cat/indices returning index_not_found_exception", e);
+                    }
                     listener.onFailure(e);
                 }
             });
@@ -227,11 +232,6 @@ public class RestIndicesAction extends AbstractCatAction {
 
             @Override
             public void onFailure(final Exception e) {
-                // Temporary logging to help debug https://github.com/elastic/elasticsearch/issues/45652
-                // TODO: remove this when we understand why _cat/indices sometimes returns a 404
-                if (e instanceof IndexNotFoundException) {
-                    logger.debug("_cat/indices returning index_not_found_exception", e);
-                }
                 listener.onFailure(e);
             }
         }, size);


### PR DESCRIPTION
Relates #45652

The most recent failure suggests the exception is
thrown earlier than previously assumed.