### PR TITLE
Watcher - catch uncaught exception.

### DIFF
--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/execution/ExecutionService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/execution/ExecutionService.java
@@ -435,11 +435,11 @@ public class ExecutionService {
                 }
                 try {
                     deleteTrigger(triggeredWatch.id());
-                } catch (Exception exc2) {
+                } catch (Exception exc) {
                     logger.error((Supplier<?>) () ->
                         new ParameterizedMessage(
                             "Error deleting entry from .triggered_watches for watch [{}] after thread pool rejection",
-                            triggeredWatch.id()), exc2);
+                            triggeredWatch.id()), exc);
                 }
             }));
         }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/execution/ExecutionService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/execution/ExecutionService.java
@@ -433,7 +433,14 @@ public class ExecutionService {
                             "Error storing watch history record for watch [{}] after thread pool rejection",
                             triggeredWatch.id()), exc);
                 }
-                deleteTrigger(triggeredWatch.id());
+                try {
+                    deleteTrigger(triggeredWatch.id());
+                } catch (Exception exc2) {
+                    logger.error((Supplier<?>) () ->
+                        new ParameterizedMessage(
+                            "Error deleting entry from .triggered_watches for watch [{}] after thread pool rejection",
+                            triggeredWatch.id()), exc2);
+                }
             }));
         }
     }


### PR DESCRIPTION
If a thread pool rejection exception happens, an alternative code
path is chosen to write history and delete the trigger. If an exception
happens during deletion of the trigger an exception may be thrown and not
caught.

This commit catches the exception and provides a meaning error message.

fixes #47008
