### PR TITLE
Fix OriginationDate parsing tests. (#47170)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleOriginationDateParserTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleOriginationDateParserTests.java
@@ -6,18 +6,18 @@
 package org.elasticsearch.xpack.core.ilm;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.test.ESTestCase;
 
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Locale;
-import java.util.TimeZone;
 
 import static org.elasticsearch.xpack.core.ilm.IndexLifecycleOriginationDateParser.parseIndexNameAndExtractDate;
 import static org.elasticsearch.xpack.core.ilm.IndexLifecycleOriginationDateParser.shouldParseIndexName;
 import static org.hamcrest.Matchers.is;
 
 public class IndexLifecycleOriginationDateParserTests extends ESTestCase {
+
+    private static final DateFormatter dateFormatter = DateFormatter.forPattern("yyyy.MM.dd");
 
     public void testShouldParseIndexNameReturnsFalseWhenOriginationDateIsSet() {
         Settings settings = Settings.builder()
@@ -41,10 +41,7 @@ public class IndexLifecycleOriginationDateParserTests extends ESTestCase {
     }
 
     public void testParseIndexNameThatMatchesExpectedFormat() throws ParseException {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy.MM.dd", Locale.getDefault());
-        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-        long expectedDate = dateFormat.parse("2019.09.04").getTime();
-
+        long expectedDate = dateFormatter.parseMillis("2019.09.04");
         {
             long parsedDate = parseIndexNameAndExtractDate("indexName-2019.09.04");
             assertThat("indexName-yyyy.MM.dd is a valid index format", parsedDate, is(expectedDate));
@@ -57,14 +54,14 @@ public class IndexLifecycleOriginationDateParserTests extends ESTestCase {
 
         {
             long parsedDate = parseIndexNameAndExtractDate("indexName-2019.09.04-2019.09.24");
-            long secondDateInIndexName = dateFormat.parse("2019.09.24").getTime();
+            long secondDateInIndexName = dateFormatter.parseMillis("2019.09.24");
             assertThat("indexName-yyyy.MM.dd-yyyy.MM.dd is a valid index format and the second date should be parsed",
                 parsedDate, is(secondDateInIndexName));
         }
 
         {
             long parsedDate = parseIndexNameAndExtractDate("index-2019.09.04-2019.09.24-00002");
-            long secondDateInIndexName = dateFormat.parse("2019.09.24").getTime();
+            long secondDateInIndexName = dateFormatter.parseMillis("2019.09.24");
             assertThat("indexName-yyyy.MM.dd-yyyy.MM.dd-digits is a valid index format and the second date should be parsed",
                 parsedDate, is(secondDateInIndexName));
         }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.index.Index;
@@ -51,7 +52,6 @@ import org.elasticsearch.xpack.core.ilm.action.StopILMAction;
 import org.junit.Before;
 
 import java.io.IOException;
-import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -59,9 +59,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.TimeZone;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -307,12 +305,11 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
             ).actionGet();
         assertAcked(createIndexResponse);
 
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy.MM.dd", Locale.getDefault());
-        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-        long parsedLifecycleDate = dateFormat.parse("2019.09.14").getTime();
+        DateFormatter dateFormatter = DateFormatter.forPattern("yyyy.MM.dd");
+        long expectedDate = dateFormatter.parseMillis("2019.09.14");
         assertBusy(() -> {
             IndexLifecycleExplainResponse indexResponse = executeExplainRequestAndGetTestIndexResponse(indexName);
-            assertThat(indexResponse.getLifecycleDate(), is(parsedLifecycleDate));
+            assertThat(indexResponse.getLifecycleDate(), is(expectedDate));
         });
 
         // disabling the lifecycle parsing would maintain the parsed value as that was set as the origination date
@@ -321,7 +318,7 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
 
         assertBusy(() -> {
             IndexLifecycleExplainResponse indexResponse = executeExplainRequestAndGetTestIndexResponse(indexName);
-            assertThat(indexResponse.getLifecycleDate(), is(parsedLifecycleDate));
+            assertThat(indexResponse.getLifecycleDate(), is(expectedDate));
         });
 
         // setting the lifecycle origination date setting to null should make the lifecyle date fallback on the index creation date
@@ -330,7 +327,7 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
 
         assertBusy(() -> {
             IndexLifecycleExplainResponse indexResponse = executeExplainRequestAndGetTestIndexResponse(indexName);
-            assertThat(indexResponse.getLifecycleDate(), is(greaterThan(parsedLifecycleDate)));
+            assertThat(indexResponse.getLifecycleDate(), is(greaterThan(expectedDate)));
         });
 
         // setting the lifecycle origination date to an explicit value overrides the date parsing


### PR DESCRIPTION
Drop the usage of `SimpleDateFormat` and use the `DateFormatter` instead

(cherry picked from commit 7cf509a7a11ecf6c40c44c18e8f03b8e81fcd1c2)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #47170 