### PR TITLE
Remove use of Setting#getRaw in deprecation tests

### DIFF
--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/TestDeprecationHeaderRestAction.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/TestDeprecationHeaderRestAction.java
@@ -100,7 +100,7 @@ public class TestDeprecationHeaderRestAction extends BaseRestHandler {
 
             builder.startObject().startArray("settings");
             for (String setting : settings) {
-                builder.startObject().field(setting, SETTINGS_MAP.get(setting).getRaw(this.settings)).endObject();
+                builder.startObject().field(setting, SETTINGS_MAP.get(setting).get(this.settings)).endObject();
             }
             builder.endArray().endObject();
             channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));


### PR DESCRIPTION
This commit removes a use of Setting#getRaw from the deprecation header tests. The use of Setting#getRaw is not needed here, the x-content infrastructure will take care of emitting the appropriate values here, and so the caller does not need to convert these to string representations of the settings values.

Relates #47258