### PR TITLE
[7.5][Transform] move root endpoint to _transform with BWC layer (#47127)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/TransformRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/TransformRequestConverters.java
@@ -48,7 +48,7 @@ final class TransformRequestConverters {
 
     static Request putTransform(PutTransformRequest putRequest) throws IOException {
         String endpoint = new RequestConverters.EndpointBuilder()
-                .addPathPartAsIs("_data_frame", "transforms")
+                .addPathPartAsIs("_transform")
                 .addPathPart(putRequest.getConfig().getId())
                 .build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
@@ -61,7 +61,7 @@ final class TransformRequestConverters {
 
     static Request updateTransform(UpdateTransformRequest updateDataFrameTransformRequest) throws IOException {
         String endpoint = new RequestConverters.EndpointBuilder()
-            .addPathPartAsIs("_data_frame", "transforms")
+            .addPathPartAsIs("_transform")
             .addPathPart(updateDataFrameTransformRequest.getId())
             .addPathPart("_update")
             .build();
@@ -75,7 +75,7 @@ final class TransformRequestConverters {
 
     static Request getTransform(GetTransformRequest getRequest) {
         String endpoint = new RequestConverters.EndpointBuilder()
-                .addPathPartAsIs("_data_frame", "transforms")
+                .addPathPartAsIs("_transform")
                 .addPathPart(Strings.collectionToCommaDelimitedString(getRequest.getId()))
                 .build();
         Request request = new Request(HttpGet.METHOD_NAME, endpoint);
@@ -93,7 +93,7 @@ final class TransformRequestConverters {
 
     static Request deleteTransform(DeleteTransformRequest deleteRequest) {
         String endpoint = new RequestConverters.EndpointBuilder()
-                .addPathPartAsIs("_data_frame", "transforms")
+                .addPathPartAsIs("_transform")
                 .addPathPart(deleteRequest.getId())
                 .build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
@@ -105,7 +105,7 @@ final class TransformRequestConverters {
 
     static Request startTransform(StartTransformRequest startRequest) {
         String endpoint = new RequestConverters.EndpointBuilder()
-                .addPathPartAsIs("_data_frame", "transforms")
+                .addPathPartAsIs("_transform")
                 .addPathPart(startRequest.getId())
                 .addPathPartAsIs("_start")
                 .build();
@@ -120,7 +120,7 @@ final class TransformRequestConverters {
 
     static Request stopTransform(StopTransformRequest stopRequest) {
         String endpoint = new RequestConverters.EndpointBuilder()
-            .addPathPartAsIs("_data_frame", "transforms")
+            .addPathPartAsIs("_transform")
             .addPathPart(stopRequest.getId())
             .addPathPartAsIs("_stop")
             .build();
@@ -141,7 +141,7 @@ final class TransformRequestConverters {
 
     static Request previewTransform(PreviewTransformRequest previewRequest) throws IOException {
         String endpoint = new RequestConverters.EndpointBuilder()
-                .addPathPartAsIs("_data_frame", "transforms", "_preview")
+                .addPathPartAsIs("_transform", "_preview")
                 .build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
         request.setEntity(createEntity(previewRequest, REQUEST_BODY_CONTENT_TYPE));
@@ -150,7 +150,7 @@ final class TransformRequestConverters {
 
     static Request getTransformStats(GetTransformStatsRequest statsRequest) {
         String endpoint = new RequestConverters.EndpointBuilder()
-                .addPathPartAsIs("_data_frame", "transforms")
+                .addPathPartAsIs("_transform")
                 .addPathPart(statsRequest.getId())
                 .addPathPartAsIs("_stats")
                 .build();

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/TransformRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/TransformRequestConvertersTests.java
@@ -24,7 +24,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.elasticsearch.client.core.PageParams;
-import org.elasticsearch.client.transform.TransformNamedXContentProvider;
 import org.elasticsearch.client.transform.DeleteTransformRequest;
 import org.elasticsearch.client.transform.GetTransformRequest;
 import org.elasticsearch.client.transform.GetTransformStatsRequest;
@@ -32,6 +31,7 @@ import org.elasticsearch.client.transform.PreviewTransformRequest;
 import org.elasticsearch.client.transform.PutTransformRequest;
 import org.elasticsearch.client.transform.StartTransformRequest;
 import org.elasticsearch.client.transform.StopTransformRequest;
+import org.elasticsearch.client.transform.TransformNamedXContentProvider;
 import org.elasticsearch.client.transform.UpdateTransformRequest;
 import org.elasticsearch.client.transform.transforms.TransformConfig;
 import org.elasticsearch.client.transform.transforms.TransformConfigTests;
@@ -56,7 +56,7 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 
-public class DataFrameRequestConvertersTests extends ESTestCase {
+public class TransformRequestConvertersTests extends ESTestCase {
 
     @Override
     protected NamedXContentRegistry xContentRegistry() {
@@ -72,7 +72,7 @@ public class DataFrameRequestConvertersTests extends ESTestCase {
         Request request = TransformRequestConverters.putTransform(putRequest);
         assertThat(request.getParameters(), not(hasKey("defer_validation")));
         assertEquals(HttpPut.METHOD_NAME, request.getMethod());
-        assertThat(request.getEndpoint(), equalTo("/_data_frame/transforms/" + putRequest.getConfig().getId()));
+        assertThat(request.getEndpoint(), equalTo("/_transform/" + putRequest.getConfig().getId()));
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, request.getEntity().getContent())) {
             TransformConfig parsedConfig = TransformConfig.PARSER.apply(parser, null);
@@ -91,7 +91,7 @@ public class DataFrameRequestConvertersTests extends ESTestCase {
         Request request = TransformRequestConverters.updateTransform(updateDataFrameTransformRequest);
         assertThat(request.getParameters(), not(hasKey("defer_validation")));
         assertEquals(HttpPost.METHOD_NAME, request.getMethod());
-        assertThat(request.getEndpoint(), equalTo("/_data_frame/transforms/" + transformId + "/_update"));
+        assertThat(request.getEndpoint(), equalTo("/_transform/" + transformId + "/_update"));
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, request.getEntity().getContent())) {
             TransformConfigUpdate parsedConfig = TransformConfigUpdate.fromXContent(parser);
@@ -108,7 +108,7 @@ public class DataFrameRequestConvertersTests extends ESTestCase {
         Request request = TransformRequestConverters.deleteTransform(deleteRequest);
 
         assertEquals(HttpDelete.METHOD_NAME, request.getMethod());
-        assertThat(request.getEndpoint(), equalTo("/_data_frame/transforms/foo"));
+        assertThat(request.getEndpoint(), equalTo("/_transform/foo"));
 
         assertThat(request.getParameters(), not(hasKey("force")));
 
@@ -128,7 +128,7 @@ public class DataFrameRequestConvertersTests extends ESTestCase {
 
         Request request = TransformRequestConverters.startTransform(startRequest);
         assertEquals(HttpPost.METHOD_NAME, request.getMethod());
-        assertThat(request.getEndpoint(), equalTo("/_data_frame/transforms/" + startRequest.getId() + "/_start"));
+        assertThat(request.getEndpoint(), equalTo("/_transform/" + startRequest.getId() + "/_start"));
 
         if (timeValue != null) {
             assertTrue(request.getParameters().containsKey("timeout"));
@@ -152,7 +152,7 @@ public class DataFrameRequestConvertersTests extends ESTestCase {
 
         Request request = TransformRequestConverters.stopTransform(stopRequest);
         assertEquals(HttpPost.METHOD_NAME, request.getMethod());
-        assertThat(request.getEndpoint(), equalTo("/_data_frame/transforms/" + stopRequest.getId() + "/_stop"));
+        assertThat(request.getEndpoint(), equalTo("/_transform/" + stopRequest.getId() + "/_stop"));
 
         if (waitForCompletion != null) {
             assertTrue(request.getParameters().containsKey("wait_for_completion"));
@@ -180,7 +180,7 @@ public class DataFrameRequestConvertersTests extends ESTestCase {
         Request request = TransformRequestConverters.previewTransform(previewRequest);
 
         assertEquals(HttpPost.METHOD_NAME, request.getMethod());
-        assertThat(request.getEndpoint(), equalTo("/_data_frame/transforms/_preview"));
+        assertThat(request.getEndpoint(), equalTo("/_transform/_preview"));
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, request.getEntity().getContent())) {
             TransformConfig parsedConfig = TransformConfig.PARSER.apply(parser, null);
@@ -193,7 +193,7 @@ public class DataFrameRequestConvertersTests extends ESTestCase {
         Request request = TransformRequestConverters.getTransformStats(getStatsRequest);
 
         assertEquals(HttpGet.METHOD_NAME, request.getMethod());
-        assertThat(request.getEndpoint(), equalTo("/_data_frame/transforms/foo/_stats"));
+        assertThat(request.getEndpoint(), equalTo("/_transform/foo/_stats"));
 
         assertFalse(request.getParameters().containsKey("from"));
         assertFalse(request.getParameters().containsKey("size"));
@@ -223,7 +223,7 @@ public class DataFrameRequestConvertersTests extends ESTestCase {
         Request request = TransformRequestConverters.getTransform(getRequest);
 
         assertEquals(HttpGet.METHOD_NAME, request.getMethod());
-        assertThat(request.getEndpoint(), equalTo("/_data_frame/transforms/bar"));
+        assertThat(request.getEndpoint(), equalTo("/_transform/bar"));
 
         assertFalse(request.getParameters().containsKey("from"));
         assertFalse(request.getParameters().containsKey("size"));
@@ -253,6 +253,6 @@ public class DataFrameRequestConvertersTests extends ESTestCase {
         Request request = TransformRequestConverters.getTransform(getRequest);
 
         assertEquals(HttpGet.METHOD_NAME, request.getMethod());
-        assertThat(request.getEndpoint(), equalTo("/_data_frame/transforms/foo,bar,baz"));
+        assertThat(request.getEndpoint(), equalTo("/_transform/foo,bar,baz"));
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/TransformDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/TransformDocumentationIT.java
@@ -42,16 +42,16 @@ import org.elasticsearch.client.transform.StopTransformRequest;
 import org.elasticsearch.client.transform.StopTransformResponse;
 import org.elasticsearch.client.transform.UpdateTransformRequest;
 import org.elasticsearch.client.transform.UpdateTransformResponse;
-import org.elasticsearch.client.transform.transforms.TransformIndexerStats;
-import org.elasticsearch.client.transform.transforms.TransformConfig;
-import org.elasticsearch.client.transform.transforms.TransformConfigUpdate;
-import org.elasticsearch.client.transform.transforms.TransformProgress;
-import org.elasticsearch.client.transform.transforms.TransformStats;
 import org.elasticsearch.client.transform.transforms.DestConfig;
 import org.elasticsearch.client.transform.transforms.NodeAttributes;
 import org.elasticsearch.client.transform.transforms.QueryConfig;
 import org.elasticsearch.client.transform.transforms.SourceConfig;
 import org.elasticsearch.client.transform.transforms.TimeSyncConfig;
+import org.elasticsearch.client.transform.transforms.TransformConfig;
+import org.elasticsearch.client.transform.transforms.TransformConfigUpdate;
+import org.elasticsearch.client.transform.transforms.TransformIndexerStats;
+import org.elasticsearch.client.transform.transforms.TransformProgress;
+import org.elasticsearch.client.transform.transforms.TransformStats;
 import org.elasticsearch.client.transform.transforms.pivot.AggregationConfig;
 import org.elasticsearch.client.transform.transforms.pivot.GroupConfig;
 import org.elasticsearch.client.transform.transforms.pivot.PivotConfig;
@@ -219,7 +219,7 @@ public class TransformDocumentationIT extends ESRestHighLevelClientTestCase {
         }
     }
 
-    public void testUpdateDataFrameTransform() throws IOException, InterruptedException {
+    public void testUpdateTransform() throws IOException, InterruptedException {
         createIndex("source-data");
 
         RestHighLevelClient client = highLevelClient();

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -1189,7 +1189,7 @@ buildRestTests.setups['simple_kibana_continuous_pivot'] = buildRestTests.setups[
   - do:
       raw:
         method: PUT
-        path: _data_frame/transforms/simple-kibana-ecomm-pivot
+        path: _transform/simple-kibana-ecomm-pivot
         body:  >
           {
             "source": {

--- a/docs/reference/transform/api-quickref.asciidoc
+++ b/docs/reference/transform/api-quickref.asciidoc
@@ -6,7 +6,7 @@ All {transform} endpoints have the following base:
 
 [source,js]
 ----
-/_data_frame/transforms/
+_transform/
 ----
 // NOTCONSOLE
 

--- a/docs/reference/transform/apis/delete-transform.asciidoc
+++ b/docs/reference/transform/apis/delete-transform.asciidoc
@@ -15,7 +15,7 @@ beta[]
 [[delete-transform-request]]
 ==== {api-request-title}
 
-`DELETE _data_frame/transforms/<transform_id>`
+`DELETE _transform/<transform_id>`
 
 [[delete-transform-prereqs]]
 ==== {api-prereq-title}
@@ -47,7 +47,7 @@ current state. The default value is `false`, meaning that the {transform} must b
 
 [source,console]
 --------------------------------------------------
-DELETE _data_frame/transforms/ecommerce_transform
+DELETE _transform/ecommerce_transform
 --------------------------------------------------
 // TEST[skip:setup kibana sample data]
 

--- a/docs/reference/transform/apis/get-transform-stats.asciidoc
+++ b/docs/reference/transform/apis/get-transform-stats.asciidoc
@@ -16,15 +16,15 @@ beta[]
 [[get-transform-stats-request]]
 ==== {api-request-title}
 
-`GET _data_frame/transforms/<transform_id>/_stats`
+`GET _transform/<transform_id>/_stats`
 
-`GET _data_frame/transforms/<transform_id>,<transform_id>/_stats` +
+`GET _transform/<transform_id>,<transform_id>/_stats` +
 
-`GET _data_frame/transforms/_stats` +
+`GET _transform/_stats` +
 
-`GET _data_frame/transforms/_all/_stats` +
+`GET _transform/_all/_stats` +
 
-`GET _data_frame/transforms/*/_stats` +
+`GET _transform/*/_stats` +
 
 
 [[get-transform-stats-prereqs]]
@@ -103,7 +103,7 @@ gets usage information for a maximum of ten results:
 
 [source,console]
 --------------------------------------------------
-GET _data_frame/transforms/_stats?from=5&size=10
+GET _transform/_stats?from=5&size=10
 --------------------------------------------------
 // TEST[skip:todo]
 
@@ -112,7 +112,7 @@ The following example gets usage information for the `ecommerce_transform`
 
 [source,console]
 --------------------------------------------------
-GET _data_frame/transforms/ecommerce_transform/_stats
+GET _transform/ecommerce_transform/_stats
 --------------------------------------------------
 // TEST[skip:todo]
 

--- a/docs/reference/transform/apis/get-transform.asciidoc
+++ b/docs/reference/transform/apis/get-transform.asciidoc
@@ -15,15 +15,15 @@ beta[]
 [[get-transform-request]]
 ==== {api-request-title}
 
-`GET _data_frame/transforms/<transform_id>` +
+`GET _transform/<transform_id>` +
 
-`GET _data_frame/transforms/<transform_id>,<transform_id>` +
+`GET _transform/<transform_id>,<transform_id>` +
 
-`GET _data_frame/transforms/` +
+`GET _transform/` +
 
-`GET _data_frame/transforms/_all` +
+`GET _transform/_all` +
 
-`GET _data_frame/transforms/*`
+`GET _transform/*`
 
 [[get-transform-prereqs]]
 ==== {api-prereq-title}
@@ -96,7 +96,7 @@ The following example retrieves information about a maximum of ten {transforms}:
 
 [source,console]
 --------------------------------------------------
-GET _data_frame/transforms?size=10
+GET _transform?size=10
 --------------------------------------------------
 // TEST[skip:setup kibana sample data]
 
@@ -105,7 +105,7 @@ The following example gets configuration information for the
 
 [source,console]
 --------------------------------------------------
-GET _data_frame/transforms/ecommerce_transform
+GET _transform/ecommerce_transform
 --------------------------------------------------
 // TEST[skip:setup kibana sample data]
 

--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -15,7 +15,7 @@ beta[]
 [[preview-transform-request]]
 ==== {api-request-title}
 
-`POST _data_frame/transforms/_preview`
+`POST _transform/_preview`
 
 [[preview-transform-prereq]]
 ==== {api-prereq-title}
@@ -69,7 +69,7 @@ on all the current data in the source index.
 
 [source,console]
 --------------------------------------------------
-POST _data_frame/transforms/_preview
+POST _transform/_preview
 {
   "source": {
     "index": "kibana_sample_data_ecommerce"

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -15,7 +15,7 @@ beta[]
 [[put-transform-request]]
 ==== {api-request-title}
 
-`PUT _data_frame/transforms/<transform_id>`
+`PUT _transform/<transform_id>`
 
 [[put-transform-prereqs]]
 ==== {api-prereq-title}
@@ -140,7 +140,7 @@ delays.
 
 [source,console]
 --------------------------------------------------
-PUT _data_frame/transforms/ecommerce_transform
+PUT _transform/ecommerce_transform
 {
   "source": {
     "index": "kibana_sample_data_ecommerce",

--- a/docs/reference/transform/apis/start-transform.asciidoc
+++ b/docs/reference/transform/apis/start-transform.asciidoc
@@ -15,7 +15,7 @@ beta[]
 [[start-transform-request]]
 ==== {api-request-title}
 
-`POST _data_frame/transforms/<transform_id>/_start`
+`POST _transform/<transform_id>/_start`
 
 [[start-transform-prereqs]]
 ==== {api-prereq-title}
@@ -63,7 +63,7 @@ required privileges on the source and destination indices, the
 
 [source,console]
 --------------------------------------------------
-POST _data_frame/transforms/ecommerce_transform/_start
+POST _transform/ecommerce_transform/_start
 --------------------------------------------------
 // TEST[skip:set up kibana samples]
 

--- a/docs/reference/transform/apis/stop-transform.asciidoc
+++ b/docs/reference/transform/apis/stop-transform.asciidoc
@@ -16,11 +16,11 @@ beta[]
 [[stop-transform-request]]
 ==== {api-request-title}
 
-`POST _data_frame/transforms/<transform_id>/_stop` +
+`POST _transform/<transform_id>/_stop` +
 
-`POST _data_frame/transforms/<transform_id1>,<transform_id2>/_stop` +
+`POST _transform/<transform_id1>,<transform_id2>/_stop` +
 
-`POST _data_frame/transforms/_all/_stop`
+`POST _transform/_all/_stop`
 
 
 [[stop-transform-prereq]]
@@ -105,7 +105,7 @@ are no matches or only partial matches.
 
 [source,console]
 --------------------------------------------------
-POST _data_frame/transforms/ecommerce_transform/_stop
+POST _transform/ecommerce_transform/_stop
 --------------------------------------------------
 // TEST[skip:set up kibana samples]
 

--- a/docs/reference/transform/apis/update-transform.asciidoc
+++ b/docs/reference/transform/apis/update-transform.asciidoc
@@ -15,7 +15,7 @@ beta[]
 [[update-transform-request]]
 ==== {api-request-title}
 
-`POST _data_frame/transforms/<transform_id>/_update`
+`POST _transform/<transform_id>/_update`
 
 [[update-transform-prereqs]]
 ==== {api-prereq-title}
@@ -123,7 +123,7 @@ delays.
 
 [source,console]
 --------------------------------------------------
-POST _data_frame/transforms/simple-kibana-ecomm-pivot/_update
+POST _transform/simple-kibana-ecomm-pivot/_update
 {
   "source": {
     "index": "kibana_sample_data_ecommerce",

--- a/docs/reference/transform/ecommerce-tutorial.asciidoc
+++ b/docs/reference/transform/ecommerce-tutorial.asciidoc
@@ -87,7 +87,7 @@ If you prefer, you can use the
 
 [source,console]
 --------------------------------------------------
-POST _data_frame/transforms/_preview
+POST _transform/_preview
 {
   "source": {
     "index": "kibana_sample_data_ecommerce",
@@ -163,7 +163,7 @@ example:
 
 [source,console]
 --------------------------------------------------
-PUT _data_frame/transforms/ecommerce-customer-transform
+PUT _transform/ecommerce-customer-transform
 {
   "source": {
     "index": [
@@ -239,7 +239,7 @@ example:
 
 [source,console]
 --------------------------------------------------
-POST _data_frame/transforms/ecommerce-customer-transform/_start
+POST _transform/ecommerce-customer-transform/_start
 --------------------------------------------------
 // TEST[skip:setup kibana sample data]
 

--- a/docs/reference/transform/examples.asciidoc
+++ b/docs/reference/transform/examples.asciidoc
@@ -29,7 +29,7 @@ order, and the total amount of ordered products for each customer.
 
 [source,console]
 ----------------------------------
-POST _data_frame/transforms/_preview
+POST _transform/_preview
 {
   "source": {
     "index": "kibana_sample_data_ecommerce"
@@ -115,7 +115,7 @@ to determine what percentage of the flight time was actually delay.
 
 [source,console]
 ----------------------------------
-POST _data_frame/transforms/_preview
+POST _transform/_preview
 {
   "source": {
     "index": "kibana_sample_data_flights",
@@ -207,7 +207,7 @@ entity is `clientip`.
 
 [source,console]
 ----------------------------------
-POST _data_frame/transforms/_preview
+POST _transform/_preview
 {
   "source": {
     "index": "kibana_sample_data_logs",

--- a/docs/reference/transform/limitations.asciidoc
+++ b/docs/reference/transform/limitations.asciidoc
@@ -120,7 +120,7 @@ viewing the destination index.
 [[transform-deletion-limitations]]
 ==== Deleting a {transform} does not delete the destination index or {kib} index pattern
 
-When deleting a {transform} using `DELETE _data_frame/transforms/index` 
+When deleting a {transform} using `DELETE _transform/index` 
 neither the destination index nor the {kib} index pattern, should one have been 
 created, are deleted. These objects must be deleted separately.
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -302,9 +302,9 @@ public class DoSection implements ExecutableSection {
                      * older master. Rather than rewrite our tests to assert this warning header, we assume that it is expected.
                      */
                 } else // noinspection StatementWithEmptyBody
-                    if (message.startsWith("[types removal]")) {
+                    if (message.startsWith("[types removal]") || message.startsWith("[_data_frame/transforms/] is deprecated")) {
                     /*
-                     * We skip warnings related to types deprecation so that we can continue to run the many
+                     * We skip warnings related to types deprecation and transform rename so that we can continue to run the many
                      * mixed-version tests that used typed APIs.
                      */
                 } else if (expected.remove(message) == false) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
@@ -50,8 +50,9 @@ public class ClusterPrivilegeResolver {
     private static final Set<String> MANAGE_TOKEN_PATTERN = Collections.singleton("cluster:admin/xpack/security/token/*");
     private static final Set<String> MANAGE_API_KEY_PATTERN = Collections.singleton("cluster:admin/xpack/security/api_key/*");
     private static final Set<String> MONITOR_PATTERN = Collections.singleton("cluster:monitor/*");
+    private static final Set<String> MONITOR_DATA_FRAME_PATTERN = Collections.unmodifiableSet(
+        Sets.newHashSet("cluster:monitor/data_frame/*", "cluster:monitor/transform/*"));
     private static final Set<String> MONITOR_ML_PATTERN = Collections.singleton("cluster:monitor/xpack/ml/*");
-    private static final Set<String> MONITOR_DATA_FRAME_PATTERN = Collections.singleton("cluster:monitor/data_frame/*");
     private static final Set<String> MONITOR_WATCHER_PATTERN = Collections.singleton("cluster:monitor/xpack/watcher/*");
     private static final Set<String> MONITOR_ROLLUP_PATTERN = Collections.singleton("cluster:monitor/xpack/rollup/*");
     private static final Set<String> ALL_CLUSTER_PATTERN = Collections.unmodifiableSet(
@@ -59,7 +60,8 @@ public class ClusterPrivilegeResolver {
     private static final Set<String> MANAGE_ML_PATTERN = Collections.unmodifiableSet(
         Sets.newHashSet("cluster:admin/xpack/ml/*", "cluster:monitor/xpack/ml/*"));
     private static final Set<String> MANAGE_DATA_FRAME_PATTERN = Collections.unmodifiableSet(
-        Sets.newHashSet("cluster:admin/data_frame/*", "cluster:monitor/data_frame/*"));
+        Sets.newHashSet("cluster:admin/data_frame/*", "cluster:monitor/data_frame/*",
+            "cluster:monitor/transform/*", "cluster:admin/transform/*"));
     private static final Set<String> MANAGE_WATCHER_PATTERN = Collections.unmodifiableSet(
         Sets.newHashSet("cluster:admin/xpack/watcher/*", "cluster:monitor/xpack/watcher/*"));
     private static final Set<String> TRANSPORT_CLIENT_PATTERN = Collections.unmodifiableSet(

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformField.java
@@ -56,9 +56,13 @@ public final class TransformField {
 
     // common strings
     public static final String TASK_NAME = "data_frame/transforms";
-    public static final String REST_BASE_PATH = "/_data_frame/";
-    public static final String REST_BASE_PATH_TRANSFORMS = REST_BASE_PATH + "transforms/";
+    public static final String REST_BASE_PATH_TRANSFORMS = "/_transform/";
     public static final String REST_BASE_PATH_TRANSFORMS_BY_ID = REST_BASE_PATH_TRANSFORMS + "{id}/";
+
+    // deprecated REST API, to be removed for 8.0.0
+    public static final String REST_BASE_PATH_TRANSFORMS_DEPRECATED = "/_data_frame/transforms/";
+    public static final String REST_BASE_PATH_TRANSFORMS_BY_ID_DEPRECATED = REST_BASE_PATH_TRANSFORMS_DEPRECATED + "{id}/";
+
     public static final String TRANSFORM_ID = "transform_id";
 
     // note: this is used to match tasks

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
@@ -31,6 +31,8 @@ public class TransformMessages {
     public static final String TRANSFORM_FAILED_TO_PERSIST_STATS = "Failed to persist transform statistics for transform [{0}]";
     public static final String UNKNOWN_TRANSFORM_STATS = "Statistics for transform [{0}] could not be found";
 
+    public static final String REST_DEPRECATED_ENDPOINT = "[_data_frame/transforms/] is deprecated, use [_transform/] in the future.";
+
     public static final String CANNOT_STOP_FAILED_TRANSFORM =
         "Unable to stop transform [{0}] as it is in a failed state with reason [{1}]." +
             " Use force stop to stop the transform.";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/DeleteTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/DeleteTransformAction.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 public class DeleteTransformAction extends ActionType<AcknowledgedResponse> {
 
     public static final DeleteTransformAction INSTANCE = new DeleteTransformAction();
-    public static final String NAME = "cluster:admin/data_frame/delete";
+    public static final String NAME = "cluster:admin/transform/delete";
 
     private DeleteTransformAction() {
         super(NAME, AcknowledgedResponse::new);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformAction.java
@@ -7,8 +7,8 @@
 package org.elasticsearch.xpack.core.transform.action;
 
 import org.apache.logging.log4j.LogManager;
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -31,7 +31,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 public class GetTransformAction extends ActionType<GetTransformAction.Response> {
 
     public static final GetTransformAction INSTANCE = new GetTransformAction();
-    public static final String NAME = "cluster:monitor/data_frame/get";
+    public static final String NAME = "cluster:monitor/transform/get";
 
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
             LogManager.getLogger(GetTransformAction.class));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsAction.java
@@ -37,7 +37,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 public class GetTransformStatsAction extends ActionType<GetTransformStatsAction.Response> {
 
     public static final GetTransformStatsAction INSTANCE = new GetTransformStatsAction();
-    public static final String NAME = "cluster:monitor/data_frame/stats/get";
+    public static final String NAME = "cluster:monitor/transform/stats/get";
     public GetTransformStatsAction() {
         super(NAME, GetTransformStatsAction.Response::new);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/PreviewTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/PreviewTransformAction.java
@@ -23,8 +23,8 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.xpack.core.transform.TransformField;
-import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.core.transform.transforms.DestConfig;
+import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -39,7 +39,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 public class PreviewTransformAction extends ActionType<PreviewTransformAction.Response> {
 
     public static final PreviewTransformAction INSTANCE = new PreviewTransformAction();
-    public static final String NAME = "cluster:admin/data_frame/preview";
+    public static final String NAME = "cluster:admin/transform/preview";
 
     private PreviewTransformAction() {
         super(NAME, PreviewTransformAction.Response::new);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/PutTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/PutTransformAction.java
@@ -31,7 +31,7 @@ import static org.elasticsearch.cluster.metadata.MetaDataCreateIndexService.vali
 public class PutTransformAction extends ActionType<AcknowledgedResponse> {
 
     public static final PutTransformAction INSTANCE = new PutTransformAction();
-    public static final String NAME = "cluster:admin/data_frame/put";
+    public static final String NAME = "cluster:admin/transform/put";
 
     private static final TimeValue MIN_FREQUENCY = TimeValue.timeValueSeconds(1);
     private static final TimeValue MAX_FREQUENCY = TimeValue.timeValueHours(1);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/StartTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/StartTransformAction.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 public class StartTransformAction extends ActionType<StartTransformAction.Response> {
 
     public static final StartTransformAction INSTANCE = new StartTransformAction();
-    public static final String NAME = "cluster:admin/data_frame/start";
+    public static final String NAME = "cluster:admin/transform/start";
 
     private StartTransformAction() {
         super(NAME, StartTransformAction.Response::new);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/StopTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/StopTransformAction.java
@@ -7,8 +7,8 @@ package org.elasticsearch.xpack.core.transform.action;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.TaskOperationFailure;
 import org.elasticsearch.action.support.tasks.BaseTasksRequest;
 import org.elasticsearch.action.support.tasks.BaseTasksResponse;
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 public class StopTransformAction extends ActionType<StopTransformAction.Response> {
 
     public static final StopTransformAction INSTANCE = new StopTransformAction();
-    public static final String NAME = "cluster:admin/data_frame/stop";
+    public static final String NAME = "cluster:admin/transform/stop";
 
     public static final TimeValue DEFAULT_TIMEOUT = new TimeValue(30, TimeUnit.SECONDS);
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/UpdateTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/UpdateTransformAction.java
@@ -31,7 +31,7 @@ import static org.elasticsearch.cluster.metadata.MetaDataCreateIndexService.vali
 public class UpdateTransformAction extends ActionType<UpdateTransformAction.Response> {
 
     public static final UpdateTransformAction INSTANCE = new UpdateTransformAction();
-    public static final String NAME = "cluster:admin/data_frame/update";
+    public static final String NAME = "cluster:admin/transform/update";
 
     private static final TimeValue MIN_FREQUENCY = TimeValue.timeValueSeconds(1);
     private static final TimeValue MAX_FREQUENCY = TimeValue.timeValueHours(1);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/compat/DeleteTransformActionDeprecated.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/compat/DeleteTransformActionDeprecated.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.transform.action.compat;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+
+public class DeleteTransformActionDeprecated extends ActionType<AcknowledgedResponse> {
+
+    public static final DeleteTransformActionDeprecated INSTANCE = new DeleteTransformActionDeprecated();
+    public static final String NAME = "cluster:admin/data_frame/delete";
+
+    private DeleteTransformActionDeprecated() {
+        super(NAME, AcknowledgedResponse::new);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/compat/GetTransformActionDeprecated.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/compat/GetTransformActionDeprecated.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.transform.action.compat;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.xpack.core.transform.action.GetTransformAction;
+
+public class GetTransformActionDeprecated extends ActionType<GetTransformAction.Response> {
+
+    public static final GetTransformActionDeprecated INSTANCE = new GetTransformActionDeprecated();
+    public static final String NAME = "cluster:monitor/data_frame/get";
+
+    private GetTransformActionDeprecated() {
+        super(NAME, GetTransformAction.Response::new);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/compat/GetTransformStatsActionDeprecated.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/compat/GetTransformStatsActionDeprecated.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.transform.action.compat;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.xpack.core.transform.action.GetTransformStatsAction;
+
+public class GetTransformStatsActionDeprecated extends ActionType<GetTransformStatsAction.Response> {
+
+    public static final GetTransformStatsActionDeprecated INSTANCE = new GetTransformStatsActionDeprecated();
+    public static final String NAME = "cluster:monitor/data_frame/stats/get";
+
+    private GetTransformStatsActionDeprecated() {
+        super(NAME, GetTransformStatsAction.Response::new);
+    }
+
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/compat/PreviewTransformActionDeprecated.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/compat/PreviewTransformActionDeprecated.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.transform.action.compat;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.xpack.core.transform.action.PreviewTransformAction;
+
+public class PreviewTransformActionDeprecated extends ActionType<PreviewTransformAction.Response> {
+
+    public static final PreviewTransformActionDeprecated INSTANCE = new PreviewTransformActionDeprecated();
+    public static final String NAME = "cluster:admin/data_frame/preview";
+
+    private PreviewTransformActionDeprecated() {
+        super(NAME, PreviewTransformAction.Response::new);
+    }
+
+
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/compat/PutTransformActionDeprecated.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/compat/PutTransformActionDeprecated.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.transform.action.compat;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+
+public class PutTransformActionDeprecated extends ActionType<AcknowledgedResponse> {
+
+    public static final PutTransformActionDeprecated INSTANCE = new PutTransformActionDeprecated();
+    public static final String NAME = "cluster:admin/data_frame/put";
+
+    private PutTransformActionDeprecated() {
+        super(NAME, AcknowledgedResponse::new);
+    }
+
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/compat/StartTransformActionDeprecated.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/compat/StartTransformActionDeprecated.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.transform.action.compat;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.xpack.core.transform.action.StartTransformAction;
+
+public class StartTransformActionDeprecated  extends ActionType<StartTransformAction.Response> {
+
+    public static final StartTransformActionDeprecated INSTANCE = new StartTransformActionDeprecated();
+    public static final String NAME = "cluster:admin/data_frame/start";
+
+    private StartTransformActionDeprecated() {
+        super(NAME, StartTransformAction.Response::new);
+    }
+
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/compat/StopTransformActionDeprecated.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/compat/StopTransformActionDeprecated.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.transform.action.compat;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.xpack.core.transform.action.StopTransformAction;
+
+public class StopTransformActionDeprecated extends ActionType<StopTransformAction.Response> {
+
+    public static final StopTransformActionDeprecated INSTANCE = new StopTransformActionDeprecated();
+    public static final String NAME = "cluster:admin/data_frame/stop";
+
+    private StopTransformActionDeprecated() {
+        super(NAME, StopTransformAction.Response::new);
+    }
+
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/compat/UpdateTransformActionDeprecated.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/compat/UpdateTransformActionDeprecated.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.transform.action.compat;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.xpack.core.transform.action.UpdateTransformAction;
+import org.elasticsearch.xpack.core.transform.action.UpdateTransformAction.Response;
+
+public class UpdateTransformActionDeprecated extends ActionType<UpdateTransformAction.Response> {
+
+    public static final UpdateTransformActionDeprecated INSTANCE = new UpdateTransformActionDeprecated();
+    public static final String NAME = "cluster:admin/data_frame/update";
+
+    private UpdateTransformActionDeprecated() {
+        super(NAME, Response::new);
+    }
+
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.delete_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.delete_transform.json
@@ -1,0 +1,35 @@
+{
+  "data_frame_transform_deprecated.delete_transform":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-transform.html"
+    },
+    "stability":"beta",
+    "url":{
+      "paths":[
+        {
+          "path":"/_data_frame/transforms/{transform_id}",
+          "methods":[
+            "DELETE"
+          ],
+          "parts":{
+            "transform_id":{
+              "type":"string",
+              "description":"The id of the transform to delete"
+            }
+          },
+          "deprecated":{
+            "version":"7.5.0",
+            "description":"[_data_frame/transforms/] is deprecated, use [_transform/] in the future."
+          }
+        }
+      ]
+    },
+    "params":{
+      "force":{
+        "type":"boolean",
+        "required":false,
+        "description":"When `true`, the transform is deleted regardless of its current state. The default value is `false`, meaning that the transform must be `stopped` before it can be deleted."
+      }
+    }
+  }
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.get_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.get_transform.json
@@ -1,0 +1,55 @@
+{
+  "data_frame_transform_deprecated.get_transform":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform.html"
+    },
+    "stability":"beta",
+    "url":{
+      "paths":[
+        {
+          "path":"/_data_frame/transforms/{transform_id}",
+          "methods":[
+            "GET"
+          ],
+          "parts":{
+            "transform_id":{
+              "type":"string",
+              "description":"The id or comma delimited list of id expressions of the transforms to get, '_all' or '*' implies get all transforms"
+            }
+          },
+          "deprecated":{
+            "version":"7.5.0",
+            "description":"[_data_frame/transforms/] is deprecated, use [_transform/] in the future."
+          }
+        },
+        {
+          "path":"/_data_frame/transforms",
+          "methods":[
+            "GET"
+          ],
+          "deprecated":{
+            "version":"7.5.0",
+            "description":"[_data_frame/transforms/] is deprecated, use [_transform/] in the future."
+          }
+        }
+      ]
+    },
+    "params":{
+      "from":{
+        "type":"int",
+        "required":false,
+        "description":"skips a number of transform configs, defaults to 0"
+      },
+      "size":{
+        "type":"int",
+        "required":false,
+        "description":"specifies a max number of transforms to get, defaults to 100"
+      },
+      "allow_no_match":{
+        "type":"boolean",
+        "required":false,
+        "description":"Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)"
+      }
+    }
+  }
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.get_transform_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.get_transform_stats.json
@@ -1,0 +1,45 @@
+{
+  "data_frame_transform_deprecated.get_transform_stats":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform-stats.html"
+    },
+    "stability":"beta",
+    "url":{
+      "paths":[
+        {
+          "path":"/_data_frame/transforms/{transform_id}/_stats",
+          "methods":[
+            "GET"
+          ],
+          "parts":{
+            "transform_id":{
+              "type":"string",
+              "description":"The id of the transform for which to get stats. '_all' or '*' implies all transforms"
+            }
+          },
+          "deprecated":{
+            "version":"7.5.0",
+            "description":"[_data_frame/transforms/] is deprecated, use [_transform/] in the future."
+          }
+        }
+      ]
+    },
+    "params":{
+      "from":{
+        "type":"number",
+        "required":false,
+        "description":"skips a number of transform stats, defaults to 0"
+      },
+      "size":{
+        "type":"number",
+        "required":false,
+        "description":"specifies a max number of transform stats to get, defaults to 100"
+      },
+      "allow_no_match":{
+        "type":"boolean",
+        "required":false,
+        "description":"Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)"
+      }
+    }
+  }
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.preview_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.preview_transform.json
@@ -1,0 +1,26 @@
+{
+  "data_frame_transform_deprecated.preview_transform":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/preview-transform.html"
+    },
+    "stability":"beta",
+    "url":{
+      "paths":[
+        {
+          "path":"/_data_frame/transforms/_preview",
+          "methods":[
+            "POST"
+          ],
+          "deprecated":{
+            "version":"7.5.0",
+            "description":"[_data_frame/transforms/] is deprecated, use [_transform/] in the future."
+          }
+        }
+      ]
+    },
+    "body":{
+      "description":"The definition for the transform to preview",
+      "required":true
+    }
+  }
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.put_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.put_transform.json
@@ -1,0 +1,39 @@
+{
+  "data_frame_transform_deprecated.put_transform":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/put-transform.html"
+    },
+    "stability":"beta",
+    "url":{
+      "paths":[
+        {
+          "path":"/_data_frame/transforms/{transform_id}",
+          "methods":[
+            "PUT"
+          ],
+          "parts":{
+            "transform_id":{
+              "type":"string",
+              "description":"The id of the new transform."
+            }
+          },
+          "deprecated":{
+            "version":"7.5.0",
+            "description":"[_data_frame/transforms/] is deprecated, use [_transform/] in the future."
+          }
+        }
+      ]
+    },
+    "params": {
+      "defer_validation": {
+        "type": "boolean",
+        "required": false,
+        "description": "If validations should be deferred until transform starts, defaults to false."
+      }
+    },
+    "body":{
+      "description":"The transform definition",
+      "required":true
+    }
+  }
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.start_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.start_transform.json
@@ -1,0 +1,35 @@
+{
+  "data_frame_transform_deprecated.start_transform":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/start-transform.html"
+    },
+    "stability":"beta",
+    "url":{
+      "paths":[
+        {
+          "path":"/_data_frame/transforms/{transform_id}/_start",
+          "methods":[
+            "POST"
+          ],
+          "parts":{
+            "transform_id":{
+              "type":"string",
+              "description":"The id of the transform to start"
+            }
+          },
+          "deprecated":{
+            "version":"7.5.0",
+            "description":"[_data_frame/transforms/] is deprecated, use [_transform/] in the future."
+          }
+        }
+      ]
+    },
+    "params":{
+      "timeout":{
+        "type":"time",
+        "required":false,
+        "description":"Controls the time to wait for the transform to start"
+      }
+    }
+  }
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.stop_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.stop_transform.json
@@ -1,0 +1,45 @@
+{
+  "data_frame_transform_deprecated.stop_transform":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-transform.html"
+    },
+    "stability":"beta",
+    "url":{
+      "paths":[
+        {
+          "path":"/_data_frame/transforms/{transform_id}/_stop",
+          "methods":[
+            "POST"
+          ],
+          "parts":{
+            "transform_id":{
+              "type":"string",
+              "description":"The id of the transform to stop"
+            }
+          },
+          "deprecated":{
+            "version":"7.5.0",
+            "description":"[_data_frame/transforms/] is deprecated, use [_transform/] in the future."
+          }
+        }
+      ]
+    },
+    "params":{
+      "wait_for_completion":{
+        "type":"boolean",
+        "required":false,
+        "description":"Whether to wait for the transform to fully stop before returning or not. Default to false"
+      },
+      "timeout":{
+        "type":"time",
+        "required":false,
+        "description":"Controls the time to wait until the transform has stopped. Default to 30 seconds"
+      },
+      "allow_no_match":{
+        "type":"boolean",
+        "required":false,
+        "description":"Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)"
+      }
+    }
+  }
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.update_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.update_transform.json
@@ -1,0 +1,38 @@
+{
+  "data_frame_transform_deprecated.update_transform": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-transform.html"
+    },
+    "stability": "beta",
+    "url": {
+      "paths": [
+        {
+          "path": "/_data_frame/transforms/{transform_id}/_update",
+          "methods": [ "POST" ],
+          "parts": {
+            "transform_id": {
+              "type": "string",
+              "required": true,
+              "description": "The id of the transform."
+            }
+          },
+          "deprecated":{
+            "version":"7.5.0",
+            "description":"[_data_frame/transforms/] is deprecated, use [_transform/] in the future."
+          }
+        }
+      ]
+    },
+    "params": {
+      "defer_validation": {
+        "type": "boolean",
+        "required": false,
+        "description": "If validations should be deferred until transform starts, defaults to false."
+      }
+    },
+    "body": {
+      "description" : "The update transform definition",
+      "required": true
+    }
+  }
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.delete_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.delete_transform.json
@@ -7,7 +7,7 @@
     "url":{
       "paths":[
         {
-          "path":"/_data_frame/transforms/{transform_id}",
+          "path":"/_transform/{transform_id}",
           "methods":[
             "DELETE"
           ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.get_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.get_transform.json
@@ -7,7 +7,7 @@
     "url":{
       "paths":[
         {
-          "path":"/_data_frame/transforms/{transform_id}",
+          "path":"/_transform/{transform_id}",
           "methods":[
             "GET"
           ],
@@ -19,7 +19,7 @@
           }
         },
         {
-          "path":"/_data_frame/transforms",
+          "path":"/_transform",
           "methods":[
             "GET"
           ]

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.get_transform_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.get_transform_stats.json
@@ -7,7 +7,7 @@
     "url":{
       "paths":[
         {
-          "path":"/_data_frame/transforms/{transform_id}/_stats",
+          "path":"/_transform/{transform_id}/_stats",
           "methods":[
             "GET"
           ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.preview_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.preview_transform.json
@@ -7,7 +7,7 @@
     "url":{
       "paths":[
         {
-          "path":"/_data_frame/transforms/_preview",
+          "path":"/_transform/_preview",
           "methods":[
             "POST"
           ]

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.put_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.put_transform.json
@@ -7,7 +7,7 @@
     "url":{
       "paths":[
         {
-          "path":"/_data_frame/transforms/{transform_id}",
+          "path":"/_transform/{transform_id}",
           "methods":[
             "PUT"
           ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.start_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.start_transform.json
@@ -7,7 +7,7 @@
     "url":{
       "paths":[
         {
-          "path":"/_data_frame/transforms/{transform_id}/_start",
+          "path":"/_transform/{transform_id}/_start",
           "methods":[
             "POST"
           ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.stop_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.stop_transform.json
@@ -7,7 +7,7 @@
     "url":{
       "paths":[
         {
-          "path":"/_data_frame/transforms/{transform_id}/_stop",
+          "path":"/_transform/{transform_id}/_stop",
           "methods":[
             "POST"
           ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.update_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.update_transform.json
@@ -7,7 +7,7 @@
     "url": {
       "paths": [
         {
-          "path": "/_data_frame/transforms/{transform_id}/_update",
+          "path": "/_transform/{transform_id}/_update",
           "methods": [ "POST" ],
           "parts": {
             "transform_id": {

--- a/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformConfigurationIndexIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformConfigurationIndexIT.java
@@ -50,7 +50,7 @@ public class TransformConfigurationIndexIT extends TransformRestTestCase {
         // refresh the index
         assertOK(client().performRequest(new Request("POST", TransformInternalIndexConstants.LATEST_INDEX_NAME + "/_refresh")));
 
-        Request deleteRequest = new Request("DELETE", TRANSFORM_ENDPOINT + fakeTransformName);
+        Request deleteRequest = new Request("DELETE", getTransformEndpoint() + fakeTransformName);
         Response deleteResponse = client().performRequest(deleteRequest);
         assertOK(deleteResponse);
         assertTrue((boolean)XContentMapValues.extractValue("acknowledged", entityAsMap(deleteResponse)));

--- a/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformGetAndGetStatsIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformGetAndGetStatsIT.java
@@ -78,19 +78,19 @@ public class TransformGetAndGetStatsIT extends TransformRestTestCase {
         String authHeader = randomFrom(BASIC_AUTH_VALUE_TRANSFORM_USER, BASIC_AUTH_VALUE_TRANSFORM_ADMIN);
 
         // check all the different ways to retrieve all stats
-        Request getRequest = createRequestWithAuth("GET", TRANSFORM_ENDPOINT + "_stats", authHeader);
+        Request getRequest = createRequestWithAuth("GET", getTransformEndpoint() + "_stats", authHeader);
         Map<String, Object> stats = entityAsMap(client().performRequest(getRequest));
         assertEquals(3, XContentMapValues.extractValue("count", stats));
-        getRequest = createRequestWithAuth("GET", TRANSFORM_ENDPOINT + "_all/_stats", authHeader);
+        getRequest = createRequestWithAuth("GET", getTransformEndpoint() + "_all/_stats", authHeader);
         stats = entityAsMap(client().performRequest(getRequest));
         assertEquals(3, XContentMapValues.extractValue("count", stats));
-        getRequest = createRequestWithAuth("GET", TRANSFORM_ENDPOINT + "*/_stats", authHeader);
+        getRequest = createRequestWithAuth("GET", getTransformEndpoint() + "*/_stats", authHeader);
         stats = entityAsMap(client().performRequest(getRequest));
         assertEquals(3, XContentMapValues.extractValue("count", stats));
-        getRequest = createRequestWithAuth("GET", TRANSFORM_ENDPOINT + "pivot_1,pivot_2/_stats", authHeader);
+        getRequest = createRequestWithAuth("GET", getTransformEndpoint() + "pivot_1,pivot_2/_stats", authHeader);
         stats = entityAsMap(client().performRequest(getRequest));
         assertEquals(2, XContentMapValues.extractValue("count", stats));
-        getRequest = createRequestWithAuth("GET", TRANSFORM_ENDPOINT + "pivot_*/_stats", authHeader);
+        getRequest = createRequestWithAuth("GET", getTransformEndpoint() + "pivot_*/_stats", authHeader);
         stats = entityAsMap(client().performRequest(getRequest));
         assertEquals(3, XContentMapValues.extractValue("count", stats));
 
@@ -111,7 +111,7 @@ public class TransformGetAndGetStatsIT extends TransformRestTestCase {
         }
 
         // only pivot_1
-        getRequest = createRequestWithAuth("GET", TRANSFORM_ENDPOINT + "pivot_1/_stats", authHeader);
+        getRequest = createRequestWithAuth("GET", getTransformEndpoint() + "pivot_1/_stats", authHeader);
         stats = entityAsMap(client().performRequest(getRequest));
         assertEquals(1, XContentMapValues.extractValue("count", stats));
 
@@ -122,7 +122,7 @@ public class TransformGetAndGetStatsIT extends TransformRestTestCase {
         assertEquals(1, XContentMapValues.extractValue("checkpointing.last.checkpoint", transformsStats.get(0)));
 
         // only continuous
-        getRequest = createRequestWithAuth("GET", TRANSFORM_ENDPOINT + "pivot_continuous/_stats", authHeader);
+        getRequest = createRequestWithAuth("GET", getTransformEndpoint() + "pivot_continuous/_stats", authHeader);
         stats = entityAsMap(client().performRequest(getRequest));
         assertEquals(1, XContentMapValues.extractValue("count", stats));
 
@@ -133,18 +133,18 @@ public class TransformGetAndGetStatsIT extends TransformRestTestCase {
 
 
         // check all the different ways to retrieve all transforms
-        getRequest = createRequestWithAuth("GET", TRANSFORM_ENDPOINT, authHeader);
+        getRequest = createRequestWithAuth("GET", getTransformEndpoint(), authHeader);
         Map<String, Object> transforms = entityAsMap(client().performRequest(getRequest));
         assertEquals(3, XContentMapValues.extractValue("count", transforms));
-        getRequest = createRequestWithAuth("GET", TRANSFORM_ENDPOINT + "_all", authHeader);
+        getRequest = createRequestWithAuth("GET", getTransformEndpoint() + "_all", authHeader);
         transforms = entityAsMap(client().performRequest(getRequest));
         assertEquals(3, XContentMapValues.extractValue("count", transforms));
-        getRequest = createRequestWithAuth("GET", TRANSFORM_ENDPOINT + "*", authHeader);
+        getRequest = createRequestWithAuth("GET", getTransformEndpoint() + "*", authHeader);
         transforms = entityAsMap(client().performRequest(getRequest));
         assertEquals(3, XContentMapValues.extractValue("count", transforms));
 
         // only pivot_1
-        getRequest = createRequestWithAuth("GET", TRANSFORM_ENDPOINT + "pivot_1", authHeader);
+        getRequest = createRequestWithAuth("GET", getTransformEndpoint() + "pivot_1", authHeader);
         transforms = entityAsMap(client().performRequest(getRequest));
         assertEquals(1, XContentMapValues.extractValue("count", transforms));
 
@@ -168,7 +168,7 @@ public class TransformGetAndGetStatsIT extends TransformRestTestCase {
         createPivotReviewsTransform("pivot_stats_2", "pivot_reviews_stats_2", null);
         startAndWaitForTransform("pivot_stats_2", "pivot_reviews_stats_2");
 
-        Request getRequest = createRequestWithAuth("GET", TRANSFORM_ENDPOINT + "_stats", BASIC_AUTH_VALUE_TRANSFORM_ADMIN);
+        Request getRequest = createRequestWithAuth("GET", getTransformEndpoint() + "_stats", BASIC_AUTH_VALUE_TRANSFORM_ADMIN);
         Map<String, Object> stats = entityAsMap(client().performRequest(getRequest));
         assertEquals(2, XContentMapValues.extractValue("count", stats));
         List<Map<String, Object>> transformsStats = (List<Map<String, Object>>)XContentMapValues.extractValue("transforms", stats);
@@ -192,7 +192,7 @@ public class TransformGetAndGetStatsIT extends TransformRestTestCase {
         // Alternate testing between admin and lowly user, as both should be able to get the configs and stats
         String authHeader = randomFrom(BASIC_AUTH_VALUE_TRANSFORM_USER, BASIC_AUTH_VALUE_TRANSFORM_ADMIN);
 
-        Request getRequest = createRequestWithAuth("GET", TRANSFORM_ENDPOINT + transformId + "/_stats", authHeader);
+        Request getRequest = createRequestWithAuth("GET", getTransformEndpoint() + transformId + "/_stats", authHeader);
         Map<String, Object> stats = entityAsMap(client().performRequest(getRequest));
         assertEquals(1, XContentMapValues.extractValue("count", stats));
         List<Map<String, Object>> transformsStats = (List<Map<String, Object>>)XContentMapValues.extractValue("transforms", stats);
@@ -218,7 +218,7 @@ public class TransformGetAndGetStatsIT extends TransformRestTestCase {
         String transformDest = transformId + "_idx";
         String transformSrc = "reviews_cont_pivot_test";
         createReviewsIndex(transformSrc);
-        final Request createTransformRequest = createRequestWithAuth("PUT", TRANSFORM_ENDPOINT + transformId, null);
+        final Request createTransformRequest = createRequestWithAuth("PUT", getTransformEndpoint() + transformId, null);
         String config = "{ \"dest\": {\"index\":\"" + transformDest + "\"},"
             + " \"source\": {\"index\":\"" + transformSrc + "\"},"
             + " \"frequency\": \"1s\","
@@ -242,7 +242,7 @@ public class TransformGetAndGetStatsIT extends TransformRestTestCase {
         assertThat(createTransformResponse.get("acknowledged"), equalTo(Boolean.TRUE));
         startAndWaitForContinuousTransform(transformId, transformDest, null);
 
-        Request getRequest = createRequestWithAuth("GET", TRANSFORM_ENDPOINT + transformId + "/_stats", null);
+        Request getRequest = createRequestWithAuth("GET", getTransformEndpoint() + transformId + "/_stats", null);
         Map<String, Object> stats = entityAsMap(client().performRequest(getRequest));
         List<Map<String, Object>> transformsStats = (List<Map<String, Object>>)XContentMapValues.extractValue("transforms", stats);
         assertEquals(1, transformsStats.size());

--- a/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformInternalIndexIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformInternalIndexIT.java
@@ -12,12 +12,6 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.search.SearchModule;
-import org.elasticsearch.xpack.core.transform.TransformField;
-import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
-import org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.transform.GetTransformRequest;
 import org.elasticsearch.client.transform.GetTransformResponse;
@@ -26,17 +20,23 @@ import org.elasticsearch.client.transform.UpdateTransformResponse;
 import org.elasticsearch.client.transform.transforms.TransformConfigUpdate;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.xpack.core.transform.TransformField;
+import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
+import org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collections;
 
-import static org.hamcrest.Matchers.is;
 import static org.elasticsearch.xpack.transform.persistence.TransformInternalIndex.addTransformsConfigMappings;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 
 public class TransformInternalIndexIT extends ESRestTestCase {

--- a/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
@@ -134,7 +134,7 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         String transformId = "simple_bucket_selector_pivot";
         String transformIndex = "bucket_selector_idx";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, transformIndex);
-        final Request createTransformRequest = createRequestWithAuth("PUT", TRANSFORM_ENDPOINT + transformId,
+        final Request createTransformRequest = createRequestWithAuth("PUT", getTransformEndpoint() + transformId,
             BASIC_AUTH_VALUE_TRANSFORM_ADMIN_WITH_SOME_DATA_ACCESS);
         String config = "{"
             + " \"source\": {\"index\":\"" + REVIEWS_INDEX_NAME + "\"},"
@@ -179,7 +179,7 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         String transformId = "simple_continuous_pivot";
         String transformIndex = "pivot_reviews_continuous";
         setupDataAccessRole(DATA_ACCESS_ROLE, indexName, transformIndex);
-        final Request createTransformRequest = createRequestWithAuth("PUT", TRANSFORM_ENDPOINT + transformId,
+        final Request createTransformRequest = createRequestWithAuth("PUT", getTransformEndpoint() + transformId,
             BASIC_AUTH_VALUE_TRANSFORM_ADMIN_WITH_SOME_DATA_ACCESS);
         String config = "{"
             + " \"source\": {\"index\":\"" + indexName + "\"},"
@@ -293,7 +293,7 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         String transformIndex = "pivot_reviews_via_histogram";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, transformIndex);
 
-        final Request createTransformRequest = createRequestWithAuth("PUT", TRANSFORM_ENDPOINT + transformId,
+        final Request createTransformRequest = createRequestWithAuth("PUT", getTransformEndpoint() + transformId,
             BASIC_AUTH_VALUE_TRANSFORM_ADMIN_WITH_SOME_DATA_ACCESS);
 
         String config = "{"
@@ -331,7 +331,7 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         String transformIndex = "bigger_pivot_reviews";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, transformIndex);
 
-        final Request createTransformRequest = createRequestWithAuth("PUT", TRANSFORM_ENDPOINT + transformId,
+        final Request createTransformRequest = createRequestWithAuth("PUT", getTransformEndpoint() + transformId,
             BASIC_AUTH_VALUE_TRANSFORM_ADMIN_WITH_SOME_DATA_ACCESS);
 
         String config = "{"
@@ -406,7 +406,7 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         String transformIndex = "pivot_reviews_via_date_histogram";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, transformIndex);
 
-        final Request createTransformRequest = createRequestWithAuth("PUT", TRANSFORM_ENDPOINT + transformId,
+        final Request createTransformRequest = createRequestWithAuth("PUT", getTransformEndpoint() + transformId,
             BASIC_AUTH_VALUE_TRANSFORM_ADMIN_WITH_SOME_DATA_ACCESS);
 
         String config = "{"
@@ -442,7 +442,7 @@ public class TransformPivotRestIT extends TransformRestTestCase {
     @SuppressWarnings("unchecked")
     public void testPreviewTransform() throws Exception {
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME);
-        final Request createPreviewRequest = createRequestWithAuth("POST", TRANSFORM_ENDPOINT + "_preview",
+        final Request createPreviewRequest = createRequestWithAuth("POST", getTransformEndpoint() + "_preview",
             BASIC_AUTH_VALUE_TRANSFORM_ADMIN_WITH_SOME_DATA_ACCESS);
 
         String config = "{"
@@ -494,7 +494,7 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         client().performRequest(pipelineRequest);
 
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME);
-        final Request createPreviewRequest = createRequestWithAuth("POST", TRANSFORM_ENDPOINT + "_preview", null);
+        final Request createPreviewRequest = createRequestWithAuth("POST", getTransformEndpoint() + "_preview", null);
 
         String config = "{ \"source\": {\"index\":\"" + REVIEWS_INDEX_NAME + "\"} ,"
             + "\"dest\": {\"pipeline\": \"" + pipelineId + "\"},"
@@ -531,7 +531,7 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         String transformIndex = "pivot_reviews_via_date_histogram_with_max_time";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, transformIndex);
 
-        final Request createTransformRequest = createRequestWithAuth("PUT", TRANSFORM_ENDPOINT + transformId,
+        final Request createTransformRequest = createRequestWithAuth("PUT", getTransformEndpoint() + transformId,
             BASIC_AUTH_VALUE_TRANSFORM_ADMIN_WITH_SOME_DATA_ACCESS);
 
         String config = "{"
@@ -578,7 +578,7 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         String transformIndex = "scripted_metric_pivot_reviews";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, transformIndex);
 
-        final Request createTransformRequest = createRequestWithAuth("PUT", TRANSFORM_ENDPOINT + transformId,
+        final Request createTransformRequest = createRequestWithAuth("PUT", getTransformEndpoint() + transformId,
             BASIC_AUTH_VALUE_TRANSFORM_ADMIN_WITH_SOME_DATA_ACCESS);
 
         String config = "{"
@@ -631,7 +631,7 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         String transformIndex = "bucket_script_pivot_reviews";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, transformIndex);
 
-        final Request createTransformRequest = createRequestWithAuth("PUT", TRANSFORM_ENDPOINT + transformId,
+        final Request createTransformRequest = createRequestWithAuth("PUT", getTransformEndpoint() + transformId,
             BASIC_AUTH_VALUE_TRANSFORM_ADMIN_WITH_SOME_DATA_ACCESS);
 
         String config = "{"
@@ -683,7 +683,7 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         String transformIndex = "geo_bounds_pivot_reviews";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, transformIndex);
 
-        final Request createTransformRequest = createRequestWithAuth("PUT", TRANSFORM_ENDPOINT + transformId,
+        final Request createTransformRequest = createRequestWithAuth("PUT", getTransformEndpoint() + transformId,
             BASIC_AUTH_VALUE_TRANSFORM_ADMIN_WITH_SOME_DATA_ACCESS);
 
         String config = "{"
@@ -736,7 +736,7 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         String transformIndex = "geo_centroid_pivot_reviews";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, transformIndex);
 
-        final Request createTransformRequest = createRequestWithAuth("PUT", TRANSFORM_ENDPOINT + transformId,
+        final Request createTransformRequest = createRequestWithAuth("PUT", getTransformEndpoint() + transformId,
             BASIC_AUTH_VALUE_TRANSFORM_ADMIN_WITH_SOME_DATA_ACCESS);
 
         String config = "{"
@@ -786,7 +786,7 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         String transformIndex = "weighted_avg_pivot_reviews";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, transformIndex);
 
-        final Request createTransformRequest = createRequestWithAuth("PUT", TRANSFORM_ENDPOINT + transformId,
+        final Request createTransformRequest = createRequestWithAuth("PUT", getTransformEndpoint() + transformId,
             BASIC_AUTH_VALUE_TRANSFORM_ADMIN_WITH_SOME_DATA_ACCESS);
 
         String config = "{"
@@ -824,7 +824,7 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         String transformId = "test_with_many_buckets";
         String transformIndex = transformId + "-idx";
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME, transformIndex);
-        final Request createTransformRequest = createRequestWithAuth("PUT", TRANSFORM_ENDPOINT + transformId,
+        final Request createTransformRequest = createRequestWithAuth("PUT", getTransformEndpoint() + transformId,
             BASIC_AUTH_VALUE_TRANSFORM_ADMIN_WITH_SOME_DATA_ACCESS);
 
         String config = "{"
@@ -853,7 +853,7 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         startAndWaitForTransform(transformId, transformIndex, BASIC_AUTH_VALUE_TRANSFORM_ADMIN_WITH_SOME_DATA_ACCESS);
         assertTrue(indexExists(transformIndex));
 
-        Map<String, Object> stats = getAsMap(TRANSFORM_ENDPOINT + transformId + "/_stats");
+        Map<String, Object> stats = getAsMap(getTransformEndpoint() + transformId + "/_stats");
         assertEquals(101, ((List<?>)XContentMapValues.extractValue("transforms.stats.pages_processed", stats)).get(0));
     }
 

--- a/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformUsageIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformUsageIT.java
@@ -64,7 +64,7 @@ public class TransformUsageIT extends TransformRestTestCase {
 
         startAndWaitForContinuousTransform("test_usage_continuous", "pivot_reviews_continuous", null);
 
-        Request getRequest = new Request("GET", TRANSFORM_ENDPOINT + "test_usage/_stats");
+        Request getRequest = new Request("GET", getTransformEndpoint() + "test_usage/_stats");
         Map<String, Object> stats = entityAsMap(client().performRequest(getRequest));
         Map<String, Integer> expectedStats = new HashMap<>();
         for(String statName : PROVIDED_STATS) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
@@ -52,6 +52,14 @@ import org.elasticsearch.xpack.core.transform.action.PutTransformAction;
 import org.elasticsearch.xpack.core.transform.action.StartTransformAction;
 import org.elasticsearch.xpack.core.transform.action.StopTransformAction;
 import org.elasticsearch.xpack.core.transform.action.UpdateTransformAction;
+import org.elasticsearch.xpack.core.transform.action.compat.DeleteTransformActionDeprecated;
+import org.elasticsearch.xpack.core.transform.action.compat.GetTransformActionDeprecated;
+import org.elasticsearch.xpack.core.transform.action.compat.GetTransformStatsActionDeprecated;
+import org.elasticsearch.xpack.core.transform.action.compat.PreviewTransformActionDeprecated;
+import org.elasticsearch.xpack.core.transform.action.compat.PutTransformActionDeprecated;
+import org.elasticsearch.xpack.core.transform.action.compat.StartTransformActionDeprecated;
+import org.elasticsearch.xpack.core.transform.action.compat.StopTransformActionDeprecated;
+import org.elasticsearch.xpack.core.transform.action.compat.UpdateTransformActionDeprecated;
 import org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants;
 import org.elasticsearch.xpack.transform.action.TransportDeleteTransformAction;
 import org.elasticsearch.xpack.transform.action.TransportGetTransformAction;
@@ -61,6 +69,14 @@ import org.elasticsearch.xpack.transform.action.TransportPutTransformAction;
 import org.elasticsearch.xpack.transform.action.TransportStartTransformAction;
 import org.elasticsearch.xpack.transform.action.TransportStopTransformAction;
 import org.elasticsearch.xpack.transform.action.TransportUpdateTransformAction;
+import org.elasticsearch.xpack.transform.action.compat.TransportDeleteTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.action.compat.TransportGetTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.action.compat.TransportGetTransformStatsActionDeprecated;
+import org.elasticsearch.xpack.transform.action.compat.TransportPreviewTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.action.compat.TransportPutTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.action.compat.TransportStartTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.action.compat.TransportStopTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.action.compat.TransportUpdateTransformActionDeprecated;
 import org.elasticsearch.xpack.transform.checkpoint.TransformCheckpointService;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
 import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
@@ -73,6 +89,14 @@ import org.elasticsearch.xpack.transform.rest.action.RestPutTransformAction;
 import org.elasticsearch.xpack.transform.rest.action.RestStartTransformAction;
 import org.elasticsearch.xpack.transform.rest.action.RestStopTransformAction;
 import org.elasticsearch.xpack.transform.rest.action.RestUpdateTransformAction;
+import org.elasticsearch.xpack.transform.rest.action.compat.RestDeleteTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.rest.action.compat.RestGetTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.rest.action.compat.RestGetTransformStatsActionDeprecated;
+import org.elasticsearch.xpack.transform.rest.action.compat.RestPreviewTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.rest.action.compat.RestPutTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.rest.action.compat.RestStartTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.rest.action.compat.RestStopTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.rest.action.compat.RestUpdateTransformActionDeprecated;
 import org.elasticsearch.xpack.transform.transforms.TransformPersistentTasksExecutor;
 import org.elasticsearch.xpack.transform.transforms.TransformTask;
 
@@ -141,7 +165,17 @@ public class Transform extends Plugin implements ActionPlugin, PersistentTaskPlu
                 new RestGetTransformAction(restController),
                 new RestGetTransformStatsAction(restController),
                 new RestPreviewTransformAction(restController),
-                new RestUpdateTransformAction(restController)
+                new RestUpdateTransformAction(restController),
+
+                // deprecated endpoints, to be removed for 8.0.0
+                new RestPutTransformActionDeprecated(restController),
+                new RestStartTransformActionDeprecated(restController),
+                new RestStopTransformActionDeprecated(restController),
+                new RestDeleteTransformActionDeprecated(restController),
+                new RestGetTransformActionDeprecated(restController),
+                new RestGetTransformStatsActionDeprecated(restController),
+                new RestPreviewTransformActionDeprecated(restController),
+                new RestUpdateTransformActionDeprecated(restController)
         );
     }
 
@@ -159,8 +193,18 @@ public class Transform extends Plugin implements ActionPlugin, PersistentTaskPlu
                 new ActionHandler<>(GetTransformAction.INSTANCE, TransportGetTransformAction.class),
                 new ActionHandler<>(GetTransformStatsAction.INSTANCE, TransportGetTransformStatsAction.class),
                 new ActionHandler<>(PreviewTransformAction.INSTANCE, TransportPreviewTransformAction.class),
-                new ActionHandler<>(UpdateTransformAction.INSTANCE, TransportUpdateTransformAction.class)
-                );
+                new ActionHandler<>(UpdateTransformAction.INSTANCE, TransportUpdateTransformAction.class),
+
+                // deprecated actions, to be removed for 8.0.0
+                new ActionHandler<>(PutTransformActionDeprecated.INSTANCE, TransportPutTransformActionDeprecated.class),
+                new ActionHandler<>(StartTransformActionDeprecated.INSTANCE, TransportStartTransformActionDeprecated.class),
+                new ActionHandler<>(StopTransformActionDeprecated.INSTANCE, TransportStopTransformActionDeprecated.class),
+                new ActionHandler<>(DeleteTransformActionDeprecated.INSTANCE, TransportDeleteTransformActionDeprecated.class),
+                new ActionHandler<>(GetTransformActionDeprecated.INSTANCE, TransportGetTransformActionDeprecated.class),
+                new ActionHandler<>(GetTransformStatsActionDeprecated.INSTANCE, TransportGetTransformStatsActionDeprecated.class),
+                new ActionHandler<>(PreviewTransformActionDeprecated.INSTANCE, TransportPreviewTransformActionDeprecated.class),
+                new ActionHandler<>(UpdateTransformActionDeprecated.INSTANCE, TransportUpdateTransformActionDeprecated.class)
+            );
     }
 
     @Override
@@ -170,7 +214,7 @@ public class Transform extends Plugin implements ActionPlugin, PersistentTaskPlu
         }
 
         FixedExecutorBuilder indexing = new FixedExecutorBuilder(settings, TASK_THREAD_POOL_NAME, 4, 4,
-                "data_frame.task_thread_pool");
+                "transform.task_thread_pool");
 
         return Collections.singletonList(indexing);
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportDeleteTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportDeleteTransformAction.java
@@ -23,8 +23,8 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.transform.action.DeleteTransformAction;
-import org.elasticsearch.xpack.core.transform.action.StopTransformAction;
 import org.elasticsearch.xpack.core.transform.action.DeleteTransformAction.Request;
+import org.elasticsearch.xpack.core.transform.action.StopTransformAction;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
 import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 
@@ -35,18 +35,25 @@ import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
 public class TransportDeleteTransformAction extends TransportMasterNodeAction<Request, AcknowledgedResponse> {
 
-    private final TransformConfigManager transformsConfigManager;
+    private final TransformConfigManager transformConfigManager;
     private final TransformAuditor auditor;
     private final Client client;
 
     @Inject
     public TransportDeleteTransformAction(TransportService transportService, ActionFilters actionFilters, ThreadPool threadPool,
-                                                   ClusterService clusterService, IndexNameExpressionResolver indexNameExpressionResolver,
-                                                   TransformConfigManager transformsConfigManager, TransformAuditor auditor,
-                                                   Client client) {
-        super(DeleteTransformAction.NAME, transportService, clusterService, threadPool, actionFilters,
-                Request::new, indexNameExpressionResolver);
-        this.transformsConfigManager = transformsConfigManager;
+                                          ClusterService clusterService, IndexNameExpressionResolver indexNameExpressionResolver,
+                                          TransformConfigManager transformsConfigManager, TransformAuditor auditor,
+                                          Client client) {
+        this(DeleteTransformAction.NAME, transportService, actionFilters, threadPool, clusterService, indexNameExpressionResolver,
+             transformsConfigManager, auditor, client);
+    }
+
+    protected TransportDeleteTransformAction(String name, TransportService transportService, ActionFilters actionFilters,
+                                             ThreadPool threadPool, ClusterService clusterService,
+                                             IndexNameExpressionResolver indexNameExpressionResolver,
+                                             TransformConfigManager transformConfigManager, TransformAuditor auditor, Client client) {
+        super(name, transportService, clusterService, threadPool, actionFilters, Request::new, indexNameExpressionResolver);
+        this.transformConfigManager = transformConfigManager;
         this.auditor = auditor;
         this.client = client;
     }
@@ -70,7 +77,7 @@ public class TransportDeleteTransformAction extends TransportMasterNodeAction<Re
                     "] as the task is running. Stop the task first", RestStatus.CONFLICT));
         } else {
             ActionListener<Void> stopTransformActionListener = ActionListener.wrap(
-                stopResponse -> transformsConfigManager.deleteTransform(request.getId(),
+                stopResponse -> transformConfigManager.deleteTransform(request.getId(),
                     ActionListener.wrap(
                         r -> {
                             auditor.info(request.getId(), "Deleted transform.");

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformAction.java
@@ -38,9 +38,14 @@ public class TransportGetTransformAction extends AbstractTransportGetResourcesAc
                                                                                      Response> {
 
     @Inject
-    public TransportGetTransformAction(TransportService transportService, ActionFilters actionFilters,
-                                       Client client, NamedXContentRegistry xContentRegistry) {
-        super(GetTransformAction.NAME, transportService, actionFilters, Request::new, client, xContentRegistry);
+    public TransportGetTransformAction(TransportService transportService, ActionFilters actionFilters, Client client,
+                                       NamedXContentRegistry xContentRegistry) {
+        this(GetTransformAction.NAME, transportService, actionFilters, client, xContentRegistry);
+    }
+
+    protected TransportGetTransformAction(String name, TransportService transportService, ActionFilters actionFilters, Client client,
+                                          NamedXContentRegistry xContentRegistry) {
+        super(name, transportService, actionFilters, Request::new, client, xContentRegistry);
     }
 
     @Override

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
@@ -59,13 +59,21 @@ public class TransportGetTransformStatsAction extends
     @Inject
     public TransportGetTransformStatsAction(TransportService transportService, ActionFilters actionFilters,
                                             ClusterService clusterService,
-                                            TransformConfigManager transformsConfigManager,
+                                            TransformConfigManager transformConfigManager,
                                             TransformCheckpointService transformsCheckpointService) {
-        super(GetTransformStatsAction.NAME, clusterService, transportService, actionFilters, Request::new, Response::new,
+        this(GetTransformStatsAction.NAME, transportService, actionFilters, clusterService, transformConfigManager,
+             transformsCheckpointService);
+    }
+
+    protected TransportGetTransformStatsAction(String name, TransportService transportService, ActionFilters actionFilters,
+                                               ClusterService clusterService, TransformConfigManager transformsConfigManager,
+                                               TransformCheckpointService transformsCheckpointService) {
+        super(name, clusterService, transportService, actionFilters, Request::new, Response::new,
             Response::new, ThreadPool.Names.SAME);
         this.transformConfigManager = transformsConfigManager;
         this.transformCheckpointService = transformsCheckpointService;
     }
+
 
     @Override
     protected Response newResponse(Request request, List<Response> tasks, List<TaskOperationFailure> taskOperationFailures,

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
@@ -43,9 +43,9 @@ import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.TransformMessages;
 import org.elasticsearch.xpack.core.transform.action.PreviewTransformAction;
-import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerStats;
-import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.core.transform.transforms.SourceConfig;
+import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
+import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerStats;
 import org.elasticsearch.xpack.transform.transforms.pivot.AggregationResultUtils;
 import org.elasticsearch.xpack.transform.transforms.pivot.Pivot;
 
@@ -74,7 +74,15 @@ public class TransportPreviewTransformAction extends
                                                     Client client, ThreadPool threadPool, XPackLicenseState licenseState,
                                                     IndexNameExpressionResolver indexNameExpressionResolver,
                                                     ClusterService clusterService) {
-        super(PreviewTransformAction.NAME,transportService, actionFilters, PreviewTransformAction.Request::new);
+        this(PreviewTransformAction.NAME,transportService, actionFilters, client, threadPool, licenseState, indexNameExpressionResolver,
+             clusterService);
+    }
+
+    protected TransportPreviewTransformAction(String name, TransportService transportService, ActionFilters actionFilters,
+                                              Client client, ThreadPool threadPool, XPackLicenseState licenseState,
+                                              IndexNameExpressionResolver indexNameExpressionResolver,
+                                              ClusterService clusterService) {
+        super(name, transportService, actionFilters, PreviewTransformAction.Request::new);
         this.licenseState = licenseState;
         this.client = client;
         this.threadPool = threadPool;

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
@@ -61,7 +61,7 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
 
     private final XPackLicenseState licenseState;
     private final Client client;
-    private final TransformConfigManager transformsConfigManager;
+    private final TransformConfigManager transformConfigManager;
     private final SecurityContext securityContext;
     private final TransformAuditor auditor;
 
@@ -69,17 +69,27 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
     public TransportPutTransformAction(Settings settings, TransportService transportService, ThreadPool threadPool,
                                        ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
                                        ClusterService clusterService, XPackLicenseState licenseState,
-                                       TransformConfigManager transformsConfigManager, Client client,
+                                       TransformConfigManager transformConfigManager, Client client,
                                        TransformAuditor auditor) {
-        super(PutTransformAction.NAME, transportService, clusterService, threadPool, actionFilters,
-                PutTransformAction.Request::new, indexNameExpressionResolver);
+        this(PutTransformAction.NAME, settings, transportService, threadPool, actionFilters, indexNameExpressionResolver,
+             clusterService, licenseState, transformConfigManager, client, auditor);
+    }
+
+    protected TransportPutTransformAction(String name, Settings settings, TransportService transportService, ThreadPool threadPool,
+                                          ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
+                                          ClusterService clusterService, XPackLicenseState licenseState,
+                                          TransformConfigManager transformConfigManager, Client client,
+                                          TransformAuditor auditor) {
+        super(name, transportService, clusterService, threadPool, actionFilters,
+              PutTransformAction.Request::new, indexNameExpressionResolver);
         this.licenseState = licenseState;
         this.client = client;
-        this.transformsConfigManager = transformsConfigManager;
+        this.transformConfigManager = transformConfigManager;
         this.securityContext = XPackSettings.SECURITY_ENABLED.get(settings) ?
             new SecurityContext(settings, threadPool.getThreadContext()) : null;
         this.auditor = auditor;
     }
+
 
     static HasPrivilegesRequest buildPrivilegeCheck(TransformConfig config,
                                                     IndexNameExpressionResolver indexNameExpressionResolver,
@@ -220,7 +230,7 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
 
         // <2> Put our transform
         ActionListener<Boolean> pivotValidationListener = ActionListener.wrap(
-            validationResult -> transformsConfigManager.putTransformConfiguration(config, putTransformConfigurationListener),
+            validationResult -> transformConfigManager.putTransformConfiguration(config, putTransformConfigurationListener),
             validationException -> {
                 if (validationException instanceof ElasticsearchStatusException) {
                     listener.onFailure(new ElasticsearchStatusException(

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
@@ -36,9 +36,9 @@ import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.transform.TransformMessages;
 import org.elasticsearch.xpack.core.transform.action.StartTransformAction;
-import org.elasticsearch.xpack.core.transform.transforms.TransformTaskParams;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformState;
+import org.elasticsearch.xpack.core.transform.transforms.TransformTaskParams;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskState;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
 import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
@@ -61,7 +61,7 @@ public class TransportStartTransformAction extends
 
     private static final Logger logger = LogManager.getLogger(TransportStartTransformAction.class);
     private final XPackLicenseState licenseState;
-    private final TransformConfigManager transformsConfigManager;
+    private final TransformConfigManager transformConfigManager;
     private final PersistentTasksService persistentTasksService;
     private final Client client;
     private final TransformAuditor auditor;
@@ -70,13 +70,23 @@ public class TransportStartTransformAction extends
     public TransportStartTransformAction(TransportService transportService, ActionFilters actionFilters,
                                          ClusterService clusterService, XPackLicenseState licenseState,
                                          ThreadPool threadPool, IndexNameExpressionResolver indexNameExpressionResolver,
-                                         TransformConfigManager transformsConfigManager,
+                                         TransformConfigManager transformConfigManager,
                                          PersistentTasksService persistentTasksService, Client client,
                                          TransformAuditor auditor) {
-        super(StartTransformAction.NAME, transportService, clusterService, threadPool, actionFilters,
-                StartTransformAction.Request::new, indexNameExpressionResolver);
+        this(StartTransformAction.NAME, transportService, actionFilters, clusterService, licenseState, threadPool,
+             indexNameExpressionResolver, transformConfigManager, persistentTasksService, client, auditor);
+    }
+
+    protected TransportStartTransformAction(String name, TransportService transportService, ActionFilters actionFilters,
+                                            ClusterService clusterService, XPackLicenseState licenseState,
+                                            ThreadPool threadPool, IndexNameExpressionResolver indexNameExpressionResolver,
+                                            TransformConfigManager transformConfigManager,
+                                            PersistentTasksService persistentTasksService, Client client,
+                                            TransformAuditor auditor) {
+        super(name, transportService, clusterService, threadPool, actionFilters, StartTransformAction.Request::new,
+              indexNameExpressionResolver);
         this.licenseState = licenseState;
-        this.transformsConfigManager = transformsConfigManager;
+        this.transformConfigManager = transformConfigManager;
         this.persistentTasksService = persistentTasksService;
         this.client = client;
         this.auditor = auditor;
@@ -208,7 +218,7 @@ public class TransportStartTransformAction extends
         );
 
         // <1> Get the config to verify it exists and is valid
-        transformsConfigManager.getTransformConfiguration(request.getId(), getTransformListener);
+        transformConfigManager.getTransformConfiguration(request.getId(), getTransformListener);
     }
 
     private void createDestinationIndex(final TransformConfig config, final ActionListener<Void> listener) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
@@ -54,7 +54,7 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
     private static final Logger logger = LogManager.getLogger(TransportStopTransformAction.class);
 
     private final ThreadPool threadPool;
-    private final TransformConfigManager transformsConfigManager;
+    private final TransformConfigManager transformConfigManager;
     private final PersistentTasksService persistentTasksService;
     private final Client client;
 
@@ -62,12 +62,21 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
     public TransportStopTransformAction(TransportService transportService, ActionFilters actionFilters,
                                         ClusterService clusterService, ThreadPool threadPool,
                                         PersistentTasksService persistentTasksService,
-                                        TransformConfigManager transformsConfigManager,
+                                        TransformConfigManager transformConfigManager,
                                         Client client) {
-        super(StopTransformAction.NAME, clusterService, transportService, actionFilters, Request::new,
-                Response::new, Response::new, ThreadPool.Names.SAME);
+        this(StopTransformAction.NAME, transportService, actionFilters, clusterService, threadPool, persistentTasksService,
+             transformConfigManager, client);
+    }
+
+    protected TransportStopTransformAction(String name, TransportService transportService, ActionFilters actionFilters,
+                                           ClusterService clusterService, ThreadPool threadPool,
+                                           PersistentTasksService persistentTasksService,
+                                           TransformConfigManager transformConfigManager,
+                                           Client client) {
+        super(name, clusterService, transportService, actionFilters, Request::new,
+              Response::new, Response::new, ThreadPool.Names.SAME);
         this.threadPool = threadPool;
-        this.transformsConfigManager = transformsConfigManager;
+        this.transformConfigManager = transformConfigManager;
         this.persistentTasksService = persistentTasksService;
         this.client = client;
     }
@@ -118,7 +127,7 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
                 finalListener = listener;
             }
 
-            transformsConfigManager.expandTransformIds(request.getId(),
+            transformConfigManager.expandTransformIds(request.getId(),
                 new PageParams(0, 10_000),
                 request.isAllowNoMatch(),
                 ActionListener.wrap(hitsAndIds -> {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
@@ -46,9 +46,9 @@ import org.elasticsearch.xpack.core.transform.action.UpdateTransformAction.Respo
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfigUpdate;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
+import org.elasticsearch.xpack.transform.persistence.SeqNoPrimaryTermAndIndex;
 import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 import org.elasticsearch.xpack.transform.persistence.TransformIndex;
-import org.elasticsearch.xpack.transform.persistence.SeqNoPrimaryTermAndIndex;
 import org.elasticsearch.xpack.transform.transforms.SourceDestValidator;
 import org.elasticsearch.xpack.transform.transforms.pivot.Pivot;
 
@@ -65,7 +65,7 @@ public class TransportUpdateTransformAction extends TransportMasterNodeAction<Re
     private static final Logger logger = LogManager.getLogger(TransportUpdateTransformAction.class);
     private final XPackLicenseState licenseState;
     private final Client client;
-    private final TransformConfigManager transformsConfigManager;
+    private final TransformConfigManager transformConfigManager;
     private final SecurityContext securityContext;
     private final TransformAuditor auditor;
 
@@ -73,13 +73,22 @@ public class TransportUpdateTransformAction extends TransportMasterNodeAction<Re
     public TransportUpdateTransformAction(Settings settings, TransportService transportService, ThreadPool threadPool,
                                           ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
                                           ClusterService clusterService, XPackLicenseState licenseState,
-                                          TransformConfigManager transformsConfigManager, Client client,
+                                          TransformConfigManager transformConfigManager, Client client,
                                           TransformAuditor auditor) {
-        super(UpdateTransformAction.NAME, transportService, clusterService, threadPool, actionFilters,
-                Request::new, indexNameExpressionResolver);
+        this(UpdateTransformAction.NAME, settings, transportService, threadPool, actionFilters, indexNameExpressionResolver, clusterService,
+             licenseState, transformConfigManager, client, auditor);
+    }
+
+    protected TransportUpdateTransformAction(String name, Settings settings, TransportService transportService, ThreadPool threadPool,
+                                             ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
+                                             ClusterService clusterService, XPackLicenseState licenseState,
+                                             TransformConfigManager transformConfigManager, Client client,
+                                             TransformAuditor auditor) {
+        super(name, transportService, clusterService, threadPool, actionFilters,
+              Request::new, indexNameExpressionResolver);
         this.licenseState = licenseState;
         this.client = client;
-        this.transformsConfigManager = transformsConfigManager;
+        this.transformConfigManager = transformConfigManager;
         this.securityContext = XPackSettings.SECURITY_ENABLED.get(settings) ?
             new SecurityContext(settings, threadPool.getThreadContext()) : null;
         this.auditor = auditor;
@@ -115,7 +124,7 @@ public class TransportUpdateTransformAction extends TransportMasterNodeAction<Re
 
         // GET transform and attempt to update
         // We don't want the update to complete if the config changed between GET and INDEX
-        transformsConfigManager.getTransformConfigurationForUpdate(request.getId(), ActionListener.wrap(
+        transformConfigManager.getTransformConfigurationForUpdate(request.getId(), ActionListener.wrap(
             configAndVersion -> {
                 final TransformConfig config = configAndVersion.v1();
                 // If it is a noop don't bother even writing the doc, save the cycles, just return here.
@@ -196,7 +205,7 @@ public class TransportUpdateTransformAction extends TransportMasterNodeAction<Re
         ActionListener<Boolean> putTransformConfigurationListener = ActionListener.wrap(
             putTransformConfigurationResult -> {
                 auditor.info(config.getId(), "updated transform.");
-                transformsConfigManager.deleteOldTransformConfigurations(request.getId(), ActionListener.wrap(
+                transformConfigManager.deleteOldTransformConfigurations(request.getId(), ActionListener.wrap(
                     r -> {
                         logger.trace("[{}] successfully deleted old transform configurations", request.getId());
                         listener.onResponse(new Response(config));
@@ -216,7 +225,7 @@ public class TransportUpdateTransformAction extends TransportMasterNodeAction<Re
 
         // <2> Update our transform
         ActionListener<Void> createDestinationListener = ActionListener.wrap(
-            createDestResponse -> transformsConfigManager.updateTransformConfiguration(config,
+            createDestResponse -> transformConfigManager.updateTransformConfiguration(config,
                 seqNoPrimaryTermAndIndex,
                 putTransformConfigurationListener),
             listener::onFailure

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportDeleteTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportDeleteTransformActionDeprecated.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.transform.action.compat;
+
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.transform.action.compat.DeleteTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.action.TransportDeleteTransformAction;
+import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
+import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
+
+public class TransportDeleteTransformActionDeprecated extends TransportDeleteTransformAction{
+
+    @Inject
+    public TransportDeleteTransformActionDeprecated(TransportService transportService, ActionFilters actionFilters, ThreadPool threadPool,
+                                                    ClusterService clusterService, IndexNameExpressionResolver indexNameExpressionResolver,
+                                                    TransformConfigManager transformsConfigManager, TransformAuditor auditor,
+                                                    Client client) {
+        super(DeleteTransformActionDeprecated.NAME, transportService, actionFilters, threadPool, clusterService,
+                indexNameExpressionResolver, transformsConfigManager, auditor, client);
+    }
+}

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportGetTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportGetTransformActionDeprecated.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.transform.action.compat;
+
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.transform.action.compat.GetTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.action.TransportGetTransformAction;
+
+public class TransportGetTransformActionDeprecated extends TransportGetTransformAction {
+
+    @Inject
+    public TransportGetTransformActionDeprecated(TransportService transportService, ActionFilters actionFilters, Client client,
+            NamedXContentRegistry xContentRegistry) {
+        super(GetTransformActionDeprecated.NAME, transportService, actionFilters, client, xContentRegistry);
+    }
+
+}

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportGetTransformStatsActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportGetTransformStatsActionDeprecated.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.transform.action.compat;
+
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.transform.action.compat.GetTransformStatsActionDeprecated;
+import org.elasticsearch.xpack.transform.action.TransportGetTransformStatsAction;
+import org.elasticsearch.xpack.transform.checkpoint.TransformCheckpointService;
+import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
+
+public class TransportGetTransformStatsActionDeprecated extends TransportGetTransformStatsAction {
+
+    @Inject
+    public TransportGetTransformStatsActionDeprecated(TransportService transportService, ActionFilters actionFilters,
+                                                      ClusterService clusterService,
+                                                      TransformConfigManager transformsConfigManager,
+                                                      TransformCheckpointService transformsCheckpointService) {
+        super(GetTransformStatsActionDeprecated.NAME, transportService, actionFilters, clusterService, transformsConfigManager,
+              transformsCheckpointService);
+    }
+}

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportPreviewTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportPreviewTransformActionDeprecated.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.transform.action.compat;
+
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.transform.action.compat.PreviewTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.action.TransportPreviewTransformAction;
+
+public class TransportPreviewTransformActionDeprecated extends TransportPreviewTransformAction {
+
+    @Inject
+    public TransportPreviewTransformActionDeprecated(TransportService transportService, ActionFilters actionFilters,
+                                                    Client client, ThreadPool threadPool, XPackLicenseState licenseState,
+                                                    IndexNameExpressionResolver indexNameExpressionResolver,
+                                                    ClusterService clusterService) {
+        super(PreviewTransformActionDeprecated.NAME, transportService, actionFilters, client, threadPool, licenseState,
+              indexNameExpressionResolver, clusterService);
+    }
+
+}

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportPutTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportPutTransformActionDeprecated.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.transform.action.compat;
+
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.transform.action.compat.PutTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.action.TransportPutTransformAction;
+import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
+import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
+
+public class TransportPutTransformActionDeprecated extends TransportPutTransformAction {
+
+    @Inject
+    public TransportPutTransformActionDeprecated(Settings settings, TransportService transportService, ThreadPool threadPool,
+                                                 ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
+                                                 ClusterService clusterService, XPackLicenseState licenseState,
+                                                 TransformConfigManager transformConfigManager, Client client,
+                                                 TransformAuditor auditor) {
+        super(PutTransformActionDeprecated.NAME, settings, transportService, threadPool, actionFilters, indexNameExpressionResolver,
+             clusterService, licenseState, transformConfigManager, client, auditor);
+    }
+
+}

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportStartTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportStartTransformActionDeprecated.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.transform.action.compat;
+
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.persistent.PersistentTasksService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.transform.action.compat.StartTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.action.TransportStartTransformAction;
+import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
+import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
+
+public class TransportStartTransformActionDeprecated extends TransportStartTransformAction {
+
+    @Inject
+    public TransportStartTransformActionDeprecated(TransportService transportService, ActionFilters actionFilters,
+                                                   ClusterService clusterService, XPackLicenseState licenseState,
+                                                   ThreadPool threadPool, IndexNameExpressionResolver indexNameExpressionResolver,
+                                                   TransformConfigManager transformConfigManager,
+                                                   PersistentTasksService persistentTasksService, Client client,
+                                                   TransformAuditor auditor) {
+        super(StartTransformActionDeprecated.NAME, transportService, actionFilters, clusterService, licenseState, threadPool,
+              indexNameExpressionResolver, transformConfigManager, persistentTasksService, client, auditor);
+    }
+}

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportStopTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportStopTransformActionDeprecated.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.transform.action.compat;
+
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.persistent.PersistentTasksService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.transform.action.compat.StopTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.action.TransportStopTransformAction;
+import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
+
+public class TransportStopTransformActionDeprecated extends TransportStopTransformAction {
+
+    @Inject
+    public TransportStopTransformActionDeprecated(TransportService transportService, ActionFilters actionFilters,
+                                                  ClusterService clusterService, ThreadPool threadPool,
+                                                  PersistentTasksService persistentTasksService,
+                                                  TransformConfigManager transformConfigManager,
+                                                  Client client) {
+        super(StopTransformActionDeprecated.NAME, transportService, actionFilters, clusterService, threadPool, persistentTasksService,
+              transformConfigManager, client);
+    }
+
+}

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportUpdateTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportUpdateTransformActionDeprecated.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.transform.action.compat;
+
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.transform.action.compat.UpdateTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.action.TransportUpdateTransformAction;
+import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
+import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
+
+public class TransportUpdateTransformActionDeprecated extends TransportUpdateTransformAction {
+
+    @Inject
+    public TransportUpdateTransformActionDeprecated(Settings settings, TransportService transportService, ThreadPool threadPool,
+                                                    ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
+                                                    ClusterService clusterService, XPackLicenseState licenseState,
+                                                    TransformConfigManager transformConfigManager, Client client,
+                                                    TransformAuditor auditor) {
+        super(UpdateTransformActionDeprecated.NAME, settings, transportService, threadPool, actionFilters, indexNameExpressionResolver,
+              clusterService, licenseState, transformConfigManager, client, auditor);
+    }
+
+}

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestDeleteTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestDeleteTransformAction.java
@@ -36,6 +36,6 @@ public class RestDeleteTransformAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "data_frame_delete_transform_action";
+        return "transform_delete_transform_action";
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestGetTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestGetTransformAction.java
@@ -41,6 +41,6 @@ public class RestGetTransformAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "data_frame_get_transforms_action";
+        return "transform_get_transform_action";
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestGetTransformStatsAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestGetTransformStatsAction.java
@@ -40,6 +40,6 @@ public class RestGetTransformStatsAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "data_frame_get_transforms_stats_action";
+        return "transform_get_transform_stats_action";
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestPreviewTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestPreviewTransformAction.java
@@ -20,12 +20,12 @@ import java.io.IOException;
 public class RestPreviewTransformAction extends BaseRestHandler {
 
     public RestPreviewTransformAction(RestController controller) {
-        controller.registerHandler(RestRequest.Method.POST, TransformField.REST_BASE_PATH + "transforms/_preview", this);
+        controller.registerHandler(RestRequest.Method.POST, TransformField.REST_BASE_PATH_TRANSFORMS + "_preview", this);
     }
 
     @Override
     public String getName() {
-        return "data_frame_preview_transform_action";
+        return "transform_preview_transform_action";
     }
 
     @Override

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestPutTransformAction.java
@@ -25,7 +25,7 @@ public class RestPutTransformAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "data_frame_put_transform_action";
+        return "transform_put_transform_action";
     }
 
     @Override

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestStartTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestStartTransformAction.java
@@ -32,6 +32,6 @@ public class RestStartTransformAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "data_frame_start_transform_action";
+        return "transform_start_transform_action";
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestStopTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestStopTransformAction.java
@@ -42,6 +42,6 @@ public class RestStopTransformAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "data_frame_stop_transform_action";
+        return "transform_stop_transform_action";
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestUpdateTransformAction.java
@@ -25,7 +25,7 @@ public class RestUpdateTransformAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "data_frame_update_transform_action";
+        return "transform_update_transform_action";
     }
 
     @Override

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestDeleteTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestDeleteTransformActionDeprecated.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.transform.rest.action.compat;
+
+
+import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.transform.TransformField;
+import org.elasticsearch.xpack.core.transform.TransformMessages;
+import org.elasticsearch.xpack.core.transform.action.DeleteTransformAction;
+import org.elasticsearch.xpack.core.transform.action.compat.DeleteTransformActionDeprecated;
+
+public class RestDeleteTransformActionDeprecated extends BaseRestHandler {
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
+            LogManager.getLogger(RestDeleteTransformActionDeprecated.class));
+
+    public RestDeleteTransformActionDeprecated(RestController controller) {
+        controller.registerAsDeprecatedHandler(RestRequest.Method.DELETE, TransformField.REST_BASE_PATH_TRANSFORMS_BY_ID_DEPRECATED, this,
+                TransformMessages.REST_DEPRECATED_ENDPOINT, deprecationLogger);
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
+        if (restRequest.hasContent()) {
+            throw new IllegalArgumentException("delete transform requests can not have a request body");
+        }
+
+        String id = restRequest.param(TransformField.ID.getPreferredName());
+        boolean force = restRequest.paramAsBoolean(TransformField.FORCE.getPreferredName(), false);
+        DeleteTransformAction.Request request = new DeleteTransformAction.Request(id, force);
+
+        return channel -> client.execute(DeleteTransformActionDeprecated.INSTANCE, request,
+                new RestToXContentListener<>(channel));
+    }
+
+    @Override
+    public String getName() {
+        return "data_frame_delete_transform_action";
+    }
+}

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestGetTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestGetTransformActionDeprecated.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.transform.rest.action.compat;
+
+import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.action.util.PageParams;
+import org.elasticsearch.xpack.core.transform.TransformField;
+import org.elasticsearch.xpack.core.transform.TransformMessages;
+import org.elasticsearch.xpack.core.transform.action.GetTransformAction;
+import org.elasticsearch.xpack.core.transform.action.compat.GetTransformActionDeprecated;
+
+import static org.elasticsearch.xpack.core.transform.TransformField.ALLOW_NO_MATCH;
+
+public class RestGetTransformActionDeprecated extends BaseRestHandler {
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
+            LogManager.getLogger(RestGetTransformActionDeprecated.class));
+
+    public RestGetTransformActionDeprecated(RestController controller) {
+        controller.registerAsDeprecatedHandler(RestRequest.Method.GET, TransformField.REST_BASE_PATH_TRANSFORMS_DEPRECATED, this,
+                TransformMessages.REST_DEPRECATED_ENDPOINT, deprecationLogger);
+        controller.registerAsDeprecatedHandler(RestRequest.Method.GET, TransformField.REST_BASE_PATH_TRANSFORMS_BY_ID_DEPRECATED, this,
+                TransformMessages.REST_DEPRECATED_ENDPOINT, deprecationLogger);
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
+        GetTransformAction.Request request = new GetTransformAction.Request();
+
+        String id = restRequest.param(TransformField.ID.getPreferredName());
+        request.setResourceId(id);
+        request.setAllowNoResources(restRequest.paramAsBoolean(ALLOW_NO_MATCH.getPreferredName(), true));
+        if (restRequest.hasParam(PageParams.FROM.getPreferredName()) || restRequest.hasParam(PageParams.SIZE.getPreferredName())) {
+            request.setPageParams(
+                new PageParams(restRequest.paramAsInt(PageParams.FROM.getPreferredName(), PageParams.DEFAULT_FROM),
+                    restRequest.paramAsInt(PageParams.SIZE.getPreferredName(), PageParams.DEFAULT_SIZE)));
+        }
+        return channel -> client.execute(GetTransformActionDeprecated.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+
+    @Override
+    public String getName() {
+        return "data_frame_get_transforms_action";
+    }
+}

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestGetTransformStatsActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestGetTransformStatsActionDeprecated.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.transform.rest.action.compat;
+
+import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.action.util.PageParams;
+import org.elasticsearch.xpack.core.transform.TransformField;
+import org.elasticsearch.xpack.core.transform.TransformMessages;
+import org.elasticsearch.xpack.core.transform.action.GetTransformStatsAction;
+import org.elasticsearch.xpack.core.transform.action.compat.GetTransformStatsActionDeprecated;
+
+import static org.elasticsearch.xpack.core.transform.TransformField.ALLOW_NO_MATCH;
+
+public class RestGetTransformStatsActionDeprecated extends BaseRestHandler {
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
+            LogManager.getLogger(RestGetTransformStatsActionDeprecated.class));
+
+    public RestGetTransformStatsActionDeprecated(RestController controller) {
+        controller.registerAsDeprecatedHandler(RestRequest.Method.GET, TransformField.REST_BASE_PATH_TRANSFORMS_DEPRECATED + "_stats",
+                this, TransformMessages.REST_DEPRECATED_ENDPOINT, deprecationLogger);
+        controller.registerAsDeprecatedHandler(RestRequest.Method.GET,
+                TransformField.REST_BASE_PATH_TRANSFORMS_BY_ID_DEPRECATED + "_stats", this,
+                TransformMessages.REST_DEPRECATED_ENDPOINT, deprecationLogger);
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
+        String id = restRequest.param(TransformField.ID.getPreferredName());
+        GetTransformStatsAction.Request request = new GetTransformStatsAction.Request(id);
+        request.setAllowNoMatch(restRequest.paramAsBoolean(ALLOW_NO_MATCH.getPreferredName(), true));
+        if (restRequest.hasParam(PageParams.FROM.getPreferredName()) || restRequest.hasParam(PageParams.SIZE.getPreferredName())) {
+            request.setPageParams(
+                new PageParams(restRequest.paramAsInt(PageParams.FROM.getPreferredName(), PageParams.DEFAULT_FROM),
+                    restRequest.paramAsInt(PageParams.SIZE.getPreferredName(), PageParams.DEFAULT_SIZE)));
+        }
+        return channel -> client.execute(GetTransformStatsActionDeprecated.INSTANCE, request,
+                new RestToXContentListener<>(channel));
+    }
+
+    @Override
+    public String getName() {
+        return "data_frame_get_transforms_stats_action";
+    }
+}

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestPreviewTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestPreviewTransformActionDeprecated.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.transform.rest.action.compat;
+
+import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.transform.TransformField;
+import org.elasticsearch.xpack.core.transform.TransformMessages;
+import org.elasticsearch.xpack.core.transform.action.PreviewTransformAction;
+import org.elasticsearch.xpack.core.transform.action.compat.PreviewTransformActionDeprecated;
+
+import java.io.IOException;
+
+public class RestPreviewTransformActionDeprecated extends BaseRestHandler {
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
+            LogManager.getLogger(RestPreviewTransformActionDeprecated.class));
+
+    public RestPreviewTransformActionDeprecated(RestController controller) {
+        controller.registerAsDeprecatedHandler(RestRequest.Method.POST, TransformField.REST_BASE_PATH_TRANSFORMS_DEPRECATED + "_preview",
+                this, TransformMessages.REST_DEPRECATED_ENDPOINT, deprecationLogger);
+    }
+
+    @Override
+    public String getName() {
+        return "data_frame_preview_transform_action";
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        XContentParser parser = restRequest.contentParser();
+
+        PreviewTransformAction.Request request = PreviewTransformAction.Request.fromXContent(parser);
+        return channel -> client.execute(PreviewTransformActionDeprecated.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+}

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestPutTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestPutTransformActionDeprecated.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.transform.rest.action.compat;
+
+import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.transform.TransformField;
+import org.elasticsearch.xpack.core.transform.TransformMessages;
+import org.elasticsearch.xpack.core.transform.action.PutTransformAction;
+import org.elasticsearch.xpack.core.transform.action.compat.PutTransformActionDeprecated;
+
+import java.io.IOException;
+
+public class RestPutTransformActionDeprecated extends BaseRestHandler {
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
+            LogManager.getLogger(RestPutTransformActionDeprecated.class));
+
+    public RestPutTransformActionDeprecated(RestController controller) {
+        controller.registerAsDeprecatedHandler(RestRequest.Method.PUT, TransformField.REST_BASE_PATH_TRANSFORMS_BY_ID_DEPRECATED, this,
+                TransformMessages.REST_DEPRECATED_ENDPOINT, deprecationLogger);
+    }
+
+    @Override
+    public String getName() {
+        return "data_frame_put_transform_action";
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        String id = restRequest.param(TransformField.ID.getPreferredName());
+        XContentParser parser = restRequest.contentParser();
+
+        boolean deferValidation = restRequest.paramAsBoolean(TransformField.DEFER_VALIDATION.getPreferredName(), false);
+        PutTransformAction.Request request = PutTransformAction.Request.fromXContent(parser, id, deferValidation);
+
+        return channel -> client.execute(PutTransformActionDeprecated.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+}

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestStartTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestStartTransformActionDeprecated.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.transform.rest.action.compat;
+
+import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.transform.TransformField;
+import org.elasticsearch.xpack.core.transform.TransformMessages;
+import org.elasticsearch.xpack.core.transform.action.StartTransformAction;
+import org.elasticsearch.xpack.core.transform.action.compat.StartTransformActionDeprecated;
+
+public class RestStartTransformActionDeprecated extends BaseRestHandler {
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
+            LogManager.getLogger(RestStartTransformActionDeprecated.class));
+
+    public RestStartTransformActionDeprecated(RestController controller) {
+        controller.registerAsDeprecatedHandler(RestRequest.Method.POST,
+                TransformField.REST_BASE_PATH_TRANSFORMS_BY_ID_DEPRECATED + "_start", this, TransformMessages.REST_DEPRECATED_ENDPOINT,
+                deprecationLogger);
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
+        String id = restRequest.param(TransformField.ID.getPreferredName());
+        StartTransformAction.Request request = new StartTransformAction.Request(id);
+        request.timeout(restRequest.paramAsTime(TransformField.TIMEOUT.getPreferredName(), AcknowledgedRequest.DEFAULT_ACK_TIMEOUT));
+        return channel -> client.execute(StartTransformActionDeprecated.INSTANCE, request,
+                new RestToXContentListener<>(channel));
+    }
+
+    @Override
+    public String getName() {
+        return "data_frame_start_transform_action";
+    }
+}

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestStopTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestStopTransformActionDeprecated.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.transform.rest.action.compat;
+
+import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.transform.TransformField;
+import org.elasticsearch.xpack.core.transform.TransformMessages;
+import org.elasticsearch.xpack.core.transform.action.StopTransformAction;
+import org.elasticsearch.xpack.core.transform.action.compat.StopTransformActionDeprecated;
+
+public class RestStopTransformActionDeprecated extends BaseRestHandler {
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
+            LogManager.getLogger(RestStopTransformActionDeprecated.class));
+
+    public RestStopTransformActionDeprecated(RestController controller) {
+        controller.registerAsDeprecatedHandler(RestRequest.Method.POST, TransformField.REST_BASE_PATH_TRANSFORMS_BY_ID_DEPRECATED + "_stop",
+                this, TransformMessages.REST_DEPRECATED_ENDPOINT, deprecationLogger);
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
+        String id = restRequest.param(TransformField.ID.getPreferredName());
+        TimeValue timeout = restRequest.paramAsTime(TransformField.TIMEOUT.getPreferredName(),
+                StopTransformAction.DEFAULT_TIMEOUT);
+        boolean waitForCompletion = restRequest.paramAsBoolean(TransformField.WAIT_FOR_COMPLETION.getPreferredName(), false);
+        boolean force = restRequest.paramAsBoolean(TransformField.FORCE.getPreferredName(), false);
+        boolean allowNoMatch = restRequest.paramAsBoolean(TransformField.ALLOW_NO_MATCH.getPreferredName(), false);
+
+
+        StopTransformAction.Request request = new StopTransformAction.Request(id,
+            waitForCompletion,
+            force,
+            timeout,
+            allowNoMatch);
+
+        return channel -> client.execute(StopTransformActionDeprecated.INSTANCE, request,
+                new RestToXContentListener<>(channel));
+    }
+
+    @Override
+    public String getName() {
+        return "data_frame_stop_transform_action";
+    }
+}

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestUpdateTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/compat/RestUpdateTransformActionDeprecated.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.transform.rest.action.compat;
+
+import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.transform.TransformField;
+import org.elasticsearch.xpack.core.transform.TransformMessages;
+import org.elasticsearch.xpack.core.transform.action.UpdateTransformAction;
+import org.elasticsearch.xpack.core.transform.action.compat.UpdateTransformActionDeprecated;
+
+import java.io.IOException;
+
+public class RestUpdateTransformActionDeprecated extends BaseRestHandler {
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
+            LogManager.getLogger(RestUpdateTransformActionDeprecated.class));
+
+    public RestUpdateTransformActionDeprecated(RestController controller) {
+        controller.registerAsDeprecatedHandler(RestRequest.Method.POST,
+                TransformField.REST_BASE_PATH_TRANSFORMS_BY_ID_DEPRECATED + "_update", this, TransformMessages.REST_DEPRECATED_ENDPOINT,
+                deprecationLogger);
+    }
+
+    @Override
+    public String getName() {
+        return "data_frame_update_transform_action";
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        String id = restRequest.param(TransformField.ID.getPreferredName());
+        boolean deferValidation = restRequest.paramAsBoolean(TransformField.DEFER_VALIDATION.getPreferredName(), false);
+        XContentParser parser = restRequest.contentParser();
+        UpdateTransformAction.Request request = UpdateTransformAction.Request.fromXContent(parser, id, deferValidation);
+
+        return channel -> client.execute(UpdateTransformActionDeprecated.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+}

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TransformSurvivesUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TransformSurvivesUpgradeIT.java
@@ -5,23 +5,27 @@
  */
 package org.elasticsearch.upgrades;
 
+import org.apache.http.HttpHost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.core.IndexerState;
 import org.elasticsearch.client.transform.GetTransformStatsResponse;
-import org.elasticsearch.client.transform.transforms.TransformConfig;
-import org.elasticsearch.client.transform.transforms.TransformStats;
 import org.elasticsearch.client.transform.transforms.DestConfig;
 import org.elasticsearch.client.transform.transforms.SourceConfig;
 import org.elasticsearch.client.transform.transforms.TimeSyncConfig;
+import org.elasticsearch.client.transform.transforms.TransformConfig;
+import org.elasticsearch.client.transform.transforms.TransformStats;
 import org.elasticsearch.client.transform.transforms.pivot.GroupConfig;
 import org.elasticsearch.client.transform.transforms.pivot.PivotConfig;
 import org.elasticsearch.client.transform.transforms.pivot.TermsGroupSource;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -52,12 +56,13 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.oneOf;
 
-public class DataFrameSurvivesUpgradeIT extends AbstractUpgradeTestCase {
+public class TransformSurvivesUpgradeIT extends AbstractUpgradeTestCase {
 
     private static final Version UPGRADE_FROM_VERSION = Version.fromString(System.getProperty("tests.upgrade_from_version"));
-    private static final String DATAFRAME_ENDPOINT = "/_data_frame/transforms/";
-    private static final String CONTINUOUS_DATA_FRAME_ID = "continuous-data-frame-upgrade-job";
-    private static final String CONTINUOUS_DATA_FRAME_SOURCE = "data-frame-upgrade-continuous-source";
+    private static final String DATAFRAME_ENDPOINT = "/_transform/";
+    private static final String DATAFRAME_ENDPOINT_DEPRECATED = "/_data_frame/transforms/";
+    private static final String CONTINUOUS_TRANSFORM_ID = "continuous-transform-upgrade-job";
+    private static final String CONTINUOUS_TRANSFORM_SOURCE = "transform-upgrade-continuous-source";
     private static final List<String> ENTITIES = Stream.iterate(1, n -> n + 1)
         .limit(5)
         .map(v -> "user_" + v)
@@ -81,6 +86,14 @@ public class DataFrameSurvivesUpgradeIT extends AbstractUpgradeTestCase {
         waitForPendingTasks(adminClient(), taskName -> taskName.startsWith("data_frame/transforms") == false);
     }
 
+    @Override
+    protected RestClient buildClient(Settings settings, HttpHost[] hosts) throws IOException {
+        RestClientBuilder builder = RestClient.builder(hosts);
+        configureClient(builder, settings);
+        builder.setStrictDeprecationMode(false);
+        return builder.build();
+    }
+
     /**
      * The purpose of this test is to ensure that when a job is open through a rolling upgrade we upgrade the results
      * index mappings when it is assigned to an upgraded node even if no other ML endpoint is called after the upgrade
@@ -91,7 +104,9 @@ public class DataFrameSurvivesUpgradeIT extends AbstractUpgradeTestCase {
         adjustLoggingLevels.setJsonEntity(
             "{\"transient\": {" +
                 "\"logger.org.elasticsearch.xpack.core.indexing.AsyncTwoPhaseIndexer\": \"trace\"," +
-                "\"logger.org.elasticsearch.xpack.dataframe\": \"trace\"}}");
+                "\"logger.org.elasticsearch.xpack.dataframe\": \"trace\"," +
+                "\"logger.org.elasticsearch.xpack.transform\": \"trace\"" +
+                "}}");
         client().performRequest(adjustLoggingLevels);
         Request waitForYellow = new Request("GET", "/_cluster/health");
         waitForYellow.addParameter("wait_for_nodes", "3");
@@ -120,17 +135,17 @@ public class DataFrameSurvivesUpgradeIT extends AbstractUpgradeTestCase {
     }
 
     private void cleanUpTransforms() throws Exception {
-        stopTransform(CONTINUOUS_DATA_FRAME_ID);
-        deleteTransform(CONTINUOUS_DATA_FRAME_ID);
+        stopTransform(CONTINUOUS_TRANSFORM_ID);
+        deleteTransform(CONTINUOUS_TRANSFORM_ID);
         waitForPendingDataFrameTasks();
     }
 
     private void createAndStartContinuousDataFrame() throws Exception {
-        createIndex(CONTINUOUS_DATA_FRAME_SOURCE);
+        createIndex(CONTINUOUS_TRANSFORM_SOURCE);
         long totalDocsWrittenSum = 0;
         for (TimeValue bucket : BUCKETS) {
             int docs = randomIntBetween(1, 25);
-            putData(CONTINUOUS_DATA_FRAME_SOURCE, docs, bucket, ENTITIES);
+            putData(CONTINUOUS_TRANSFORM_SOURCE, docs, bucket, ENTITIES);
             totalDocsWrittenSum += docs * ENTITIES.size();
         }
         long totalDocsWritten = totalDocsWrittenSum;
@@ -140,18 +155,18 @@ public class DataFrameSurvivesUpgradeIT extends AbstractUpgradeTestCase {
                 .setAggregations(new AggregatorFactories.Builder().addAggregator(AggregationBuilders.avg("stars").field("stars")))
                 .setGroups(GroupConfig.builder().groupBy("user_id", TermsGroupSource.builder().setField("user_id").build()).build())
                 .build())
-            .setDest(DestConfig.builder().setIndex(CONTINUOUS_DATA_FRAME_ID + "_idx").build())
-            .setSource(SourceConfig.builder().setIndex(CONTINUOUS_DATA_FRAME_SOURCE).build())
-            .setId(CONTINUOUS_DATA_FRAME_ID)
+            .setDest(DestConfig.builder().setIndex(CONTINUOUS_TRANSFORM_ID + "_idx").build())
+            .setSource(SourceConfig.builder().setIndex(CONTINUOUS_TRANSFORM_SOURCE).build())
+            .setId(CONTINUOUS_TRANSFORM_ID)
             .setFrequency(TimeValue.timeValueSeconds(1))
             .build();
-        putTransform(CONTINUOUS_DATA_FRAME_ID, config);
+        putTransform(CONTINUOUS_TRANSFORM_ID, config);
 
-        startTransform(CONTINUOUS_DATA_FRAME_ID);
-        waitUntilAfterCheckpoint(CONTINUOUS_DATA_FRAME_ID, 0L);
+        startTransform(CONTINUOUS_TRANSFORM_ID);
+        waitUntilAfterCheckpoint(CONTINUOUS_TRANSFORM_ID, 0L);
 
         assertBusy(() -> {
-            TransformStats stateAndStats = getTransformStats(CONTINUOUS_DATA_FRAME_ID);
+            TransformStats stateAndStats = getTransformStats(CONTINUOUS_TRANSFORM_ID);
             assertThat(stateAndStats.getIndexerStats().getOutputDocuments(), equalTo((long)ENTITIES.size()));
             assertThat(stateAndStats.getIndexerStats().getNumDocuments(), equalTo(totalDocsWritten));
             // Even if we get back to started, we may periodically get set back to `indexing` when triggered.
@@ -161,7 +176,7 @@ public class DataFrameSurvivesUpgradeIT extends AbstractUpgradeTestCase {
 
 
         // We want to make sure our latest state is written before we turn the node off, this makes the testing more reliable
-        awaitWrittenIndexerState(CONTINUOUS_DATA_FRAME_ID, IndexerState.STARTED.value());
+        awaitWrittenIndexerState(CONTINUOUS_TRANSFORM_ID, IndexerState.STARTED.value());
     }
 
     @SuppressWarnings("unchecked")
@@ -170,13 +185,13 @@ public class DataFrameSurvivesUpgradeIT extends AbstractUpgradeTestCase {
         // A continuous data frame should automatically become started when it gets assigned to a node
         // if it was assigned to the node that was removed from the cluster
         assertBusy(() -> {
-            TransformStats stateAndStats = getTransformStats(CONTINUOUS_DATA_FRAME_ID);
+            TransformStats stateAndStats = getTransformStats(CONTINUOUS_TRANSFORM_ID);
             assertThat(stateAndStats.getState(), oneOf(TransformStats.State.STARTED, TransformStats.State.INDEXING));
         },
         120,
         TimeUnit.SECONDS);
 
-        TransformStats previousStateAndStats = getTransformStats(CONTINUOUS_DATA_FRAME_ID);
+        TransformStats previousStateAndStats = getTransformStats(CONTINUOUS_TRANSFORM_ID);
 
         // Add a new user and write data to it
         // This is so we can have more reliable data counts, as writing to existing entities requires
@@ -186,20 +201,20 @@ public class DataFrameSurvivesUpgradeIT extends AbstractUpgradeTestCase {
         int docs = 5;
         // Index the data
         // The frequency and delay should see the data once its indexed
-        putData(CONTINUOUS_DATA_FRAME_SOURCE, docs, TimeValue.timeValueSeconds(0), entities);
+        putData(CONTINUOUS_TRANSFORM_SOURCE, docs, TimeValue.timeValueSeconds(0), entities);
 
-        waitUntilAfterCheckpoint(CONTINUOUS_DATA_FRAME_ID, expectedLastCheckpoint);
+        waitUntilAfterCheckpoint(CONTINUOUS_TRANSFORM_ID, expectedLastCheckpoint);
 
         assertBusy(() -> assertThat(
-            getTransformStats(CONTINUOUS_DATA_FRAME_ID).getIndexerStats().getNumDocuments(),
+            getTransformStats(CONTINUOUS_TRANSFORM_ID).getIndexerStats().getNumDocuments(),
             greaterThanOrEqualTo(docs + previousStateAndStats.getIndexerStats().getNumDocuments())),
             120,
             TimeUnit.SECONDS);
-        TransformStats stateAndStats = getTransformStats(CONTINUOUS_DATA_FRAME_ID);
+        TransformStats stateAndStats = getTransformStats(CONTINUOUS_TRANSFORM_ID);
 
         assertThat(stateAndStats.getState(),
             oneOf(TransformStats.State.STARTED, TransformStats.State.INDEXING));
-        awaitWrittenIndexerState(CONTINUOUS_DATA_FRAME_ID, (responseBody) -> {
+        awaitWrittenIndexerState(CONTINUOUS_TRANSFORM_ID, (responseBody) -> {
             Map<String, Object> indexerStats = (Map<String,Object>)((List<?>)XContentMapValues.extractValue("hits.hits._source.stats",
                 responseBody))
                 .get(0);
@@ -250,33 +265,37 @@ public class DataFrameSurvivesUpgradeIT extends AbstractUpgradeTestCase {
         });
     }
 
+    private String getTransformEndpoint() {
+        return CLUSTER_TYPE == ClusterType.UPGRADED ? DATAFRAME_ENDPOINT : DATAFRAME_ENDPOINT_DEPRECATED;
+    }
+
     private void putTransform(String id, TransformConfig config) throws IOException {
-        final Request createDataframeTransformRequest = new Request("PUT", DATAFRAME_ENDPOINT + id);
+        final Request createDataframeTransformRequest = new Request("PUT", getTransformEndpoint() + id);
         createDataframeTransformRequest.setJsonEntity(Strings.toString(config));
         Response response = client().performRequest(createDataframeTransformRequest);
         assertEquals(200, response.getStatusLine().getStatusCode());
     }
 
     private void deleteTransform(String id) throws IOException {
-        Response response = client().performRequest(new Request("DELETE", DATAFRAME_ENDPOINT + id));
+        Response response = client().performRequest(new Request("DELETE", getTransformEndpoint() + id));
         assertEquals(200, response.getStatusLine().getStatusCode());
     }
 
     private void startTransform(String id) throws IOException  {
-        final Request startDataframeTransformRequest = new Request("POST", DATAFRAME_ENDPOINT + id + "/_start");
+        final Request startDataframeTransformRequest = new Request("POST", getTransformEndpoint() + id + "/_start");
         Response response = client().performRequest(startDataframeTransformRequest);
         assertEquals(200, response.getStatusLine().getStatusCode());
     }
 
     private void stopTransform(String id) throws IOException  {
         final Request stopDataframeTransformRequest = new Request("POST",
-            DATAFRAME_ENDPOINT + id + "/_stop?wait_for_completion=true");
+            getTransformEndpoint() + id + "/_stop?wait_for_completion=true");
         Response response = client().performRequest(stopDataframeTransformRequest);
         assertEquals(200, response.getStatusLine().getStatusCode());
     }
 
     private TransformStats getTransformStats(String id) throws IOException {
-        final Request getStats = new Request("GET", DATAFRAME_ENDPOINT + id + "/_stats");
+        final Request getStats = new Request("GET", getTransformEndpoint() + id + "/_stats");
         Response response = client().performRequest(getStats);
         assertEquals(200, response.getStatusLine().getStatusCode());
         XContentType xContentType = XContentType.fromMediaTypeOrFormat(response.getEntity().getContentType().getValue());

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_data_frame_jobs_crud.yml
@@ -7,7 +7,7 @@
         timeout: 70s
 
   - do:
-      transform.put_transform:
+      data_frame_transform_deprecated.put_transform:
         transform_id: "mixed-simple-transform"
         body: >
           {
@@ -21,11 +21,11 @@
   - match: { acknowledged: true }
 
   - do:
-      transform.start_transform:
+      data_frame_transform_deprecated.start_transform:
         transform_id: "mixed-simple-transform"
   - match: { acknowledged: true }
   - do:
-      transform.get_transform_stats:
+      data_frame_transform_deprecated.get_transform_stats:
         transform_id: "mixed-simple-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-simple-transform" }
@@ -34,13 +34,13 @@
   #- match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
 
   - do:
-      transform.stop_transform:
+      data_frame_transform_deprecated.stop_transform:
         transform_id: "mixed-simple-transform"
         wait_for_completion: true
   - match: { acknowledged: true }
 
   - do:
-      transform.get_transform_stats:
+      data_frame_transform_deprecated.get_transform_stats:
         transform_id: "mixed-simple-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-simple-transform" }
@@ -49,7 +49,7 @@
   #- match: { transforms.0.state: "stopped" }
 
   - do:
-      transform.put_transform:
+      data_frame_transform_deprecated.put_transform:
         transform_id: "mixed-complex-transform"
         body: >
           {
@@ -76,17 +76,17 @@
   - match: { acknowledged: true }
 
   - do:
-      transform.get_transform:
+      data_frame_transform_deprecated.get_transform:
         transform_id: "mixed-complex-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-complex-transform" }
 
   - do:
-      transform.start_transform:
+      data_frame_transform_deprecated.start_transform:
         transform_id: "mixed-complex-transform"
   - match: { acknowledged: true }
   - do:
-      transform.get_transform_stats:
+      data_frame_transform_deprecated.get_transform_stats:
         transform_id: "mixed-complex-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-complex-transform" }
@@ -95,13 +95,13 @@
   #- match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
 
   - do:
-      transform.stop_transform:
+      data_frame_transform_deprecated.stop_transform:
         transform_id: "mixed-complex-transform"
         wait_for_completion: true
   - match: { acknowledged: true }
 
   - do:
-      transform.get_transform_stats:
+      data_frame_transform_deprecated.get_transform_stats:
         transform_id: "mixed-complex-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-complex-transform" }
@@ -118,7 +118,7 @@
         timeout: 70s
 
   - do:
-      transform.put_transform:
+      data_frame_transform_deprecated.put_transform:
         transform_id: "mixed-simple-continuous-transform"
         body: >
           {
@@ -138,7 +138,7 @@
   - match: { acknowledged: true }
 
   - do:
-      transform.get_transform:
+      data_frame_transform_deprecated.get_transform:
         transform_id: "mixed-simple-continuous-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-simple-continuous-transform" }
@@ -148,24 +148,24 @@
   - is_true: transforms.0.create_time
 
   - do:
-      transform.start_transform:
+      data_frame_transform_deprecated.start_transform:
         transform_id: "mixed-simple-continuous-transform"
   - match: { acknowledged: true }
   - do:
-      transform.get_transform_stats:
+      data_frame_transform_deprecated.get_transform_stats:
         transform_id: "mixed-simple-continuous-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-simple-continuous-transform" }
   - match: { transforms.0.state: "/started|indexing/" }
 
   - do:
-      transform.stop_transform:
+      data_frame_transform_deprecated.stop_transform:
         transform_id: "mixed-simple-continuous-transform"
         wait_for_completion: true
   - match: { acknowledged: true }
 
   - do:
-      transform.get_transform_stats:
+      data_frame_transform_deprecated.get_transform_stats:
         transform_id: "mixed-simple-continuous-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-simple-continuous-transform" }
@@ -180,7 +180,7 @@
         timeout: 70s
 
   - do:
-      transform.get_transform:
+      data_frame_transform_deprecated.get_transform:
         transform_id: "old-simple-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-transform" }
@@ -190,11 +190,11 @@
   - match: { transforms.0.pivot.aggregations.avg_response.avg.field: "responsetime" }
 
   - do:
-      transform.start_transform:
+      data_frame_transform_deprecated.start_transform:
         transform_id: "old-simple-transform"
   - match: { acknowledged: true }
   - do:
-      transform.get_transform_stats:
+      data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-simple-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-transform" }
@@ -203,12 +203,12 @@
   #- match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
 
   - do:
-      transform.stop_transform:
+      data_frame_transform_deprecated.stop_transform:
         transform_id: "old-simple-transform"
         wait_for_completion: true
   - match: { acknowledged: true }
   - do:
-      transform.get_transform_stats:
+      data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-simple-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-transform" }
@@ -217,7 +217,7 @@
   #- match: { transforms.0.state: "stopped" }
 
   - do:
-      transform.get_transform:
+      data_frame_transform_deprecated.get_transform:
         transform_id: "old-complex-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-complex-transform" }
@@ -229,11 +229,11 @@
   - match: { transforms.0.pivot.aggregations.avg_response.avg.field: "responsetime" }
 
   - do:
-      transform.start_transform:
+      data_frame_transform_deprecated.start_transform:
         transform_id: "old-complex-transform"
   - match: { acknowledged: true }
   - do:
-      transform.get_transform_stats:
+      data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-complex-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-complex-transform" }
@@ -242,12 +242,12 @@
   #- match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
 
   - do:
-      transform.stop_transform:
+      data_frame_transform_deprecated.stop_transform:
         transform_id: "old-complex-transform"
         wait_for_completion: true
   - match: { acknowledged: true }
   - do:
-      transform.get_transform_stats:
+      data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-complex-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-complex-transform" }
@@ -264,7 +264,7 @@
         timeout: 70s
 
   - do:
-      transform.get_transform:
+      data_frame_transform_deprecated.get_transform:
         transform_id: "old-simple-continuous-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-continuous-transform" }
@@ -274,24 +274,24 @@
   - is_true: transforms.0.create_time
 
   - do:
-      transform.start_transform:
+      data_frame_transform_deprecated.start_transform:
         transform_id: "old-simple-continuous-transform"
   - match: { acknowledged: true }
   - do:
-      transform.get_transform_stats:
+      data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-simple-continuous-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-continuous-transform" }
   - match: { transforms.0.state: "/started|indexing/" }
 
   - do:
-      transform.stop_transform:
+      data_frame_transform_deprecated.stop_transform:
         transform_id: "old-simple-continuous-transform"
         wait_for_completion: true
   - match: { acknowledged: true }
 
   - do:
-      transform.get_transform_stats:
+      data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-simple-continuous-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-continuous-transform" }

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/80_data_frame_jobs_crud.yml
@@ -21,7 +21,7 @@
         timeout: 70s
 
   - do:
-      transform.put_transform:
+      data_frame_transform_deprecated.put_transform:
         transform_id: "old-simple-transform"
         body: >
           {
@@ -35,35 +35,35 @@
   - match: { acknowledged: true }
 
   - do:
-      transform.get_transform:
+      data_frame_transform_deprecated.get_transform:
         transform_id: "old-simple-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-transform" }
 
   - do:
-      transform.start_transform:
+      data_frame_transform_deprecated.start_transform:
         transform_id: "old-simple-transform"
   - match: { acknowledged: true }
   - do:
-      transform.get_transform_stats:
+      data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-simple-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-transform" }
 
   - do:
-      transform.stop_transform:
+      data_frame_transform_deprecated.stop_transform:
         transform_id: "old-simple-transform"
         wait_for_completion: true
   - match: { acknowledged: true }
 
   - do:
-      transform.get_transform_stats:
+      data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-simple-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-transform" }
 
   - do:
-      transform.put_transform:
+      data_frame_transform_deprecated.put_transform:
         transform_id: "old-complex-transform"
         body: >
           {
@@ -90,29 +90,29 @@
   - match: { acknowledged: true }
 
   - do:
-      transform.get_transform:
+      data_frame_transform_deprecated.get_transform:
         transform_id: "old-complex-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-complex-transform" }
 
   - do:
-      transform.start_transform:
+      data_frame_transform_deprecated.start_transform:
         transform_id: "old-complex-transform"
   - match: { acknowledged: true }
   - do:
-      transform.get_transform_stats:
+      data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-complex-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-complex-transform" }
 
   - do:
-      transform.stop_transform:
+      data_frame_transform_deprecated.stop_transform:
         transform_id: "old-complex-transform"
         wait_for_completion: true
   - match: { acknowledged: true }
 
   - do:
-      transform.get_transform_stats:
+      data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-complex-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-complex-transform" }
@@ -140,7 +140,7 @@
         timeout: 70s
 
   - do:
-      transform.put_transform:
+      data_frame_transform_deprecated.put_transform:
         transform_id: "old-simple-continuous-transform"
         body: >
           {
@@ -160,7 +160,7 @@
   - match: { acknowledged: true }
 
   - do:
-      transform.get_transform:
+      data_frame_transform_deprecated.get_transform:
         transform_id: "old-simple-continuous-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-continuous-transform" }
@@ -170,23 +170,23 @@
   - is_true: transforms.0.create_time
 
   - do:
-      transform.start_transform:
+      data_frame_transform_deprecated.start_transform:
         transform_id: "old-simple-continuous-transform"
   - match: { acknowledged: true }
   - do:
-      transform.get_transform_stats:
+      data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-simple-continuous-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-continuous-transform" }
 
   - do:
-      transform.stop_transform:
+      data_frame_transform_deprecated.stop_transform:
         transform_id: "old-simple-continuous-transform"
         wait_for_completion: true
   - match: { acknowledged: true }
 
   - do:
-      transform.get_transform_stats:
+      data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-simple-continuous-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-continuous-transform" }


### PR DESCRIPTION
move the main endpoint to /_transform/ from /_data_frame/transforms/ with providing backwards compatibility and deprecation warnings

backport of #47127