### PR TITLE
[7.x] Add support for POST requests to SLM Execute API  (#47061)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleRequestConverters.java
@@ -204,7 +204,7 @@ final class IndexLifecycleRequestConverters {
     }
 
     static Request executeSnapshotLifecyclePolicy(ExecuteSnapshotLifecyclePolicyRequest executeSnapshotLifecyclePolicyRequest) {
-        Request request = new Request(HttpPut.METHOD_NAME,
+        Request request = new Request(HttpPost.METHOD_NAME,
             new RequestConverters.EndpointBuilder()
                 .addPathPartAsIs("_slm/policy")
                 .addPathPartAsIs(executeSnapshotLifecyclePolicyRequest.getPolicyId())

--- a/docs/reference/ilm/apis/slm-api.asciidoc
+++ b/docs/reference/ilm/apis/slm-api.asciidoc
@@ -185,7 +185,7 @@ To take an immediate snapshot using a policy, use the following
 
 [source,console]
 --------------------------------------------------
-PUT /_slm/policy/daily-snapshots/_execute
+POST /_slm/policy/daily-snapshots/_execute
 --------------------------------------------------
 // TEST[skip:we can't easily handle snapshots from docs tests]
 
@@ -279,7 +279,7 @@ Another snapshot can immediately be executed to ensure the new policy works:
 
 [source,console]
 --------------------------------------------------
-PUT /_slm/policy/daily-snapshots/_execute
+POST /_slm/policy/daily-snapshots/_execute
 --------------------------------------------------
 // TEST[skip:we can't handle snapshots in docs tests]
 

--- a/docs/reference/ilm/getting-started-slm.asciidoc
+++ b/docs/reference/ilm/getting-started-slm.asciidoc
@@ -132,7 +132,7 @@ as using the configuration from our policy right now instead of waiting for
 
 [source,console]
 --------------------------------------------------
-PUT /_slm/policy/nightly-snapshots/_execute
+POST /_slm/policy/nightly-snapshots/_execute
 --------------------------------------------------
 // TEST[skip:we can't easily handle snapshots from docs tests]
 

--- a/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleRestIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleRestIT.java
@@ -207,7 +207,7 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
         createSnapshotPolicy(policyName, "snap", "1 2 3 4 5 ?", repoId, indexName, true);
 
         ResponseException badResp = expectThrows(ResponseException.class,
-            () -> client().performRequest(new Request("PUT", "/_slm/policy/" + policyName + "-bad/_execute")));
+            () -> client().performRequest(new Request("POST", "/_slm/policy/" + policyName + "-bad/_execute")));
         assertThat(EntityUtils.toString(badResp.getResponse().getEntity()),
             containsString("no such snapshot lifecycle policy [" + policyName + "-bad]"));
 
@@ -335,7 +335,7 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
      */
     private String executePolicy(String policyId) {
         try {
-            Response executeRepsonse = client().performRequest(new Request("PUT", "/_slm/policy/" + policyId + "/_execute"));
+            Response executeRepsonse = client().performRequest(new Request("POST", "/_slm/policy/" + policyId + "/_execute"));
             try (XContentParser parser = JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY,
                 DeprecationHandler.THROW_UNSUPPORTED_OPERATION, EntityUtils.toByteArray(executeRepsonse.getEntity()))) {
                 return parser.mapStrings().get("snapshot_name");

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/RestExecuteSnapshotLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/RestExecuteSnapshotLifecycleAction.java
@@ -17,6 +17,7 @@ public class RestExecuteSnapshotLifecycleAction extends BaseRestHandler {
 
     public RestExecuteSnapshotLifecycleAction(RestController controller) {
         controller.registerHandler(RestRequest.Method.PUT, "/_slm/policy/{name}/_execute", this);
+        controller.registerHandler(RestRequest.Method.POST, "/_slm/policy/{name}/_execute", this);
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add support for POST requests to SLM Execute API   (#47061)