### PR TITLE
Remove unused pluggable metadata upgraders

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
@@ -38,11 +38,9 @@ import org.elasticsearch.indices.mapper.MapperRegistry;
 import org.elasticsearch.script.ScriptService;
 
 import java.util.AbstractMap;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.UnaryOperator;
 
 /**
  * This service is responsible for upgrading legacy index metadata to the current version
@@ -60,22 +58,13 @@ public class MetaDataIndexUpgradeService {
     private final NamedXContentRegistry xContentRegistry;
     private final MapperRegistry mapperRegistry;
     private final IndexScopedSettings indexScopedSettings;
-    private final UnaryOperator<IndexMetaData> upgraders;
 
     public MetaDataIndexUpgradeService(Settings settings, NamedXContentRegistry xContentRegistry, MapperRegistry mapperRegistry,
-                                       IndexScopedSettings indexScopedSettings,
-                                       Collection<UnaryOperator<IndexMetaData>> indexMetaDataUpgraders) {
+                                       IndexScopedSettings indexScopedSettings) {
         this.settings = settings;
         this.xContentRegistry = xContentRegistry;
         this.mapperRegistry = mapperRegistry;
         this.indexScopedSettings = indexScopedSettings;
-        this.upgraders = indexMetaData -> {
-            IndexMetaData newIndexMetaData = indexMetaData;
-            for (UnaryOperator<IndexMetaData> upgrader : indexMetaDataUpgraders) {
-                newIndexMetaData = upgrader.apply(newIndexMetaData);
-            }
-            return newIndexMetaData;
-        };
     }
 
     /**
@@ -95,14 +84,11 @@ public class MetaDataIndexUpgradeService {
             return archiveBrokenIndexSettings(indexMetaData);
         }
         checkSupportedVersion(indexMetaData, minimumIndexCompatibilityVersion);
-        IndexMetaData newMetaData = indexMetaData;
         // we have to run this first otherwise in we try to create IndexSettings
         // with broken settings and fail in checkMappingsCompatibility
-        newMetaData = archiveBrokenIndexSettings(newMetaData);
+        final IndexMetaData newMetaData = archiveBrokenIndexSettings(indexMetaData);
         // only run the check with the upgraded settings!!
         checkMappingsCompatibility(newMetaData);
-        // apply plugin checks
-        newMetaData = upgraders.apply(newMetaData);
         return markAsUpgraded(newMetaData);
     }
 

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -33,6 +33,7 @@ import org.elasticsearch.cluster.ClusterStateApplier;
 import org.elasticsearch.cluster.coordination.CoordinationState.PersistedState;
 import org.elasticsearch.cluster.coordination.InMemoryPersistedState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
 import org.elasticsearch.cluster.metadata.Manifest;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.metadata.MetaDataIndexUpgradeService;
@@ -213,7 +214,6 @@ public class GatewayMetaState {
      * Elasticsearch 2.0 removed several deprecated features and as well as support for Lucene 3.x. This method calls
      * {@link MetaDataIndexUpgradeService} to makes sure that indices are compatible with the current version. The
      * MetaDataIndexUpgradeService might also update obsolete settings if needed.
-     * Allows upgrading global custom meta data via {@link MetaDataUpgrader#customMetaDataUpgraders}
      *
      * @return input <code>metaData</code> if no upgrade is needed or an upgraded metaData
      */
@@ -229,11 +229,6 @@ public class GatewayMetaState {
             changed |= indexMetaData != newMetaData;
             upgradedMetaData.put(newMetaData, false);
         }
