### PR TITLE
Throw error retrieving non-existent SLM policy

### DIFF
--- a/x-pack/plugin/ilm/qa/rest/src/test/resources/rest-api-spec/test/ilm/11_basic_slm.yml
+++ b/x-pack/plugin/ilm/qa/rest/src/test/resources/rest-api-spec/test/ilm/11_basic_slm.yml
@@ -1,0 +1,87 @@
+---
+setup:
+  - do:
+      cluster.health:
+          wait_for_status: yellow
+
+---
+"Test Basic Policy CRUD":
+  - do:
+      catch: missing
+      slm.get_lifecycle:
+        policy_id: "daily-snapshots"
+
+  - do:
+      catch: missing
+      slm.delete_lifecycle:
+        policy_id: "daily-snapshots"
+
+  - do:
+      snapshot.create_repository:
+        repository: repo
+        body:
+          type: fs
+          settings:
+            location: "my-snaps"
+
+  - do:
+      slm.put_lifecycle:
+        policy_id: "daily-snapshots"
+        body: |
+          {
+            "schedule": "0 1 2 3 4 ?",
+            "name": "<production-snap-{now/d}>",
+            "repository": "repo",
+            "config": {
+              "indices": ["foo-*", "important"],
+              "ignore_unavailable": false,
+              "include_global_state": false
+            },
+            "retention": {
+              "expire_after": "30d",
+              "min_count": 1,
+              "max_count": 50
+            }
+          }
+
+  - do:
+      slm.get_lifecycle:
+        policy_id: "daily-snapshots"
+  - match: { daily-snapshots.version: 1 }
+  - match: { daily-snapshots.policy.name: "<production-snap-{now/d}>" }
+  - is_true: daily-snapshots.next_execution_millis
+  - is_true: daily-snapshots.stats
+  - match: { daily-snapshots.policy.schedule: "0 1 2 3 4 ?" }
+
+  - do:
+      slm.put_lifecycle:
+        policy_id: "daily-snapshots"
+        body: |
+          {
+            "schedule": "1 1 1 1 1 ?",
+            "name": "<production-snap-{now/d}>",
+            "repository": "repo",
+            "config": {
+              "indices": ["foo-*", "important"],
+              "ignore_unavailable": false,
+              "include_global_state": false
+            },
+            "retention": {
+              "expire_after": "30d",
+              "min_count": 1,
+              "max_count": 50
+            }
+          }
+
+  - do:
+      catch: missing
+      slm.get_lifecycle:
+        policy_id: "doesnt-exist"
+
+  - do:
+      slm.get_lifecycle:
+        policy_id: "daily-snapshots"
+  - match: { daily-snapshots.version: 2 }
+  - match: { daily-snapshots.policy.schedule: "1 1 1 1 1 ?" }
+  - is_true: daily-snapshots.next_execution_millis
+  - is_true: daily-snapshots.stats

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportGetSnapshotLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportGetSnapshotLifecycleAction.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.slm.action;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
@@ -65,7 +66,13 @@ public class TransportGetSnapshotLifecycleAction extends
                                    final ActionListener<GetSnapshotLifecycleAction.Response> listener) {
         SnapshotLifecycleMetadata snapMeta = state.metaData().custom(SnapshotLifecycleMetadata.TYPE);
         if (snapMeta == null) {
-            listener.onResponse(new GetSnapshotLifecycleAction.Response(Collections.emptyList()));
+            if (request.getLifecycleIds().length == 0) {
+                listener.onResponse(new GetSnapshotLifecycleAction.Response(Collections.emptyList()));
+            } else {
+                listener.onFailure(new ResourceNotFoundException(
+                    "snapshot lifecycle policy or policies {} not found, no policies are configured",
+                    Arrays.toString(request.getLifecycleIds())));
+            }
         } else {
             final Map<String, SnapshotLifecyclePolicyItem.SnapshotInProgress> inProgress;
             SnapshotsInProgress sip = state.custom(SnapshotsInProgress.TYPE);
@@ -100,7 +107,16 @@ public class TransportGetSnapshotLifecycleAction extends
                     new SnapshotLifecyclePolicyItem(policyMeta, inProgress.get(policyMeta.getPolicy().getId()),
                         slmStats.getMetrics().get(policyMeta.getPolicy().getId())))
                 .collect(Collectors.toList());
-            listener.onResponse(new GetSnapshotLifecycleAction.Response(lifecycles));
+            if (lifecycles.size() == 0) {
+                if (request.getLifecycleIds().length == 0) {
+                    listener.onResponse(new GetSnapshotLifecycleAction.Response(Collections.emptyList()));
+                } else {
+                    listener.onFailure(new ResourceNotFoundException("snapshot lifecycle policy or policies {} not found",
+                        Arrays.toString(request.getLifecycleIds())));
+                }
+            } else {
+                listener.onResponse(new GetSnapshotLifecycleAction.Response(lifecycles));
+            }
         }
     }
 


### PR DESCRIPTION
Previously when retrieving an SLM policy it would always return a 200
with `{}` in the body, even if the policy did not exist. This changes
that behavior to throw an error (similar to our other APIs) if a
policy doesn't exist.

This also adds a basic CRUD yml test for the behavior.

Resolves #47664
