### PR TITLE
Remove Dead BwC Code from Snapshots

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/FilterRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/FilterRepository.java
@@ -74,11 +74,6 @@ public class FilterRepository implements Repository {
     }
 
     @Override
-    public void initializeSnapshot(SnapshotId snapshotId, List<IndexId> indices, MetaData metaData) {
-        in.initializeSnapshot(snapshotId, indices, metaData);
-    }
-
-    @Override
     public void finalizeSnapshot(SnapshotId snapshotId, List<IndexId> indices, long startTime, String failure, int totalShards,
                                  List<SnapshotShardFailure> shardFailures, long repositoryStateId, boolean includeGlobalState,
                                  MetaData metaData, Map<String, Object> userMetadata, ActionListener<SnapshotInfo> listener) {

--- a/server/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -109,19 +109,6 @@ public interface Repository extends LifecycleComponent {
     RepositoryData getRepositoryData();
 
     /**
-     * Starts snapshotting process
-     *
-     * @param snapshotId snapshot id
-     * @param indices    list of indices to be snapshotted
-     * @param metaData   cluster metadata
-     *
-     * @deprecated this method is only used when taking snapshots in a mixed version cluster where a master node older than
-     *             {@link org.elasticsearch.snapshots.SnapshotsService#NO_REPO_INITIALIZE_VERSION} is present.
-     */
-    @Deprecated
-    void initializeSnapshot(SnapshotId snapshotId, List<IndexId> indices, MetaData metaData);
-
-    /**
      * Finalizes snapshotting process
      * <p>
      * This method is called on master after all shards are snapshotted.

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -87,7 +87,6 @@ import org.elasticsearch.repositories.RepositoryCleanupResult;
 import org.elasticsearch.repositories.RepositoryData;
 import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.repositories.RepositoryVerificationException;
-import org.elasticsearch.snapshots.SnapshotCreationException;
 import org.elasticsearch.snapshots.SnapshotException;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotInfo;
@@ -354,21 +353,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     @Override
     public RepositoryMetaData getMetadata() {
         return metadata;
-    }
-
-    @Override
-    public void initializeSnapshot(SnapshotId snapshotId, List<IndexId> indices, MetaData clusterMetaData) {
-        try {
-            // Write Global MetaData
-            globalMetaDataFormat.write(clusterMetaData, blobContainer(), snapshotId.getUUID(), true);
-
-            // write the index metadata for each index in the snapshot
-            for (IndexId index : indices) {
-                indexMetaDataFormat.write(clusterMetaData.index(index.getName()), indexContainer(index), snapshotId.getUUID(), true);
-            }
-        } catch (IOException ex) {
-            throw new SnapshotCreationException(metadata.name(), snapshotId, ex);
-        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/package-info.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/package-info.java
@@ -116,21 +116,7 @@
  * </ol>
  * <h2>Creating a Snapshot</h2>
  *
- * <p>Creating a snapshot in the repository happens in the three steps described in detail below.</p>
- *
- * <h3>Initializing a Snapshot in the Repository (Mixed Version Clusters only)</h3>
- *
- * <p>In mixed version clusters that contain a node older than
- * {@link org.elasticsearch.snapshots.SnapshotsService#NO_REPO_INITIALIZE_VERSION}, creating a snapshot in the repository starts with a
- * call to {@link org.elasticsearch.repositories.Repository#initializeSnapshot} which the blob store repository implements via the
- * following actions:</p>
- * <ol>
- * <li>Verify that no snapshot by the requested name exists.</li>
- * <li>Write a blob containing the cluster metadata to the root of the blob store repository at {@code /meta-${snapshot-uuid}.dat}</li>
- * <li>Write the metadata for each index to a blob in that index's directory at
- * {@code /indices/${index-snapshot-uuid}/meta-${snapshot-uuid}.dat}</li>
- * </ol>
- * TODO: Remove this section once BwC logic it references is removed
+ * <p>Creating a snapshot in the repository happens in the two steps described in detail below.</p>
  *
  * <h3>Writing Shard Data (Segments)</h3>
  *

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -117,12 +117,6 @@ import static org.elasticsearch.cluster.SnapshotsInProgress.completed;
  */
 public class SnapshotsService extends AbstractLifecycleComponent implements ClusterStateApplier {
 
-    /**
-     * Minimum node version which does not use {@link Repository#initializeSnapshot(SnapshotId, List, MetaData)} to write snapshot metadata
-     * when starting a snapshot.
-     */
-    public static final Version NO_REPO_INITIALIZE_VERSION = Version.V_7_5_0;
-
     public static final Version SHARD_GEN_IN_REPO_DATA_VERSION = Version.V_8_0_0;
 
     private static final Logger logger = LogManager.getLogger(SnapshotsService.class);
@@ -418,13 +412,6 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 if (repositoryData.getSnapshotIds().stream().anyMatch(s -> s.getName().equals(snapshotName))) {
                     throw new InvalidSnapshotNameException(
                         repository.getMetadata().name(), snapshotName, "snapshot with the same name already exists");
-                }
-                if (clusterState.nodes().getMinNodeVersion().onOrAfter(NO_REPO_INITIALIZE_VERSION) == false) {
-                    // In mixed version clusters we initialize the snapshot in the repository so that in case of a master failover to an
-                    // older version master node snapshot finalization (that assumes initializeSnapshot was called) produces a valid
-                    // snapshot.
-                    repository.initializeSnapshot(
-                        snapshot.snapshot().getSnapshotId(), snapshot.indices(), metaDataForSnapshot(snapshot, clusterState.metaData()));
                 }
                 snapshotCreated = true;
 

--- a/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
@@ -154,11 +154,6 @@ public class RepositoriesServiceTests extends ESTestCase {
         }
 
         @Override
-        public void initializeSnapshot(SnapshotId snapshotId, List<IndexId> indices, MetaData metaData) {
-
-        }
-
-        @Override
         public void finalizeSnapshot(SnapshotId snapshotId, List<IndexId> indices, long startTime, String failure,
                                      int totalShards, List<SnapshotShardFailure> shardFailures, long repositoryStateId,
                                      boolean includeGlobalState, MetaData metaData, Map<String, Object> userMetadata,

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
@@ -94,10 +94,6 @@ public abstract class RestoreOnlyRepository extends AbstractLifecycleComponent i
     }
 
     @Override
-    public void initializeSnapshot(SnapshotId snapshotId, List<IndexId> indices, MetaData metaData) {
-    }
-
-    @Override
     public void finalizeSnapshot(SnapshotId snapshotId, List<IndexId> indices, long startTime, String failure,
                                  int totalShards, List<SnapshotShardFailure> shardFailures, long repositoryStateId,
                                  boolean includeGlobalState, MetaData metaData, Map<String, Object> userMetadata,

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -250,10 +250,6 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
     }
 
     @Override
-    public void initializeSnapshot(SnapshotId snapshotId, List<IndexId> indices, MetaData metaData) {
-        throw new UnsupportedOperationException("Unsupported for repository of type: " + TYPE);
-    }
-    @Override
     public void finalizeSnapshot(SnapshotId snapshotId, List<IndexId> indices, long startTime, String failure, int totalShards,
                                  List<SnapshotShardFailure> shardFailures, long repositoryStateId, boolean includeGlobalState,
                                  MetaData metaData, Map<String, Object> userMetadata, ActionListener<SnapshotInfo> listener) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/snapshots/SourceOnlySnapshotRepository.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/snapshots/SourceOnlySnapshotRepository.java
@@ -78,18 +78,6 @@ public final class SourceOnlySnapshotRepository extends FilterRepository {
     }
 
     @Override
-    public void initializeSnapshot(SnapshotId snapshotId, List<IndexId> indices, MetaData metaData) {
-        // we process the index metadata at snapshot time. This means if somebody tries to restore
-        // a _source only snapshot with a plain repository it will be just fine since we already set the
-        // required engine, that the index is read-only and the mapping to a default mapping
-        try {
-            super.initializeSnapshot(snapshotId, indices, metadataToSnapshot(indices, metaData));
-        } catch (IOException ex) {
-            throw new UncheckedIOException(ex);
-        }
-    }
-
-    @Override
     public void finalizeSnapshot(SnapshotId snapshotId, List<IndexId> indices, long startTime, String failure, int totalShards,
                                  List<SnapshotShardFailure> shardFailures, long repositoryStateId, boolean includeGlobalState,
                                  MetaData metaData, Map<String, Object> userMetadata, ActionListener<SnapshotInfo> listener) {


### PR DESCRIPTION
We don't support rolling restarts with ES pre 7.5 in 8.x so this code can just go away.
