### PR TITLE
Store dense_vector values as bfloat16

### DIFF
--- a/docs/reference/mapping/types/dense-vector.asciidoc
+++ b/docs/reference/mapping/types/dense-vector.asciidoc
@@ -53,4 +53,5 @@ PUT my_index/_doc/2
 
 Internally, each document's dense vector is encoded as a binary
 doc value. Its size in bytes is equal to
-`4 * dims + 4`, where `dims`—the number of the vector's dimensions.
+`2 * dims + 4`, where `dims` — the number of the vector's dimensions.
+Each dimension value is represented as bfloat16 value.

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/10_dense_vector_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/10_dense_vector_basic.yml
@@ -60,18 +60,18 @@ setup:
 
   # result should be 65425.624, but we allow 1% error because vectors are indexed as bfloat16
   - match: {hits.hits.0._id: "1"}
-  - gte: {hits.hits.0._score: 62154.34}
-  - lte: {hits.hits.0._score: 68696.91}
+  - gte: {hits.hits.0._score: 65098.50}
+  - lte: {hits.hits.0._score: 65752.75}
 
   # result should be 37111.98, but we allow 1% error because vectors are indexed as bfloat16
   - match: {hits.hits.1._id: "3"}
-  - gte: {hits.hits.1._score: 35256.38}
-  - lte: {hits.hits.1._score: 38967.58}
+  - gte: {hits.hits.1._score: 36926.42}
+  - lte: {hits.hits.1._score: 37297.54}
 
   # result should be 35853.78, but we allow 1% error because vectors are indexed as bfloat16
   - match: {hits.hits.2._id: "2"}
-  - gte: {hits.hits.2._score: 34061.09}
-  - lte: {hits.hits.2._score: 37646.47}
+  - gte: {hits.hits.2._score: 35674.51}
+  - lte: {hits.hits.2._score: 36033.05}
 
 ---
 "Cosine Similarity":

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/10_dense_vector_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/10_dense_vector_basic.yml
@@ -58,17 +58,20 @@ setup:
 
   - match: {hits.total: 3}
 
+  # result should be 65425.624, but we allow 1% error because vectors are indexed as bfloat16
   - match: {hits.hits.0._id: "1"}
-  - gte: {hits.hits.0._score: 65425.62}
-  - lte: {hits.hits.0._score: 65425.63}
+  - gte: {hits.hits.0._score: 62154.34}
+  - lte: {hits.hits.0._score: 68696.91}
 
+  # result should be 37111.98, but we allow 1% error because vectors are indexed as bfloat16
   - match: {hits.hits.1._id: "3"}
-  - gte: {hits.hits.1._score: 37111.98}
-  - lte: {hits.hits.1._score: 37111.99}
+  - gte: {hits.hits.1._score: 35256.38}
+  - lte: {hits.hits.1._score: 38967.58}
 
+  # result should be 35853.78, but we allow 1% error because vectors are indexed as bfloat16
   - match: {hits.hits.2._id: "2"}
-  - gte: {hits.hits.2._score: 35853.78}
-  - lte: {hits.hits.2._score: 35853.79}
+  - gte: {hits.hits.2._score: 34061.09}
+  - lte: {hits.hits.2._score: 37646.47}
 
 ---
 "Cosine Similarity":

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/15_dense_vector_l1l2.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/15_dense_vector_l1l2.yml
@@ -59,17 +59,20 @@ setup:
 
   - match: {hits.total: 3}
 
+  # result should be 485.18, but we allow 1% error because vectors are indexed as bfloat16
   - match: {hits.hits.0._id: "1"}
-  - gte: {hits.hits.0._score: 485.18}
-  - lte: {hits.hits.0._score: 485.19}
+  - gte: {hits.hits.0._score: 460.92}
+  - lte: {hits.hits.0._score: 509.44}
 
+  # result should be 12.3, but we allow 1% error because vectors are indexed as bfloat16
   - match: {hits.hits.1._id: "2"}
-  - gte: {hits.hits.1._score: 12.29}
-  - lte: {hits.hits.1._score: 12.31}
+  - gte: {hits.hits.1._score: 11.68}
+  - lte: {hits.hits.1._score: 12.91}
 
