### PR TITLE
[7.0] Update deprecation logging doc with logger configuration  (#47652)

### DIFF
--- a/docs/reference/setup/logging-config.asciidoc
+++ b/docs/reference/setup/logging-config.asciidoc
@@ -212,7 +212,13 @@ logs to roll and compress after 1 GB, and to preserve a maximum of five log
 files (four rolled logs, and the active log).
 
 You can disable it in the `config/log4j2.properties` file by setting the deprecation
-log level to `error`.
+log level to `error` like this:
+[source,properties]
+--------------------------------------------------
+logger.deprecation.name = org.elasticsearch.deprecation
+logger.deprecation.level = error
+--------------------------------------------------
+
 
 
 [float]


### PR DESCRIPTION
Backports the following commits to 7.0:
 - Update deprecation logging doc with logger configuration  (#47652)