### PR TITLE
Provide better error when updating geo_shape field mapper settings

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
@@ -105,6 +105,17 @@ public class GeoShapeFieldMapper extends AbstractGeometryFieldMapper<Geometry, G
     }
 
     @Override
+    protected void doMerge(Mapper mergeWith) {
+        if (mergeWith instanceof LegacyGeoShapeFieldMapper) {
+            LegacyGeoShapeFieldMapper legacy = (LegacyGeoShapeFieldMapper) mergeWith;
+            throw new IllegalArgumentException("[" + fieldType().name() + "] with field mapper [" + fieldType().typeName() + "] " +
+                "using [BKD] strategy cannot be merged with " + "[" + legacy.fieldType().typeName() + "] with [" +
+                legacy.fieldType().strategy() + "] strategy");
+        }
+        super.doMerge(mergeWith);
+    }
+
+    @Override
     public GeoShapeFieldType fieldType() {
         return (GeoShapeFieldType) super.fieldType();
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
@@ -534,6 +534,17 @@ public class LegacyGeoShapeFieldMapper extends AbstractGeometryFieldMapper<Shape
     }
 
     @Override
+    protected void doMerge(Mapper mergeWith) {
+        if (mergeWith instanceof GeoShapeFieldMapper) {
+            GeoShapeFieldMapper fieldMapper = (GeoShapeFieldMapper) mergeWith;
+            throw new IllegalArgumentException("[" + fieldType().name() + "] with field mapper [" + fieldType().typeName() + "] " +
+                "using [" + fieldType().strategy() + "] strategy cannot be merged with " + "[" + fieldMapper.typeName() +
+                "] with [BKD] strategy");
+        }
+        super.doMerge(mergeWith);
+    }
+
+    @Override
     protected String contentType() {
         return CONTENT_TYPE;
     }


### PR DESCRIPTION
Improve the error message when trying to merge `LegacyGeoShapeFieldMapper` and `GeoShapeFieldMapper` by updating mapping settings

Fixes #47006 