### PR TITLE
[7.4] [DOCS] Remove support for `// CONSOLE` magic comment (#46936)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
@@ -206,8 +206,11 @@ public class RestTestsFromSnippetsTask extends SnippetsTask {
                 response(snippet)
                 return
             }
-            if (snippet.test || snippet.console ||
-                    snippet.language == 'console') {
+            if ((snippet.language == 'js') && (snippet.console)) {
+                throw new InvalidUserDataException(
+                        "$snippet: Use `[source,console]` instead of `// CONSOLE`.")
+            }
+            if (snippet.test || snippet.language == 'console') {
                 test(snippet)
                 previousTest = snippet
                 return


### PR DESCRIPTION
7.4 backport of #46936