### PR TITLE
[DOCS] Qualifies Watcher transforms

### DIFF
--- a/x-pack/docs/en/watcher/transform.asciidoc
+++ b/x-pack/docs/en/watcher/transform.asciidoc
@@ -1,17 +1,17 @@
 [role="xpack"]
 [[transform]]
-== Transforms
+== {watcher-transforms-cap}
 
-A _transform_ processes and changes the payload in the watch execution context
-to prepare it for the watch actions. {watcher} supports three types of 
-transforms: <<transform-search,`search`>>,
+A _{watcher-transform}_ processes and changes the payload in the watch execution
+context to prepare it for the watch actions. {watcher} supports three types of 
+{watcher-transforms}: <<transform-search,`search`>>,
 <<transform-script,`script`>> and <<transform-chain,`chain`>>.
 
 
-NOTE: Transforms are optional. When none are defined, the actions have access to
-      the payload as loaded by the watch input.
+NOTE: {watcher-transforms-cap} are optional. When none are defined, the actions
+have access to the payload as loaded by the watch input.
 
-You can define transforms in two places:
+You can define {watcher-transforms} in two places:
 
 * As a top level construct in the watch definition. In this case, the payload is
   transformed before any of the watch actions are executed.
@@ -20,13 +20,13 @@ You can define transforms in two places:
   transformed before that action is executed. The transformation is only applied
   to the payload for that specific action.
 
-If all actions require the same view of the payload, define a transform as part
-of the watch definition. If each action requires a different view of the payload,
-define different transforms as part of the action definitions so each action has
-the payload prepared by its own dedicated transform.
+If all actions require the same view of the payload, define a {watcher-transform}
+as part of the watch definition. If each action requires a different view of the
+payload, define different {watcher-transforms} as part of the action definitions
+so each action has the payload prepared by its own dedicated {watcher-transform}.
 
-The following example defines two transforms, one at the watch level and one as
-part of the definition of the `my_webhook` action.
+The following example defines two {watcher-transforms}, one at the watch level
+and one as part of the definition of the `my_webhook` action.
 
 [source,js]
 --------------------------------------------------

--- a/x-pack/docs/en/watcher/transform/chain.asciidoc
+++ b/x-pack/docs/en/watcher/transform/chain.asciidoc
@@ -1,17 +1,18 @@
 [role="xpack"]
 [[transform-chain]]
-=== Chain transform
+=== Chain {watcher-transform}
 
-A <<transform,transform>> that executes an ordered list of configured transforms
-in a chain, where the output of one transform serves as the input of the next
-transform in the chain. The payload that is accepted by this transform serves as
-the input of the first transform in the chain and the output of the last transform
-in the chain is the output of the `chain` transform as a whole.
+A <<transform,{watcher-transform}>> that executes an ordered list of configured
+{watcher-transforms} in a chain, where the output of one transform serves as the
+input of the next transform in the chain. The payload that is accepted by this
+transform serves as the input of the first transform in the chain and the output
+of the last transform in the chain is the output of the `chain` transform as a
+whole.
 
-You can use chain transforms to build more complex transforms out of the other
-available transforms. For example, you can combine a <<transform-search,`search`>>
-transform and a <<transform-script,`script`>> transform, as shown in the
-following snippet:
+You can use chain {watcher-transforms} to build more complex transforms out of
+the other available transforms. For example, you can combine a
+<<transform-search,`search`>> {watcher-transform} and a
+<<transform-script,`script`>> {watcher-transform}, as shown in the following snippet:
 
 [source,js]
 --------------------------------------------------
@@ -35,13 +36,14 @@ following snippet:
 }
 --------------------------------------------------
 // NOTCONSOLE
-<1> The `chain` transform definition
-<2> The first transform in the chain (in this case, a `search` transform)
+<1> The `chain` {watcher-transform} definition
+<2> The first transform in the chain (in this case, a `search` {watcher-transform})
 <3> The second and final transform in the chain (in this case, a `script`
-    transform)
+    {watcher-transform})
 
 This example executes a `count` search on the cluster to look for `error` events.
-The search results are then passed to the second `script` transform. The `script`
-transform extracts the total hit count and assigns it to the `error_count` field
-in a newly-generated payload. This new payload is the output of the `chain`
-transform and replaces the payload in the watch execution context.
+The search results are then passed to the second `script` {watcher-transform}.
+The `script` {watcher-transform} extracts the total hit count and assigns it to
+the `error_count` field in a newly-generated payload. This new payload is the
+output of the `chain` {watcher-transform} and replaces the payload in the watch
+execution context.

