### PR TITLE
[DOCS] Cleans up links to security content

### DIFF
--- a/docs/reference/ccr/apis/auto-follow/delete-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/delete-auto-follow-pattern.asciidoc
@@ -41,13 +41,13 @@ DELETE /_ccr/auto_follow/<auto_follow_pattern_name>
 
 * If the {es} {security-features} are enabled, you must have `manage_ccr` cluster
 privileges on the cluster that contains the follower index. For more information,
-see {stack-ov}/security-privileges.html[Security privileges].
+see <<security-privileges>>.
 
 [[ccr-delete-auto-follow-pattern-desc]]
 ==== {api-description-title}
 
 This API deletes a configured collection of
-{stack-ov}/ccr-auto-follow.html[auto-follow patterns].
+<<ccr-auto-follow,auto-follow patterns>>.
 
 [[ccr-delete-auto-follow-pattern-path-parms]]
 ==== {api-path-parms-title}

--- a/docs/reference/ccr/apis/auto-follow/get-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/get-auto-follow-pattern.asciidoc
@@ -53,12 +53,12 @@ GET /_ccr/auto_follow/<auto_follow_pattern_name>
 
 * If the {es} {security-features} are enabled, you must have `manage_ccr` cluster
 privileges on the cluster that contains the follower index. For more information,
-see {stack-ov}/security-privileges.html[Security privileges].
+see <<security-privileges>>.
 
 [[ccr-get-auto-follow-pattern-desc]]
 ==== {api-description-title}
 
-This API gets configured {stack-ov}/ccr-auto-follow.html[auto-follow patterns].
+This API gets configured <<ccr-auto-follow,auto-follow patterns>>.
 This API will return the specified auto-follow pattern collection.
 
 [[ccr-get-auto-follow-pattern-path-parms]]

--- a/docs/reference/ccr/apis/auto-follow/put-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/put-auto-follow-pattern.asciidoc
@@ -45,14 +45,13 @@ DELETE /_ccr/auto_follow/auto_follow_pattern_name
 * If the {es} {security-features} are enabled, you must have `read` and `monitor`
 index privileges for the leader index patterns. You must also have `manage_ccr`
 cluster privileges on the cluster that contains the follower index. For more
-information, see
-{stack-ov}/security-privileges.html[Security privileges].
+information, see <<security-privileges>>.
 
 [[ccr-put-auto-follow-pattern-desc]]
 ==== {api-description-title}
 
 This API creates a new named collection of
-{stack-ov}/ccr-auto-follow.html[auto-follow patterns] against the remote cluster
+<<ccr-auto-follow,auto-follow patterns>> against the remote cluster
 specified in the request body. Newly created indices on the remote cluster
 matching any of the specified patterns will be automatically configured as follower
 indices.

--- a/docs/reference/ccr/apis/follow/get-follow-info.asciidoc
+++ b/docs/reference/ccr/apis/follow/get-follow-info.asciidoc
@@ -42,8 +42,7 @@ GET /<index>/_ccr/info
 ==== {api-prereq-title}
 
 * If the {es} {security-features} are enabled, you must have `monitor` cluster
-privileges. For more information, see
-{stack-ov}/security-privileges.html[Security privileges].
+privileges. For more information, see <<security-privileges>>.
 
 [[ccr-get-follow-info-desc]]
 ==== {api-description-title}

--- a/docs/reference/ccr/apis/follow/get-follow-stats.asciidoc
+++ b/docs/reference/ccr/apis/follow/get-follow-stats.asciidoc
@@ -43,7 +43,7 @@ GET /<index>/_ccr/stats
 
 * If the {es} {security-features} are enabled, you must have `monitor` cluster
 privileges on the cluster that contains the follower index. For more information,
-see {stack-ov}/security-privileges.html[Security privileges].
+see <<security-privileges>>.
 
 [[ccr-get-follow-stats-desc]]
 ==== {api-description-title}

--- a/docs/reference/ccr/apis/follow/post-forget-follower.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-forget-follower.asciidoc
@@ -70,7 +70,7 @@ POST /<leader_index>/_ccr/forget_follower
 
 * If the {es} {security-features} are enabled, you must have `manage_leader_index`
 index privileges for the leader index. For more information, see
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ccr-post-forget-follower-desc]]
 ==== {api-description-title}

--- a/docs/reference/ccr/apis/follow/post-pause-follow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-pause-follow.asciidoc
@@ -37,7 +37,7 @@ POST /<follower_index>/_ccr/pause_follow
 
 * If the {es} {security-features} are enabled, you must have `manage_ccr` cluster
 privileges on the cluster that contains the follower index. For more information,
-see {stack-ov}/security-privileges.html[Security privileges].
+see <<security-privileges>>.
 
 [[ccr-post-pause-follow-desc]]
 ==== {api-description-title}

--- a/docs/reference/ccr/apis/follow/post-resume-follow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-resume-follow.asciidoc
@@ -51,7 +51,7 @@ POST /<follower_index>/_ccr/resume_follow
 index privileges for the follower index. You must have `read` and `monitor`
 index privileges for the leader index. You must also have `manage_ccr` cluster
 privileges on the cluster that contains the follower index. For more information,
-see {stack-ov}/security-privileges.html[Security privileges].
+see <<security-privileges>>.
 
 [[ccr-post-resume-follow-desc]]
 ==== {api-description-title}

--- a/docs/reference/ccr/apis/follow/post-unfollow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-unfollow.asciidoc
@@ -41,7 +41,7 @@ POST /<follower_index>/_ccr/unfollow
 
 * If the {es} {security-features} are enabled, you must have `manage_follow_index` 
 index privileges for the follower index. For more information, see
-{stack-ov}/security-privileges.html[Security privileges].  
+<<security-privileges>>.  
 
 [[ccr-post-unfollow-desc]]
 ==== {api-description-title}

--- a/docs/reference/ccr/apis/follow/put-follow.asciidoc
+++ b/docs/reference/ccr/apis/follow/put-follow.asciidoc
@@ -41,8 +41,7 @@ PUT /<follower_index>/_ccr/follow?wait_for_active_shards=1
 and `manage_follow_index` index privileges for the follower index. You must have
 `read` and `monitor` index privileges for the leader index. You must also have
 `manage_ccr` cluster privileges on the cluster that contains the follower index.
-For more information, see
-{stack-ov}/security-privileges.html[Security privileges].
+For more information, see <<security-privileges>>.
 
 [[ccr-put-follow-desc]]
 ==== {api-description-title}

--- a/docs/reference/ccr/apis/get-ccr-stats.asciidoc
+++ b/docs/reference/ccr/apis/get-ccr-stats.asciidoc
@@ -42,7 +42,7 @@ GET /_ccr/stats
 
 * If the {es} {security-features} are enabled, you must have `monitor` cluster
 privileges on the cluster that contains the follower index. For more information,
-see {stack-ov}/security-privileges.html[Security privileges].
+see <<security-privileges>>.
 
 [[ccr-get-stats-desc]]
 ==== {api-description-title}

--- a/docs/reference/ccr/getting-started.asciidoc
+++ b/docs/reference/ccr/getting-started.asciidoc
@@ -34,7 +34,7 @@ to control which users have authority to manage {ccr}.
 By default, you can perform all of the steps in this tutorial by
 using the built-in `elastic` user. However, a password must be set for this user
 before the user can do anything. For information about how to set that password,
-see {stack-ov}/security-getting-started.html[Tutorial: Getting started with security].
+see <<security-getting-started>>.
 
 If you are performing these steps in a production environment, take extra care
 because the `elastic` user has the `superuser` role and you could inadvertently

--- a/docs/reference/commands/certutil.asciidoc
+++ b/docs/reference/commands/certutil.asciidoc
@@ -224,7 +224,7 @@ Alternatively, you can specify the `--ca-pass`, `--out`, and `--pass` parameters
 By default, this command generates a file called `elastic-certificates.p12`,
 which you can copy to the relevant configuration directory for each Elastic
 product that you want to configure. For more information, see
-{xpack-ref}/ssl-tls.html[Setting Up TLS on a Cluster].
+<<ssl-tls>>.
 
 [float]
 [[certutil-silent]]

--- a/docs/reference/commands/setup-passwords.asciidoc
+++ b/docs/reference/commands/setup-passwords.asciidoc
@@ -4,7 +4,7 @@
 == elasticsearch-setup-passwords
 
 The `elasticsearch-setup-passwords` command sets the passwords for the
-{stack-ov}/built-in-users.html[built-in users].
+<<built-in-users,built-in users>>.
 
 [float]
 === Synopsis
@@ -21,7 +21,7 @@ bin/elasticsearch-setup-passwords auto|interactive
 
 This command is intended for use only during the initial configuration of the
 {es} {security-features}. It uses the
-{stack-ov}/built-in-users.html#bootstrap-elastic-passwords[`elastic` bootstrap password]
+<<bootstrap-elastic-passwords,`elastic` bootstrap password>>
 to run user management API requests. After you set a password for the `elastic`
 user, the bootstrap password is no longer active and you cannot use this command.
 Instead, you can change passwords by using the *Management > Users* UI in {kib}
@@ -36,7 +36,7 @@ location, ensure that the *ES_PATH_CONF* environment variable returns the
 correct path before you run the `elasticsearch-setup-passwords` command. You can
 override settings in your `elasticsearch.yml` file by using the `-E` command
 option. For more information about debugging connection failures, see
-{stack-ov}/trb-security-setup.html[`elasticsearch-setup-passwords` command fails due to connection failure].
+<<trb-security-setup>>.
 
 [float]
 === Parameters

--- a/docs/reference/commands/users-command.asciidoc
+++ b/docs/reference/commands/users-command.asciidoc
@@ -33,7 +33,7 @@ Leading or trailing whitespace is not allowed.
 
 Passwords must be at least 6 characters long.
 
-For more information, see {xpack-ref}/file-realm.html[File-based User Authentication].
+For more information, see <<file-realm>>.
 
 TIP: To ensure that {es} can read the user and role information at startup, run
 `elasticsearch-users useradd` as the same user you use to run {es}. Running the

--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -36,7 +36,7 @@ current master node fails.
 // tag::ccr-def[]
 The {ccr} feature enables you to replicate indices in remote clusters to your
 local cluster. For more information, see 
-{stack-ov}/xpack-ccr.html[{ccr-cap}].  
+{ref}/xpack-ccr.html[{ccr-cap}].  
 // end::ccr-def[]
   
 [[glossary-ccs]] {ccs} (CCS)::

--- a/docs/reference/high-availability/backup-and-restore-security-config.asciidoc
+++ b/docs/reference/high-availability/backup-and-restore-security-config.asciidoc
@@ -95,7 +95,7 @@ prevent non-administrators exfiltrating data.
 +
 --
 The following example creates a new user `snapshot_user` in the
-{stack-ov}/native-realm.html[native realm], but it is not important which
+<<native-realm,native realm>>, but it is not important which
 realm the user is a member of:
 
 [source,console]
@@ -202,7 +202,7 @@ Then log into one of the node hosts, navigate to {es} installation directory,
 and follow these steps:
 
 . Add a new user with the `superuser` built-in role to the
-{stack-ov}/file-realm.html[file realm].
+<<file-realm,file realm>>.
 +
 --
 For example, create a user named `restore_user`:

--- a/docs/reference/high-availability/backup-cluster-data.asciidoc
+++ b/docs/reference/high-availability/backup-cluster-data.asciidoc
@@ -22,6 +22,6 @@ It does *not* grant privileges to create repositories, restore snapshots, or
 search within indices. Hence, the user can view and snapshot all indices, but cannot
 access or modify any data.
 
-For more information, see {stack-ov}/security-privileges.html[Security privileges]
-and {stack-ov}/built-in-roles.html[Built-in roles].
+For more information, see <<security-privileges>>
+and <<built-in-roles>>.
 ====

--- a/docs/reference/ilm/apis/delete-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/delete-lifecycle.asciidoc
@@ -30,7 +30,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 ==== Authorization
 
 You must have the `manage_ilm` cluster privilege to use this API.
-For more information, see {stack-ov}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 ==== Examples
 

--- a/docs/reference/ilm/apis/explain.asciidoc
+++ b/docs/reference/ilm/apis/explain.asciidoc
@@ -41,7 +41,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 You must have the `view_index_metadata` or `manage_ilm` or both privileges on the indices
 being managed to use this API.
-For more information, see {stack-ov}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 ==== Examples
 

--- a/docs/reference/ilm/apis/get-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/get-lifecycle.asciidoc
@@ -30,7 +30,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 ==== Authorization
 
 You must have the `manage_ilm` or `read_ilm` or both cluster privileges to use this API.
-For more information, see {stack-ov}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 ==== Examples
 

--- a/docs/reference/ilm/apis/get-status.asciidoc
+++ b/docs/reference/ilm/apis/get-status.asciidoc
@@ -28,7 +28,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 ==== Authorization
 
 You must have the `manage_ilm` or `read_ilm` or both cluster privileges to use this API.
-For more information, see {stack-ov}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 ==== Examples
 

--- a/docs/reference/ilm/apis/move-to-step.asciidoc
+++ b/docs/reference/ilm/apis/move-to-step.asciidoc
@@ -39,7 +39,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 ==== Authorization
 
 You must have the `manage_ilm` privileges on the indices being managed to use this API.
-For more information, see {stack-ov}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 ==== Examples
 

--- a/docs/reference/ilm/apis/put-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/put-lifecycle.asciidoc
@@ -36,7 +36,7 @@ You must have the `manage_ilm` cluster privilege to use this API. You must
 also have the `manage` index privilege on all indices being managed by `policy`.
 All operations executed by {ilm} for a policy are executed as the user that
 put the latest version of a policy.
-For more information, see {stack-ov}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 ==== Examples
 

--- a/docs/reference/ilm/apis/remove-policy-from-index.asciidoc
+++ b/docs/reference/ilm/apis/remove-policy-from-index.asciidoc
@@ -30,7 +30,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 ==== Authorization
 
 You must have the `manage_ilm` privileges on the indices being managed to use this API.
-For more information, see {stack-ov}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 ==== Examples
 