+  # result here should be 0, but we allow it be up to 0.5 because vectors are indexed as bfloat16
   - match: {hits.hits.2._id: "3"}
   - gte: {hits.hits.2._score: 0.00}
-  - lte: {hits.hits.2._score: 0.01}
+  - lte: {hits.hits.2._score: 0.5}
 
 ---
 "L2 norm":
@@ -89,14 +92,17 @@ setup:
 
   - match: {hits.total: 3}
 
+  # result should be 301.36, but we allow 1% error because vectors are indexed as bfloat16
   - match: {hits.hits.0._id: "1"}
-  - gte: {hits.hits.0._score: 301.36}
-  - lte: {hits.hits.0._score: 301.37}
+  - gte: {hits.hits.0._score: 286.29}
+  - lte: {hits.hits.0._score: 316.43}
 
+  # result should be 11.34, but we allow 1% error because vectors are indexed as bfloat16
   - match: {hits.hits.1._id: "2"}
-  - gte: {hits.hits.1._score: 11.34}
-  - lte: {hits.hits.1._score: 11.35}
+  - gte: {hits.hits.1._score: 10.77}
+  - lte: {hits.hits.1._score: 11.90}
 
+  # result here should be 0, but we allow it be up to 0.5 because vectors are indexed as bfloat16
   - match: {hits.hits.2._id: "3"}
   - gte: {hits.hits.2._score: 0.00}
-  - lte: {hits.hits.2._score: 0.01}
+  - lte: {hits.hits.2._score: 0.5}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/15_dense_vector_l1l2.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/15_dense_vector_l1l2.yml
@@ -61,18 +61,18 @@ setup:
 
   # result should be 485.18, but we allow 1% error because vectors are indexed as bfloat16
   - match: {hits.hits.0._id: "1"}
-  - gte: {hits.hits.0._score: 460.92}
-  - lte: {hits.hits.0._score: 509.44}
+  - gte: {hits.hits.0._score: 482.75}
+  - lte: {hits.hits.0._score: 487.61}
 
   # result should be 12.3, but we allow 1% error because vectors are indexed as bfloat16
   - match: {hits.hits.1._id: "2"}
-  - gte: {hits.hits.1._score: 11.68}
-  - lte: {hits.hits.1._score: 12.91}
+  - gte: {hits.hits.1._score: 12.24}
+  - lte: {hits.hits.1._score: 12.36}
 
-  # result here should be 0, but we allow it be up to 0.5 because vectors are indexed as bfloat16
+  # result here should be 0, but we allow it be up to 0.4 because vectors are indexed as bfloat16
   - match: {hits.hits.2._id: "3"}
   - gte: {hits.hits.2._score: 0.00}
-  - lte: {hits.hits.2._score: 0.5}
+  - lte: {hits.hits.2._score: 0.4}
 
 ---
 "L2 norm":
@@ -94,15 +94,15 @@ setup:
 
   # result should be 301.36, but we allow 1% error because vectors are indexed as bfloat16
   - match: {hits.hits.0._id: "1"}
-  - gte: {hits.hits.0._score: 286.29}
-  - lte: {hits.hits.0._score: 316.43}
+  - gte: {hits.hits.0._score: 299.85}
+  - lte: {hits.hits.0._score: 302.87}
 
   # result should be 11.34, but we allow 1% error because vectors are indexed as bfloat16
   - match: {hits.hits.1._id: "2"}
-  - gte: {hits.hits.1._score: 10.77}
-  - lte: {hits.hits.1._score: 11.90}
+  - gte: {hits.hits.1._score: 11.28}
+  - lte: {hits.hits.1._score: 11.40}
 
-  # result here should be 0, but we allow it be up to 0.5 because vectors are indexed as bfloat16
+  # result here should be 0, but we allow it be up to 0.4 because vectors are indexed as bfloat16
   - match: {hits.hits.2._id: "3"}
   - gte: {hits.hits.2._score: 0.00}
