### PR TITLE
Increase ensureGreen timeout for testReplicaCorruption

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/store/CorruptedFileIT.java
+++ b/server/src/test/java/org/elasticsearch/index/store/CorruptedFileIT.java
@@ -53,6 +53,7 @@ import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
@@ -606,7 +607,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
             Settings.builder().putNull(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING.getKey())
         ));
 
-        ensureGreen();
+        ensureGreen(TimeValue.timeValueSeconds(60));
     }
 
     private int numShards(String... index) {


### PR DESCRIPTION
We can have a large number of shard copies in this test. For example, the two recent failures have 24 and 27 copies respectively and all replicas have to copy segment files as their stores are corrupted. Our CI needs more than 30 seconds to start all these copies.

Note that in two recent failures, the cluster was green just after the cluster health timed out.

Closes #41899