### PR TITLE
[DOCS] Puts the ML anomaly detection configuration sections to one level lower in the structure

### DIFF
--- a/docs/reference/ml/anomaly-detection/aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/aggregations.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-configuring-aggregation]]
-=== Aggregating data for faster performance
+==== Aggregating data for faster performance
 
 By default, {dfeeds} fetch data from {es} using search and scroll requests.
 It can be significantly more efficient, however, to aggregate data in {es}

--- a/docs/reference/ml/anomaly-detection/categories.asciidoc
+++ b/docs/reference/ml/anomaly-detection/categories.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-configuring-categories]]
-=== Categorizing log messages
+==== Categorizing log messages
 
 Application log events are often unstructured and contain variable data. For
 example:
@@ -79,7 +79,7 @@ NOTE: To add the `categorization_examples_limit` property, you must use the
 
 [float]
 [[ml-configuring-analyzer]]
-==== Customizing the categorization analyzer
+===== Customizing the categorization analyzer
 
 Categorization uses English dictionary words to identify log message categories.
 By default, it also uses English tokenization rules. For this reason, if you use
@@ -217,7 +217,7 @@ API examples above.
 
 [float]
 [[ml-viewing-categories]]
-==== Viewing categorization results
+===== Viewing categorization results
 
 After you open the job and start the {dfeed} or supply data to the job, you can
 view the categorization results in {kib}. For example:

--- a/docs/reference/ml/anomaly-detection/configuring.asciidoc
+++ b/docs/reference/ml/anomaly-detection/configuring.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-configuring]]
-== Configuring machine learning
+=== Configuring machine learning
 
 If you want to use {ml-features}, there must be at least one {ml} node in
 your cluster and all master-eligible nodes must have {ml} enabled. By default,

--- a/docs/reference/ml/anomaly-detection/customurl.asciidoc
+++ b/docs/reference/ml/anomaly-detection/customurl.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-configuring-url]]
-=== Adding custom URLs to machine learning results
+==== Adding custom URLs to machine learning results
 
 When you create an advanced {anomaly-job} or edit any {anomaly-jobs} in {kib},
 you can optionally attach one or more custom URLs. 
@@ -49,7 +49,7 @@ You can also specify these custom URL settings when you create or update
 
 [float]
 [[ml-configuring-url-strings]]
-==== String substitution in custom URLs
+===== String substitution in custom URLs
 
 You can use dollar sign ($) delimited tokens in a custom URL. These tokens are
 substituted for the values of the corresponding fields in the anomaly records.

--- a/docs/reference/ml/anomaly-detection/delayed-data-detection.asciidoc
+++ b/docs/reference/ml/anomaly-detection/delayed-data-detection.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-delayed-data-detection]]
-=== Handling delayed data
+==== Handling delayed data
 
 Delayed data are documents that are indexed late. That is to say, it is data
 related to a time that the {dfeed} has already processed.
@@ -14,7 +14,7 @@ indexed and consequently miss that document. Conversely, if it is set too high,
 analysis drifts farther away from real-time. The balance that is struck depends
 upon each use case and the environmental factors of the cluster.
 
-==== Why worry about delayed data?
+===== Why worry about delayed data?
 
 This is a particularly prescient question. If data are delayed randomly (and
 consequently are missing from analysis), the results of certain types of
@@ -26,7 +26,7 @@ however, {anomaly-jobs} with a `low_count` function may provide false positives.
 In this situation, it would be useful to see if data comes in after an anomaly is
 recorded so that you can determine a next course of action.
 
-==== How do we detect delayed data?
+===== How do we detect delayed data?
 
 In addition to the `query_delay` field, there is a
 {ref}/ml-datafeed-resource.html#ml-datafeed-delayed-data-check-config[delayed data check config],
@@ -41,7 +41,7 @@ arrived since the analysis. If there is indeed missing data due to their ingest
 delay, the end user is notified. For example, you can see annotations in {kib}
 for the periods where these delays occur.
 
-==== What to do about delayed data?
+===== What to do about delayed data?
 
 The most common course of action is to simply to do nothing. For many functions
 and situations, ignoring the data is acceptable. However, if the amount of

--- a/docs/reference/ml/anomaly-detection/detector-custom-rules.asciidoc
+++ b/docs/reference/ml/anomaly-detection/detector-custom-rules.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-configuring-detector-custom-rules]]
-=== Customizing detectors with custom rules
+==== Customizing detectors with custom rules
 
 <<ml-rules,Custom rules>> enable you to change the behavior of anomaly
 detectors based on domain-specific knowledge.
@@ -14,7 +14,7 @@ scope and conditions.
 
 Let us see how those can be configured by examples.
 
-==== Specifying custom rule scope
+===== Specifying custom rule scope
 
 Let us assume we are configuring an {anomaly-job} in order to detect DNS data
 exfiltration. Our data contain fields "subdomain" and "highest_registered_domain".
@@ -127,7 +127,7 @@ PUT _ml/anomaly_detectors/scoping_multiple_fields
 Such a detector will skip results when the values of all 3 scoped fields
 are included in the referenced filters.
 
-==== Specifying custom rule conditions
+===== Specifying custom rule conditions
 
 Imagine a detector that looks for anomalies in CPU utilization.
 Given a machine that is idle for long enough, small movement in CPU could
@@ -206,7 +206,7 @@ PUT _ml/anomaly_detectors/rule_with_range
 ----------------------------------
 // TEST[skip:needs-licence]
 
-==== Custom rules in the life-cycle of a job
+===== Custom rules in the life-cycle of a job
 
 Custom rules only affect results created after the rules were applied.
 Let us imagine that we have configured an {anomaly-job} and it has been running
@@ -216,7 +216,7 @@ the {ref}/ml-update-job.html[update {anomaly-job} API] to do so. However, the
 rule we added will only be in effect for any results created from the moment we
 added  the rule onwards. Past results will remain unaffected.
 
-==== Using custom rules vs. filtering data
+===== Using custom rules vs. filtering data
 
 It might appear like using rules is just another way of filtering the data
 that feeds into an {anomaly-job}. For example, a rule that skips results when

--- a/docs/reference/ml/anomaly-detection/populations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/populations.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-configuring-pop]]
-=== Performing population analysis
+==== Performing population analysis
 
 Entities or events in your data can be considered anomalous when:
 

--- a/docs/reference/ml/anomaly-detection/transforms.asciidoc
+++ b/docs/reference/ml/anomaly-detection/transforms.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-configuring-transform]]
-=== Transforming data with script fields
+==== Transforming data with script fields
 
 If you use {dfeeds}, you can add scripts to transform your data before
 it is analyzed. {dfeeds-cap} contain an optional `script_fields` property, where
@@ -190,7 +190,7 @@ the **Edit JSON** tab. For example:
 image::images/ml-scriptfields.jpg[Adding script fields to a {dfeed} in {kib}]
 
 [[ml-configuring-transform-examples]]
-==== Common script field examples
+===== Common script field examples
 
 While the possibilities are limitless, there are a number of common scenarios
 where you might use script fields in your {dfeeds}.


### PR DESCRIPTION
This PR changes the ML AD configuration files to one level lower in the structure. It is required for the new ML Anomaly Detection structure in the Stack Docs.