-  - lte: {hits.hits.2._score: 0.5}
+  - lte: {hits.hits.2._score: 0.4}

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/VectorEncoderDecoder.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/VectorEncoderDecoder.java
@@ -158,7 +158,7 @@ public final class VectorEncoderDecoder {
 
     public static int denseVectorLength(Version indexVersion, BytesRef vectorBR) {
         return indexVersion.onOrAfter(Version.V_7_5_0)
-            ? (vectorBR.length - INT_BYTES) / INT_BYTES
+            ? (vectorBR.length - INT_BYTES) / SHORT_BYTES
             : vectorBR.length / INT_BYTES;
     }
 

--- a/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/query/ScoreScriptUtilsTests.java
+++ b/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/query/ScoreScriptUtilsTests.java
@@ -50,23 +50,31 @@ public class ScoreScriptUtilsTests extends ESTestCase {
 
         // test dotProduct
         DotProduct dotProduct = new DotProduct(scoreScript, queryVector);
+        double expected = 65425.624;
+        float delta = indexVersion.onOrAfter(Version.V_7_5_0) ? (float) expected/100 : 0.001f; // allow 1% error rate
         double result = dotProduct.dotProduct(dvs);
-        assertEquals("dotProduct result is not equal to the expected value!", 65425.624, result, 0.001);
+        assertEquals("dotProduct result is not equal to the expected value!", expected, result, delta);
 
         // test cosineSimilarity
         CosineSimilarity cosineSimilarity = new CosineSimilarity(scoreScript, queryVector);
+        double expected2 = 0.790;
+        float delta2 = indexVersion.onOrAfter(Version.V_7_5_0) ? (float) expected2/100 : 0.001f;
         double result2 = cosineSimilarity.cosineSimilarity(dvs);
-        assertEquals("cosineSimilarity result is not equal to the expected value!", 0.790, result2, 0.001);
+        assertEquals("cosineSimilarity result is not equal to the expected value!", expected2, result2, delta2);
 
         // test l1Norm
         L1Norm l1norm = new L1Norm(scoreScript, queryVector);
+        double expected3 = 485.184;
+        float delta3 = indexVersion.onOrAfter(Version.V_7_5_0) ? (float) expected3/100 : 0.001f;
         double result3 = l1norm.l1norm(dvs);
-        assertEquals("l1norm result is not equal to the expected value!", 485.184, result3, 0.001);
+        assertEquals("l1norm result is not equal to the expected value!", expected3, result3, delta3);
 
         // test l2norm
         L2Norm l2norm = new L2Norm(scoreScript, queryVector);
+        double expected4 = 301.36;
+        float delta4 = indexVersion.onOrAfter(Version.V_7_5_0) ? (float) expected4/100 : 0.001f;
         double result4 = l2norm.l2norm(dvs);
-        assertEquals("l2norm result is not equal to the expected value!", 301.361, result4, 0.001);
+        assertEquals("l2norm result is not equal to the expected value!", 301.361, result4, delta4);
 
         // test dotProduct fails when queryVector has wrong number of dims
         List<Number> invalidQueryVector = Arrays.asList(0.5, 111.3);

--- a/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/query/ScoreScriptUtilsTests.java
+++ b/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/query/ScoreScriptUtilsTests.java
@@ -71,10 +71,10 @@ public class ScoreScriptUtilsTests extends ESTestCase {
 
         // test l2norm
         L2Norm l2norm = new L2Norm(scoreScript, queryVector);
-        double expected4 = 301.36;
+        double expected4 = 301.361;
         float delta4 = indexVersion.onOrAfter(Version.V_7_5_0) ? (float) expected4/100 : 0.001f;
         double result4 = l2norm.l2norm(dvs);
-        assertEquals("l2norm result is not equal to the expected value!", 301.361, result4, delta4);
+        assertEquals("l2norm result is not equal to the expected value!", expected4, result4, delta4);
 
         // test dotProduct fails when queryVector has wrong number of dims
         List<Number> invalidQueryVector = Arrays.asList(0.5, 111.3);


### PR DESCRIPTION
Currently dense_vector values are stored as usual floats of 32 bits.
This patch make vector values to be stored as bfloat16,
which should twice reduce index size for dense_vector field
at the expense of loss of some precision (less that 1% relative
error).

Closes #46980