### PR TITLE
Fix serialization of evaluation response.

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/EvaluateDataFrameAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/EvaluateDataFrameAction.java
@@ -217,7 +217,7 @@ public class EvaluateDataFrameAction extends ActionType<EvaluateDataFrameAction.
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeString(evaluationName);
-            out.writeList(metrics);
+            out.writeNamedWriteableList(metrics);
         }
 
         @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/EvaluateDataFrameActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/EvaluateDataFrameActionResponseTests.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ml.action;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.core.ml.action.EvaluateDataFrameAction.Response;
+import org.elasticsearch.xpack.core.ml.dataframe.evaluation.EvaluationMetricResult;
+import org.elasticsearch.xpack.core.ml.dataframe.evaluation.MlEvaluationNamedXContentProvider;
+import org.elasticsearch.xpack.core.ml.dataframe.evaluation.regression.MeanSquaredError;
+
+import java.util.List;
+
+public class EvaluateDataFrameActionResponseTests extends AbstractWireSerializingTestCase<Response> {
+
+    @Override
+    protected NamedWriteableRegistry getNamedWriteableRegistry() {
+        return new NamedWriteableRegistry(new MlEvaluationNamedXContentProvider().getNamedWriteables());
+    }
+
+    @Override
+    protected Response createTestInstance() {
+        String evaluationName = randomAlphaOfLength(10);
+        List<EvaluationMetricResult> metrics = List.of(new MeanSquaredError.Result(1.0));
+        return new Response(evaluationName, metrics);
+    }
+
+    @Override
+    protected Writeable.Reader<Response> instanceReader() {
+        return Response::new;
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/EvaluateDataFrameActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/EvaluateDataFrameActionResponseTests.java
@@ -11,7 +11,9 @@ import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.EvaluateDataFrameAction.Response;
 import org.elasticsearch.xpack.core.ml.dataframe.evaluation.EvaluationMetricResult;
 import org.elasticsearch.xpack.core.ml.dataframe.evaluation.MlEvaluationNamedXContentProvider;
+import org.elasticsearch.xpack.core.ml.dataframe.evaluation.classification.MulticlassConfusionMatrixResultTests;
 import org.elasticsearch.xpack.core.ml.dataframe.evaluation.regression.MeanSquaredError;
+import org.elasticsearch.xpack.core.ml.dataframe.evaluation.regression.RSquared;
 
 import java.util.List;
 
@@ -25,8 +27,13 @@ public class EvaluateDataFrameActionResponseTests extends AbstractWireSerializin
     @Override
     protected Response createTestInstance() {
         String evaluationName = randomAlphaOfLength(10);
-        List<EvaluationMetricResult> metrics = List.of(new MeanSquaredError.Result(1.0));
-        return new Response(evaluationName, metrics);
+        List<EvaluationMetricResult> metrics =
+            List.of(
+                MulticlassConfusionMatrixResultTests.createRandom(),
+                new MeanSquaredError.Result(randomDouble()),
+                new RSquared.Result(randomDouble()));
+        int numMetrics = randomIntBetween(0, metrics.size());
+        return new Response(evaluationName, metrics.subList(0, numMetrics));
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/MulticlassConfusionMatrixResultTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/MulticlassConfusionMatrixResultTests.java
@@ -19,13 +19,7 @@ import java.util.stream.Stream;
 
 public class MulticlassConfusionMatrixResultTests extends AbstractSerializingTestCase<MulticlassConfusionMatrix.Result> {
 
-    @Override
-    protected MulticlassConfusionMatrix.Result doParseInstance(XContentParser parser) throws IOException {
-        return MulticlassConfusionMatrix.Result.fromXContent(parser);
-    }
-
-    @Override
-    protected MulticlassConfusionMatrix.Result createTestInstance() {
+    public static MulticlassConfusionMatrix.Result createRandom() {
         int numClasses = randomIntBetween(2, 100);
         List<String> classNames = Stream.generate(() -> randomAlphaOfLength(10)).limit(numClasses).collect(Collectors.toList());
         Map<String, Map<String, Long>> confusionMatrix = new TreeMap<>();
@@ -40,6 +34,16 @@ public class MulticlassConfusionMatrixResultTests extends AbstractSerializingTes
         }
         long otherClassesCount = randomNonNegativeLong();
         return new MulticlassConfusionMatrix.Result(confusionMatrix, otherClassesCount);
+    }
+
+    @Override
+    protected MulticlassConfusionMatrix.Result doParseInstance(XContentParser parser) throws IOException {
+        return MulticlassConfusionMatrix.Result.fromXContent(parser);
+    }
+
+    @Override
+    protected MulticlassConfusionMatrix.Result createTestInstance() {
+        return createRandom();
     }
 
     @Override


### PR DESCRIPTION
Serialization and deserialization routines for `EvaluateDataFrameAction.Response` were not in sync since https://github.com/elastic/elasticsearch/pull/41937.
This PR fixes that.