### PR TITLE
[DOCS] Remove beta label for tasks API docs

### DIFF
--- a/docs/reference/cat/tasks.asciidoc
+++ b/docs/reference/cat/tasks.asciidoc
@@ -4,8 +4,6 @@
 <titleabbrev>cat task management</titleabbrev>
 ++++
 
-beta::[The cat task management API is new and should still be considered a beta feature. The API may change in ways that are not backwards compatible.]
-
 Returns information about tasks currently executing in the cluster,
 similar to the <<tasks,task management>> API.
 

--- a/docs/reference/cluster/tasks.asciidoc
+++ b/docs/reference/cluster/tasks.asciidoc
@@ -4,8 +4,6 @@
 <titleabbrev>Task management</titleabbrev>
 ++++
 
-beta[The task management API is new and should still be considered a beta feature. The API may change in ways that are not backwards compatible.]
-
 Returns information about the tasks currently executing in the cluster.
 
 [[tasks-api-request]]


### PR DESCRIPTION
Removes the beta tag from the `/_tasks` and `/_cat/_tasks` task management APIs. 

It looks like these tags have been in place since 2.3:
https://www.elastic.co/guide/en/elasticsearch/reference/2.3/tasks.html

Before merging, I want to confirm that these tags are no longer needed.