### PR TITLE
[7.2] [DOCS] Fixes an attribute in the update datafeed API docs

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
@@ -28,7 +28,7 @@ cluster privileges to use this API. For more information, see
 [[ml-update-datafeed-desc]]
 ==== {api-description-title}
 
-If you update a {datafeed} property, you must stop and start the {dfeed} for the 
+If you update a {dfeed} property, you must stop and start the {dfeed} for the 
 change to be applied.
 
 


### PR DESCRIPTION
Backports the following commit to 7.2:

[DOCS] Fixes an attribute in the update datafeed API docs #47551