### PR TITLE
Add realm uniqueness enforcement in 7.4 migration docs

### DIFF
--- a/docs/reference/migration/migrate_7_4.asciidoc
+++ b/docs/reference/migration/migrate_7_4.asciidoc
@@ -124,6 +124,13 @@ be disabled by setting the system property
 === Settings changes
 
 [discrete]
+[[breaking_74_unique_realm_names]]
+==== Authenticion realm name uniqueness is enforced
+
+Authentication realm name uniqueness is now enforced. If you configure more than one realm of any type
+with the same name, the node fails to start.
+
+[discrete]
 [[deprecate-pidfile]]
 ==== `pidfile` setting is being replaced by `node.pidfile`
 

--- a/docs/reference/migration/migrate_7_4.asciidoc
+++ b/docs/reference/migration/migrate_7_4.asciidoc
@@ -125,7 +125,7 @@ be disabled by setting the system property
 
 [discrete]
 [[breaking_74_unique_realm_names]]
-==== Authenticion realm name uniqueness is enforced
+==== Authentication realm name uniqueness is enforced
 
 Authentication realm name uniqueness is now enforced. If you configure more than one realm of any type
 with the same name, the node fails to start.


### PR DESCRIPTION
Add the change to the migration docs as it was omitted in #46253