### PR TITLE
[DOCS] Fix links to transform pages

### DIFF
--- a/docs/reference/transform/apis/transformresource.asciidoc
+++ b/docs/reference/transform/apis/transformresource.asciidoc
@@ -5,8 +5,7 @@
 
 {transform-cap} resources relate to the <<transform-apis>>.
 
-For more information, see
-{stack-ov}/ecommerce-dataframes.html[Transforming your data with {dataframes}].
+For more information, see <<transforms>>.
 
 [discrete]
 [[transform-properties]]
@@ -101,8 +100,7 @@ pivot function `group by` fields and the aggregation to reduce the data.
 * {ref}/search-aggregations-pipeline-bucket-selector-aggregation.html[Bucket Selector]
 
 IMPORTANT: {transforms-cap} support a subset of the functionality in
-composite aggregations. See
-{stack-ov}/dataframe-limitations.html[{dataframe-cap} limitations].
+composite aggregations. See <<transform-limitations>>.
 
 --
 

--- a/docs/reference/transform/index.asciidoc
+++ b/docs/reference/transform/index.asciidoc
@@ -13,6 +13,7 @@ your data.
 * <<transform-overview>>
 * <<transform-usage>>
 * <<transform-api-quickref>>
+* <<ecommerce-transforms>>
 * <<transform-examples>>
 * <<transform-troubleshooting>>
 * <<transform-limitations>>


### PR DESCRIPTION
This PR updates links to content related to transforms, so that they no longer rely on redirects.
It also adds a missing link in the transform landing page.