### PR TITLE
Ensure char array test uses different values

### DIFF
--- a/libs/core/src/test/java/org/elasticsearch/common/CharArraysTests.java
+++ b/libs/core/src/test/java/org/elasticsearch/common/CharArraysTests.java
@@ -69,8 +69,10 @@ public class CharArraysTests extends ESTestCase {
         assertTrue(CharArrays.constantTimeEquals(value, value));
         assertTrue(CharArrays.constantTimeEquals(value.toCharArray(), value.toCharArray()));
 
-        final String other = randomAlphaOfLengthBetween(1, 32);
-        assertFalse(CharArrays.constantTimeEquals(value, other));
+        // we want a different string, so ensure the first character is different, but the same overall length
+        final String other = new String(
+            randomAlphaOfLengthNotBeginningWith(value.substring(0, 1), value.length(), value.length()));
+        assertFalse("value: " + value + ", other: " + other, CharArrays.constantTimeEquals(value, other));
         assertFalse(CharArrays.constantTimeEquals(value.toCharArray(), other.toCharArray()));
     }
 


### PR DESCRIPTION
The test of constantTimeEquals could get unlucky and randomly produce
the same two strings. This commit tweaks the test to ensure the two
string are unique, and the loop inside constantTimeEquals is actually
executed (which requires the strings be of the same length).

fixes #47076

