### PR TITLE
[DOCS] Reformat put pipeline API

### DIFF
--- a/docs/reference/ingest/apis/put-pipeline.asciidoc
+++ b/docs/reference/ingest/apis/put-pipeline.asciidoc
@@ -1,10 +1,14 @@
 [[put-pipeline-api]]
-=== Put Pipeline API
+=== Put pipeline API
+++++
+<titleabbrev>Put pipeline</titleabbrev>
+++++
 
-The put pipeline API adds pipelines and updates existing pipelines in the cluster.
+Creates or updates an ingest pipeline.
+Changes made using this API take effect immediately.
 
 [source,console]
---------------------------------------------------
+----
 PUT _ingest/pipeline/my-pipeline-id
 {
   "description" : "describe pipeline",
@@ -17,16 +21,73 @@ PUT _ingest/pipeline/my-pipeline-id
     }
   ]
 }
---------------------------------------------------
+----
 
-[float]
+
+[[put-pipeline-api-request]]
+==== {api-request-title}
+
+`PUT /_ingest/pipeline/<pipeline>`
+
+
+[[put-pipeline-api-path-params]]
+==== {api-path-parms-title}
+
+`<pipeline>`::
+(Required, string) ID of the ingest pipeline to create or update.
+
+
+[[put-pipeline-api-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+
+
+[[put-pipeline-api-response-body]]
+==== {api-response-body-title}
+
+`description`::
+(Required, string)
+Description of the ingest pipeline.
+
+`processors`::
++
+--
+(Required, array of <<ingest-processors,processor objects>>)
+Array of processors used to pre-process documents
+before indexing.
+
+Processors are executed in the order provided.
+
+See <<ingest-processors>> for processor object definitions
+and a list of built-in processors.
+--
+
+`version`::
++
+--
+(Optional, integer)
+Optional version number used by external systems to manage ingest pipelines.
+
+Versions are not used or validated by {es};
+they are intended for external management only.
+--
+
+
+[[put-pipeline-api-example]]
+==== {api-examples-title}
+
+
 [[versioning-pipelines]]
-==== Pipeline versioning
+===== Pipeline versioning
 
-Pipelines can optionally add a `version` number, which can be any integer value,
-in order to simplify pipeline management by external systems. The `version`
-field is completely optional and it is meant solely for external management of
-pipelines.
+When creating or updating an ingest pipeline,
+you can specify an optional `version` parameter.
+The version is useful for managing changes to pipeline
+and viewing the current pipeline for an ingest node.
+
+The following request sets a version number of `123`
+for `my-pipeline-id`.
 
 [source,console]
 --------------------------------------------------
@@ -45,8 +106,8 @@ PUT /_ingest/pipeline/my-pipeline-id
 }
 --------------------------------------------------
 
-To unset a `version`, simply replace the pipeline without specifying
-one.
+To unset the version number,
+replace the pipeline without specifying a `version` parameter.
 
 [source,console]
 --------------------------------------------------
@@ -64,8 +125,7 @@ PUT /_ingest/pipeline/my-pipeline-id
 }
 --------------------------------------------------
 
-//////////////////////////
-
+////
 [source,console]
 --------------------------------------------------
 DELETE /_ingest/pipeline/my-pipeline-id
@@ -78,8 +138,4 @@ DELETE /_ingest/pipeline/my-pipeline-id
 "acknowledged": true
 }
 --------------------------------------------------
-
-//////////////////////////
-
-NOTE: The put pipeline API also instructs all ingest nodes to reload their in-memory representation of pipelines, so that
-      pipeline changes take effect immediately.
+////


### PR DESCRIPTION
### Changes

- Rewrites and relocates note about API changes taking effect immediately.
- Simplifies "Pipeline versioning" example
- Reformats the put pipeline API docs to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc).

Relates to #47049.