### PR TITLE
SQL: [TESTS] Improve error messages on failures

### DIFF
--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/SpecBaseIntegrationTestCase.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/SpecBaseIntegrationTestCase.java
@@ -90,8 +90,8 @@ public abstract class SpecBaseIntegrationTestCase extends JdbcIntegrationTestCas
         try {
             assumeFalse("Test marked as Ignored", testName.endsWith("-Ignore"));
             doTest();
-        } catch (AssertionError ae) {
-            throw reworkException(ae);
+        } catch (Exception e) {
+            throw reworkException(e);
         }
     }
 


### PR DESCRIPTION
When a test fails before the assertion of the results it's missing
information like the file name and the line in the file where the test
resides.