--- a/docs/reference/ilm/apis/retry-policy.asciidoc
+++ b/docs/reference/ilm/apis/retry-policy.asciidoc
@@ -30,7 +30,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 ==== Authorization
 
 You must have the `manage_ilm` privileges on the indices being managed to use this API.
-For more information, see {stack-ov}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 ==== Examples
 

--- a/docs/reference/ilm/apis/slm-api.asciidoc
+++ b/docs/reference/ilm/apis/slm-api.asciidoc
@@ -43,7 +43,7 @@ You must have the `manage_slm` cluster privilege to use this API. You must also
 have the `manage` index privilege on all indices being managed by `policy`. All
 operations executed by {slm} for a policy are executed as the user that put the
 latest version of a policy. For more information, see
-{stack-ov}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 ==== Example
 

--- a/docs/reference/ilm/apis/start.asciidoc
+++ b/docs/reference/ilm/apis/start.asciidoc
@@ -27,7 +27,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 ==== Authorization
 
 You must have the `manage_ilm` cluster privilege to use this API.
-For more information, see {stack-ov}/security-privileges.html[Security privileges].
+For more information, see <<security-privileges>>.
 
 ==== Examples
 

--- a/docs/reference/ilm/apis/stop.asciidoc
+++ b/docs/reference/ilm/apis/stop.asciidoc
@@ -32,7 +32,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 ==== Authorization
 
 You must have the `manage_ilm` cluster privilege to use this API.
-For more information, see {stack-ov}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 ==== Examples
 

--- a/docs/reference/licensing/delete-license.asciidoc
+++ b/docs/reference/licensing/delete-license.asciidoc
@@ -17,14 +17,14 @@ This API enables you to delete licensing information.
 ==== Description
 
 When your license expires, {xpack} operates in a degraded mode.  For more
-information, see {xpack-ref}/license-expiration.html[License Expiration].
+information, see {stack-ov}/license-expiration.html[License Expiration].
 
 [float]
 ==== Authorization
 
 You must have `manage` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 [float]
 ==== Examples

--- a/docs/reference/licensing/get-basic-status.asciidoc
+++ b/docs/reference/licensing/get-basic-status.asciidoc
@@ -25,8 +25,7 @@ https://www.elastic.co/subscriptions.
 ==== Authorization
 
 You must have `monitor` cluster privileges to use this API.
-For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 [float]
 ==== Examples

--- a/docs/reference/licensing/get-license.asciidoc
+++ b/docs/reference/licensing/get-license.asciidoc
@@ -35,8 +35,7 @@ https://www.elastic.co/subscriptions.
 ==== Authorization
 
 You must have `monitor` cluster privileges to use this API.
-For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 
 [float]

--- a/docs/reference/licensing/get-trial-status.asciidoc
+++ b/docs/reference/licensing/get-trial-status.asciidoc
@@ -32,7 +32,7 @@ https://www.elastic.co/subscriptions.
 
 You must have `monitor` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 [float]
 ==== Examples

--- a/docs/reference/licensing/start-basic.asciidoc
+++ b/docs/reference/licensing/start-basic.asciidoc
@@ -32,7 +32,7 @@ https://www.elastic.co/subscriptions.
 
 You must have `manage` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 [float]
 ==== Examples

--- a/docs/reference/licensing/start-trial.asciidoc
+++ b/docs/reference/licensing/start-trial.asciidoc
@@ -35,7 +35,7 @@ https://www.elastic.co/subscriptions.
 
 You must have `manage` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 [float]
 ==== Examples

--- a/docs/reference/licensing/update-license.asciidoc
+++ b/docs/reference/licensing/update-license.asciidoc
@@ -160,4 +160,4 @@ curl -XPUT -u elastic 'http://<host>:<port>/_license?acknowledge=true' -H "Conte
 // NOTCONSOLE
 
 For more information about the features that are disabled when you downgrade
-your license, see {xpack-ref}/license-expiration.html[License Expiration].
+your license, see {stack-ov}/license-expiration.html[License Expiration].

--- a/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
@@ -26,7 +26,7 @@ operations, but you can still explore and navigate results.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-close-job-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/datafeedresource.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/datafeedresource.asciidoc
@@ -9,7 +9,7 @@ A {dfeed} resource has the following properties:
   (object) If set, the {dfeed} performs aggregation searches.
   Support for aggregations is limited and should only be used with
   low cardinality data. For more information, see
-  {xpack-ref}/ml-configuring-aggregation.html[Aggregating Data for Faster Performance].
+  {stack-ov}/ml-configuring-aggregation.html[Aggregating Data for Faster Performance].
 
 `chunking_config`::
   (object) Specifies how data searches are split into time chunks.
@@ -53,7 +53,7 @@ A {dfeed} resource has the following properties:
   The <<ml-detectorconfig,detector configuration objects>> in a job can contain
   functions that use these script fields.
   For more information, see
-  {xpack-ref}/ml-configuring-transform.html[Transforming Data With Script Fields].
+  {stack-ov}/ml-configuring-transform.html[Transforming Data With Script Fields].
 
 `scroll_size`::
   (unsigned integer) The `size` parameter that is used in {es} searches.

--- a/docs/reference/ml/anomaly-detection/apis/delete-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-calendar-event.asciidoc
@@ -18,7 +18,7 @@ Deletes scheduled events from a calendar.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-delete-calendar-event-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-calendar-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-calendar-job.asciidoc
@@ -18,7 +18,7 @@ Deletes {anomaly-jobs} from a calendar.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-delete-calendar-job-path-parms]]
 ==== {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-calendar.asciidoc
@@ -18,7 +18,7 @@ Deletes a calendar.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-delete-calendar-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-datafeed.asciidoc
@@ -22,7 +22,7 @@ Deletes an existing {dfeed}.
 can delete it.
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-delete-datafeed-path-parms]]
 ==== {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-expired-data.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-expired-data.asciidoc
@@ -18,7 +18,7 @@ Deletes expired and unused machine learning data.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-delete-expired-data-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-filter.asciidoc
@@ -23,7 +23,7 @@ Deletes a filter.
 [[ml-delete-filter-desc]]
 ==== {api-description-title}
 
-This API deletes a <<ml-rules,filter>>. 
+This API deletes a {stack-ov}/ml-rules.html[filter]. 
 If a {ml} job references the filter, you cannot delete the filter. You must 
 update or delete the job before you can delete the filter.
 

--- a/docs/reference/ml/anomaly-detection/apis/delete-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-filter.asciidoc
@@ -18,12 +18,12 @@ Deletes a filter.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-delete-filter-desc]]
 ==== {api-description-title}
 
-This API deletes a {stack-ov}/ml-rules.html[filter]. 
+This API deletes a <<ml-rules,filter>>. 
 If a {ml} job references the filter, you cannot delete the filter. You must 
 update or delete the job before you can delete the filter.
 

--- a/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
@@ -22,7 +22,7 @@ Deletes forecasts from a {ml} job.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-delete-forecast-desc]]
 ==== {api-description-title}
@@ -34,8 +34,7 @@ one or more forecasts before they expire.
 
 NOTE: When you delete a job, its associated forecasts are deleted. 
 
