### PR TITLE
[DOCS] Correct callouts in search template docs

### DIFF
--- a/docs/reference/search/search-template.asciidoc
+++ b/docs/reference/search/search-template.asciidoc
@@ -536,14 +536,14 @@ The `params` would look like:
     "params": {
         "text":      "words to search for",
         "line_no": { <1>
-            "start": 10, <1>
-            "end":   20  <1>
+            "start": 10,
+            "end":   20
         }
     }
 }
 ------------------------------------------
 // NOTCONSOLE
-<1> All three of these elements are optional.
+<1> The `line_no`, `start`, and `end` parameters are optional.
 
 
 We could write the query as:
@@ -565,13 +565,13 @@ We could write the query as:
               {{#start}} <3>
                 "gte": "{{start}}" <4>
                 {{#end}},{{/end}} <5>
-              {{/start}} <3>
+              {{/start}}
               {{#end}} <6>
                 "lte": "{{end}}" <7>
-              {{/end}} <6>
+              {{/end}}
             }
           }
-        {{/line_no}} <2>
+        {{/line_no}}
       }
     }
   }


### PR DESCRIPTION
Corrects several empty callouts in the search template docs.

![image](https://user-images.githubusercontent.com/40268737/66313794-fc04c480-e8e0-11e9-9dc2-2278e9fa399c.png)

![image](https://user-images.githubusercontent.com/40268737/66313815-0030e200-e8e1-11e9-984c-154f46f369ba.png)

Fixes #46109