### PR TITLE
[WIP] Cache between cluster state changes, allow checking of specific settings

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/settings/ConsistentSettingsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/ConsistentSettingsServiceTests.java
@@ -69,10 +69,12 @@ public class ConsistentSettingsServiceTests extends ESTestCase {
         assertThat(consistentService.areAllConsistent(), is(true));
         // change value
         secureSettings.setString(stringSetting.getKey(), "_TYPO_somethingsecure");
+        consistentService.clusterChanged(null);
         assertThat(consistentService.areAllConsistent(), is(false));
         assertThat(new ConsistentSettingsService(settings, clusterService, List.of(stringSetting)).areAllConsistent(), is(false));
         // publish change
         new ConsistentSettingsService(settings, clusterService, List.of(stringSetting)).newHashPublisher().onMaster();
+        consistentService.clusterChanged(null);
         assertThat(consistentService.areAllConsistent(), is(true));
         assertThat(new ConsistentSettingsService(settings, clusterService, List.of(stringSetting)).areAllConsistent(), is(true));
     }
@@ -96,10 +98,12 @@ public class ConsistentSettingsServiceTests extends ESTestCase {
         assertThat(consistentService.areAllConsistent(), is(true));
         // change value
         secureSettings.setString("test.affix.second.bar", "_TYPO_second_secure");
+        consistentService.clusterChanged(null);
         assertThat(consistentService.areAllConsistent(), is(false));
         assertThat(new ConsistentSettingsService(settings, clusterService, List.of(affixStringSetting)).areAllConsistent(), is(false));
         // publish change
         new ConsistentSettingsService(settings, clusterService, List.of(affixStringSetting)).newHashPublisher().onMaster();
+        consistentService.clusterChanged(null);
         assertThat(consistentService.areAllConsistent(), is(true));
         assertThat(new ConsistentSettingsService(settings, clusterService, List.of(affixStringSetting)).areAllConsistent(), is(true));
         // add value
@@ -110,6 +114,7 @@ public class ConsistentSettingsServiceTests extends ESTestCase {
         assertThat(new ConsistentSettingsService(settings, clusterService, List.of(affixStringSetting)).areAllConsistent(), is(false));
         // publish
         new ConsistentSettingsService(settings, clusterService, List.of(affixStringSetting)).newHashPublisher().onMaster();
+        consistentService.clusterChanged(null);
         assertThat(new ConsistentSettingsService(settings, clusterService, List.of(affixStringSetting)).areAllConsistent(), is(true));
         // remove value
         secureSettings = new MockSecureSettings();


### PR DESCRIPTION
These two changes allow the `ConsistentSettingsService` to be used with the new hash processor:

1. The consistency of a setting relative to the current master node can change only when the cluster's master node changes, so the consistency of settings can be cached and re-computed only when the cluster's master node changes. The hash processor must ensure that its hash key is consistent on every execution and checking this cached value will be faster.
1. The hash processor should fail only if its own hash key is inconsistent, not if other unrelated settings are inconsistent. The overloaded `areAllConsistent(Collection<Setting<?>>)` method allows the hash processor to query the consistency of only the settings that are relevant to it.
