### PR TITLE
Updated highlights-7.2.0.asciidoc

### DIFF
--- a/docs/reference/release-notes/highlights-7.2.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.2.0.asciidoc
@@ -4,8 +4,6 @@
 <titleabbrev>7.2.0</titleabbrev>
 ++++
 
-coming[7.2.0]
-
 //NOTE: The notable-highlights tagged regions are re-used in the
 //Installation and Upgrade Guide
 


### PR DESCRIPTION
Removed "Note: Coming in 7.2.0." as the version has been released now.
