### PR TITLE
Differentiate base paths in repository integration tests

### DIFF
--- a/plugins/repository-azure/build.gradle
+++ b/plugins/repository-azure/build.gradle
@@ -88,7 +88,7 @@ task thirdPartyTest(type: Test) {
   systemProperty 'test.azure.key', azureKey ? azureKey : ""
   systemProperty 'test.azure.sas_token', azureSasToken ? azureSasToken : ""
   systemProperty 'test.azure.container', azureContainer ? azureContainer : ""
-  systemProperty 'test.azure.base', azureBasePath ? azureBasePath : ""
+  systemProperty 'test.azure.base', (azureBasePath ? azureBasePath : "") + "_third_party_tests_" + project.testSeed
 }
 
 if (azureAccount || azureKey || azureContainer || azureBasePath || azureSasToken) {

--- a/plugins/repository-azure/qa/microsoft-azure-storage/build.gradle
+++ b/plugins/repository-azure/qa/microsoft-azure-storage/build.gradle
@@ -54,7 +54,7 @@ task azureStorageFixture(type: AntFixture) {
 
 Map<String, Object> expansions = [
         'container': azureContainer,
-        'base_path': azureBasePath + "_integration_tests_" + project.testSeed
+        'base_path': azureBasePath + "_integration_tests"
 ]
 
 processTestResources {

--- a/plugins/repository-azure/qa/microsoft-azure-storage/build.gradle
+++ b/plugins/repository-azure/qa/microsoft-azure-storage/build.gradle
@@ -54,7 +54,7 @@ task azureStorageFixture(type: AntFixture) {
 
 Map<String, Object> expansions = [
         'container': azureContainer,
-        'base_path': azureBasePath
+        'base_path': azureBasePath + "_integration_tests_" + project.testSeed
 ]
 
 processTestResources {

--- a/plugins/repository-azure/qa/microsoft-azure-storage/src/test/resources/rest-api-spec/test/repository_azure/10_repository.yml
+++ b/plugins/repository-azure/qa/microsoft-azure-storage/src/test/resources/rest-api-spec/test/repository_azure/10_repository.yml
@@ -16,12 +16,8 @@ setup:
 ---
 "Snapshot/Restore with repository-azure":
   - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/47201"
-# BELOW 3 lines to be uncommented when un-muting
-#  - skip:
-#      version: " - 7.9.99"
-#      reason: "8.0 changes get snapshots response format"
+      version: " - 7.9.99"
+      reason: "8.0 changes get snapshots response format"
 
   # Get repository
   - do:

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageCleanupThirdPartyTests.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageCleanupThirdPartyTests.java
@@ -109,25 +109,4 @@ public class AzureStorageCleanupThirdPartyTests extends AbstractThirdPartyReposi
         }));
         future.actionGet();
     }
-
-    // override here to mute only for Azure, please remove this overload when un-muting
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/47202")
-    @Override
-    public void testCreateSnapshot() {
-        super.testCreateSnapshot();
-    }
-
-    // override here to mute only for Azure, please remove this overload when un-muting
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/47202")
-    @Override
-    public void testCleanup() throws Exception {
-        super.testCleanup();
-    }
-
-    // override here to mute only for Azure, please remove this overload when un-muting
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/47202")
-    @Override
-    public void testListChildren() throws Exception {
-        super.testListChildren();
-    }
 }

--- a/plugins/repository-gcs/build.gradle
+++ b/plugins/repository-gcs/build.gradle
@@ -1,5 +1,3 @@
-import java.nio.file.Files
-
 /*
  * Licensed to Elasticsearch under one or more contributor
  * license agreements. See the NOTICE file distributed with

--- a/plugins/repository-gcs/qa/google-cloud-storage/build.gradle
+++ b/plugins/repository-gcs/qa/google-cloud-storage/build.gradle
@@ -89,7 +89,7 @@ task thirdPartyTest (type: Test) {
     include '**/GoogleCloudStorageThirdPartyTests.class'
     systemProperty 'tests.security.manager', false
     systemProperty 'test.google.bucket', gcsBucket
