### PR TITLE
Change interval notation to plain english

### DIFF
--- a/docs/reference/query-dsl/match-query.asciidoc
+++ b/docs/reference/query-dsl/match-query.asciidoc
@@ -279,7 +279,7 @@ automatically transformed into a pure conjunction (`and`) query to
 ensure fast execution.
 
 The `cutoff_frequency` can either be relative to the total number of
-documents if in the range `[0..1)` or absolute if greater or equal to
+documents if in the range from 0 (inclusive) to 1 (exclusive) or absolute if greater or equal to
 `1.0`.
 
 Here is an example showing a query composed of stopwords exclusively:


### PR DESCRIPTION
As we discussed previously [here](https://github.com/elastic/elasticsearch/pull/36371/), it seems the interval notation was a bit confusing to some people and maybe it could be better if we explicitly talked about the interval in words rather than in notation.

In the previous PR, @colings86 mentioned that there were some places in the code that should be changed to reflect this change as well. Does it still make sense to fix it?
