### PR TITLE
[DOCS] Fixes missing link title

### DIFF
--- a/x-pack/docs/en/watcher/condition/compare.asciidoc
+++ b/x-pack/docs/en/watcher/condition/compare.asciidoc
@@ -7,7 +7,7 @@ the watch payload. You can use the `compare` condition without enabling
 dynamic scripting. 
 
 [[condition-compare-operators]]
-. Supported comparison operators
+.Supported comparison operators
 [options="header"]
 |======
 | Name      | Description


### PR DESCRIPTION
This PR fixes a missing link title in https://www.elastic.co/guide/en/elasticsearch/reference/master/condition-array-compare.html

![image](https://user-images.githubusercontent.com/26471269/66089423-0ebf7800-e534-11e9-9338-c751fa6935f3.png)