-    systemProperty 'test.google.base', gcsBasePath
+    systemProperty 'test.google.base', gcsBasePath + "_third_party_tests_" + project.testSeed
     nonInputProperties.systemProperty 'test.google.account', "${ -> encodedCredentials.call() }"
 }
 
@@ -128,7 +128,7 @@ check.dependsOn thirdPartyTest
 
 Map<String, Object> expansions = [
         'bucket': gcsBucket,
-        'base_path': gcsBasePath
+        'base_path': gcsBasePath + "_integration_tests"
 ]
 
 processTestResources {

--- a/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsRepositoryTests.java
+++ b/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsRepositoryTests.java
@@ -47,8 +47,15 @@ public class HdfsRepositoryTests extends AbstractThirdPartyRepositoryTestCase {
     }
 
     @Override
+    public void tearDown() throws Exception {
+        if (isJava11() == false) {
+            super.tearDown();
+        }
+    }
+
+    @Override
     protected void createRepository(String repoName) {
-        assumeFalse("https://github.com/elastic/elasticsearch/issues/31498", JavaVersion.current().equals(JavaVersion.parse("11")));
+        assumeFalse("https://github.com/elastic/elasticsearch/issues/31498", isJava11());
         AcknowledgedResponse putRepositoryResponse = client().admin().cluster().preparePutRepository(repoName)
             .setType("hdfs")
             .setSettings(Settings.builder()
@@ -69,5 +76,9 @@ public class HdfsRepositoryTests extends AbstractThirdPartyRepositoryTestCase {
         } else {
             assertThat(response.result().blobs(), equalTo(0L));
         }
+    }
+
+    private static boolean isJava11() {
+        return JavaVersion.current().equals(JavaVersion.parse("11"));
     }
 }

--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -134,7 +134,7 @@ task thirdPartyTest(type: Test) {
   systemProperty 'test.s3.account', s3PermanentAccessKey
   systemProperty 'test.s3.key', s3PermanentSecretKey
   systemProperty 'test.s3.bucket', s3PermanentBucket
-  systemProperty 'test.s3.base', s3PermanentBasePath
+  systemProperty 'test.s3.base', s3PermanentBasePath + "_third_party_tests_" + project.testSeed
 }
 
 if (useFixture) {
@@ -248,9 +248,9 @@ task s3Fixture(type: AntFixture) {
 processTestResources {
   Map<String, Object> expansions = [
           'permanent_bucket': s3PermanentBucket,
-          'permanent_base_path': s3PermanentBasePath,
+          'permanent_base_path': s3PermanentBasePath + "_integration_tests",
           'temporary_bucket': s3TemporaryBucket,
-          'temporary_base_path': s3TemporaryBasePath,
+          'temporary_base_path': s3TemporaryBasePath + "_integration_tests",
           'ec2_bucket': s3EC2Bucket,
           'ec2_base_path': s3EC2BasePath,
           'ecs_bucket': s3ECSBucket,

--- a/test/framework/src/main/java/org/elasticsearch/repositories/AbstractThirdPartyRepositoryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/AbstractThirdPartyRepositoryTestCase.java
@@ -73,6 +73,12 @@ public abstract class AbstractThirdPartyRepositoryTestCase extends ESSingleNodeT
         deleteAndAssertEmpty(getRepository().basePath());
     }
 
+    @Override
+    public void tearDown() throws Exception {
+        deleteAndAssertEmpty(getRepository().basePath());
+        super.tearDown();
+    }
+
     private void deleteAndAssertEmpty(BlobPath path) throws Exception {
         final BlobStoreRepository repo = getRepository();
         final PlainActionFuture<Void> future = PlainActionFuture.newFuture();


### PR DESCRIPTION
This commit change the repositories base paths used in Azure integration tests so that they don't conflict with each other when tests run in parallel on real Azure storage service.

Closes #47202