### PR TITLE
[DOCS] Adds classification type evaluation docs to the DFA evaluation API

### DIFF
--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -17,11 +17,13 @@ experimental[]
 
 `POST _ml/data_frame/_evaluate`
 
+
 [[ml-evaluate-dfanalytics-prereq]]
 ==== {api-prereq-title}
 
 * You must have `monitor_ml` privilege to use this API. For more 
 information, see <<security-privileges>> and <<built-in-roles>>.
+
 
 [[ml-evaluate-dfanalytics-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -277,7 +277,8 @@ POST _ml/data_frame/_evaluate
 <2> The field that contains the ground truth value for the actual animal 
 classification. This is required in order to evaluate results.
 <3> The field that contains the predicted value for animal classification by 
-the {classanalysis}.
+the {classanalysis}. Note that you need to add the `.keyword` suffix to the 
+name.
 
 
 The API returns the following result:
@@ -324,7 +325,9 @@ The API returns the following result:
     }
   }
 --------------------------------------------------
-<1>
-<2>
-<3>
-<4>
+<1> The name of the actual class that the analysis tried to predict.
+<2> The number of documents that the {classanalysis} successfully predicted as 
+the member of the actual class.
+<3> The number of documents that the {classanalysis} misclassified.
+<4> This object contains the list of the possible classes and the number of 
+predictions associated with the class.

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -254,9 +254,6 @@ calculated by the {reganalysis}.
 
 ===== {classification-cap}
 
-In the first example, `size` is not provided. The full matrix returns in the 
-response as the actual size is less than the maximum size (1000). 
-
 
 [source,console]
 --------------------------------------------------
@@ -288,157 +285,15 @@ The API returns the following result:
    "classification" : {
       "multiclass_confusion_matrix" : {
          "confusion_matrix" : {
-            "ant" : {
-               "mouse" : 2,
-               "horse" : 1,
-               "dog" : 3,
-               "ant" : 5,
-               "cat" : 4
-            },
             "cat" : {
-               "ant" : 4,
-               "cat" : 5,
+               "cat" : 12,
                "dog" : 3,
-               "horse" : 1,
-               "mouse" : 2
             },
             "dog" : {
-               "dog" : 5,
+               "dog" : 11,
                "cat" : 4,
-               "ant" : 3,
-               "mouse" : 2,
-               "horse" : 1
-            },
-            "horse" : {
-               "mouse" : 2,
-               "horse" : 5,
-               "dog" : 3,
-               "ant" : 1,
-               "cat" : 4
-            },
-            "mouse" : {
-               "mouse" : 5,
-               "horse" : 1,
-               "dog" : 3,
-               "ant" : 2,
-               "cat" : 4
             }
          }
-      }
-   }
-}
---------------------------------------------------
-
-
-In the second example the `size` is still not provided, but this time the 
-response contains only the restricted matrix as the actual size is grater than 
-the maximum size (1000).
-
-[source,console]
---------------------------------------------------
-POST _ml/data_frame/_evaluate
-{ 
-   "index": "my-index",
-   "evaluation": { 
-      "classification": { 
-         "actual_field": "a",
-         "predicted_field": "b"
-      }
-   }
-}
---------------------------------------------------
-// TEST[skip:TBD]
-
-
-The API returns the following result:
-
-[source,console-result]
---------------------------------------------------
-{
-   "classification" : {
-      "multiclass_confusion_matrix" : {
-         "confusion_matrix" : {
-            "class_1" : {
-               "class_1" : 5, <1>
-               ...
-               "class_100" : 4, <2>
-               "_other_": 6 <3>
-            },
-            "class_2" : {
-               "class_1" : 5,
-               ...
-               "class_100" : 3,
-               "_other_": 7
-            },
-            ...
-            "class_100" : {
-               "class_1" : 15,
-               ...
-               "class_100" : 30,
-            }
-         },
-         "_other_" : 25 <4>
-      }
-   }
-}
---------------------------------------------------
-<1> Number of datapoints that are classified correctly as class_1.
-<2> Number of datapoints that are misclassified as class_100.
-<3> Number of datapoints that are misclassified as one of the classes that 
-doesn't fit into the response specifically.
-<4> Number of actual classes that doesn't fit into the response specifically.
-
-
-In the third example, the `size` is provided, the response only contains the 
-restricted matrix as the actual size is greater than the maximum size (1000).
-
-[source,console]
---------------------------------------------------
-POST _ml/data_frame/_evaluate
-{ 
-   "index": "my-index",
-   "evaluation": { 
-      "classification": { 
-         "actual_field": "a",
-         "predicted_field": "b",
-         "metrics": {
-           "multiclass_confusion_matrix": {
-             "size": 3
-           }
-         }
-      }
-   }
-}
---------------------------------------------------
-
-
-The API returns the following results:
-
-[source,console-result]
---------------------------------------------------
-{
-   "classification" : {
-      "multiclass_confusion_matrix" : {
-         "confusion_matrix" : {
-            "ant" : {
-               "ant" : 5,
-               "cat" : 4,
-               "dog" : 0,
-               "_other_": 6
-            },
-            "cat" : {
-               "ant" : 0,
-               "cat" : 5,
-               "dog" : 3,
-               "_other_": 7
-            },
-            "dog" : {
-               "ant" : 0,
-               "cat" : 0,
-               "dog" : 15
-            }
-         },
-         "_other_" : 2
       }
    }
 }

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -263,7 +263,9 @@ POST _ml/data_frame/_evaluate
    "evaluation": {
       "classification": { <1>
          "actual_field": "animal_class", <2>
-         "predicted_field": "animal_class_prediction" <3>
+         "predicted_field": "ml.animal_class_prediction.keyword" <3>
+         "metrics": {  
+           "multiclass_confusion_matrix" : {}
       }
    }
 }

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -52,6 +52,7 @@ Available evaluation types:
 
 * `binary_soft_classification`
 * `regression`
