### PR TITLE
Fix SQL Translate spec documentation

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/sql.translate.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/sql.translate.json
@@ -1,7 +1,8 @@
 {
   "sql.translate":{
     "documentation":{
-      "url":"Translate SQL into Elasticsearch queries"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-translate.html",
+      "description":"Translate SQL into Elasticsearch queries"
     },
     "stability":"stable",
     "url":{


### PR DESCRIPTION
mismatching documentation of `sql.translate` spec.

/cc @elastic/es-clients 