### PR TITLE
[DOCS] Adds machine learning PRs to release notes

### DIFF
--- a/docs/reference/release-notes/7.4.asciidoc
+++ b/docs/reference/release-notes/7.4.asciidoc
@@ -425,6 +425,10 @@ Machine Learning::
 * Wait for .ml-config primary before assigning persistent tasks {pull}44170[#44170] (issue: {issue}44156[#44156])
 * Fix ML memory tracker lockup when inner step fails {pull}44158[#44158] (issue: {issue}44156[#44156])
 * Fix datafeed checks when a concrete remote index is present {pull}43923[#43923] (issue: {issue}42113[#42113])
+* Rename outlier detection method values `knn` and `tnn` to `distance_kth_nn` and `distance_knn`
+respectively to match the API. {ml-pull}598[#598]
+* Fix occasional (non-deterministic) reinitialisation of modelling for the `lat_long`
+function. {ml-pull}641[#641]
 
 Mapping::
 * Make sure to validate the type before attempting to merge a new mapping. {pull}45157[#45157] (issues: {issue}29316[#29316], {issue}43012[#43012])

--- a/docs/reference/release-notes/7.4.asciidoc
+++ b/docs/reference/release-notes/7.4.asciidoc
@@ -9,15 +9,11 @@ Also see <<breaking-changes-7.4,Breaking changes in 7.4>>.
 [float]
 === Breaking changes
 
-Data Frame::
-* [ML-DataFrame] Combine task_state and indexer_state in _stats {pull}45276[#45276] (issue: {issue}45201[#45201])
-* [ML] Improve response format of data frame stats endpoint {pull}44350[#44350] (issue: {issue}43767[#43767])
-
 Infra/REST API::
 * Update the schema for the REST API specification {pull}42346[#42346] (issue: {issue}35262[#35262])
 
 Machine Learning::
-* [ML] Improve progress reportings for DF analytics {pull}45856[#45856]
+* Improve progress reportings for data frame analytics {pull}45856[#45856]
 
 Ranking::
 * Forbid empty doc values on vector functions {pull}43944[#43944]
@@ -28,6 +24,9 @@ Search::
 Snapshot/Restore::
 * Provide an Option to Use Path-Style-Access with S3 Repo {pull}41966[#41966] (issue: {issue}41816[#41816])
 
+Transforms::
+* Combine task_state and indexer_state in _stats {pull}45276[#45276] (issue: {issue}45201[#45201])
+* Improve response format of transform stats endpoint {pull}44350[#44350] (issue: {issue}43767[#43767])
 
 
 [[breaking-java-7.4.0]]
@@ -59,7 +58,7 @@ Infra/Settings::
 * Add deprecation check for processors {pull}45925[#45925] (issues: {issue}45855[#45855], {issue}45905[#45905])
 
 Machine Learning::
-* [ML] [7.x] Only emit deprecation warning if there was actual change of a datafeed's job_id. {pull}44755[#44755]
+* Only emit deprecation warning if there was actual change of a datafeed's job_id. {pull}44755[#44755]
 * Deprecate the ability to update datafeed's job_id. {pull}44691[#44691] (issue: {issue}44615[#44615])
 
 
@@ -141,15 +140,6 @@ Cluster Coordination::
 * Ignore unknown fields if overriding node metadata {pull}44689[#44689]
 * Allow pending tasks before state recovery {pull}44685[#44685] (issue: {issue}44652[#44652])
 
-Data Frame::
-* [ML][Data Frame] Add update transform api endpoint {pull}45154[#45154] (issue: {issue}43438[#43438])
-* [ML][Data Frame] add support for bucket_selector {pull}44718[#44718] (issues: {issue}43744[#43744], {issue}44557[#44557])
-* [ML][Data Frame] adding force delete {pull}44590[#44590] (issue: {issue}43961[#43961])
-* [ML][Data Frame] adding dynamic cluster setting for failure retries {pull}44577[#44577]
-* [ML][Data Frame] Add optional defer_validation param to PUT {pull}44455[#44455] (issue: {issue}43439[#43439])
-* [ML][Data Frame] add support for geo_bounds aggregation {pull}44441[#44441]
-* [ML-DataFrame] Add a frequency option to transform config, default 1m {pull}44120[#44120]
-
 Distributed::
 * Do not create engine under IndexShard#mutex {pull}45263[#45263] (issue: {issue}43699[#43699])
 
@@ -224,19 +214,19 @@ Infra/Settings::
 * Normalize environment paths {pull}45179[#45179] (issue: {issue}45176[#45176])
 
 Machine Learning::
-* [ML] Support boolean fields for DF analytics {pull}46037[#46037]
-* [ML] Add description to DF analytics {pull}45774[#45774]
-* [ML] Add regression analysis to DF analytics {pull}45292[#45292]
+* Support boolean fields for DF analytics {pull}46037[#46037]
+* Add description to DF analytics {pull}45774[#45774]
+* Add regression analysis to DF analytics {pull}45292[#45292]
 * Introduce formal node ML role {pull}45174[#45174] (issues: {issue}29943[#29943], {issue}43175[#43175])
-* [ML] Improve CSV header row detection in find_file_structure {pull}45099[#45099] (issue: {issue}45047[#45047])
-* [ML] Outlier detection should only fetch docs that have the analyzed … {pull}44944[#44944]
+* Improve CSV header row detection in find_file_structure {pull}45099[#45099] (issue: {issue}45047[#45047])
+* Outlier detection should only fetch docs that have the analyzed … {pull}44944[#44944]
 * Persist DatafeedTimingStats with RefreshPolicy.NONE by default {pull}44940[#44940] (issue: {issue}44792[#44792])
 * Add result_type field to TimingStats and DatafeedTimingStats documents {pull}44812[#44812]
 * Implement exponential average search time per hour statistics. {pull}44683[#44683] (issue: {issue}29857[#29857])
-* [ML] Add r_squared eval metric to regression {pull}44248[#44248]
-* [ML] Adds support for regression.mean_squared_error to eval API {pull}44140[#44140]
+* Add r_squared eval metric to regression {pull}44248[#44248]
+* Adds support for regression.mean_squared_error to eval API {pull}44140[#44140]
 * Add DatafeedTimingStats.average_search_time_per_bucket_ms and TimingStats.total_bucket_processing_time_ms stats {pull}44125[#44125] (issue: {issue}29857[#29857])
-* [ML] Add DatafeedTimingStats to datafeed GetDatafeedStatsAction.Response {pull}43045[#43045] (issue: {issue}29857[#29857])
+* Add DatafeedTimingStats to datafeed GetDatafeedStatsAction.Response {pull}43045[#43045] (issue: {issue}29857[#29857])
 
 Network::
 * Better logging for TLS message on non-secure transport channel {pull}45835[#45835] (issue: {issue}32688[#32688])
@@ -284,6 +274,14 @@ Task Management::
 * TaskListener#onFailure to accept Exception instead of Throwable {pull}44946[#44946]
 * Move child task cancellation to TaskManager {pull}44573[#44573] (issue: {issue}44494[#44494])
 
+Transforms::
+* Add update transform api endpoint {pull}45154[#45154] (issue: {issue}43438[#43438])
+* Add support for bucket_selector {pull}44718[#44718] (issues: {issue}43744[#43744], {issue}44557[#44557])
+* Add force delete {pull}44590[#44590] (issue: {issue}43961[#43961])
+* Add dynamic cluster setting for failure retries {pull}44577[#44577]
+* Add optional defer_validation param to PUT {pull}44455[#44455] (issue: {issue}43439[#43439])
+* Add support for geo_bounds aggregation {pull}44441[#44441]
+* Add a frequency option to transform config, default 1m {pull}44120[#44120]
 
 
 [[bug-7.4.0]]
@@ -331,22 +329,6 @@ CRUD::
 Cluster Coordination::
 * Assert no exceptions during state application {pull}47090[#47090] (issue: {issue}47038[#47038])
 * Avoid counting votes from master-ineligible nodes {pull}43688[#43688]
-
-Data Frame::
-* [ML][Transform] Use field_caps API for mapping deduction {pull}46703[#46703] (issue: {issue}46694[#46694])
-* [ML-DataFrame] Fix off-by-one error in checkpoint operations_behind {pull}46235[#46235]
-* [ML][Data Frame] moves failure state transition for MT safety {pull}45676[#45676] (issue: {issue}45664[#45664])
-* [ML][Data Frame] fixing _start?force=true bug {pull}45660[#45660]
-* [ML][Data frame] fixing failure state transitions and race condition {pull}45627[#45627] (issues: {issue}45562[#45562], {issue}45609[#45609])
-* [ML-DataFrame] fix starting a batch data frame after stopping at runtime  {pull}45340[#45340] (issues: {issue}44219[#44219], {issue}45339[#45339])
-* [ML][Data Frames] Fix null aggregation handling in indexer {pull}45061[#45061] (issue: {issue}44906[#44906])
-* [ML][Data Frames] unify validation exceptions between PUT/_preview {pull}44983[#44983] (issue: {issue}44953[#44953])
-* [ML][Data Frame] treat bulk index failures as an indexing failure {pull}44351[#44351] (issue: {issue}44101[#44101])
-* [ML][Data Frame] prevent task from attempting to run when failed {pull}44239[#44239] (issue: {issue}44121[#44121])
-* [ML][Data Frame] responding with 409 status code when failing _stop {pull}44231[#44231] (issue: {issue}44103[#44103])
-* [ML][Data Frame] adds index validations to _start data frame transform {pull}44191[#44191] (issue: {issue}44104[#44104])
-* [ML] Data frame task failure do not make a 500 response {pull}44058[#44058] (issue: {issue}44011[#44011])
-* [ML-DataFrame] audit message missing for autostop {pull}43984[#43984] (issue: {issue}43977[#43977])
 
 Distributed::
 * Fix false positive out of sync warning in synced-flush {pull}46576[#46576] (issues: {issue}28464[#28464], {issue}30244[#30244])
@@ -431,18 +413,18 @@ Infra/Settings::
 * bug fix about elasticsearch.common.settings.Settings.processSetting {pull}44047[#44047] (issue: {issue}43791[#43791])
 
 Machine Learning::
-* [ML] fix two datafeed flush lockup bugs {pull}46982[#46982]
-* [ML] Throw an error when a datafeed needs CCS but it is not enabled for the node {pull}46044[#46044] (issue: {issue}46025[#46025])
+* Fix two datafeed flush lockup bugs {pull}46982[#46982]
+* Throw an error when a datafeed needs CCS but it is not enabled for the node {pull}46044[#46044] (issue: {issue}46025[#46025])
 * Handle "null" value of Estimate memory usage API response gracefully. {pull}45726[#45726] (issue: {issue}44699[#44699])
-* [ML] Remove timeout on waiting for DF analytics result processor to complete {pull}45724[#45724] (issue: {issue}45723[#45723])
-* [ML] Check dest index is empty when starting DF analytics {pull}45094[#45094]
-* [ML] Catch any error thrown while closing data frame analytics process {pull}44958[#44958]
+* Remove timeout on waiting for DF analytics result processor to complete {pull}45724[#45724] (issue: {issue}45723[#45723])
+* Check dest index is empty when starting DF analytics {pull}45094[#45094]
+* Catch any error thrown while closing data frame analytics process {pull}44958[#44958]
 * Treat PostDataActionResponse.DataCounts.bucketCount as incremental rather than absolute (total). {pull}44803[#44803] (issue: {issue}44792[#44792])
 * Treat big changes in searchCount as significant and persist the document after such changes {pull}44413[#44413] (issues: {issue}44196[#44196], {issue}44335[#44335])
 * Update .ml-config mappings before indexing job, datafeed or df analytics config {pull}44216[#44216] (issue: {issue}44263[#44263])
-* [ML] Wait for .ml-config primary before assigning persistent tasks {pull}44170[#44170] (issue: {issue}44156[#44156])
-* [ML] Fix ML memory tracker lockup when inner step fails {pull}44158[#44158] (issue: {issue}44156[#44156])
-* [ML] Fix datafeed checks when a concrete remote index is present {pull}43923[#43923] (issue: {issue}42113[#42113])
+* Wait for .ml-config primary before assigning persistent tasks {pull}44170[#44170] (issue: {issue}44156[#44156])
+* Fix ML memory tracker lockup when inner step fails {pull}44158[#44158] (issue: {issue}44156[#44156])
+* Fix datafeed checks when a concrete remote index is present {pull}43923[#43923] (issue: {issue}42113[#42113])
 
 Mapping::
 * Make sure to validate the type before attempting to merge a new mapping. {pull}45157[#45157] (issues: {issue}29316[#29316], {issue}43012[#43012])
@@ -507,7 +489,21 @@ Snapshot/Restore::
 Task Management::
 * Catch AllocatedTask registration failures {pull}45300[#45300]
 
-
+Data Frame::
+* Use field_caps API for mapping deduction {pull}46703[#46703] (issue: {issue}46694[#46694])
+* Fix off-by-one error in checkpoint operations_behind {pull}46235[#46235]
+* Moves failure state transition for MT safety {pull}45676[#45676] (issue: {issue}45664[#45664])
+* Fix _start?force=true bug {pull}45660[#45660]
+* Fix failure state transitions and race condition {pull}45627[#45627] (issues: {issue}45562[#45562], {issue}45609[#45609])
+* Fix starting a batch data frame after stopping at runtime  {pull}45340[#45340] (issues: {issue}44219[#44219], {issue}45339[#45339])
+* Fix null aggregation handling in indexer {pull}45061[#45061] (issue: {issue}44906[#44906])
+* Unify validation exceptions between PUT/_preview {pull}44983[#44983] (issue: {issue}44953[#44953])
+* Treat bulk index failures as an indexing failure {pull}44351[#44351] (issue: {issue}44101[#44101])
+* Prevent task from attempting to run when failed {pull}44239[#44239] (issue: {issue}44121[#44121])
+* Repond with 409 status code when failing _stop {pull}44231[#44231] (issue: {issue}44103[#44103])
+* Add index validations to _start data frame transform {pull}44191[#44191] (issue: {issue}44104[#44104])
+* Data frame task failure does not make a 500 response {pull}44058[#44058] (issue: {issue}44011[#44011])
+* Audit message missing for autostop {pull}43984[#43984] (issue: {issue}43977[#43977])
 
 [[regression-7.4.0]]
 [float]


### PR DESCRIPTION
This PR adds content from https://github.com/elastic/ml-cpp/blob/7.4/docs/CHANGELOG.asciidoc to the Elasticsearch Release Notes.  It also edits the descriptions of the machine learning PRs that already existed in the release notes.