### PR TITLE
[7.3] [DOCS] Reformat type exists API docs (#47601)

### DIFF
--- a/docs/reference/indices/indices-exists.asciidoc
+++ b/docs/reference/indices/indices-exists.asciidoc
@@ -5,8 +5,6 @@
 ++++
 
 Checks if an index exists.
-The returned HTTP status code indicates if the index exists or not.
-A `404` means it does not exist, and `200` means it does.
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/indices/types-exists.asciidoc
+++ b/docs/reference/indices/types-exists.asciidoc
@@ -1,17 +1,41 @@
 [[indices-types-exists]]
-=== Types Exists
+=== Type exists API
+++++
+<titleabbrev>Type exists</titleabbrev>
+++++
 
-deprecated[7.0.0, Types are deprecated and are in the process of being removed.  See <<removal-of-types>>.]
+deprecated::[7.0.0, Types are deprecated and are in the process of being removed.  See <<removal-of-types>>.]
 
-Used to check if a type/types exists in an index/indices.
+Checks if a <<mapping-type-field,mapping type>> exists.
 
 [source,js]
---------------------------------------------------
+----
 HEAD twitter/_mapping/tweet
---------------------------------------------------
+----
 // CONSOLE
 // TEST[setup:twitter]
 // TEST[warning:Type exists requests are deprecated, as types have been deprecated.]
 
-The HTTP status code indicates if the type exists or not. A `404` means
-it does not exist, and `200` means it does.
+
+[[indices-types-exists-api-request]]
+==== {api-request-title}
+
+`HEAD /<index>/mapping/<type>`
+
+
+[[indices-types-exists-api-path-params]]
+==== {api-path-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=type]
+
+
+[[indices-types-exists-api-response-codes]]
+==== {api-response-codes-title}
+
+`200`::
+Indicates all specified mapping types exist.
+
+ `404`::
+Indicates one or more specified mapping types **do not** exist.

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -662,6 +662,13 @@ end::master-timeout[]
 
 end::timeoutparms[]
 
+tag::type[]
+`<type>`::
+(Optional, string)
+Comma-separated list or wildcard expression of types
+used to limit the request.
+end::type[]
+
 tag::cat-v[]
 `v`::
 (Optional, boolean) If `true`, the response includes column headings. Defaults


### PR DESCRIPTION
7.3 backport of #47601