### PR TITLE
Fix CharArraysTests.testConstantTimeEquals()

### DIFF
--- a/libs/core/src/test/java/org/elasticsearch/common/CharArraysTests.java
+++ b/libs/core/src/test/java/org/elasticsearch/common/CharArraysTests.java
@@ -23,6 +23,8 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.nio.charset.StandardCharsets;
 
+import static org.hamcrest.Matchers.is;
+
 public class CharArraysTests extends ESTestCase {
 
     public void testCharsToBytes() {
@@ -70,10 +72,12 @@ public class CharArraysTests extends ESTestCase {
         assertTrue(CharArrays.constantTimeEquals(value.toCharArray(), value.toCharArray()));
 
         // we want a different string, so ensure the first character is different, but the same overall length
-        final String other = new String(
-            randomAlphaOfLengthNotBeginningWith(value.substring(0, 1), value.length(), value.length()));
-        assertFalse("value: " + value + ", other: " + other, CharArrays.constantTimeEquals(value, other));
-        assertFalse(CharArrays.constantTimeEquals(value.toCharArray(), other.toCharArray()));
+        final int length = value.length();
+        final String other = length > 0 ? new String(randomAlphaOfLengthNotBeginningWith(value.substring(0, 1), length, length)) : "";
+        final boolean expectedEquals = length == 0;
+
+        assertThat("value: " + value + ", other: " + other, CharArrays.constantTimeEquals(value, other), is(expectedEquals));
+        assertThat(CharArrays.constantTimeEquals(value.toCharArray(), other.toCharArray()), is(expectedEquals));
     }
 
     private char[] randomAlphaOfLengthNotBeginningWith(String undesiredPrefix, int min, int max) {


### PR DESCRIPTION
The change #47238 fixed a first issue (#47076) but introduced another one that can be reproduced using:

```
org.elasticsearch.common.CharArraysTests > testConstantTimeEquals FAILED

java.lang.StringIndexOutOfBoundsException: String index out of range: 1
at __randomizedtesting.SeedInfo.seed([DFCA64FE2C786BE3:ED987E883715C63B]:0)
at java.lang.String.substring(String.java:1963)
at org.elasticsearch.common.CharArraysTests.testConstantTimeEquals(CharArraysTests.java:74)
REPRODUCE WITH: ./gradlew ':libs:elasticsearch-core:test' --tests "org.elasticsearch.common.CharArraysTests.testConstantTimeEquals" -Dtests.seed=DFCA64FE2C786BE3 -Dtests.security.manager=true -Dtests.locale=fr-CA -Dtests.timezone=Pacific/Johnston -Dcompiler.java=12 -Druntime.java=8
```

that happens when the first randomized string has a length of 0.