-        // upgrade global custom meta data
-        if (applyPluginUpgraders(metaData.getCustoms(), metaDataUpgrader.customMetaDataUpgraders,
-                upgradedMetaData::removeCustom, upgradedMetaData::putCustom)) {
-            changed = true;
-        }
         // upgrade current templates
         if (applyPluginUpgraders(metaData.getTemplates(), metaDataUpgrader.indexTemplateMetaDataUpgraders,
                 upgradedMetaData::removeTemplate, (s, indexTemplateMetaData) -> upgradedMetaData.put(indexTemplateMetaData))) {
@@ -242,21 +237,21 @@ public class GatewayMetaState {
         return changed ? upgradedMetaData.build() : metaData;
     }
 
-    private static <Data> boolean applyPluginUpgraders(ImmutableOpenMap<String, Data> existingData,
-                                                       UnaryOperator<Map<String, Data>> upgrader,
-                                                       Consumer<String> removeData,
-                                                       BiConsumer<String, Data> putData) {
+    private static boolean applyPluginUpgraders(ImmutableOpenMap<String, IndexTemplateMetaData> existingData,
+                                                UnaryOperator<Map<String, IndexTemplateMetaData>> upgrader,
+                                                Consumer<String> removeData,
+                                                BiConsumer<String, IndexTemplateMetaData> putData) {
         // collect current data
-        Map<String, Data> existingMap = new HashMap<>();
-        for (ObjectObjectCursor<String, Data> customCursor : existingData) {
+        Map<String, IndexTemplateMetaData> existingMap = new HashMap<>();
+        for (ObjectObjectCursor<String, IndexTemplateMetaData> customCursor : existingData) {
             existingMap.put(customCursor.key, customCursor.value);
         }
         // upgrade global custom meta data
-        Map<String, Data> upgradedCustoms = upgrader.apply(existingMap);
+        Map<String, IndexTemplateMetaData> upgradedCustoms = upgrader.apply(existingMap);
         if (upgradedCustoms.equals(existingMap) == false) {
             // remove all data first so a plugin can remove custom metadata or templates if needed
             existingMap.keySet().forEach(removeData);
-            for (Map.Entry<String, Data> upgradedCustomEntry : upgradedCustoms.entrySet()) {
+            for (Map.Entry<String, IndexTemplateMetaData> upgradedCustomEntry : upgradedCustoms.entrySet()) {
                 putData.accept(upgradedCustomEntry.getKey(), upgradedCustomEntry.getValue());
             }
             return true;

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -461,19 +461,13 @@ public class Node implements Closeable {
             final NetworkModule networkModule = new NetworkModule(settings, false, pluginsService.filterPlugins(NetworkPlugin.class),
                 threadPool, bigArrays, pageCacheRecycler, circuitBreakerService, namedWriteableRegistry, xContentRegistry,
                 networkService, restController);
-            Collection<UnaryOperator<Map<String, MetaData.Custom>>> customMetaDataUpgraders =
-                pluginsService.filterPlugins(Plugin.class).stream()
-                    .map(Plugin::getCustomMetaDataUpgrader)
-                    .collect(Collectors.toList());
             Collection<UnaryOperator<Map<String, IndexTemplateMetaData>>> indexTemplateMetaDataUpgraders =
                 pluginsService.filterPlugins(Plugin.class).stream()
                     .map(Plugin::getIndexTemplateMetaDataUpgrader)
                     .collect(Collectors.toList());
-            Collection<UnaryOperator<IndexMetaData>> indexMetaDataUpgraders = pluginsService.filterPlugins(Plugin.class).stream()
-                    .map(Plugin::getIndexMetaDataUpgrader).collect(Collectors.toList());
-            final MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(customMetaDataUpgraders, indexTemplateMetaDataUpgraders);
+            final MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(indexTemplateMetaDataUpgraders);
             final MetaDataIndexUpgradeService metaDataIndexUpgradeService = new MetaDataIndexUpgradeService(settings, xContentRegistry,
-                indicesModule.getMapperRegistry(), settingsModule.getIndexScopedSettings(), indexMetaDataUpgraders);
+                indicesModule.getMapperRegistry(), settingsModule.getIndexScopedSettings());
             new TemplateUpgradeService(client, clusterService, threadPool, indexTemplateMetaDataUpgraders);
             final Transport transport = networkModule.getTransportSupplier().get();
             Set<String> taskHeaders = Stream.concat(

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -47,7 +47,6 @@ import org.elasticsearch.cluster.InternalClusterInfoService;
 import org.elasticsearch.cluster.NodeConnectionsService;
 import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
 import org.elasticsearch.cluster.metadata.AliasValidator;
-import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.metadata.MetaDataCreateIndexService;

--- a/server/src/main/java/org/elasticsearch/plugins/MetaDataUpgrader.java
+++ b/server/src/main/java/org/elasticsearch/plugins/MetaDataUpgrader.java
@@ -31,20 +31,9 @@ import java.util.function.UnaryOperator;
  * Upgrades {@link MetaData} on startup on behalf of installed {@link Plugin}s
  */
 public class MetaDataUpgrader {
-    public final UnaryOperator<Map<String, MetaData.Custom>> customMetaDataUpgraders;
-
     public final UnaryOperator<Map<String, IndexTemplateMetaData>> indexTemplateMetaDataUpgraders;
 
-    public MetaDataUpgrader(Collection<UnaryOperator<Map<String, MetaData.Custom>>> customMetaDataUpgraders,
-                            Collection<UnaryOperator<Map<String, IndexTemplateMetaData>>> indexTemplateMetaDataUpgraders) {
-        this.customMetaDataUpgraders = customs -> {
-            Map<String, MetaData.Custom> upgradedCustoms = new HashMap<>(customs);
-            for (UnaryOperator<Map<String, MetaData.Custom>> customMetaDataUpgrader : customMetaDataUpgraders) {
-                upgradedCustoms = customMetaDataUpgrader.apply(upgradedCustoms);
-            }
-            return upgradedCustoms;
-        };
-
+    public MetaDataUpgrader(Collection<UnaryOperator<Map<String, IndexTemplateMetaData>>> indexTemplateMetaDataUpgraders) {
         this.indexTemplateMetaDataUpgraders = templates -> {
             Map<String, IndexTemplateMetaData> upgradedTemplates = new HashMap<>(templates);
             for (UnaryOperator<Map<String, IndexTemplateMetaData>> upgrader : indexTemplateMetaDataUpgraders) {

--- a/server/src/main/java/org/elasticsearch/plugins/Plugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/Plugin.java
@@ -22,7 +22,6 @@ package org.elasticsearch.plugins;
 import org.elasticsearch.bootstrap.BootstrapCheck;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;

--- a/server/src/main/java/org/elasticsearch/plugins/Plugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/Plugin.java
@@ -173,22 +173,6 @@ public abstract class Plugin implements Closeable {
     }
 
     /**
-     * Provides a function to modify global custom meta data on startup.
-     * <p>
-     * Plugins should return the input custom map via {@link UnaryOperator#identity()} if no upgrade is required.
-     * <p>
-     * The order of custom meta data upgraders calls is undefined and can change between runs so, it is expected that
-     * plugins will modify only data owned by them to avoid conflicts.
-     * <p>
-     * @return Never {@code null}. The same or upgraded {@code MetaData.Custom} map.
-     * @throws IllegalStateException if the node should not start because at least one {@code MetaData.Custom}
-     *                               is unsupported
-     */
-    public UnaryOperator<Map<String, MetaData.Custom>> getCustomMetaDataUpgrader() {
-        return UnaryOperator.identity();
-    }
-
-    /**
      * Provides a function to modify index template meta data on startup.
      * <p>
      * Plugins should return the input template map via {@link UnaryOperator#identity()} if no upgrade is required.
@@ -201,21 +185,6 @@ public abstract class Plugin implements Closeable {
      *                               cannot be upgraded
      */
     public UnaryOperator<Map<String, IndexTemplateMetaData>> getIndexTemplateMetaDataUpgrader() {
-        return UnaryOperator.identity();
-    }
-
-    /**
-     * Provides a function to modify index meta data when an index is introduced into the cluster state for the first time.
-     * <p>
-     * Plugins should return the input index metadata via {@link UnaryOperator#identity()} if no upgrade is required.
-     * <p>
-     * The order of the index upgrader calls for the same index is undefined and can change between runs so, it is expected that
-     * plugins will modify only indices owned by them to avoid conflicts.
-     * <p>
-     * @return Never {@code null}. The same or upgraded {@code IndexMetaData}.
-     * @throws IllegalStateException if the node should not start because the index is unsupported
-     */
-    public UnaryOperator<IndexMetaData> getIndexMetaDataUpgrader() {
         return UnaryOperator.identity();
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeServiceTests.java
@@ -116,44 +116,12 @@ public class MetaDataIndexUpgradeServiceTests extends ESTestCase {
         service.upgradeIndexMetaData(goodMeta, Version.CURRENT.minimumIndexCompatibilityVersion());
     }
 
-    public void testPluginUpgrade() {
-        MetaDataIndexUpgradeService service = new MetaDataIndexUpgradeService(Settings.EMPTY, xContentRegistry(),
-            new MapperRegistry(Collections.emptyMap(), Collections.emptyMap(), MapperPlugin.NOOP_FIELD_FILTER),
-                IndexScopedSettings.DEFAULT_SCOPED_SETTINGS, Collections.singletonList(
-                        indexMetaData -> IndexMetaData.builder(indexMetaData).settings(
-                            Settings.builder()
-                                .put(indexMetaData.getSettings())
-                                .put("index.refresh_interval", "10s")
-                        ).build()));
-        IndexMetaData src = newIndexMeta("foo", Settings.builder().put("index.refresh_interval", "200s").build());
-        assertFalse(service.isUpgraded(src));
-        src = service.upgradeIndexMetaData(src, Version.CURRENT.minimumIndexCompatibilityVersion());
-        assertTrue(service.isUpgraded(src));
-        assertEquals("10s", src.getSettings().get("index.refresh_interval"));
-        assertSame(src, service.upgradeIndexMetaData(src, Version.CURRENT.minimumIndexCompatibilityVersion())); // no double upgrade
-    }
-
-    public void testPluginUpgradeFailure() {
-        MetaDataIndexUpgradeService service = new MetaDataIndexUpgradeService(Settings.EMPTY, xContentRegistry(),
-            new MapperRegistry(Collections.emptyMap(), Collections.emptyMap(), MapperPlugin.NOOP_FIELD_FILTER),
-                IndexScopedSettings.DEFAULT_SCOPED_SETTINGS, Collections.singletonList(
-                    indexMetaData -> {
-                        throw new IllegalStateException("Cannot upgrade index " + indexMetaData.getIndex().getName());
-                    }
-                ));
-        IndexMetaData src = newIndexMeta("foo", Settings.EMPTY);
-        String message = expectThrows(IllegalStateException.class, () -> service.upgradeIndexMetaData(src,
-            Version.CURRENT.minimumIndexCompatibilityVersion())).getMessage();
-        assertEquals(message, "Cannot upgrade index foo");
-    }
-
     private MetaDataIndexUpgradeService getMetaDataIndexUpgradeService() {
         return new MetaDataIndexUpgradeService(
             Settings.EMPTY,
             xContentRegistry(),
             new MapperRegistry(Collections.emptyMap(), Collections.emptyMap(), MapperPlugin.NOOP_FIELD_FILTER),
-            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
-            Collections.emptyList());
+            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS);
     }
 
     public static IndexMetaData newIndexMeta(String name, Settings indexSettings) {

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
@@ -127,22 +127,22 @@ public class GatewayMetaStateTests extends ESTestCase {
                 throw new IllegalStateException("should never happen");
         }
         MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(Arrays.asList(
-                        indexTemplateMetaDatas -> {
-                            indexTemplateMetaDatas.put("template1", IndexTemplateMetaData.builder("template1")
-                                .patterns(randomIndexPatterns())
-                                .settings(Settings.builder().put(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 20).build())
-                                .build());
-                            return indexTemplateMetaDatas;
+                indexTemplateMetaDatas -> {
+                    indexTemplateMetaDatas.put("template1", IndexTemplateMetaData.builder("template1")
+                        .patterns(randomIndexPatterns())
+                        .settings(Settings.builder().put(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 20).build())
+                        .build());
+                    return indexTemplateMetaDatas;
 
-                        },
-                        indexTemplateMetaDatas -> {
-                            indexTemplateMetaDatas.put("template2", IndexTemplateMetaData.builder("template2")
-                                .patterns(randomIndexPatterns())
-                                .settings(Settings.builder().put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 10).build()).build());
-                            return indexTemplateMetaDatas;
+                },
+                indexTemplateMetaDatas -> {
+                    indexTemplateMetaDatas.put("template2", IndexTemplateMetaData.builder("template2")
+                        .patterns(randomIndexPatterns())
+                        .settings(Settings.builder().put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 10).build()).build());
+                    return indexTemplateMetaDatas;
 
-                        }
-                    ));
+                }
+            ));
         MetaData upgrade = GatewayMetaState.upgradeMetaData(metaData, new MockMetaDataIndexUpgradeService(false), metaDataUpgrader);
         assertNotSame(upgrade, metaData);
         assertFalse(MetaData.isGlobalStateEquals(upgrade, metaData));

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
@@ -33,96 +33,43 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
 
 import static org.hamcrest.Matchers.equalTo;
 
 public class GatewayMetaStateTests extends ESTestCase {
 
-    public void testAddCustomMetaDataOnUpgrade() throws Exception {
+    public void testUpdateTemplateMetaDataOnUpgrade() {
         MetaData metaData = randomMetaData();
-        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(
-            Collections.singletonList(customs -> {
-                customs.put(CustomMetaData1.TYPE, new CustomMetaData1("modified_data1"));
-                return customs;
-            }),
-            Collections.emptyList()
-        );
-        MetaData upgrade = GatewayMetaState.upgradeMetaData(metaData, new MockMetaDataIndexUpgradeService(false), metaDataUpgrader);
-        assertTrue(upgrade != metaData);
-        assertFalse(MetaData.isGlobalStateEquals(upgrade, metaData));
-        assertNotNull(upgrade.custom(CustomMetaData1.TYPE));
-        assertThat(((TestCustomMetaData) upgrade.custom(CustomMetaData1.TYPE)).getData(), equalTo("modified_data1"));
-    }
-
-    public void testRemoveCustomMetaDataOnUpgrade() throws Exception {
-        MetaData metaData = randomMetaData(new CustomMetaData1("data"));
-        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(
-            Collections.singletonList(customs -> {
-                customs.remove(CustomMetaData1.TYPE);
-                return customs;
-            }),
-            Collections.emptyList()
-        );
-        MetaData upgrade = GatewayMetaState.upgradeMetaData(metaData, new MockMetaDataIndexUpgradeService(false), metaDataUpgrader);
-        assertTrue(upgrade != metaData);
-        assertFalse(MetaData.isGlobalStateEquals(upgrade, metaData));
-        assertNull(upgrade.custom(CustomMetaData1.TYPE));
-    }
-
-    public void testUpdateCustomMetaDataOnUpgrade() throws Exception {
-        MetaData metaData = randomMetaData(new CustomMetaData1("data"));
-        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(
-            Collections.singletonList(customs -> {
-                customs.put(CustomMetaData1.TYPE, new CustomMetaData1("modified_data1"));
-                return customs;
-            }),
-            Collections.emptyList()
-        );
+        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(Collections.singletonList(
+                        templates -> {
+                            templates.put("added_test_template", IndexTemplateMetaData.builder("added_test_template")
+                                .patterns(randomIndexPatterns()).build());
+                            return templates;
+                        }
+                    ));
 
         MetaData upgrade = GatewayMetaState.upgradeMetaData(metaData, new MockMetaDataIndexUpgradeService(false), metaDataUpgrader);
-        assertTrue(upgrade != metaData);
-        assertFalse(MetaData.isGlobalStateEquals(upgrade, metaData));
-        assertNotNull(upgrade.custom(CustomMetaData1.TYPE));
-        assertThat(((TestCustomMetaData) upgrade.custom(CustomMetaData1.TYPE)).getData(), equalTo("modified_data1"));
-    }
-
-
-    public void testUpdateTemplateMetaDataOnUpgrade() throws Exception {
-        MetaData metaData = randomMetaData();
-        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(
-            Collections.emptyList(),
-            Collections.singletonList(
-                templates -> {
-                    templates.put("added_test_template", IndexTemplateMetaData.builder("added_test_template")
-                        .patterns(Arrays.asList(generateRandomStringArray(10, 100, false, false))).build());
-                    return templates;
-                }
-            ));
-
-        MetaData upgrade = GatewayMetaState.upgradeMetaData(metaData, new MockMetaDataIndexUpgradeService(false), metaDataUpgrader);
-        assertTrue(upgrade != metaData);
+        assertNotSame(upgrade, metaData);
         assertFalse(MetaData.isGlobalStateEquals(upgrade, metaData));
         assertTrue(upgrade.templates().containsKey("added_test_template"));
     }
 
-    public void testNoMetaDataUpgrade() throws Exception {
+    public void testNoMetaDataUpgrade() {
         MetaData metaData = randomMetaData(new CustomMetaData1("data"));
-        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(Collections.emptyList(), Collections.emptyList());
+        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(Collections.emptyList());
         MetaData upgrade = GatewayMetaState.upgradeMetaData(metaData, new MockMetaDataIndexUpgradeService(false), metaDataUpgrader);
-        assertTrue(upgrade == metaData);
+        assertSame(upgrade, metaData);
         assertTrue(MetaData.isGlobalStateEquals(upgrade, metaData));
         for (IndexMetaData indexMetaData : upgrade) {
             assertTrue(metaData.hasIndexMetaData(indexMetaData));
         }
     }
 
-    public void testCustomMetaDataValidation() throws Exception {
+    public void testCustomMetaDataValidation() {
         MetaData metaData = randomMetaData(new CustomMetaData1("data"));
-        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(Collections.singletonList(
-            customs -> {
-                throw new IllegalStateException("custom meta data too old");
-            }
-        ), Collections.emptyList());
+        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(Collections.emptyList());
         try {
             GatewayMetaState.upgradeMetaData(metaData, new MockMetaDataIndexUpgradeService(false), metaDataUpgrader);
         } catch (IllegalStateException e) {
@@ -130,82 +77,41 @@ public class GatewayMetaStateTests extends ESTestCase {
         }
     }
 
-    public void testMultipleCustomMetaDataUpgrade() throws Exception {
-        final MetaData metaData;
-        switch (randomIntBetween(0, 2)) {
-            case 0:
-                metaData = randomMetaData(new CustomMetaData1("data1"), new CustomMetaData2("data2"));
-                break;
-            case 1:
-                metaData = randomMetaData(randomBoolean() ? new CustomMetaData1("data1") : new CustomMetaData2("data2"));
-                break;
-            case 2:
-                metaData = randomMetaData();
-                break;
-            default:
-                throw new IllegalStateException("should never happen");
-        }
-        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(
-            Arrays.asList(
-                customs -> {
-                    customs.put(CustomMetaData1.TYPE, new CustomMetaData1("modified_data1"));
-                    return customs;
-                },
-                customs -> {
-                    customs.put(CustomMetaData2.TYPE, new CustomMetaData1("modified_data2"));
-                    return customs;
-                }
-            ), Collections.emptyList());
-        MetaData upgrade = GatewayMetaState.upgradeMetaData(metaData, new MockMetaDataIndexUpgradeService(false), metaDataUpgrader);
-        assertTrue(upgrade != metaData);
-        assertFalse(MetaData.isGlobalStateEquals(upgrade, metaData));
-        assertNotNull(upgrade.custom(CustomMetaData1.TYPE));
-        assertThat(((TestCustomMetaData) upgrade.custom(CustomMetaData1.TYPE)).getData(), equalTo("modified_data1"));
-        assertNotNull(upgrade.custom(CustomMetaData2.TYPE));
-        assertThat(((TestCustomMetaData) upgrade.custom(CustomMetaData2.TYPE)).getData(), equalTo("modified_data2"));
-        for (IndexMetaData indexMetaData : upgrade) {
-            assertTrue(metaData.hasIndexMetaData(indexMetaData));
-        }
-    }
-
-    public void testIndexMetaDataUpgrade() throws Exception {
+    public void testIndexMetaDataUpgrade() {
         MetaData metaData = randomMetaData();
-        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(Collections.emptyList(), Collections.emptyList());
+        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(Collections.emptyList());
         MetaData upgrade = GatewayMetaState.upgradeMetaData(metaData, new MockMetaDataIndexUpgradeService(true), metaDataUpgrader);
-        assertTrue(upgrade != metaData);
+        assertNotSame(upgrade, metaData);
         assertTrue(MetaData.isGlobalStateEquals(upgrade, metaData));
         for (IndexMetaData indexMetaData : upgrade) {
             assertFalse(metaData.hasIndexMetaData(indexMetaData));
         }
     }
 
-    public void testCustomMetaDataNoChange() throws Exception {
+    public void testCustomMetaDataNoChange() {
         MetaData metaData = randomMetaData(new CustomMetaData1("data"));
-        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(Collections.singletonList(HashMap::new),
-            Collections.singletonList(HashMap::new));
+        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(Collections.singletonList(HashMap::new));
         MetaData upgrade = GatewayMetaState.upgradeMetaData(metaData, new MockMetaDataIndexUpgradeService(false), metaDataUpgrader);
-        assertTrue(upgrade == metaData);
+        assertSame(upgrade, metaData);
         assertTrue(MetaData.isGlobalStateEquals(upgrade, metaData));
         for (IndexMetaData indexMetaData : upgrade) {
             assertTrue(metaData.hasIndexMetaData(indexMetaData));
         }
     }
 
-    public void testIndexTemplateValidation() throws Exception {
+    public void testIndexTemplateValidation() {
         MetaData metaData = randomMetaData();
-        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(
-            Collections.emptyList(),
-            Collections.singletonList(
-                customs -> {
-                    throw new IllegalStateException("template is incompatible");
-                }));
+        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(Collections.singletonList(
+                        customs -> {
+                            throw new IllegalStateException("template is incompatible");
+                        }));
         String message = expectThrows(IllegalStateException.class,
             () -> GatewayMetaState.upgradeMetaData(metaData, new MockMetaDataIndexUpgradeService(false), metaDataUpgrader)).getMessage();
         assertThat(message, equalTo("template is incompatible"));
     }
 
 
-    public void testMultipleIndexTemplateUpgrade() throws Exception {
+    public void testMultipleIndexTemplateUpgrade() {
         final MetaData metaData;
         switch (randomIntBetween(0, 2)) {
             case 0:
@@ -220,27 +126,25 @@ public class GatewayMetaStateTests extends ESTestCase {
             default:
                 throw new IllegalStateException("should never happen");
         }
-        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(
-            Collections.emptyList(),
-            Arrays.asList(
-                indexTemplateMetaDatas -> {
-                    indexTemplateMetaDatas.put("template1", IndexTemplateMetaData.builder("template1")
-                        .patterns(Arrays.asList(generateRandomStringArray(10, 100, false, false)))
-                        .settings(Settings.builder().put(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 20).build())
-                        .build());
-                    return indexTemplateMetaDatas;
+        MetaDataUpgrader metaDataUpgrader = new MetaDataUpgrader(Arrays.asList(
+                        indexTemplateMetaDatas -> {
+                            indexTemplateMetaDatas.put("template1", IndexTemplateMetaData.builder("template1")
+                                .patterns(randomIndexPatterns())
+                                .settings(Settings.builder().put(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 20).build())
+                                .build());
+                            return indexTemplateMetaDatas;
 
-                },
-                indexTemplateMetaDatas -> {
-                    indexTemplateMetaDatas.put("template2", IndexTemplateMetaData.builder("template2")
-                        .patterns(Arrays.asList(generateRandomStringArray(10, 100, false, false)))
-                        .settings(Settings.builder().put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 10).build()).build());
-                    return indexTemplateMetaDatas;
+                        },
+                        indexTemplateMetaDatas -> {
+                            indexTemplateMetaDatas.put("template2", IndexTemplateMetaData.builder("template2")
+                                .patterns(randomIndexPatterns())
+                                .settings(Settings.builder().put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 10).build()).build());
+                            return indexTemplateMetaDatas;
 
-                }
-            ));
+                        }
+                    ));
         MetaData upgrade = GatewayMetaState.upgradeMetaData(metaData, new MockMetaDataIndexUpgradeService(false), metaDataUpgrader);
-        assertTrue(upgrade != metaData);
+        assertNotSame(upgrade, metaData);
         assertFalse(MetaData.isGlobalStateEquals(upgrade, metaData));
         assertNotNull(upgrade.templates().get("template1"));
         assertThat(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.get(upgrade.templates().get("template1").settings()), equalTo(20));
@@ -255,7 +159,7 @@ public class GatewayMetaStateTests extends ESTestCase {
         private final boolean upgrade;
 
         MockMetaDataIndexUpgradeService(boolean upgrade) {
-            super(Settings.EMPTY, null, null, null, null);
+            super(Settings.EMPTY, null, null, null);
             this.upgrade = upgrade;
         }
 
@@ -268,30 +172,7 @@ public class GatewayMetaStateTests extends ESTestCase {
     private static class CustomMetaData1 extends TestCustomMetaData {
         public static final String TYPE = "custom_md_1";
 
-        protected CustomMetaData1(String data) {
-            super(data);
-        }
-
-        @Override
-        public String getWriteableName() {
-            return TYPE;
-        }
-
-        @Override
-        public Version getMinimalSupportedVersion() {
-            return Version.CURRENT;
-        }
-
-        @Override
-        public EnumSet<MetaData.XContentContext> context() {
-            return EnumSet.of(MetaData.XContentContext.GATEWAY);
-        }
-    }
-
-    private static class CustomMetaData2 extends TestCustomMetaData {
-        public static final String TYPE = "custom_md_2";
-
-        protected CustomMetaData2(String data) {
+        CustomMetaData1(String data) {
             super(data);
         }
 
@@ -334,7 +215,7 @@ public class GatewayMetaStateTests extends ESTestCase {
                 .settings(settings(Version.CURRENT)
                     .put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), randomIntBetween(0, 3))
                     .put(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), randomIntBetween(1, 5)))
-                .patterns(Arrays.asList(generateRandomStringArray(10, 100, false, false)))
+                .patterns(randomIndexPatterns())
                 .build();
             builder.put(templateMetaData);
         }
@@ -347,5 +228,9 @@ public class GatewayMetaStateTests extends ESTestCase {
             );
         }
         return builder.build();
+    }
+
+    private static List<String> randomIndexPatterns() {
+        return Arrays.asList(Objects.requireNonNull(generateRandomStringArray(10, 100, false, false)));
     }
 }

--- a/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
@@ -182,8 +182,7 @@ public class ClusterStateChanges {
             TransportService.NOOP_TRANSPORT_INTERCEPTOR,
             boundAddress -> DiscoveryNode.createLocal(SETTINGS, boundAddress.publishAddress(), UUIDs.randomBase64UUID()), clusterSettings,
             Collections.emptySet());
-        MetaDataIndexUpgradeService metaDataIndexUpgradeService = new MetaDataIndexUpgradeService(SETTINGS, xContentRegistry, null, null,
-            null) {
+        MetaDataIndexUpgradeService metaDataIndexUpgradeService = new MetaDataIndexUpgradeService(SETTINGS, xContentRegistry, null, null) {
             // metaData upgrader should do nothing
             @Override
             public IndexMetaData upgradeIndexMetaData(IndexMetaData indexMetaData, Version minimumIndexCompatibilityVersion) {

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -1077,9 +1077,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
                     new MetaDataIndexUpgradeService(
                         settings, namedXContentRegistry,
                         mapperRegistry,
-                        indexScopedSettings,
-                        Collections.emptyList()
-                    ),
+                        indexScopedSettings),
                     clusterSettings
                 );
                 actions.put(PutMappingAction.INSTANCE,


### PR DESCRIPTION
Today plugins may provide upgraders for custom metadata and index metadata, but
these upgraders are bypassed during a rolling restart. Fortunately this
extension mechanism is unused by all known plugins. This commit removes these
extension points.