+* `classification`
 --
 
 
@@ -247,3 +248,196 @@ only. It means that a testing error will be calculated.
 performance. This is required in order to evaluate results.
 <3> The field that contains the predicted value for student performance 
 calculated by the {reganalysis}.
+
+
+===== {classification-cap}
+
+In the first example, `size` is not provided. The full matrix returns in the 
+response as the actual size is less than the maximum size (1000). 
+
+
+[source,console]
+--------------------------------------------------
+POST _ml/data_frame/_evaluate
+{ 
+   "index": "animal_classification",
+   "evaluation": {
+      "classification": { <1>
+         "actual_field": "animal_class", <2>
+         "predicted_field": "animal_class_prediction" <3>
+      }
+   }
+}
+--------------------------------------------------
+// TEST[skip:TBD]
+
+<1> The evaluation type.
+<2> The field that contains the ground truth value for the actual animal 
+classification. This is required in order to evaluate results.
+<3> The field that contains the predicted value for animal classification by 
+the {classanalysis}.
+
+
+The API returns the following result:
+
+[source,console-result]
+--------------------------------------------------
+{
+   "classification" : {
+      "multiclass_confusion_matrix" : {
+         "confusion_matrix" : {
+            "ant" : {
+               "mouse" : 2,
+               "horse" : 1,
+               "dog" : 3,
+               "ant" : 5,
+               "cat" : 4
+            },
+            "cat" : {
+               "ant" : 4,
+               "cat" : 5,
+               "dog" : 3,
+               "horse" : 1,
+               "mouse" : 2
+            },
+            "dog" : {
+               "dog" : 5,
+               "cat" : 4,
+               "ant" : 3,
+               "mouse" : 2,
+               "horse" : 1
+            },
+            "horse" : {
+               "mouse" : 2,
+               "horse" : 5,
+               "dog" : 3,
+               "ant" : 1,
+               "cat" : 4
+            },
+            "mouse" : {
+               "mouse" : 5,
+               "horse" : 1,
+               "dog" : 3,
+               "ant" : 2,
+               "cat" : 4
+            }
+         }
+      }
+   }
+}
+--------------------------------------------------
+
+
+In the second example the `size` is still not provided, but this time the 
+response contains only the restricted matrix as the actual size is grater than 
+the maximum size (1000).
+
+[source,console]
+--------------------------------------------------
+POST _ml/data_frame/_evaluate
+{ 
+   "index": "my-index",
+   "evaluation": { 
+      "classification": { 
+         "actual_field": "a",
+         "predicted_field": "b"
+      }
+   }
+}
+--------------------------------------------------
+// TEST[skip:TBD]
+
+
+The API returns the following result:
+
+[source,console-result]
+--------------------------------------------------
+{
+   "classification" : {
+      "multiclass_confusion_matrix" : {
+         "confusion_matrix" : {
+            "class_1" : {
+               "class_1" : 5, <1>
+               ...
+               "class_100" : 4, <2>
+               "_other_": 6 <3>
+            },
+            "class_2" : {
+               "class_1" : 5,
+               ...
+               "class_100" : 3,
+               "_other_": 7
+            },
+            ...
+            "class_100" : {
+               "class_1" : 15,
+               ...
+               "class_100" : 30,
+            }
+         },
+         "_other_" : 25 <4>
+      }
+   }
+}
+--------------------------------------------------
+<1> Number of datapoints that are classified correctly as class_1.
+<2> Number of datapoints that are misclassified as class_100.
+<3> Number of datapoints that are misclassified as one of the classes that 
+doesn't fit into the response specifically.
+<4> Number of actual classes that doesn't fit into the response specifically.
+
+
+In the third example, the `size` is provided, the response only contains the 
+restricted matrix as the actual size is greater than the maximum size (1000).
+
+[source,console]
+--------------------------------------------------
+POST _ml/data_frame/_evaluate
+{ 
+   "index": "my-index",
+   "evaluation": { 
+      "classification": { 
+         "actual_field": "a",
+         "predicted_field": "b",
+         "metrics": {
+           "multiclass_confusion_matrix": {
+             "size": 3
+           }
+         }
+      }
+   }
+}
+--------------------------------------------------
+
+
+The API returns the following results:
+
+[source,console-result]
+--------------------------------------------------
+{
+   "classification" : {
+      "multiclass_confusion_matrix" : {
+         "confusion_matrix" : {
+            "ant" : {
+               "ant" : 5,
+               "cat" : 4,
+               "dog" : 0,
+               "_other_": 6
+            },
+            "cat" : {
+               "ant" : 0,
+               "cat" : 5,
+               "dog" : 3,
+               "_other_": 7
+            },
+            "dog" : {
+               "ant" : 0,
+               "cat" : 0,
+               "dog" : 15
+            }
+         },
+         "_other_" : 2
+      }
+   }
+}
+--------------------------------------------------

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -277,8 +277,8 @@ POST _ml/data_frame/_evaluate
 <2> The field that contains the ground truth value for the actual animal 
 classification. This is required in order to evaluate results.
 <3> The field that contains the predicted value for animal classification by 
