### PR TITLE
Add workaround for building docker on debian 8

### DIFF
--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -39,8 +39,8 @@ FROM centos:7
 
 ENV ELASTIC_CONTAINER true
 
-RUN for iter in {1..10}; do yum update -y && \
-    yum install -y nc && \
+RUN for iter in {1..10}; do yum update  --setopt=tsflags=nodocs -y && \
+    yum install -y  --setopt=tsflags=nodocs nc && \
     yum clean all && exit_code=0 && break || exit_code=\$? && echo "yum error: retry \$iter in 10s" && sleep 10; done; \
     (exit \$exit_code)
 


### PR DESCRIPTION
Looks like there's a workaround with aufs used in debian 8.
Adding `tsflags=nodocs` works around this issue and results in smaller
image files also.

Closes #47097 and elastic/infra#14780
