### PR TITLE
Fix windows packaging tests

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Shell.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Shell.java
@@ -170,8 +170,12 @@ public class Shell {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         } finally {
-           FileUtils.deleteIfExists(stdOut);
-           FileUtils.deleteIfExists(stdErr);
+            try {
+                FileUtils.deleteIfExists(stdOut);
+                FileUtils.deleteIfExists(stdErr);
+            } catch (UncheckedIOException e) {
+                logger.info("Cleanup of output files failed", e);
+            }
         }
     }
 


### PR DESCRIPTION
On windows, it happens that the process we called terminates but some
other process it creates still has the same output strems and thus the
files open, so we can't clean it up.

This PR makes the cleanup a best effort.