-the {classanalysis}. Note that you need to add the `.keyword` suffix to the 
-name.
+the {classanalysis}. Since the field storing predicted class is dynamically 
+mapped as text and keyword, you need to add the `.keyword` suffix to the name.
 
 
 The API returns the following result:
@@ -292,31 +292,31 @@ The API returns the following result:
          {
             "actual_class" : "cat", <1>
             "actual_class_doc_count" : 12, <2>
-            "other_predicted_class_doc_count" : 0, <3>
-            "predicted_classes" : [ <4>
+            "predicted_classes" : [ <3>
               {
-                "count" : 12,
-                "predicted_class" : "cat"
+                "predicted_class" : "cat",
+                "count" : 12 <4>
               },
               {
-                "count" : 0,
-                "predicted_class" : "dog"
+                "predicted_class" : "dog",
+                "count" : 0 <5>
               }
+            "other_predicted_class_doc_count" : 0, <6>
             ]
           },
           {
             "actual_class" : "dog",
             "actual_class_doc_count" : 11,
-            "other_predicted_class_doc_count" : 4,
             "predicted_classes" : [
               {
-                "count" : 11,
-                "predicted_class" : "dog"
+                "predicted_class" : "dog",
+                "count" : 11
               },
               {
-                "count" : 4,
-                "predicted_class" : "cat"
+                "predicted_class" : "cat",
+                "count" : 4
               }
+            "other_predicted_class_doc_count" : 4,
             ]
           }
         ],
