### PR TITLE
[DOCS] Correct link to `index.store.preload` setting

### DIFF
--- a/docs/reference/how-to/search-speed.asciidoc
+++ b/docs/reference/how-to/search-speed.asciidoc
@@ -336,8 +336,8 @@ If the machine running Elasticsearch is restarted, the filesystem cache will be
 empty, so it will take some time before the operating system loads hot regions
 of the index into memory so that search operations are fast. You can explicitly
 tell the operating system which files should be loaded into memory eagerly
-depending on the file extension using the <<file-system,`index.store.preload`>>
-setting.
+depending on the file extension using the
+<<preload-data-to-file-system-cache,`index.store.preload`>> setting.
 
 WARNING: Loading data into the filesystem cache eagerly on too many indices or
 too many files will make search _slower_ if the filesystem cache is not large

--- a/docs/reference/index-modules/store.asciidoc
+++ b/docs/reference/index-modules/store.asciidoc
@@ -83,7 +83,8 @@ setting is useful, for example, if you are in an environment where you can not
 control the ability to create a lot of memory maps so you need disable the
 ability to use memory-mapping.
 
-=== Pre-loading data into the file system cache
+[[preload-data-to-file-system-cache]]
+=== Preloading data into the file system cache
 
 NOTE: This is an expert setting, the details of which may change in the future.
 


### PR DESCRIPTION
Corrects an erroneous link to more information about the `index.store.preload` setting.

Closes #47144. CC @inqueue.