### PR TITLE
Remove dead leniency in allow rebalance setting use

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ClusterRebalanceAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ClusterRebalanceAllocationDecider.java
@@ -95,16 +95,8 @@ public class ClusterRebalanceAllocationDecider extends AllocationDecider {
     private volatile ClusterRebalanceType type;
 
     public ClusterRebalanceAllocationDecider(Settings settings, ClusterSettings clusterSettings) {
-        try {
-            type = CLUSTER_ROUTING_ALLOCATION_ALLOW_REBALANCE_SETTING.get(settings);
-        } catch (IllegalStateException e) {
-            logger.warn("[{}] has a wrong value {}, defaulting to 'indices_all_active'",
-                    CLUSTER_ROUTING_ALLOCATION_ALLOW_REBALANCE_SETTING,
-                    CLUSTER_ROUTING_ALLOCATION_ALLOW_REBALANCE_SETTING.getRaw(settings));
-            type = ClusterRebalanceType.INDICES_ALL_ACTIVE;
-        }
+        type = CLUSTER_ROUTING_ALLOCATION_ALLOW_REBALANCE_SETTING.get(settings);
         logger.debug("using [{}] with [{}]", CLUSTER_ROUTING_ALLOCATION_ALLOW_REBALANCE, type);
-
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_ALLOCATION_ALLOW_REBALANCE_SETTING, this::setType);
     }
 


### PR DESCRIPTION
This commit removes some leniency that exists in getting the allow rebalance setting. Fortunately, that leniency is dead code, this can never happen. The reason this can never happen is because the settings infrastructure will not allow setting an invalid value for this setting. If you try to set this in the elasticsearch.yml, then the node will fail to start, since parsing the setting will fail. If you try to set this via an update settings API call, then parsing the setting will fail and the settings update will be rejected. Therefore, this leniency can never be activated, so we remove it.

This commit is the first of a few in an attempt to remove the public uses of Setting#getRaw.

Relates #47258
