### PR TITLE
[DOCS] Change index name in rollover ILM example

### DIFF
--- a/docs/reference/ilm/policy-definitions.asciidoc
+++ b/docs/reference/ilm/policy-definitions.asciidoc
@@ -362,12 +362,12 @@ follower index into a regular index as if <<ilm-unfollow-action,the Unfollow
 action>> had been used instead of rolling over.
 
 For example, if an index to be managed has an alias `my_data`. The managed
-index "my_index" must be the write index for the alias. For more information, read
+index "my_index-000001" must be the write index for the alias. For more information, read
 <<indices-rollover-is-write-index,Write Index Alias Behavior>>.
 
 [source,console]
 --------------------------------------------------
-PUT my_index
+PUT my_index-000001
 {
   "settings": {
     "index.lifecycle.name": "my_policy",


### PR DESCRIPTION
The warning section above the example tells that index name has to end with the digits but the example itself uses index name without digits which is confusing.

I understand that it meant to be a generic rollover example, but here we are in the context of ILM