### PR TITLE
Fix dependency resolution conflict in SQL security integration tests

### DIFF
--- a/x-pack/plugin/sql/qa/build.gradle
+++ b/x-pack/plugin/sql/qa/build.gradle
@@ -54,7 +54,7 @@ subprojects {
     apply plugin: 'elasticsearch.build'
   }
 
-  configurations.testRuntimeClasspath {
+  configurations.all {
     resolutionStrategy.force "org.slf4j:slf4j-api:1.7.25"
   }
   dependencies {


### PR DESCRIPTION
This PR fixes a dependency resolution conflict when attempting to resolve the `testRuntime` configuration in the `7.4` branch. Right now this is blowing up our CI image builds since our `packer_cache.sh` script attempts to resolve this configuration.

https://scans.gradle.com/s/6rqjlft2jvdow/console-log?task=:distribution:bwc:bugfix:resolveAllBwcDependencies