### PR TITLE
[TEST] Only wait for 6.6 prerequisites if BWC version is 6.6 or higher

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlConfigIndexMappingsFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlConfigIndexMappingsFullClusterRestartIT.java
@@ -76,11 +76,12 @@ public class MlConfigIndexMappingsFullClusterRestartIT extends AbstractFullClust
 
     @Before
     public void waitForMlTemplates() throws Exception {
-        List<String> templatesToWaitFor = XPackRestTestConstants.ML_POST_V660_TEMPLATES;
-        XPackRestTestHelper.waitForTemplates(client(), templatesToWaitFor);
+        if (getOldClusterVersion().onOrAfter(Version.V_6_6_0)) {
+            List<String> templatesToWaitFor = XPackRestTestConstants.ML_POST_V660_TEMPLATES;
+            XPackRestTestHelper.waitForTemplates(client(), templatesToWaitFor);
+        }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/47286")
     public void testMlConfigIndexMappingsAfterMigration() throws Exception {
         assumeTrue("This test only makes sense in version 6.6.0 and above", getOldClusterVersion().onOrAfter(Version.V_6_6_0));
         if (isRunningAgainstOldCluster()) {


### PR DESCRIPTION
With this change the test setup for ML config upgrade
tests only waits for v6.6+ ML index templates to be
installed if the old cluster is running version 6.6.0
or higher.

Previously it was always waiting, but timing out without
failing the test if the templates were not installed
within 10 seconds, effectively just adding a pointless
10 second sleep to BWC tests against versions earlier
than 6.6.0. This problem was exposed by #47112.

Fixes #47286