### PR TITLE
[7.4] [DOCS] Document missing query parms for cat recovery API (#47181)

### DIFF
--- a/docs/reference/cat/recovery.asciidoc
+++ b/docs/reference/cat/recovery.asciidoc
@@ -13,6 +13,8 @@ to the <<indices-recovery, indices recovery>> API.
 
 `GET /_cat/recovery/<index>`
 
+`GET /_cat/recovery`
+
 
 [[cat-recovery-api-desc]]
 ==== {api-description-title}
@@ -37,13 +39,19 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
 [[cat-recovery-query-params]]
 ==== {api-query-parms-title}
 
+include::{docdir}/rest-api/common-parms.asciidoc[tag=active-only]
+
 include::{docdir}/rest-api/common-parms.asciidoc[tag=bytes]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=detailed]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index-query-parm]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
 

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -1,4 +1,12 @@
 
+tag::active-only[]
+`active_only`::
+(Optional, boolean)
+If `true`,
+the response only includes ongoing shard recoveries.
+Defaults to `false`.
+end::active-only[]
+
 tag::index-alias[]
 Comma-separated list or wildcard expression of index alias names
 used to limit the request.
@@ -74,6 +82,14 @@ tag::default_operator[]
 (Optional, string) The default operator for query string query: AND or OR. 
 Defaults to `OR`.
 end::default_operator[]
+
+tag::detailed[]
+`detailed`::
+(Optional, boolean)
+If `true`,
+the response includes detailed information about shard recoveries.
+Defaults to `false`.
+end::detailed[]
 
 tag::df[]
 `df`::
@@ -242,6 +258,13 @@ tag::include-unloaded-segments[]
 (Optional, boolean) If `true`, the response includes information from segments
 that are **not** loaded into memory. Defaults to `false`.
 end::include-unloaded-segments[]
+
+tag::index-query-parm[]
+`index`::
+(Optional, string)
+Comma-separated list or wildcard expression of index names
+used to limit the request.
+end::index-query-parm[]
 
 tag::index[]
 `<index>`::

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json
@@ -21,7 +21,7 @@
           "parts":{
             "index":{
               "type":"list",
-              "description":"A comma-separated list of index names to limit the returned information"
+              "description":"Comma-separated list or wildcard expression of index names to limit the returned information"
             }
           }
         }
@@ -31,6 +31,11 @@
       "format":{
         "type":"string",
         "description":"a short version of the Accept header, e.g. json, yaml"
+      },
+      "active_only":{
+        "type":"boolean",
+        "description":"If `true`, the response only includes ongoing shard recoveries",
+        "default":false
       },
       "bytes":{
         "type":"enum",
@@ -49,6 +54,11 @@
           "pb"
         ]
       },
+      "detailed":{
+        "type":"boolean",
+        "description":"If `true`, the response includes detailed information about shard recoveries",
+        "default":false
+      },
       "master_timeout":{
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
@@ -61,6 +71,10 @@
         "type":"boolean",
         "description":"Return help information",
         "default":false
+      },
+      "index":{
+        "type":"list",
+        "description":"Comma-separated list or wildcard expression of index names to limit the returned information"
       },
       "s":{
         "type":"list",


### PR DESCRIPTION
7.x backport of #47181