### PR TITLE
Extract proxy connection logic to specialized class (#46898)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
@@ -36,6 +36,7 @@ import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.discovery.zen.NodesFaultDetection;
 import org.elasticsearch.threadpool.ThreadPool.Names;
 import org.elasticsearch.transport.ConnectTransportException;
+import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportConnectionListener;
 import org.elasticsearch.transport.TransportException;
@@ -120,7 +121,7 @@ public class FollowersChecker {
                 channel.sendResponse(new NodesFaultDetection.PingResponse()));
         transportService.addConnectionListener(new TransportConnectionListener() {
             @Override
-            public void onNodeDisconnected(DiscoveryNode node) {
+            public void onNodeDisconnected(DiscoveryNode node, Transport.Connection connection) {
                 handleDisconnectedNode(node);
             }
         });

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
@@ -37,6 +37,7 @@ import org.elasticsearch.discovery.zen.MasterFaultDetection;
 import org.elasticsearch.threadpool.ThreadPool.Names;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.NodeDisconnectedException;
+import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportConnectionListener;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequest;
@@ -118,7 +119,7 @@ public class LeaderChecker {
 
         transportService.addConnectionListener(new TransportConnectionListener() {
             @Override
-            public void onNodeDisconnected(DiscoveryNode node) {
+            public void onNodeDisconnected(DiscoveryNode node, Transport.Connection connection) {
                 handleDisconnectedNode(node);
             }
         });

--- a/server/src/main/java/org/elasticsearch/discovery/zen/FaultDetection.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/FaultDetection.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportConnectionListener;
 import org.elasticsearch.transport.TransportService;
 
@@ -97,7 +98,7 @@ public abstract class FaultDetection implements Closeable {
 
     private class FDConnectionListener implements TransportConnectionListener {
         @Override
-        public void onNodeDisconnected(DiscoveryNode node) {
+        public void onNodeDisconnected(DiscoveryNode node, Transport.Connection connection) {
             AbstractRunnable runnable = new AbstractRunnable() {
                 @Override
                 public void onFailure(Exception e) {

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
@@ -23,7 +23,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.util.SetOnce;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.StepListener;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
@@ -53,7 +52,6 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -78,7 +76,7 @@ final class RemoteClusterConnection implements TransportConnectionListener, Clos
     private static final Logger logger = LogManager.getLogger(RemoteClusterConnection.class);
 
     private final TransportService transportService;
-    private final ConnectionManager connectionManager;
+    private final RemoteConnectionManager remoteConnectionManager;
     private final String clusterAlias;
     private final int maxNumRemoteConnections;
     private final Predicate<DiscoveryNode> nodePredicate;
@@ -116,7 +114,7 @@ final class RemoteClusterConnection implements TransportConnectionListener, Clos
         this.maxNumRemoteConnections = maxNumRemoteConnections;
         this.nodePredicate = nodePredicate;
         this.clusterAlias = clusterAlias;
-        this.connectionManager = connectionManager;
+        this.remoteConnectionManager = new RemoteConnectionManager(clusterAlias, connectionManager);
         this.seedNodes = Collections.unmodifiableList(seedNodes);
         this.skipUnavailable = RemoteClusterService.REMOTE_CLUSTER_SKIP_UNAVAILABLE
             .getConcreteSettingForNamespace(clusterAlias).get(settings);
@@ -168,8 +166,8 @@ final class RemoteClusterConnection implements TransportConnectionListener, Clos
     }
 
     @Override
-    public void onNodeDisconnected(DiscoveryNode node) {
-        if (connectionManager.size() < maxNumRemoteConnections) {
+    public void onNodeDisconnected(DiscoveryNode node, Transport.Connection connection) {
+        if (remoteConnectionManager.size() < maxNumRemoteConnections) {
             // try to reconnect and fill up the slot of the disconnected node
             connectHandler.connect(ActionListener.wrap(
                 ignore -> logger.trace("successfully connected after disconnect of {}", node),
@@ -182,7 +180,7 @@ final class RemoteClusterConnection implements TransportConnectionListener, Clos
      * will invoke the listener immediately.
      */
     void ensureConnected(ActionListener<Void> voidActionListener) {
-        if (connectionManager.size() == 0) {
+        if (remoteConnectionManager.size() == 0) {
             connectHandler.connect(voidActionListener);
         } else {
             voidActionListener.onResponse(null);
@@ -211,8 +209,7 @@ final class RemoteClusterConnection implements TransportConnectionListener, Clos
                 request.clear();
                 request.nodes(true);
                 request.local(true); // run this on the node that gets the request it's as good as any other
-                final DiscoveryNode node = getAnyConnectedNode();
-                Transport.Connection connection = connectionManager.getConnection(node);
+                Transport.Connection connection = remoteConnectionManager.getAnyRemoteConnection();
                 transportService.sendRequest(connection, ClusterStateAction.NAME, request, TransportRequestOptions.EMPTY,
                     new TransportResponseHandler<ClusterStateResponse>() {
 
@@ -256,12 +253,7 @@ final class RemoteClusterConnection implements TransportConnectionListener, Clos
      * If such node is not connected, the returned connection will be a proxy connection that redirects to it.
      */
     Transport.Connection getConnection(DiscoveryNode remoteClusterNode) {
-        if (connectionManager.nodeConnected(remoteClusterNode)) {
-            return connectionManager.getConnection(remoteClusterNode);
-        }
-        DiscoveryNode discoveryNode = getAnyConnectedNode();
-        Transport.Connection connection = connectionManager.getConnection(discoveryNode);
-        return new ProxyConnection(connection, remoteClusterNode);
+        return remoteConnectionManager.getRemoteConnection(remoteClusterNode);
     }
 
     private Predicate<ClusterName> getRemoteClusterNamePredicate() {
@@ -280,65 +272,17 @@ final class RemoteClusterConnection implements TransportConnectionListener, Clos
             };
     }
 
-
-    static final class ProxyConnection implements Transport.Connection {
-        private final Transport.Connection proxyConnection;
-        private final DiscoveryNode targetNode;
-
-        private ProxyConnection(Transport.Connection proxyConnection, DiscoveryNode targetNode) {
-            this.proxyConnection = proxyConnection;
-            this.targetNode = targetNode;
-        }
-
-        @Override
-        public DiscoveryNode getNode() {
-            return targetNode;
-        }
-
-        @Override
-        public void sendRequest(long requestId, String action, TransportRequest request, TransportRequestOptions options)
-                throws IOException, TransportException {
-            proxyConnection.sendRequest(requestId, TransportActionProxy.getProxyAction(action),
-                    TransportActionProxy.wrapRequest(targetNode, request), options);
-        }
-
-        @Override
-        public void close() {
-            assert false: "proxy connections must not be closed";
-        }
-
-        @Override
-        public void addCloseListener(ActionListener<Void> listener) {
-            proxyConnection.addCloseListener(listener);
-        }
-
-        @Override
-        public boolean isClosed() {
-            return proxyConnection.isClosed();
-        }
-
-        @Override
-        public Version getVersion() {
-            return proxyConnection.getVersion();
-        }
-    }
-
     Transport.Connection getConnection() {
-        return connectionManager.getConnection(getAnyConnectedNode());
+        return remoteConnectionManager.getAnyRemoteConnection();
     }
 
     @Override
     public void close() throws IOException {
-        IOUtils.close(connectHandler);
-        connectionManager.closeNoBlock();
+        IOUtils.close(connectHandler, remoteConnectionManager);
     }
 
     public boolean isClosed() {
         return connectHandler.isClosed();
-    }
-
-    public String getProxyAddress() {
-        return proxyAddress;
     }
 
     public List<Tuple<String, Supplier<DiscoveryNode>>> getSeedNodes() {
@@ -456,14 +400,14 @@ final class RemoteClusterConnection implements TransportConnectionListener, Clos
                 final ConnectionProfile profile = ConnectionProfile.buildSingleChannelProfile(TransportRequestOptions.Type.REG);
                 final StepListener<Transport.Connection> openConnectionStep = new StepListener<>();
                 try {
-                    connectionManager.openConnection(seedNode, profile, openConnectionStep);
+                    remoteConnectionManager.openConnection(seedNode, profile, openConnectionStep);
                 } catch (Exception e) {
                     onFailure.accept(e);
                 }
 
                 final StepListener<TransportService.HandshakeResponse> handShakeStep = new StepListener<>();
                 openConnectionStep.whenComplete(connection -> {
-                    ConnectionProfile connectionProfile = connectionManager.getConnectionProfile();
+                    ConnectionProfile connectionProfile = remoteConnectionManager.getConnectionManager().getConnectionProfile();
                     transportService.handshake(connection, connectionProfile.getHandshakeTimeout().millis(),
                         getRemoteClusterNamePredicate(), handShakeStep);
                 }, onFailure);
@@ -472,8 +416,8 @@ final class RemoteClusterConnection implements TransportConnectionListener, Clos
                 handShakeStep.whenComplete(handshakeResponse -> {
                     final DiscoveryNode handshakeNode = maybeAddProxyAddress(proxyAddress, handshakeResponse.getDiscoveryNode());
 
-                    if (nodePredicate.test(handshakeNode) && connectionManager.size() < maxNumRemoteConnections) {
-                        connectionManager.connectToNode(handshakeNode, null,
+                    if (nodePredicate.test(handshakeNode) && remoteConnectionManager.size() < maxNumRemoteConnections) {
+                        remoteConnectionManager.connectToNode(handshakeNode, null,
                             transportService.connectionValidator(handshakeNode), fullConnectionStep);
                     } else {
                         fullConnectionStep.onResponse(null);
@@ -565,8 +509,8 @@ final class RemoteClusterConnection implements TransportConnectionListener, Clos
             private void handleNodes(Iterator<DiscoveryNode> nodesIter) {
                 while (nodesIter.hasNext()) {
                     final DiscoveryNode node = maybeAddProxyAddress(proxyAddress, nodesIter.next());
-                    if (nodePredicate.test(node) && connectionManager.size() < maxNumRemoteConnections) {
-                        connectionManager.connectToNode(node, null,
+                    if (nodePredicate.test(node) && remoteConnectionManager.size() < maxNumRemoteConnections) {
+                        remoteConnectionManager.connectToNode(node, null,
                             transportService.connectionValidator(node), new ActionListener<Void>() {
                                 @Override
                                 public void onResponse(Void aVoid) {
@@ -625,20 +569,7 @@ final class RemoteClusterConnection implements TransportConnectionListener, Clos
     }
 
     boolean isNodeConnected(final DiscoveryNode node) {
-        return connectionManager.nodeConnected(node);
-    }
-
-    private final AtomicLong nextNodeId = new AtomicLong();
-
-    DiscoveryNode getAnyConnectedNode() {
-        List<DiscoveryNode> nodes = new ArrayList<>(connectionManager.connectedNodes());
-        if (nodes.isEmpty()) {
-            throw new NoSuchRemoteClusterException(clusterAlias);
-        } else {
-            long curr;
-            while ((curr = nextNodeId.incrementAndGet()) == Long.MIN_VALUE);
-            return nodes.get(Math.toIntExact(Math.floorMod(curr, nodes.size())));
-        }
+        return remoteConnectionManager.getConnectionManager().nodeConnected(node);
     }
 
     /**
@@ -655,7 +586,7 @@ final class RemoteClusterConnection implements TransportConnectionListener, Clos
     }
 
     int getNumNodesConnected() {
-        return connectionManager.size();
+        return remoteConnectionManager.size();
     }
 
     private static ConnectionManager createConnectionManager(ConnectionProfile connectionProfile, TransportService transportService) {
@@ -663,6 +594,6 @@ final class RemoteClusterConnection implements TransportConnectionListener, Clos
     }
 
     ConnectionManager getConnectionManager() {
-        return connectionManager;
+        return remoteConnectionManager.getConnectionManager();
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/RemoteConnectionManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteConnectionManager.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.transport;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class RemoteConnectionManager implements Closeable {
+
+    private final String clusterAlias;
+    private final ConnectionManager connectionManager;
+    private final AtomicLong counter = new AtomicLong();
+    private volatile List<Transport.Connection> connections = Collections.emptyList();
+
+    RemoteConnectionManager(String clusterAlias, ConnectionManager connectionManager) {
+        this.clusterAlias = clusterAlias;
+        this.connectionManager = connectionManager;
+        this.connectionManager.addListener(new TransportConnectionListener() {
+            @Override
+            public void onNodeConnected(DiscoveryNode node, Transport.Connection connection) {
+                addConnection(connection);
+            }
+
+            @Override
+            public void onNodeDisconnected(DiscoveryNode node, Transport.Connection connection) {
+                removeConnection(connection);
+            }
+        });
+    }
+
+    public void connectToNode(DiscoveryNode node, ConnectionProfile connectionProfile,
+                              ConnectionManager.ConnectionValidator connectionValidator,
+                              ActionListener<Void> listener) throws ConnectTransportException {
+        connectionManager.connectToNode(node, connectionProfile, connectionValidator, listener);
+    }
+
+    public void openConnection(DiscoveryNode node, ConnectionProfile profile, ActionListener<Transport.Connection> listener) {
+        connectionManager.openConnection(node, profile, listener);
+    }
+
+    public Transport.Connection getRemoteConnection(DiscoveryNode node) {
+        try {
+            return connectionManager.getConnection(node);
+        } catch (NodeNotConnectedException e) {
+            return new ProxyConnection(getAnyRemoteConnection(), node);
+        }
+    }
+
+    public Transport.Connection getAnyRemoteConnection() {
+        List<Transport.Connection> localConnections = this.connections;
+        if (localConnections.isEmpty()) {
+            throw new NoSuchRemoteClusterException(clusterAlias);
+        } else {
+            long curr;
+            while ((curr = counter.incrementAndGet()) == Long.MIN_VALUE);
+            return localConnections.get(Math.toIntExact(Math.floorMod(curr, (long) localConnections.size())));
+        }
+    }
+
+    public ConnectionManager getConnectionManager() {
+        return connectionManager;
+    }
+
+    public int size() {
+        return connectionManager.size();
+    }
+
+    public void close() {
+        connectionManager.closeNoBlock();
+    }
+
+    private synchronized void addConnection(Transport.Connection addedConnection) {
+        ArrayList<Transport.Connection> newConnections = new ArrayList<>(this.connections);
+        newConnections.add(addedConnection);
+        this.connections = Collections.unmodifiableList(newConnections);
+    }
+
+    private synchronized void removeConnection(Transport.Connection removedConnection) {
+        int newSize = this.connections.size() - 1;
+        ArrayList<Transport.Connection> newConnections = new ArrayList<>(newSize);
+        for (Transport.Connection connection : this.connections) {
+            if (connection.equals(removedConnection) == false) {
+                newConnections.add(connection);
+            }
+        }
+        assert newConnections.size() == newSize : "Expected connection count: " + newSize + ", Found: " + newConnections.size();
+        this.connections = Collections.unmodifiableList(newConnections);
+    }
+
+    static final class ProxyConnection implements Transport.Connection {
+        private final Transport.Connection connection;
+        private final DiscoveryNode targetNode;
+
+        private ProxyConnection(Transport.Connection connection, DiscoveryNode targetNode) {
+            this.connection = connection;
+            this.targetNode = targetNode;
+        }
+
+        @Override
+        public DiscoveryNode getNode() {
+            return targetNode;
+        }
+
+        @Override
+        public void sendRequest(long requestId, String action, TransportRequest request, TransportRequestOptions options)
+            throws IOException, TransportException {
+            connection.sendRequest(requestId, TransportActionProxy.getProxyAction(action),
+                TransportActionProxy.wrapRequest(targetNode, request), options);
+        }
+
+        @Override
+        public void close() {
+            assert false: "proxy connections must not be closed";
+        }
+
+        @Override
+        public void addCloseListener(ActionListener<Void> listener) {
+            connection.addCloseListener(listener);
+        }
+
+        @Override
+        public boolean isClosed() {
+            return connection.isClosed();
+        }
+
+        @Override
+        public Version getVersion() {
+            return connection.getVersion();
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/transport/TransportConnectionListener.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportConnectionListener.java
@@ -43,10 +43,10 @@ public interface TransportConnectionListener {
     /**
      * Called once a node connection is opened and registered.
      */
-    default void onNodeConnected(DiscoveryNode node) {}
+    default void onNodeConnected(DiscoveryNode node, Transport.Connection connection) {}
 
     /**
      * Called once a node connection is closed and unregistered.
      */
-    default void onNodeDisconnected(DiscoveryNode node) {}
+    default void onNodeDisconnected(DiscoveryNode node, Transport.Connection connection) {}
 }

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -492,7 +492,7 @@ public class TransportSearchActionTests extends ESTestCase {
             CountDownLatch disconnectedLatch = new CountDownLatch(numDisconnectedClusters);
             RemoteClusterServiceTests.addConnectionListener(remoteClusterService, new TransportConnectionListener() {
                 @Override
-                public void onNodeDisconnected(DiscoveryNode node) {
+                public void onNodeDisconnected(DiscoveryNode node, Transport.Connection connection) {
                     if (disconnectedNodes.remove(node)) {
                         disconnectedLatch.countDown();
                     }
@@ -662,7 +662,7 @@ public class TransportSearchActionTests extends ESTestCase {
             CountDownLatch disconnectedLatch = new CountDownLatch(numDisconnectedClusters);
             RemoteClusterServiceTests.addConnectionListener(remoteClusterService, new TransportConnectionListener() {
                 @Override
-                public void onNodeDisconnected(DiscoveryNode node) {
+                public void onNodeDisconnected(DiscoveryNode node, Transport.Connection connection) {
                     if (disconnectedNodes.remove(node)) {
                         disconnectedLatch.countDown();
                     }

--- a/server/src/test/java/org/elasticsearch/client/transport/TransportClientNodesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/client/transport/TransportClientNodesServiceTests.java
@@ -166,7 +166,7 @@ public class TransportClientNodesServiceTests extends ESTestCase {
                 assert addr == null : "boundAddress: " + addr;
                 return DiscoveryNode.createLocal(settings, buildNewFakeTransportAddress(), UUIDs.randomBase64UUID());
             }, null, Collections.emptySet());
-            transportService.addNodeConnectedBehavior(cm -> Collections.emptySet());
+            transportService.addNodeConnectedBehavior((cm, dn) -> false);
             transportService.addGetConnectionBehavior((connectionManager, discoveryNode) -> {
                 // The FailAndRetryTransport does not use the connection profile
                 PlainActionFuture<Transport.Connection> future = PlainActionFuture.newFuture();

--- a/server/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
@@ -102,12 +102,12 @@ public class ZenFaultDetectionTests extends ESTestCase {
         final CountDownLatch latch = new CountDownLatch(2);
         TransportConnectionListener waitForConnection = new TransportConnectionListener() {
             @Override
-            public void onNodeConnected(DiscoveryNode node) {
+            public void onNodeConnected(DiscoveryNode node, Transport.Connection connection) {
                 latch.countDown();
             }
 
             @Override
-            public void onNodeDisconnected(DiscoveryNode node) {
+            public void onNodeDisconnected(DiscoveryNode node, Transport.Connection connection) {
                 fail("disconnect should not be called " + node);
             }
         };

--- a/server/src/test/java/org/elasticsearch/discovery/zen/PublishClusterStateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/zen/PublishClusterStateActionTests.java
@@ -52,6 +52,7 @@ import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.BytesTransportRequest;
+import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportConnectionListener;
 import org.elasticsearch.transport.TransportResponse;
@@ -193,12 +194,12 @@ public class PublishClusterStateActionTests extends ESTestCase {
         final CountDownLatch latch = new CountDownLatch(nodes.size() * 2);
         TransportConnectionListener waitForConnection = new TransportConnectionListener() {
             @Override
-            public void onNodeConnected(DiscoveryNode node) {
+            public void onNodeConnected(DiscoveryNode node, Transport.Connection connection) {
                 latch.countDown();
             }
 
             @Override
-            public void onNodeDisconnected(DiscoveryNode node) {
+            public void onNodeDisconnected(DiscoveryNode node, Transport.Connection connection) {
                 fail("disconnect should not be called " + node);
             }
         };

--- a/server/src/test/java/org/elasticsearch/transport/ConnectionManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/ConnectionManagerTests.java
@@ -77,12 +77,12 @@ public class ConnectionManagerTests extends ESTestCase {
         AtomicInteger nodeDisconnectedCount = new AtomicInteger();
         connectionManager.addListener(new TransportConnectionListener() {
             @Override
-            public void onNodeConnected(DiscoveryNode node) {
+            public void onNodeConnected(DiscoveryNode node, Transport.Connection connection) {
                 nodeConnectedCount.incrementAndGet();
             }
 
             @Override
-            public void onNodeDisconnected(DiscoveryNode node) {
+            public void onNodeDisconnected(DiscoveryNode node, Transport.Connection connection) {
                 nodeDisconnectedCount.incrementAndGet();
             }
         });
@@ -204,12 +204,12 @@ public class ConnectionManagerTests extends ESTestCase {
         AtomicInteger nodeDisconnectedCount = new AtomicInteger();
         connectionManager.addListener(new TransportConnectionListener() {
             @Override
-            public void onNodeConnected(DiscoveryNode node) {
+            public void onNodeConnected(DiscoveryNode node, Transport.Connection connection) {
                 nodeConnectedCount.incrementAndGet();
             }
 
             @Override
-            public void onNodeDisconnected(DiscoveryNode node) {
+            public void onNodeDisconnected(DiscoveryNode node, Transport.Connection connection) {
                 nodeDisconnectedCount.incrementAndGet();
             }
         });
@@ -244,12 +244,12 @@ public class ConnectionManagerTests extends ESTestCase {
         AtomicInteger nodeDisconnectedCount = new AtomicInteger();
         connectionManager.addListener(new TransportConnectionListener() {
             @Override
-            public void onNodeConnected(DiscoveryNode node) {
+            public void onNodeConnected(DiscoveryNode node, Transport.Connection connection) {
                 nodeConnectedCount.incrementAndGet();
             }
 
             @Override
-            public void onNodeDisconnected(DiscoveryNode node) {
+            public void onNodeDisconnected(DiscoveryNode node, Transport.Connection connection) {
                 nodeDisconnectedCount.incrementAndGet();
             }
         });
@@ -293,7 +293,6 @@ public class ConnectionManagerTests extends ESTestCase {
         @Override
         public void sendRequest(long requestId, String action, TransportRequest request, TransportRequestOptions options)
             throws TransportException {
-
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterClientTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterClientTests.java
@@ -87,7 +87,7 @@ public class RemoteClusterClientTests extends ESTestCase {
                 service.getRemoteClusterService().getConnections().forEach(con -> {
                     con.getConnectionManager().addListener(new TransportConnectionListener() {
                         @Override
-                        public void onNodeDisconnected(DiscoveryNode node) {
+                        public void onNodeDisconnected(DiscoveryNode node, Transport.Connection connection) {
                             if (remoteNode.equals(node)) {
                                 semaphore.release();
                             }

--- a/server/src/test/java/org/elasticsearch/transport/RemoteConnectionManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteConnectionManagerTests.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.transport;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.test.ESTestCase;
+
+import java.net.InetAddress;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+public class RemoteConnectionManagerTests extends ESTestCase {
+
+    private Transport transport;
+    private RemoteConnectionManager remoteConnectionManager;
+    private ConnectionManager.ConnectionValidator validator = (connection, profile, listener) -> listener.onResponse(null);
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        transport = mock(Transport.class);
+        remoteConnectionManager = new RemoteConnectionManager("remote-cluster", new ConnectionManager(Settings.EMPTY, transport));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testGetConnection() {
+        TransportAddress address = new TransportAddress(InetAddress.getLoopbackAddress(), 1000);
+
+        doAnswer(invocationOnMock -> {
+            ActionListener<Transport.Connection> listener = (ActionListener<Transport.Connection>) invocationOnMock.getArguments()[2];
+            listener.onResponse(new TestRemoteConnection((DiscoveryNode) invocationOnMock.getArguments()[0]));
+            return null;
+        }).when(transport).openConnection(any(DiscoveryNode.class), any(ConnectionProfile.class), any(ActionListener.class));
+
+        DiscoveryNode node1 = new DiscoveryNode("node-1", address, Version.CURRENT);
+        PlainActionFuture<Void> future1 = PlainActionFuture.newFuture();
+        remoteConnectionManager.connectToNode(node1, null, validator, future1);
+        assertTrue(future1.isDone());
+
+        // Add duplicate connect attempt to ensure that we do not get duplicate connections in the round robin
+        remoteConnectionManager.connectToNode(node1, null, validator, PlainActionFuture.newFuture());
+
+        DiscoveryNode node2 = new DiscoveryNode("node-2", address, Version.CURRENT.minimumCompatibilityVersion());
+        PlainActionFuture<Void> future2 = PlainActionFuture.newFuture();
+        remoteConnectionManager.connectToNode(node2, null, validator, future2);
+        assertTrue(future2.isDone());
+
+        assertEquals(node1, remoteConnectionManager.getRemoteConnection(node1).getNode());
+        assertEquals(node2, remoteConnectionManager.getRemoteConnection(node2).getNode());
+
+        DiscoveryNode node4 = new DiscoveryNode("node-4", address, Version.CURRENT);
+        assertThat(remoteConnectionManager.getRemoteConnection(node4), instanceOf(RemoteConnectionManager.ProxyConnection.class));
+
+        // Test round robin
+        Set<Version> versions = new HashSet<>();
+        versions.add(remoteConnectionManager.getRemoteConnection(node4).getVersion());
+        versions.add(remoteConnectionManager.getRemoteConnection(node4).getVersion());
+
+        assertThat(versions, hasItems(Version.CURRENT, Version.CURRENT.minimumCompatibilityVersion()));
+
+        // Test that the connection is cleared from the round robin list when it is closed
+        remoteConnectionManager.getRemoteConnection(node1).close();
+
+        versions.clear();
+        versions.add(remoteConnectionManager.getRemoteConnection(node4).getVersion());
+        versions.add(remoteConnectionManager.getRemoteConnection(node4).getVersion());
+
+        assertThat(versions, hasItems(Version.CURRENT.minimumCompatibilityVersion()));
+        assertEquals(1, versions.size());
+    }
+
+    private static class TestRemoteConnection extends CloseableConnection {
+
+        private final DiscoveryNode node;
+
+        private TestRemoteConnection(DiscoveryNode node) {
+            this.node = node;
+        }
+
+        @Override
+        public DiscoveryNode getNode() {
+            return node;
+        }
+
+        @Override
+        public void sendRequest(long requestId, String action, TransportRequest request, TransportRequestOptions options)
+            throws TransportException {
+        }
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransport.java
@@ -81,7 +81,7 @@ public class MockTransport implements Transport, LifecycleComponent {
                                                    @Nullable ClusterSettings clusterSettings, Set<String> taskHeaders) {
         StubbableConnectionManager connectionManager = new StubbableConnectionManager(new ConnectionManager(settings, this),
             settings, this);
-        connectionManager.setDefaultNodeConnectedBehavior(cm -> Collections.emptySet());
+        connectionManager.setDefaultNodeConnectedBehavior((cm, node) -> false);
         connectionManager.setDefaultGetConnectionBehavior((cm, discoveryNode) -> createConnection(discoveryNode));
         return new TransportService(settings, this, threadPool, interceptor, localNodeFactory, clusterSettings, taskHeaders,
             connectionManager);

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -463,7 +463,7 @@ public final class MockTransportService extends TransportService {
      * @return {@code true} if no other get connection behavior was registered for this address before.
      */
     public boolean addGetConnectionBehavior(TransportAddress transportAddress, StubbableConnectionManager.GetConnectionBehavior behavior) {
-        return connectionManager().addConnectBehavior(transportAddress, behavior);
+        return connectionManager().addGetConnectionBehavior(transportAddress, behavior);
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -163,12 +163,12 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         final CountDownLatch latch = new CountDownLatch(2);
         TransportConnectionListener waitForConnection = new TransportConnectionListener() {
             @Override
-            public void onNodeConnected(DiscoveryNode node) {
+            public void onNodeConnected(DiscoveryNode node, Transport.Connection connection) {
                 latch.countDown();
             }
 
             @Override
-            public void onNodeDisconnected(DiscoveryNode node) {
+            public void onNodeDisconnected(DiscoveryNode node, Transport.Connection connection) {
                 fail("disconnect should not be called " + node);
             }
         };
@@ -689,12 +689,12 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         final CountDownLatch latch = new CountDownLatch(1);
         TransportConnectionListener disconnectListener = new TransportConnectionListener() {
             @Override
-            public void onNodeConnected(DiscoveryNode node) {
+            public void onNodeConnected(DiscoveryNode node, Transport.Connection connection) {
                 fail("node connected should not be called, all connection have been done previously, node: " + node);
             }
 
             @Override
-            public void onNodeDisconnected(DiscoveryNode node) {
+            public void onNodeDisconnected(DiscoveryNode node, Transport.Connection connection) {
                 latch.countDown();
             }
         };
@@ -1731,12 +1731,12 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         final CountDownLatch latch = new CountDownLatch(4);
         TransportConnectionListener waitForConnection = new TransportConnectionListener() {
             @Override
-            public void onNodeConnected(DiscoveryNode node) {
+            public void onNodeConnected(DiscoveryNode node, Transport.Connection connection) {
                 latch.countDown();
             }
 
             @Override
-            public void onNodeDisconnected(DiscoveryNode node) {
+            public void onNodeDisconnected(DiscoveryNode node, Transport.Connection connection) {
                 fail("disconnect should not be called " + node);
             }
         };


### PR DESCRIPTION
Currently the logic to check if a connection to a remote discovery node
exists and otherwise create a proxy connection is mixed with the
collect nodes, cluster connection lifecycle, and other
RemoteClusterConnection logic. This commit introduces a specialized
RemoteConnectionManager class which handles the open connections.
Additionally, it reworks the "round-robin" proxy logic to create the list
of potential connections at connection open/close time, opposed to each
time a connection is requested.