### PR TITLE
Watcher remove assertion that is susceptible to a race condition

### DIFF
--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/action/activate/ActivateWatchTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/action/activate/ActivateWatchTests.java
@@ -84,15 +84,8 @@ public class ActivateWatchTests extends AbstractWatcherIntegrationTestCase {
             assertThat(sum, is(0));
         });
 
-        logger.info("Ensured no more watches are being executed");
         refresh();
         long count1 = docCount(".watcher-history*", matchAllQuery());
-
-        refresh();
-        // Ensure no new watch history. The assertion ought to always return false, but if it returns true
-        // then we know that more history has been written.
-        boolean hasNewHistory = waitUntil(() -> count1 != docCount(".watcher-history*", matchAllQuery()), 5, TimeUnit.SECONDS);
-        assertFalse("Watcher should have stopped executing but new history found", hasNewHistory);
 
         // lets activate it again
         logger.info("Activating watch again");


### PR DESCRIPTION
When deactivating a watch, there is a chance that it is fully deactivated
and reporting as not running but the history is not fully written yet.
There is not a tight coupling between the associated watcher history
index and the deactivation. This test assumes that once a watch is
deactivated that all history is fully written in a very short time period.
If the Watch is deactivated, but the history is slow to write it can result
in a failing test.

This change removes an assertion that assumes that the deactivation of a watch
ensured the all of the watch history was written. There is still a minor race
condition with respect to the remaining history assertions. However, if the
history is slow to be written, it will allow the test to still passing.

fixes #47503
