### PR TITLE
[DOCS] Remove coming tags for 7.4.0 release

### DIFF
--- a/docs/reference/migration/migrate_7_4.asciidoc
+++ b/docs/reference/migration/migrate_7_4.asciidoc
@@ -9,8 +9,6 @@ your application to Elasticsearch 7.4.
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
-coming[7.4.0]
-
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
 

--- a/docs/reference/release-notes/7.4.asciidoc
+++ b/docs/reference/release-notes/7.4.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-7.4.0]]
 == {es} version 7.4.0
 
-coming[7.4.0]
-
 Also see <<breaking-changes-7.4,Breaking changes in 7.4>>.
 
 [[breaking-7.4.0]]


### PR DESCRIPTION
Remove the `coming[]` tag for the 7.4.0 release.

Do not merge until release day.