### PR TITLE
[DOCS] Fixes typos in the PUT dfa and the evaluate dfa documentation

### DIFF
--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -50,6 +50,7 @@ result field to be present.
 +
 --
 Available evaluation types:
+
 * `binary_soft_classification`
 * `regression`
 --

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -179,8 +179,8 @@ The API returns the following result:
 [[ml-put-dfanalytics-example-r]]
 ===== {regression-cap} example
 
-The following example creates the `house_price_regression_analysis` {
-dfanalytics-job}, the analysis type is `regression`:
+The following example creates the `house_price_regression_analysis` 
+{dfanalytics-job}, the analysis type is `regression`:
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
This PR removes an extra space from an abbreviation and adds a line break between two items of a bulleted list.