### PR TITLE
Ensure test node count is always in upper bound

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
@@ -594,7 +594,7 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
     }
 
     public void testUnderShardLimit() {
-        int nodesInCluster = randomIntBetween(2,100);
+        int nodesInCluster = randomIntBetween(2,90);
         // Calculate the counts for a cluster 1 node smaller than we have to ensure we have headroom
         ClusterShardLimitIT.ShardCounts counts = forDataNodeCount(nodesInCluster - 1);
 


### PR DESCRIPTION
The math for the randomization in this test can only handle up to 90
nodes (although the production logic is fine with more). This call
wasn't adjusted when that limit was put in place.

Fixes https://github.com/elastic/elasticsearch/issues/47381