### PR TITLE
[DOCS] Deletes prematurely documented  outlier detection parameters

### DIFF
--- a/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
@@ -96,21 +96,19 @@ PUT _ml/data_frame/analytics/loganalytics
     as this object is passed verbatim to {es}. By default, this property has 
     the following value: `{"match_all": {}}`.
 
+
 [[dfanalytics-types]]
 ==== Analysis objects
 
 {dfanalytics-cap} resources contain `analysis` objects. For example, when you
 create a {dfanalytics-job}, you must define the type of analysis it performs.
 
+
 [discrete]
 [[oldetection-resources]]
 ==== {oldetection-cap} configuration objects 
 
 An `outlier_detection` configuration object has the following properties:
-
-`compute_feature_influence`::
-  (boolean) If `true`, the feature influence calculation is enabled. Defaults to 
-  `true`.
   
 `feature_influence_threshold`:: 
   (double) The minimum {olscore} that a document needs to have in order to 
@@ -129,17 +127,6 @@ An `outlier_detection` configuration object has the following properties:
   different values will be used for different ensemble members. This helps 
   improve diversity in the ensemble. Therefore, only override this if you are 
   confident that the value you choose is appropriate for the data set.
-  
-`outlier_fraction`::
-  (double) Sets the proportion of the data set that is assumed to be outlying prior to 
-  {oldetection}. For example, 0.05 means it is assumed that 5% of values are real outliers 
-  and 95% are inliers.
-  
-`standardize_columns`::
-  (boolean) If `true`, then the following operation is performed on the columns 
-  before computing outlier scores: (x_i - mean(x_i)) / sd(x_i). Defaults to 
-  `true`. For more information, see 
-  https://en.wikipedia.org/wiki/Feature_scaling#Standardization_(Z-score_Normalization)[this wiki page about standardization].
 
 
 [discrete]


### PR DESCRIPTION
This PR deletes the following parameters from the data frame analytics resources on the 7.4 branch:

* `compute_feature_influence`
* `outlier_fraction`
* `standardize_columns`