### PR TITLE
Exclude the demo folder form the JDK

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -399,6 +399,7 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
       }
       return copySpec {
         from project.jdks."bundled_${platform}"
+        exclude "demo/**"
         eachFile { FileCopyDetails details ->
           if (details.relativePath.segments[-2] == 'bin' || details.relativePath.segments[-1] == 'jspawnhelper') {
             details.mode = 0755

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DebMetadataTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DebMetadataTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.packaging.util.Distribution;
 import org.elasticsearch.packaging.util.FileUtils;
 import org.elasticsearch.packaging.util.Shell;
 import org.junit.Before;
-import org.junit.Ignore;
 
 import java.util.regex.Pattern;
 
@@ -38,7 +37,6 @@ public class DebMetadataTests extends PackagingTestCase {
         assumeTrue("only deb", distribution.packaging == Distribution.Packaging.DEB);
     }
 
-    @Ignore
     public void test05CheckLintian() {
         sh.run("lintian --fail-on-warnings " + FileUtils.getDistributionFile(distribution()));
     }


### PR DESCRIPTION
The folder contains jars with source code that fail the lintian test on
debian (based) distributions.

relates to #46903 