### PR TITLE
Remove "force" version type

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -191,8 +191,6 @@ final class RequestConverters {
                             metadata.field("version_type", "external");
                         } else if (versionType == VersionType.EXTERNAL_GTE) {
                             metadata.field("version_type", "external_gte");
-                        } else if (versionType == VersionType.FORCE) {
-                            metadata.field("version_type", "force");
                         }
                     }
 

--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -131,9 +131,7 @@ better GET scaling we will have.
 ===== Versioning support
 
 You can use the `version` parameter to retrieve the document only if
-its current version is equal to the specified one. This behavior is the same
-for all version types with the exception of version type `FORCE` which always
-retrieves the document. Note that `FORCE` version type is deprecated.
+its current version is equal to the specified one.
 
 Internally, Elasticsearch has marked the old document as deleted and added an
 entirely new document. The old version of the document doesn’t disappear

--- a/server/src/main/java/org/elasticsearch/action/DocWriteRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/DocWriteRequest.java
@@ -72,8 +72,7 @@ public interface DocWriteRequest<T> extends IndicesRequest {
      * @return the Request
      */
     T defaultTypeIfNull(String defaultType);
-    
-    
+
     /**
      * Get the id of the document for this request
      * @return the id
@@ -256,9 +255,6 @@ public interface DocWriteRequest<T> extends IndicesRequest {
         if (versionType.validateVersionForWrites(version) == false) {
             validationException = addValidationError("illegal version value [" + version + "] for version type ["
                 + versionType.name() + "]", validationException);
-        }
-        if (versionType == VersionType.FORCE) {
-            validationException = addValidationError("version type [force] may no longer be used", validationException);
         }
 
         if (versionType == VersionType.INTERNAL && version != Versions.MATCH_ANY && version != Versions.MATCH_DELETED) {

--- a/server/src/main/java/org/elasticsearch/action/get/GetRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/get/GetRequest.java
@@ -111,9 +111,6 @@ public class GetRequest extends SingleShardRequest<GetRequest> implements Realti
             validationException = ValidateActions.addValidationError("illegal version value [" + version + "] for version type ["
                     + versionType.name() + "]", validationException);
         }
-        if (versionType == VersionType.FORCE) {
-            validationException = ValidateActions.addValidationError("version type [force] may no longer be used", validationException);
-        }
         return validationException;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/VersionType.java
+++ b/server/src/main/java/org/elasticsearch/index/VersionType.java
@@ -201,55 +201,6 @@ public enum VersionType implements Writeable {
             return version >= 0L || version == Versions.MATCH_ANY;
         }
 
-    },
-    /**
-     * Warning: this version type should be used with care. Concurrent indexing may result in loss of data on replicas
-     *
-     * @deprecated this will be removed in 7.0 and should not be used! It is *ONLY* for backward compatibility with 5.0 indices
-     */
-    @Deprecated
-    FORCE((byte) 3) {
-        @Override
-        public boolean isVersionConflictForWrites(long currentVersion, long expectedVersion, boolean deleted) {
-            if (currentVersion == Versions.NOT_FOUND) {
-                return false;
-            }
-            if (expectedVersion == Versions.MATCH_ANY) {
-                throw new IllegalStateException("you must specify a version when use VersionType.FORCE");
-            }
-            return false;
-        }
-
-        @Override
-        public String explainConflictForWrites(long currentVersion, long expectedVersion, boolean deleted) {
-            throw new AssertionError("VersionType.FORCE should never result in a write conflict");
-        }
-
-        @Override
-        public boolean isVersionConflictForReads(long currentVersion, long expectedVersion) {
-            return false;
-        }
-
-        @Override
-        public String explainConflictForReads(long currentVersion, long expectedVersion) {
-            throw new AssertionError("VersionType.FORCE should never result in a read conflict");
-        }
-
-        @Override
-        public long updateVersion(long currentVersion, long expectedVersion) {
-            return expectedVersion;
-        }
-
-        @Override
-        public boolean validateVersionForWrites(long version) {
-            return version >= 0L;
-        }
-
-        @Override
-        public boolean validateVersionForReads(long version) {
-            return version >= 0L || version == Versions.MATCH_ANY;
-        }
-
     };
 
     private final byte value;
@@ -335,8 +286,6 @@ public enum VersionType implements Writeable {
             return EXTERNAL;
         } else if ("external_gte".equals(versionType)) {
             return EXTERNAL_GTE;
-        } else if ("force".equals(versionType)) {
-            return FORCE;
         }
         throw new IllegalArgumentException("No version type match [" + versionType + "]");
     }
@@ -359,8 +308,6 @@ public enum VersionType implements Writeable {
             return EXTERNAL;
         } else if (value == 2) {
             return EXTERNAL_GTE;
-        } else if (value == 3) {
-            return FORCE;
         }
         throw new IllegalArgumentException("No version type match [" + value + "]");
     }

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -1805,7 +1805,7 @@ public class InternalEngineTests extends EngineTestCase {
 
     public void testOutOfOrderDocsOnReplica() throws IOException {
         final List<Engine.Operation> ops = generateSingleDocHistory(true,
-            randomFrom(VersionType.INTERNAL, VersionType.EXTERNAL, VersionType.EXTERNAL_GTE, VersionType.FORCE),
+            randomFrom(VersionType.INTERNAL, VersionType.EXTERNAL, VersionType.EXTERNAL_GTE),
             2, 2, 20, "1");
         assertOpsOnReplica(ops, replicaEngine, true, logger);
     }

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -803,9 +803,6 @@ public abstract class EngineTestCase extends ESTestCase {
                 case EXTERNAL_GTE:
                     version = randomBoolean() ? Math.max(i - 1, 0) : i;
                     break;
-                case FORCE:
-                    version = randomNonNegativeLong();
-                    break;
                 default:
                     throw new UnsupportedOperationException("unknown version type: " + versionType);
             }

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
@@ -139,7 +139,7 @@ public class FollowingEngineTests extends ESTestCase {
             final EngineConfig engineConfig = engineConfig(shardId, indexSettings, threadPool, store, logger, xContentRegistry());
             try (FollowingEngine followingEngine = createEngine(store, engineConfig)) {
                 final VersionType versionType =
-                        randomFrom(VersionType.INTERNAL, VersionType.EXTERNAL, VersionType.EXTERNAL_GTE, VersionType.FORCE);
+                        randomFrom(VersionType.INTERNAL, VersionType.EXTERNAL, VersionType.EXTERNAL_GTE);
                 final List<Engine.Operation> ops = EngineTestCase.generateSingleDocHistory(true, versionType, 2, 2, 20, "id");
                 ops.stream().mapToLong(op -> op.seqNo()).max().ifPresent(followingEngine::advanceMaxSeqNoOfUpdatesOrDeletes);
                 EngineTestCase.assertOpsOnReplica(ops, followingEngine, true, logger);


### PR DESCRIPTION
It's been deprecated long ago and can be removed.

Relates to #20377

Closes #19769