### PR TITLE
Remove Incorrect Assertion from SnapshotsInProgress

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -279,7 +279,6 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             state = ShardState.fromValue(in.readByte());
             if (in.getVersion().onOrAfter(SnapshotsService.SHARD_GEN_IN_REPO_DATA_VERSION)) {
                 generation = in.readOptionalString();
-                assert generation != null || state != ShardState.SUCCESS : "Received null generation for shard state [" + state + "]";
             } else {
                 generation = null;
             }


### PR DESCRIPTION
This relates to the effort towards #46250. We added
tracking of the shard generation for successful
snapshots to `8.0`.
This assertion isn't correct though. While an `8.0`
master won't create an entry with sucess state and
a null shard generation it may still (on e.g. master
failover) send a success entry created by a 7.x master
with a `null` generation over the wire.

Closes #47406