@@ -326,8 +326,10 @@ The API returns the following result:
   }
 --------------------------------------------------
 <1> The name of the actual class that the analysis tried to predict.
-<2> The number of documents that the {classanalysis} successfully predicted as 
-the member of the actual class.
-<3> The number of documents that the {classanalysis} misclassified.
-<4> This object contains the list of the possible classes and the number of 
+<2> The number of documents that belong to the `actual_class`.
+<3> This object contains the list of the possible classes and the number of 
 predictions associated with the class.
+<4> The number of cats in the dataset that are correctly identified as cats.
+<5> The number of cats in the dataset that are incorrectly classified as dogs.
+<6> The number of documents that are classified as a class that is not listed as 
+a `predicted_class`.

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -327,8 +327,8 @@ The API returns the following result:
   }
 --------------------------------------------------
 <1> The name of the actual class that the analysis tried to predict.
-<2> The number of documents that belong to the `actual_class`.
-<3> This object contains the list of the possible classes and the number of 
+<2> The number of documents in the index that belong to the `actual_class`.
+<3> This object contains the list of the predicted classes and the number of 
 predictions associated with the class.
 <4> The number of cats in the dataset that are correctly identified as cats.
 <5> The number of cats in the dataset that are incorrectly classified as dogs.

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -263,7 +263,7 @@ POST _ml/data_frame/_evaluate
    "evaluation": {
       "classification": { <1>
          "actual_field": "animal_class", <2>
-         "predicted_field": "ml.animal_class_prediction.keyword" <3>
+         "predicted_field": "ml.animal_class_prediction.keyword", <3>
          "metrics": {  
            "multiclass_confusion_matrix" : {}
          }
@@ -289,10 +289,10 @@ The API returns the following result:
       "multiclass_confusion_matrix" : {
          "confusion_matrix" : [
          {
-            "actual_class" : "cat",
-            "actual_class_doc_count" : 12,
-            "other_predicted_class_doc_count" : 0,
-            "predicted_classes" : [
+            "actual_class" : "cat", <1>
+            "actual_class_doc_count" : 12, <2>
+            "other_predicted_class_doc_count" : 0, <3>
+            "predicted_classes" : [ <4>
               {
                 "count" : 12,
                 "predicted_class" : "cat"
@@ -324,3 +324,7 @@ The API returns the following result:
     }
   }
 --------------------------------------------------
+<1>
+<2>
+<3>
+<4>

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -266,6 +266,7 @@ POST _ml/data_frame/_evaluate
          "predicted_field": "ml.animal_class_prediction.keyword" <3>
          "metrics": {  
            "multiclass_confusion_matrix" : {}
+         }
       }
    }
 }
@@ -286,17 +287,40 @@ The API returns the following result:
 {
    "classification" : {
       "multiclass_confusion_matrix" : {
-         "confusion_matrix" : {
-            "cat" : {
-               "cat" : 12,
-               "dog" : 3,
-            },
-            "dog" : {
-               "dog" : 11,
-               "cat" : 4,
-            }
-         }
+         "confusion_matrix" : [
+         {
+            "actual_class" : "cat",
+            "actual_class_doc_count" : 12,
+            "other_predicted_class_doc_count" : 0,
+            "predicted_classes" : [
+              {
+                "count" : 12,
+                "predicted_class" : "cat"
+              },
+              {
+                "count" : 0,
+                "predicted_class" : "dog"
+              }
+            ]
+          },
+          {
+            "actual_class" : "dog",
+            "actual_class_doc_count" : 11,
+            "other_predicted_class_doc_count" : 4,
+            "predicted_classes" : [
+              {
+                "count" : 11,
+                "predicted_class" : "dog"
+              },
+              {
+                "count" : 4,
+                "predicted_class" : "cat"
+              }
+            ]
+          }
+        ],
+        "other_actual_class_count" : 0
       }
-   }
-}
+    }
+  }
 --------------------------------------------------

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -265,7 +265,7 @@ POST _ml/data_frame/_evaluate
          "actual_field": "animal_class", <2>
          "predicted_field": "ml.animal_class_prediction.keyword", <3>
          "metrics": {  
-           "multiclass_confusion_matrix" : {}
+           "multiclass_confusion_matrix" : {} <4>
          }
       }
    }
