### PR TITLE
Mention ip fields in the global ordinals docs.

### DIFF
--- a/docs/reference/mapping/params/eager-global-ordinals.asciidoc
+++ b/docs/reference/mapping/params/eager-global-ordinals.asciidoc
@@ -26,9 +26,9 @@ ordinal for each segment.
 
 Global ordinals are used if a search contains any of the following components:
 
-* Bucket aggregations on `keyword` and `flattened` fields. This includes
-`terms` aggregations as mentioned above, as well as `composite`, `sampler`,
-and `significant_terms`.
+* Certain bucket aggregations on `keyword`, `ip`, and `flattened` fields. This
+includes `terms` aggregations as mentioned above, as well as `composite`,
+`diversified_sampler`, and `significant_terms`.
 * Bucket aggregations on `text` fields that require <<fielddata, `fielddata`>>
 to be enabled.
 * Operations on parent and child documents from a `join` field, including


### PR DESCRIPTION
Although they do not support `eager_global_ordinals`, `ip` fields use global
ordinals for certain aggregations like `terms`.

This commit also corrects a reference to the `sampler` aggregation.