--- a/x-pack/docs/en/watcher/transform/script.asciidoc
+++ b/x-pack/docs/en/watcher/transform/script.asciidoc
@@ -1,16 +1,17 @@
 [role="xpack"]
 [[transform-script]]
-=== Script transform
+=== Script {watcher-transform}
 
-A <<transform,transform>> that executes a script on the current payload in the
-watch execution context and replaces it with a newly generated one. The following
-snippet shows how a simple script transform can be defined on the watch level:
+A <<transform,{watcher-transform}>> that executes a script on the current
+payload in the watch execution context and replaces it with a newly generated
+one. The following snippet shows how a simple script {watcher-transform} can be
+defined on the watch level:
 
-TIP:  The `script` transform is often useful when used in combination with the
-      <<transform-search,`search`>> transform, where the script can extract only
-      the significant data from a search result, and by that, keep the payload
-      minimal. This can be achieved with the <<transform-chain,`chain`>>
-      transform.
+TIP:  The `script` {watcher-transform} is often useful when used in combination
+      with the <<transform-search,`search`>> {watcher-transform}, where the
+      script can extract only the significant data from a search result, and by
+      that, keep the payload minimal. This can be achieved with the
+      <<transform-chain,`chain`>> {watcher-transform}.
 
 
 [source,js]
@@ -39,7 +40,7 @@ to set the `script` field to an object describing the script and its language.
 The following table lists the possible settings that can be configured:
 
 [[transform-script-settings]]
-.Script transform settings
+.Script {watcher-transform} settings
 [options="header"]
 |======
 | Name      |Required | Default    | Description

--- a/x-pack/docs/en/watcher/transform/search.asciidoc
+++ b/x-pack/docs/en/watcher/transform/search.asciidoc
@@ -1,11 +1,11 @@
 [role="xpack"]
 [[transform-search]]
-=== Search transform
+=== Search {watcher-transform}
 
-A <<transform,transform>> that executes a search on the cluster and replaces
-the current payload in the watch execution context with the returned search
-response. The following snippet shows how a simple search transform can be
-defined on the watch level:
+A <<transform,{watcher-transform}>> that executes a search on the cluster and
+replaces the current payload in the watch execution context with the returned
+search response. The following snippet shows how a simple search transform can
+be defined on the watch level:
 
 [source,js]
 --------------------------------------------------
@@ -22,8 +22,9 @@ defined on the watch level:
 // NOTCONSOLE
 
 Like every other search based construct, one can make use of the full search
-API supported by Elasticsearch. For example, the following search transform
-execute a search over all events indices, matching events with `error` priority:
+API supported by Elasticsearch. For example, the following search
+{watcher-transform} execute a search over all events indices, matching events
+with `error` priority:
 
 [source,js]
 --------------------------------------------------
@@ -45,10 +46,11 @@ execute a search over all events indices, matching events with `error` priority:
 --------------------------------------------------
 // NOTCONSOLE
 
-The following table lists all available settings for the search transform:
+The following table lists all available settings for the search
+{watcher-transform}:
 
 [[transform-search-settings]]
-.Search transform settings
+.Search {watcher-transform} settings
 [cols=",^,,", options="header"]
 |======
 | Name                                          |Required   | Default           | Description
@@ -80,17 +82,17 @@ The following table lists all available settings for the search transform:
 
 | `timeout`                                     | no        | 30s               | The timeout for waiting for the search api call to
                                                                                   return. If no response is returned within this time,
-                                                                                  the search transform times out and fails. This setting
+                                                                                  the search {watcher-transform} times out and fails. This setting
                                                                                   overrides the default timeouts.
 |======
 
 [[transform-search-template]]
 ==== Template support
 
-The search transform support mustache <<templates, templates>>. This can either
-be as part of the body definition, or alternatively, point to an existing
-template (either defined in a file or <<pre-registered-templates,registered>>
-as a script in Elasticsearch).
+The search {watcher-transform} support mustache <<templates, templates>>. This
+can either be as part of the body definition or alternatively point to an
+existing template (either defined in a file or
+<<pre-registered-templates,registered>> as a script in Elasticsearch).
 
 For example, the following snippet shows a search that refers to the scheduled
 time of the watch:


### PR DESCRIPTION
This PR updates the terminology used for Watcher transforms (https://www.elastic.co/guide/en/elasticsearch/reference/master/transform.html) so that it's not confused with data transforms (https://www.elastic.co/guide/en/elasticsearch/reference/master/transforms.html).

Depends on https://github.com/elastic/docs/pull/1248

Preview: http://elasticsearch_47482.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/transform.html