### PR TITLE
Add a verifyVersions to the test FW

### DIFF
--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -68,3 +68,7 @@ test {
 task integTest(type: Test) {
   include "**/*IT.class"
 }
+
+tasks.register("verifyVersions") {
+  dependsOn  test
+}


### PR DESCRIPTION
The test FW has a method to check that it's implementation of getting
index and wire compatible versions as well as reasoning about which
version is released or not produces the same rezults as the simillar
implementation in the build.

This PR adds the `verifyVersions` task to the test FW so we have one
task to check everything related to versions.

