### PR TITLE
[DOCS] Reformat delete pipeline API

### DIFF
--- a/docs/reference/ingest/apis/delete-pipeline.asciidoc
+++ b/docs/reference/ingest/apis/delete-pipeline.asciidoc
@@ -1,73 +1,96 @@
 [[delete-pipeline-api]]
-=== Delete Pipeline API
+=== Delete pipeline API
+++++
+<titleabbrev>Delete pipeline</titleabbrev>
+++++
 
-The delete pipeline API deletes pipelines by ID or wildcard match (`my-*`, `*`).
+Deletes one or more existing ingest pipeline.
 
-//////////////////////////
-
+////
 [source,console]
---------------------------------------------------
-PUT _ingest/pipeline/my-pipeline-id
+----
+PUT /_ingest/pipeline/my-pipeline-id
 {
-  "description" : "describe pipeline",
-  "version" : 123,
-  "processors" : [
-    {
-      "set" : {
-        "field": "foo",
-        "value": "bar"
-      }
-    }
-  ]
-}
---------------------------------------------------
-
-//////////////////////////
-
-[source,console]
---------------------------------------------------
-DELETE _ingest/pipeline/my-pipeline-id
---------------------------------------------------
-// TEST[continued]
-
-//////////////////////////
-
-[source,console-result]
---------------------------------------------------
-{
-"acknowledged": true
-}
---------------------------------------------------
-
-[source,console]
---------------------------------------------------
-PUT _ingest/pipeline/wild-one
-{
-  "description" : "first pipeline to be wildcard deleted",
+  "description" : "example pipeline to delete",
   "processors" : [ ]
 }
 
-PUT _ingest/pipeline/wild-two
+PUT /_ingest/pipeline/pipeline-one
 {
-  "description" : "second pipeline to be wildcard deleted",
+  "description" : "another example pipeline to delete",
   "processors" : [ ]
 }
---------------------------------------------------
-
-//////////////////////////
+----
+// TESTSETUP
+////
 
 [source,console]
---------------------------------------------------
-DELETE _ingest/pipeline/*
---------------------------------------------------
+----
+DELETE /_ingest/pipeline/my-pipeline-id
+----
 
-//////////////////////////
 
+[[delete-pipeline-api-request]]
+==== {api-request-title}
+
+`DELETE /_ingest/pipeline/<pipeline>`
+
+
+[[delete-pipeline-api-path-params]]
+==== {api-path-parms-title}
+
+`<pipeline>`::
++
+--
+(Required, string) Pipeline ID or wildcard expression of pipeline IDs
+used to limit the request.
+
+To delete all ingest pipelines in a cluster,
+use a value of `*`.
+--
+
+
+[[delete-pipeline-api-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+
+
+[[delete-pipeline-api-api-example]]
+==== {api-examples-title}
+
+
+[[delete-pipeline-api-specific-ex]]
+===== Delete a specific ingest pipeline
+
+[source,console]
+----
+DELETE /_ingest/pipeline/pipeline-one
+----
+
+
+[[delete-pipeline-api-wildcard-ex]]
+===== Delete ingest pipelines using a wildcard expression
+
+[source,console]
+----
+DELETE /_ingest/pipeline/pipeline-*
+----
+
+
+[[delete-pipeline-api-all-ex]]
+===== Delete all ingest pipelines
+
+[source,console]
+----
+DELETE /_ingest/pipeline/*
+----
+
+////
 [source,console-result]
---------------------------------------------------
+----
 {
 "acknowledged": true
 }
---------------------------------------------------
-
-//////////////////////////
+----
+////


### PR DESCRIPTION
Reformats the delete pipeline API docs to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc).

Relates to #47049.