### PR TITLE
Ensure index is green after closing in test

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
@@ -423,6 +423,7 @@ public class RolloverIT extends ESIntegTestCase {
 
         assertAcked(client().admin().indices().prepareClose(closedIndex).get());
         assertAcked(client().admin().indices().prepareClose(writeIndexPrefix + "000001").get());
+        ensureGreen(aliasName);
 
         RolloverResponse rolloverResponse = client().admin().indices().prepareRolloverIndex(aliasName)
             .addMaxIndexDocsCondition(1)


### PR DESCRIPTION
This test was less stable following a backport as the shards in these
indices did not always show up as allocated immediately after closing
them. This ensures those shards have stabilized before trying to roll
over.

This change has already been made in backports of #47148, this PR just adds it to master

Relates https://github.com/elastic/elasticsearch/pull/47148