@@ -279,6 +279,7 @@ classification. This is required in order to evaluate results.
 <3> The field that contains the predicted value for animal classification by 
 the {classanalysis}. Since the field storing predicted class is dynamically 
 mapped as text and keyword, you need to add the `.keyword` suffix to the name.
+<4> Specifies the metric for the evaluation.
 
 
 The API returns the following result:

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -302,8 +302,8 @@ The API returns the following result:
                 "predicted_class" : "dog",
                 "count" : 0 <5>
               }
-            "other_predicted_class_doc_count" : 0, <6>
-            ]
+            ],
+            "other_predicted_class_doc_count" : 0 <6>
           },
           {
             "actual_class" : "dog",
@@ -317,8 +317,8 @@ The API returns the following result:
                 "predicted_class" : "cat",
                 "count" : 4
               }
-            "other_predicted_class_doc_count" : 4,
-            ]
+            ],
+            "other_predicted_class_doc_count" : 4
           }
         ],
         "other_actual_class_count" : 0

--- a/docs/reference/ml/df-analytics/apis/evaluateresources.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluateresources.asciidoc
@@ -122,5 +122,7 @@ belongs.
 `predicted_field`::
   (string) The field in the `index` that contains the predicted value, in other 
   words the results of the {classanalysis}. The data type of this field is 
