### PR TITLE
Remove empty buildSrc subproject

### DIFF
--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -1,2 +1,1 @@
 include 'reaper'
-include 'symbolic-link-preserving-tar'


### PR DESCRIPTION
I believe this subproject was added to `:buildSrc` by mistake. There's no project folder, and we just end up building an empty JAR on every build for this. @jasontedor can you confirm this was simply an oversight?