### PR TITLE
[Doc]Update link to ls monitoring settings

### DIFF
--- a/docs/reference/settings/monitoring-settings.asciidoc
+++ b/docs/reference/settings/monitoring-settings.asciidoc
@@ -19,7 +19,7 @@ To adjust how monitoring data is displayed in the monitoring UI, configure
 {kibana-ref}/monitoring-settings-kb.html[`xpack.monitoring` settings] in
 `kibana.yml`. To control how monitoring data is collected from
 Logstash, configure
-{logstash-ref}/configuring-logstash.html#monitoring-settings[`xpack.monitoring` settings]
+{logstash-ref}/monitoring-internal-collection.html#monitoring-settings[`xpack.monitoring` settings]
 in `logstash.yml`.
 
 For more information, see


### PR DESCRIPTION
Restructuring Monitoring content for Logstash (elastic/logstash#11033) resulted in a broken link in a deprecated topic. This PR corrects the link.

NOTE:  This PR will fail `elasticsearch-ci/doc` and cannot be merged until elastic/logstash#11033 is merged. 