### PR TITLE
[DOCS] Adds missing security anchors

### DIFF
--- a/x-pack/docs/en/security/authentication/oidc-guide.asciidoc
+++ b/x-pack/docs/en/security/authentication/oidc-guide.asciidoc
@@ -552,7 +552,7 @@ OP or a third party (see <<third-party-login>>). In order to do so, you must exp
 OpenID Connect authentication endpoint within {kib}, so that the {kib} server will
 not reject these external messages.
 
-
+[[oidc-without-kibana]]
 === OpenID Connect without {kib}
 
 The OpenID Connect realm is designed to allow users to authenticate to {kib} and as

--- a/x-pack/docs/en/security/authentication/saml-guide.asciidoc
+++ b/x-pack/docs/en/security/authentication/saml-guide.asciidoc
@@ -843,6 +843,7 @@ It is possible to have one or more {kib} instances that use SAML, while other
 instances use basic authentication against another realm type (e.g.
 <<native-realm, Native>> or <<ldap-realm, LDAP>>).
 
+[[saml-troubleshooting]]
 === Troubleshooting SAML Realm Configuration
 
 The SAML 2.0 specification offers a lot of options and flexibility for the implementers


### PR DESCRIPTION
This PR adds explicit anchors for two security-related pages.

Related to https://github.com/elastic/elasticsearch/issues/46880