### PR TITLE
MockSearchService concurrency fix

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/search/MockSearchService.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/MockSearchService.java
@@ -74,8 +74,8 @@ public class MockSearchService extends SearchService {
 
     @Override
     protected void putContext(SearchContext context) {
-        super.putContext(context);
         addActiveContext(context);
+        super.putContext(context);
     }
 
     @Override


### PR DESCRIPTION
Fixed MockSearchService concurrency, assertNoInFlightContext could
have false negative result (rarely).

Split out from #46060
Closes #47048