-  string. You need to add `.keyword` to the predicted field name. For example, 
+  string. You need to add `.keyword` to the predicted field name (the name you 
+  put in the {classanalysis} object as `prediction_field_name` or the default 
+  value of the same field if you didn't specified explicitly). For example, 
   `predicted_field` : `ml.animal_class_prediction.keyword`.

--- a/docs/reference/ml/df-analytics/apis/evaluateresources.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluateresources.asciidoc
@@ -112,8 +112,7 @@ analysis which outputs
 
 `actual_field`::
   (string) The field of the `index` which contains the ground truth. The data 
-  type of this field can be boolean or integer. If the data type is integer, the 
-  value has to be either `0` (false) or `1` (true).
+  type of this field must be string.
   
 `metrics`::
   (object) Specifies the metrics that are used for the evaluation. Available 

--- a/docs/reference/ml/df-analytics/apis/evaluateresources.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluateresources.asciidoc
@@ -113,7 +113,7 @@ belongs.
 
 `actual_field`::
   (string) The field of the `index` which contains the ground truth. The data 
-  type of this field must be string.
+  type of this field must be keyword.
   
 `metrics`::
   (object) Specifies the metrics that are used for the evaluation. Available 

--- a/docs/reference/ml/df-analytics/apis/evaluateresources.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluateresources.asciidoc
@@ -18,6 +18,7 @@ Evaluation configuration objects relate to the <<evaluate-dfanalytics>>.
 Available evaluation types:
 * `binary_soft_classification`
 * `regression`
+* `classification`
 --
   
 `query`::
@@ -96,3 +97,38 @@ which outputs a prediction of values.
 `metrics`::
   (object) Specifies the metrics that are used for the evaluation. Available 
   metrics are `r_squared` and `mean_squared_error`.
+  
+  
+[[classification-evaluation-resources]]
+==== {classification-cap} evaluation objects
+
+{classification-cap} evaluation evaluates the results of a {classification} 
+analysis which outputs 
+
+
+[discrete]
+[[classification-evaluation-resources-properties]]
+===== {api-definitions-title}
+
+`actual_field`::
+  (string) The field of the `index` which contains the ground truth. The data 
+  type of this field can be boolean or integer. If the data type is integer, the 
+  value has to be either `0` (false) or `1` (true).
+  
+`metrics`::
+  (object) Specifies the metrics that are used for the evaluation. Available 
+  metric is `multiclass_confusion_matrix`.
+  
+`size`:::
+  (integer) Restrict the number of classes that the
+  `multiclass_confusion_matrix` is calculated on. The evaluation uses the 
+  classes that occur the most frequently in the dataset. For example, if the 
+  `size` is set to 20 and the number of classes in the dataset is 50, then the 
+  matrix in the response will contain the 20 most common classes in the dataset 
+  and an `_other_` object which accumulates all the other categories that 
+  couldn't fit into the response. Defaults to 10. Maximum value is 1000.
+  
+`predicted_field`::
+  (string) The field in the `index` that contains the predicted value, in other 
+  words the results of the {classification} analysis. The data type of this 
+  field is string.

--- a/docs/reference/ml/df-analytics/apis/evaluateresources.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluateresources.asciidoc
@@ -102,9 +102,9 @@ which outputs a prediction of values.
 [[classification-evaluation-resources]]
 ==== {classification-cap} evaluation objects
 
-{classification-cap} evaluation evaluates the results of a {classification} 
-analysis which outputs a prediction that identifies to which of the classes each 
-document belongs.
+{classification-cap} evaluation evaluates the results of a {classanalysis} which 
+outputs a prediction that identifies to which of the classes each document 
+belongs.
 
 
 [discrete]
@@ -119,16 +119,7 @@ document belongs.
   (object) Specifies the metrics that are used for the evaluation. Available 
   metric is `multiclass_confusion_matrix`.
   
-`size`:::
-  (integer) Restrict the number of classes that the
-  `multiclass_confusion_matrix` is calculated on. The evaluation uses the 
-  classes that occur the most frequently in the dataset. For example, if the 
-  `size` is set to 20 and the number of classes in the dataset is 50, then the 
-  matrix in the response will contain the 20 most common classes in the dataset 
-  and an `_other_` object which accumulates all the other categories that 
-  couldn't fit into the response. Defaults to 10. Maximum value is 1000.
-  
 `predicted_field`::
   (string) The field in the `index` that contains the predicted value, in other 
-  words the results of the {classification} analysis. The data type of this 
-  field is string.
+  words the results of the {classanalysis}. The data type of this field is 
+  string.

--- a/docs/reference/ml/df-analytics/apis/evaluateresources.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluateresources.asciidoc
@@ -103,7 +103,8 @@ which outputs a prediction of values.
 ==== {classification-cap} evaluation objects
 
 {classification-cap} evaluation evaluates the results of a {classification} 
-analysis which outputs 
+analysis which outputs a prediction that identifies to which of the classes each 
+document belongs.
 
 
 [discrete]

--- a/docs/reference/ml/df-analytics/apis/evaluateresources.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluateresources.asciidoc
@@ -122,4 +122,5 @@ belongs.
 `predicted_field`::
   (string) The field in the `index` that contains the predicted value, in other 
   words the results of the {classanalysis}. The data type of this field is 
-  string.
+  string. You need to add `.keyword` to the predicted field name. For example, 
+  `predicted_field` : `ml.animal_class_prediction.keyword`.


### PR DESCRIPTION
This PR adds the documentation of a new evaluation type – `classification` – to the data frame analytics evaluation API documentation.

Depends on the following PR: https://github.com/elastic/docs/pull/1260 (docs attributes)