### PR TITLE
Remove unused private methods and fields

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/DetailAnalyzeResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/DetailAnalyzeResponse.java
@@ -113,8 +113,6 @@ public class DetailAnalyzeResponse {
         private final String name;
         private final AnalyzeResponse.AnalyzeToken[] tokens;
 
-        private static final String TOKENS = "tokens";
-
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/BulkRequestWithGlobalParametersIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/BulkRequestWithGlobalParametersIT.java
@@ -24,7 +24,6 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.rest.action.document.RestBulkAction;
 import org.elasticsearch.search.SearchHit;
 
 import java.io.IOException;
@@ -180,13 +179,6 @@ public class BulkRequestWithGlobalParametersIT extends ESRestHighLevelClientTest
 
         Iterable<SearchHit> hits = searchAll("global_index");
         assertThat(hits, everyItem(hasIndex("global_index")));
-    }
-
-    private BulkResponse bulkWithTypes(BulkRequest request) throws IOException {
-        BulkResponse bulkResponse = execute(request, highLevelClient()::bulk, highLevelClient()::bulkAsync,
-                expectWarnings(RestBulkAction.TYPES_DEPRECATION_MESSAGE));
-        assertFalse(bulkResponse.hasFailures());
-        return bulkResponse;
     }
 
     private BulkResponse bulk(BulkRequest request) throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MigrationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MigrationIT.java
@@ -21,12 +21,10 @@ package org.elasticsearch.client;
 
 import org.elasticsearch.client.migration.DeprecationInfoRequest;
 import org.elasticsearch.client.migration.DeprecationInfoResponse;
-import org.elasticsearch.client.tasks.TaskSubmissionResponse;
 import org.elasticsearch.common.settings.Settings;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.function.BooleanSupplier;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -41,21 +39,5 @@ public class MigrationIT extends ESRestHighLevelClientTestCase {
         assertThat(response.getIndexSettingsIssues().size(), equalTo(0));
         assertThat(response.getNodeSettingsIssues().size(), equalTo(0));
         assertThat(response.getMlSettingsIssues().size(), equalTo(0));
-    }
-
-    /**
-     * Using low-level api as high-level-rest-client's getTaskById work is in progress.
-     * TODO revisit once that work is finished
-     */
-    private BooleanSupplier checkCompletionStatus(TaskSubmissionResponse upgrade) {
-        return () -> {
-            try {
-                Response response = client().performRequest(new Request("GET", "/_tasks/" + upgrade.getTask()));
-                return (boolean) entityAsMap(response).get("completed");
-            } catch (IOException e) {
-                fail(e.getMessage());
-                return false;
-            }
-        };
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
@@ -71,7 +71,6 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.VersionType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.TermQueryBuilder;
@@ -158,7 +157,6 @@ public class RequestConvertersTests extends ESTestCase {
     }
 
     public void testSourceExistsWithType() throws IOException {
-        String type = frequently() ? randomAlphaOfLengthBetween(3, 10) : MapperService.SINGLE_MAPPING_NAME;
         doTestSourceExists((index, id) -> new GetRequest(index, id));
     }
 
@@ -358,17 +356,6 @@ public class RequestConvertersTests extends ESTestCase {
         Request request = requestConverter.apply(getRequest);
         assertEquals("/" + index + "/_doc/" + id, request.getEndpoint());
         assertEquals(expectedParams, request.getParameters());
-        assertNull(request.getEntity());
-        assertEquals(method, request.getMethod());
-    }
-
-    private static void getAndExistsWithTypeTest(Function<GetRequest, Request> requestConverter, String method) {
-        String index = randomAlphaOfLengthBetween(3, 10);
-        String id = randomAlphaOfLengthBetween(3, 10);
-        GetRequest getRequest = new GetRequest(index, id);
-
-        Request request = requestConverter.apply(getRequest);
-        assertEquals("/" + index + "/" + id, request.getEndpoint());
         assertNull(request.getEntity());
         assertEquals(method, request.getMethod());
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/DeleteModelSnapshotRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/DeleteModelSnapshotRequestTests.java
@@ -33,8 +33,4 @@ public class DeleteModelSnapshotRequestTests extends ESTestCase {
             -> new DeleteModelSnapshotRequest(randomAlphaOfLength(10), null));
         assertEquals("[snapshot_id] must not be null", ex.getMessage());
     }
-
-    private DeleteModelSnapshotRequest createTestInstance() {
-        return new DeleteModelSnapshotRequest(randomAlphaOfLength(10), randomAlphaOfLength(10));
-    }
 }

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CJKBigramFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CJKBigramFilterFactory.java
@@ -19,11 +19,9 @@
 
 package org.elasticsearch.analysis.common;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.cjk.CJKBigramFilter;
 import org.apache.lucene.analysis.miscellaneous.DisableGraphAttribute;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexSettings;
