### PR TITLE
Doc:  Added a direct reference to remote cluster page

### DIFF
--- a/docs/reference/ccr/overview.asciidoc
+++ b/docs/reference/ccr/overview.asciidoc
@@ -17,6 +17,7 @@ Replication is pull-based. This means that replication is driven by the
 follower index. This simplifies state management on the leader index and means
 that {ccr} does not interfere with indexing on the leader index.
 
+IMPORTANT: {ccr-cap} requires <<modules-remote-clusters, remote clusters>>.
 
 ==== Configuring replication
 


### PR DESCRIPTION
This has come up multiple times from the field in the past.  Some users have trouble finding version compatibility information for CCR clusters, even though this information is well documented at https://www.elastic.co/guide/en/elasticsearch/reference/7.3/modules-remote-clusters.html.  

We are actually implicitly linking the above already via the link to the Kibana documentation as part of this statement:  "For more information about managing cross-cluster replication in Kibana, see Working with remote clusters." (the Kibana docs then link back to the remote clusters page).

CCS documentation (https://www.elastic.co/guide/en/elasticsearch/reference/7.3/modules-cross-cluster-search.html) has a nice explicit link to remote clusters at the beginning of the page.  This is just an attempt to adopt the same note at the beginning of the CCR documentation for consistency.  Hopefully, this will make it easier for end users to find the nice compatibility information upfront.

