### PR TITLE
Omit writing index metadata for non-replicated closed indices on data-only node

### DIFF
--- a/server/src/main/java/org/elasticsearch/gateway/IncrementalClusterStateWriter.java
+++ b/server/src/main/java/org/elasticsearch/gateway/IncrementalClusterStateWriter.java
@@ -230,15 +230,13 @@ public class IncrementalClusterStateWriter {
 
     // exposed for tests
     static Set<Index> getRelevantIndices(ClusterState state) {
-        Set<Index> relevantIndices;
         if (state.nodes().getLocalNode().isMasterNode()) {
-            relevantIndices = getRelevantIndicesForMasterEligibleNode(state);
+            return getRelevantIndicesForMasterEligibleNode(state);
         } else if (state.nodes().getLocalNode().isDataNode()) {
-            relevantIndices = getRelevantIndicesOnDataOnlyNode(state);
+            return getRelevantIndicesOnDataOnlyNode(state);
         } else {
-            relevantIndices = Collections.emptySet();
+            return Collections.emptySet();
         }
-        return relevantIndices;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/gateway/IncrementalClusterStateWriter.java
+++ b/server/src/main/java/org/elasticsearch/gateway/IncrementalClusterStateWriter.java
@@ -231,18 +231,14 @@ public class IncrementalClusterStateWriter {
     // exposed for tests
     static Set<Index> getRelevantIndices(ClusterState state) {
         Set<Index> relevantIndices;
-        if (isDataOnlyNode(state)) {
-            relevantIndices = getRelevantIndicesOnDataOnlyNode(state);
-        } else if (state.nodes().getLocalNode().isMasterNode()) {
+        if (state.nodes().getLocalNode().isMasterNode()) {
             relevantIndices = getRelevantIndicesForMasterEligibleNode(state);
+        } else if (state.nodes().getLocalNode().isDataNode()) {
+            relevantIndices = getRelevantIndicesOnDataOnlyNode(state);
         } else {
             relevantIndices = Collections.emptySet();
         }
         return relevantIndices;
-    }
-
-    private static boolean isDataOnlyNode(ClusterState state) {
-        return state.nodes().getLocalNode().isMasterNode() == false && state.nodes().getLocalNode().isDataNode();
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/gateway/IncrementalClusterStateWriterTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/IncrementalClusterStateWriterTests.java
@@ -153,44 +153,38 @@ public class IncrementalClusterStateWriterTests extends ESAllocationTestCase {
 
     public void testGetRelevantIndicesWithUnassignedShardsOnMasterEligibleNode() {
         IndexMetaData indexMetaData = createIndexMetaData("test");
-        Set<Index> indices = IncrementalClusterStateWriter.getRelevantIndices(
-            clusterStateWithUnassignedIndex(indexMetaData, true));
+        Set<Index> indices = IncrementalClusterStateWriter.getRelevantIndices(clusterStateWithUnassignedIndex(indexMetaData, true));
         assertThat(indices.size(), equalTo(1));
     }
 
     public void testGetRelevantIndicesWithUnassignedShardsOnDataOnlyNode() {
         IndexMetaData indexMetaData = createIndexMetaData("test");
-        Set<Index> indices = IncrementalClusterStateWriter.getRelevantIndices(
-            clusterStateWithUnassignedIndex(indexMetaData, false));
+        Set<Index> indices = IncrementalClusterStateWriter.getRelevantIndices(clusterStateWithUnassignedIndex(indexMetaData, false));
         assertThat(indices.size(), equalTo(0));
     }
 
     public void testGetRelevantIndicesWithAssignedShards() {
         IndexMetaData indexMetaData = createIndexMetaData("test");
         boolean masterEligible = randomBoolean();
-        Set<Index> indices = IncrementalClusterStateWriter.getRelevantIndices(
-            clusterStateWithAssignedIndex(indexMetaData, masterEligible));
+        Set<Index> indices = IncrementalClusterStateWriter.getRelevantIndices(clusterStateWithAssignedIndex(indexMetaData, masterEligible));
         assertThat(indices.size(), equalTo(1));
     }
 
     public void testGetRelevantIndicesForClosedPrevWrittenIndexOnDataOnlyNode() {
         IndexMetaData indexMetaData = createIndexMetaData("test");
-        Set<Index> indices = IncrementalClusterStateWriter.getRelevantIndices(
-            clusterStateWithClosedIndex(indexMetaData, false));
+        Set<Index> indices = IncrementalClusterStateWriter.getRelevantIndices(clusterStateWithClosedIndex(indexMetaData, false));
         assertThat(indices.size(), equalTo(0));
     }
 
     public void testGetRelevantIndicesForClosedPrevNotWrittenIndexOnDataOnlyNode() {
         IndexMetaData indexMetaData = createIndexMetaData("test");
-        Set<Index> indices = IncrementalClusterStateWriter.getRelevantIndices(
-            clusterStateWithJustOpenedIndex(indexMetaData, false));
+        Set<Index> indices = IncrementalClusterStateWriter.getRelevantIndices(clusterStateWithJustOpenedIndex(indexMetaData, false));
         assertThat(indices.size(), equalTo(0));
     }
 
     public void testGetRelevantIndicesForWasClosedPrevWrittenIndexOnDataOnlyNode() {
         IndexMetaData indexMetaData = createIndexMetaData("test");
-        Set<Index> indices = IncrementalClusterStateWriter.getRelevantIndices(
-            clusterStateWithJustOpenedIndex(indexMetaData, false));
+        Set<Index> indices = IncrementalClusterStateWriter.getRelevantIndices(clusterStateWithJustOpenedIndex(indexMetaData, false));
         assertThat(indices.size(), equalTo(0));
     }
 

--- a/server/src/test/java/org/elasticsearch/indices/state/CloseIndexIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/state/CloseIndexIT.java
@@ -432,6 +432,31 @@ public class CloseIndexIT extends ESIntegTestCase {
         }
     }
 
+    /**
+     * Test for https://github.com/elastic/elasticsearch/issues/47276 which checks that the persisted metadata on a data node does not
+     * become inconsistent when using replicated closed indices.
+     */
+    public void testRelocatedClosedIndexIssue() throws Exception {
+        final String indexName = "closed-index";
+        final List<String> dataNodes = internalCluster().startDataOnlyNodes(2);
+        // allocate shard to first data node
+        createIndex(indexName, Settings.builder()
+            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.routing.allocation.include._name", String.join(",", dataNodes.get(0)))
+            .build());
+        indexRandom(randomBoolean(), randomBoolean(), randomBoolean(), IntStream.range(0, randomIntBetween(0, 50))
+            .mapToObj(n -> client().prepareIndex(indexName, "_doc").setSource("num", n)).collect(toList()));
+        assertAcked(client().admin().indices().prepareClose(indexName));
+        // move single shard to second node
+        client().admin().indices().prepareUpdateSettings(indexName).setSettings(Settings.builder()
+            .put("index.routing.allocation.include._name", String.join(",", dataNodes.get(1)))).get();
+        ensureGreen(indexName);
+        internalCluster().fullRestart();
+        assertIndexIsClosed(indexName);
+        ensureGreen(indexName);
+    }
+
     public void testResyncPropagatePrimaryTerm() throws Exception {
         internalCluster().ensureAtLeastNumDataNodes(3);
         final String indexName = "closed_indices_promotion";

--- a/server/src/test/java/org/elasticsearch/indices/state/CloseIndexIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/state/CloseIndexIT.java
@@ -443,14 +443,14 @@ public class CloseIndexIT extends ESIntegTestCase {
         createIndex(indexName, Settings.builder()
             .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
-            .put("index.routing.allocation.include._name", String.join(",", dataNodes.get(0)))
+            .put("index.routing.allocation.include._name", dataNodes.get(0))
             .build());
         indexRandom(randomBoolean(), randomBoolean(), randomBoolean(), IntStream.range(0, randomIntBetween(0, 50))
             .mapToObj(n -> client().prepareIndex(indexName, "_doc").setSource("num", n)).collect(toList()));
         assertAcked(client().admin().indices().prepareClose(indexName));
         // move single shard to second node
         client().admin().indices().prepareUpdateSettings(indexName).setSettings(Settings.builder()
-            .put("index.routing.allocation.include._name", String.join(",", dataNodes.get(1)))).get();
+            .put("index.routing.allocation.include._name", dataNodes.get(1))).get();
         ensureGreen(indexName);
         internalCluster().fullRestart();
         assertIndexIsClosed(indexName);


### PR DESCRIPTION
Fixes a bug related to how "closed replicated indices" (introduced in 7.2) interact with the index metadata storage mechanism, which has special handling for closed indices (but incorrectly handles replicated closed indices). On non-master-eligible data nodes, it's possible for the node's manifest file (which tracks the relevant metadata state that the node should persist) to become out of sync with what's actually stored on disk, leading to an inconsistency that is then detected at startup, refusing for the node to start up.

The solution used here is to remove the code that treats closed indices specially. This code has not aged well, and its use is dubious as best.

Closes #47276