### PR TITLE
SQL: Add 3rd optional arg to DATE_PART

### DIFF
--- a/docs/reference/sql/functions/date-time.asciidoc
+++ b/docs/reference/sql/functions/date-time.asciidoc
@@ -257,13 +257,16 @@ function as the maximum number of second fractional digits returned is 3 (millis
 --------------------------------------------------
 DATE_PART(
     string_exp, <1>
-    datetime_exp) <2>
+    datetime_exp <2>
+    [,startofweek_exp]) <3>
 --------------------------------------------------
 
 *Input*:
 
 <1> string expression denoting the unit to extract from the date/datetime
 <2> date/datetime expression
+<3> string expression denoting the day on which the week starts, valid values: `Sunday`,`Monday`; optional, if missing,
+defaults to `Sunday`.
 
 *Output*: integer
 
@@ -271,7 +274,9 @@ DATE_PART(
 
 Extract the specified unit from a date/datetime. If any of the two arguments is `null` a `null` is returned.
 It's similar to <<sql-functions-datetime-extract>> but with different names and aliases for the units and
-provides more options (e.g.: `TZOFFSET`).
+provides more options (e.g.: `TZOFFSET`). The third argument, is used for the extraction of `week` or `weekday`.
+If missing the default value `Sunday` is used, which results in non-ISO extraction of the fields `week` or `weekday`.
+If an ISO extraction is preferred then the value `Monday` should be provided as a third argument.
 
 [cols="^,^"]
 |===
@@ -318,12 +323,18 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[datePartDateMonth]
 --------------------------------------------------
 
 [NOTE]
-For `week` and `weekday` the unit is extracted using the non-ISO calculation, which means
-that a given week is considered to start from Sunday, not Monday.
+For `week` and `weekday` the unit is extracted using the non-ISO calculation by default, which means
+that a given week is considered to start from Sunday, not Monday. If an ISO calculation is required,
+then use the third optional argument with the value: `Monday`.
 
 [source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[datePartDateTimeWeek]
+--------------------------------------------------
+
+[source, sql]
+--------------------------------------------------
+include-tagged::{sql-specs}/docs/docs.csv-spec[datePartDateTimeWeekIso]
 --------------------------------------------------
 
 [NOTE]

--- a/x-pack/plugin/sql/qa/src/main/resources/datetime.csv-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/datetime.csv-spec
@@ -269,27 +269,31 @@ F       | 1997-05-19 00:00:00.000Z
 ;
 
 selectDatePartWithDate
-SELECT DATE_PART('year', '2019-09-04'::date) as dp_years, DATE_PART('quarter', '2019-09-04'::date) as dp_quarter, DATE_PART('month', '2019-09-04'::date) as dp_month,
-DATE_PART('dayofyear', '2019-09-04'::date) as dp_doy, DATE_PART('day', '2019-09-04'::date) as dp_day, DATE_PART('week', '2019-09-04'::date) as dp_week,
-DATE_PART('weekday', '2019-09-04'::date) as dp_weekday, DATE_PART('hour', '2019-09-04'::date) as dp_hour, DATE_PART('minute', '2019-09-04'::date) as dp_minute,
-DATE_PART('second', '2019-09-04'::date) as dp_second, DATE_PART('millisecond', '2019-09-04'::date) as dp_millis, DATE_PART('mcs', '2019-09-04'::date) as dp_micros,
-DATE_PART('ns', '2019-09-04'::date) as dp_nanos, DATE_PART('tz', '2019-09-04'::date) as dp_tzoffset;
+SELECT DATE_PART('year', '2019-09-08'::date) as dp_years, DATE_PART('quarter', '2019-09-08'::date) as dp_quarter, DATE_PART('month', '2019-09-08'::date) as dp_month,
+DATE_PART('dayofyear', '2019-09-08'::date) as dp_doy, DATE_PART('day', '2019-09-08'::date) as dp_day,
+DATE_PART('week', '2019-09-08'::date) as dp_week, DATE_PART('week', '2019-09-08'::date, 'monday') as dp_week_iso,
+DATE_PART('weekday', '2019-09-08'::date) as dp_weekday, DATE_PART('weekday', '2019-09-08'::date, 'monday') as dp_weekday_iso,
+DATE_PART('hour', '2019-09-08'::date) as dp_hour, DATE_PART('minute', '2019-09-08'::date) as dp_minute,
+DATE_PART('second', '2019-09-08'::date) as dp_second, DATE_PART('millisecond', '2019-09-08'::date) as dp_millis, DATE_PART('mcs', '2019-09-08'::date) as dp_micros,
+DATE_PART('ns', '2019-09-08'::date) as dp_nanos, DATE_PART('tz', '2019-09-08'::date) as dp_tzoffset;
 
-dp_years | dp_quarter | dp_month | dp_doy | dp_day | dp_week | dp_weekday | dp_hour | dp_minute | dp_second | dp_millis | dp_micros | dp_nanos  | dp_tzoffset
----------+------------+----------+--------+--------+---------+------------+---------+-----------+-----------+-----------+-----------+-----------+------------
-2019     | 3          | 9        |247     | 4      | 36      | 4          | 0       | 0         | 0         | 0         | 0         | 0         | 0
+dp_years | dp_quarter | dp_month | dp_doy | dp_day | dp_week | dp_week_iso | dp_weekday | dp_weekday_iso | dp_hour | dp_minute | dp_second | dp_millis | dp_micros | dp_nanos  | dp_tzoffset
+---------+------------+----------+--------+--------+---------+-------------+------------+----------------+---------+-----------+-----------+-----------+-----------+-----------+------------
+2019     | 3          | 9        |251     | 8      | 37      | 36          | 1          | 7              | 0       | 0         | 0         | 0         | 0         | 0         | 0
 ;
 
 selectDatePartWithDateTime
-SELECT DATE_PART('year', '2019-09-04T11:22:33.123Z'::datetime) as dp_years, DATE_PART('quarter', '2019-09-04T11:22:33.123Z'::datetime) as dp_quarter, DATE_PART('month', '2019-09-04T11:22:33.123Z'::datetime) as dp_month,
-DATE_PART('dayofyear', '2019-09-04T11:22:33.123Z'::datetime) as dp_doy, DATE_PART('day', '2019-09-04T11:22:33.123Z'::datetime) as dp_day, DATE_PART('week', '2019-09-04T11:22:33.123Z'::datetime) as dp_week,
-DATE_PART('weekday', '2019-09-04T11:22:33.123Z'::datetime) as dp_weekday, DATE_PART('hour', '2019-09-04T11:22:33.123Z'::datetime) as dp_hour, DATE_PART('minute', '2019-09-04T11:22:33.123Z'::datetime) as dp_minute,
-DATE_PART('second', '2019-09-04T11:22:33.123Z'::datetime) as dp_second, DATE_PART('millisecond', '2019-09-04T11:22:33.123Z'::datetime) as dp_millis, DATE_PART('mcs', '2019-09-04T11:22:33.123Z'::datetime) as dp_micros,
-DATE_PART('ns', '2019-09-04T11:22:33.123Z'::datetime) as dp_nanos, DATE_PART('tz', '2019-09-04T11:22:33.123Z'::datetime) as dp_tzoffset;
+SELECT DATE_PART('year', '2019-10-13T11:22:33.123Z'::datetime) as dp_years, DATE_PART('quarter', '2019-10-13T11:22:33.123Z'::datetime) as dp_quarter, DATE_PART('month', '2019-10-13T11:22:33.123Z'::datetime) as dp_month,
+DATE_PART('dayofyear', '2019-10-13T11:22:33.123Z'::datetime) as dp_doy, DATE_PART('day', '2019-10-13T11:22:33.123Z'::datetime) as dp_day,
+DATE_PART('week', '2019-10-13T11:22:33.123Z'::datetime) as dp_week, DATE_PART('week', '2019-10-13T11:22:33.123Z'::datetime, 'monday') as dp_week_iso,
+DATE_PART('weekday', '2019-10-13T11:22:33.123Z'::datetime) as dp_weekday, DATE_PART('weekday', '2019-10-13T11:22:33.123Z'::datetime, 'monday') as dp_weekday_iso,
+DATE_PART('hour', '2019-10-13T11:22:33.123Z'::datetime) as dp_hour, DATE_PART('minute', '2019-10-13T11:22:33.123Z'::datetime) as dp_minute,
+DATE_PART('second', '2019-10-13T11:22:33.123Z'::datetime) as dp_second, DATE_PART('millisecond', '2019-10-13T11:22:33.123Z'::datetime) as dp_millis, DATE_PART('mcs', '2019-10-13T11:22:33.123Z'::datetime) as dp_micros,
+DATE_PART('ns', '2019-10-13T11:22:33.123Z'::datetime) as dp_nanos, DATE_PART('tz', '2019-10-13T11:22:33.123Z'::datetime) as dp_tzoffset;
 
-dp_years | dp_quarter | dp_month | dp_doy | dp_day | dp_week | dp_weekday | dp_hour | dp_minute | dp_second | dp_millis | dp_micros | dp_nanos  | dp_tzoffset
----------+------------+----------+--------+--------+---------+------------+---------+-----------+-----------+-----------+-----------+-----------+------------
-2019     | 3          | 9        |247     | 4      | 36      | 4          | 11      | 22        | 33        | 123       | 123000    | 123000000 | 0
+dp_years | dp_quarter | dp_month | dp_doy | dp_day | dp_week | dp_week_iso | dp_weekday | dp_weekday_iso | dp_hour | dp_minute | dp_second | dp_millis | dp_micros | dp_nanos  | dp_tzoffset
+---------+------------+----------+--------+--------+---------+-------------+------------+----------------+---------+-----------+-----------+-----------+-----------+-----------+------------
+2019     | 4          | 10       |286     | 13     | 42      | 41          | 1          | 7              | 11      | 22        | 33        | 123       | 123000    | 123000000 | 0
 ;
 
 selectDatePartWithNullTruncateField

--- a/x-pack/plugin/sql/qa/src/main/resources/docs/docs.csv-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/docs/docs.csv-spec
@@ -2430,12 +2430,22 @@ SELECT DATE_PART('year', '2019-09-22T11:22:33.123Z'::datetime) AS "years";
 
 datePartDateTimeWeek
 // tag::datePartDateTimeWeek
-SELECT DATE_PART('week', '2019-09-22T11:22:33.123Z'::datetime) AS week;
+SELECT DATE_PART('week', '2019-09-22T11:22:33.123Z'::datetime) AS week,  DATE_PART('weekday', '2019-09-22T11:22:33.123Z'::datetime) AS weekday;
 
-   week
-----------
-39
+   week  |  weekday
+---------+---------
+39       | 1
 // end::datePartDateTimeWeek
+;
+
+datePartDateTimeWeekIso
+// tag::datePartDateTimeWeekIso
+SELECT DATE_PART('week', '2019-09-22T11:22:33.123Z'::datetime, 'Monday') AS week, DATE_PART('weekday', '2019-09-22T11:22:33.123Z'::datetime, 'Monday') AS weekday;
+
+   week  |  weekday
+---------+---------
+38       | 7
+// end::datePartDateTimeWeekIso
 ;
 
 datePartDateTimeMinutes

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/BinaryDateTimeFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/BinaryDateTimeFunction.java
@@ -20,19 +20,15 @@ import java.util.Objects;
 import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
 import static org.elasticsearch.xpack.sql.expression.TypeResolutions.isDate;
 import static org.elasticsearch.xpack.sql.expression.TypeResolutions.isString;
-import static org.elasticsearch.xpack.sql.expression.function.scalar.datetime.BinaryDateTimeProcessor.BinaryDateOperation;
 import static org.elasticsearch.xpack.sql.expression.gen.script.ParamsBuilder.paramsBuilder;
 
 public abstract class BinaryDateTimeFunction extends BinaryScalarFunction {
 
     private final ZoneId zoneId;
-    private final BinaryDateOperation operation;
 
-    public BinaryDateTimeFunction(Source source, Expression datePart, Expression timestamp, ZoneId zoneId,
-                                  BinaryDateOperation operation) {
+    public BinaryDateTimeFunction(Source source, Expression datePart, Expression timestamp, ZoneId zoneId) {
         super(source, datePart, timestamp);
         this.zoneId = zoneId;
-        this.operation = operation;
     }
 
     @Override
@@ -78,8 +74,10 @@ public abstract class BinaryDateTimeFunction extends BinaryScalarFunction {
 
     @Override
     protected Pipe makePipe() {
-        return new BinaryDateTimePipe(source(), this, Expressions.pipe(left()), Expressions.pipe(right()), zoneId, operation);
+        return createPipe(Expressions.pipe(left()), Expressions.pipe(right()), zoneId);
     }
+
+    protected abstract Pipe createPipe(Pipe left, Pipe right, ZoneId zoneId);
 
     @Override
     public Nullability nullable() {
@@ -101,7 +99,7 @@ public abstract class BinaryDateTimeFunction extends BinaryScalarFunction {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), zoneId, operation);
+        return Objects.hash(super.hashCode(), zoneId);
     }
 
     @Override
@@ -116,6 +114,6 @@ public abstract class BinaryDateTimeFunction extends BinaryScalarFunction {
             return false;
         }
         BinaryDateTimeFunction that = (BinaryDateTimeFunction) o;
-        return zoneId.equals(that.zoneId) && operation == that.operation;
+        return zoneId.equals(that.zoneId);
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/BinaryDateTimePipe.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/BinaryDateTimePipe.java
@@ -9,50 +9,34 @@ import org.elasticsearch.xpack.sql.expression.Expression;
 import org.elasticsearch.xpack.sql.expression.gen.pipeline.BinaryPipe;
 import org.elasticsearch.xpack.sql.expression.gen.pipeline.Pipe;
 import org.elasticsearch.xpack.sql.expression.gen.processor.Processor;
-import org.elasticsearch.xpack.sql.tree.NodeInfo;
 import org.elasticsearch.xpack.sql.tree.Source;
 
 import java.time.ZoneId;
 import java.util.Objects;
 
-public class BinaryDateTimePipe extends BinaryPipe {
+public abstract class BinaryDateTimePipe extends BinaryPipe {
 
     private final ZoneId zoneId;
-    private final BinaryDateTimeProcessor.BinaryDateOperation operation;
 
-    public BinaryDateTimePipe(Source source, Expression expression, Pipe left, Pipe right, ZoneId zoneId,
-                              BinaryDateTimeProcessor.BinaryDateOperation operation) {
+    public BinaryDateTimePipe(Source source, Expression expression, Pipe left, Pipe right, ZoneId zoneId) {
         super(source, expression, left, right);
         this.zoneId = zoneId;
-        this.operation = operation;
     }
 
     ZoneId zoneId() {
         return zoneId;
     }
 
-    BinaryDateTimeProcessor.BinaryDateOperation operation() {
-        return operation;
-    }
-
-    @Override
-    protected NodeInfo<BinaryDateTimePipe> info() {
-        return NodeInfo.create(this, BinaryDateTimePipe::new, expression(), left(), right(), zoneId, operation);
-    }
-
-    @Override
-    protected BinaryPipe replaceChildren(Pipe left, Pipe right) {
-        return new BinaryDateTimePipe(source(), expression(), left, right, zoneId, operation);
-    }
-
     @Override
     public Processor asProcessor() {
-        return BinaryDateTimeProcessor.asProcessor(operation, left().asProcessor(), right().asProcessor(), zoneId);
+        return makeProcessor(left().asProcessor(), right().asProcessor(), zoneId);
     }
+
+    protected abstract Processor makeProcessor(Processor left, Processor right, ZoneId zoneId);
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), zoneId, operation);
+        return Objects.hash(super.hashCode(), zoneId);
     }
 
     @Override
@@ -67,7 +51,6 @@ public class BinaryDateTimePipe extends BinaryPipe {
             return false;
         }
         BinaryDateTimePipe that = (BinaryDateTimePipe) o;
-        return Objects.equals(zoneId, that.zoneId) &&
-            operation == that.operation;
+        return Objects.equals(zoneId, that.zoneId);
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/BinaryDateTimeProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/BinaryDateTimeProcessor.java
@@ -15,15 +15,7 @@ import java.io.IOException;
 import java.time.ZoneId;
 import java.util.Objects;
 
-import static org.elasticsearch.xpack.sql.expression.function.scalar.datetime.BinaryDateTimeProcessor.BinaryDateOperation.TRUNC;
-
 public abstract class BinaryDateTimeProcessor extends BinaryProcessor {
-
-    // TODO: Remove and in favour of inheritance (subclasses which implement abstract methods)
-    public enum BinaryDateOperation {
-        TRUNC,
-        PART;
-    }
 
     private final ZoneId zoneId;
 
@@ -48,28 +40,24 @@ public abstract class BinaryDateTimeProcessor extends BinaryProcessor {
     @Override
     protected abstract Object doProcess(Object left, Object right);
 
-    public static BinaryDateTimeProcessor asProcessor(BinaryDateOperation operation, Processor left, Processor right, ZoneId zoneId) {
-        if (operation == TRUNC) {
-            return new DateTruncProcessor(left, right, zoneId);
-        } else {
-            return new DatePartProcessor(left, right, zoneId);
-        }
-    }
-
     @Override
     public int hashCode() {
-        return Objects.hash(zoneId);
+        return Objects.hash(left(), right(), zoneId);
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
+    public boolean equals(Object obj) {
+        if (this == obj) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+
+        if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        BinaryDateTimeProcessor that = (BinaryDateTimeProcessor) o;
-        return zoneId.equals(that.zoneId);
+
+        BinaryDateTimeProcessor other = (BinaryDateTimeProcessor) obj;
+        return Objects.equals(left(), other.left())
+            && Objects.equals(right(), other.right())
+            && Objects.equals(zoneId(), other.zoneId());
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DatePart.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DatePart.java
@@ -5,9 +5,11 @@
  */
 package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
+import org.elasticsearch.common.time.IsoLocale;
 import org.elasticsearch.xpack.sql.expression.Expression;
+import org.elasticsearch.xpack.sql.expression.Expressions;
+import org.elasticsearch.xpack.sql.expression.Literal;
 import org.elasticsearch.xpack.sql.expression.Nullability;
-import org.elasticsearch.xpack.sql.expression.function.scalar.BinaryScalarFunction;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeProcessor.DateTimeExtractor;
 import org.elasticsearch.xpack.sql.tree.NodeInfo;
 import org.elasticsearch.xpack.sql.tree.Source;
@@ -19,27 +21,42 @@ import java.time.temporal.ChronoField;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
+import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
+import static org.elasticsearch.xpack.sql.expression.TypeResolutions.isDate;
+import static org.elasticsearch.xpack.sql.expression.TypeResolutions.isString;
 import static org.elasticsearch.xpack.sql.expression.function.scalar.datetime.NonIsoDateTimeProcessor.NonIsoDateTimeExtractor;
 
-public class DatePart extends BinaryDateTimeFunction {
+public class DatePart extends ThreeArgsDateTimeFunction {
 
     public enum Part implements DateTimeField {
-        YEAR(DateTimeExtractor.YEAR::extract, "years", "yyyy", "yy"),
-        QUARTER(QuarterProcessor::quarter, "quarters", "qq", "q"),
-        MONTH(DateTimeExtractor.MONTH_OF_YEAR::extract, "months", "mm", "m"),
-        DAYOFYEAR(DateTimeExtractor.DAY_OF_YEAR::extract, "dy", "y"),
-        DAY(DateTimeExtractor.DAY_OF_MONTH::extract, "days", "dd", "d"),
-        WEEK(NonIsoDateTimeExtractor.WEEK_OF_YEAR::extract, "weeks", "wk", "ww"),
-        WEEKDAY(NonIsoDateTimeExtractor.DAY_OF_WEEK::extract, "weekdays", "dw"),
-        HOUR(DateTimeExtractor.HOUR_OF_DAY::extract, "hours", "hh"),
-        MINUTE(DateTimeExtractor.MINUTE_OF_HOUR::extract, "minutes", "mi", "n"),
-        SECOND(DateTimeExtractor.SECOND_OF_MINUTE::extract, "seconds", "ss", "s"),
-        MILLISECOND(dt -> dt.get(ChronoField.MILLI_OF_SECOND), "milliseconds", "ms"),
-        MICROSECOND(dt -> dt.get(ChronoField.MICRO_OF_SECOND), "microseconds", "mcs"),
-        NANOSECOND(ZonedDateTime::getNano, "nanoseconds", "ns"),
-        TZOFFSET(dt -> dt.getOffset().getTotalSeconds() / 60, "tz");
+        YEAR((dt, sw) -> DateTimeExtractor.YEAR.extract(dt), "years", "yyyy", "yy"),
+        QUARTER((dt, sw) -> QuarterProcessor.quarter(dt), "quarters", "qq", "q"),
+        MONTH((dt, sw) -> DateTimeExtractor.MONTH_OF_YEAR.extract(dt), "months", "mm", "m"),
+        DAYOFYEAR((dt, sw) -> DateTimeExtractor.DAY_OF_YEAR.extract(dt), "dy", "y"),
+        DAY((dt, sw) -> DateTimeExtractor.DAY_OF_MONTH.extract(dt), "days", "dd", "d"),
+        WEEK((dt, sw) -> {
+            if (sw == StartOfWeek.MONDAY) {
+                return DateTimeExtractor.ISO_WEEK_OF_YEAR.extract(dt);
+            } else {
+                return NonIsoDateTimeExtractor.WEEK_OF_YEAR.extract(dt);
+            }
+        }, "weeks", "wk", "ww"),
+        WEEKDAY((dt, sw) -> {
+            if (sw == StartOfWeek.MONDAY) {
+                return DateTimeExtractor.ISO_DAY_OF_WEEK.extract(dt);
+            } else {
+                return NonIsoDateTimeExtractor.DAY_OF_WEEK.extract(dt);
+            }
+        }, "weekdays", "dw"),
+        HOUR((dt, sw) -> DateTimeExtractor.HOUR_OF_DAY.extract(dt), "hours", "hh"),
+        MINUTE((dt, sw) -> DateTimeExtractor.MINUTE_OF_HOUR.extract(dt), "minutes", "mi", "n"),
+        SECOND((dt, sw) -> DateTimeExtractor.SECOND_OF_MINUTE.extract(dt), "seconds", "ss", "s"),
+        MILLISECOND((dt, sw) -> dt.get(ChronoField.MILLI_OF_SECOND), "milliseconds", "ms"),
+        MICROSECOND((dt, sw) -> dt.get(ChronoField.MICRO_OF_SECOND), "microseconds", "mcs"),
+        NANOSECOND((dt, sw) -> dt.getNano(), "nanoseconds", "ns"),
+        TZOFFSET((dt, sw) -> dt.getOffset().getTotalSeconds() / 60, "tz");
 
         private static final Map<String, Part> NAME_TO_PART;
         private static final List<String> VALID_VALUES;
@@ -49,10 +66,10 @@ public class DatePart extends BinaryDateTimeFunction {
             VALID_VALUES = DateTimeField.initializeValidValues(values());
         }
 
-        private Function<ZonedDateTime, Integer> extractFunction;
+        private BiFunction<ZonedDateTime, StartOfWeek, Integer> extractFunction;
         private Set<String> aliases;
 
-        Part(Function<ZonedDateTime, Integer> extractFunction, String... aliases) {
+        Part(BiFunction<ZonedDateTime, StartOfWeek, Integer> extractFunction, String... aliases) {
             this.extractFunction = extractFunction;
             this.aliases = Set.of(aliases);
         }
@@ -70,13 +87,76 @@ public class DatePart extends BinaryDateTimeFunction {
             return DateTimeField.resolveMatch(NAME_TO_PART, truncateTo);
         }
 
-        public Integer extract(ZonedDateTime dateTime) {
-            return extractFunction.apply(dateTime);
+        public Integer extract(ZonedDateTime dateTime, StartOfWeek startOfWeek) {
+            return extractFunction.apply(dateTime, startOfWeek);
         }
     }
 
-    public DatePart(Source source, Expression truncateTo, Expression timestamp, ZoneId zoneId) {
-        super(source, truncateTo, timestamp, zoneId, BinaryDateTimeProcessor.BinaryDateOperation.PART);
+    enum StartOfWeek {
+        SUNDAY,
+        MONDAY;
+
+        public static StartOfWeek resolve(String match) {
+            try {
+                return valueOf(match.toUpperCase(IsoLocale.ROOT));
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+        }
+    }
+
+    public DatePart(Source source, Expression truncateTo, Expression timestamp, Expression startOfWeek, ZoneId zoneId) {
+        super(source, truncateTo, timestamp, startOfWeek == null ? Literal.of(Source.EMPTY, "Sunday") : startOfWeek, zoneId);
+    }
+
+    // Used by DatePartProcessorTests
+    DatePart(Source source, Expression truncateTo, Expression timestamp, ZoneId zoneId) {
+        this(source, truncateTo, timestamp, null, zoneId);
+    }
+
+    @Override
+    protected TypeResolution resolveType() {
+        TypeResolution resolution = isString(first(), sourceText(), Expressions.ParamOrdinal.FIRST);
+        if (resolution.unresolved()) {
+            return resolution;
+        }
+
+        if (first().foldable()) {
+            String datePartValue = (String) first().fold();
+            if (datePartValue != null && resolveDateTimeField(datePartValue) == false) {
+                List<String> similar = findSimilarDateTimeFields(datePartValue);
+                if (similar.isEmpty()) {
+                    return new TypeResolution(format(null, "first argument of [{}] must be one of {} or their aliases; found value [{}]",
+                        sourceText(),
+                        validDateTimeFieldValues(),
+                        Expressions.name(first())));
+                } else {
+                    return new TypeResolution(format(null, "Unknown value [{}] for first argument of [{}]; did you mean {}?",
+                        Expressions.name(first()),
+                        sourceText(),
+                        similar));
+                }
+            }
+        }
+        resolution = isDate(second(), sourceText(), Expressions.ParamOrdinal.SECOND);
+        if (resolution.unresolved()) {
+            return resolution;
+        }
+
+        resolution = isString(third(), sourceText(), Expressions.ParamOrdinal.THIRD);
+        if (resolution.unresolved()) {
+            return resolution;
+        }
+        if (third().foldable()) {
+            String startOfWeekStr = (String) third().fold();
+            if (StartOfWeek.resolve(startOfWeekStr) == null) {
+                return new TypeResolution(format(null, "third argument of [{}] must be one of {}; found value [{}]",
+                    sourceText(),
+                    StartOfWeek.values(),
+                    Expressions.name(third())));
+            }
+        }
+        return TypeResolution.TYPE_RESOLVED;
     }
 
     @Override
@@ -85,18 +165,18 @@ public class DatePart extends BinaryDateTimeFunction {
     }
 
     @Override
-    protected BinaryScalarFunction replaceChildren(Expression newTruncateTo, Expression newTimestamp) {
-        return new DatePart(source(), newTruncateTo, newTimestamp, zoneId());
+    protected ThreeArgsDateTimeFunction replaceChildren(Expression newFirst, Expression newSecond, Expression newThird) {
+        return new DatePart(source(), newFirst, newSecond, newThird, zoneId());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, DatePart::new, left(), right(), zoneId());
+        return NodeInfo.create(this, DatePart::new, first(), second(), third(), zoneId());
     }
 
     @Override
     public Nullability nullable() {
-        return Nullability.TRUE;
+        return Nullability.UNKNOWN;
     }
 
     @Override
@@ -116,7 +196,7 @@ public class DatePart extends BinaryDateTimeFunction {
 
     @Override
     public Object fold() {
-        return DatePartProcessor.process(left().fold(), right().fold(), zoneId());
+        return DatePartProcessor.process(first().fold(), second().fold(), third().fold(), zoneId());
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DatePartPipe.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DatePartPipe.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
+
+import org.elasticsearch.xpack.sql.expression.Expression;
+import org.elasticsearch.xpack.sql.expression.gen.pipeline.Pipe;
+import org.elasticsearch.xpack.sql.expression.gen.processor.Processor;
+import org.elasticsearch.xpack.sql.tree.NodeInfo;
+import org.elasticsearch.xpack.sql.tree.Source;
+
+import java.time.ZoneId;
+
+public class DatePartPipe extends ThreeArgsDateTimePipe {
+
+    public DatePartPipe(Source source, Expression expression, Pipe first, Pipe second, Pipe third, ZoneId zoneId) {
+        super(source, expression, first, second, third, zoneId);
+    }
+
+    @Override
+    protected NodeInfo<DatePartPipe> info() {
+        return NodeInfo.create(this, DatePartPipe::new, expression(), first(), second(), third(), zoneId());
+    }
+
+    @Override
+    public ThreeArgsDateTimePipe replaceChildren(Pipe newFirst, Pipe newSecond, Pipe newThird) {
+        return new DatePartPipe(source(), expression(), newFirst, newSecond, newThird, zoneId());
+    }
+
+    @Override
+    protected Processor makeProcessor(Processor first, Processor second, Processor third, ZoneId zoneId) {
+        return new DatePartProcessor(first, second, third, zoneId);
+    }
+}

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTruncPipe.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTruncPipe.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
+
+import org.elasticsearch.xpack.sql.expression.Expression;
+import org.elasticsearch.xpack.sql.expression.gen.pipeline.Pipe;
+import org.elasticsearch.xpack.sql.expression.gen.processor.Processor;
+import org.elasticsearch.xpack.sql.tree.NodeInfo;
+import org.elasticsearch.xpack.sql.tree.Source;
+
+import java.time.ZoneId;
+
+public class DateTruncPipe extends BinaryDateTimePipe {
+
+    public DateTruncPipe(Source source, Expression expression, Pipe left, Pipe right, ZoneId zoneId) {
+        super(source, expression, left, right, zoneId);
+    }
+
+    @Override
+    protected NodeInfo<DateTruncPipe> info() {
+        return NodeInfo.create(this, DateTruncPipe::new, expression(), left(), right(), zoneId());
+    }
+
+    @Override
+    protected DateTruncPipe replaceChildren(Pipe left, Pipe right) {
+        return new DateTruncPipe(source(), expression(), left, right, zoneId());
+    }
+
+    @Override
+    protected Processor makeProcessor(Processor left, Processor right, ZoneId zoneId) {
+        return new DateTruncProcessor(left, right, zoneId);
+    }
+}

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/ThreeArgsDateTimeFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/ThreeArgsDateTimeFunction.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
+
+import org.elasticsearch.xpack.sql.expression.Expression;
+import org.elasticsearch.xpack.sql.expression.Expressions;
+import org.elasticsearch.xpack.sql.expression.Nullability;
+import org.elasticsearch.xpack.sql.expression.function.scalar.ScalarFunction;
+import org.elasticsearch.xpack.sql.expression.gen.pipeline.Pipe;
+import org.elasticsearch.xpack.sql.expression.gen.script.ScriptTemplate;
+import org.elasticsearch.xpack.sql.tree.Source;
+
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import static org.elasticsearch.xpack.sql.expression.gen.script.ParamsBuilder.paramsBuilder;
+
+public abstract class ThreeArgsDateTimeFunction extends ScalarFunction {
+
+    private final ZoneId zoneId;
+
+    public ThreeArgsDateTimeFunction(Source source, Expression first, Expression second, Expression third, ZoneId zoneId) {
+        super(source, Arrays.asList(first, second, third));
+        this.zoneId = zoneId;
+    }
+
+    public Expression first() {
+        return arguments().get(0);
+    }
+
+    public Expression second() {
+        return arguments().get(1);
+    }
+
+    public Expression third() {
+        return arguments().get(2);
+    }
+
+    public ZoneId zoneId() {
+        return zoneId;
+    }
+
+    protected abstract boolean resolveDateTimeField(String dateTimeField);
+
+    protected abstract List<String> findSimilarDateTimeFields(String dateTimeField);
+
+    protected abstract List<String> validDateTimeFieldValues();
+
+    @Override
+    public final ThreeArgsDateTimeFunction replaceChildren(List<Expression> newChildren) {
+        if (newChildren.size() != 3) {
+            throw new IllegalArgumentException("expected [3] children but received [" + newChildren.size() + "]");
+        }
+        return replaceChildren(newChildren.get(0), newChildren.get(1), newChildren.get(2));
+    }
+
+    protected abstract ThreeArgsDateTimeFunction replaceChildren(Expression newFirst, Expression newSecond, Expression newThird);
+
+    @Override
+    protected Pipe makePipe() {
+        return new DatePartPipe(source(), this, Expressions.pipe(first()), Expressions.pipe(second()), Expressions.pipe(third()), zoneId);
+    }
+
+    @Override
+    public Nullability nullable() {
+        return Nullability.TRUE;
+    }
+
+    @Override
+    public boolean foldable() {
+        return first().foldable() && second().foldable() && third().foldable();
+    }
+
+    @Override
+    public ScriptTemplate asScript() {
+        ScriptTemplate firstScript = asScript(first());
+        ScriptTemplate secondScript = asScript(second());
+        ScriptTemplate thirdScript = asScript(third());
+
+        return asScriptFrom(firstScript, secondScript, thirdScript);
+    }
+
+    protected ScriptTemplate asScriptFrom(ScriptTemplate firstScript, ScriptTemplate secondScript, ScriptTemplate thirdScript) {
+        return new ScriptTemplate(
+            formatTemplate("{sql}." + scriptMethodName() +
+                "(" + firstScript.template() + "," + secondScript.template() + "," + thirdScript.template() + ",{})"),
+            paramsBuilder()
+                .script(firstScript.params())
+                .script(secondScript.params())
+                .script(thirdScript.params())
+                .variable(zoneId.getId())
+                .build(),
+            dataType());
+    }
+
+    protected String scriptMethodName() {
+        return getClass().getSimpleName().toLowerCase(Locale.ROOT);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), zoneId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        ThreeArgsDateTimeFunction that = (ThreeArgsDateTimeFunction) o;
+        return zoneId.equals(that.zoneId);
+    }
+}

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/ThreeArgsDateTimePipe.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/ThreeArgsDateTimePipe.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
+
+import org.elasticsearch.xpack.sql.expression.Expression;
+import org.elasticsearch.xpack.sql.expression.gen.pipeline.Pipe;
+import org.elasticsearch.xpack.sql.expression.gen.processor.Processor;
+import org.elasticsearch.xpack.sql.tree.Source;
+
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+public abstract class ThreeArgsDateTimePipe extends Pipe {
+
+    private final Pipe first, second, third;
+    private final ZoneId zoneId;
+
+    public ThreeArgsDateTimePipe(Source source, Expression expression, Pipe first, Pipe second, Pipe third, ZoneId zoneId) {
+        super(source, expression, Arrays.asList(first, second, third));
+        this.first = first;
+        this.second = second;
+        this.third = third;
+        this.zoneId = zoneId;
+    }
+
+    public Pipe first() {
+        return first;
+    }
+
+    public Pipe second() {
+        return second;
+    }
+
+    public Pipe third() {
+        return third;
+    }
+
+    ZoneId zoneId() {
+        return zoneId;
+    }
+
+    @Override
+    public final Pipe replaceChildren(List<Pipe> newChildren) {
+        if (newChildren.size() != 3) {
+            throw new IllegalArgumentException("expected [3] children but received [" + newChildren.size() + "]");
+        }
+        return replaceChildren(newChildren.get(0), newChildren.get(1), newChildren.get(2));
+    }
+
+    public abstract Pipe replaceChildren(Pipe newFirst, Pipe newSecond, Pipe newThird);
+
+    @Override
+    public Processor asProcessor() {
+        return makeProcessor(first.asProcessor(), second.asProcessor(), third.asProcessor(), zoneId);
+    }
+
+    protected abstract Processor makeProcessor(Processor first, Processor second, Processor third, ZoneId zoneId);
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), first, second, third, zoneId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        ThreeArgsDateTimePipe that = (ThreeArgsDateTimePipe) o;
+        return first.equals(that.first) &&
+            second.equals(that.second) &&
+            third.equals(that.third) &&
+            zoneId.equals(that.zoneId);
+    }
+}

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/ThreeArgsDateTimeProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/ThreeArgsDateTimeProcessor.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.sql.common.io.SqlStreamInput;
+import org.elasticsearch.xpack.sql.expression.gen.processor.Processor;
+
+import java.io.IOException;
+import java.time.ZoneId;
+import java.util.Objects;
+
+public abstract class ThreeArgsDateTimeProcessor implements Processor {
+
+    private final Processor first, second, third;
+    private final ZoneId zoneId;
+
+    public ThreeArgsDateTimeProcessor(Processor first, Processor second, Processor third, ZoneId zoneId) {
+        this.first = first;
+        this.second = second;
+        this.third = third;
+        this.zoneId = zoneId;
+    }
+
+    protected ThreeArgsDateTimeProcessor(StreamInput in) throws IOException {
+        this.first = in.readNamedWriteable(Processor.class);
+        this.second = in.readNamedWriteable(Processor.class);
+        this.third = in.readNamedWriteable(Processor.class);
+        zoneId = SqlStreamInput.asSqlStream(in).zoneId();
+    }
+
+    @Override
+    public final void writeTo(StreamOutput out) throws IOException {
+        out.writeNamedWriteable(first);
+        out.writeNamedWriteable(second);
+        out.writeNamedWriteable(third);
+    }
+
+    public Processor first() {
+        return first;
+    }
+
+    public Processor second() {
+        return second;
+    }
+
+    public Processor third() {
+        return third;
+    }
+
+    ZoneId zoneId() {
+        return zoneId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(first, second, third, zoneId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ThreeArgsDateTimeProcessor that = (ThreeArgsDateTimeProcessor) o;
+        return Objects.equals(first, that.first) &&
+            Objects.equals(second, that.second) &&
+            Objects.equals(third, that.third) &&
+            Objects.equals(zoneId, that.zoneId);
+    }
+}

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/whitelist/InternalSqlScriptUtils.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/whitelist/InternalSqlScriptUtils.java
@@ -235,7 +235,7 @@ public final class InternalSqlScriptUtils {
     public static Double atan(Number value) {
         return MathOperation.ATAN.apply(value);
     }
-    
+
     public static Number atan2(Number left, Number right) {
         return BinaryMathOperation.ATAN2.apply(left, right);
     }
@@ -291,7 +291,7 @@ public final class InternalSqlScriptUtils {
     public static Double pi(Number value) {
         return MathOperation.PI.apply(value);
     }
-    
+
     public static Number power(Number left, Number right) {
         return BinaryMathOperation.POWER.apply(left, right);
     }
@@ -350,7 +350,7 @@ public final class InternalSqlScriptUtils {
         }
         return NonIsoDateTimeExtractor.DAY_OF_WEEK.extract(asDateTime(dateTime), tzId);
     }
-    
+
     public static String monthName(Object dateTime, String tzId) {
         if (dateTime == null || tzId == null) {
             return null;
@@ -364,7 +364,7 @@ public final class InternalSqlScriptUtils {
         }
         return QuarterProcessor.quarter(asDateTime(dateTime), tzId);
     }
-    
+
     public static Integer weekOfYear(Object dateTime, String tzId) {
         if (dateTime == null || tzId == null) {
             return null;
@@ -376,8 +376,8 @@ public final class InternalSqlScriptUtils {
         return (ZonedDateTime) DateTruncProcessor.process(truncateTo, asDateTime(dateTime) , ZoneId.of(tzId));
     }
 
-    public static Integer datePart(String dateField, Object dateTime, String tzId) {
-        return (Integer) DatePartProcessor.process(dateField, asDateTime(dateTime) , ZoneId.of(tzId));
+    public static Integer datePart(String dateField, Object dateTime, String startOfWeek, String tzId) {
+        return (Integer) DatePartProcessor.process(dateField, asDateTime(dateTime), startOfWeek, ZoneId.of(tzId));
     }
 
     public static ZonedDateTime asDateTime(Object dateTime) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/optimizer/Optimizer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/optimizer/Optimizer.java
@@ -43,6 +43,7 @@ import org.elasticsearch.xpack.sql.expression.function.aggregate.TopHits;
 import org.elasticsearch.xpack.sql.expression.function.scalar.Cast;
 import org.elasticsearch.xpack.sql.expression.function.scalar.ScalarFunction;
 import org.elasticsearch.xpack.sql.expression.function.scalar.ScalarFunctionAttribute;
+import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DatePart;
 import org.elasticsearch.xpack.sql.expression.predicate.BinaryOperator;
 import org.elasticsearch.xpack.sql.expression.predicate.BinaryPredicate;
 import org.elasticsearch.xpack.sql.expression.predicate.Negatable;
@@ -946,7 +947,7 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
                                 }
                             });
                         }
-                        
+
                         if (isMatching.get() == true) {
                             // move grouping in front
                             groupings.remove(group);
@@ -1215,6 +1216,12 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
                 In in = (In) e;
                 if (Expressions.isNull(in.value())) {
                     return Literal.of(in, null);
+                }
+
+            } else if (e instanceof DatePart) {
+                DatePart dp = (DatePart) e;
+                if (Expressions.isNull(dp.first()) || Expressions.isNull(dp.second())) {
+                    return Literal.of(dp, null);
                 }
 
             } else if (e instanceof Alias == false

--- a/x-pack/plugin/sql/src/main/resources/org/elasticsearch/xpack/sql/plugin/sql_whitelist.txt
+++ b/x-pack/plugin/sql/src/main/resources/org/elasticsearch/xpack/sql/plugin/sql_whitelist.txt
@@ -116,7 +116,7 @@ class org.elasticsearch.xpack.sql.expression.function.scalar.whitelist.InternalS
   Integer quarter(Object, String)
   Integer weekOfYear(Object, String)
   ZonedDateTime dateTrunc(String, Object, String)
-  Integer datePart(String, Object, String)
+  Integer datePart(String, Object, String, String)
   IntervalDayTime intervalDayTime(String, String)
   IntervalYearMonth intervalYearMonth(String, String)
   ZonedDateTime asDateTime(Object)

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DatePartPipeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DatePartPipeTests.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.sql.expression.Expression;
+import org.elasticsearch.xpack.sql.expression.function.scalar.FunctionTestUtils;
+import org.elasticsearch.xpack.sql.expression.gen.pipeline.Pipe;
+import org.elasticsearch.xpack.sql.tree.AbstractNodeTestCase;
+import org.elasticsearch.xpack.sql.tree.Source;
+import org.elasticsearch.xpack.sql.tree.SourceTests;
+
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+import static org.elasticsearch.xpack.sql.expression.Expressions.pipe;
+import static org.elasticsearch.xpack.sql.expression.function.scalar.FunctionTestUtils.randomDatetimeLiteral;
+import static org.elasticsearch.xpack.sql.expression.function.scalar.FunctionTestUtils.randomStringLiteral;
+import static org.elasticsearch.xpack.sql.tree.SourceTests.randomSource;
+
+public class DatePartPipeTests extends AbstractNodeTestCase<DatePartPipe, Pipe> {
+
+    @Override
+    protected DatePartPipe randomInstance() {
+        return randomDatePartPipe();
+    }
+
+    private Expression randomDatePartPipeExpression() {
+        return randomDatePartPipe().expression();
+    }
+
+    public static DatePartPipe randomDatePartPipe() {
+        return (DatePartPipe) new DatePart(
+                randomSource(),
+                randomStringLiteral(),
+                randomDatetimeLiteral(),
+                randomStringLiteral(),
+                randomZone()).makePipe();
+    }
+
+    @Override
+    public void testTransform() {
+        // test transforming only the properties (source, expression),
+        // skipping the children (the two parameters of the binary function) which are tested separately
+        DatePartPipe b1 = randomInstance();
+
+        Expression newExpression = randomValueOtherThan(b1.expression(), this::randomDatePartPipeExpression);
+        DatePartPipe newB = new DatePartPipe(
+                b1.source(),
+                newExpression,
+                b1.first(),
+                b1.second(),
+                b1.third(),
+                b1.zoneId());
+        assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
+
+        DatePartPipe b2 = randomInstance();
+        Source newLoc = randomValueOtherThan(b2.source(), SourceTests::randomSource);
+        newB = new DatePartPipe(
+                newLoc,
+                b2.expression(),
+                b2.first(),
+                b2.second(),
+                b2.third(),
+                b2.zoneId());
+        assertEquals(newB,
+                b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
+    }
+
+    @Override
+    public void testReplaceChildren() {
+        DatePartPipe b = randomInstance();
+        Pipe newFirst = pipe(((Expression) randomValueOtherThan(b.first(), FunctionTestUtils::randomStringLiteral)));
+        Pipe newSecond = pipe(((Expression) randomValueOtherThan(b.second(), FunctionTestUtils::randomDatetimeLiteral)));
+        Pipe newThird = pipe(((Expression) randomValueOtherThan(b.first(), FunctionTestUtils::randomStringLiteral)));
+        ZoneId newZoneId = randomValueOtherThan(b.zoneId(), ESTestCase::randomZone);
+        DatePartPipe newB = new DatePartPipe( b.source(), b.expression(), b.first(), b.second(), b.third(), newZoneId);
+        ThreeArgsDateTimePipe transformed = newB.replaceChildren(newFirst, b.second(), b.third());
+
+        assertEquals(transformed.source(), b.source());
+        assertEquals(transformed.expression(), b.expression());
+        assertEquals(transformed.first(), newFirst);
+        assertEquals(transformed.second(), b.second());
+        assertEquals(transformed.third(), b.third());
+
+        transformed = newB.replaceChildren(b.first(), newSecond, b.third());
+        assertEquals(transformed.source(), b.source());
+        assertEquals(transformed.expression(), b.expression());
+        assertEquals(transformed.first(), b.first());
+        assertEquals(transformed.second(), newSecond);
+        assertEquals(transformed.third(), b.third());
+
+        transformed = newB.replaceChildren(b.first(), b.second(), newThird);
+        assertEquals(transformed.source(), b.source());
+        assertEquals(transformed.expression(), b.expression());
+        assertEquals(transformed.first(), b.first());
+        assertEquals(transformed.second(), b.second());
+        assertEquals(transformed.third(), newThird);
+
+        transformed = newB.replaceChildren(newFirst, newSecond, newThird);
+        assertEquals(transformed.source(), b.source());
+        assertEquals(transformed.expression(), b.expression());
+        assertEquals(transformed.first(), newFirst);
+        assertEquals(transformed.second(), newSecond);
+        assertEquals(transformed.third(), newThird);
+    }
+
+    @Override
+    protected DatePartPipe mutate(DatePartPipe instance) {
+        List<Function<DatePartPipe, DatePartPipe>> randoms = new ArrayList<>();
+        randoms.add(f -> new DatePartPipe(f.source(),
+                f.expression(),
+                pipe(((Expression) randomValueOtherThan(f.first(), FunctionTestUtils::randomStringLiteral))),
+                f.second(),
+                f.third(),
+                randomValueOtherThan(f.zoneId(), ESTestCase::randomZone)));
+        randoms.add(f -> new DatePartPipe(f.source(),
+                f.expression(),
+                f.first(),
+                pipe(((Expression) randomValueOtherThan(f.second(), FunctionTestUtils::randomDatetimeLiteral))),
+                f.third(),
+                randomValueOtherThan(f.zoneId(), ESTestCase::randomZone)));
+        randoms.add(f -> new DatePartPipe(f.source(),
+                f.expression(),
+                f.first(),
+                f.second(),
+                pipe(((Expression) randomValueOtherThan(f.third(), FunctionTestUtils::randomStringLiteral))),
+                randomValueOtherThan(f.zoneId(), ESTestCase::randomZone)));
+        randoms.add(f -> new DatePartPipe(f.source(),
+                f.expression(),
+                pipe(((Expression) randomValueOtherThan(f.first(), FunctionTestUtils::randomStringLiteral))),
+                pipe(((Expression) randomValueOtherThan(f.second(), FunctionTestUtils::randomDatetimeLiteral))),
+                pipe(((Expression) randomValueOtherThan(f.third(), FunctionTestUtils::randomStringLiteral))),
+                randomValueOtherThan(f.zoneId(), ESTestCase::randomZone)));
+
+        return randomFrom(randoms).apply(instance);
+    }
+
+    @Override
+    protected DatePartPipe copy(DatePartPipe instance) {
+        return new DatePartPipe(instance.source(),
+                instance.expression(),
+                instance.first(),
+                instance.second(),
+                instance.third(),
+                instance.zoneId());
+    }
+}

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeTestUtils.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeTestUtils.java
@@ -8,6 +8,8 @@ package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
 import org.elasticsearch.xpack.sql.util.DateUtils;
 
+import java.time.Clock;
+import java.time.Duration;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -38,5 +40,10 @@ public class DateTimeTestUtils {
 
     public static OffsetTime time(int hour, int minute, int second, int nano) {
         return OffsetTime.of(hour, minute, second, nano, ZoneOffset.UTC);
+    }
+
+    public static ZonedDateTime nowWithMillisResolution() {
+        Clock millisResolutionClock = Clock.tick(Clock.systemUTC(), Duration.ofMillis(1));
+        return ZonedDateTime.now(millisResolutionClock);
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTruncPipeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTruncPipeTests.java
@@ -22,13 +22,14 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import static org.elasticsearch.xpack.sql.expression.Expressions.pipe;
+import static org.elasticsearch.xpack.sql.expression.function.scalar.FunctionTestUtils.randomDatetimeLiteral;
 import static org.elasticsearch.xpack.sql.expression.function.scalar.FunctionTestUtils.randomStringLiteral;
 import static org.elasticsearch.xpack.sql.tree.SourceTests.randomSource;
 
-public class BinaryDateTimePipeTests extends AbstractNodeTestCase<BinaryDateTimePipe, Pipe> {
+public class DateTruncPipeTests extends AbstractNodeTestCase<DateTruncPipe, Pipe> {
 
     @Override
-    protected BinaryDateTimePipe randomInstance() {
+    protected DateTruncPipe randomInstance() {
         return randomDateTruncPipe();
     }
 
@@ -36,11 +37,11 @@ public class BinaryDateTimePipeTests extends AbstractNodeTestCase<BinaryDateTime
         return randomDateTruncPipe().expression();
     }
 
-    public static BinaryDateTimePipe randomDateTruncPipe() {
-        return (BinaryDateTimePipe) new DateTrunc(
+    public static DateTruncPipe randomDateTruncPipe() {
+        return (DateTruncPipe) new DateTrunc(
                 randomSource(),
                 randomStringLiteral(),
-                randomStringLiteral(),
+                randomDatetimeLiteral(),
                 randomZone())
                 .makePipe();
     }
@@ -49,39 +50,36 @@ public class BinaryDateTimePipeTests extends AbstractNodeTestCase<BinaryDateTime
     public void testTransform() {
         // test transforming only the properties (source, expression),
         // skipping the children (the two parameters of the binary function) which are tested separately
-        BinaryDateTimePipe b1 = randomInstance();
+        DateTruncPipe b1 = randomInstance();
 
         Expression newExpression = randomValueOtherThan(b1.expression(), this::randomDateTruncPipeExpression);
-        BinaryDateTimePipe newB = new BinaryDateTimePipe(
+        DateTruncPipe newB = new DateTruncPipe(
                 b1.source(),
                 newExpression,
                 b1.left(),
                 b1.right(),
-                b1.zoneId(),
-                b1.operation());
+                b1.zoneId());
         assertEquals(newB, b1.transformPropertiesOnly(v -> Objects.equals(v, b1.expression()) ? newExpression : v, Expression.class));
 
-        BinaryDateTimePipe b2 = randomInstance();
+        DateTruncPipe b2 = randomInstance();
         Source newLoc = randomValueOtherThan(b2.source(), SourceTests::randomSource);
-        newB = new BinaryDateTimePipe(
+        newB = new DateTruncPipe(
                 newLoc,
                 b2.expression(),
                 b2.left(),
                 b2.right(),
-                b2.zoneId(),
-                b2.operation());
+                b2.zoneId());
         assertEquals(newB,
                 b2.transformPropertiesOnly(v -> Objects.equals(v, b2.source()) ? newLoc : v, Source.class));
     }
 
     @Override
     public void testReplaceChildren() {
-        BinaryDateTimePipe b = randomInstance();
+        DateTruncPipe b = randomInstance();
         Pipe newLeft = pipe(((Expression) randomValueOtherThan(b.left(), FunctionTestUtils::randomStringLiteral)));
         Pipe newRight = pipe(((Expression) randomValueOtherThan(b.right(), FunctionTestUtils::randomDatetimeLiteral)));
         ZoneId newZoneId = randomValueOtherThan(b.zoneId(), ESTestCase::randomZone);
-        BinaryDateTimePipe newB = new BinaryDateTimePipe(
-            b.source(), b.expression(), b.left(), b.right(), newZoneId, randomFrom(BinaryDateTimeProcessor.BinaryDateOperation.values()));
+        DateTruncPipe newB = new DateTruncPipe( b.source(), b.expression(), b.left(), b.right(), newZoneId);
         BinaryPipe transformed = newB.replaceChildren(newLeft, b.right());
 
         assertEquals(transformed.left(), newLeft);
@@ -103,37 +101,33 @@ public class BinaryDateTimePipeTests extends AbstractNodeTestCase<BinaryDateTime
     }
 
     @Override
-    protected BinaryDateTimePipe mutate(BinaryDateTimePipe instance) {
-        List<Function<BinaryDateTimePipe, BinaryDateTimePipe>> randoms = new ArrayList<>();
-        randoms.add(f -> new BinaryDateTimePipe(f.source(),
+    protected DateTruncPipe mutate(DateTruncPipe instance) {
+        List<Function<DateTruncPipe, DateTruncPipe>> randoms = new ArrayList<>();
+        randoms.add(f -> new DateTruncPipe(f.source(),
                 f.expression(),
                 pipe(((Expression) randomValueOtherThan(f.left(), FunctionTestUtils::randomStringLiteral))),
                 f.right(),
-                randomValueOtherThan(f.zoneId(), ESTestCase::randomZone),
-                randomFrom(BinaryDateTimeProcessor.BinaryDateOperation.values())));
-        randoms.add(f -> new BinaryDateTimePipe(f.source(),
+                randomValueOtherThan(f.zoneId(), ESTestCase::randomZone)));
+        randoms.add(f -> new DateTruncPipe(f.source(),
                 f.expression(),
                 f.left(),
                 pipe(((Expression) randomValueOtherThan(f.right(), FunctionTestUtils::randomDatetimeLiteral))),
-                randomValueOtherThan(f.zoneId(), ESTestCase::randomZone),
-                randomFrom(BinaryDateTimeProcessor.BinaryDateOperation.values())));
-        randoms.add(f -> new BinaryDateTimePipe(f.source(),
+                randomValueOtherThan(f.zoneId(), ESTestCase::randomZone)));
+        randoms.add(f -> new DateTruncPipe(f.source(),
                 f.expression(),
                 pipe(((Expression) randomValueOtherThan(f.left(), FunctionTestUtils::randomStringLiteral))),
                 pipe(((Expression) randomValueOtherThan(f.right(), FunctionTestUtils::randomDatetimeLiteral))),
-                randomValueOtherThan(f.zoneId(), ESTestCase::randomZone),
-                randomFrom(BinaryDateTimeProcessor.BinaryDateOperation.values())));
+                randomValueOtherThan(f.zoneId(), ESTestCase::randomZone)));
 
         return randomFrom(randoms).apply(instance);
     }
 
     @Override
-    protected BinaryDateTimePipe copy(BinaryDateTimePipe instance) {
-        return new BinaryDateTimePipe(instance.source(),
+    protected DateTruncPipe copy(DateTruncPipe instance) {
+        return new DateTruncPipe(instance.source(),
                 instance.expression(),
                 instance.left(),
                 instance.right(),
-                instance.zoneId(),
-                instance.operation());
+                instance.zoneId());
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTruncProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTruncProcessorTests.java
@@ -29,7 +29,7 @@ public class DateTruncProcessorTests extends AbstractSqlWireSerializingTestCase<
     public static DateTruncProcessor randomDateTruncProcessor() {
         return new DateTruncProcessor(
             new ConstantProcessor(randomRealisticUnicodeOfLengthBetween(0, 128)),
-            new ConstantProcessor(ZonedDateTime.now()),
+            new ConstantProcessor(DateTimeTestUtils.nowWithMillisResolution()),
             randomZone());
     }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.xpack.sql.expression.function.aggregate.Sum;
 import org.elasticsearch.xpack.sql.expression.function.aggregate.SumOfSquares;
 import org.elasticsearch.xpack.sql.expression.function.aggregate.VarPop;
 import org.elasticsearch.xpack.sql.expression.function.scalar.Cast;
+import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DatePart;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DayName;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DayOfMonth;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DayOfYear;
@@ -571,6 +572,14 @@ public class OptimizerTests extends ESTestCase {
         assertEquals(orig, f);
     }
 
+    public void testFoldNullDatePart() {
+        FoldNull foldNull = new FoldNull();
+        assertNullLiteral(foldNull.rule(new DatePart(EMPTY, ONE, NULL, THREE, UTC)));
+        assertNullLiteral(foldNull.rule(new DatePart(EMPTY, NULL, TWO, THREE, UTC)));
+        assertNullLiteral(foldNull.rule(new DatePart(EMPTY, NULL, NULL, THREE, UTC)));
+        assertEquals(DatePart.class, foldNull.rule(new DatePart(EMPTY, ONE, TWO, NULL, UTC)).getClass());
+    }
+
     public void testSimplifyGreatestNulls() {
         Expression e = new SimplifyConditional().rule(new Greatest(EMPTY, asList(NULL, NULL)));
         assertEquals(Greatest.class, e.getClass());
@@ -614,7 +623,7 @@ public class OptimizerTests extends ESTestCase {
         assertEquals(TWO, e.children().get(1));
         assertEquals(DataType.INTEGER, e.dataType());
     }
-    
+
     public void testConcatFoldingIsNotNull() {
         FoldNull foldNull = new FoldNull();
         assertEquals(1, foldNull.rule(new Concat(EMPTY, NULL, ONE)).fold());
@@ -1453,7 +1462,7 @@ public class OptimizerTests extends ESTestCase {
         assertSame(last, aggregates.get(0));
         assertEquals(max2, aggregates.get(1));
     }
-    
+
     public void testSortAggregateOnOrderByWithTwoFields() {
         FieldAttribute firstField = new FieldAttribute(EMPTY, "first_field", new EsField("first_field", DataType.BYTE, emptyMap(), true));
         FieldAttribute secondField = new FieldAttribute(EMPTY, "second_field",
@@ -1462,12 +1471,12 @@ public class OptimizerTests extends ESTestCase {
         Alias secondAlias = new Alias(EMPTY, "second_alias", secondField);
         Order firstOrderBy = new Order(EMPTY, firstField, OrderDirection.ASC, Order.NullsPosition.LAST);
         Order secondOrderBy = new Order(EMPTY, secondField, OrderDirection.ASC, Order.NullsPosition.LAST);
-        
+
         OrderBy orderByPlan = new OrderBy(EMPTY,
                 new Aggregate(EMPTY, FROM(), Arrays.asList(secondField, firstField), Arrays.asList(secondAlias, firstAlias)),
                 Arrays.asList(firstOrderBy, secondOrderBy));
         LogicalPlan result = new SortAggregateOnOrderBy().apply(orderByPlan);
-        
+
         assertTrue(result instanceof OrderBy);
         List<Order> order = ((OrderBy) result).order();
         assertEquals(2, order.size());
@@ -1475,7 +1484,7 @@ public class OptimizerTests extends ESTestCase {
         assertTrue(order.get(1).child() instanceof FieldAttribute);
         assertEquals("first_field", ((FieldAttribute) order.get(0).child()).name());
         assertEquals("second_field", ((FieldAttribute) order.get(1).child()).name());
-        
+
         assertTrue(((OrderBy) result).child() instanceof Aggregate);
         Aggregate agg = (Aggregate) ((OrderBy) result).child();
         List<?> groupings = agg.groupings();
@@ -1485,7 +1494,7 @@ public class OptimizerTests extends ESTestCase {
         assertEquals(firstField, groupings.get(0));
         assertEquals(secondField, groupings.get(1));
     }
-    
+
     public void testSortAggregateOnOrderByOnlyAliases() {
         FieldAttribute firstField = new FieldAttribute(EMPTY, "first_field", new EsField("first_field", DataType.BYTE, emptyMap(), true));
         FieldAttribute secondField = new FieldAttribute(EMPTY, "second_field",
@@ -1494,12 +1503,12 @@ public class OptimizerTests extends ESTestCase {
         Alias secondAlias = new Alias(EMPTY, "second_alias", secondField);
         Order firstOrderBy = new Order(EMPTY, firstAlias, OrderDirection.ASC, Order.NullsPosition.LAST);
         Order secondOrderBy = new Order(EMPTY, secondAlias, OrderDirection.ASC, Order.NullsPosition.LAST);
-        
+
         OrderBy orderByPlan = new OrderBy(EMPTY,
                 new Aggregate(EMPTY, FROM(), Arrays.asList(secondAlias, firstAlias), Arrays.asList(secondAlias, firstAlias)),
                 Arrays.asList(firstOrderBy, secondOrderBy));
         LogicalPlan result = new SortAggregateOnOrderBy().apply(orderByPlan);
-        
+
         assertTrue(result instanceof OrderBy);
         List<Order> order = ((OrderBy) result).order();
         assertEquals(2, order.size());
@@ -1507,7 +1516,7 @@ public class OptimizerTests extends ESTestCase {
         assertTrue(order.get(1).child() instanceof Alias);
         assertEquals("first_alias", ((Alias) order.get(0).child()).name());
         assertEquals("second_alias", ((Alias) order.get(1).child()).name());
-        
+
         assertTrue(((OrderBy) result).child() instanceof Aggregate);
         Aggregate agg = (Aggregate) ((OrderBy) result).child();
         List<?> groupings = agg.groupings();
@@ -1536,7 +1545,7 @@ public class OptimizerTests extends ESTestCase {
         assertEquals(column, in.value());
         assertEquals(Arrays.asList(L(1), L(2)), in.list());
     }
-    
+
     /**
      * Test queries like SELECT MIN(agg_field), MAX(agg_field) FROM table WHERE MATCH(match_field,'A') AND/OR QUERY('match_field:A')
      * or SELECT STDDEV_POP(agg_field), VAR_POP(agg_field) FROM table WHERE MATCH(match_field,'A') AND/OR QUERY('match_field:A')
@@ -1544,7 +1553,7 @@ public class OptimizerTests extends ESTestCase {
     public void testAggregatesPromoteToStats_WithFullTextPredicatesConditions() {
         FieldAttribute matchField = new FieldAttribute(EMPTY, "match_field", new EsField("match_field", DataType.TEXT, emptyMap(), true));
         FieldAttribute aggField = new FieldAttribute(EMPTY, "agg_field", new EsField("agg_field", DataType.INTEGER, emptyMap(), true));
-        
+
         FullTextPredicate matchPredicate = new MatchQueryPredicate(EMPTY, matchField, "A", StringUtils.EMPTY);
         FullTextPredicate multiMatchPredicate = new MultiMatchQueryPredicate(EMPTY, "match_field", "A", StringUtils.EMPTY);
         FullTextPredicate stringQueryPredicate = new StringQueryPredicate(EMPTY, "match_field:A", StringUtils.EMPTY);
@@ -1552,12 +1561,12 @@ public class OptimizerTests extends ESTestCase {
 
         FullTextPredicate left = randomFrom(predicates);
         FullTextPredicate right = randomFrom(predicates);
-        
+
         BinaryLogic or = new Or(EMPTY, left, right);
         BinaryLogic and = new And(EMPTY, left, right);
         BinaryLogic condition = randomFrom(or, and);
         Filter filter = new Filter(EMPTY, FROM(), condition);
-        
+
         List<AggregateFunction> aggregates;
         boolean isSimpleStats = randomBoolean();
         if (isSimpleStats) {
@@ -1576,13 +1585,13 @@ public class OptimizerTests extends ESTestCase {
         } else {
             result = new ReplaceAggsWithExtendedStats().apply(aggregatePlan);
         }
-        
+
         assertTrue(result instanceof Aggregate);
         Aggregate resultAgg = (Aggregate) result;
         assertEquals(2, resultAgg.aggregates().size());
         assertTrue(resultAgg.aggregates().get(0) instanceof InnerAggregate);
         assertTrue(resultAgg.aggregates().get(1) instanceof InnerAggregate);
-        
+
         InnerAggregate resultFirstAgg = (InnerAggregate) resultAgg.aggregates().get(0);
         InnerAggregate resultSecondAgg = (InnerAggregate) resultAgg.aggregates().get(1);
         assertEquals(resultFirstAgg.inner(), firstAggregate);
@@ -1598,7 +1607,7 @@ public class OptimizerTests extends ESTestCase {
             assertEquals(((ExtendedStats) resultFirstAgg.outer()).field(), aggField);
             assertEquals(((ExtendedStats) resultSecondAgg.outer()).field(), aggField);
         }
-        
+
         assertTrue(resultAgg.child() instanceof Filter);
         assertEquals(resultAgg.child(), filter);
     }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
@@ -102,7 +102,7 @@ public class QueryTranslatorTests extends ESTestCase {
     private LogicalPlan plan(String sql) {
         return analyzer.analyze(parser.createStatement(sql), true);
     }
-    
+
     private PhysicalPlan optimizeAndPlan(String sql) {
         return  planner.plan(optimizer.optimize(plan(sql)), true);
     }
@@ -134,7 +134,7 @@ public class QueryTranslatorTests extends ESTestCase {
         assertEquals("int", tq.term());
         assertEquals(5, tq.value());
     }
-    
+
     public void testTermEqualityForDate() {
         LogicalPlan p = plan("SELECT some.string FROM test WHERE date = 5");
         assertTrue(p instanceof Project);
@@ -148,7 +148,7 @@ public class QueryTranslatorTests extends ESTestCase {
         assertEquals("date", tq.term());
         assertEquals(5, tq.value());
     }
-    
+
     public void testTermEqualityForDateWithLiteralDate() {
         LogicalPlan p = plan("SELECT some.string FROM test WHERE date = CAST('2019-08-08T12:34:56' AS DATETIME)");
         assertTrue(p instanceof Project);
@@ -166,7 +166,7 @@ public class QueryTranslatorTests extends ESTestCase {
         assertTrue(rq.includeUpper());
         assertEquals(DATE_FORMAT, rq.format());
     }
-    
+
     public void testTermEqualityForDateWithLiteralTime() {
         LogicalPlan p = plan("SELECT some.string FROM test WHERE date = CAST('12:34:56' AS TIME)");
         assertTrue(p instanceof Project);
@@ -236,27 +236,27 @@ public class QueryTranslatorTests extends ESTestCase {
         assertEquals("date", rq.field());
         assertEquals("1969-05-13T12:34:56.000Z", rq.lower());
     }
-    
+
     public void testDateRangeWithCurrentTimestamp() {
         testDateRangeWithCurrentFunctions("CURRENT_TIMESTAMP()", DATE_FORMAT, TestUtils.TEST_CFG.now());
     }
-    
+
     public void testDateRangeWithCurrentDate() {
         testDateRangeWithCurrentFunctions("CURRENT_DATE()", DATE_FORMAT, DateUtils.asDateOnly(TestUtils.TEST_CFG.now()));
     }
-    
+
     public void testDateRangeWithToday() {
         testDateRangeWithCurrentFunctions("TODAY()", DATE_FORMAT, DateUtils.asDateOnly(TestUtils.TEST_CFG.now()));
     }
-    
+
     public void testDateRangeWithNow() {
         testDateRangeWithCurrentFunctions("NOW()", DATE_FORMAT, TestUtils.TEST_CFG.now());
     }
-    
+
     public void testDateRangeWithCurrentTime() {
         testDateRangeWithCurrentFunctions("CURRENT_TIME()", TIME_FORMAT, TestUtils.TEST_CFG.now());
     }
-    
+
     private void testDateRangeWithCurrentFunctions(String function, String pattern, ZonedDateTime now) {
         String operator = randomFrom(new String[] {">", ">=", "<", "<=", "=", "!="});
         LogicalPlan p = plan("SELECT some.string FROM test WHERE date" + operator + function);
@@ -267,7 +267,7 @@ public class QueryTranslatorTests extends ESTestCase {
         QueryTranslation translation = QueryTranslator.toQuery(condition, false);
         Query query = translation.query;
         RangeQuery rq;
-        
+
         if (operator.equals("!=")) {
             assertTrue(query instanceof NotQuery);
             NotQuery nq = (NotQuery) query;
@@ -278,7 +278,7 @@ public class QueryTranslatorTests extends ESTestCase {
             rq = (RangeQuery) query;
         }
         assertEquals("date", rq.field());
-        
+
         if (operator.contains("<") || operator.equals("=") || operator.equals("!=")) {
             assertEquals(DateFormatter.forPattern(pattern).format(now.withNano(DateUtils.getNanoPrecision(null, now.getNano()))),
                     rq.upper());
@@ -320,9 +320,27 @@ public class QueryTranslatorTests extends ESTestCase {
         assertTrue(translation.query instanceof ScriptQuery);
         ScriptQuery sc = (ScriptQuery) translation.query;
         assertEquals("InternalSqlScriptUtils.nullSafeFilter(InternalSqlScriptUtils.gt(InternalSqlScriptUtils.datePart(" +
-                "params.v0,InternalSqlScriptUtils.docValue(doc,params.v1),params.v2),InternalSqlScriptUtils.asDateTime(params.v3)))",
+                "params.v0,InternalSqlScriptUtils.docValue(doc,params.v1),params.v2,params.v3)," +
+                "InternalSqlScriptUtils.asDateTime(params.v4)))",
             sc.script().toString());
-        assertEquals("[{v=month}, {v=date}, {v=Z}, {v=2018-09-04T00:00:00.000Z}]", sc.script().params().toString());
+        assertEquals("[{v=month}, {v=date}, {v=Sunday}, {v=Z}, {v=2018-09-04T00:00:00.000Z}]", sc.script().params().toString());
+    }
+
+    public void testTranslateDatePart_ThreeArgs_WhereClause_Painless() {
+        LogicalPlan p = plan("SELECT int FROM test WHERE DATE_PART('month', date, 'monday') > '2018-09-04'::date");
+        assertTrue(p instanceof Project);
+        assertTrue(p.children().get(0) instanceof Filter);
+        Expression condition = ((Filter) p.children().get(0)).condition();
+        assertFalse(condition.foldable());
+        QueryTranslation translation = QueryTranslator.toQuery(condition, false);
+        assertNull(translation.aggFilter);
+        assertTrue(translation.query instanceof ScriptQuery);
+        ScriptQuery sc = (ScriptQuery) translation.query;
+        assertEquals("InternalSqlScriptUtils.nullSafeFilter(InternalSqlScriptUtils.gt(InternalSqlScriptUtils.datePart(" +
+                "params.v0,InternalSqlScriptUtils.docValue(doc,params.v1),params.v2,params.v3)," +
+                "InternalSqlScriptUtils.asDateTime(params.v4)))",
+            sc.script().toString());
+        assertEquals("[{v=month}, {v=date}, {v=monday}, {v=Z}, {v=2018-09-04T00:00:00.000Z}]", sc.script().params().toString());
     }
 
     public void testLikeOnInexact() {
@@ -336,7 +354,7 @@ public class QueryTranslatorTests extends ESTestCase {
         WildcardQuery qsq = ((WildcardQuery) qt.query);
         assertEquals("some.string.typical", qsq.field());
     }
-    
+
     public void testRLikeOnInexact() {
         LogicalPlan p = plan("SELECT * FROM test WHERE some.string RLIKE '.*a.*'");
         assertTrue(p instanceof Project);
@@ -348,7 +366,7 @@ public class QueryTranslatorTests extends ESTestCase {
         RegexQuery qsq = ((RegexQuery) qt.query);
         assertEquals("some.string.typical", qsq.field());
     }
-    
+
     public void testLikeConstructsNotSupported() {
         LogicalPlan p = plan("SELECT LTRIM(keyword) lt FROM test WHERE LTRIM(keyword) like '%a%'");
         assertTrue(p instanceof Project);
@@ -358,7 +376,7 @@ public class QueryTranslatorTests extends ESTestCase {
         SqlIllegalArgumentException ex = expectThrows(SqlIllegalArgumentException.class, () -> QueryTranslator.toQuery(condition, false));
         assertEquals("Scalar function [LTRIM(keyword)] not allowed (yet) as argument for LIKE", ex.getMessage());
     }
-    
+
     public void testRLikeConstructsNotSupported() {
         LogicalPlan p = plan("SELECT LTRIM(keyword) lt FROM test WHERE LTRIM(keyword) RLIKE '.*a.*'");
         assertTrue(p instanceof Project);
@@ -368,13 +386,13 @@ public class QueryTranslatorTests extends ESTestCase {
         SqlIllegalArgumentException ex = expectThrows(SqlIllegalArgumentException.class, () -> QueryTranslator.toQuery(condition, false));
         assertEquals("Scalar function [LTRIM(keyword)] not allowed (yet) as argument for RLIKE", ex.getMessage());
     }
-    
+
     public void testDifferentLikeAndNotLikePatterns() {
         LogicalPlan p = plan("SELECT keyword k FROM test WHERE k LIKE 'X%' AND k NOT LIKE 'Y%'");
         assertTrue(p instanceof Project);
         p = ((Project) p).child();
         assertTrue(p instanceof Filter);
-        
+
         Expression condition = ((Filter) p).condition();
         QueryTranslation qt = QueryTranslator.toQuery(condition, false);
         assertEquals(BoolQuery.class, qt.query.getClass());
@@ -382,18 +400,18 @@ public class QueryTranslatorTests extends ESTestCase {
         assertTrue(bq.isAnd());
         assertTrue(bq.left() instanceof WildcardQuery);
         assertTrue(bq.right() instanceof NotQuery);
-        
+
         NotQuery nq = (NotQuery) bq.right();
         assertTrue(nq.child() instanceof WildcardQuery);
         WildcardQuery lqsq = (WildcardQuery) bq.left();
         WildcardQuery rqsq = (WildcardQuery) nq.child();
-        
+
         assertEquals("X*", lqsq.query());
         assertEquals("keyword", lqsq.field());
         assertEquals("Y*", rqsq.query());
         assertEquals("keyword", rqsq.field());
     }
-    
+
     public void testRLikePatterns() {
         String[] patterns = new String[] {"(...)+", "abab(ab)?", "(ab){1,2}", "(ab){3}", "aabb|bbaa", "a+b+|b+a+", "aa(cc|bb)",
                 "a{4,6}b{4,6}", ".{3}.{3}", "aaa*bbb*", "a+.+", "a.c.e", "[^abc\\-]"};
@@ -401,13 +419,13 @@ public class QueryTranslatorTests extends ESTestCase {
             assertDifferentRLikeAndNotRLikePatterns(randomFrom(patterns), randomFrom(patterns));
         }
     }
-    
+
     private void assertDifferentRLikeAndNotRLikePatterns(String firstPattern, String secondPattern) {
         LogicalPlan p = plan("SELECT keyword k FROM test WHERE k RLIKE '" + firstPattern + "' AND k NOT RLIKE '" + secondPattern + "'");
         assertTrue(p instanceof Project);
         p = ((Project) p).child();
         assertTrue(p instanceof Filter);
-        
+
         Expression condition = ((Filter) p).condition();
         QueryTranslation qt = QueryTranslator.toQuery(condition, false);
         assertEquals(BoolQuery.class, qt.query.getClass());
@@ -415,12 +433,12 @@ public class QueryTranslatorTests extends ESTestCase {
         assertTrue(bq.isAnd());
         assertTrue(bq.left() instanceof RegexQuery);
         assertTrue(bq.right() instanceof NotQuery);
-        
+
         NotQuery nq = (NotQuery) bq.right();
         assertTrue(nq.child() instanceof RegexQuery);
         RegexQuery lqsq = (RegexQuery) bq.left();
         RegexQuery rqsq = (RegexQuery) nq.child();
-        
+
         assertEquals(firstPattern, lqsq.regex());
         assertEquals("keyword", lqsq.field());
         assertEquals(secondPattern, rqsq.regex());
@@ -646,7 +664,7 @@ public class QueryTranslatorTests extends ESTestCase {
         assertThat(aggFilter.scriptTemplate().params().toString(), startsWith("[{a=max(int){a->"));
         assertThat(aggFilter.scriptTemplate().params().toString(), endsWith(", {v=10}]"));
     }
-    
+
     public void testTranslateRoundWithOneParameter() {
         LogicalPlan p = plan("SELECT ROUND(YEAR(date)) FROM test GROUP BY ROUND(YEAR(date))");
 
@@ -667,16 +685,16 @@ public class QueryTranslatorTests extends ESTestCase {
             scriptTemplate.toString());
         assertEquals("[{v=date}, {v=Z}, {v=YEAR}, {v=null}]", scriptTemplate.params().toString());
     }
-    
+
     public void testTranslateRoundWithTwoParameters() {
         LogicalPlan p = plan("SELECT ROUND(YEAR(date), -2) FROM test GROUP BY ROUND(YEAR(date), -2)");
-        
+
         assertTrue(p instanceof Aggregate);
         assertEquals(1, ((Aggregate) p).groupings().size());
         assertEquals(1, ((Aggregate) p).aggregates().size());
         assertTrue(((Aggregate) p).groupings().get(0) instanceof Round);
         assertTrue(((Aggregate) p).aggregates().get(0) instanceof Round);
-        
+
         Round groupingRound = (Round) ((Aggregate) p).groupings().get(0);
         assertEquals(2, groupingRound.children().size());
         assertTrue(groupingRound.children().get(1) instanceof Literal);
@@ -905,7 +923,7 @@ public class QueryTranslatorTests extends ESTestCase {
             containsString("\"date_histogram\":{\"field\":\"date\",\"missing_bucket\":true,\"value_type\":\"date\",\"order\":\"asc\","
                     + "\"fixed_interval\":\"62208000000ms\",\"time_zone\":\"Z\"}}}]}"));
     }
-    
+
     public void testGroupByYearQueryTranslator() {
         PhysicalPlan p = optimizeAndPlan("SELECT YEAR(date) FROM test GROUP BY YEAR(date)");
         assertEquals(EsQueryExec.class, p.getClass());
@@ -971,7 +989,7 @@ public class QueryTranslatorTests extends ESTestCase {
         assertEquals(2, ee.output().size());
         assertThat(ee.output().get(0).toString(), startsWith("dkey{a->"));
         assertThat(ee.output().get(1).toString(), startsWith("key{a->"));
-        
+
         Collection<AggregationBuilder> subAggs = ee.queryContainer().aggs().asAggBuilder().getSubAggregations();
         assertEquals(2, subAggs.size());
         assertTrue(subAggs.toArray()[0] instanceof CardinalityAggregationBuilder);
@@ -979,15 +997,15 @@ public class QueryTranslatorTests extends ESTestCase {
 
         CardinalityAggregationBuilder cardinalityKeyword = (CardinalityAggregationBuilder) subAggs.toArray()[0];
         assertEquals("keyword", cardinalityKeyword.field());
-        
+
         FilterAggregationBuilder existsKeyword = (FilterAggregationBuilder) subAggs.toArray()[1];
         assertTrue(existsKeyword.getFilter() instanceof ExistsQueryBuilder);
         assertEquals("keyword", ((ExistsQueryBuilder) existsKeyword.getFilter()).fieldName());
-        
+
         assertThat(ee.queryContainer().aggs().asAggBuilder().toString().replaceAll("\\s+", ""),
                 endsWith("{\"filter\":{\"exists\":{\"field\":\"keyword\",\"boost\":1.0}}}}}}"));
     }
-    
+
     public void testAllCountVariantsWithHavingGenerateCorrectAggregations() {
         PhysicalPlan p = optimizeAndPlan("SELECT AVG(int), COUNT(keyword) ln, COUNT(distinct keyword) dln, COUNT(some.dotted.field) fn,"
                 + "COUNT(distinct some.dotted.field) dfn, COUNT(*) ccc FROM test GROUP BY bool "
@@ -1001,7 +1019,7 @@ public class QueryTranslatorTests extends ESTestCase {
         assertThat(ee.output().get(3).toString(), startsWith("fn{a->"));
         assertThat(ee.output().get(4).toString(), startsWith("dfn{a->"));
         assertThat(ee.output().get(5).toString(), startsWith("ccc{a->"));
-        
+
         Collection<AggregationBuilder> subAggs = ee.queryContainer().aggs().asAggBuilder().getSubAggregations();
         assertEquals(5, subAggs.size());
         assertTrue(subAggs.toArray()[0] instanceof AvgAggregationBuilder);
@@ -1009,21 +1027,21 @@ public class QueryTranslatorTests extends ESTestCase {
         assertTrue(subAggs.toArray()[2] instanceof CardinalityAggregationBuilder);
         assertTrue(subAggs.toArray()[3] instanceof FilterAggregationBuilder);
         assertTrue(subAggs.toArray()[4] instanceof CardinalityAggregationBuilder);
-        
+
         AvgAggregationBuilder avgInt = (AvgAggregationBuilder) subAggs.toArray()[0];
         assertEquals("int", avgInt.field());
-        
+
         FilterAggregationBuilder existsKeyword = (FilterAggregationBuilder) subAggs.toArray()[1];
         assertTrue(existsKeyword.getFilter() instanceof ExistsQueryBuilder);
         assertEquals("keyword", ((ExistsQueryBuilder) existsKeyword.getFilter()).fieldName());
-        
+
         CardinalityAggregationBuilder cardinalityKeyword = (CardinalityAggregationBuilder) subAggs.toArray()[2];
         assertEquals("keyword", cardinalityKeyword.field());
-        
+
         FilterAggregationBuilder existsDottedField = (FilterAggregationBuilder) subAggs.toArray()[3];
         assertTrue(existsDottedField.getFilter() instanceof ExistsQueryBuilder);
         assertEquals("some.dotted.field", ((ExistsQueryBuilder) existsDottedField.getFilter()).fieldName());
-        
+
         CardinalityAggregationBuilder cardinalityDottedField = (CardinalityAggregationBuilder) subAggs.toArray()[4];
         assertEquals("some.dotted.field", cardinalityDottedField.field());
 
@@ -1193,7 +1211,7 @@ public class QueryTranslatorTests extends ESTestCase {
                 + "\"lang\":\"painless\","
                 + "\"params\":{\"v0\":\"date\",\"v1\":\"P1Y\",\"v2\":\"INTERVAL_YEAR\",\"v3\":\"2019-03-11T12:34:56.000Z\"}},"));
     }
-    
+
     public void testChronoFieldBasedDateTimeFunctionsWithMathIntervalAndGroupBy() {
         DateTimeExtractor randomFunction = randomValueOtherThan(DateTimeExtractor.YEAR, () -> randomFrom(DateTimeExtractor.values()));
         PhysicalPlan p = optimizeAndPlan(
@@ -1210,7 +1228,7 @@ public class QueryTranslatorTests extends ESTestCase {
                 + "\"v3\":\"Z\",\"v4\":\"" + randomFunction.chronoField().name() + "\"}},\"missing_bucket\":true,"
                 + "\"value_type\":\"long\",\"order\":\"asc\"}}}]}}}}"));
     }
-    
+
     public void testDateTimeFunctionsWithMathIntervalAndGroupBy() {
         String[] functions = new String[] {"DAY_NAME", "MONTH_NAME", "DAY_OF_WEEK", "WEEK_OF_YEAR", "QUARTER"};
         String[] scriptMethods = new String[] {"dayName", "monthName", "dayOfWeek", "weekOfYear", "quarter"};


### PR DESCRIPTION
Add a 3rd argument to the DATE_PART function which is optional
and can take one of the `['Monday', 'Sunday']` values. If missing then
`Sunday` is used by default. This value is used for the `week` and
`weekday` extraction to allow for ISO-style calculation of the two
fields if the value `Monday` is used.

Follows: #47206