@@ -50,9 +48,6 @@ import java.util.Set;
  * In all cases, all non-CJK input is passed thru unmodified.
  */
 public final class CJKBigramFilterFactory extends AbstractTokenFilterFactory {
-
-    private static final DeprecationLogger DEPRECATION_LOGGER
-        = new DeprecationLogger(LogManager.getLogger(CJKBigramFilterFactory.class));
 
     private final int flags;
     private final boolean outputUnigrams;

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonGramsTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonGramsTokenFilterFactory.java
@@ -19,12 +19,10 @@
 
 package org.elasticsearch.analysis.common;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.commongrams.CommonGramsFilter;
 import org.apache.lucene.analysis.commongrams.CommonGramsQueryFilter;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexSettings;
@@ -33,9 +31,6 @@ import org.elasticsearch.index.analysis.Analysis;
 import org.elasticsearch.index.analysis.TokenFilterFactory;
 
 public class CommonGramsTokenFilterFactory extends AbstractTokenFilterFactory {
-
-    private static final DeprecationLogger DEPRECATION_LOGGER
-        = new DeprecationLogger(LogManager.getLogger(CommonGramsTokenFilterFactory.class));
 
     private final CharArraySet words;
 

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/EdgeNGramTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/EdgeNGramTokenFilterFactory.java
@@ -19,11 +19,9 @@
 
 package org.elasticsearch.analysis.common;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.ngram.EdgeNGramTokenFilter;
 import org.apache.lucene.analysis.reverse.ReverseStringFilter;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexSettings;
@@ -32,9 +30,6 @@ import org.elasticsearch.index.analysis.TokenFilterFactory;
 
 
 public class EdgeNGramTokenFilterFactory extends AbstractTokenFilterFactory {
-
-    private static final DeprecationLogger DEPRECATION_LOGGER
-        = new DeprecationLogger(LogManager.getLogger(EdgeNGramTokenFilterFactory.class));
 
     private final int minGram;
 

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/FingerprintTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/FingerprintTokenFilterFactory.java
@@ -19,10 +19,8 @@
 
 package org.elasticsearch.analysis.common;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.miscellaneous.FingerprintFilter;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexSettings;
@@ -33,9 +31,6 @@ import static org.elasticsearch.analysis.common.FingerprintAnalyzerProvider.DEFA
 import static org.elasticsearch.analysis.common.FingerprintAnalyzerProvider.MAX_OUTPUT_SIZE;
 
 public class FingerprintTokenFilterFactory extends AbstractTokenFilterFactory {
-
-    private static final DeprecationLogger DEPRECATION_LOGGER
-        = new DeprecationLogger(LogManager.getLogger(FingerprintTokenFilterFactory.class));
 
     private final char separator;
     private final int maxOutputSize;

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/MultiplexerTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/MultiplexerTokenFilterFactory.java
@@ -19,14 +19,12 @@
 
 package org.elasticsearch.analysis.common;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.miscellaneous.ConditionalTokenFilter;
 import org.apache.lucene.analysis.miscellaneous.RemoveDuplicatesTokenFilter;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexSettings;
@@ -41,9 +39,6 @@ import java.util.List;
 import java.util.function.Function;
 
 public class MultiplexerTokenFilterFactory extends AbstractTokenFilterFactory {
-
-    private static final DeprecationLogger DEPRECATION_LOGGER
-        = new DeprecationLogger(LogManager.getLogger(MultiplexerTokenFilterFactory.class));
 
     private List<String> filterNames;
     private final boolean preserveOriginal;

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/NGramTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/NGramTokenFilterFactory.java
@@ -19,10 +19,8 @@
 
 package org.elasticsearch.analysis.common;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.ngram.NGramTokenFilter;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexSettings;
@@ -31,9 +29,6 @@ import org.elasticsearch.index.analysis.TokenFilterFactory;
 
 
 public class NGramTokenFilterFactory extends AbstractTokenFilterFactory {
-
-    private static final DeprecationLogger DEPRECATION_LOGGER
-        = new DeprecationLogger(LogManager.getLogger(NGramTokenFilterFactory.class));
 
     private final int minGram;
 

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/WordDelimiterGraphTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/WordDelimiterGraphTokenFilterFactory.java
@@ -19,12 +19,10 @@
 
 package org.elasticsearch.analysis.common;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.miscellaneous.WordDelimiterGraphFilter;
 import org.apache.lucene.analysis.miscellaneous.WordDelimiterIterator;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexSettings;
@@ -47,9 +45,6 @@ import static org.apache.lucene.analysis.miscellaneous.WordDelimiterGraphFilter.
 import static org.elasticsearch.analysis.common.WordDelimiterTokenFilterFactory.parseTypes;
 
 public class WordDelimiterGraphTokenFilterFactory extends AbstractTokenFilterFactory {
-
-    private static final DeprecationLogger DEPRECATION_LOGGER =
-        new DeprecationLogger(LogManager.getLogger(WordDelimiterGraphTokenFilterFactory.class));
 
     private final byte[] charTypeTable;
     private final int flags;

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/WordDelimiterTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/WordDelimiterTokenFilterFactory.java
@@ -19,12 +19,10 @@
 
 package org.elasticsearch.analysis.common;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.miscellaneous.WordDelimiterFilter;
 import org.apache.lucene.analysis.miscellaneous.WordDelimiterIterator;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexSettings;
@@ -52,9 +50,6 @@ import static org.apache.lucene.analysis.miscellaneous.WordDelimiterFilter.SPLIT
 import static org.apache.lucene.analysis.miscellaneous.WordDelimiterFilter.STEM_ENGLISH_POSSESSIVE;
 
 public class WordDelimiterTokenFilterFactory extends AbstractTokenFilterFactory {
-
-    private static final DeprecationLogger DEPRECATION_LOGGER =
-        new DeprecationLogger(LogManager.getLogger(WordDelimiterTokenFilterFactory.class));
 
     private final byte[] charTypeTable;
     private final int flags;

--- a/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
+++ b/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
@@ -25,7 +25,6 @@ import org.elasticsearch.ingest.AbstractProcessor;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.ingest.useragent.UserAgentParser.Details;
-import org.elasticsearch.ingest.useragent.UserAgentParser.VersionedName;
 
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -147,37 +146,6 @@ public class UserAgentProcessor extends AbstractProcessor {
 
         ingestDocument.setFieldValue(targetField, uaDetails);
         return ingestDocument;
-    }
-
-    /** To maintain compatibility with logstash-filter-useragent */
-    private String buildFullOSName(VersionedName operatingSystem) {
-        if (operatingSystem == null || operatingSystem.name == null) {
-            return null;
-        }
-
-        StringBuilder sb = new StringBuilder(operatingSystem.name);
-
-        if (operatingSystem.major != null) {
-            sb.append(" ");
-            sb.append(operatingSystem.major);
-
-            if (operatingSystem.minor != null) {
-                sb.append(".");
-                sb.append(operatingSystem.minor);
-
-                if (operatingSystem.patch != null) {
-                    sb.append(".");
-                    sb.append(operatingSystem.patch);
-
-                    if (operatingSystem.build != null) {
-                        sb.append(".");
-                        sb.append(operatingSystem.build);
-                    }
-                }
-            }
-        }
-
-        return sb.toString();
     }
 
     @Override

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
@@ -455,7 +455,6 @@ public class PercolatorFieldMapper extends FieldMapper {
             }
         }
 
-        Version indexVersionCreated = context.mapperService().getIndexSettings().getIndexVersionCreated();
         if (result.matchAllDocs) {
             doc.add(new Field(extractionResultField.name(), EXTRACTION_FAILED, extractionResultField.fieldType()));
             if (result.verified) {

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryAnalyzerTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryAnalyzerTests.java
@@ -66,7 +66,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -1112,19 +1111,6 @@ public class QueryAnalyzerTests extends ESTestCase {
 
     private static void assertTermsEqual(Set<QueryExtraction> actual, Term... expected) {
         assertEquals(Arrays.stream(expected).map(QueryExtraction::new).collect(Collectors.toSet()), actual);
-    }
-
-    private static Set<QueryExtraction> terms(int[] intervals, String... values) {
-        Set<QueryExtraction> queryExtractions = new HashSet<>();
-        for (int interval : intervals) {
-            byte[] encodedInterval = new byte[4];
-            IntPoint.encodeDimension(interval, encodedInterval, 0);
-            queryExtractions.add(new QueryAnalyzer.QueryExtraction(new QueryAnalyzer.Range("_field", null, null, encodedInterval)));
-        }
-        for (String value : values) {
-            queryExtractions.add(new QueryExtraction(new Term("_field", value)));
-        }
-        return queryExtractions;
     }
 
 }

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuilders.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuilders.java
@@ -176,15 +176,6 @@ final class RemoteRequestBuilders {
         }
     }
 
-    private static void checkIndexOrType(String name, String indexOrType) {
-        if (indexOrType.indexOf(',') >= 0) {
-            throw new IllegalArgumentException(name + " containing [,] not supported but got [" + indexOrType + "]");
-        }
-        if (indexOrType.indexOf('/') >= 0) {
-            throw new IllegalArgumentException(name + " containing [/] not supported but got [" + indexOrType + "]");
-        }
-    }
-
     private static String sortToUri(SortBuilder<?> sort) {
         if (sort instanceof FieldSortBuilder) {
             FieldSortBuilder f = (FieldSortBuilder) sort;

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/analysis/IcuNormalizerTokenFilterFactory.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/analysis/IcuNormalizerTokenFilterFactory.java
@@ -22,9 +22,7 @@ package org.elasticsearch.index.analysis;
 import com.ibm.icu.text.FilteredNormalizer2;
 import com.ibm.icu.text.Normalizer2;
 import com.ibm.icu.text.UnicodeSet;
-import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.analysis.TokenStream;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexSettings;
@@ -36,9 +34,6 @@ import org.elasticsearch.index.IndexSettings;
  * <p>The {@code unicodeSetFilter} attribute can be used to provide the UniCodeSet for filtering.</p>
  */
 public class IcuNormalizerTokenFilterFactory extends AbstractTokenFilterFactory implements NormalizingTokenFilterFactory {
-
-    private static final DeprecationLogger deprecationLogger =
-        new DeprecationLogger(LogManager.getLogger(IcuNormalizerTokenFilterFactory.class));
 
     private final Normalizer2 normalizer;
 

--- a/plugins/analysis-phonetic/src/main/java/org/elasticsearch/index/analysis/PhoneticTokenFilterFactory.java
+++ b/plugins/analysis-phonetic/src/main/java/org/elasticsearch/index/analysis/PhoneticTokenFilterFactory.java
@@ -30,13 +30,11 @@ import org.apache.commons.codec.language.bm.Languages.LanguageSet;
 import org.apache.commons.codec.language.bm.NameType;
 import org.apache.commons.codec.language.bm.PhoneticEngine;
 import org.apache.commons.codec.language.bm.RuleType;
-import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.phonetic.BeiderMorseFilter;
 import org.apache.lucene.analysis.phonetic.DaitchMokotoffSoundexFilter;
 import org.apache.lucene.analysis.phonetic.DoubleMetaphoneFilter;
 import org.apache.lucene.analysis.phonetic.PhoneticFilter;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexSettings;
@@ -48,10 +46,6 @@ import java.util.HashSet;
 import java.util.List;
 
 public class PhoneticTokenFilterFactory extends AbstractTokenFilterFactory {
-
-
-    private static final DeprecationLogger DEPRECATION_LOGGER
-        = new DeprecationLogger(LogManager.getLogger(PhoneticTokenFilterFactory.class));
 
     private final Encoder encoder;
     private final boolean replace;

--- a/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -155,47 +155,6 @@ public class IndicesOptions implements ToXContentFragment {
     }
 
     /**
-     * See: {@link #fromByte(byte)}
-     */
-    private static byte toByte(IndicesOptions options) {
-        byte id = 0;
-        if (options.ignoreUnavailable()) {
-            id |= 1;
-        }
-        if (options.allowNoIndices()) {
-            id |= 2;
-        }
-        if (options.expandWildcardsOpen()) {
-            id |= 4;
-        }
-        if (options.expandWildcardsClosed()) {
-            id |= 8;
-        }
-        // true is default here, for bw comp we keep the first 16 values
-        // in the array same as before + the default value for the new flag
-        if (options.allowAliasesToMultipleIndices() == false) {
-            id |= 16;
-        }
-        if (options.forbidClosedIndices()) {
-            id |= 32;
-        }
-        if (options.ignoreAliases()) {
-            id |= 64;
-        }
-        return id;
-    }
-
-    private static final IndicesOptions[] OLD_VALUES;
-
-    static {
-        short max = 1 << 7;
-        OLD_VALUES = new IndicesOptions[max];
-        for (short id = 0; id < max; id++) {
-            OLD_VALUES[id] = IndicesOptions.fromByte((byte)id);
-        }
-    }
-
-    /**
      * @return Whether specified concrete indices should be ignored when unavailable (missing or closed)
      */
     public boolean ignoreUnavailable() {

--- a/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredTokenFilter.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredTokenFilter.java
@@ -19,11 +19,9 @@
 
 package org.elasticsearch.index.analysis;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.indices.analysis.PreBuiltCacheFactory;
 import org.elasticsearch.indices.analysis.PreBuiltCacheFactory.CachingStrategy;
 
@@ -34,9 +32,6 @@ import java.util.function.Function;
  * Provides pre-configured, shared {@link TokenFilter}s.
  */
 public final class PreConfiguredTokenFilter extends PreConfiguredAnalysisComponent<TokenFilterFactory> {
-
-    private static final DeprecationLogger DEPRECATION_LOGGER
-        = new DeprecationLogger(LogManager.getLogger(PreConfiguredTokenFilter.class));
 
     /**
      * Create a pre-configured token filter that may not vary at all.

--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicTemplate.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicTemplate.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.apache.logging.log4j.LogManager;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -34,8 +32,6 @@ import java.util.Map;
 import java.util.TreeMap;
 
 public class DynamicTemplate implements ToXContentObject {
-
-    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(DynamicTemplate.class));
 
     public enum MatchType {
         SIMPLE {

--- a/server/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.Version;
@@ -28,7 +27,6 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -50,12 +48,8 @@ import static org.elasticsearch.common.xcontent.ObjectParser.fromList;
  * A query that will return only documents matching specific ids (and a type).
  */
 public class IdsQueryBuilder extends AbstractQueryBuilder<IdsQueryBuilder> {
-    public static final String NAME = "ids";
-    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
-        LogManager.getLogger(IdsQueryBuilder.class));
-    static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Types are deprecated in [ids] queries.";
 
-    private static final ParseField TYPE_FIELD = new ParseField("type");
+    public static final String NAME = "ids";
     private static final ParseField VALUES_FIELD = new ParseField("values");
 
     private final Set<String> ids = new HashSet<>();

--- a/server/src/main/java/org/elasticsearch/search/slice/SliceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/slice/SliceBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.slice;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
@@ -33,7 +32,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -65,11 +63,9 @@ import java.util.Set;
  */
 public class SliceBuilder implements Writeable, ToXContentObject {
 
-    private static final DeprecationLogger DEPRECATION_LOG = new DeprecationLogger(LogManager.getLogger(SliceBuilder.class));
-
-    public static final ParseField FIELD_FIELD = new ParseField("field");
+    private static final ParseField FIELD_FIELD = new ParseField("field");
     public static final ParseField ID_FIELD = new ParseField("id");
-    public static final ParseField MAX_FIELD = new ParseField("max");
+    private static final ParseField MAX_FIELD = new ParseField("max");
     private static final ObjectParser<SliceBuilder, Void> PARSER =
         new ObjectParser<>("slice", SliceBuilder::new);
 

--- a/server/src/main/java/org/elasticsearch/threadpool/Scheduler.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/Scheduler.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.threadpool;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.settings.Settings;
@@ -263,7 +261,6 @@ public interface Scheduler {
      * tasks to the uncaught exception handler
      */
     class SafeScheduledThreadPoolExecutor extends ScheduledThreadPoolExecutor {
-        private static final Logger logger = LogManager.getLogger(SafeScheduledThreadPoolExecutor.class);
 
         @SuppressForbidden(reason = "properly rethrowing errors, see EsExecutors.rethrowErrors")
         public SafeScheduledThreadPoolExecutor(int corePoolSize, ThreadFactory threadFactory, RejectedExecutionHandler handler) {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexCreationTaskTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexCreationTaskTests.java
@@ -360,10 +360,6 @@ public class IndexCreationTaskTests extends ESTestCase {
             .numberOfReplicas(numReplicas);
     }
 
-    private Map<String, String> createCustom() {
-        return Collections.singletonMap("a", "b");
-    }
-
     private interface MetaDataBuilderConfigurator {
         void configure(IndexTemplateMetaData.Builder builder) throws IOException;
     }

--- a/server/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
@@ -22,7 +22,6 @@ package org.elasticsearch.common.xcontent;
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParseException;
-
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -1206,11 +1205,6 @@ public abstract class BaseXContentTestCase extends ESTestCase {
     private static void expectNonNullFieldException(ThrowingRunnable runnable) {
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, runnable);
         assertThat(e.getMessage(), containsString("Field name cannot be null"));
-    }
-
-    private static void expectNonNullFormatterException(ThrowingRunnable runnable) {
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, runnable);
-        assertThat(e.getMessage(), containsString("DateTimeFormatter cannot be null"));
     }
 
     private static void expectObjectException(ThrowingRunnable runnable) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorTests.java
@@ -56,7 +56,6 @@ import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
-import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
@@ -521,16 +520,6 @@ public class RareTermsAggregatorTests extends AggregatorTestCase {
         documents.add(document);
 
         return documents;
-    }
-
-
-    private InternalAggregation buildInternalAggregation(RareTermsAggregationBuilder builder, MappedFieldType fieldType,
-                                                         IndexSearcher searcher) throws IOException {
-        AbstractRareTermsAggregator aggregator = createAggregator(builder, searcher, fieldType);
-        aggregator.preCollection();
-        searcher.search(new MatchAllDocsQuery(), aggregator);
-        aggregator.postCollection();
-        return aggregator.buildAggregation(0L);
     }
 
     private void testSearchCase(Query query, List<Long> dataset,

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.index.shard;
 
 import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.IndexNotFoundException;
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.flush.FlushRequest;
@@ -693,20 +692,6 @@ public abstract class IndexShardTestCase extends ESTestCase {
                 listener.onResponse(new PrimaryReplicaSyncer.ResyncTask(1, "type", "action", "desc", null, Collections.emptyMap())),
             currentClusterStateVersion.incrementAndGet(),
             inSyncIds, newRoutingTable);
-    }
-
-    private Store.MetadataSnapshot getMetadataSnapshotOrEmpty(IndexShard replica) throws IOException {
-        Store.MetadataSnapshot result;
-        try {
-            result = replica.snapshotStoreMetadata();
-        } catch (IndexNotFoundException e) {
-            // OK!
-            result = Store.MetadataSnapshot.EMPTY;
-        } catch (IOException e) {
-            logger.warn("failed read store, treating as empty", e);
-            result = Store.MetadataSnapshot.EMPTY;
-        }
-        return result;
     }
 
     public static Set<String> getShardDocUIDs(final IndexShard shard) throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/indices/analysis/AnalysisFactoryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/indices/analysis/AnalysisFactoryTestCase.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -51,18 +50,7 @@ public abstract class AnalysisFactoryTestCase extends ESTestCase {
 
     private static final Pattern UNDERSCORE_THEN_ANYTHING = Pattern.compile("_(.)");
 
-    private static String toCamelCase(String s) {
-        Matcher m = UNDERSCORE_THEN_ANYTHING.matcher(s);
-        StringBuffer sb = new StringBuffer();
-        while (m.find()) {
-            m.appendReplacement(sb, m.group(1).toUpperCase(Locale.ROOT));
-        }
-        m.appendTail(sb);
-        sb.setCharAt(0, Character.toUpperCase(sb.charAt(0)));
-        return sb.toString();
-    }
-
-    static final Map<String,Class<?>> KNOWN_TOKENIZERS = Map.ofEntries(
+    private static final Map<String,Class<?>> KNOWN_TOKENIZERS = Map.ofEntries(
         // exposed in ES
         entry("classic", MovedToAnalysisCommon.class),
         entry("edgengram", MovedToAnalysisCommon.class),

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/cumulativecardinality/CumulativeCardinalityAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/cumulativecardinality/CumulativeCardinalityAggregatorTests.java
@@ -226,32 +226,4 @@ public class CumulativeCardinalityAggregatorTests extends AggregatorTestCase {
     private static long asLong(String dateTime) {
         return DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(dateTime)).toInstant().toEpochMilli();
     }
-
-
-    private static AggregatorFactory getRandomSequentiallyOrderedParentAgg() throws IOException {
-        AggregatorFactory factory;
-        ValuesSourceConfig<ValuesSource> valuesSource = new ValuesSourceConfig<>(ValuesSourceType.NUMERIC);
-        ValuesSourceConfig<ValuesSource.Numeric> numericVS = new ValuesSourceConfig<>(ValuesSourceType.NUMERIC);
-        switch (randomIntBetween(0, 2)) {
-            case 0:
-                factory = new HistogramAggregatorFactory("name", valuesSource, 0.0d, 0.0d,
-                    mock(InternalOrder.class), false, 0L, 0.0d, 1.0d, mock(QueryShardContext.class), null,
-                    new AggregatorFactories.Builder(), Collections.emptyMap());
-                break;
-            case 1:
-                factory = new DateHistogramAggregatorFactory("name", valuesSource, 0L,
-                    mock(InternalOrder.class), false, 0L, mock(Rounding.class), mock(Rounding.class),
-                    mock(ExtendedBounds.class), mock(QueryShardContext.class), mock(AggregatorFactory.class),
-                    new AggregatorFactories.Builder(), Collections.emptyMap());
-                break;
-            case 2:
-            default:
-                AutoDateHistogramAggregationBuilder.RoundingInfo[] roundings = new AutoDateHistogramAggregationBuilder.RoundingInfo[1];
-                factory = new AutoDateHistogramAggregatorFactory("name", numericVS,
-                    1, roundings,
-                    mock(QueryShardContext.class), null, new AggregatorFactories.Builder(), Collections.emptyMap());
-        }
-
-        return factory;
-    }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
@@ -165,10 +165,6 @@ public class TransportOpenJobAction extends TransportMasterNodeAction<OpenJobAct
         return node.getVersion().onOrAfter(job.getModelSnapshotMinVersion());
     }
 
-    private static boolean jobHasRules(Job job) {
-        return job.getAnalysisConfig().getDetectors().stream().anyMatch(d -> d.getRules().isEmpty() == false);
-    }
-
     public static String nodeFilter(DiscoveryNode node, Job job) {
 
         String jobId = job.getId();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobConfigProvider.java
@@ -543,21 +543,6 @@ public class JobConfigProvider {
 
     }
 
-    private SearchRequest makeExpandIdsSearchRequest(String expression, boolean excludeDeleting) {
-        String [] tokens = ExpandedIdsMatcher.tokenizeExpression(expression);
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(buildQuery(tokens, excludeDeleting));
-        sourceBuilder.sort(Job.ID.getPreferredName());
-        sourceBuilder.fetchSource(false);
-        sourceBuilder.docValueField(Job.ID.getPreferredName(), null);
-        sourceBuilder.docValueField(Job.GROUPS.getPreferredName(), null);
-
-        return client.prepareSearch(AnomalyDetectorsIndex.configIndexName())
-                .setIndicesOptions(IndicesOptions.lenientExpandOpen())
-                .setSource(sourceBuilder)
-                .setSize(AnomalyDetectorsIndex.CONFIG_INDEX_MAX_RESULTS_WINDOW)
-                .request();
-    }
-
     /**
      * The same logic as {@link #expandJobsIds(String, boolean, boolean, ActionListener)} but
      * the full anomaly detector job configuration is returned.

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
@@ -1032,10 +1032,6 @@ public class JobResultsProviderTests extends ESTestCase {
         verifyNoMoreInteractions(client);
     }
 
-    private Bucket createBucketAtEpochTime(long epoch) {
-        return new Bucket("foo", new Date(epoch), 123);
-    }
-
     private JobResultsProvider createProvider(Client client) {
         return new JobResultsProvider(client, Settings.EMPTY);
     }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/integration/MonitoringIT.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/integration/MonitoringIT.java
@@ -5,9 +5,7 @@
  */
 package org.elasticsearch.xpack.monitoring.integration;
 
-import org.apache.lucene.util.Constants;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
@@ -24,7 +22,6 @@ import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.license.License;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
@@ -43,12 +40,6 @@ import org.elasticsearch.xpack.core.monitoring.action.MonitoringBulkResponse;
 import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringTemplateUtils;
 import org.elasticsearch.xpack.monitoring.LocalStateMonitoring;
 import org.elasticsearch.xpack.monitoring.MonitoringService;
-import org.elasticsearch.xpack.monitoring.collector.cluster.ClusterStatsMonitoringDoc;
-import org.elasticsearch.xpack.monitoring.collector.indices.IndexRecoveryMonitoringDoc;
-import org.elasticsearch.xpack.monitoring.collector.indices.IndexStatsMonitoringDoc;
-import org.elasticsearch.xpack.monitoring.collector.indices.IndicesStatsMonitoringDoc;
-import org.elasticsearch.xpack.monitoring.collector.node.NodeStatsMonitoringDoc;
-import org.elasticsearch.xpack.monitoring.collector.shards.ShardMonitoringDoc;
 import org.elasticsearch.xpack.monitoring.test.MockIngestPlugin;
 
 import java.io.IOException;
@@ -74,13 +65,11 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.threadpool.ThreadPool.Names.WRITE;
 import static org.elasticsearch.xpack.core.monitoring.exporter.MonitoringTemplateUtils.TEMPLATE_VERSION;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.hamcrest.Matchers.isOneOf;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -286,204 +275,6 @@ public class MonitoringIT extends ESSingleNodeTestCase {
         assertThat(sourceNode.get("ip"), equalTo(node.getAddress().getAddress()));
         assertThat(sourceNode.get("name"), equalTo(node.getName()));
         assertThat((String) sourceNode.get("timestamp"), not(isEmptyOrNullString()));
-    }
-
-    /**
-     * Assert that a {@link ClusterStatsMonitoringDoc} contains the expected information
-     */
-    @SuppressWarnings("unchecked")
-    private void assertClusterStatsMonitoringDoc(final Map<String, Object> document,
-                                                 final boolean apmIndicesExist) {
-        final Map<String, Object> source = (Map<String, Object>) document.get("_source");
-        assertEquals(12, source.size());
-
-        assertThat((String) source.get("cluster_name"), not(isEmptyOrNullString()));
-        assertThat(source.get("version"), equalTo(Version.CURRENT.toString()));
-
-        final Map<String, Object> license = (Map<String, Object>) source.get("license");
-        assertThat(license, notNullValue());
-        assertThat((String) license.get(License.Fields.ISSUER), not(isEmptyOrNullString()));
-        assertThat((String) license.get(License.Fields.ISSUED_TO), not(isEmptyOrNullString()));
-        assertThat((Long) license.get(License.Fields.ISSUE_DATE_IN_MILLIS), greaterThan(0L));
-        assertThat((Integer) license.get(License.Fields.MAX_NODES), greaterThan(0));
-
-        String uid = (String) license.get("uid");
-        assertThat(uid, not(isEmptyOrNullString()));
-
-        String type = (String) license.get("type");
-        assertThat(type, not(isEmptyOrNullString()));
-
-        String status = (String) license.get(License.Fields.STATUS);
-        assertThat(status, not(isEmptyOrNullString()));
-
-        if ("basic".equals(license.get("type")) == false) {
-            Long expiryDate = (Long) license.get(License.Fields.EXPIRY_DATE_IN_MILLIS);
-            assertThat(expiryDate, greaterThan(0L));
-        }
-
-        Boolean clusterNeedsTLS = (Boolean) license.get("cluster_needs_tls");
-        assertThat(clusterNeedsTLS, isOneOf(true, null));
-
-        final Map<String, Object> clusterStats = (Map<String, Object>) source.get("cluster_stats");
-        assertThat(clusterStats, notNullValue());
-        assertThat(clusterStats.size(), equalTo(5));
-
-        final Map<String, Object> stackStats = (Map<String, Object>) source.get("stack_stats");
-        assertThat(stackStats, notNullValue());
-        assertThat(stackStats.size(), equalTo(2));
-
-        final Map<String, Object> apm = (Map<String, Object>) stackStats.get("apm");
-        assertThat(apm, notNullValue());
-        assertThat(apm.size(), equalTo(1));
-        assertThat(apm.remove("found"), is(apmIndicesExist));
-        assertThat(apm.keySet(), empty());
-
-        final Map<String, Object> xpackStats = (Map<String, Object>) stackStats.get("xpack");
-        assertThat(xpackStats, notNullValue());
-        assertThat("X-Pack stats must have at least monitoring, but others may be hidden", xpackStats.size(), greaterThanOrEqualTo(1));
-
-        final Map<String, Object> monitoring = (Map<String, Object>) xpackStats.get("monitoring");
-        // we don't make any assumptions about what's in it, only that it's there
-        assertThat(monitoring, notNullValue());
-
-        final Map<String, Object> clusterState = (Map<String, Object>) source.get("cluster_state");
-        assertThat(clusterState, notNullValue());
-        assertThat(clusterState.remove("nodes_hash"), notNullValue());
-        assertThat(clusterState.remove("status"), notNullValue());
-        assertThat(clusterState.remove("version"), notNullValue());
-        assertThat(clusterState.remove("state_uuid"), notNullValue());
-        assertThat(clusterState.remove("cluster_uuid"), notNullValue());
-        assertThat(clusterState.remove("master_node"), notNullValue());
-        assertThat(clusterState.remove("nodes"), notNullValue());
-        assertThat(clusterState.keySet(), empty());
-
-        final Map<String, Object> clusterSettings = (Map<String, Object>) source.get("cluster_settings");
-        assertThat(clusterSettings, notNullValue());
-        assertThat(clusterSettings.remove("cluster"), notNullValue());
-        assertThat(clusterSettings.keySet(), empty());
-    }
-
-    /**
-     * Assert that a {@link IndexRecoveryMonitoringDoc} contains the expected information
-     */
-    @SuppressWarnings("unchecked")
-    private void assertIndexRecoveryMonitoringDoc(final Map<String, Object> document) {
-        final Map<String, Object> source = (Map<String, Object>) document.get("_source");
-        assertEquals(6, source.size());
-
-        final Map<String, Object> indexRecovery = (Map<String, Object>) source.get(IndexRecoveryMonitoringDoc.TYPE);
-        assertEquals(1, indexRecovery.size());
-
-        final List<Object> shards = (List<Object>) indexRecovery.get("shards");
-        assertThat(shards, notNullValue());
-    }
-
-    /**
-     * Assert that a {@link IndicesStatsMonitoringDoc} contains the expected information
-     */
-    @SuppressWarnings("unchecked")
-    private void assertIndicesStatsMonitoringDoc(final Map<String, Object> document) {
-        final Map<String, Object> source = (Map<String, Object>) document.get("_source");
-        assertEquals(6, source.size());
-
-        final Map<String, Object> indicesStats = (Map<String, Object>) source.get(IndicesStatsMonitoringDoc.TYPE);
-        assertEquals(1, indicesStats.size());
-
-        IndicesStatsMonitoringDoc.XCONTENT_FILTERS.forEach(filter ->
-                assertThat(filter + " must not be null in the monitoring document", extractValue(filter, source), notNullValue()));
-    }
-
-    /**
-     * Assert that a {@link IndexStatsMonitoringDoc} contains the expected information
-     */
-    @SuppressWarnings("unchecked")
-    private void assertIndexStatsMonitoringDoc(final Map<String, Object> document) {
-        final Map<String, Object> source = (Map<String, Object>) document.get("_source");
-        assertEquals(6, source.size());
-
-        // particular field values checked in the index stats tests
-        final Map<String, Object> indexStats = (Map<String, Object>) source.get(IndexStatsMonitoringDoc.TYPE);
-        assertEquals(7, indexStats.size());
-        assertThat((String) indexStats.get("index"), not(isEmptyOrNullString()));
-        assertThat((String) indexStats.get("uuid"), not(isEmptyOrNullString()));
-        assertThat(indexStats.get("created"), notNullValue());
-        assertThat((String) indexStats.get("status"), not(isEmptyOrNullString()));
-        assertThat(indexStats.get("shards"), notNullValue());
-        final Map<String, Object> shards = (Map<String, Object>) indexStats.get("shards");
-        assertEquals(11, shards.size());
-        assertThat(indexStats.get("primaries"), notNullValue());
-        assertThat(indexStats.get("total"), notNullValue());
-
-        IndexStatsMonitoringDoc.XCONTENT_FILTERS.forEach(filter ->
-                assertThat(filter + " must not be null in the monitoring document", extractValue(filter, source), notNullValue()));
-    }
-
-    /**
-     * Assert that a {@link NodeStatsMonitoringDoc} contains the expected information
-     */
-    @SuppressWarnings("unchecked")
-    private void assertNodeStatsMonitoringDoc(final Map<String, Object> document) {
-        final Map<String, Object> source = (Map<String, Object>) document.get("_source");
-        assertEquals(6, source.size());
-
-        NodeStatsMonitoringDoc.XCONTENT_FILTERS.forEach(filter -> {
-            if (Constants.WINDOWS && filter.startsWith("node_stats.os.cpu.load_average")) {
-                // load average is unavailable on Windows
-                return;
-            }
-
-            // fs and cgroup stats are only reported on Linux, but it's acceptable for _node/stats to report them as null if the OS is
-            //  misconfigured or not reporting them for some reason (e.g., older kernel)
-            if (filter.startsWith("node_stats.fs") || filter.startsWith("node_stats.os.cgroup")) {
-                return;
-            }
-
-            // load average is unavailable on macOS for 5m and 15m (but we get 1m), but it's also possible on Linux too
-            if ("node_stats.os.cpu.load_average.5m".equals(filter) || "node_stats.os.cpu.load_average.15m".equals(filter)) {
-                return;
-            }
-
-            // bulk is not a thread pool in the current version but we allow it to support mixed version clusters
-            if (filter.startsWith("node_stats.thread_pool.bulk")) {
-                return;
-            }
-
-            assertThat(filter + " must not be null in the monitoring document", extractValue(filter, source), notNullValue());
-        });
-    }
-
-    /**
-     * Assert that a {@link ShardMonitoringDoc} contains the expected information
-     */
-    @SuppressWarnings("unchecked")
-    private void assertShardMonitoringDoc(final Map<String, Object> document) {
-        final Map<String, Object> source = (Map<String, Object>) document.get("_source");
-        assertEquals(7, source.size());
-        assertThat(source.get("state_uuid"), notNullValue());
-
-        final Map<String, Object> shard = (Map<String, Object>) source.get("shard");
-        assertEquals(6, shard.size());
-
-        final String currentNodeId = (String) shard.get("node");
-        if (Strings.hasLength(currentNodeId)) {
-            assertThat(source.get("source_node"), notNullValue());
-        } else {
-            assertThat(source.get("source_node"), nullValue());
-        }
-
-        ShardMonitoringDoc.XCONTENT_FILTERS.forEach(filter -> {
-            if (filter.equals("shard.relocating_node")) {
-                // Shard's relocating node is null most of the time in this test, we only check that the field is here
-                assertTrue(filter + " must exist in the monitoring document", shard.containsKey("relocating_node"));
-                return;
-            }
-            if (filter.equals("shard.node")) {
-                // Current node is null for replicas in this test, we only check that the field is here
-                assertTrue(filter + " must exist in the monitoring document", shard.containsKey("node"));
-                return;
-            }
-            assertThat(filter + " must not be null in the monitoring document", extractValue(filter, source), notNullValue());
-        });
     }
 
     /**

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringBulkActionTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringBulkActionTests.java
@@ -148,13 +148,6 @@ public class RestMonitoringBulkActionTests extends ESTestCase {
         return randomFrom(MonitoredSystem.LOGSTASH, MonitoredSystem.KIBANA, MonitoredSystem.BEATS);
     }
 
-    /**
-     * Returns a {@link String} representing a {@link MonitoredSystem} supported by the Monitoring Bulk API
-     */
-    private static String randomSystemId() {
-        return randomSystem().getSystem();
-    }
-
     private void prepareRequest(final RestRequest restRequest) throws Exception {
         final NodeClient client = mock(NodeClient.class);
         final CheckedConsumer<RestChannel, Exception> consumer = action.prepareRequest(restRequest, client);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/tool/SetupPasswordToolTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/tool/SetupPasswordToolTests.java
@@ -12,19 +12,15 @@ import org.elasticsearch.cli.ExitCodes;
 import org.elasticsearch.cli.UserException;
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.CheckedSupplier;
-import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.settings.KeyStoreWrapper;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.DeprecationHandler;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.protocol.xpack.XPackInfoResponse;
@@ -441,21 +437,6 @@ public class SetupPasswordToolTests extends CommandTestCase {
                     passwordCaptor.capture(), any(CheckedFunction.class));
             assertThat(passwordCaptor.getValue().get(), CoreMatchers.containsString(user + "-password"));
         }
-    }
-
-    private String parsePassword(String value) throws IOException {
-        try (XContentParser parser = JsonXContent.jsonXContent
-                .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, value)) {
-            XContentParser.Token token = parser.nextToken();
-            if (token == XContentParser.Token.START_OBJECT) {
-                if (parser.nextToken() == XContentParser.Token.FIELD_NAME) {
-                    if (parser.nextToken() == XContentParser.Token.VALUE_STRING) {
-                        return parser.text();
-                    }
-                }
-            }
-        }
-        throw new RuntimeException("Did not properly parse password.");
     }
 
     private URL authenticateUrl(URL url) throws MalformedURLException, URISyntaxException {

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/trigger/TriggerServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/trigger/TriggerServiceTests.java
@@ -178,10 +178,4 @@ public class TriggerServiceTests extends ESTestCase {
         newActions.add(actionWrapper);
         when(watch.actions()).thenReturn(newActions);
     }
-
-    private void setTransform(Watch watch, String type) {
-        ExecutableTransform transform = mock(ExecutableTransform.class);
-        when(transform.type()).thenReturn(type);
-        when(watch.transform()).thenReturn(transform);
-    }
 }


### PR DESCRIPTION
This commit removes a bunch of unused private fields (mostly unused deprecation loggers) and unused private methods from the codebase.

(labeling this with `:Search/Search` as many unused code are related to search changes)