-For more information, see
-{stack-ov}/ml-overview.html#ml-forecasting[Forecasting the future].
+For more information, see <<ml-forecasting>>.
 
 [[ml-delete-forecast-path-parms]]
 ==== {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
@@ -34,7 +34,8 @@ one or more forecasts before they expire.
 
 NOTE: When you delete a job, its associated forecasts are deleted. 
 
-For more information, see <<ml-forecasting>>.
+For more information, see
+{stack-ov}/ml-overview.html#ml-forecasting[Forecasting the future].
 
 [[ml-delete-forecast-path-parms]]
 ==== {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-job.asciidoc
@@ -17,8 +17,7 @@ Deletes an existing {anomaly-job}.
 ==== {api-prereq-title}
 
 * If {es} {security-features} are enabled, you must have `manage_ml` or `manage`
-cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+cluster privileges to use this API. See <<security-privileges>>.
 
 [[ml-delete-job-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-snapshot.asciidoc
@@ -17,8 +17,7 @@ Deletes an existing model snapshot.
 ==== {api-prereq-title}
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
-`manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+`manage` cluster privileges to use this API. See <<security-privileges>>.
 
 [[ml-delete-snapshot-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/eventresource.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/eventresource.asciidoc
@@ -24,4 +24,4 @@ An events resource has the following properties:
  in milliseconds since the epoch or ISO 8601 format.
 
 For more information, see
-{xpack-ref}/ml-calendars.html[Calendars and Scheduled Events].
+{stack-ov}/ml-calendars.html[Calendars and Scheduled Events].

--- a/docs/reference/ml/anomaly-detection/apis/find-file-structure.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/find-file-structure.asciidoc
@@ -21,7 +21,7 @@ suitable to be ingested into {es}.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml` or
 `monitor` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-find-file-structure-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/flush-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/flush-job.asciidoc
@@ -18,7 +18,7 @@ Forces any buffered data to be processed by the job.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-flush-job-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
@@ -18,7 +18,7 @@ Predicts the future behavior of a time series by using its historical behavior.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-forecast-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-bucket.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-bucket.asciidoc
@@ -23,8 +23,8 @@ Retrieves {anomaly-job} results for one or more buckets.
 need `read` index privilege on the index that stores the results. The
 `machine_learning_admin` and `machine_learning_user` roles provide these
 privileges. For more information, see
-{stack-ov}/security-privileges.html[Security privileges] and
-{stack-ov}/built-in-roles.html[Built-in roles].
+<<security-privileges>> and
+<<built-in-roles>>.
 
 [[ml-get-bucket-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
@@ -20,7 +20,7 @@ Retrieves information about the scheduled events in calendars.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-get-calendar-event-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
@@ -20,7 +20,7 @@ Retrieves configuration information for calendars.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-get-calendar-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
@@ -22,8 +22,8 @@ Retrieves {anomaly-job} results for one or more categories.
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. You also
 need `read` index privilege on the index that stores the results. The
 `machine_learning_admin` and `machine_learning_user` roles provide these
-privileges. See {stack-ov}/security-privileges.html[Security privileges] and
-{stack-ov}/built-in-roles.html[Built-in roles].
+privileges. See <<security-privileges>> and
+<<built-in-roles>>.
 
 [[ml-get-category-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
@@ -26,7 +26,7 @@ Retrieves usage information for {dfeeds}.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-get-datafeed-stats-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
@@ -26,7 +26,7 @@ Retrieves configuration information for {dfeeds}.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-get-datafeed-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-filter.asciidoc
@@ -20,7 +20,7 @@ Retrieves filters.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-get-filter-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
@@ -20,8 +20,8 @@ Retrieves {anomaly-job} results for one or more influencers.
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. You also
 need `read` index privilege on the index that stores the results. The
 `machine_learning_admin` and `machine_learning_user` roles provide these
-privileges. See {stack-ov}/security-privileges.html[Security privileges] and
-{stack-ov}/built-in-roles.html[Built-in roles].
+privileges. See <<security-privileges>> and
+<<built-in-roles>>.
 
 [[ml-get-influencer-path-parms]]
 ==== {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
@@ -24,7 +24,7 @@ Retrieves usage information for {anomaly-jobs}.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-get-job-stats-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
@@ -24,7 +24,7 @@ Retrieves configuration information for {anomaly-jobs}.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-get-job-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-ml-info.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-ml-info.asciidoc
@@ -21,8 +21,8 @@ Returns defaults and limits used by machine learning.
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. The
 `machine_learning_admin` and `machine_learning_user` roles provide these
-privileges. See {stack-ov}/security-privileges.html[Security privileges] and
-{stack-ov}/built-in-roles.html[Built-in roles].
+privileges. See <<security-privileges>> and
+<<built-in-roles>>.
 
 [[get-ml-info-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
@@ -25,8 +25,7 @@ Retrieves overall bucket results that summarize the bucket results of multiple
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. You also
 need `read` index privilege on the index that stores the results. The
 `machine_learning_admin` and `machine_learning_user` roles provide these
-privileges. See {stack-ov}/security-privileges.html[Security privileges] and
-{stack-ov}/built-in-roles.html[Built-in roles].
+privileges. See <<security-privileges>> and <<built-in-roles>>.
 
 [[ml-get-overall-buckets-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
@@ -20,8 +20,7 @@ Retrieves anomaly records for an {anomaly-job}.
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. You also
 need `read` index privilege on the index that stores the results. The
 `machine_learning_admin` and `machine_learning_user` roles provide these
-privileges. See {stack-ov}/security-privileges.html[Security privileges] and
-{stack-ov}/built-in-roles.html[Built-in roles].
+privileges. See <<security-privileges>> and <<built-in-roles>>.
 
 [[ml-get-record-path-parms]]
 ==== {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
@@ -20,7 +20,7 @@ Retrieves information about model snapshots.
 
 * If the {es} {security-features} are enabled, you must have `monitor_ml`,
 `monitor`, `manage_ml`, or `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-get-snapshot-path-parms]]
 ==== {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/jobresource.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/jobresource.asciidoc
@@ -33,7 +33,7 @@ so do not set the `background_persist_interval` value too low.
 `custom_settings`::
   (object) Advanced configuration option. Contains custom meta data about the
   job. For example, it can contain custom URL information as shown in
-  {xpack-ref}/ml-configuring-url.html[Adding Custom URLs to Machine Learning Results].
+  {stack-ov}/ml-configuring-url.html[Adding Custom URLs to Machine Learning Results].
 
 `data_description`::
   (object) Describes the data format and how APIs parse timestamp fields.
@@ -110,7 +110,7 @@ An analysis configuration object has the following properties:
   be categorized. The resulting categories must be used in a detector by setting
   `by_field_name`, `over_field_name`, or `partition_field_name` to the keyword
   `mlcategory`. For more information, see
-  {xpack-ref}/ml-configuring-categories.html[Categorizing Log Messages].
+  {stack-ov}/ml-configuring-categories.html[Categorizing Log Messages].
 
 `categorization_filters`::
   (array of strings) If `categorization_field_name` is specified,
@@ -120,7 +120,7 @@ An analysis configuration object has the following properties:
   tune the categorization by excluding sequences from consideration when
   categories are defined. For example, you can exclude SQL statements that
   appear in your log files. For more information, see
-  {xpack-ref}/ml-configuring-categories.html[Categorizing Log Messages].
+  {stack-ov}/ml-configuring-categories.html[Categorizing Log Messages].
   This property cannot be used at the same time as `categorization_analyzer`.
   If you only want to define simple regular expression filters that are applied
   prior to tokenization, setting this property is the easiest method.
@@ -243,14 +243,14 @@ NOTE: The `field_name` cannot contain double quotes or backslashes.
 `function`::
   (string) The analysis function that is used. 
   For example, `count`, `rare`, `mean`, `min`, `max`, and `sum`. For more
-  information, see {xpack-ref}/ml-functions.html[Function Reference].
+  information, see {stack-ov}/ml-functions.html[Function Reference].
 
 `over_field_name`::
   (string) The field used to split the data.
   In particular, this property is used for analyzing the splits with respect to
   the history of all splits. It is used for finding unusual values in the
   population of all splits. For more information, see
-  {xpack-ref}/ml-configuring-pop.html[Performing Population Analysis].
+  {stack-ov}/ml-configuring-pop.html[Performing population analysis].
 
 `partition_field_name`::
   (string) The field used to segment the analysis.
@@ -406,7 +406,7 @@ the categorization analyzer produces then you find the original document that
 the categorization field value came from.
 
 For more information, see
-{xpack-ref}/ml-configuring-categories.html[Categorizing Log Messages].
+{stack-ov}/ml-configuring-categories.html[Categorizing log messages].
 
 [float]
 [[ml-detector-custom-rule]]
@@ -489,7 +489,7 @@ The `analysis_limits` object has the following properties:
 --
 NOTE: The `categorization_examples_limit` only applies to analysis that uses categorization.
 For more information, see
-{xpack-ref}/ml-configuring-categories.html[Categorizing Log Messages].
+{stack-ov}/ml-configuring-categories.html[Categorizing log messages].
 
 --
 

--- a/docs/reference/ml/anomaly-detection/apis/open-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/open-job.asciidoc
@@ -18,7 +18,7 @@ Opens one or more {anomaly-jobs}.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-open-job-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/post-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/post-calendar-event.asciidoc
@@ -18,7 +18,7 @@ Posts scheduled events in a calendar.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-post-calendar-event-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/post-data.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/post-data.asciidoc
@@ -18,7 +18,7 @@ Sends data to an anomaly detection job for analysis.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-post-data-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/preview-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/preview-datafeed.asciidoc
@@ -20,7 +20,7 @@ Previews a {dfeed}.
 
 * If {es} {security-features} are enabled, you must have `monitor_ml`, `monitor`,
 `manage_ml`, or `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-preview-datafeed-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-calendar-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-calendar-job.asciidoc
@@ -18,7 +18,7 @@ Adds an {anomaly-job} to a calendar.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-put-calendar-job-path-parms]]
 ==== {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-calendar.asciidoc
@@ -18,7 +18,7 @@ Instantiates a calendar.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-put-calendar-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
@@ -21,7 +21,7 @@ Instantiates a {dfeed}.
 * You must create an {anomaly-job} before you create a {dfeed}.  
 * If {es} {security-features} are enabled, you must have `manage_ml` or `manage`
 cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-put-datafeed-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-filter.asciidoc
@@ -18,7 +18,7 @@ Instantiates a filter.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-put-filter-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -18,7 +18,7 @@ Instantiates an {anomaly-job}.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-put-job-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/resultsresource.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/resultsresource.asciidoc
@@ -38,7 +38,7 @@ Categorization results contain the definitions of _categories_ that have been
 identified. These are only applicable for jobs that are configured to analyze
 unstructured log data using categorization. These results do not contain a
 timestamp or any calculated scores. For more information, see
-{xpack-ref}/ml-configuring-categories.html[Categorizing Log Messages].
+{stack-ov}/ml-configuring-categories.html[Categorizing log messages].
 
 * <<ml-results-buckets,Buckets>>
 * <<ml-results-influencers,Influencers>>

--- a/docs/reference/ml/anomaly-detection/apis/revert-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/revert-snapshot.asciidoc
@@ -19,7 +19,7 @@ Reverts to a specific snapshot.
 * Before you revert to a saved snapshot, you must close the job.
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-revert-snapshot-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/set-upgrade-mode.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/set-upgrade-mode.asciidoc
@@ -29,7 +29,7 @@ POST /_ml/set_upgrade_mode?enabled=false&timeout=10m
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-set-upgrade-mode-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/start-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/start-datafeed.asciidoc
@@ -22,7 +22,7 @@ Starts one or more {dfeeds}.
 error occurs.
 * If {es} {security-features} are enabled, you must have `manage_ml` or `manage`
 cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-start-datafeed-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
@@ -24,7 +24,7 @@ Stops one or more {dfeeds}.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-stop-datafeed-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
@@ -22,7 +22,7 @@ Updates certain properties of a {dfeed}.
 
 * If {es} {security-features} are enabled, you must have `manage_ml`, or `manage`
 cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 
 [[ml-update-datafeed-desc]]

--- a/docs/reference/ml/anomaly-detection/apis/update-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-filter.asciidoc
@@ -18,7 +18,7 @@ Updates the description of a filter, adds items, or removes items.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-update-filter-path-parms]]
 ==== {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
@@ -18,7 +18,7 @@ Updates certain properties of an {anomaly-job}.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 
 [[ml-update-job-path-parms]]

--- a/docs/reference/ml/anomaly-detection/apis/update-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-snapshot.asciidoc
@@ -18,7 +18,7 @@ Updates certain properties of a snapshot.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 
 [[ml-update-snapshot-path-parms]]

--- a/docs/reference/ml/anomaly-detection/apis/validate-detector.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/validate-detector.asciidoc
@@ -18,7 +18,7 @@ Validates detector configuration information.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-valid-detector-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/validate-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/validate-job.asciidoc
@@ -18,7 +18,7 @@ Validates {anomaly-job} configuration information.
 
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-valid-job-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
@@ -20,8 +20,7 @@ experimental[]
 ==== {api-prereq-title}
 
 * You must have `machine_learning_admin` built-in role to use this API. For more 
-information, see {stack-ov}/security-privileges.html[Security privileges] and 
-{stack-ov}/built-in-roles.html[Built-in roles].
+information, see <<security-privileges>> and <<built-in-roles>>.
 
 [[ml-delete-dfanalytics-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/ml/df-analytics/apis/estimate-memory-usage-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/estimate-memory-usage-dfanalytics.asciidoc
@@ -21,8 +21,7 @@ experimental[]
 ==== {api-prereq-title}
 
 * You must have `monitor_ml` privilege to use this API. For more 
-information, see {stack-ov}/security-privileges.html[Security privileges] and 
-{stack-ov}/built-in-roles.html[Built-in roles].
+information, see <<security-privileges>> and <<built-in-roles>>.
 
 [[ml-estimate-memory-usage-dfanalytics-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -21,8 +21,7 @@ experimental[]
 ==== {api-prereq-title}
 
 * You must have `monitor_ml` privilege to use this API. For more 
-information, see {stack-ov}/security-privileges.html[Security privileges] and 
-{stack-ov}/built-in-roles.html[Built-in roles].
+information, see <<security-privileges>> and <<built-in-roles>>.
 
 [[ml-evaluate-dfanalytics-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -29,8 +29,7 @@ experimental[]
 ==== {api-prereq-title}
 
 * You must have `monitor_ml` privilege to use this API. For more 
-information, see {stack-ov}/security-privileges.html[Security privileges] and 
-{stack-ov}/built-in-roles.html[Built-in roles].
+information, see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[ml-get-dfanalytics-stats-path-params]]

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
@@ -26,8 +26,7 @@ experimental[]
 ==== {api-prereq-title}
 
 * You must have `monitor_ml` privilege to use this API. For more 
-information, see {stack-ov}/security-privileges.html[Security privileges] and 
-{stack-ov}/built-in-roles.html[Built-in roles].
+information, see <<security-privileges>> and <<built-in-roles>>.
 
 [[ml-get-dfanalytics-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -23,8 +23,7 @@ experimental[]
 * You must have `machine_learning_admin` built-in role to use this API. You must 
 also have `read` and `view_index_metadata` privileges on the source index and 
 `read`, `create_index`, and `index` privileges on the destination index. For 
-more information, see {stack-ov}/security-privileges.html[Security privileges] 
-and {stack-ov}/built-in-roles.html[Built-in roles].
+more information, see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[ml-put-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
@@ -23,8 +23,7 @@ experimental[]
 * You must have `machine_learning_admin` built-in role to use this API. You must 
 also have `read` and `view_index_metadata` privileges on the source index and 
 `read`, `create_index`, and `index` privileges on the destination index. For 
-more information, see {stack-ov}/security-privileges.html[Security privileges] 
-and {stack-ov}/built-in-roles.html[Built-in roles].
+more information, see <<security-privileges>> and <<built-in-roles>>.
 
 [[ml-start-dfanalytics-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
@@ -25,8 +25,7 @@ experimental[]
 ==== {api-prereq-title}
 
 * You must have `machine_learning_admin` built-in role to use this API. For more 
-information, see {stack-ov}/security-privileges.html[Security privileges] and 
-{stack-ov}/built-in-roles.html[Built-in roles].
+information, see <<security-privileges>> and <<built-in-roles>>.
 
 [[ml-stop-dfanalytics-desc]]
 ==== {api-description-title}

--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -9,7 +9,7 @@ endif::[]
 ifdef::include-xpack[]
 The _remote clusters_ module enables you to establish uni-directional
 connections to a remote cluster. This functionality is used in
-{stack-ov}/xpack-ccr.html[{ccr}] and
+<<xpack-ccr,{ccr}>> and
 <<modules-cross-cluster-search,{ccs}>>.
 endif::[]
 

--- a/docs/reference/monitoring/collecting-monitoring-data.asciidoc
+++ b/docs/reference/monitoring/collecting-monitoring-data.asciidoc
@@ -18,8 +18,7 @@ Advanced monitoring settings enable you to control how frequently data is
 collected, configure timeouts, and set the retention period for locally-stored 
 monitoring indices. You can also adjust how monitoring data is displayed. 
 
-To learn about monitoring in general, see 
-{stack-ov}/xpack-monitoring.html[Monitoring the {stack}]. 
+To learn about monitoring in general, see <<monitor-elasticsearch-cluster>>. 
 
 . Configure your cluster to collect monitoring data:
 
@@ -131,9 +130,9 @@ xpack.monitoring.exporters:
 must provide appropriate credentials when data is shipped to the monitoring cluster:
 
 ... Create a user on the monitoring cluster that has the 
-{stack-ov}/built-in-roles.html[`remote_monitoring_agent` built-in role]. 
+<<built-in-roles,`remote_monitoring_agent` built-in role>>. 
 Alternatively, use the 
-{stack-ov}/built-in-users.html[`remote_monitoring_user` built-in user].
+<<built-in-users,`remote_monitoring_user` built-in user>>.
 
 ... Add the user ID and password settings to the HTTP exporter settings in the 
 `elasticsearch.yml` file on each node. +
@@ -197,8 +196,7 @@ xpack.monitoring.exporters:
 
 . Configure your cluster to route monitoring data from sources such as {kib}, 
 Beats, and {ls} to the monitoring cluster. For information about configuring
-each product to collect and send monitoring data, see
-{stack-ov}/xpack-monitoring.html[Monitoring the {stack}].
+each product to collect and send monitoring data, see <<monitor-elasticsearch-cluster>>.
 
 . If you updated settings in the `elasticsearch.yml` files on your production 
 cluster, restart {es}. See <<stopping-elasticsearch>> and <<starting-elasticsearch>>. 

--- a/docs/reference/monitoring/configuring-filebeat.asciidoc
+++ b/docs/reference/monitoring/configuring-filebeat.asciidoc
@@ -39,12 +39,12 @@ For more information, see <<monitoring-settings>> and <<cluster-update-settings>
 +
 --
 The {filebeat} {es} module can handle
-{stack-ov}/audit-log-output.html[audit logs],
-{ref}/logging.html#deprecation-logging[deprecation logs],
-{ref}/gc-logging.html[gc logs], {ref}/logging.html[server logs], and 
-{ref}/index-modules-slowlog.html[slow logs].
+<<audit-log-output,audit logs>>,
+<<deprecation-logging,deprecation logs>>,
+<<gc-logging,gc logs>>, <<logging,server logs>>, and 
+<<index-modules-slowlog,slow logs>>.
 For more information about the location of your {es} logs, see the
-{ref}/path-settings.html[path.logs] setting.
+<<path-settings,path.logs>> setting.
 
 IMPORTANT: If there are both structured (`*.json`) and unstructured (plain text)
 versions of the logs, you must use the structured logs. Otherwise, they might
@@ -117,7 +117,7 @@ If {security-features} are enabled, you must provide a valid user ID and
 password so that {filebeat} can connect to {kib}: 
 
 .. Create a user on the monitoring cluster that has the 
-{stack-ov}/built-in-roles.html[`kibana_user` built-in role] or equivalent
+<<built-in-roles,`kibana_user` built-in role>> or equivalent
 privileges.
 
 .. Add the `username` and `password` settings to the {es} output information in 
@@ -175,7 +175,7 @@ to file ownership or permissions when you try to run {filebeat} modules. See
 . Check whether the appropriate indices exist on the monitoring cluster.
 +
 --
-For example, use the {ref}/cat-indices.html[cat indices] command to verify
+For example, use the <<cat-indices,cat indices>> command to verify
 that there are new `filebeat-*` indices. 
 
 TIP: If you want to use the *Monitoring* UI in {kib}, there must also be 

--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -14,9 +14,6 @@ as described in <<collecting-monitoring-data>>.
 
 image::monitoring/images/metricbeat.png[Example monitoring architecture]
 
-To learn about monitoring in general, see 
-{stack-ov}/xpack-monitoring.html[Monitoring the {stack}]. 
-
 //NOTE: The tagged regions are re-used in the Stack Overview.
 
 . Enable the collection of monitoring data. +
@@ -106,9 +103,9 @@ If Elastic {security-features} are enabled, you must also provide a user ID
 and password so that {metricbeat} can collect metrics successfully: 
 
 .. Create a user on the production cluster that has the
-{stack-ov}/built-in-roles.html[`remote_monitoring_collector` built-in role]. 
+<<built-in-roles,`remote_monitoring_collector` built-in role>>. 
 Alternatively, use the
-{stack-ov}/built-in-users.html[`remote_monitoring_user` built-in user].
+<<built-in-users,`remote_monitoring_user` built-in user>>.
 
 .. Add the `username` and `password` settings to the {es} module configuration
 file. 
@@ -171,9 +168,9 @@ provide a valid user ID and password so that {metricbeat} can send metrics
 successfully: 
 
 .. Create a user on the monitoring cluster that has the 
-{stack-ov}/built-in-roles.html[`remote_monitoring_agent` built-in role]. 
+<<built-in-roles,`remote_monitoring_agent` built-in role>>. 
 Alternatively, use the 
-{stack-ov}/built-in-users.html[`remote_monitoring_user` built-in user].
+<<built-in-users,`remote_monitoring_user` built-in user>>.
 
 .. Add the `username` and `password` settings to the {es} output information in 
 the {metricbeat} configuration file.

--- a/docs/reference/monitoring/production.asciidoc
+++ b/docs/reference/monitoring/production.asciidoc
@@ -60,12 +60,12 @@ credentials must be valid on both the {kib} server and the monitoring cluster.
 *** If you plan to use {metricbeat} to collect data about {es} or {kib}, 
 create a user that has the `remote_monitoring_collector` built-in role and a 
 user that has the `remote_monitoring_agent` 
-{stack-ov}/built-in-roles.html#built-in-roles-remote-monitoring-agent[built-in role]. Alternatively, use the 
-`remote_monitoring_user` {stack-ov}/built-in-users.html[built-in user]. 
+<<built-in-roles-remote-monitoring-agent,built-in role>>. Alternatively, use the 
+`remote_monitoring_user` <<built-in-users,built-in user>>. 
 
 *** If you plan to use HTTP exporters to route data through your production 
 cluster, create a user that has the `remote_monitoring_agent` 
-{stack-ov}/built-in-roles.html#built-in-roles-remote-monitoring-agent[built-in role]. 
+<<built-in-roles-remote-monitoring-agent,built-in role>>. 
 +
 --
 For example, the 
@@ -83,7 +83,7 @@ POST /_security/user/remote_monitor
 ---------------------------------------------------------------
 // TEST[skip:needs-gold+-license]
 
-Alternatively, use the `remote_monitoring_user` {stack-ov}/built-in-users.html[built-in user]. 
+Alternatively, use the `remote_monitoring_user` <<built-in-users,built-in user>>. 
 --
 
 . Configure your production cluster to collect data and send it to the 

--- a/docs/reference/rollup/apis/delete-job.asciidoc
+++ b/docs/reference/rollup/apis/delete-job.asciidoc
@@ -21,7 +21,7 @@ experimental[]
 
 * If the {es} {security-features} are enabled, you must have `manage` or
 `manage_rollup` cluster privileges to use this API. For more information, see
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[rollup-delete-job-desc]]
 ==== {api-description-title}

--- a/docs/reference/rollup/apis/get-job.asciidoc
+++ b/docs/reference/rollup/apis/get-job.asciidoc
@@ -20,7 +20,7 @@ experimental[]
 
 * You must have `monitor`, `monitor_rollup`, `manage` or `manage_rollup` cluster
 privileges to use this API. For more information, see
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[rollup-get-job-desc]]
 ==== {api-description-title}

--- a/docs/reference/rollup/apis/put-job.asciidoc
+++ b/docs/reference/rollup/apis/put-job.asciidoc
@@ -21,7 +21,7 @@ experimental[]
 
 * If the {es} {security-features} are enabled, you must have `manage` or
 `manage_rollup` cluster privileges to use this API. For more information, see
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[rollup-put-job-api-desc]]
 ==== {api-description-title}

--- a/docs/reference/rollup/apis/rollup-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-caps.asciidoc
@@ -43,7 +43,7 @@ There is no request body for the Get Rollup Caps API.
 
 You must have `monitor`, `monitor_rollup`, `manage` or `manage_rollup` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 ==== Examples
 

--- a/docs/reference/rollup/apis/rollup-index-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-index-caps.asciidoc
@@ -35,7 +35,7 @@ There is no request body for the Get Jobs API.
 
 You must have the `read` index privilege on the index that stores the rollup results.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 ==== Examples
 

--- a/docs/reference/rollup/apis/start-job.asciidoc
+++ b/docs/reference/rollup/apis/start-job.asciidoc
@@ -21,7 +21,7 @@ experimental[]
 
 * You must have `manage` or `manage_rollup` cluster privileges to use this API.
 For more information, see
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[rollup-start-job-desc]]
 ==== {api-description-title}

--- a/docs/reference/rollup/apis/stop-job.asciidoc
+++ b/docs/reference/rollup/apis/stop-job.asciidoc
@@ -21,7 +21,7 @@ experimental[]
 
 * You must have `manage` or `manage_rollup` cluster privileges to use this API.
 For more information, see
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[rollup-stop-job-desc]]
 ===== {api-description-title}

--- a/docs/reference/settings/audit-settings.asciidoc
+++ b/docs/reference/settings/audit-settings.asciidoc
@@ -6,8 +6,7 @@
 ++++
 
 All of these settings can be added to the `elasticsearch.yml` configuration
-file. For more information, see
-{stack-ov}/auditing.html[Auditing Security Events].
+file. For more information, see <<auditing>>.
 
 [[general-audit-settings]]
 ==== General Auditing Settings
@@ -69,7 +68,7 @@ The default value is `true`.
 [[audit-event-ignore-policies]]
 ==== Audit Logfile Event Ignore Policies
 
-These settings affect the {stack-ov}/audit-log-output.html#audit-log-ignore-policy[ignore policies]
+These settings affect the <<audit-log-ignore-policy,ignore policies>>
 that enable fine-grained control over which audit events are printed to the log file.
 All of the settings with the same policy name combine to form a single policy.
 If an event matches all of the conditions for a specific policy, it is ignored 

--- a/docs/reference/settings/ccr-settings.asciidoc
+++ b/docs/reference/settings/ccr-settings.asciidoc
@@ -10,7 +10,7 @@ These {ccr} settings can be dynamically updated on a live cluster with the
 ==== Remote recovery settings
 
 The following setting can be used to rate-limit the data transmitted during
-{stack-ov}/remote-recovery.html[remote recoveries]:
+<<remote-recovery,remote recoveries>>:
 
 `ccr.indices.recovery.max_bytes_per_sec` (<<cluster-update-settings,Dynamic>>)::
 Limits the total inbound and outbound remote recovery traffic on each node.

--- a/docs/reference/settings/monitoring-settings.asciidoc
+++ b/docs/reference/settings/monitoring-settings.asciidoc
@@ -22,8 +22,7 @@ Logstash, configure
 {logstash-ref}/monitoring-internal-collection.html#monitoring-settings[`xpack.monitoring` settings]
 in `logstash.yml`.
 
-For more information, see
-{xpack-ref}/xpack-monitoring.html[Monitoring the Elastic Stack].
+For more information, see <<monitor-elasticsearch-cluster>>.
 
 [float]
 [[general-monitoring-settings]]

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -242,7 +242,7 @@ Defaults to `ssha256`.
 
 `authentication.enabled`:: If set to `false`, disables authentication support in
 this realm, so that it only supports user lookups.
-(See the <<run-as-privilege.html,run as>> and
+(See the <<run-as-privilege,run as>> and
 <<authorization_realms,authorization realms>> features).
 Defaults to `true`.
 

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -64,8 +64,7 @@ See <<password-hashing-algorithms>>. Defaults to `bcrypt`.
 [[anonymous-access-settings]]
 ==== Anonymous access settings
 You can configure the following anonymous access settings in
-`elasticsearch.yml`.  For more information, see {stack-ov}/anonymous-access.html[
-Enabling anonymous access].
+`elasticsearch.yml`.  For more information, see <<anonymous-access>>.
 
 `xpack.security.authc.anonymous.username`::
 The username (principal) of the anonymous user. Defaults to `_es_anonymous_user`.
@@ -115,8 +114,7 @@ Defaults to `48h` (48 hours).
 
 You can set the following document and field level security
 settings in `elasticsearch.yml`. For more information, see
-{stack-ov}/field-and-document-access-control.html[Setting up document and field
-level security].
+<<field-and-document-access-control>>.
 
 `xpack.security.dls_fls.enabled`::
 Set to `false` to prevent document and field level security
@@ -205,7 +203,7 @@ xpack.security.authc.realms:
 ----------------------------------------
 
 The valid settings vary depending on the realm type. For more
-information, see {stack-ov}/setting-up-authentication.html[Setting up authentication].
+information, see <<setting-up-authentication>>.
 
 [float]
 [[ref-realm-settings]]
@@ -244,8 +242,8 @@ Defaults to `ssha256`.
 
 `authentication.enabled`:: If set to `false`, disables authentication support in
 this realm, so that it only supports user lookups.
-(See the {stack-ov}/run-as-privilege.html[run as] and
-{stack-ov}/realm-chains.html#authorization_realms[authorization realms] features).
+(See the <<run-as-privilege.html,run as>> and
+<<authorization_realms,authorization realms>> features).
 Defaults to `true`.
 
 [[ref-users-settings]]
@@ -260,7 +258,7 @@ the following settings:
 `cache.ttl`::
 The time-to-live for cached user entries. A user and a hash of its credentials 
 are cached for this configured period of time. Defaults to `20m`. Specify values 
-using the standard {es} {ref}/common-options.html#time-units[time units].
+using the standard {es} <<time-units,time units>>.
 Defaults to `20m`.
 
 `cache.max_users`::
@@ -273,8 +271,8 @@ user credentials. See <<cache-hash-algo>>. Defaults to `ssha256`.
 
 `authentication.enabled`:: If set to `false`, disables authentication support in
 this realm, so that it only supports user lookups.
-(See the {stack-ov}/run-as-privilege.html[run as] and
-{stack-ov}/realm-chains.html#authorization_realms[authorization realms] features).
+(See the <<run-as-privilege,run as>> and
+<<authorization_realms,authorization realms>> features).
 Defaults to `true`.
 
 [[ref-ldap-settings]]
@@ -325,14 +323,14 @@ The DN template that replaces the user name with the string `{0}`.
 This setting is multivalued; you can specify multiple user contexts.
 Required to operate in user template mode. If `user_search.base_dn` is specified, 
 this setting is not valid. For more information on
-the different modes, see {stack-ov}/ldap-realm.html[LDAP realms].
+the different modes, see <<ldap-realm>>.
 
 `authorization_realms`::
 The names of the realms that should be consulted for delegated authorization.
 If this setting is used, then the LDAP realm does not perform role mapping and
 instead loads the user from the listed realms. The referenced realms are
 consulted in the order that they are defined in this list.
-See {stack-ov}/realm-chains.html#authorization_realms[Delegating authorization to another realm] 
+See <<authorization_realms>>.
 +
 --
 NOTE: If any settings starting with `user_search` are specified, the 
@@ -349,7 +347,7 @@ to `memberOf`.
 Specifies a container DN to search for users. Required
 to operated in user search mode. If `user_dn_templates` is specified, this 
 setting is not valid. For more information on
-the different modes, see {stack-ov}/ldap-realm.html[LDAP realms].
+the different modes, see <<ldap-realm>>.
 
 `user_search.scope`::
 The scope of the user search. Valid values are `sub_tree`, `one_level` or
@@ -421,13 +419,12 @@ the filter.  If not set, the user DN is passed into the filter. Defaults to Empt
 `unmapped_groups_as_roles`::
 If set to `true`, the names of any unmapped LDAP groups are used as role names 
 and assigned to the user. A group is considered to be _unmapped_ if it is not 
-referenced in a
-{stack-ov}/mapping-roles.html#mapping-roles-file[role-mapping file]. API-based 
+referenced in a <<mapping-roles-file,role-mapping file>>. API-based 
 role mappings are not considered. Defaults to `false`.
 
 `files.role_mapping`::
-The <<security-files,location>> for the {stack-ov}/mapping-roles.html#mapping-roles[
-YAML role mapping configuration file]. Defaults to
+The <<security-files,location>> for the
+<<mapping-roles,YAML role mapping configuration file>>. Defaults to
 `ES_PATH_CONF/role_mapping.yml`.
 
 `follow_referrals`::
@@ -542,8 +539,8 @@ in-memory cached user credentials. See <<cache-hash-algo>>. Defaults to `ssha256
 
 `authentication.enabled`:: If set to `false`, disables authentication support in
 this realm, so that it only supports user lookups.
-(See the {stack-ov}/run-as-privilege.html[run as] and
-{stack-ov}/realm-chains.html#authorization_realms[authorization realms] features).
+(See the <<run-as-privilege,run as>> and
+<<authorization_realms,authorization realms>> features).
 Defaults to `true`.
 
 [[ref-ad-settings]]
@@ -781,7 +778,7 @@ the default values.
 `cache.ttl`::
 Specifies the time-to-live for cached user entries. A user and a hash of its 
 credentials are cached for this configured period of time. Use the
-standard Elasticsearch {ref}/common-options.html#time-units[time units]).
+standard Elasticsearch <<time-units,time units>>).
 Defaults to `20m`.
 
 `cache.max_users`::
@@ -794,8 +791,8 @@ the in-memory cached user credentials. See <<cache-hash-algo>>. Defaults to `ssh
 
 `authentication.enabled`:: If set to `false`, disables authentication support in
 this realm, so that it only supports user lookups.
-(See the {stack-ov}/run-as-privilege.html[run as] and
-{stack-ov}/realm-chains.html#authorization_realms[authorization realms] features).
+(See the <<run-as-privilege,run as>> and
+<<authorization_realms,authorization realms>> features).
 Defaults to `true`.
 
 `follow_referrals`::
@@ -836,19 +833,19 @@ for SSL. This setting cannot be used with `certificate_authorities`.
 
 `files.role_mapping`::
 Specifies the <<security-files,location>> of the
-{stack-ov}/mapping-roles.html[YAML role  mapping configuration file].
+<<mapping-roles,YAML role  mapping configuration file>>.
 Defaults to `ES_PATH_CONF/role_mapping.yml`.
 
 `authorization_realms`::
 The names of the realms that should be consulted for delegated authorization.
 If this setting is used, then the PKI realm does not perform role mapping and
 instead loads the user from the listed realms.
-See {stack-ov}/realm-chains.html#authorization_realms[Delegating authorization to another realm] 
+See <<authorization_realms>>. 
 
 `cache.ttl`::
 Specifies the time-to-live for cached user entries. A user and a hash of its 
 credentials are cached for this period of time. Use the
-standard {es} {ref}/common-options.html#time-units[time units]).
+standard {es} <<time-units,time units>>).
 Defaults to `20m`.
 
 `cache.max_users`::
@@ -978,7 +975,7 @@ provided by the SAML attributes. Defaults to `true`.
 The names of the realms that should be consulted for delegated authorization.
 If this setting is used, then the SAML realm does not perform role mapping and
 instead loads the user from the listed realms.
-See {stack-ov}/realm-chains.html#authorization_realms[Delegating authorization to another realm] 
+See <<authorization_realms>>.
 
 `allowed_clock_skew`::
 The maximum amount of skew that can be tolerated between the IdP's clock and the
@@ -992,7 +989,7 @@ authenticate the current user. The Authentication Context of the corresponding
 authentication response should contain at least one of the requested values.
 +
 For more information, see
-{stack-ov}/saml-guide-authentication.html#req-authn-context[Requesting specific authentication methods].
+<<req-authn-context>>.
 
 [float]
 [[ref-saml-signing-settings]]
@@ -1224,7 +1221,7 @@ cache at any given time. Defaults to 100,000.
 The names of the realms that should be consulted for delegated authorization.
 If this setting is used, then the Kerberos realm does not perform role mapping and
 instead loads the user from the listed realms.
-See {stack-ov}/realm-chains.html#authorization_realms[Delegating authorization to another realm]
+See <<authorization_realms>>.
 
 [[ref-oidc-settings]]
 [float]
@@ -1503,7 +1500,7 @@ used (e.g. `xpack.security.authc.realms.ldap.corp_ldap.ssl.verification_mode`
 or `xpack.security.transport.ssl.supported_protocols`).
 
 For more information, see
-{stack-ov}/encrypting-communications.html[Encrypting communications].
+<<encrypting-communications>>.
 
 `*.ssl.supported_protocols`::
 Supported protocols with versions. Valid protocols: `SSLv2Hello`,
@@ -1566,7 +1563,7 @@ SSL enabled server.
 [[pkcs12-truststore-note]]
 [NOTE]
 Storing trusted certificates in a PKCS#12 file, although supported, is
-uncommon in practice. The {ref}/certutil.html[`elasticsearch-certutil`] tool,
+uncommon in practice. The <<certutil,`elasticsearch-certutil` tool>>,
 as well as Java's `keytool`, are designed to generate PKCS#12 files that
 can be used both as a keystore and as a truststore, but this may not be the
 case for container files that are created using other tools. Usually,
@@ -1613,7 +1610,7 @@ setting, this would be `transport.profiles.$PROFILE.xpack.security.ssl.key`.
 [float]
 [[ip-filtering-settings]]
 ==== IP filtering settings
-You can configure the following settings for {stack-ov}/ip-filtering.html[IP filtering].
+You can configure the following settings for <<ip-filtering,IP filtering>>.
 
 `xpack.security.transport.filter.allow`::
 List of IP addresses to allow.

--- a/docs/reference/setup/bootstrap-checks-xes.asciidoc
+++ b/docs/reference/setup/bootstrap-checks-xes.asciidoc
@@ -23,8 +23,7 @@ on each node in the cluster. For more information, see <<encrypting-data>>.
 If you use {es} {security-features} and a Public Key Infrastructure (PKI) realm,
 you must configure Transport Layer Security (TLS) on your cluster and enable
 client authentication on the network layers (either transport or http). For more
-information, see {stack-ov}/pki-realm.html[PKI user authentication] and
-{stack-ov}/ssl-tls.html[Setting up TLS on a cluster].
+information, see <<pki-realm>> and <<ssl-tls>>.
 
 To pass this bootstrap check, if a PKI realm is enabled, you must configure TLS
 and enable client authentication on at least one network communication layer.
@@ -41,7 +40,7 @@ and copy it to each node in the cluster. By default, role mappings are stored in
 `ES_PATH_CONF/role_mapping.yml`. Alternatively, you can specify a
 different role mapping file for each type of realm and specify its location in
 the `elasticsearch.yml` file. For more information, see
-{stack-ov}/mapping-roles.html#mapping-roles-file[Using role mapping files].
+<<mapping-roles-file>>.
 
 To pass this bootstrap check, the role mapping files must exist and must be
 valid. The Distinguished Names (DNs) that are listed in the role mappings files
@@ -57,10 +56,10 @@ must configure SSL/TLS for internode-communication.
 
 NOTE: Single-node clusters that use a loopback interface do not have this
 requirement.  For more information, see
-{stack-ov}/encrypting-communications.html[Encrypting communications].
+<<encrypting-communications>>.
 
 To pass this bootstrap check, you must
-{stack-ov}/ssl-tls.html[set up SSL/TLS in your cluster].
+<<ssl-tls,set up SSL/TLS in your cluster>>.
 
 
 [float]

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -11,7 +11,7 @@ https://github.com/elastic/elasticsearch/blob/{branch}/distribution/docker[Githu
 
 These images are free to use under the Elastic license. They contain open source 
 and free commercial features and access to paid commercial features.  
-{xpack-ref}/license-management.html[Start a 30-day trial] to try out all of the 
+{stack-ov}/license-management.html[Start a 30-day trial] to try out all of the 
 paid commercial features. See the 
 https://www.elastic.co/subscriptions[Subscriptions] page for information about 
 Elastic license levels.

--- a/docs/reference/sql/functions/system.asciidoc
+++ b/docs/reference/sql/functions/system.asciidoc
@@ -44,7 +44,7 @@ USER()
 .Description:
 
 Returns the username of the authenticated user executing the query. This function can
-return `null` in case {stack-ov}/elasticsearch-security.html[Security] is disabled.
+return `null` in case <<elasticsearch-security,security>> is disabled.
 
 [source, sql]
 --------------------------------------------------

--- a/docs/reference/transform/apis/delete-transform.asciidoc
+++ b/docs/reference/transform/apis/delete-transform.asciidoc
@@ -24,8 +24,7 @@ beta[]
 * If the {es} {security-features} are enabled, you must have
 `manage_data_frame_transforms` cluster privileges to use this API. The built-in
 `data_frame_transforms_admin` role has these privileges. For more information,
-see {stack-ov}/security-privileges.html[Security privileges] and
-{stack-ov}/built-in-roles.html[Built-in roles].
+see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[delete-transform-path-parms]]

--- a/docs/reference/transform/apis/get-transform-stats.asciidoc
+++ b/docs/reference/transform/apis/get-transform-stats.asciidoc
@@ -33,8 +33,7 @@ beta[]
 * If the {es} {security-features} are enabled, you must have
 `monitor_data_frame_transforms` cluster privileges to use this API. The built-in
 `data_frame_transforms_user` role has these privileges. For more information,
-see {stack-ov}/security-privileges.html[Security privileges] and
-{stack-ov}/built-in-roles.html[Built-in roles].
+see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[get-transform-stats-desc]]

--- a/docs/reference/transform/apis/get-transform.asciidoc
+++ b/docs/reference/transform/apis/get-transform.asciidoc
@@ -31,8 +31,7 @@ beta[]
 * If the {es} {security-features} are enabled, you must have
 `monitor_data_frame_transforms` cluster privileges to use this API. The built-in
 `data_frame_transforms_user` role has these privileges. For more information,
-see {stack-ov}/security-privileges.html[Security privileges] and
-{stack-ov}/built-in-roles.html[Built-in roles].
+see <<security-privileges>> and <<built-in-roles>>.
 
 [[get-transform-desc]]
 ==== {api-description-title}

--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -24,9 +24,8 @@ beta[]
 `manage_data_frame_transforms` cluster privileges to use this API. The built-in
 `data_frame_transforms_admin` role has these privileges. You must also have
 `read` and `view_index_metadata` privileges on the source index for the
-{transform}. For more information, see
-{stack-ov}/security-privileges.html[Security privileges] and
-{stack-ov}/built-in-roles.html[Built-in roles].
+{transform}. For more information,
+see <<security-privileges>> and <<built-in-roles>>.
 
 [[preview-transform-desc]]
 ==== {api-description-title}

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -25,8 +25,7 @@ beta[]
 `data_frame_transforms_admin` role has these privileges. You must also
 have `read` and `view_index_metadata` privileges on the source index and `read`,
 `create_index`, and `index` privileges on the destination index. For more
-information, see {stack-ov}/security-privileges.html[Security privileges] and
-{stack-ov}/built-in-roles.html[Built-in roles].
+information, see <<security-privileges>> and <<built-in-roles>>.
 
 [[put-transform-desc]]
 ==== {api-description-title}

--- a/docs/reference/transform/apis/start-transform.asciidoc
+++ b/docs/reference/transform/apis/start-transform.asciidoc
@@ -23,9 +23,8 @@ beta[]
 * If the {es} {security-features} are enabled, you must have
 `manage_data_frame_transforms` cluster privileges to use this API. You must also
 have `view_index_metadata` privileges on the source index for the
-{transform}. For more information, see
-{stack-ov}/security-privileges.html[Security privileges] and
-{stack-ov}/built-in-roles.html[Built-in roles].
+{transform}. For more information,
+see <<security-privileges>> and <<built-in-roles>>.
 
 [[start-transform-desc]]
 ==== {api-description-title}

--- a/docs/reference/transform/apis/stop-transform.asciidoc
+++ b/docs/reference/transform/apis/stop-transform.asciidoc
@@ -29,8 +29,7 @@ beta[]
 * If the {es} {security-features} are enabled, you must have
 `manage_data_frame_transforms` cluster privileges to use this API. The built-in
 `data_frame_transforms_admin` role has these privileges. For more information,
-see {stack-ov}/security-privileges.html[Security privileges] and
-{stack-ov}/built-in-roles.html[Built-in roles].
+see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[stop-transform-desc]]

--- a/docs/reference/transform/apis/update-transform.asciidoc
+++ b/docs/reference/transform/apis/update-transform.asciidoc
@@ -25,8 +25,7 @@ beta[]
 `data_frame_transforms_admin` role has these privileges. You must also
 have `read` and `view_index_metadata` privileges on the source index and `read`,
 `create_index`, and `index` privileges on the destination index. For more
-information, see {stack-ov}/security-privileges.html[Security privileges] and
-{stack-ov}/built-in-roles.html[Built-in roles].
+information, see <<security-privileges>> and <<built-in-roles>>.
 
 [[update-transform-desc]]
 ==== {api-description-title}

--- a/docs/reference/transform/ecommerce-tutorial.asciidoc
+++ b/docs/reference/transform/ecommerce-tutorial.asciidoc
@@ -23,9 +23,7 @@ You also need `read` and `view_index_metadata` index privileges on the source
 index and `read`, `create_index`, and `index` privileges on the destination
 index. 
 
-For more information, see
-{stack-ov}/security-privileges.html[Security privileges] and
-{stack-ov}/built-in-roles.html[Built-in roles].
+For more information, see <<security-privileges>> and <<built-in-roles>>.
 --
 
 . Choose your _source index_.

--- a/x-pack/docs/en/rest-api/security/change-password.asciidoc
+++ b/x-pack/docs/en/rest-api/security/change-password.asciidoc
@@ -28,7 +28,7 @@ You can use the <<security-api-put-user,create user API>> to update everything
 but a user's `username` and `password`. This API changes a user's password.
 
 For more information about the native realm, see 
-{stack-ov}/realms.html[Realms] and <<configuring-native-realm>>. 
+<<realms>> and <<configuring-native-realm>>. 
 
 
 [[security-api-change-password-path-params]]

--- a/x-pack/docs/en/rest-api/security/clear-cache.asciidoc
+++ b/x-pack/docs/en/rest-api/security/clear-cache.asciidoc
@@ -23,7 +23,7 @@ User credentials are cached in memory on each node to avoid connecting to a
 remote authentication service or hitting the disk for every incoming request.
 There are realm settings that you can use to configure the user cache. For more
 information, see
-{stack-ov}/controlling-user-cache.html[Controlling the user cache].
+<<controlling-user-cache>>.
 
 To evict roles from the role cache, see the 
 <<security-api-clear-role-cache,Clear roles cache API>>.

--- a/x-pack/docs/en/rest-api/security/clear-roles-cache.asciidoc
+++ b/x-pack/docs/en/rest-api/security/clear-roles-cache.asciidoc
@@ -22,7 +22,7 @@ privilege.
 ==== {api-description-title}
 
 For more information about the native realm, see 
-{stack-ov}/realms.html[Realms] and <<configuring-native-realm>>. 
+<<realms>> and <<configuring-native-realm>>. 
 
 [[security-api-clear-role-cache-path-params]]
 ==== {api-path-parms-title}

--- a/x-pack/docs/en/rest-api/security/create-role-mappings.asciidoc
+++ b/x-pack/docs/en/rest-api/security/create-role-mappings.asciidoc
@@ -29,10 +29,9 @@ granted to those users.
 
 NOTE: This API does not create roles. Rather, it maps users to existing roles.
 Roles can be created by using <<security-api-roles, Role Management APIs>> or
-{stack-ov}/defining-roles.html#roles-management-file[roles files].
+<<roles-management-file,roles files>>.
 
-For more information, see 
-{stack-ov}/mapping-roles.html[Mapping users and groups to roles].
+For more information, see <<mapping-roles>>.
 
 
 [[security-api-put-role-mapping-path-params]]
@@ -313,7 +312,7 @@ POST /_security/role_mapping/mapping8
 A templated role can be used to automatically map every user to their own
 custom role. The role itself can be defined through the
 <<security-api-put-role, Roles API>> or using a
-{stack-ov}/custom-roles-authorization.html#implementing-custom-roles-provider[custom roles provider].
+<<implementing-custom-roles-provider,custom roles provider>>.
 
 In this example every user who authenticates using the "cloud-saml" realm
 will be automatically mapped to two roles - the `"saml_user"` role and a

--- a/x-pack/docs/en/rest-api/security/create-roles.asciidoc
+++ b/x-pack/docs/en/rest-api/security/create-roles.asciidoc
@@ -25,7 +25,7 @@ privilege.
 ==== {api-description-title}
 
 The role management APIs are generally the preferred way to manage roles, rather than using
-{stack-ov}/defining-roles.html#roles-management-file[file-based role management]. The create
+<<roles-management-file,file-based role management>>. The create
 or update roles API cannot update roles that are defined in roles files.
 
 [[security-api-put-role-path-params]]
@@ -58,7 +58,7 @@ This field is optional.
 `indices`:: (list) A list of indices permissions entries.
 `field_security`::: (list) The document fields that the owners of the role have
 read access to. For more information, see
-{stack-ov}/field-and-document-access-control.html[Setting up field and document level security].
+<<field-and-document-access-control>>.
 `names` (required)::: (list) A list of indices (or index name patterns) to which the
 permissions in this entry apply.
 `privileges`(required)::: (list) The index level privileges that the owners of the role
@@ -72,9 +72,9 @@ that begin with `_` are reserved for system usage.
 
 `run_as`:: (list) A list of users that the owners of this role can impersonate.
 For more information, see
-{stack-ov}/run-as-privilege.html[Submitting requests on behalf of other users].
+<<run-as-privilege>>.
 
-For more information, see {stack-ov}/defining-roles.html[Defining roles].
+For more information, see <<defining-roles>>.
 
 [[security-api-put-role-example]]
 ==== {api-examples-title}

--- a/x-pack/docs/en/rest-api/security/create-users.asciidoc
+++ b/x-pack/docs/en/rest-api/security/create-users.asciidoc
@@ -31,7 +31,7 @@ To change a user's password, use the
 <<security-api-change-password, change password API>>.
 
 For more information about the native realm, see 
-{stack-ov}/realms.html[Realms] and <<configuring-native-realm>>. 
+<<realms>> and <<configuring-native-realm>>. 
 
 [[security-api-put-user-path-params]]
 ==== {api-path-parms-title}

--- a/x-pack/docs/en/rest-api/security/delegate-pki-authentication.asciidoc
+++ b/x-pack/docs/en/rest-api/security/delegate-pki-authentication.asciidoc
@@ -18,7 +18,7 @@ token.
 
 * To call this API, the (proxy) user must have the `delegate_pki` or the `all`
 cluster privilege. The `kibana_system` built-in role already grants this
-privilege. See {stack-ov}/security-privileges.html[Security privileges].
+privilege. See <<security-privileges>>.
 
 [[security-api-delegate-pki-authentication-desc]]
 ==== {api-description-title}

--- a/x-pack/docs/en/rest-api/security/delete-app-privileges.asciidoc
+++ b/x-pack/docs/en/rest-api/security/delete-app-privileges.asciidoc
@@ -5,8 +5,7 @@
 <titleabbrev>Delete application privileges</titleabbrev>
 ++++
 
-Removes 
-{stack-ov}/security-privileges.html#application-privileges[application privileges].
+Removes <<application-privileges,application privileges>>.
 
 [[security-api-delete-privilege-request]]
 ==== {api-request-title}

--- a/x-pack/docs/en/rest-api/security/delete-role-mappings.asciidoc
+++ b/x-pack/docs/en/rest-api/security/delete-role-mappings.asciidoc
@@ -21,7 +21,7 @@ Removes role mappings.
 ==== {api-description-title}
 
 Role mappings define which roles are assigned to each user. For more information, 
-see {stack-ov}/mapping-roles.html[Mapping users and groups to roles]. 
+see <<mapping-roles>>. 
 
 [[security-api-delete-role-mapping-path-params]]
 ==== {api-path-parms-title}

--- a/x-pack/docs/en/rest-api/security/delete-roles.asciidoc
+++ b/x-pack/docs/en/rest-api/security/delete-roles.asciidoc
@@ -23,7 +23,7 @@ Removes roles in the native realm.
 ==== {api-description-title}
 
 The role management APIs are generally the preferred way to manage roles, rather than using
-{stack-ov}/defining-roles.html#roles-management-file[file-based role management]. The delete roles API cannot remove roles that are defined in roles files.
+<<roles-management-file,file-based role management>>. The delete roles API cannot remove roles that are defined in roles files.
 
 [[security-api-delete-role-path-params]]
 ==== {api-path-parms-title}

--- a/x-pack/docs/en/rest-api/security/delete-users.asciidoc
+++ b/x-pack/docs/en/rest-api/security/delete-users.asciidoc
@@ -21,7 +21,7 @@ Deletes users from the native realm.
 ==== {api-description-title}
 
 For more information about the native realm, see 
-{stack-ov}/realms.html[Realms] and <<configuring-native-realm>>. 
+<<realms>> and <<configuring-native-realm>>. 
 
 [[security-api-delete-user-path-params]]
 ==== {api-path-parms-title}

--- a/x-pack/docs/en/rest-api/security/disable-users.asciidoc
+++ b/x-pack/docs/en/rest-api/security/disable-users.asciidoc
@@ -27,7 +27,7 @@ revoke a user's access to {es}. To re-enable a user, there is an
 <<security-api-enable-user,enable users API>>. 
 
 For more information about the native realm, see 
-{stack-ov}/realms.html[Realms] and <<configuring-native-realm>>. 
+<<realms>> and <<configuring-native-realm>>. 
 
 [[security-api-disable-user-path-params]]
 ==== {api-path-parms-title}

--- a/x-pack/docs/en/rest-api/security/enable-users.asciidoc
+++ b/x-pack/docs/en/rest-api/security/enable-users.asciidoc
@@ -26,7 +26,7 @@ By default, when you create users, they are enabled. You can use this enable
 users API and the <<security-api-disable-user,disable users API>> to change that attribute. 
 
 For more information about the native realm, see 
-{stack-ov}/realms.html[Realms] and <<configuring-native-realm>>. 
+<<realms>> and <<configuring-native-realm>>. 
 
 [[security-api-enable-user-path-params]]
 ==== {api-path-parms-title}

--- a/x-pack/docs/en/rest-api/security/get-app-privileges.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-app-privileges.asciidoc
@@ -5,8 +5,7 @@
 <titleabbrev>Get application privileges</titleabbrev>
 ++++
 
-Retrieves 
-{stack-ov}/security-privileges.html#application-privileges[application privileges].
+Retrieves <<application-privileges,application privileges>>.
 
 [[security-api-get-privileges-request]]
 ==== {api-request-title}

--- a/x-pack/docs/en/rest-api/security/get-builtin-privileges.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-builtin-privileges.asciidoc
@@ -5,9 +5,8 @@
 <titleabbrev>Get builtin privileges</titleabbrev>
 ++++
 
-Retrieves the list of 
-{stack-ov}/security-privileges.html#privileges-list-cluster[cluster privileges] and
-{stack-ov}/security-privileges.html#privileges-list-indices[index privileges] that are
+Retrieves the list of <<privileges-list-cluster,cluster privileges>> and
+<<privileges-list-indices,index privileges>> that are
 available in this version of {es}.
 
 [[security-api-get-builtin-privileges-request]]
@@ -38,12 +37,12 @@ To check whether a user has particular privileges, use the
 The response is an object with two fields:
 
 `cluster`:: (array of string) The list of
- {stack-ov}/security-privileges.html#privileges-list-cluster[cluster privileges]
- that are understood by this version of {es}
+<<privileges-list-cluster,cluster privileges>> that are understood by this
+version of {es}.
 
 `index`:: (array of string) The list of
- {stack-ov}/security-privileges.html#privileges-list-indices[index privileges]
- that are understood by this version of {es}
+<<privileges-list-indices,index privileges>> that are understood by this version
+of {es}.
 
 
 [[security-api-get-builtin-privileges-example]]

--- a/x-pack/docs/en/rest-api/security/get-role-mappings.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-role-mappings.asciidoc
@@ -23,7 +23,7 @@ Retrieves role mappings.
 ==== {api-description-title}
 
 Role mappings define which roles are assigned to each user. For more information, 
-see {stack-ov}/mapping-roles.html[Mapping users and groups to roles]. 
+see <<mapping-roles>>. 
 
 [[security-api-get-role-mapping-path-params]]
 ==== {api-path-parms-title}

--- a/x-pack/docs/en/rest-api/security/get-roles.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-roles.asciidoc
@@ -24,7 +24,7 @@ privilege.
 ==== {api-description-title}
 
 The role management APIs are generally the preferred way to manage roles, rather than using
-{stack-ov}/defining-roles.html#roles-management-file[file-based role management]. The get roles
+<<roles-management-file,file-based role management>>. The get roles
 API cannot retrieve roles that are defined in roles files.
 
 [[security-api-get-role-path-params]]

--- a/x-pack/docs/en/rest-api/security/get-users.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-users.asciidoc
@@ -25,7 +25,7 @@ Retrieves information about users in the native realm and built-in users.
 ==== {api-description-title}
 
 For more information about the native realm, see 
-{stack-ov}/realms.html[Realms] and <<configuring-native-realm>>. 
+<<realms>> and <<configuring-native-realm>>. 
 
 [[security-api-get-user-path-params]]
 ==== {api-path-parms-title}

--- a/x-pack/docs/en/rest-api/security/has-privileges.asciidoc
+++ b/x-pack/docs/en/rest-api/security/has-privileges.asciidoc
@@ -21,7 +21,7 @@ a specified list of privileges.
 * All users can use this API, but only to determine their own privileges.
 To check the privileges of other users, you must use the run as feature. For
 more information, see
-{stack-ov}/run-as-privilege.html[Submitting requests on behalf of other users].
+<<run-as-privilege>>.
 
 [[security-api-has-privileges-desc]]
 ==== {api-description-title}

--- a/x-pack/docs/en/rest-api/security/has-privileges.asciidoc
+++ b/x-pack/docs/en/rest-api/security/has-privileges.asciidoc
@@ -27,7 +27,7 @@ more information, see
 ==== {api-description-title}
 
 For a list of the privileges that you can specify in this API,
-see {stack-ov}/security-privileges.html[Security privileges].
+see <<security-privileges>>.
 
 A successful call returns a JSON structure that shows whether each specified
 privilege is assigned to the user.

--- a/x-pack/docs/en/rest-api/security/put-app-privileges.asciidoc
+++ b/x-pack/docs/en/rest-api/security/put-app-privileges.asciidoc
@@ -5,8 +5,7 @@
 <titleabbrev>Create or update application privileges</titleabbrev>
 ++++
 
-Adds or updates 
-{stack-ov}/security-privileges.html#application-privileges[application privileges].
+Adds or updates <<application-privileges,application privileges>>.
 
 [[security-api-put-privileges-request]]
 ==== {api-request-title}
@@ -31,8 +30,7 @@ being referenced in the request
 This API creates or updates privileges. To remove privileges, use the 
 <<security-api-delete-privilege,delete application privilege API>>. 
 
-For more information, see 
-{stack-ov}/defining-roles.html#roles-application-priv[Application privileges].
+For more information, see <<roles-application-priv>>.
 
 To check a user's application privileges, use the
 <<security-api-has-privileges,has privileges API>>.

--- a/x-pack/docs/en/rest-api/security/role-mapping-resources.asciidoc
+++ b/x-pack/docs/en/rest-api/security/role-mapping-resources.asciidoc
@@ -49,7 +49,7 @@ The value specified in the field rule can be one of the following types:
 | Simple String      | Exactly matches the provided value.                             | "esadmin"
 | Wildcard String    | Matches the provided value using a wildcard.                    | "*,dc=example,dc=com"
 | Regular Expression | Matches the provided value using a
-                       {ref}/regexp-syntax.html[Lucene regexp]. | "/.\*-admin[0-9]*/"
+                       <<regexp-syntax,Lucene regexp>>. | "/.\*-admin[0-9]*/"
 | Number             | Matches an equivalent numerical value.                          | 7
 | Null               | Matches a null or missing value.                                | null
 | Array              | Tests each element in the array in
@@ -87,4 +87,4 @@ other groups they belong to:
 // NOTCONSOLE
 
 For additional realm-specific details, see
-{stack-ov}/mapping-roles.html#ldap-role-mapping[Mapping Users and Groups to Roles].
+<<ldap-role-mapping>>.

--- a/x-pack/docs/en/rest-api/security/ssl.asciidoc
+++ b/x-pack/docs/en/rest-api/security/ssl.asciidoc
@@ -26,7 +26,7 @@ privileges to use this API. For more information, see
 
 For more information about how certificates are configured in conjunction with
 Transport Layer Security (TLS), see
-{stack-ov}/ssl-tls.html[Setting up SSL/TLS on a cluster].
+<<ssl-tls>>.
 
 The API returns a list that includes certificates from all TLS contexts
 including:

--- a/x-pack/docs/en/rest-api/security/ssl.asciidoc
+++ b/x-pack/docs/en/rest-api/security/ssl.asciidoc
@@ -19,7 +19,7 @@ certificates that are used to encrypt communications in your {es} cluster.
 
 * If the {security-features} are enabled, you must have `monitor` cluster
 privileges to use this API. For more information, see
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[security-api-ssl-desc]]
 ==== {api-description-title}

--- a/x-pack/docs/en/rest-api/watcher/ack-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/ack-watch.asciidoc
@@ -19,7 +19,7 @@ to manually throttle execution of the watch's actions.
 ==== {api-prereq-title}
 
 * You must have `manage_watcher` cluster privileges to use this API. For more
-information, see {stack-ov}/security-privileges.html[Security privileges].
+information, see <<security-privileges>>.
 
 [[watcher-api-ack-watch-desc]]
 ==== {api-description-title}

--- a/x-pack/docs/en/rest-api/watcher/activate-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/activate-watch.asciidoc
@@ -17,7 +17,7 @@ API enables you to activate a currently inactive watch.
 ==== {api-prereq-title}
 
 * You must have `manage_watcher` cluster privileges to use this API. For more
-information, see {stack-ov}/security-privileges.html[Security privileges].
+information, see <<security-privileges>>.
 
 //[[watcher-api-activate-watch-desc]]
 //==== {api-description-title}

--- a/x-pack/docs/en/rest-api/watcher/deactivate-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/deactivate-watch.asciidoc
@@ -17,7 +17,7 @@ API enables you to deactivate a currently active watch.
 ==== {api-prereq-title}
 
 * You must have `manage_watcher` cluster privileges to use this API. For more
-information, see {stack-ov}/security-privileges.html[Security privileges].
+information, see <<security-privileges>>.
 
 //[[watcher-api-deactivate-watch-desc]]
 //==== {api-description-title}

--- a/x-pack/docs/en/rest-api/watcher/delete-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/delete-watch.asciidoc
@@ -16,7 +16,7 @@ Removes a watch from {watcher}.
 ==== {api-prereq-title}
 
 * You must have `manage_watcher` cluster privileges to use this API. For more
-information, see {stack-ov}/security-privileges.html[Security privileges].
+information, see <<security-privileges>>.
 
 [[watcher-api-delete-watch-desc]]
 ==== {api-description-title}

--- a/x-pack/docs/en/rest-api/watcher/execute-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/execute-watch.asciidoc
@@ -18,7 +18,7 @@ Forces the execution of a stored watch.
 ==== {api-prereq-title}
 
 * You must have `manage_watcher` cluster privileges to use this API. For more
-information, see {stack-ov}/security-privileges.html[Security privileges].
+information, see <<security-privileges>>.
 
 [[watcher-api-execute-watch-desc]]
 ==== {api-description-title}

--- a/x-pack/docs/en/rest-api/watcher/get-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/get-watch.asciidoc
@@ -17,7 +17,7 @@ Retrieves a watch by its ID.
 
 * You must have `manage_watcher` or `monitor_watcher` cluster privileges to use
 this API. For more information, see
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 //[[watcher-api-get-watch-desc]]
 //==== {api-description-title}

--- a/x-pack/docs/en/rest-api/watcher/put-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/put-watch.asciidoc
@@ -16,7 +16,7 @@ Either registers a new watch in {watcher} or updates an existing one.
 ==== {api-prereq-title}
 
 * You must have `manage_watcher` cluster privileges to use this API. For more
-information, see {stack-ov}/security-privileges.html[Security privileges].
+information, see <<security-privileges>>.
 
 [[watcher-api-put-watch-desc]]
 ==== {api-description-title}

--- a/x-pack/docs/en/rest-api/watcher/start.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/start.asciidoc
@@ -16,7 +16,7 @@ Starts the {watcher} service if it is not already running.
 ==== {api-prereq-title}
 
 * You must have `manage_watcher` cluster privileges to use this API. For more
-information, see {stack-ov}/security-privileges.html[Security privileges].
+information, see <<security-privileges>>.
 
 //[[watcher-api-start-desc]]
 //==== {api-description-title}

--- a/x-pack/docs/en/rest-api/watcher/stats.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/stats.asciidoc
@@ -20,7 +20,7 @@ Retrieves the current {watcher} metrics.
 
 * You must have `manage_watcher` or `monitor_watcher` cluster privileges to use
 this API. For more information, see
-{stack-ov}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 //[[watcher-api-stats-desc]]
 //==== {api-description-title}

--- a/x-pack/docs/en/rest-api/watcher/stop.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/stop.asciidoc
@@ -16,7 +16,7 @@ Stops the {watcher} service if it is running.
 ==== {api-prereq-title}
 
 * You must have `manage_watcher` cluster privileges to use this API. For more
-information, see {stack-ov}/security-privileges.html[Security privileges].
+information, see <<security-privileges>>.
 
 //[[watcher-api-stop-desc]]
 //==== {api-description-title}

--- a/x-pack/docs/en/security/authentication/configuring-active-directory-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-active-directory-realm.asciidoc
@@ -7,7 +7,7 @@ users. To integrate with Active Directory, you configure an `active_directory`
 realm and map Active Directory users and groups to roles in the role mapping file.
 
 For more information about Active Directory realms, see 
-{stack-ov}/active-directory-realm.html[Active Directory User Authentication].
+<<active-directory-realm>>.
 
 . Add a realm configuration of type `active_directory` to `elasticsearch.yml`
 under the `xpack.security.authc.realms.active_directory` namespace.
@@ -119,7 +119,7 @@ can be configured and is used to perform all operations other than the LDAP bind
 request, which is required to authenticate the credentials provided by the user.
 
 The use of a bind user enables the 
-{stack-ov}/run-as-privilege.html[run as feature] to be used with the Active 
+<<run-as-privilege,run as feature>> to be used with the Active 
 Directory realm and the ability to maintain a set of pooled connections to 
 Active Directory. These pooled connection reduce the number of resources that 
 must be created and destroyed with every user authentication.
@@ -235,7 +235,7 @@ user:
 <4> The Active Directory distinguished name (DN) of the user `John Doe`.
 
 For more information, see 
-{stack-ov}/mapping-roles.html[Mapping users and groups to roles].
+<<mapping-roles>>.
 --
 
 . (Optional) Configure the `metadata` setting in the Active Directory realm to 
@@ -244,5 +244,5 @@ include extra properties in the user's metadata.
 --
 By default, `ldap_dn` and `ldap_groups` are populated in the user's metadata. 
 For more information, see 
-{xpack-ref}/active-directory-realm.html#ad-user-metadata[User Metadata in Active Directory Realms]. 
+<<ad-user-metadata>>. 
 --

--- a/x-pack/docs/en/security/authentication/configuring-file-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-file-realm.asciidoc
@@ -22,8 +22,7 @@ or using a configuration management system such as Puppet or Chef).
 The `file` realm is added to the realm chain by default. You don't need to
 explicitly configure a `file` realm.
 
-For more information about file realms, see 
-{xpack-ref}/file-realm.html[File-based user authentication].
+For more information about file realms, see <<file-realm>>.
 
 . (Optional) Add a realm configuration to `elasticsearch.yml` under the
 `xpack.security.authc.realms.file` namespace. At a minimum, you must set 

--- a/x-pack/docs/en/security/authentication/configuring-kerberos-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-kerberos-realm.asciidoc
@@ -15,7 +15,7 @@ Refer to your Kerberos installation documentation for more information about
 obtaining TGT. {es} clients must first obtain a TGT then initiate the process of 
 authenticating with {es}.
 
-For a summary of Kerberos terminology, see {stack-ov}/kerberos-realm.html[Kerberos authentication].
+For a summary of Kerberos terminology, see <<kerberos-realm>>.
 
 ==== Before you begin
 
@@ -65,7 +65,7 @@ default realm, the Key Distribution Center (KDC), and other configuration detail
 required for Kerberos authentication. When the JVM needs some configuration 
 properties, it tries to find those values by locating and loading this file. The 
 JVM system property to configure the file path is `java.security.krb5.conf`. To 
-configure JVM system properties see {ref}/jvm-options.html[configuring jvm options]. 
+configure JVM system properties see <<jvm-options>>. 
 If this system property is not specified, Java tries to locate the file based on 
 the conventions.
 
@@ -133,7 +133,7 @@ set to `true`, the realm part (`@REALM`) is removed. The resulting `username`
 is used for role mapping.
 
 For detailed information of available realm settings,
-see {ref}/security-settings.html#ref-kerberos-settings[Kerberos realm settings].
+see <<ref-kerberos-settings>>.
 
 --
 
@@ -145,7 +145,7 @@ see {ref}/security-settings.html#ref-kerberos-settings[Kerberos realm settings].
 
 The `kerberos` realm enables you to map Kerberos users to roles. You can 
 configure these role mappings by using the 
-{ref}/security-api-role-mapping.html[role-mapping API]. You identify 
+<<security-api-role-mapping,role-mapping API>>. You identify 
 users by their `username` field.
 
 The following example uses the role mapping API to map `user@REALM` to the roles 
@@ -169,10 +169,10 @@ following are the additional user metadata available for role mapping:
 - `kerberos_realm` will be set to Kerberos realm name.
 - `kerberos_user_principal_name` will be set to user principal name from the Kerberos ticket.
 
-For more information, see {stack-ov}/mapping-roles.html[Mapping users and groups to roles].
+For more information, see <<mapping-roles>>.
 
 NOTE: The Kerberos realm supports
-{stack-ov}/realm-chains.html#authorization_realms[authorization realms] as an
+<<authorization_realms,authorization realms>> as an
 alternative to role mapping.
 
 --

--- a/x-pack/docs/en/security/authentication/configuring-ldap-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-ldap-realm.asciidoc
@@ -7,7 +7,7 @@ Directory Access Protocol (LDAP) server. To integrate with LDAP, you configure
 an `ldap` realm and map LDAP groups to user roles.
 
 For more information about LDAP realms, see 
-{stack-ov}/ldap-realm.html[LDAP User Authentication].
+<<ldap-realm>>.
 
 . Determine which mode you want to use. The `ldap` realm supports two modes of 
 operation, a user search mode and a mode with specific templates for user DNs. 
@@ -134,7 +134,7 @@ See <<ref-ldap-settings>>.
 --
 The `ldap` realm enables you to map LDAP users to roles via their LDAP
 groups, or other metadata. This role mapping can be configured via the
-{ref}/security-api-put-role-mapping.html[add role mapping API] or by using a file stored
+<<security-api-put-role-mapping,add role mapping API>> or by using a file stored
 on each node. When a user authenticates with LDAP, the privileges
 for that user are the union of all privileges defined by the roles to which
 the user is mapped.
@@ -188,12 +188,10 @@ user:
 <3> The LDAP distinguished name (DN) of the `users` group.
 
 For more information, see 
-{stack-ov}/ldap-realm.html#mapping-roles-ldap[Mapping LDAP Groups to Roles] 
-and 
-{stack-ov}/mapping-roles.html[Mapping Users and Groups to Roles].
+<<mapping-roles-ldap>> and <<mapping-roles>>.
 
 NOTE: The LDAP realm supports
-{stack-ov}/realm-chains.html#authorization_realms[authorization realms] as an
+<<authorization_realms,authorization realms>> as an
 alternative to role mapping.
 
 --
@@ -204,7 +202,7 @@ fields in the user's metadata.
 --
 By default, `ldap_dn` and `ldap_groups` are populated in the user's metadata. 
 For more information, see 
-{stack-ov}/ldap-realm.html#ldap-user-metadata[User Metadata in LDAP Realms]. 
+<<ldap-user-metadata>>. 
 
 The example below includes the user's common name (`cn`) as an additional
 field in their metadata.

--- a/x-pack/docs/en/security/authentication/configuring-pki-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-pki-realm.asciidoc
@@ -14,7 +14,7 @@ requires some <<pki-realm-for-proxied-clients,additional configuration>>. On
 authentication and to submit the client certificates to {es} for further
 validation by a PKI realm.
 
-For more general information, see {stack-ov}/pki-realm.html[PKI user authentication].
+For more general information, see <<pki-realm>>.
 
 [float]
 [role="xpack"]
@@ -209,11 +209,9 @@ certificate as the means of authentication) and inspect the metadata field in
 the result. The user's distinguished name will be populated under the `pki_dn`
 key. You can also use the authenticate API to validate your role mapping.
 
-For more information, see 
-{stack-ov}/mapping-roles.html[Mapping Users and Groups to Roles].
+For more information, see <<mapping-roles>>.
 
-NOTE: The PKI realm supports
-{stack-ov}/realm-chains.html#authorization_realms[authorization realms] as an
+NOTE: The PKI realm supports <<authorization_realms,authorization realms>> as an
 alternative to role mapping.
 
 --
@@ -254,9 +252,8 @@ PKI certificate authentication].
 A PKI realm with `delegation.enabled` still works unchanged for clients
 connecting directly to {es}. Directly authenticated users, and users that are PKI
 authenticated by delegation to {kib} both follow the same
-{stack-ov}/mapping-roles.html[role mapping rules] or
-{stack-ov}/realm-chains.html#authorization_realms[authorization realms
-configurations].
+<<mapping-roles,role mapping rules>> or
+<<authorization_realms,authorization realms configurations>>.
 
 However, if you use the <<security-role-mapping-apis,role mapping APIs>>,
 you can distinguish between users that are authenticated by delegation and

--- a/x-pack/docs/en/security/authentication/configuring-saml-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-saml-realm.asciidoc
@@ -9,8 +9,7 @@ integrate with any identity provider (IdP) that supports at least the SAML 2.0
 Web Browser SSO Profile. 
 
 In SAML terminology, the {stack} is operating as a _service provider_ (SP). For more 
-information, see {stack-ov}/saml-realm.html[SAML authentication] and 
-{stack-ov}/saml-guide.html[Configuring SAML SSO on the {stack}]. 
+information, see <<saml-realm>> and <<saml-guide>>. 
 
 [NOTE]
 --
@@ -55,7 +54,7 @@ download or generate such a document within your IdP administration interface.
 
 Most IdPs will provide an appropriate metadata file with all the features that
 the {stack} requires. For more information, see 
-{stack-ov}/saml-guide-idp.html[The identity provider].
+<<saml-guide-idp>>.
 --
 
 .. Download the IdP metadata document and store it within the `config` directory 
@@ -96,7 +95,7 @@ xpack.security.authc.realms:
 ------------------------------------------------------------
 <1> The realm must be within the `xpack.security.authc.realms.saml` namespace.
 <2> This setting defines a new authentication realm named "saml1". For an 
-introduction to realms, see {stack-ov}/realms.html[Realms]. 
+introduction to realms, see <<realms>>. 
 <3>  You should define a unique order on each realm in your authentication chain.
 It is recommended that the SAML realm be at the bottom of your authentication 
 chain (that is, it has the _highest_ order).
@@ -130,7 +129,7 @@ we recommend that you include at least one additional realm such as the
 native realm in your authentication chain for use by API clients.
 
 For more information, see 
-{stack-ov}/saml-guide-authentication.html#saml-create-realm[Create a SAML realm].
+<<saml-create-realm>>.
 --
 
 . Add attribute mappings. 
@@ -177,7 +176,7 @@ xpack.security.authc.realms.saml.saml1:
 ------------------------------------------------------------
 
 For more information, see 
-{stack-ov}/saml-guide-authentication.html#saml-attribute-mapping[Attribute mapping]. 
+<<saml-attribute-mapping>>. 
 --
 
 . (Optional) Configure logout services. 
@@ -187,7 +186,7 @@ The SAML protocol supports the concept of Single Logout (SLO). The level of
 support for SLO varies between identity providers. 
 
 For more information, see 
-{stack-ov}/saml-guide-authentication.html#saml-logout[SAML logout]. 
+<<saml-logout>>. 
 --
 
 . (Optional) Configure encryption and signing.
@@ -199,7 +198,7 @@ and logout), and processing encrypted content.
 
 You can configure {es} for signing, encryption, or both, with the same or 
 separate keys. For more information, see 
-{stack-ov}/saml-guide-authentication.html#saml-enc-sign[Encryption and signing]. 
+<<saml-enc-sign>>. 
 --
 
 . (Optional) Generate service provider metadata.
@@ -219,13 +218,13 @@ but this does not automatically grant them access to perform any actions or
 access any data.
 
 Your SAML users cannot do anything until they are assigned roles. This can be done
-through either the {stack-ov}/saml-role-mapping.html[role mapping API], or with
-{stack-ov}/realm-chains.html#authorization_realms[authorization realms].
+through either the <<saml-role-mapping,role mapping API>>, or with
+<<authorization_realms,authorization realms>>.
 
-NOTE: You cannot use {stack-ov}/mapping-roles.html#mapping-roles-file[role mapping files]
+NOTE: You cannot use <<mapping-roles-file,role mapping files>>
 to grant roles to users authenticating via SAML.
 
 --
 
-. {stack-ov}/saml-kibana.html[Configure {kib} to use SAML SSO]. 
+. <<saml-kibana,Configure {kib} to use SAML SSO>>. 
 

--- a/x-pack/docs/en/security/authentication/oidc-guide.asciidoc
+++ b/x-pack/docs/en/security/authentication/oidc-guide.asciidoc
@@ -414,9 +414,9 @@ access any data.
 Your OpenID Connect users cannot do anything until they are assigned roles. This can be done
 through either the
 {ref}/security-api-put-role-mapping.html[add role mapping API], or with
-<<authorization_realms, authorization realms>>.
+<<authorization_realms,authorization realms>>.
 
-NOTE: You cannot use {stack-ov}/mapping-roles.html#mapping-roles-file[role mapping files]
+NOTE: You cannot use <<mapping-roles-file,role mapping files>>
 to grant roles to users authenticating via OpenID Connect.
 
 This is an example of a simple role mapping that grants the `kibana_user` role

--- a/x-pack/docs/en/security/authentication/saml-guide.asciidoc
+++ b/x-pack/docs/en/security/authentication/saml-guide.asciidoc
@@ -853,5 +853,5 @@ Additionally, different security domains have different security requirements th
 specific configuration to be satisfied.
 A conscious effort has been made to mask this complexity with sane defaults and the detailed
 documentation above but in case you encounter issues while configuring a SAML realm, you can
-look through our {stack-ov}/trb-security-saml.html[SAML troubleshooting documentation] that has
+look through our <<trb-security-saml,SAML troubleshooting documentation>> that has
 suggestions and resolutions for common issues.

--- a/x-pack/docs/en/security/authentication/saml-guide.asciidoc
+++ b/x-pack/docs/en/security/authentication/saml-guide.asciidoc
@@ -90,7 +90,7 @@ configure the HTTP interface to use SSL/TLS before you can enable SAML
 authentication.
 
 For more information, see
-{ref}/configuring-tls.html#tls-http[Encrypting HTTP Client Communications].
+<<tls-http>>.
 
 [[saml-enable-token]]
 ==== Enable the token service
@@ -382,7 +382,7 @@ successfully authenticated, the Authentication Statement of the SAML Response
 contains an indication of the restrictions that were satisfied.
 
 You can define the Authentication Context Class Reference values by using the `req_authn_context_class_ref` option in the SAML realm configuration. See 
-{ref}/security-settings.html#ref-saml-settings[SAML realm settings]. 
+<<ref-saml-settings>>. 
 
 {es} supports only the `exact` comparison method for the Authentication Context. 
 When it receives the Authentication Response from the IdP, {es} examines the 
@@ -501,7 +501,7 @@ You should consult the documentation for your IdP to determine what formats they
 support. Since PEM format is the most commonly supported format, the examples
 below will generate certificates in that format.
 
-Using the {ref}/certutil.html[`elasticsearch-certutil`] tool, you can generate a
+Using the <<certutil,`elasticsearch-certutil` tool>>, you can generate a
 signing certificate with the following command:
 
 [source, sh]
@@ -541,7 +541,7 @@ The path to the PEM formatted key file. e.g. `saml/saml-sign.key`
 
 `signing.secure_key_passphrase`::
 The passphrase for the key, if the file is encrypted. This is a
-{ref}/secure-settings.html[secure setting] that must be set with the
+<<secure-settings,secure setting>> that must be set with the
 `elasticsearch-keystore` tool.
 
 If you wish to use *PKCS#12 formatted* files or a *Java Keystore* for
@@ -555,7 +555,7 @@ The alias of the key within the keystore. e.g. `signing-key`
 
 `signing.keystore.secure_password`::
 The passphrase for the keystore, if the file is encrypted. This is a
-{ref}/secure-settings.html[secure setting] that must be set with the
+<<secure-settings,secure setting>> that must be set with the
 `elasticsearch-keystore` tool.
 
 If you wish to sign some, but not all outgoing *SAML messages*, then you
@@ -592,7 +592,7 @@ The path to the PEM formatted key file. e.g. `saml/saml-crypt.key`
 
 `encryption.secure_key_passphrase`::
 The passphrase for the key, if the file is encrypted. This is a
-{ref}/secure-settings.html[secure setting] that must be set with the
+<<secure-settings,secure setting>> that must be set with the
 `elasticsearch-keystore` tool.
 
 If you wish to use *PKCS#12 formatted* files or a *Java Keystore* for SAML
@@ -606,7 +606,7 @@ The alias of the key within the keystore. e.g. `encryption-key`
 
 `encryption.keystore.secure_password`::
 The passphrase for the keystore, if the file is encrypted. This is a
-{ref}/secure-settings.html[secure setting] that must be set with the
+<<secure-settings,secure setting>> that must be set with the
 `elasticsearch-keystore` tool.
 
 [[saml-sp-metadata]]
@@ -619,7 +619,7 @@ between the IdP and the SP.
 The Elastic Stack supports generating such a metadata file using the
 `bin/elasticsearch-saml-metadata` command in your {es} directory.
 
-The {ref}/saml-metadata.html[documentation for the elasticsearch-saml-metadata utility]
+The <<saml-metadata,documentation for the elasticsearch-saml-metadata utility>>
 describes how to run it, and the available command line options.
 
 [[saml-role-mapping]]
@@ -631,10 +631,10 @@ access any data.
 
 Your SAML users cannot do anything until they are assigned roles. This can be done
 through either the
-{ref}/security-api-put-role-mapping.html[add role mapping API], or with
-<<authorization_realms, authorization realms>>.
+<<security-api-put-role-mapping,add role mapping API>> or with
+<<authorization_realms,authorization realms>>.
 
-NOTE: You cannot use {stack-ov}/mapping-roles.html#mapping-roles-file[role mapping files]
+NOTE: You cannot use <<mapping-roles-file,role mapping files>>
 to grant roles to users authenticating via SAML.
 
 This is an example of a simple role mapping that grants the `kibana_user` role
@@ -665,7 +665,7 @@ mapping are derived from the SAML attributes as follows:
 - `metadata`: See <<saml-user-metadata>>
 
 For more information, see <<mapping-roles>> and
-{ref}/security-api.html#security-role-mapping-apis[role mapping APIs]. 
+<<security-role-mapping-apis>>. 
 
 If your IdP has the ability to provide groups or roles to Service Providers,
 then you should map this SAML attribute to the `attributes.groups` setting in

--- a/x-pack/docs/en/security/configuring-es.asciidoc
+++ b/x-pack/docs/en/security/configuring-es.asciidoc
@@ -9,7 +9,7 @@ The {es} {security-features} enable you to easily secure a cluster. You can
 password-protect your data as well as implement more advanced security measures
 such as encrypting communications, role-based access control, IP filtering, and
 auditing. For more information, see
-{stack-ov}/elasticsearch-security.html[Securing the {stack}].
+<<elasticsearch-security>>.
 
 . Verify that you are using a license that includes the specific
 {security-features} you want.
@@ -21,7 +21,7 @@ For more information, see https://www.elastic.co/subscriptions and
 
 . Verify that the `xpack.security.enabled` setting is `true` on each node in
 your cluster. If you are using basic or trial licenses, the default value is `false`.
-For more information, see {ref}/security-settings.html[Security settings in {es}].
+For more information, see <<security-settings>>.
 
 . If you plan to run {es} in a Federal Information Processing Standard (FIPS) 
 140-2 enabled JVM, see <<fips-140-compliance>>. 
@@ -33,7 +33,7 @@ NOTE: This requirement applies to clusters with more than one node and to
 clusters with a single node that listens on an external interface. Single-node
 clusters that use a loopback interface do not have this requirement.  For more
 information, see
-{stack-ov}/encrypting-communications.html[Encrypting communications].
+<<encrypting-communications>>.
 
 --
 
@@ -43,7 +43,7 @@ information, see
 +
 --
 The {es} {security-features} provide
-{stack-ov}/built-in-users.html[built-in users] to
+<<built-in-users,built-in users>> to
 help you get up and running. The +elasticsearch-setup-passwords+ command is the
 simplest method to set the built-in users' passwords for the first time.
 
@@ -127,8 +127,7 @@ information, see https://www.elastic.co/subscriptions.
 xpack.security.audit.enabled: true
 ----------------------------
 +
-For more information, see {stack-ov}/auditing.html[Auditing Security Events] 
-and <<auditing-settings>>. 
+For more information, see <<auditing>> and <<auditing-settings>>. 
 
 .. Restart {es}.
 
@@ -136,8 +135,7 @@ Events are logged to a dedicated `<clustername>_audit.json` file in
 `ES_HOME/logs`, on each cluster node.
 --
 
-To walk through the configuration of {security-features} in {es}, {kib}, {ls}, and {metricbeat}, see
-{stack-ov}/security-getting-started.html[Getting started with security].
+To walk through the configuration of {security-features} in {es}, {kib}, {ls}, and {metricbeat}, see <<security-getting-started>>.
 
 include::securing-communications/securing-elasticsearch.asciidoc[]
 

--- a/x-pack/docs/en/security/reference/files.asciidoc
+++ b/x-pack/docs/en/security/reference/files.asciidoc
@@ -6,7 +6,7 @@
 The {es} {security-features} use the following files:
 
 * `ES_PATH_CONF/roles.yml` defines the roles in use on the cluster. See
-{stack-ov}/defining-roles.html[Defining roles].
+<<defining-roles>>.
 
 * `ES_PATH_CONF/elasticsearch-users` defines the users and their hashed passwords for
   the `file` realm. See <<configuring-file-realm>>.
@@ -17,10 +17,10 @@ The {es} {security-features} use the following files:
 * `ES_PATH_CONF/role_mapping.yml` defines the role assignments for a
   Distinguished Name (DN) to a role. This allows for LDAP and Active Directory
   groups and users and PKI users to be mapped to roles. See
-  {stack-ov}/mapping-roles.html[Mapping users and groups to roles].
+  <<mapping-roles>>.
 
 * `ES_PATH_CONF/log4j2.properties` contains audit information. See
-{stack-ov}/audit-log-output.html[Logfile audit output].
+<<audit-log-output>>.
 
 [[security-files-location]]
 

--- a/x-pack/docs/en/security/securing-communications/configuring-tls-docker.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/configuring-tls-docker.asciidoc
@@ -9,8 +9,8 @@ This section demonstrates an easy path to get started with SSL/TLS for both
 HTTPS and transport using the {es} Docker image. The example uses
 Docker Compose to manage the containers.
 
-For further details, please refer to
-{stack-ov}/encrypting-communications.html[Encrypting communications] and
+For further details, see
+<<encrypting-communications>> and
 https://www.elastic.co/subscriptions[available subscriptions].
 
 [float]
@@ -163,7 +163,7 @@ volumes: {"data01", "data02", "certs"}
 ----
 
 <1> Bootstrap `elastic` with the password defined in `.env`. See
-{stack-ov}/built-in-users.html#bootstrap-elastic-passwords[the Elastic Bootstrap Password].
+<<bootstrap-elastic-passwords>>.
 <2> Automatically generate and apply a trial subscription, in order to enable
 {security-features}.
 <3> Disable verification of authenticity for inter-node communication. Allows

--- a/x-pack/docs/en/security/securing-communications/securing-elasticsearch.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/securing-elasticsearch.asciidoc
@@ -29,7 +29,7 @@ information, see <<security-settings>>.
 <<tls-ldap,encrypt communications between {es} and your LDAP server>>. 
 
 For more information about encrypting communications across the Elastic Stack,
-see {stack-ov}/encrypting-communications.html[Encrypting Communications].
+see <<encrypting-communications>>.
 
 include::node-certificates.asciidoc[]
 


### PR DESCRIPTION
Related to elastic/elasticsearch#46880

This PR fixes out-dated links to the security content in the Stack Overview, since the content has moved to the Elasticsearch book.