### PR TITLE
[ML][Inference] adds lazy model loader and inference

### DIFF
--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -43,6 +43,7 @@ import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.gateway.GatewayService;

--- a/server/src/main/java/org/elasticsearch/ingest/Processor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/Processor.java
@@ -132,7 +132,7 @@ public interface Processor {
          */
         public final Client client;
 
-        public Parameters(Environment env, ScriptService scriptService, AnalysisRegistry analysisRegistry,  ThreadContext threadContext,
+        public Parameters(Environment env, ScriptService scriptService, AnalysisRegistry analysisRegistry, ThreadContext threadContext,
                           LongSupplier relativeTimeSupplier, BiFunction<Long, Runnable, Scheduler.ScheduledCancellable> scheduler,
                           IngestService ingestService, Client client) {
             this.env = env;

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -364,9 +364,7 @@ public class Node implements Closeable {
             clusterService.addLocalNodeMasterListener(
                     new ConsistentSettingsService(settings, clusterService, settingsModule.getConsistentSettings())
                             .newHashPublisher());
-            final IngestService ingestService = new IngestService(clusterService, threadPool, this.environment,
-                scriptModule.getScriptService(), analysisModule.getAnalysisRegistry(),
-                pluginsService.filterPlugins(IngestPlugin.class), client);
+
             final ClusterInfoService clusterInfoService = newClusterInfoService(settings, clusterService, threadPool, client);
             final UsageService usageService = new UsageService();
 
@@ -405,7 +403,9 @@ public class Node implements Closeable {
                 ClusterModule.getNamedXWriteables().stream())
                 .flatMap(Function.identity()).collect(toList()));
             final MetaStateService metaStateService = new MetaStateService(nodeEnvironment, xContentRegistry);
-
+            final IngestService ingestService = new IngestService(clusterService, threadPool, this.environment,
+                scriptModule.getScriptService(), analysisModule.getAnalysisRegistry(),
+                pluginsService.filterPlugins(IngestPlugin.class), client);
             // collect engine factory providers from server and from plugins
             final Collection<EnginePlugin> enginePlugins = pluginsService.filterPlugins(EnginePlugin.class);
             final Collection<Function<IndexSettings, Optional<EngineFactory>>> engineFactoryProviders =

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/Ensemble.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/Ensemble.java
@@ -107,7 +107,7 @@ public class Ensemble implements LenientlyParsedTrainedModel, StrictlyParsedTrai
 
     @Override
     public double infer(Map<String, Object> fields) {
-        List<Double> features = featureNames.stream().map(f -> (Double) fields.get(f)).collect(Collectors.toList());
+        List<Double> features = featureNames.stream().map(f -> ((Number)fields.get(f)).doubleValue()).collect(Collectors.toList());
         return infer(features);
     }
 
@@ -128,7 +128,7 @@ public class Ensemble implements LenientlyParsedTrainedModel, StrictlyParsedTrai
             throw new UnsupportedOperationException(
                 "Cannot determine classification probability with target_type [" + targetType.toString() + "]");
         }
-        List<Double> features = featureNames.stream().map(f -> (Double) fields.get(f)).collect(Collectors.toList());
+        List<Double> features = featureNames.stream().map(f -> ((Number)fields.get(f)).doubleValue()).collect(Collectors.toList());
         return classificationProbability(features);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInferModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInferModelAction.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.action;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.ml.inference.action.InferModelAction;
+import org.elasticsearch.xpack.ml.inference.loadingservice.Model;
+import org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingService;
+import org.elasticsearch.xpack.ml.utils.TypedChainTaskExecutor;
+
+import java.util.List;
+
+public class TransportInferModelAction extends HandledTransportAction<InferModelAction.Request, InferModelAction.Response> {
+
+    private final ModelLoadingService modelLoadingService;
+    private final Client client;
+
+    @Inject
+    public TransportInferModelAction(String actionName,
+                                     TransportService transportService,
+                                     ActionFilters actionFilters,
+                                     ModelLoadingService modelLoadingService,
+                                     Client client) {
+        super(actionName, transportService, actionFilters, InferModelAction.Request::new);
+        this.modelLoadingService = modelLoadingService;
+        this.client = client;
+    }
+
+    @Override
+    protected void doExecute(Task task, InferModelAction.Request request, ActionListener<InferModelAction.Response> listener) {
+
+        ActionListener<List<Object>> inferenceCompleteListener = ActionListener.wrap(
+            inferenceResponse -> listener.onResponse(new InferModelAction.Response(inferenceResponse)),
+            listener::onFailure
+        );
+
+        ActionListener<Model> getModelListener = ActionListener.wrap(
+            model -> {
+                TypedChainTaskExecutor<Object> typedChainTaskExecutor =
+                    new TypedChainTaskExecutor<>(client.threadPool().executor(ThreadPool.Names.SAME),
+                    // run through all tasks
+                    r -> true,
+                    // Always fail immediately and return an error
+                    ex -> true);
+                if (request.getTopClasses() != null) {
+                    request.getObjectsToInfer().forEach(stringObjectMap ->
+                        typedChainTaskExecutor.add(chainedTask -> model.confidence(stringObjectMap, request.getTopClasses(), chainedTask))
+                    );
+                } else {
+                    request.getObjectsToInfer().forEach(stringObjectMap ->
+                        typedChainTaskExecutor.add(chainedTask -> model.infer(stringObjectMap, chainedTask))
+                    );
+                }
+                typedChainTaskExecutor.execute(inferenceCompleteListener);
+            },
+            listener::onFailure
+        );
+
+        this.modelLoadingService.getModelAndCache(request.getModelId(), request.getModelVersion(), getModelListener);
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/action/InferModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/action/InferModelAction.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.inference.action;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestBuilder;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.client.ElasticsearchClient;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class InferModelAction extends ActionType<InferModelAction.Response> {
+
+    public static final InferModelAction INSTANCE = new InferModelAction();
+    public static final String NAME = "cluster:admin/xpack/ml/infer";
+
+    private InferModelAction() {
+        super(NAME, Response::new);
+    }
+
+    public static class Request extends ActionRequest {
+
+        private final String modelId;
+        private final long modelVersion;
+        private final List<Map<String, Object>> objectsToInfer;
+        private final boolean cacheModel;
+        private final Integer topClasses;
+
+        public Request(String modelId, long modelVersion) {
+            this(modelId, modelVersion, Collections.emptyList(), null);
+        }
+
+        public Request(String modelId, long modelVersion, List<Map<String, Object>> objectsToInfer, Integer topClasses) {
+            this.modelId = modelId;
+            this.modelVersion = modelVersion;
+            this.objectsToInfer = objectsToInfer == null ? Collections.emptyList() :
+                Collections.unmodifiableList(new ArrayList<>(objectsToInfer));
+            this.cacheModel = true;
+            this.topClasses = topClasses;
+        }
+
+        public Request(String modelId, long modelVersion, Map<String, Object> objectToInfer, Integer topClasses) {
+            this(modelId,
+                modelVersion,
+                objectToInfer == null ? Collections.emptyList() : Collections.singletonList(objectToInfer),
+                topClasses);
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.modelId = in.readString();
+            this.modelVersion = in.readVLong();
+            this.objectsToInfer = Collections.unmodifiableList(in.readList(StreamInput::readMap));
+            this.topClasses = in.readOptionalInt();
+            this.cacheModel = in.readBoolean();
+        }
+
+        public String getModelId() {
+            return modelId;
+        }
+
+        public long getModelVersion() {
+            return modelVersion;
+        }
+
+        public List<Map<String, Object>> getObjectsToInfer() {
+            return objectsToInfer;
+        }
+
+        public boolean isCacheModel() {
+            return cacheModel;
+        }
+
+        public Integer getTopClasses() {
+            return topClasses;
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(modelId);
+            out.writeVLong(modelVersion);
+            out.writeCollection(objectsToInfer, StreamOutput::writeMap);
+            out.writeOptionalInt(topClasses);
+            out.writeBoolean(cacheModel);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            InferModelAction.Request that = (InferModelAction.Request) o;
+            return Objects.equals(modelId, that.modelId)
+                && Objects.equals(modelVersion, that.modelVersion)
+                && Objects.equals(topClasses, that.topClasses)
+                && Objects.equals(cacheModel, that.cacheModel)
+                && Objects.equals(objectsToInfer, that.objectsToInfer);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(modelId, modelVersion, objectsToInfer, topClasses, cacheModel);
+        }
+
+    }
+
+    public static class RequestBuilder extends ActionRequestBuilder<Request, Response> {
+        public RequestBuilder(ElasticsearchClient client, Request request) {
+            super(client, INSTANCE, request);
+        }
+    }
+
+    public static class Response extends ActionResponse {
+
+        // TODO come up with a better union type object
+        private final List<Object> inferenceResponse;
+
+        public Response(List<Object> inferenceResponse) {
+            super();
+            this.inferenceResponse = Collections.unmodifiableList(inferenceResponse);
+        }
+
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            this.inferenceResponse = Collections.unmodifiableList(in.readList(StreamInput::readGenericValue));
+        }
+
+        public List<Object> getInferenceResponse() {
+            return inferenceResponse;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeCollection(inferenceResponse, StreamOutput::writeGenericValue);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            InferModelAction.Response that = (InferModelAction.Response) o;
+            return Objects.equals(inferenceResponse, that.inferenceResponse);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(inferenceResponse);
+        }
+
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.inference.ingest;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.ingest.AbstractProcessor;
+import org.elasticsearch.ingest.ConfigurationUtils;
+import org.elasticsearch.ingest.IngestDocument;
+import org.elasticsearch.ingest.Processor;
+import org.elasticsearch.xpack.ml.inference.action.InferModelAction;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+
+public class InferenceProcessor extends AbstractProcessor {
+
+    public static final String TYPE = "inference";
+    private static final String MODEL_ID = "model_id";
+    private static final String MODEL_TYPE = "model_type";
+    private static final String TOP_N_CLASSES = "top_n_classes";
+    private static final String TARGET_FIELD = "target_field";
+    private static final String FIELD_MAPPINGS = "field_mappings";
+    private static final String IGNORE_MISSING = "ignore_missing";
+
+    private final Client client;
+    private final InferModelRequestGenerator requestGenerator;
+    public InferenceProcessor(Client client, String tag, InferModelRequestGenerator requestGenerator) {
+        super(tag);
+        this.client = client;
+        this.requestGenerator = requestGenerator;
+    }
+
+    @Override
+    public void execute(IngestDocument ingestDocument, BiConsumer<IngestDocument, Exception> handler) {
+        //TODO actually work
+        handler.accept(ingestDocument, null);
+    }
+
+    @Override
+    public IngestDocument execute(IngestDocument ingestDocument) {
+        throw new UnsupportedOperationException("should never be called");
+    }
+
+    @Override
+    public String getType() {
+        return null;
+    }
+
+    public static final class Factory implements Processor.Factory {
+
+        private final Client client;
+        public Factory(Client client) {
+            this.client = client;
+        }
+
+        @Override
+        public InferenceProcessor create(Map<String, Processor.Factory> processorFactories, String tag, Map<String, Object> config)
+            throws Exception {
+            // TODO add cluster state listener info for processor limits
+            String modelId = ConfigurationUtils.readStringProperty(TYPE, tag, config, MODEL_ID);
+            String modelType = ConfigurationUtils.readStringProperty(TYPE, tag, config, MODEL_TYPE, "local");
+            Map<String, String> fieldMapping = ConfigurationUtils.readMap(TYPE, tag, config, FIELD_MAPPINGS);
+            Integer modelVersion = ConfigurationUtils.readIntProperty(TYPE, tag, config, MODEL_TYPE, 0);
+            Integer topNClasses = ConfigurationUtils.readIntProperty(TYPE, tag, config, TOP_N_CLASSES, null);
+            boolean ignoreMissing = ConfigurationUtils.readBooleanProperty(TYPE, tag, config, IGNORE_MISSING, false);
+            InferModelRequestGenerator inferModelRequestGenerator = new InferModelRequestGenerator(modelId,
+                modelVersion.longValue(),
+                topNClasses,
+                fieldMapping);
+            return new InferenceProcessor(client, tag, inferModelRequestGenerator);
+        }
+    }
+
+    private static class InferModelRequestGenerator {
+
+        private final String modelId;
+        private final Long modelVersion;
+        private final Integer topNClasses;
+        private final Map<String, String> fieldMapping;
+
+        InferModelRequestGenerator(String modelId, Long modelVersion, Integer topNClasses, Map<String, String> fieldMapping) {
+            this.modelId = modelId;
+            this.modelVersion = modelVersion;
+            this.topNClasses = topNClasses;
+            this.fieldMapping = fieldMapping;
+        }
+
+        InferModelAction.Request buildRequest(IngestDocument document) {
+            Map<String, Object> fields = new HashMap<>(document.getSourceAndMetadata());
+            if (fieldMapping != null) {
+                fieldMapping.forEach((src, dest) -> {
+                    fields.put(dest, fields.get(src));
+                });
+            }
+            return new InferModelAction.Request(modelId, modelVersion, fields, topNClasses);
+        }
+    }
+
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.inference.loadingservice;
+
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.xpack.core.ml.inference.TrainedModelDefinition;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TargetType;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class LocalModel implements Model {
+
+    private final TrainedModelDefinition trainedModelDefinition;
+    public LocalModel(TrainedModelDefinition trainedModelDefinition) {
+        this.trainedModelDefinition = trainedModelDefinition;
+    }
+
+    @Override
+    public void infer(Map<String, Object> fields, ActionListener<Object> listener) {
+        trainedModelDefinition.getPreProcessors().forEach(preProcessor -> preProcessor.process(fields));
+        double value = trainedModelDefinition.getTrainedModel().infer(fields);
+        if (trainedModelDefinition.getTrainedModel().targetType() == TargetType.CLASSIFICATION &&
+            trainedModelDefinition.getTrainedModel().classificationLabels() != null) {
+            assert value == Math.rint(value);
+            int classIndex = Double.valueOf(value).intValue();
+            if (classIndex < 0 || classIndex >= trainedModelDefinition.getTrainedModel().classificationLabels().size()) {
+                listener.onFailure(new ElasticsearchStatusException("model returned classification [{}] which is invalid given labels {}",
+                    RestStatus.INTERNAL_SERVER_ERROR,
+                    classIndex,
+                    trainedModelDefinition.getTrainedModel().classificationLabels()));
+                return;
+            }
+            listener.onResponse(trainedModelDefinition.getTrainedModel().classificationLabels().get(classIndex));
+            return;
+        }
+        listener.onResponse(Double.valueOf(value));
+    }
+
+    @Override
+    public void confidence(Map<String, Object> fields, int topN, ActionListener<Object> listener) {
+        if (topN == 0) {
+            listener.onResponse(Collections.emptyMap());
+            return;
+        }
+        if (trainedModelDefinition.getTrainedModel().targetType() != TargetType.CLASSIFICATION) {
+            listener.onFailure(ExceptionsHelper
+                .badRequestException("top result probabilities is only available for classification models"));
+            return;
+        }
+        trainedModelDefinition.getPreProcessors().forEach(preProcessor -> preProcessor.process(fields));
+        List<Double> probabilities = trainedModelDefinition.getTrainedModel().classificationProbability(fields);
+        int[] sortedIndices = IntStream.range(0, probabilities.size())
+            .boxed()
+            .sorted(Comparator.comparing(probabilities::get).reversed())
+            .mapToInt(i -> i)
+            .toArray();
+        if (trainedModelDefinition.getTrainedModel().classificationLabels() != null) {
+            if (probabilities.size() != trainedModelDefinition.getTrainedModel().classificationLabels().size()) {
+                listener.onFailure(ExceptionsHelper
+                    .badRequestException(
+                        "model returned classification probabilities of size [{}] which is not equal to classification labels size [{}]",
+                        probabilities.size(),
+                        trainedModelDefinition.getTrainedModel().classificationLabels()));
+                return;
+            }
+        }
+        List<String> labels = trainedModelDefinition.getTrainedModel().classificationLabels() == null ?
+            // If we don't have the labels we should return the top classification values anyways, they will just be numeric
+            IntStream.range(0, probabilities.size()).boxed().map(String::valueOf).collect(Collectors.toList()) :
+            trainedModelDefinition.getTrainedModel().classificationLabels();
+
+        int count = topN < 0 ? probabilities.size() : topN;
+        Map<String, Double> probabilityMap = new HashMap<>(count);
+        for(int i = 0; i < count; i++) {
+            int idx = sortedIndices[i];
+            probabilityMap.put(labels.get(idx), probabilities.get(idx));
+        }
+        listener.onResponse(probabilityMap);
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/Model.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/Model.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.inference.loadingservice;
+
+import org.elasticsearch.action.ActionListener;
+
+import java.util.Map;
+
+public interface Model {
+
+    void infer(Map<String, Object> fields, ActionListener<Object> listener);
+
+    void confidence(Map<String, Object> fields, int topN, ActionListener<Object> listener);
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.inference.loadingservice;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
+import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelProvider;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ModelLoadingService implements ClusterStateListener {
+
+    private static final Logger logger = LogManager.getLogger(ModelLoadingService.class);
+    private final ConcurrentHashMap<String, Model> loadedModels = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Queue<ActionListener<Model>>> loadingListeners = new ConcurrentHashMap<>();
+    private final TrainedModelProvider provider;
+
+    public ModelLoadingService(TrainedModelProvider trainedModelProvider) {
+        this.provider = trainedModelProvider;
+    }
+
+    public void getModelAndCache(String modelId, long modelVersion, ActionListener<Model> modelActionListener) {
+        String key = modelKey(modelId, modelVersion);
+        Model cachedModel = loadedModels.get(key);
+        if (cachedModel != null) {
+            modelActionListener.onResponse(cachedModel);
+            return;
+        }
+        SetOnce<Boolean> newLoad = new SetOnce<>();
+        synchronized (loadingListeners) {
+            cachedModel = loadedModels.get(key);
+            if (cachedModel != null) {
+                modelActionListener.onResponse(cachedModel);
+                return;
+            }
+            loadingListeners.compute(key, (modelKey, listeners) -> {
+                if (listeners == null) {
+                    newLoad.set(true);
+                    Deque<ActionListener<Model>> listenerDeque = new ArrayDeque<>();
+                    listenerDeque.addLast(modelActionListener);
+                    return listenerDeque;
+                }
+                newLoad.set(false);
+                listeners.add(modelActionListener);
+                return listeners;
+            });
+        }
+        if (newLoad.get()) {
+            // TODO support loading other types of models?
+            loadModel(key, modelId, modelVersion);
+        }
+    }
+
+    private void loadModel(String modelKey, String modelId, long modelVersion) {
+        provider.getTrainedModel(modelId, modelVersion, ActionListener.wrap(
+            trainedModelConfig -> {
+                logger.debug("[{}] successfully loaded model", modelKey);
+                handleLoadSuccess(modelKey, trainedModelConfig);
+            },
+            failure -> {
+                logger.warn(new ParameterizedMessage("[{}] failed to load model", modelKey), failure);
+                handleLoadFailure(modelKey, failure);
+            }
+        ));
+    }
+
+    private void handleLoadSuccess(String modelKey, TrainedModelConfig trainedModelConfig) {
+        Queue<ActionListener<Model>> listeners;
+        Model loadedModel = new LocalModel(trainedModelConfig.getDefinition());
+        synchronized (loadingListeners) {
+            loadedModels.put(modelKey, loadedModel);
+            listeners = loadingListeners.remove(modelKey);
+        }
+        if (listeners != null) {
+            for(ActionListener<Model> listener = listeners.poll(); listener != null; listener = listeners.poll()) {
+                listener.onResponse(loadedModel);
+            }
+        }
+    }
+
+    private void handleLoadFailure(String modelKey, Exception failure) {
+        Queue<ActionListener<Model>> listeners;
+        synchronized (loadingListeners) {
+            // TODO do we want to cache the failure?
+            listeners = loadingListeners.remove(modelKey);
+        }
+        if (listeners != null) {
+            for(ActionListener<Model> listener = listeners.poll(); listener != null; listener = listeners.poll()) {
+                listener.onFailure(failure);
+            }
+        }
+    }
+
+    private String modelKey(String modelId, long modelVersion) {
+        return modelId + "_" + modelVersion;
+    }
+
+    private Tuple<String, Long> splitModelKey(String modelKey) {
+        int delimIdx = modelKey.lastIndexOf("_");
+        String modelId = modelKey.substring(0, delimIdx);
+        Long modelVersion = Long.valueOf(modelKey.substring(delimIdx + 1));
+        return Tuple.tuple(modelId, modelVersion);
+    }
+
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        // TODO
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/action/InferModelActionRequestTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/action/InferModelActionRequestTests.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.inference.action;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.ml.inference.action.InferModelAction.Request;
+
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class InferModelActionRequestTests extends AbstractWireSerializingTestCase<Request> {
+
+    @Override
+    protected Request createTestInstance() {
+        return new Request(randomAlphaOfLength(10),
+            randomLongBetween(1, 100),
+            randomBoolean() ? null : Stream.generate(()-> randomAlphaOfLength(10))
+                .limit(randomInt(10))
+                .collect(Collectors.toMap(Function.identity(), (v) -> randomAlphaOfLength(10))),
+            randomBoolean() ? null : randomIntBetween(-1, 100));
+    }
+
+    @Override
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
+    }
+
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/action/InferModelActionResponseTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/action/InferModelActionResponseTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.inference.action;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.ml.inference.action.InferModelAction.Response;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class InferModelActionResponseTests extends AbstractWireSerializingTestCase<Response> {
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Response createTestInstance() {
+        Supplier<Object> resultSupplier = randomFrom(() -> randomAlphaOfLength(10),
+            ESTestCase::randomDouble,
+            () -> Stream.generate(() -> randomAlphaOfLength(10))
+                .limit(randomIntBetween(1, 10))
+                .collect(Collectors.toMap(Function.identity(), v -> randomDouble())));
+        return new Response(Stream.generate(resultSupplier).limit(randomIntBetween(0, 10)).collect(Collectors.toList()));
+    }
+
+    @Override
+    protected Writeable.Reader<Response> instanceReader() {
+        return Response::new;
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.inference.loadingservice;
+
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.ml.inference.TrainedModelDefinition;
+import org.elasticsearch.xpack.core.ml.inference.preprocessing.OneHotEncoding;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TargetType;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TrainedModel;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ensemble.Ensemble;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ensemble.WeightedMode;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ensemble.WeightedSum;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.tree.Tree;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.tree.TreeNode;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
+
+public class LocalModelTests extends ESTestCase {
+
+    @SuppressWarnings("unchecked")
+    public void testClassificationInfer() throws Exception {
+        TrainedModelDefinition definition = new TrainedModelDefinition.Builder()
+            .setPreProcessors(Arrays.asList(new OneHotEncoding("categorical", oneHotMap())))
+            .setTrainedModel(buildClassification(false))
+            .build();
+
+        Model model = new LocalModel(definition);
+        Map<String, Object> fields = new HashMap<>() {{
+            put("foo", 1.0);
+            put("bar", 0.5);
+            put("categorical", "dog");
+        }};
+
+        PlainActionFuture<Object> future = new PlainActionFuture<>();
+        model.infer(fields, future);
+        assertThat(future.get(), equalTo(0.0));
+
+        future = new PlainActionFuture<>();
+        model.confidence(fields, 0, future);
+        assertThat(future.get(), equalTo(Collections.emptyMap()));
+
+        future = new PlainActionFuture<>();
+        model.confidence(fields, 1, future);
+        assertThat(((Map<String, Double>)future.get()).get("0"), closeTo(0.5498339973124778, 0.0000001));
+
+        // Test with labels
+        definition = new TrainedModelDefinition.Builder()
+            .setPreProcessors(Arrays.asList(new OneHotEncoding("categorical", oneHotMap())))
+            .setTrainedModel(buildClassification(true))
+            .build();
+        model = new LocalModel(definition);
+        future = new PlainActionFuture<>();
+        model.infer(fields, future);
+        assertThat(future.get(), equalTo("not_to_be"));
+
+        future = new PlainActionFuture<>();
+        model.confidence(fields, 0, future);
+        assertThat(future.get(), equalTo(Collections.emptyMap()));
+
+        future = new PlainActionFuture<>();
+        model.confidence(fields, 1, future);
+        assertThat(((Map<String, Double>)future.get()).get("not_to_be"), closeTo(0.5498339973124778, 0.0000001));
+
+        future = new PlainActionFuture<>();
+        model.confidence(fields, 2, future);
+        assertThat((Map<String, Double>)future.get(), aMapWithSize(2));
+
+        future = new PlainActionFuture<>();
+        model.confidence(fields, -1, future);
+        assertThat((Map<String, Double>)future.get(), aMapWithSize(2));
+    }
+
+    public void testRegression() throws Exception {
+        TrainedModelDefinition trainedModelDefinition = new TrainedModelDefinition.Builder()
+            .setPreProcessors(Arrays.asList(new OneHotEncoding("categorical", oneHotMap())))
+            .setTrainedModel(buildRegression())
+            .build();
+        Model model = new LocalModel(trainedModelDefinition);
+
+        Map<String, Object> fields = new HashMap<>() {{
+            put("foo", 1.0);
+            put("bar", 0.5);
+            put("categorical", "dog");
+        }};
+
+        PlainActionFuture<Object> future = new PlainActionFuture<>();
+        model.infer(fields, future);
+        assertThat(future.get(), equalTo(1.3));
+
+        PlainActionFuture<Object> failedFuture = new PlainActionFuture<>();
+        model.confidence(fields, -1, failedFuture);
+        ExecutionException ex = expectThrows(ExecutionException.class, failedFuture::get);
+        assertThat(ex.getCause().getMessage(), equalTo("top result probabilities is only available for classification models"));
+    }
+
+    private static Map<String, String> oneHotMap() {
+        Map<String, String> oneHotEncoding = new HashMap<>();
+        oneHotEncoding.put("cat", "animal_cat");
+        oneHotEncoding.put("dog", "animal_dog");
+        return oneHotEncoding;
+    }
+
+    private static TrainedModel buildClassification(boolean includeLabels) {
+        List<String> featureNames = Arrays.asList("foo", "bar", "animal_cat", "animal_dog");
+        Tree tree1 = Tree.builder()
+            .setFeatureNames(featureNames)
+            .setRoot(TreeNode.builder(0)
+                .setLeftChild(1)
+                .setRightChild(2)
+                .setSplitFeature(0)
+                .setThreshold(0.5))
+            .addNode(TreeNode.builder(1).setLeafValue(1.0))
+            .addNode(TreeNode.builder(2)
+                .setThreshold(0.8)
+                .setSplitFeature(1)
+                .setLeftChild(3)
+                .setRightChild(4))
+            .addNode(TreeNode.builder(3).setLeafValue(0.0))
+            .addNode(TreeNode.builder(4).setLeafValue(1.0)).build();
+        Tree tree2 = Tree.builder()
+            .setFeatureNames(featureNames)
+            .setRoot(TreeNode.builder(0)
+                .setLeftChild(1)
+                .setRightChild(2)
+                .setSplitFeature(3)
+                .setThreshold(1.0))
+            .addNode(TreeNode.builder(1).setLeafValue(0.0))
+            .addNode(TreeNode.builder(2).setLeafValue(1.0))
+            .build();
+        Tree tree3 = Tree.builder()
+            .setFeatureNames(featureNames)
+            .setRoot(TreeNode.builder(0)
+                .setLeftChild(1)
+                .setRightChild(2)
+                .setSplitFeature(0)
+                .setThreshold(1.0))
+            .addNode(TreeNode.builder(1).setLeafValue(1.0))
+            .addNode(TreeNode.builder(2).setLeafValue(0.0))
+            .build();
+        return Ensemble.builder()
+            .setClassificationLabels(includeLabels ? Arrays.asList("not_to_be", "to_be") : null)
+            .setTargetType(TargetType.CLASSIFICATION)
+            .setFeatureNames(featureNames)
+            .setTrainedModels(Arrays.asList(tree1, tree2, tree3))
+            .setOutputAggregator(new WeightedMode(Arrays.asList(0.7, 0.5, 1.0)))
+            .build();
+    }
+
+    private static TrainedModel buildRegression() {
+        List<String> featureNames = Arrays.asList("foo", "bar", "animal_cat", "animal_dog");
+        Tree tree1 = Tree.builder()
+            .setFeatureNames(featureNames)
+            .setRoot(TreeNode.builder(0)
+                .setLeftChild(1)
+                .setRightChild(2)
+                .setSplitFeature(0)
+                .setThreshold(0.5))
+            .addNode(TreeNode.builder(1).setLeafValue(0.3))
+            .addNode(TreeNode.builder(2)
+                .setThreshold(0.0)
+                .setSplitFeature(3)
+                .setLeftChild(3)
+                .setRightChild(4))
+            .addNode(TreeNode.builder(3).setLeafValue(0.1))
+            .addNode(TreeNode.builder(4).setLeafValue(0.2)).build();
+        Tree tree2 = Tree.builder()
+            .setFeatureNames(featureNames)
+            .setRoot(TreeNode.builder(0)
+                .setLeftChild(1)
+                .setRightChild(2)
+                .setSplitFeature(2)
+                .setThreshold(1.0))
+            .addNode(TreeNode.builder(1).setLeafValue(1.5))
+            .addNode(TreeNode.builder(2).setLeafValue(0.9))
+            .build();
+        Tree tree3 = Tree.builder()
+            .setFeatureNames(featureNames)
+            .setRoot(TreeNode.builder(0)
+                .setLeftChild(1)
+                .setRightChild(2)
+                .setSplitFeature(1)
+                .setThreshold(0.2))
+            .addNode(TreeNode.builder(1).setLeafValue(1.5))
+            .addNode(TreeNode.builder(2).setLeafValue(0.9))
+            .build();
+        return Ensemble.builder()
+            .setTargetType(TargetType.REGRESSION)
+            .setFeatureNames(featureNames)
+            .setTrainedModels(Arrays.asList(tree1, tree2, tree3))
+            .setOutputAggregator(new WeightedSum(Arrays.asList(0.5, 0.5, 0.5)))
+            .build();
+    }
+
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.inference.loadingservice;
+
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
+import org.elasticsearch.xpack.core.ml.inference.TrainedModelDefinitionTests;
+import org.elasticsearch.xpack.core.ml.job.messages.Messages;
+import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelProvider;
+import org.junit.Before;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class ModelLoadingServiceTests extends ESTestCase {
+
+    TrainedModelProvider trainedModelProvider;
+
+    @Before
+    public void setUpComponents() {
+        trainedModelProvider = mock(TrainedModelProvider.class);
+    }
+
+    public void testGetModelAndCache() throws Exception {
+        String model1 = "test-load-model-1";
+        String model2 = "test-load-model-2";
+        String model3 = "test-load-model-3";
+        withTrainedModel(model1, 0);
+        withTrainedModel(model2, 0);
+        withTrainedModel(model3, 0);
+
+        ModelLoadingService modelLoadingService = new ModelLoadingService(trainedModelProvider);
+
+        String[] modelIds = new String[]{model1, model2, model3};
+        for(int i = 0; i < 10; i++) {
+            String model = modelIds[i%3];
+            PlainActionFuture<Model> future = new PlainActionFuture<>();
+            modelLoadingService.getModelAndCache(model, 0, future);
+            assertThat(future.get(), is(not(nullValue())));
+        }
+
+        verify(trainedModelProvider, times(1)).getTrainedModel(eq(model1), eq(0L), any());
+        verify(trainedModelProvider, times(1)).getTrainedModel(eq(model2), eq(0L), any());
+        verify(trainedModelProvider, times(1)).getTrainedModel(eq(model3), eq(0L), any());
+    }
+
+    public void testGetMissingModelAndCache() {
+        String model = "test-load-missing-model";
+        withMissingModel(model, 0);
+
+        ModelLoadingService modelLoadingService = new ModelLoadingService(trainedModelProvider);
+
+        modelLoadingService.getModelAndCache(model, 0, ActionListener.wrap(
+            m -> fail("Should not have succeeded"),
+            f -> assertThat(f.getMessage(), equalTo(Messages.getMessage(Messages.INFERENCE_NOT_FOUND, model, 0)))
+        ));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void withTrainedModel(String modelId, long modelVersion) {
+        TrainedModelConfig trainedModelConfig = buildTrainedModelConfigBuilder(modelId, modelVersion).build(Version.CURRENT);
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("rawtypes")
+            ActionListener listener = (ActionListener) invocationOnMock.getArguments()[2];
+            listener.onResponse(trainedModelConfig);
+            return null;
+        }).when(trainedModelProvider).getTrainedModel(eq(modelId), eq(modelVersion), any());
+    }
+
+    private void withMissingModel(String modelId, long modelVersion) {
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("rawtypes")
+            ActionListener listener = (ActionListener) invocationOnMock.getArguments()[2];
+            listener.onFailure(new ResourceNotFoundException(
+                Messages.getMessage(Messages.INFERENCE_NOT_FOUND, modelId, modelVersion)));
+            return null;
+        }).when(trainedModelProvider).getTrainedModel(eq(modelId), eq(modelVersion), any());
+    }
+
+    private static TrainedModelConfig.Builder buildTrainedModelConfigBuilder(String modelId, long modelVersion) {
+        return TrainedModelConfig.builder()
+            .setCreatedBy("ml_test")
+            .setDefinition(TrainedModelDefinitionTests.createRandomBuilder())
+            .setDescription("trained model config for test")
+            .setModelId(modelId)
+            .setModelType("binary_decision_tree")
+            .setModelVersion(modelVersion);
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/ModelInferenceActionIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/ModelInferenceActionIT.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.integration;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvider;
+import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
+import org.elasticsearch.xpack.core.ml.inference.TrainedModelDefinition;
+import org.elasticsearch.xpack.core.ml.inference.TrainedModelDefinitionTests;
+import org.elasticsearch.xpack.core.ml.inference.preprocessing.OneHotEncoding;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TargetType;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TrainedModel;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ensemble.Ensemble;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ensemble.WeightedMode;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ensemble.WeightedSum;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.tree.Tree;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.tree.TreeNode;
+import org.elasticsearch.xpack.core.ml.job.messages.Messages;
+import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
+import org.elasticsearch.xpack.ml.inference.action.InferModelAction;
+import org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingService;
+import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelProvider;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.nullValue;
+
+public class ModelInferenceActionIT extends MlSingleNodeTestCase {
+
+    private TrainedModelProvider trainedModelProvider;
+
+    @Before
+    public void createComponents() throws Exception {
+        trainedModelProvider = new TrainedModelProvider(client(), xContentRegistry());
+        waitForMlTemplates();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testInferModels() throws Exception {
+        String modelId1 = "test-load-models-regression";
+        String modelId2 = "test-load-models-classification";
+        Map<String, String> oneHotEncoding = new HashMap<>();
+        oneHotEncoding.put("cat", "animal_cat");
+        oneHotEncoding.put("dog", "animal_dog");
+        TrainedModelConfig config1 = buildTrainedModelConfigBuilder(modelId2, 0)
+            .setDefinition(new TrainedModelDefinition.Builder()
+                .setPreProcessors(Arrays.asList(new OneHotEncoding("categorical", oneHotEncoding)))
+                .setTrainedModel(buildClassification()))
+            .build(Version.CURRENT);
+        TrainedModelConfig config2 = buildTrainedModelConfigBuilder(modelId1, 0)
+            .setDefinition(new TrainedModelDefinition.Builder()
+                .setPreProcessors(Arrays.asList(new OneHotEncoding("categorical", oneHotEncoding)))
+                .setTrainedModel(buildRegression()))
+            .build(Version.CURRENT);
+        AtomicReference<Boolean> putConfigHolder = new AtomicReference<>();
+        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+
+        blockingCall(listener -> trainedModelProvider.storeTrainedModel(config1, listener), putConfigHolder, exceptionHolder);
+        assertThat(putConfigHolder.get(), is(true));
+        assertThat(exceptionHolder.get(), is(nullValue()));
+        blockingCall(listener -> trainedModelProvider.storeTrainedModel(config2, listener), putConfigHolder, exceptionHolder);
+        assertThat(putConfigHolder.get(), is(true));
+        assertThat(exceptionHolder.get(), is(nullValue()));
+
+
+        List<Map<String, Object>> toInfer = new ArrayList<>();
+        toInfer.add(new HashMap<>() {{
+            put("foo", 1.0);
+            put("bar", 0.5);
+            put("categorical", "dog");
+        }});
+        toInfer.add(new HashMap<>() {{
+            put("foo", 0.9);
+            put("bar", 1.5);
+            put("categorical", "cat");
+        }});
+
+        List<Map<String, Object>> toInfer2 = new ArrayList<>();
+        toInfer2.add(new HashMap<>() {{
+            put("foo", 0.0);
+            put("bar", 0.01);
+            put("categorical", "dog");
+        }});
+        toInfer2.add(new HashMap<>() {{
+            put("foo", 1.0);
+            put("bar", 0.0);
+            put("categorical", "cat");
+        }});
+
+        // Test regression
+        InferModelAction.Request request = new InferModelAction.Request(modelId1, 0, toInfer, null);
+        InferModelAction.Response response = client().execute(InferModelAction.INSTANCE, request).actionGet();
+        assertThat(response.getInferenceResponse(), contains(1.3, 1.25));
+
+        request = new InferModelAction.Request(modelId1, 0, toInfer2, null);
+        response = client().execute(InferModelAction.INSTANCE, request).actionGet();
+        assertThat(response.getInferenceResponse(), contains(1.65, 1.55));
+
+
+        // Test classification
+        request = new InferModelAction.Request(modelId2, 0, toInfer, null);
+        response = client().execute(InferModelAction.INSTANCE, request).actionGet();
+        assertThat(response.getInferenceResponse(), contains("not_to_be", "to_be"));
+
+        // Get top classes
+        request = new InferModelAction.Request(modelId2, 0, toInfer, 2);
+        response = client().execute(InferModelAction.INSTANCE, request).actionGet();
+
+        Map<String, Double> probabilities = (Map<String, Double>) response.getInferenceResponse().get(0);
+        assertThat(probabilities.get("not_to_be"), greaterThan(probabilities.get("to_be")));
+
+        probabilities = (Map<String, Double>) response.getInferenceResponse().get(1);
+        assertThat(probabilities.get("to_be"), greaterThan(probabilities.get("not_to_be")));
+
+
+        request = new InferModelAction.Request(modelId2, 0, toInfer2, null);
+        response = client().execute(InferModelAction.INSTANCE, request).actionGet();
+        assertThat(response.getInferenceResponse(), contains("to_be", "not_to_be"));
+
+        request = new InferModelAction.Request(modelId2, 0, toInfer2, 2);
+        response = client().execute(InferModelAction.INSTANCE, request).actionGet();
+
+        probabilities = (Map<String, Double>) response.getInferenceResponse().get(0);
+        assertThat(probabilities.get("to_be"), greaterThan(probabilities.get("not_to_be")));
+
+        probabilities = (Map<String, Double>) response.getInferenceResponse().get(1);
+        assertThat(probabilities.get("not_to_be"), greaterThan(probabilities.get("to_be")));
+
+        // Test that top classes restrict the number returned
+        request = new InferModelAction.Request(modelId2, 0, toInfer2, 1);
+        response = client().execute(InferModelAction.INSTANCE, request).actionGet();
+        probabilities = (Map<String, Double>) response.getInferenceResponse().get(0);
+        assertThat(probabilities.size(), equalTo(1));
+
+        probabilities = (Map<String, Double>) response.getInferenceResponse().get(1);
+        assertThat(probabilities.size(), equalTo(1));
+
+        // test -1 gets all top classes
+        request = new InferModelAction.Request(modelId2, 0, toInfer2, -1);
+        response = client().execute(InferModelAction.INSTANCE, request).actionGet();
+        probabilities = (Map<String, Double>) response.getInferenceResponse().get(0);
+        assertThat(probabilities.size(), equalTo(2));
+    }
+
+    public void testInferMissingModel() {
+        String model = "test-infer-missing-model";
+        InferModelAction.Request request = new InferModelAction.Request(model, 0, Collections.emptyList(), null);
+        try {
+            client().execute(InferModelAction.INSTANCE, request).actionGet();
+        } catch (ElasticsearchException ex) {
+            assertThat(ex.getMessage(), equalTo(Messages.getMessage(Messages.INFERENCE_NOT_FOUND, model, 0)));
+        }
+    }
+
+    private static TrainedModel buildClassification() {
+        List<String> featureNames = Arrays.asList("foo", "bar", "animal_cat", "animal_dog");
+        Tree tree1 = Tree.builder()
+            .setFeatureNames(featureNames)
+            .setRoot(TreeNode.builder(0)
+                .setLeftChild(1)
+                .setRightChild(2)
+                .setSplitFeature(0)
+                .setThreshold(0.5))
+            .addNode(TreeNode.builder(1).setLeafValue(1.0))
+            .addNode(TreeNode.builder(2)
+                .setThreshold(0.8)
+                .setSplitFeature(1)
+                .setLeftChild(3)
+                .setRightChild(4))
+            .addNode(TreeNode.builder(3).setLeafValue(0.0))
+            .addNode(TreeNode.builder(4).setLeafValue(1.0)).build();
+        Tree tree2 = Tree.builder()
+            .setFeatureNames(featureNames)
+            .setRoot(TreeNode.builder(0)
+                .setLeftChild(1)
+                .setRightChild(2)
+                .setSplitFeature(3)
+                .setThreshold(1.0))
+            .addNode(TreeNode.builder(1).setLeafValue(0.0))
+            .addNode(TreeNode.builder(2).setLeafValue(1.0))
+            .build();
+        Tree tree3 = Tree.builder()
+            .setFeatureNames(featureNames)
+            .setRoot(TreeNode.builder(0)
+                .setLeftChild(1)
+                .setRightChild(2)
+                .setSplitFeature(0)
+                .setThreshold(1.0))
+            .addNode(TreeNode.builder(1).setLeafValue(1.0))
+            .addNode(TreeNode.builder(2).setLeafValue(0.0))
+            .build();
+        return Ensemble.builder()
+            .setClassificationLabels(Arrays.asList("not_to_be", "to_be"))
+            .setTargetType(TargetType.CLASSIFICATION)
+            .setFeatureNames(featureNames)
+            .setTrainedModels(Arrays.asList(tree1, tree2, tree3))
+            .setOutputAggregator(new WeightedMode(Arrays.asList(0.7, 0.5, 1.0)))
+            .build();
+    }
+
+    private static TrainedModel buildRegression() {
+        List<String> featureNames = Arrays.asList("foo", "bar", "animal_cat", "animal_dog");
+        Tree tree1 = Tree.builder()
+            .setFeatureNames(featureNames)
+            .setRoot(TreeNode.builder(0)
+                .setLeftChild(1)
+                .setRightChild(2)
+                .setSplitFeature(0)
+                .setThreshold(0.5))
+            .addNode(TreeNode.builder(1).setLeafValue(0.3))
+            .addNode(TreeNode.builder(2)
+                .setThreshold(0.0)
+                .setSplitFeature(3)
+                .setLeftChild(3)
+                .setRightChild(4))
+            .addNode(TreeNode.builder(3).setLeafValue(0.1))
+            .addNode(TreeNode.builder(4).setLeafValue(0.2)).build();
+        Tree tree2 = Tree.builder()
+            .setFeatureNames(featureNames)
+            .setRoot(TreeNode.builder(0)
+                .setLeftChild(1)
+                .setRightChild(2)
+                .setSplitFeature(2)
+                .setThreshold(1.0))
+            .addNode(TreeNode.builder(1).setLeafValue(1.5))
+            .addNode(TreeNode.builder(2).setLeafValue(0.9))
+            .build();
+        Tree tree3 = Tree.builder()
+            .setFeatureNames(featureNames)
+            .setRoot(TreeNode.builder(0)
+                .setLeftChild(1)
+                .setRightChild(2)
+                .setSplitFeature(1)
+                .setThreshold(0.2))
+            .addNode(TreeNode.builder(1).setLeafValue(1.5))
+            .addNode(TreeNode.builder(2).setLeafValue(0.9))
+            .build();
+        return Ensemble.builder()
+            .setTargetType(TargetType.REGRESSION)
+            .setFeatureNames(featureNames)
+            .setTrainedModels(Arrays.asList(tree1, tree2, tree3))
+            .setOutputAggregator(new WeightedSum(Arrays.asList(0.5, 0.5, 0.5)))
+            .build();
+    }
+
+
+    public void testLoadMissingModels() throws Exception {
+
+    }
+
+    private static TrainedModelConfig buildTrainedModelConfig(String modelId, long modelVersion) {
+        return buildTrainedModelConfigBuilder(modelId, modelVersion).build(Version.CURRENT);
+    }
+
+    private static TrainedModelConfig.Builder buildTrainedModelConfigBuilder(String modelId, long modelVersion) {
+        return TrainedModelConfig.builder()
+            .setCreatedBy("ml_test")
+            .setDefinition(TrainedModelDefinitionTests.createRandomBuilder())
+            .setDescription("trained model config for test")
+            .setModelId(modelId)
+            .setModelType("binary_decision_tree")
+            .setModelVersion(modelVersion);
+    }
+
+    @Override
+    public NamedXContentRegistry xContentRegistry() {
+        List<NamedXContentRegistry.Entry> namedXContent = new ArrayList<>();
+        namedXContent.addAll(new MlInferenceNamedXContentProvider().getNamedXContentParsers());
+        namedXContent.addAll(new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedXContents());
+        return new NamedXContentRegistry(namedXContent);
+
+    }
+
+}


### PR DESCRIPTION
This adds a couple of things:

- A model loader service that is accessible via transport calls. This service will load in models and cache them (still need to work on cache EXPIRY)
- A Model class and its first sub-class LocalModel. Used to cache model information and run inference (naming is not final, WIP)
- Transport action and handler for requests to infer against a local model

TODO (WIP): 
- [] InferModelAction.Response is not finalized. I don't like passing around a List of objects. I need to come up with an appropriate union type. 
- [] Cache invalidation for model service
- [] Fix Naming. Model#confidence is incongruous with the rest of the stack.