### PR TITLE
[7.x] [DOCS] Correct typo in ICU Analysis plugin description (#47175)

### DIFF
--- a/docs/plugins/analysis-icu.asciidoc
+++ b/docs/plugins/analysis-icu.asciidoc
@@ -1,7 +1,7 @@
 [[analysis-icu]]
 === ICU Analysis Plugin
 
-The ICU Analysis plugin integrates the Lucene ICU module into elasticsearch,
+The ICU Analysis plugin integrates the Lucene ICU module into {es},
 adding extended Unicode support using the http://site.icu-project.org/[ICU]
 libraries, including better analysis of Asian languages, Unicode
 normalization, Unicode-aware case folding, collation support, and

--- a/docs/reference/cat/plugins.asciidoc
+++ b/docs/reference/cat/plugins.asciidoc
@@ -44,7 +44,7 @@ The API returns the following response:
 ["source","txt",subs="attributes,callouts"]
 ------------------------------------------------------------------------------
 name    component               version   description
-U7321H6 analysis-icu            {version_qualified} The ICU Analysis plugin integrates Lucene ICU module into elasticsearch, adding ICU relates analysis components.
+U7321H6 analysis-icu            {version_qualified} The ICU Analysis plugin integrates the Lucene ICU module into Elasticsearch, adding ICU-related analysis components.
 U7321H6 analysis-kuromoji       {version_qualified} The Japanese (kuromoji) Analysis plugin integrates Lucene kuromoji analysis module into elasticsearch.
 U7321H6 analysis-nori           {version_qualified} The Korean (nori) Analysis plugin integrates Lucene nori analysis module into elasticsearch.
 U7321H6 analysis-phonetic       {version_qualified} The Phonetic Analysis plugin integrates phonetic token filter analysis with elasticsearch.

--- a/plugins/analysis-icu/build.gradle
+++ b/plugins/analysis-icu/build.gradle
@@ -20,7 +20,7 @@ import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApis
  */
 
 esplugin {
-  description 'The ICU Analysis plugin integrates Lucene ICU module into elasticsearch, adding ICU relates analysis components.'
+  description 'The ICU Analysis plugin integrates the Lucene ICU module into Elasticsearch, adding ICU-related analysis components.'
   classname 'org.elasticsearch.plugin.analysis.icu.AnalysisICUPlugin'
   hasClientJar = true
 }


### PR DESCRIPTION
7.x backport of #47175.