### PR TITLE
[DOCS] Backporting API ref reformatting for document APIs (#47631)

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -1,28 +1,37 @@
 [[docs-bulk]]
 === Bulk API
+++++
+<titleabbrev>Bulk</titleabbrev>
+++++
 
-The bulk API makes it possible to perform many index/delete operations
-in a single API call. This can greatly increase the indexing speed.
+Performs multiple indexing or delete operations in a single API call. 
+This reduces overhead and can greatly increase indexing speed.
 
-.Client support for bulk requests
-*********************************************
+[source,console]
+--------------------------------------------------
+POST _bulk
+{ "index" : { "_index" : "test", "_id" : "1" } }
+{ "field1" : "value1" }
+{ "delete" : { "_index" : "test", "_id" : "2" } }
+{ "create" : { "_index" : "test", "_id" : "3" } }
+{ "field1" : "value3" }
+{ "update" : {"_id" : "1", "_index" : "test"} }
+{ "doc" : {"field2" : "value2"} }
+--------------------------------------------------
 
-Some of the officially supported clients provide helpers to assist with
-bulk requests and reindexing of documents from one index to another:
+[[docs-bulk-api-request]]
+==== {api-request-title}
 
-Perl::
+`POST /_bulk`
 
-    See https://metacpan.org/pod/Search::Elasticsearch::Client::5_0::Bulk[Search::Elasticsearch::Client::5_0::Bulk]
-    and https://metacpan.org/pod/Search::Elasticsearch::Client::5_0::Scroll[Search::Elasticsearch::Client::5_0::Scroll]
+`POST /<index>/_bulk`
 
-Python::
+[[docs-bulk-api-desc]]
+==== {api-description-title}
 
-    See http://elasticsearch-py.readthedocs.org/en/master/helpers.html[elasticsearch.helpers.*]
+Provides a way to perform multiple `index`, `create`, `delete`, and `update` actions in a single request.
 
-*********************************************
-
-The REST API endpoint is `/_bulk`, and it expects the following newline delimited JSON
-(NDJSON) structure:
+The actions are specified in the request body using a newline delimited JSON (NDJSON) structure:
 
 [source,js]
 --------------------------------------------------
@@ -36,19 +45,70 @@ optional_source\n
 --------------------------------------------------
 // NOTCONSOLE
 
-*NOTE*: The final line of data must end with a newline character `\n`. Each newline character
-may be preceded by a carriage return `\r`. When sending requests to this endpoint the
-`Content-Type` header should be set to `application/x-ndjson`.
+The `index` and `create` actions expect a source on the next line, 
+and have the same semantics as the `op_type` parameter in the standard index API: 
+create fails if a document with the same name already exists in the index,  
+index adds or replaces a document as necessary. 
 
-The possible actions are `index`, `create`, `delete`, and `update`.
-`index` and `create` expect a source on the next
-line, and have the same semantics as the `op_type` parameter to the
-standard index API (i.e. create will fail if a document with the same
-index exists already, whereas index will add or replace a
-document as necessary). `delete` does not expect a source on the
-following line, and has the same semantics as the standard delete API.
-`update` expects that the partial doc, upsert and script and its options
-are specified on the next line.
+`update` expects that the partial doc, upsert, 
+and script and its options are specified on the next line.
+
+`delete` does not expect a source on the next line and 
+has the same semantics as the standard delete API.
+
+[NOTE]
+====
+The final line of data must end with a newline character `\n`. 
+Each newline character may be preceded by a carriage return `\r`. 
+When sending requests to the `_bulk` endpoint,
+the `Content-Type` header should be set to `application/x-ndjson`.
+====
+
+Because this format uses literal `\n`'s as delimiters, 
+make sure that the JSON actions and sources are not pretty printed.
+
+If you specify an index in the request URI, 
+it is used for any actions that don't explicitly specify an index.
+
+A note on the format: The idea here is to make processing of this as
+fast as possible. As some of the actions are redirected to other
+shards on other nodes, only `action_meta_data` is parsed on the
+receiving node side.
+
+Client libraries using this protocol should try and strive to do
+something similar on the client side, and reduce buffering as much as
+possible.
+
+The response to a bulk action is a large JSON structure with 
+the individual results of each action performed, 
+in the same order as the actions that appeared in the request. 
+The failure of a single action does not affect the remaining actions.
+
+There is no "correct" number of actions to perform in a single bulk request. 
+Experiment with different settings to find the optimal size for your particular workload.
+
+When using the HTTP API, make sure that the client does not send HTTP chunks, 
+as this will slow things down.
+
+[float]
+[[bulk-clients]]
+===== Client support for bulk requests
+
+Some of the officially supported clients provide helpers to assist with
+bulk requests and reindexing of documents from one index to another:
+
+Perl::
+
+    See https://metacpan.org/pod/Search::Elasticsearch::Client::5_0::Bulk[Search::Elasticsearch::Client::5_0::Bulk]
+    and https://metacpan.org/pod/Search::Elasticsearch::Client::5_0::Scroll[Search::Elasticsearch::Client::5_0::Scroll]
+
+Python::
+
+    See http://elasticsearch-py.readthedocs.org/en/master/helpers.html[elasticsearch.helpers.*]
+
+[float]
+[[bulk-curl]]
+===== Submitting bulk requests with cURL
 
 If you're providing text file input to `curl`, you *must* use the
 `--data-binary` flag instead of plain `-d`. The latter doesn't preserve
@@ -65,9 +125,97 @@ $ curl -s -H "Content-Type: application/x-ndjson" -XPOST localhost:9200/_bulk --
 // NOTCONSOLE
 // Not converting to console because this shows how curl works
 
-Because this format uses literal `\n`'s as delimiters, please be sure
-that the JSON actions and sources are not pretty printed. Here is an
-example of a correct sequence of bulk commands:
+[float]
+[[bulk-optimistic-concurrency-control]]
+===== Optimistic Concurrency Control
+
+Each `index` and `delete` action within a bulk API call may include the
+`if_seq_no` and `if_primary_term` parameters in their respective action
+and meta data lines. The `if_seq_no` and `if_primary_term` parameters control
+how operations are executed, based on the last modification to existing
+documents. See <<optimistic-concurrency-control>> for more details.
+
+
+[float]
+[[bulk-versioning]]
+===== Versioning
+
+Each bulk item can include the version value using the
+`version` field. It automatically follows the behavior of the
+index / delete operation based on the `_version` mapping. It also
+support the `version_type` (see <<index-versioning, versioning>>).
+
+[float]
+[[bulk-routing]]
+===== Routing
+
+Each bulk item can include the routing value using the
+`routing` field. It automatically follows the behavior of the
+index / delete operation based on the `_routing` mapping.
+
+[float]
+[[bulk-wait-for-active-shards]]
+===== Wait For Active Shards
+
+When making bulk calls, you can set the `wait_for_active_shards`
+parameter to require a minimum number of shard copies to be active
+before starting to process the bulk request. See
+<<index-wait-for-active-shards,here>> for further details and a usage
+example.
+
+[float]
+[[bulk-refresh]]
+===== Refresh
+
+Control when the changes made by this request are visible to search. See
+<<docs-refresh,refresh>>.
+
+NOTE: Only the shards that receive the bulk request will be affected by
+`refresh`. Imagine a `_bulk?refresh=wait_for` request with three
+documents in it that happen to be routed to different shards in an index
+with five shards. The request will only wait for those three shards to
+refresh. The other two shards that make up the index do not
+participate in the `_bulk` request at all.
+
+[float]
+[[bulk-security]]
+===== Security
+
+See <<url-access-control>>.
+
+[float]
+[[bulk-partial-responses]]
+===== Partial responses
+To ensure fast responses, the bulk API will respond with partial results if one or more shards fail. 
+See <<shard-failures, Shard failures>> for more information.
+
+[[docs-bulk-api-path-params]]
+==== {api-path-parms-title}
+
+`<index>`::
+(Optional, string) Name of the index to perform the bulk actions against.
+
+[[docs-bulk-api-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=pipeline]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=refresh]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=routing]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=source]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=source_excludes]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=source_includes]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=timeout]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
+
+[[docs-bulk-api-example]]
+==== {api-examples-title}
 
 [source,js]
 --------------------------------------------------
@@ -82,7 +230,7 @@ POST _bulk
 --------------------------------------------------
 // CONSOLE
 
-The result of this bulk operation is:
+The API returns the following result:
 
 [source,js]
 --------------------------------------------------
@@ -172,85 +320,9 @@ The result of this bulk operation is:
 // TESTRESPONSE[s/"_seq_no" : 3/"_seq_no" : $body.items.3.update._seq_no/]
 // TESTRESPONSE[s/"_primary_term" : 4/"_primary_term" : $body.items.3.update._primary_term/]
 
-The endpoints are `/_bulk` and `/{index}/_bulk`. When the index is provided, it
-will be used by default on bulk items that don't provide it explicitly.
-
-A note on the format. The idea here is to make processing of this as
-fast as possible. As some of the actions will be redirected to other
-shards on other nodes, only `action_meta_data` is parsed on the
-receiving node side.
-
-Client libraries using this protocol should try and strive to do
-something similar on the client side, and reduce buffering as much as
-possible.
-
-The response to a bulk action is a large JSON structure with the individual
-results of each action that was performed in the same order as the actions that
-appeared in the request. The failure of a single action does not affect the
-remaining actions.
-
-There is no "correct" number of actions to perform in a single bulk
-call. You should experiment with different settings to find the optimum
-size for your particular workload.
-
-If using the HTTP API, make sure that the client does not send HTTP
-chunks, as this will slow things down.
-
-[float]
-[[bulk-optimistic-concurrency-control]]
-==== Optimistic Concurrency Control
-
-Each `index` and `delete` action within a bulk API call may include the
-`if_seq_no` and `if_primary_term` parameters in their respective action
-and meta data lines. The `if_seq_no` and `if_primary_term` parameters control
-how operations are executed, based on the last modification to existing
-documents. See <<optimistic-concurrency-control>> for more details.
-
-
-[float]
-[[bulk-versioning]]
-==== Versioning
-
-Each bulk item can include the version value using the
-`version` field. It automatically follows the behavior of the
-index / delete operation based on the `_version` mapping. It also
-support the `version_type` (see <<index-versioning, versioning>>).
-
-[float]
-[[bulk-routing]]
-==== Routing
-
-Each bulk item can include the routing value using the
-`routing` field. It automatically follows the behavior of the
-index / delete operation based on the `_routing` mapping.
-
-[float]
-[[bulk-wait-for-active-shards]]
-==== Wait For Active Shards
-
-When making bulk calls, you can set the `wait_for_active_shards`
-parameter to require a minimum number of shard copies to be active
-before starting to process the bulk request. See
-<<index-wait-for-active-shards,here>> for further details and a usage
-example.
-
-[float]
-[[bulk-refresh]]
-==== Refresh
-
-Control when the changes made by this request are visible to search. See
-<<docs-refresh,refresh>>.
-
-NOTE: Only the shards that receive the bulk request will be affected by
-`refresh`. Imagine a `_bulk?refresh=wait_for` request with three
-documents in it that happen to be routed to different shards in an index
-with five shards. The request will only wait for those three shards to
-refresh. The other two shards that make up the index do not
-participate in the `_bulk` request at all.
-
 [float]
 [[bulk-update]]
-==== Update
+===== Bulk update example
 
 When using the `update` action, `retry_on_conflict` can be used as a field in
 the action itself (not in the extra payload line), to specify how many
@@ -278,13 +350,3 @@ POST _bulk
 // CONSOLE
 // TEST[continued]
 
-[float]
-[[bulk-security]]
-==== Security
-
-See <<url-access-control>>.
-
-[float]
-[[bulk-partial-responses]]
-==== Partial responses
-To ensure fast responses, the bulk API will respond with partial results if one or more shards fail. See <<shard-failures, Shard failures>> for more information.

--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -6,6 +6,12 @@
 
 Retrieves the specified JSON document from an index.
 
+[source,console]
+--------------------------------------------------
+GET twitter/_doc/0
+--------------------------------------------------
+// TEST[setup:twitter]
+
 [[docs-get-api-request]]
 ==== {api-request-title}
 
@@ -156,32 +162,21 @@ deleted documents in the background as you continue to index more data.
 [[docs-get-api-query-params]]
 ==== {api-query-parms-title}
 
-`preference`::
-(Optional, string) Specify the node or shard the operation should
-be performed on (default: random).
+include::{docdir}/rest-api/common-parms.asciidoc[tag=preference]
 
-`realtime`::
-(Optional, boolean) Set to `false` to disable real time GET
-(default: `true`). See <<realtime>>.
+include::{docdir}/rest-api/common-parms.asciidoc[tag=realtime]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=refresh]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=routing]
 
-`stored_fields`::
-(Optional, boolean) Set to `true` to retrieve the document fields stored in the
-index rather than the document `_source` (default: `false`).
+include::{docdir}/rest-api/common-parms.asciidoc[tag=stored_fields]
 
-`_source`::
-(Optional, list) Set to `false` to disable source retrieval (default: `true`).
- You can also specify a comma-separated list of the fields
-you want to retrieve.
+include::{docdir}/rest-api/common-parms.asciidoc[tag=source]
 
-`_source_excludes`::
-(Optional, list) Specify the source fields you want to exclude.
+include::{docdir}/rest-api/common-parms.asciidoc[tag=source_excludes]
 
-`_source_includes`::
-(Optional, list) Specify the source fields you want to retrieve.
+include::{docdir}/rest-api/common-parms.asciidoc[tag=source_includes]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=doc-version]
 

--- a/docs/reference/docs/multi-get.asciidoc
+++ b/docs/reference/docs/multi-get.asciidoc
@@ -1,15 +1,10 @@
 [[docs-multi-get]]
-=== Multi Get API
+=== Multi get (mget) API
+++++
+<titleabbrev>Multi get</titleabbrev>
+++++
 
-The Multi get API returns multiple documents based on an index, type,
-(optional) and id (and possibly routing). The response includes a `docs` array
-with all the fetched documents in order corresponding to the original multi-get
-request (if there was a failure for a specific get, an object containing this
-error is included in place in the response instead). The structure of a
-successful get is similar in structure to a document provided by the
-<<docs-get,get>> API.
-
-Here is an example:
+Retrieves multiple JSON documents by ID. 
 
 [source,js]
 --------------------------------------------------
@@ -17,26 +12,121 @@ GET /_mget
 {
     "docs" : [
         {
-            "_index" : "test",
-            "_type" : "_doc",
+            "_index" : "twitter",
             "_id" : "1"
         },
         {
-            "_index" : "test",
-            "_type" : "_doc",
+            "_index" : "twitter",
             "_id" : "2"
         }
     ]
 }
 --------------------------------------------------
-// CONSOLE
+// TEST[setup:twitter]
 
-The `mget` endpoint can also be used against an index (in which case it
-is not required in the body):
+[[docs-multi-get-api-request]]
+==== {api-request-title}
+
+`GET /_mget`
+
+`GET /<index>/_mget`
+
+[[docs-multi-get-api-desc]]
+==== {api-description-title}
+
+You use `mget` to retrieve multiple documents from one or more indices.
+If you specify an index in the request URI, you only need to specify the document IDs in the request body.
+
+[[mget-security]]
+===== Security
+
+See <<url-access-control>>.
+
+[[multi-get-partial-responses]]
+===== Partial responses
+
+To ensure fast responses, the multi get API responds with partial results if one or more shards fail. 
+See <<shard-failures, Shard failures>> for more information.
+
+[[docs-multi-get-api-path-params]]
+==== {api-path-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+
+[[docs-multi-get-api-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=preference]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=realtime]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=refresh]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=routing]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=stored_fields]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=source]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=source_excludes]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=source_includes]
+
+[[docs-multi-get-api-request-body]]
+==== {api-request-body-title}
+
+`docs`::
+(Optional, array) The documents you want to retrieve.
+Required if no index is specified in the request URI.
+You can specify the following attributes for each
+document:
++
+--
+`_id`::
+(Required, string) The unique document ID.
+
+`_index`::
+(Optional, string)
+The index that contains the document.
+Required if no index is specified in the request URI.
+
+`_routing`::
+(Optional, string) The key for the primary shard the document resides on.
+Required if routing is used during indexing.
+
+`_source`::
+(Optional, boolean) If `false`,  excludes all `_source` fields. Defaults to `true`.
+`source_include`:::
+(Optional, array) The fields to extract and return from the `_source` field.
+`source_exclude`:::
+(Optional, array) The fields to exclude from the returned `_source` field.
+
+`_stored_fields`::
+(Optional, array) The stored fields you want to retrieve.
+--
+
+`ids`::
+(Optional, array) The IDs of the documents you want to retrieve.
+Allowed when the index is specified in the request URI.
+
+[[multi-get-api-response-body]]
+==== {api-response-body-title}
+
+The response includes a `docs` array that contains the documents in the order specified in the request. 
+The structure of the returned documents is similar to that returned by the <<docs-get,get>> API.
+If there is a failure getting a particular document, the error is included in place of the document. 
+
+[[docs-multi-get-api-example]]
+==== {api-examples-title}
+
+[[mget-ids]]
+===== Get documents by ID
+
+If you specify an index in the request URI, only the document IDs are required in the request body:
 
 [source,js]
 --------------------------------------------------
-GET /test/_mget
+GET /twitter/_mget
 {
     "docs" : [
         {
@@ -68,31 +158,31 @@ GET /test/_doc/_mget
     ]
 }
 --------------------------------------------------
-//CONSOLE
+// TEST[setup:twitter]
 
-In which case, the `ids` element can directly be used to simplify the
-request:
+You can use the `ids` element to simplify the request:
 
 [source,js]
 --------------------------------------------------
-GET /test/_doc/_mget
+GET /twitter/_mget
 {
     "ids" : ["1", "2"]
 }
 --------------------------------------------------
-// CONSOLE
+// TEST[setup:twitter]
 
-[float]
 [[mget-source-filtering]]
-==== Source filtering
+===== Filter source fields
 
-By default, the `_source` field will be returned for every document (if stored).
-Similar to the <<get-source-filtering,get>> API, you can retrieve only parts of
-the `_source` (or not at all) by using the `_source` parameter. You can also use
-the url parameters `_source`, `_source_includes`, and `_source_excludes` to specify defaults,
-which will be used when there are no per-document instructions.
+By default, the `_source` field is returned for every document (if stored). 
+Use the `_source` and `_source_include` or `source_exclude` attributes to 
+filter what fields are returned for a particular document.
+You can include the `_source`, `_source_includes`, and `_source_excludes` query parameters in the
+request URI to specify the defaults to use when there are no per-document instructions.
 
-For example:
+For example, the following request sets `_source` to false for document 1 to exclude the
+source entirely, retrieves `field3` and `field4` from document 2, and retrieves the `user` field
+from document 3 but filters out the `user.location` field.
 
 [source,js]
 --------------------------------------------------
@@ -125,13 +215,16 @@ GET /_mget
 --------------------------------------------------
 // CONSOLE
 
-
-[float]
 [[mget-fields]]
-==== Fields
+===== Get stored fields
 
-Specific stored fields can be specified to be retrieved per document to get, similar to the <<get-stored-fields,stored_fields>> parameter of the Get API.
-For example:
+Use the `stored_fields` attribute to specify the set of stored fields you want
+to retrieve. Any requested fields that are not stored are ignored. 
+You can include the `stored_fields` query parameter in the request URI to specify the defaults 
+to use when there are no per-document instructions. 
+
+For example, the following request retrieves `field1` and `field2` from document 1, and
+`field3` and `field4`from document 2:
 
 [source,js]
 --------------------------------------------------
@@ -155,8 +248,9 @@ GET /_mget
 --------------------------------------------------
 // CONSOLE
 
-Alternatively, you can specify the `stored_fields` parameter in the query string
-as a default to be applied to all documents.
+The following request retrieves `field1` and `field2` from all documents by default.
+These default fields are returned for document 1, but 
+overridden to return `field3` and `field4` for document 2.
 
 [source,js]
 --------------------------------------------------
@@ -164,24 +258,22 @@ GET /test/_doc/_mget?stored_fields=field1,field2
 {
     "docs" : [
         {
-            "_id" : "1" <1>
+            "_id" : "1"
         },
         {
             "_id" : "2",
-            "stored_fields" : ["field3", "field4"] <2>
+            "stored_fields" : ["field3", "field4"]
         }
     ]
 }
 --------------------------------------------------
-// CONSOLE
-<1> Returns `field1` and `field2`
-<2> Returns `field3` and `field4`
 
-[float]
 [[mget-routing]]
-==== Routing
+===== Specify document routing
 
-You can also specify a routing value as a parameter:
+If routing is used during indexing, you need to specify the routing value to retrieve documents. 
+For example, the following request fetches `test/_doc/2`  from the shard corresponding to routing key `key1`,
+and fetches `test/_doc/1` from the shard corresponding to routing key `key2`.
 
 [source,js]
 --------------------------------------------------
@@ -202,18 +294,3 @@ GET /_mget?routing=key1
     ]
 }
 --------------------------------------------------
-// CONSOLE
-
-In this example, document `test/_doc/2` will be fetched from the shard corresponding to routing key `key1` but
-document `test/_doc/1` will be fetched from the shard corresponding to routing key `key2`.
-
-[float]
-[[mget-security]]
-==== Security
-
-See <<url-access-control>>.
-
-[float]
-[[multi-get-partial-responses]]
-==== Partial responses
-To ensure fast responses, the multi get API will respond with partial results if one or more shards fail. See <<shard-failures, Shard failures>> for more information.

--- a/docs/reference/docs/multi-get.asciidoc
+++ b/docs/reference/docs/multi-get.asciidoc
@@ -6,7 +6,7 @@
 
 Retrieves multiple JSON documents by ID. 
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_mget
 {
@@ -124,7 +124,7 @@ If there is a failure getting a particular document, the error is included in pl
 
 If you specify an index in the request URI, only the document IDs are required in the request body:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /twitter/_mget
 {
@@ -140,11 +140,10 @@ GET /twitter/_mget
     ]
 }
 --------------------------------------------------
-// CONSOLE
 
 And type:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /test/_doc/_mget
 {
@@ -162,7 +161,7 @@ GET /test/_doc/_mget
 
 You can use the `ids` element to simplify the request:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /twitter/_mget
 {
@@ -184,7 +183,7 @@ For example, the following request sets `_source` to false for document 1 to exc
 source entirely, retrieves `field3` and `field4` from document 2, and retrieves the `user` field
 from document 3 but filters out the `user.location` field.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_mget
 {
@@ -213,7 +212,6 @@ GET /_mget
     ]
 }
 --------------------------------------------------
-// CONSOLE
 
 [[mget-fields]]
 ===== Get stored fields
@@ -226,7 +224,7 @@ to use when there are no per-document instructions.
 For example, the following request retrieves `field1` and `field2` from document 1, and
 `field3` and `field4`from document 2:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_mget
 {
@@ -246,13 +244,12 @@ GET /_mget
     ]
 }
 --------------------------------------------------
-// CONSOLE
 
 The following request retrieves `field1` and `field2` from all documents by default.
 These default fields are returned for document 1, but 
 overridden to return `field3` and `field4` for document 2.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /test/_doc/_mget?stored_fields=field1,field2
 {
@@ -275,7 +272,7 @@ If routing is used during indexing, you need to specify the routing value to ret
 For example, the following request fetches `test/_doc/2`  from the shard corresponding to routing key `key1`,
 and fetches `test/_doc/1` from the shard corresponding to routing key `key2`.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET /_mget?routing=key1
 {

--- a/docs/reference/docs/multi-termvectors.asciidoc
+++ b/docs/reference/docs/multi-termvectors.asciidoc
@@ -1,14 +1,10 @@
 [[docs-multi-termvectors]]
-=== Multi termvectors API
+=== Multi term vectors API
+++++
+<titleabbrev>Multi term vectors</titleabbrev>
+++++
 
-Multi termvectors API allows to get multiple termvectors at once. The
-documents from which to retrieve the term vectors are specified by an index and id.
-But the documents could also be artificially provided in the request itself.
-
-The response includes a `docs`
-array with all the fetched termvectors, each element having the structure
-provided by the <<docs-termvectors,termvectors>>
-API. Here is an example:
+Retrieves multiple term vectors with a single request. 
 
 [source,js]
 --------------------------------------------------
@@ -33,10 +29,64 @@ POST /_mtermvectors
 // CONSOLE
 // TEST[setup:twitter]
 
-See the <<docs-termvectors,termvectors>> API for a description of possible parameters.
+[[docs-multi-termvectors-api-request]]
+==== {api-request-title}
 
-The `_mtermvectors` endpoint can also be used against an index (in which case it
-is not required in the body):
+`POST /_mtermvectors`
+
+`POST /<index>/_mtermvectors`
+
+[[docs-multi-termvectors-api-desc]]
+==== {api-description-title}
+
+You can specify existing documents by index and ID or 
+provide artificial documents in the body of the request.  
+The index can be specified the body of the request or in the request URI.
+
+The response contains a `docs` array with all the fetched termvectors. 
+Each element has the structure provided by the <<docs-termvectors,termvectors>>
+API. 
+
+See the <<docs-termvectors,termvectors>> API for more information about the information
+that can be included in the response.  
+
+[[docs-multi-termvectors-api-path-params]]
+==== {api-path-parms-title}
+
+`<index>`::
+(Optional, string) Name of the index that contains the documents.
+
+[[docs-multi-termvectors-api-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=fields]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=field_statistics]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=offsets]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=payloads]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=positions]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=preference]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=routing]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=realtime]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=term_statistics]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=version]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=version_type]
+
+[float]
+[[docs-multi-termvectors-api-example]]
+==== {api-examples-title}
+
+If you specify an index in the request URI, the index does not need to be specified for each documents
+in the request body:
 
 [source,js]
 --------------------------------------------------
@@ -59,7 +109,8 @@ POST /twitter/_mtermvectors
 // CONSOLE
 // TEST[setup:twitter]
 
-If all requested documents are on same index and also the parameters are the same, the request can be simplified:
+If all requested documents are in same index and the parameters are the same, you can use the
+following simplified syntax:
 
 [source,js]
 --------------------------------------------------
@@ -77,9 +128,11 @@ POST /twitter/_mtermvectors
 // CONSOLE
 // TEST[setup:twitter]
 
-Additionally, just like for the <<docs-termvectors,termvectors>>
-API, term vectors could be generated for user provided documents.
-The mapping used is determined by `_index`.
+[[docs-multi-termvectors-artificial-doc]]
+===== Artificial documents
+
+You can also use `mtermvectors` to generate term vectors for _artificial_ documents provided
+in the body of the request. The mapping used is determined by the specified `_index`.
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -1,16 +1,20 @@
 [[docs-reindex]]
 === Reindex API
+++++
+<titleabbrev>Reindex</titleabbrev>
+++++
 
-IMPORTANT: Reindex requires <<mapping-source-field,`_source`>> to be enabled for
+Copies documents from one index to another. 
+
+[IMPORTANT]
+=================================================
+Reindex requires <<mapping-source-field,`_source`>> to be enabled for
 all documents in the source index.
 
-IMPORTANT: Reindex does not attempt to set up the destination index.  It does
-not copy the settings of the source index.  You should set up the destination
-index prior to running a `_reindex` action, including setting up mappings, shard
-counts, replicas, etc.
-
-The most basic form of `_reindex` just copies documents from one index to another.
-This will copy documents from the `twitter` index into the `new_twitter` index:
+You must set up the destination index before calling `_reindex`.
+Reindex does not copy the settings from the source index. 
+Mappings, shard counts, replicas, and so on must be configured ahead of time.
+=================================================
 
 [source,js]
 --------------------------------------------------
@@ -27,7 +31,7 @@ POST _reindex
 // CONSOLE
 // TEST[setup:big_twitter]
 
-That will return something like this:
+////
 
 [source,js]
 --------------------------------------------------
@@ -53,151 +57,201 @@ That will return something like this:
 --------------------------------------------------
 // TESTRESPONSE[s/"took" : 147/"took" : "$body.took"/]
 
+////
+
+[[docs-reindex-api-request]]
+==== {api-request-title}
+
+`POST /_reindex`
+
+[[docs-reindex-api-desc]]
+==== {api-description-title}
+
+Extracts the document source from the source index and indexes the documents into the destination index. 
+You can copy all documents to the destination index, or reindex a subset of the documents. 
+
 Just like <<docs-update-by-query,`_update_by_query`>>, `_reindex` gets a
 snapshot of the source index but its target must be a **different** index so
 version conflicts are unlikely. The `dest` element can be configured like the
-index API to control optimistic concurrency control. Just leaving out
-`version_type` (as above) or setting it to `internal` will cause Elasticsearch
+index API to control optimistic concurrency control. Omitting
+`version_type` or setting it to `internal` causes Elasticsearch
 to blindly dump documents into the target, overwriting any that happen to have
-the same type and id:
+the same ID.
 
-[source,js]
---------------------------------------------------
-POST _reindex
-{
-  "source": {
-    "index": "twitter"
-  },
-  "dest": {
-    "index": "new_twitter",
-    "version_type": "internal"
-  }
-}
---------------------------------------------------
-// CONSOLE
-// TEST[setup:twitter]
-
-Setting `version_type` to `external` will cause Elasticsearch to preserve the
+Setting `version_type` to `external` causes Elasticsearch to preserve the
 `version` from the source, create any documents that are missing, and update
 any documents that have an older version in the destination index than they do
-in the source index:
+in the source index.
 
-[source,js]
---------------------------------------------------
-POST _reindex
-{
-  "source": {
-    "index": "twitter"
-  },
-  "dest": {
-    "index": "new_twitter",
-    "version_type": "external"
-  }
-}
---------------------------------------------------
-// CONSOLE
-// TEST[setup:twitter]
-
-Settings `op_type` to `create` will cause `_reindex` to only create missing
+Setting `op_type` to `create` causes `_reindex` to only create missing
 documents in the target index. All existing documents will cause a version
-conflict:
+conflict. 
+
+By default, version conflicts abort the `_reindex` process. 
+To continue reindexing if there are conflicts, set the `"conflicts"` request body parameter to `proceed`. 
+In this case, the response includes a count of the version conflicts that were encountered.
+Note that the handling of other error types is unaffected by the `"conflicts"` parameter.
+
+[[docs-reindex-task-api]]
+===== Running reindex asynchronously
+
+If the request contains `wait_for_completion=false`, {es}
+performs some preflight checks, launches the request, and returns a
+<<tasks,`task`>> you can use to cancel or get the status of the task. 
+{es} creates a record of this task as a document at `.tasks/task/${taskId}`. 
+When you are done with a task, you should delete the task document so 
+{es} can reclaim the space.
+
+[[docs-reindex-many-indices]]
+===== Reindexing many indices
+If you have many indices to reindex it is generally better to reindex them
+one at a time rather than using a glob pattern to pick up many indices. That
+way you can resume the process if there are any errors by removing the
+partially completed index and starting over at that index. It also makes
+parallelizing the process fairly simple: split the list of indices to reindex
+and run each list in parallel.
+
+One-off bash scripts seem to work nicely for this:
+
+[source,bash]
+----------------------------------------------------------------
+for index in i1 i2 i3 i4 i5; do
+  curl -HContent-Type:application/json -XPOST localhost:9200/_reindex?pretty -d'{
+    "source": {
+      "index": "'$index'"
+    },
+    "dest": {
+      "index": "'$index'-reindexed"
+    }
+  }'
+done
+----------------------------------------------------------------
+// NOTCONSOLE
+
+[[docs-reindex-throttle]]
+===== Throttling
+
+Set `requests_per_second` to any positive decimal number (`1.4`, `6`,
+`1000`, etc.) to throttle the rate at which `_reindex` issues batches of index
+operations. Requests are throttled by padding each batch with a wait time. 
+To disable throttling, set `requests_per_second` to `-1`.
+
+The throttling is done by waiting between batches so that the `scroll` that `_reindex`
+uses internally can be given a timeout that takes into account the padding.
+The padding time is the difference between the batch size divided by the
+`requests_per_second` and the time spent writing. By default the batch size is
+`1000`, so if `requests_per_second` is set to `500`:
+
+[source,txt]
+--------------------------------------------------
+target_time = 1000 / 500 per second = 2 seconds
+wait_time = target_time - write_time = 2 seconds - .5 seconds = 1.5 seconds
+--------------------------------------------------
+
+Since the batch is issued as a single `_bulk` request, large batch sizes 
+cause Elasticsearch to create many requests and then wait for a while before
+starting the next set. This is "bursty" instead of "smooth".
+
+[[docs-reindex-rethrottle]]
+===== Rethrottling
+
+The value of `requests_per_second` can be changed on a running reindex using
+the `_rethrottle` API:
 
 [source,js]
 --------------------------------------------------
-POST _reindex
-{
-  "source": {
-    "index": "twitter"
-  },
-  "dest": {
-    "index": "new_twitter",
-    "op_type": "create"
-  }
-}
+POST _reindex/r1A2WoRbTwKZ516z6NEs5A:36619/_rethrottle?requests_per_second=-1
 --------------------------------------------------
-// CONSOLE
-// TEST[setup:twitter]
 
-By default, version conflicts abort the `_reindex` process. The `"conflicts"` request body
-parameter can be used to instruct `_reindex` to proceed with the next document on version conflicts.
-It is important to note that the handling of other error types is unaffected by the `"conflicts"` parameter.
-When `"conflicts": "proceed"` is set in the request body, the `_reindex` process will continue on version conflicts
-and return a count of version conflicts encountered:
+The task ID can be found using the <<tasks,tasks API>>.
 
-[source,js]
---------------------------------------------------
-POST _reindex
-{
-  "conflicts": "proceed",
-  "source": {
-    "index": "twitter"
-  },
-  "dest": {
-    "index": "new_twitter",
-    "op_type": "create"
-  }
-}
---------------------------------------------------
-// CONSOLE
-// TEST[setup:twitter]
+Just like when setting it on the Reindex API, `requests_per_second`
+can be either `-1` to disable throttling or any decimal number
+like `1.7` or `12` to throttle to that level. Rethrottling that speeds up the
+query takes effect immediately, but rethrottling that slows down the query will
+take effect after completing the current batch. This prevents scroll
+timeouts.
 
-You can limit the documents by adding a query to the `source`.
-This will only copy tweets made by `kimchy` into `new_twitter`:
+[[docs-reindex-slice]]
+===== Slicing
 
-[source,js]
---------------------------------------------------
+Reindex supports <<sliced-scroll>> to parallelize the reindexing process.
+This parallelization can improve efficiency and provide a convenient way to
+break the request down into smaller parts.
+
+NOTE: Reindexing from remote clusters does not support
+<<docs-reindex-manual-slice, manual>> or
+<<docs-reindex-automatic-slice, automatic slicing>>.
+
+[[docs-reindex-manual-slice]]
+====== Manual slicing
+Slice a reindex request manually by providing a slice id and total number of
+slices to each request:
+
+[source,console]
+----------------------------------------------------------------
 POST _reindex
 {
   "source": {
     "index": "twitter",
-    "query": {
-      "term": {
-        "user": "kimchy"
-      }
+    "slice": {
+      "id": 0,
+      "max": 2
     }
   },
   "dest": {
     "index": "new_twitter"
   }
 }
---------------------------------------------------
-// CONSOLE
-// TEST[setup:twitter]
-
-`index` in `source` can be a list, allowing you to copy from lots 
-of sources in one request. This will copy documents from the
-`twitter` and `blog` indices:
-
-[source,js]
---------------------------------------------------
 POST _reindex
 {
   "source": {
-    "index": ["twitter", "blog"]
+    "index": "twitter",
+    "slice": {
+      "id": 1,
+      "max": 2
+    }
   },
   "dest": {
-    "index": "all_together"
+    "index": "new_twitter"
   }
 }
---------------------------------------------------
-// CONSOLE
-// TEST[setup:twitter]
-// TEST[s/^/PUT blog\/post\/post1?refresh\n{"test": "foo"}\n/]
+----------------------------------------------------------------
+// TEST[setup:big_twitter]
 
-NOTE: The Reindex API makes no effort to handle ID collisions so the last
-document written will "win" but the order isn't usually predictable so it is
-not a good idea to rely on this behavior. Instead, make sure that IDs are unique
-using a script.
+You can verify this works by:
 
-It's also possible to limit the number of processed documents by setting
-`max_docs`. This will only copy a single document from `twitter` to
-`new_twitter`:
+[source,console]
+----------------------------------------------------------------
+GET _refresh
+POST new_twitter/_search?size=0&filter_path=hits.total
+----------------------------------------------------------------
+// TEST[continued]
 
-[source,js]
---------------------------------------------------
-POST _reindex
+which results in a sensible `total` like this one:
+
+[source,console-result]
+----------------------------------------------------------------
 {
-  "max_docs": 1,
+  "hits": {
+    "total" : {
+        "value": 120,
+        "relation": "eq"
+    }
+  }
+}
+----------------------------------------------------------------
+
+[[docs-reindex-automatic-slice]]
+====== Automatic slicing
+
+You can also let `_reindex` automatically parallelize using <<sliced-scroll>> to
+slice on `_uid`. Use `slices` to specify the number of slices to use:
+
+[source,console]
+----------------------------------------------------------------
+POST _reindex?slices=5&refresh
+{
   "source": {
     "index": "twitter"
   },
@@ -205,108 +259,80 @@ POST _reindex
     "index": "new_twitter"
   }
 }
---------------------------------------------------
-// CONSOLE
-// TEST[setup:twitter]
+----------------------------------------------------------------
+// TEST[setup:big_twitter]
 
-If you want a particular set of documents from the `twitter` index you'll
-need to use `sort`. Sorting makes the scroll less efficient but in some contexts
-it's worth it. If possible, prefer a more selective query to `max_docs` and `sort`.
-This will copy 10000 documents from `twitter` into `new_twitter`:
+You can also this verify works by:
 
-[source,js]
---------------------------------------------------
-POST _reindex
+[source,console]
+----------------------------------------------------------------
+POST new_twitter/_search?size=0&filter_path=hits.total
+----------------------------------------------------------------
+// TEST[continued]
+
+which results in a sensible `total` like this one:
+
+[source,console-result]
+----------------------------------------------------------------
 {
-  "max_docs": 10000,
-  "source": {
-    "index": "twitter",
-    "sort": { "date": "desc" }
-  },
-  "dest": {
-    "index": "new_twitter"
+  "hits": {
+    "total" : {
+        "value": 120,
+        "relation": "eq"
+    }
   }
 }
---------------------------------------------------
-// CONSOLE
-// TEST[setup:twitter]
+----------------------------------------------------------------
 
-The `source` section supports all the elements that are supported in a
-<<search-request-body,search request>>. For instance, only a subset of the
-fields from the original documents can be reindexed using `source` filtering
-as follows:
+Setting `slices` to `auto` will let Elasticsearch choose the number of slices
+to use. This setting will use one slice per shard, up to a certain limit. If
+there are multiple source indices, it will choose the number of slices based
+on the index with the smallest number of shards.
 
-[source,js]
---------------------------------------------------
-POST _reindex
-{
-  "source": {
-    "index": "twitter",
-    "_source": ["user", "_doc"]
-  },
-  "dest": {
-    "index": "new_twitter"
-  }
-}
---------------------------------------------------
-// CONSOLE
-// TEST[setup:twitter]
+Adding `slices` to `_reindex` just automates the manual process used in the
+section above, creating sub-requests which means it has some quirks:
 
-[[reindex-scripts]]
-Like `_update_by_query`, `_reindex` supports a script that modifies the
-document. Unlike `_update_by_query`, the script is allowed to modify the
-document's metadata. This example bumps the version of the source document:
+* You can see these requests in the <<docs-reindex-task-api,Tasks APIs>>. These
+sub-requests are "child" tasks of the task for the request with `slices`.
+* Fetching the status of the task for the request with `slices` only contains
+the status of completed slices.
+* These sub-requests are individually addressable for things like cancelation
+and rethrottling.
+* Rethrottling the request with `slices` will rethrottle the unfinished
+sub-request proportionally.
+* Canceling the request with `slices` will cancel each sub-request.
+* Due to the nature of `slices` each sub-request won't get a perfectly even
+portion of the documents. All documents will be addressed, but some slices may
+be larger than others. Expect larger slices to have a more even distribution.
+* Parameters like `requests_per_second` and `max_docs` on a request with
+`slices` are distributed proportionally to each sub-request. Combine that with
+the point above about distribution being uneven and you should conclude that
+using `max_docs` with `slices` might not result in exactly `max_docs` documents
+being reindexed.
+* Each sub-request gets a slightly different snapshot of the source index,
+though these are all taken at approximately the same time.
 
-[source,js]
---------------------------------------------------
-POST _reindex
-{
-  "source": {
-    "index": "twitter"
-  },
-  "dest": {
-    "index": "new_twitter",
-    "version_type": "external"
-  },
-  "script": {
-    "source": "if (ctx._source.foo == 'bar') {ctx._version++; ctx._source.remove('foo')}",
-    "lang": "painless"
-  }
-}
---------------------------------------------------
-// CONSOLE
-// TEST[setup:twitter]
+[[docs-reindex-picking-slices]]
+====== Picking the number of slices
 
-Just as in `_update_by_query`, you can set `ctx.op` to change the
-operation that is executed on the destination index:
+If slicing automatically, setting `slices` to `auto` will choose a reasonable
+number for most indices. If slicing manually or otherwise tuning
+automatic slicing, use these guidelines.
 
-`noop`::
+Query performance is most efficient when the number of `slices` is equal to the
+number of shards in the index. If that number is large (e.g. 500),
+choose a lower number as too many `slices` will hurt performance. Setting
+`slices` higher than the number of shards generally does not improve efficiency
+and adds overhead.
 
-Set `ctx.op = "noop"` if your script decides that the document doesn't have
-to be indexed in the destination index. This no operation will be reported
-in the `noop` counter in the <<docs-reindex-response-body, response body>>.
+Indexing performance scales linearly across available resources with the
+number of slices.
 
-`delete`::
+Whether query or indexing performance dominates the runtime depends on the
+documents being reindexed and cluster resources.
 
-Set `ctx.op = "delete"` if your script decides that the document must be
- deleted from the destination index. The deletion will be reported in the
- `deleted` counter in the <<docs-reindex-response-body, response body>>.
-
-Setting `ctx.op` to anything else will return an error, as will setting any
-other field in `ctx`.
-
-Think of the possibilities! Just be careful; you are able to
-change:
-
- * `_id`
- * `_index`
- * `_version`
- * `_routing`
-
-Setting `_version` to `null` or clearing it from the `ctx` map is just like not
-sending the version in an indexing request; it will cause the document to be
-overwritten in the target index regardless of the version on the target or the
-version type you use in the `_reindex` request.
+[[docs-reindex-routing]]
+===== Reindex routing
 
 By default if `_reindex` sees a document with routing then the routing is
 preserved unless it's changed by the script. You can set `routing` on the
@@ -351,6 +377,8 @@ POST _reindex
 // CONSOLE
 // TEST[s/^/PUT source\n/]
 
+
+
 By default `_reindex` uses scroll batches of 1000. You can change the
 batch size with the `size` field in the `source` element:
 
@@ -390,13 +418,502 @@ POST _reindex
 // CONSOLE
 // TEST[s/^/PUT source\n/]
 
-[float]
+[[docs-reindex-api-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=refresh]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=timeout]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=wait_for_completion]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=requests_per_second]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=scroll]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=slices]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=max_docs]
+
+[[docs-reindex-api-request-body]]
+==== {api-request-body-title}
+
+`conflicts`::
+(Optional, enum) Set to `proceed` to continue reindexing even if there are conflicts. 
+Defaults to `abort`.
+
+`source`::
+`index`:::
+(Required, string) The name of the index you are copying _from_. 
+Also accepts a comma-separated list of indices to reindex from multiple sources.  
+
+`max_docs`:::
+(Optional, integer) The maximum number of documents to reindex.
+
+`query`:::
+(Optional, <<query-dsl, query object>>) Specifies the documents to reindex using the Query DSL.
+
+`remote`:::
+`host`::::
+(Optional, string) The URL for the remote instance of {es} that you want to index _from_.
+Required when indexing from remote.
+`username`::::
+(Optional, string) The username to use for authentication with the remote host.
+`password`::::
+(Optional, string) The password to use for authentication with the remote host. 
+`socket_timeout`:::: 
+(Optional, <<time-units, time units>>) The remote socket read timeout. Defaults to 30 seconds.
+`connect_timeout`:::: 
+(Optional, <<time-units, time units>>) The remote connection timeout. Defaults to 30 seconds.
+
+`size`:::
+{Optional, integer) The number of documents to index per batch. 
+Use when indexing from remote to ensure that the batches fit within the on-heap buffer, 
+which defaults to a maximum size of 100 MB. 
+
+`slice`:::
+`id`::::
+(Optional, integer) Slice ID for <<docs-reindex-manual-slice, manual slicing>>. 
+`max`::::
+(Optional, integer) Total number of slices. 
+
+`sort`:::
+(Optional, list) A comma-separated list of `<field>:<direction>` pairs to sort by before indexing.
+Use in conjunction with `max_docs` to control what documents are reindexed.
+
+`_source`:::
+(Optional, string) If `true` reindexes all source fields. 
+Set to a list to reindex select fields. 
+Defaults to `true`. 
+
+`dest`::
+`index`:::
+(Required, string) The name of the index you are copying _to_.
+
+`version_type`:::
+(Optional, enum) The versioning to use for the indexing operation.  
+Valid values: `internal`, `external`, `external_gt`, `external_gte`. 
+See <<index-version-types>> for more information.
+
+`op_type`::: 
+(Optional, enum) Set to create to only index documents that do not already exist (put if absent). 
+Valid values: `index`, `create`. Defaults to `index`.
+
+`script`::
+`source`::: 
+(Optional, string) The script to run to update the document source or metadata when reindexing. 
+`lang`:::
+(Optional, enum) The script language: `painless`, `expression`, `mustache`, `java`. 
+For more information, see <<modules-scripting>>.
+
+
+[[docs-reindex-api-response-body]]
+==== {api-response-body-title}
+
+`took`::
+
+(integer) The total milliseconds the entire operation took.
+
+`timed_out`::
+
+{boolean) This flag is set to `true` if any of the requests executed during the
+reindex timed out.
+
+`total`::
+
+(integer) The number of documents that were successfully processed.
+
+`updated`::
+
+(integer) The number of documents that were successfully updated.
+
+`created`::
+
+(integer) The number of documents that were successfully created.
+
+`deleted`::
+
+(integer) The number of documents that were successfully deleted.
+
+`batches`::
+
+(integer) The number of scroll responses pulled back by the reindex.
+
+`noops`::
+
+(integer) The number of documents that were ignored because the script used for
+the reindex returned a `noop` value for `ctx.op`.
+
+`version_conflicts`::
+
+{integer)The number of version conflicts that reindex hit.
+
+`retries`::
+
+(integer) The number of retries attempted by reindex. `bulk` is the number of bulk
+actions retried and `search` is the number of search actions retried.
+
+`throttled_millis`::
+
+(integer) Number of milliseconds the request slept to conform to `requests_per_second`.
+
+`requests_per_second`::
+
+(integer) The number of requests per second effectively executed during the reindex.
+
+`throttled_until_millis`::
+
+(integer) This field should always be equal to zero in a `_reindex` response. It only
+has meaning when using the <<docs-reindex-task-api, Task API>>, where it
+indicates the next time (in milliseconds since epoch) a throttled request will be
+executed again in order to conform to `requests_per_second`.
+
+`failures`::
+
+(array) Array of failures if there were any unrecoverable errors during the process. If
+this is non-empty then the request aborted because of those failures. Reindex
+is implemented using batches and any failure causes the entire process to abort
+but all failures in the current batch are collected into the array. You can use
+the `conflicts` option to prevent reindex from aborting on version conflicts.
+
+[[docs-reindex-api-example]]
+==== {api-examples-title}
+
+[[docs-reindex-select-query]]
+===== Reindex select documents with a query
+
+You can limit the documents by adding a query to the `source`.
+For example, the following request only copies tweets made by `kimchy` into `new_twitter`:
+
+[source,js]
+--------------------------------------------------
+POST _reindex
+{
+  "source": {
+    "index": "twitter",
+    "query": {
+      "term": {
+        "user": "kimchy"
+      }
+    }
+  },
+  "dest": {
+    "index": "new_twitter"
+  }
+}
+--------------------------------------------------
+// TEST[setup:twitter]
+
+[[docs-reindex-select-sort]]
+===== Reindex select documents with sort
+
+You can limit the number of processed documents by setting `max_docs`. 
+For example, this request copies a single document from `twitter` to
+`new_twitter`:
+
+[source,console]
+--------------------------------------------------
+POST _reindex
+{
+  "max_docs": 1,
+  "source": {
+    "index": "twitter"
+  },
+  "dest": {
+    "index": "new_twitter"
+  }
+}
+--------------------------------------------------
+// TEST[setup:twitter]
+
+You can use `sort` in conjunction with `max_docs` to select the documents you want to reindex. 
+Sorting makes the scroll less efficient but in some contexts it's worth it. 
+If possible, it's better to use a more selective query instead of `max_docs` and `sort`.
+
+For example, following request copies 10000 documents from `twitter` into `new_twitter`:
+
+[source,js]
+--------------------------------------------------
+POST _reindex
+{
+  "max_docs": 10000,
+  "source": {
+    "index": "twitter",
+    "sort": { "date": "desc" }
+  },
+  "dest": {
+    "index": "new_twitter"
+  }
+}
+--------------------------------------------------
+// TEST[setup:twitter]
+
+[[docs-reindex-multiple-indices]]
+===== Reindex from multiple indices
+
+The `index` attribute in `source` can be a list, allowing you to copy from lots 
+of sources in one request. This will copy documents from the
+`twitter` and `blog` indices:
+
+[source,js]
+--------------------------------------------------
+POST _reindex
+{
+  "source": {
+    "index": ["twitter", "blog"]
+  },
+  "dest": {
+    "index": "all_together"
+  }
+}
+--------------------------------------------------
+// TEST[setup:twitter]
+// TEST[s/^/PUT blog\/post\/post1?refresh\n{"test": "foo"}\n/]
+
+NOTE: The Reindex API makes no effort to handle ID collisions so the last
+document written will "win" but the order isn't usually predictable so it is
+not a good idea to rely on this behavior. Instead, make sure that IDs are unique
+using a script.
+
+[[docs-reindex-filter-source]]
+===== Reindex select fields with a source filter
+
+You can use source filtering to reindex a subset of the fields in the original documents.
+For example, the following request only reindexes the `user` and `_doc` fields of each document:
+
+[source,console]
+--------------------------------------------------
+POST _reindex
+{
+  "source": {
+    "index": "twitter",
+    "_source": ["user", "_doc"]
+  },
+  "dest": {
+    "index": "new_twitter"
+  }
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[setup:twitter]
+
+[[docs-reindex-change-name]]
+===== Reindex to change the name of a field
+
+`_reindex` can be used to build a copy of an index with renamed fields. Say you
+create an index containing documents that look like this:
+
+[source,js]
+--------------------------------------------------
+POST test/_doc/1?refresh
+{
+  "text": "words words",
+  "flag": "foo"
+}
+--------------------------------------------------
+// CONSOLE
+
+but you don't like the name `flag` and want to replace it with `tag`.
+`_reindex` can create the other index for you:
+
+[source,js]
+--------------------------------------------------
+POST _reindex
+{
+  "source": {
+    "index": "test"
+  },
+  "dest": {
+    "index": "test2"
+  },
+  "script": {
+    "source": "ctx._source.tag = ctx._source.remove(\"flag\")"
+  }
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[continued]
+
+Now you can get the new document:
+
+[source,js]
+--------------------------------------------------
+GET test2/_doc/1
+--------------------------------------------------
+// CONSOLE
+// TEST[continued]
+
+which will return:
+
+[source,js]
+--------------------------------------------------
+{
+  "found": true,
+  "_id": "1",
+  "_index": "test2",
+  "_type": "_doc",
+  "_version": 1,
+  "_seq_no": 44,
+  "_primary_term": 1,
+  "_source": {
+    "text": "words words",
+    "tag": "foo"
+  }
+}
+--------------------------------------------------
+// TESTRESPONSE[s/"_seq_no": \d+/"_seq_no" : $body._seq_no/ s/"_primary_term": 1/"_primary_term" : $body._primary_term/]
+
+[[docs-reindex-daily-indices]]
+===== Reindex daily indices
+
+You can use `_reindex` in combination with <<modules-scripting-painless, Painless>> to reindex
+daily indices to apply a new template to the existing documents.
+
+Assuming you have indices that contain documents like:
+
+[source,console]
+----------------------------------------------------------------
+PUT metricbeat-2016.05.30/_doc/1?refresh
+{"system.cpu.idle.pct": 0.908}
+PUT metricbeat-2016.05.31/_doc/1?refresh
+{"system.cpu.idle.pct": 0.105}
+----------------------------------------------------------------
+
+The new template for the `metricbeat-*` indices is already loaded into Elasticsearch,
+but it applies only to the newly created indices. Painless can be used to reindex
+the existing documents and apply the new template.
+
+The script below extracts the date from the index name and creates a new index
+with `-1` appended. All data from `metricbeat-2016.05.31` will be reindexed
+into `metricbeat-2016.05.31-1`.
+
+[source,js]
+----------------------------------------------------------------
+POST _reindex
+{
+  "source": {
+    "index": "metricbeat-*"
+  },
+  "dest": {
+    "index": "metricbeat"
+  },
+  "script": {
+    "lang": "painless",
+    "source": "ctx._index = 'metricbeat-' + (ctx._index.substring('metricbeat-'.length(), ctx._index.length())) + '-1'"
+  }
+}
+----------------------------------------------------------------
+// TEST[continued]
+
+All documents from the previous metricbeat indices can now be found in the `*-1` indices.
+
+[source,js]
+----------------------------------------------------------------
+GET metricbeat-2016.05.30-1/_doc/1
+GET metricbeat-2016.05.31-1/_doc/1
+----------------------------------------------------------------
+// CONSOLE
+// TEST[continued]
+
+The previous method can also be used in conjunction with <<docs-reindex-change-name, changing a field name>>
+to load only the existing data into the new index and rename any fields if needed.
+
+[[docs-reindex-api-subset]]
+===== Extract a random subset of an index
+
+`_reindex` can be used to extract a random subset of an index for testing:
+
+[source,js]
+----------------------------------------------------------------
+POST _reindex
+{
+  "max_docs": 10,
+  "source": {
+    "index": "twitter",
+    "query": {
+      "function_score" : {
+        "query" : { "match_all": {} },
+        "random_score" : {}
+      }
+    },
+    "sort": "_score"    <1>
+  },
+  "dest": {
+    "index": "random_twitter"
+  }
+}
+----------------------------------------------------------------
+// CONSOLE
+// TEST[setup:big_twitter]
+
+<1> `_reindex` defaults to sorting by `_doc` so `random_score` will not have any
+effect unless you override the sort to `_score`.
+
+[[reindex-scripts]]
+===== Modify documents during reindexing
+
+Like `_update_by_query`, `_reindex` supports a script that modifies the
+document. Unlike `_update_by_query`, the script is allowed to modify the
+document's metadata. This example bumps the version of the source document:
+
+[source,console]
+--------------------------------------------------
+POST _reindex
+{
+  "source": {
+    "index": "twitter"
+  },
+  "dest": {
+    "index": "new_twitter",
+    "version_type": "external"
+  },
+  "script": {
+    "source": "if (ctx._source.foo == 'bar') {ctx._version++; ctx._source.remove('foo')}",
+    "lang": "painless"
+  }
+}
+--------------------------------------------------
+// TEST[setup:twitter]
+
+Just as in `_update_by_query`, you can set `ctx.op` to change the
+operation that is executed on the destination index:
+
+`noop`::
+
+Set `ctx.op = "noop"` if your script decides that the document doesn't have
+to be indexed in the destination index. This no operation will be reported
+in the `noop` counter in the <<docs-reindex-api-response-body, response body>>.
+
+`delete`::
+
+Set `ctx.op = "delete"` if your script decides that the document must be
+ deleted from the destination index. The deletion will be reported in the
+ `deleted` counter in the <<docs-reindex-api-response-body, response body>>.
+
+Setting `ctx.op` to anything else will return an error, as will setting any
+other field in `ctx`.
+
+Think of the possibilities! Just be careful; you are able to
+change:
+
+ * `_id`
+ * `_index`
+ * `_version`
+ * `_routing`
+
+Setting `_version` to `null` or clearing it from the `ctx` map is just like not
+sending the version in an indexing request; it will cause the document to be
+overwritten in the target index regardless of the version on the target or the
+version type you use in the `_reindex` request.
+
 [[reindex-from-remote]]
-==== Reindex from Remote
+==== Reindex from remote
 
 Reindex supports reindexing from a remote Elasticsearch cluster:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _reindex
 {
@@ -418,7 +935,6 @@ POST _reindex
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:host]
 // TEST[s/^/PUT source\n/]
 // TEST[s/otherhost:9200",/\${host}"/]
@@ -464,7 +980,7 @@ maximum size of 100mb. If the remote index includes very large documents you'll
 need to use a smaller batch size. The example below sets the batch size to `10`
 which is very, very small.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _reindex
 {
@@ -485,7 +1001,6 @@ POST _reindex
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:host]
 // TEST[s/^/PUT source\n/]
 // TEST[s/otherhost:9200/\${host}/]
@@ -496,7 +1011,7 @@ with the `socket_timeout` field and the connection timeout with the
 sets the socket read timeout to one minute and the connection timeout to 10
 seconds:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _reindex
 {
@@ -518,12 +1033,10 @@ POST _reindex
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:host]
 // TEST[s/^/PUT source\n/]
 // TEST[s/otherhost:9200/\${host}/]
 
-[float]
 [[reindex-ssl]]
 ===== Configuring SSL parameters
 
@@ -615,641 +1128,3 @@ Defaults to the keystore password. This setting cannot be used with
 The password for the key in the keystore (`reindex.ssl.keystore.path`).
 Defaults to the keystore password. This setting cannot be used with 
 `reindex.ssl.keystore.key_password`.
-
-[float]
-==== URL Parameters
-
-In addition to the standard parameters like `pretty`, the Reindex API also
-supports `refresh`, `wait_for_completion`, `wait_for_active_shards`, `timeout`,
-`scroll`, and `requests_per_second`.
-
-Sending the `refresh` url parameter will cause all indexes to which the request
-wrote to be refreshed. This is different than the Index API's `refresh`
-parameter which causes just the shard that received the new data to be
-refreshed. Also unlike the Index API it does not support `wait_for`.
-
-If the request contains `wait_for_completion=false` then Elasticsearch will
-perform some preflight checks, launch the request, and then return a `task`
-which can be used with <<docs-reindex-task-api,Tasks APIs>>
-to cancel or get the status of the task. Elasticsearch will also create a
-record of this task as a document at `.tasks/task/${taskId}`. This is yours
-to keep or remove as you see fit. When you are done with it, delete it so
-Elasticsearch can reclaim the space it uses.
-
-`wait_for_active_shards` controls how many copies of a shard must be active
-before proceeding with the reindexing. See <<index-wait-for-active-shards,here>>
-for details. `timeout` controls how long each write request waits for unavailable
-shards to become available. Both work exactly how they work in the
-<<docs-bulk,Bulk API>>. As `_reindex` uses scroll search, you can also specify
-the `scroll` parameter to control how long it keeps the "search context" alive,
-(e.g. `?scroll=10m`). The default value is 5 minutes.
-
-`requests_per_second` can be set to any positive decimal number (`1.4`, `6`,
-`1000`, etc.) and throttles the rate at which `_reindex` issues batches of index
-operations by padding each batch with a wait time. The throttling can be
-disabled by setting `requests_per_second` to `-1`.
-
-The throttling is done by waiting between batches so that the `scroll` which `_reindex`
-uses internally can be given a timeout that takes into account the padding.
-The padding time is the difference between the batch size divided by the
-`requests_per_second` and the time spent writing. By default the batch size is
-`1000`, so if the `requests_per_second` is set to `500`:
-
-[source,txt]
---------------------------------------------------
-target_time = 1000 / 500 per second = 2 seconds
-wait_time = target_time - write_time = 2 seconds - .5 seconds = 1.5 seconds
---------------------------------------------------
-
-Since the batch is issued as a single `_bulk` request, large batch sizes will
-cause Elasticsearch to create many requests and then wait for a while before
-starting the next set. This is "bursty" instead of "smooth". The default value is `-1`.
-
-[float]
-[[docs-reindex-response-body]]
-==== Response body
-
-//////////////////////////
-[source,js]
---------------------------------------------------
-POST /_reindex?wait_for_completion
-{
-  "source": {
-    "index": "twitter"
-  },
-  "dest": {
-    "index": "new_twitter"
-  }
-}
---------------------------------------------------
-// CONSOLE
-// TEST[setup:twitter]
-
-//////////////////////////
-
-The JSON response looks like this:
-
-[source,js]
---------------------------------------------------
-{
-  "took": 639,
-  "timed_out": false,
-  "total": 5,
-  "updated": 0,
-  "created": 5,
-  "deleted": 0,
-  "batches": 1,
-  "noops": 0,
-  "version_conflicts": 2,
-  "retries": {
-    "bulk": 0,
-    "search": 0
-  },
-  "throttled_millis": 0,
-  "requests_per_second": 1,
-  "throttled_until_millis": 0,
-  "failures": [ ]
-}
---------------------------------------------------
-// TESTRESPONSE[s/: [0-9]+/: $body.$_path/]
-
-`took`::
-
-The total milliseconds the entire operation took.
-
-`timed_out`::
-
-This flag is set to `true` if any of the requests executed during the
-reindex timed out.
-
-`total`::
-
-The number of documents that were successfully processed.
-
-`updated`::
-
-The number of documents that were successfully updated.
-
-`created`::
-
-The number of documents that were successfully created.
-
-`deleted`::
-
-The number of documents that were successfully deleted.
-
-`batches`::
-
-The number of scroll responses pulled back by the reindex.
-
-`noops`::
-
-The number of documents that were ignored because the script used for
-the reindex returned a `noop` value for `ctx.op`.
-
-`version_conflicts`::
-
-The number of version conflicts that reindex hit.
-
-`retries`::
-
-The number of retries attempted by reindex. `bulk` is the number of bulk
-actions retried and `search` is the number of search actions retried.
-
-`throttled_millis`::
-
-Number of milliseconds the request slept to conform to `requests_per_second`.
-
-`requests_per_second`::
-
-The number of requests per second effectively executed during the reindex.
-
-`throttled_until_millis`::
-
-This field should always be equal to zero in a `_reindex` response. It only
-has meaning when using the <<docs-reindex-task-api, Task API>>, where it
-indicates the next time (in milliseconds since epoch) a throttled request will be
-executed again in order to conform to `requests_per_second`.
-
-`failures`::
-
-Array of failures if there were any unrecoverable errors during the process. If
-this is non-empty then the request aborted because of those failures. Reindex
-is implemented using batches and any failure causes the entire process to abort
-but all failures in the current batch are collected into the array. You can use
-the `conflicts` option to prevent reindex from aborting on version conflicts.
-
-[float]
-[[docs-reindex-task-api]]
-==== Works with the Task API
-
-You can fetch the status of all running reindex requests with the
-<<tasks,Task API>>:
-
-[source,js]
---------------------------------------------------
-GET _tasks?detailed=true&actions=*reindex
---------------------------------------------------
-// CONSOLE
-// TEST[skip:No tasks to retrieve]
-
-The response looks like:
-
-[source,js]
---------------------------------------------------
-{
-  "nodes" : {
-    "r1A2WoRbTwKZ516z6NEs5A" : {
-      "name" : "r1A2WoR",
-      "transport_address" : "127.0.0.1:9300",
-      "host" : "127.0.0.1",
-      "ip" : "127.0.0.1:9300",
-      "attributes" : {
-        "testattr" : "test",
-        "portsfile" : "true"
-      },
-      "tasks" : {
-        "r1A2WoRbTwKZ516z6NEs5A:36619" : {
-          "node" : "r1A2WoRbTwKZ516z6NEs5A",
-          "id" : 36619,
-          "type" : "transport",
-          "action" : "indices:data/write/reindex",
-          "status" : {    <1>
-            "total" : 6154,
-            "updated" : 3500,
-            "created" : 0,
-            "deleted" : 0,
-            "batches" : 4,
-            "version_conflicts" : 0,
-            "noops" : 0,
-            "retries": {
-              "bulk": 0,
-              "search": 0
-            },
-            "throttled_millis": 0,
-            "requests_per_second": -1,
-            "throttled_until_millis": 0
-          },
-          "description" : "",
-          "start_time_in_millis": 1535149899665,
-          "running_time_in_nanos": 5926916792,
-          "cancellable": true,
-          "headers": {}
-        }
-      }
-    }
-  }
-}
---------------------------------------------------
-// TESTRESPONSE
-<1> This object contains the actual status. It is identical to the response JSON
-except for the important addition of the `total` field. `total` is the total number
-of operations that the `_reindex` expects to perform. You can estimate the
-progress by adding the `updated`, `created`, and `deleted` fields. The request
-will finish when their sum is equal to the `total` field.
-
-With the task id you can look up the task directly. The following example 
-retrieves information about the task `r1A2WoRbTwKZ516z6NEs5A:36619`:
-
-[source,js]
---------------------------------------------------
-GET /_tasks/r1A2WoRbTwKZ516z6NEs5A:36619
---------------------------------------------------
-// CONSOLE
-// TEST[catch:missing]
-
-The advantage of this API is that it integrates with `wait_for_completion=false`
-to transparently return the status of completed tasks. If the task is completed
-and `wait_for_completion=false` was set, it will return a
-`results` or an `error` field. The cost of this feature is the document that
-`wait_for_completion=false` creates at `.tasks/task/${taskId}`. It is up to
-you to delete that document.
-
-
-[float]
-[[docs-reindex-cancel-task-api]]
-==== Works with the Cancel Task API
-
-Any reindex can be canceled using the <<task-cancellation,Task Cancel API>>. For 
-example:
-
-[source,js]
---------------------------------------------------
-POST _tasks/r1A2WoRbTwKZ516z6NEs5A:36619/_cancel
---------------------------------------------------
-// CONSOLE
-
-The task ID can be found using the <<tasks,Tasks API>>.
-
-Cancelation should happen quickly but might take a few seconds. The Tasks
-API will continue to list the task until it wakes to cancel itself.
-
-
-[float]
-[[docs-reindex-rethrottle]]
-==== Rethrottling
-
-The value of `requests_per_second` can be changed on a running reindex using
-the `_rethrottle` API:
-
-[source,js]
---------------------------------------------------
-POST _reindex/r1A2WoRbTwKZ516z6NEs5A:36619/_rethrottle?requests_per_second=-1
---------------------------------------------------
-// CONSOLE
-
-The task ID can be found using the <<tasks,tasks API>>.
-
-Just like when setting it on the Reindex API, `requests_per_second`
-can be either `-1` to disable throttling or any decimal number
-like `1.7` or `12` to throttle to that level. Rethrottling that speeds up the
-query takes effect immediately, but rethrottling that slows down the query will
-take effect after completing the current batch. This prevents scroll
-timeouts.
-
-[float]
-[[docs-reindex-change-name]]
-==== Reindex to change the name of a field
-
-`_reindex` can be used to build a copy of an index with renamed fields. Say you
-create an index containing documents that look like this:
-
-[source,js]
---------------------------------------------------
-POST test/_doc/1?refresh
-{
-  "text": "words words",
-  "flag": "foo"
-}
---------------------------------------------------
-// CONSOLE
-
-but you don't like the name `flag` and want to replace it with `tag`.
-`_reindex` can create the other index for you:
-
-[source,js]
---------------------------------------------------
-POST _reindex
-{
-  "source": {
-    "index": "test"
-  },
-  "dest": {
-    "index": "test2"
-  },
-  "script": {
-    "source": "ctx._source.tag = ctx._source.remove(\"flag\")"
-  }
-}
---------------------------------------------------
-// CONSOLE
-// TEST[continued]
-
-Now you can get the new document:
-
-[source,js]
---------------------------------------------------
-GET test2/_doc/1
---------------------------------------------------
-// CONSOLE
-// TEST[continued]
-
-which will return:
-
-[source,js]
---------------------------------------------------
-{
-  "found": true,
-  "_id": "1",
-  "_index": "test2",
-  "_type": "_doc",
-  "_version": 1,
-  "_seq_no": 44,
-  "_primary_term": 1,
-  "_source": {
-    "text": "words words",
-    "tag": "foo"
-  }
-}
---------------------------------------------------
-// TESTRESPONSE[s/"_seq_no": \d+/"_seq_no" : $body._seq_no/ s/"_primary_term": 1/"_primary_term" : $body._primary_term/]
-
-[float]
-[[docs-reindex-slice]]
-==== Slicing
-
-Reindex supports <<sliced-scroll>> to parallelize the reindexing process.
-This parallelization can improve efficiency and provide a convenient way to
-break the request down into smaller parts.
-
-[float]
-[[docs-reindex-manual-slice]]
-===== Manual slicing
-Slice a reindex request manually by providing a slice id and total number of
-slices to each request:
-
-[source,js]
-----------------------------------------------------------------
-POST _reindex
-{
-  "source": {
-    "index": "twitter",
-    "slice": {
-      "id": 0,
-      "max": 2
-    }
-  },
-  "dest": {
-    "index": "new_twitter"
-  }
-}
-POST _reindex
-{
-  "source": {
-    "index": "twitter",
-    "slice": {
-      "id": 1,
-      "max": 2
-    }
-  },
-  "dest": {
-    "index": "new_twitter"
-  }
-}
-----------------------------------------------------------------
-// CONSOLE
-// TEST[setup:big_twitter]
-
-You can verify this works by:
-
-[source,js]
-----------------------------------------------------------------
-GET _refresh
-POST new_twitter/_search?size=0&filter_path=hits.total
-----------------------------------------------------------------
-// CONSOLE
-// TEST[continued]
-
-which results in a sensible `total` like this one:
-
-[source,js]
-----------------------------------------------------------------
-{
-  "hits": {
-    "total" : {
-        "value": 120,
-        "relation": "eq"
-    }
-  }
-}
-----------------------------------------------------------------
-// TESTRESPONSE
-
-[float]
-[[docs-reindex-automatic-slice]]
-===== Automatic slicing
-
-You can also let `_reindex` automatically parallelize using <<sliced-scroll>> to
-slice on `_uid`. Use `slices` to specify the number of slices to use:
-
-[source,js]
-----------------------------------------------------------------
-POST _reindex?slices=5&refresh
-{
-  "source": {
-    "index": "twitter"
-  },
-  "dest": {
-    "index": "new_twitter"
-  }
-}
-----------------------------------------------------------------
-// CONSOLE
-// TEST[setup:big_twitter]
-
-You can also this verify works by:
-
-[source,js]
-----------------------------------------------------------------
-POST new_twitter/_search?size=0&filter_path=hits.total
-----------------------------------------------------------------
-// CONSOLE
-// TEST[continued]
-
-which results in a sensible `total` like this one:
-
-[source,js]
-----------------------------------------------------------------
-{
-  "hits": {
-    "total" : {
-        "value": 120,
-        "relation": "eq"
-    }
-  }
-}
-----------------------------------------------------------------
-// TESTRESPONSE
-
-Setting `slices` to `auto` will let Elasticsearch choose the number of slices
-to use. This setting will use one slice per shard, up to a certain limit. If
-there are multiple source indices, it will choose the number of slices based
-on the index with the smallest number of shards.
-
-Adding `slices` to `_reindex` just automates the manual process used in the
-section above, creating sub-requests which means it has some quirks:
-
-* You can see these requests in the <<docs-reindex-task-api,Tasks APIs>>. These
-sub-requests are "child" tasks of the task for the request with `slices`.
-* Fetching the status of the task for the request with `slices` only contains
-the status of completed slices.
-* These sub-requests are individually addressable for things like cancelation
-and rethrottling.
-* Rethrottling the request with `slices` will rethrottle the unfinished
-sub-request proportionally.
-* Canceling the request with `slices` will cancel each sub-request.
-* Due to the nature of `slices` each sub-request won't get a perfectly even
-portion of the documents. All documents will be addressed, but some slices may
-be larger than others. Expect larger slices to have a more even distribution.
-* Parameters like `requests_per_second` and `max_docs` on a request with
-`slices` are distributed proportionally to each sub-request. Combine that with
-the point above about distribution being uneven and you should conclude that
-using `max_docs` with `slices` might not result in exactly `max_docs` documents
-being reindexed.
-* Each sub-request gets a slightly different snapshot of the source index,
-though these are all taken at approximately the same time.
-
-[float]
-[[docs-reindex-picking-slices]]
-====== Picking the number of slices
-
-If slicing automatically, setting `slices` to `auto` will choose a reasonable
-number for most indices. If slicing manually or otherwise tuning
-automatic slicing, use these guidelines.
-
-Query performance is most efficient when the number of `slices` is equal to the
-number of shards in the index. If that number is large (e.g. 500),
-choose a lower number as too many `slices` will hurt performance. Setting
-`slices` higher than the number of shards generally does not improve efficiency
-and adds overhead.
-
-Indexing performance scales linearly across available resources with the
-number of slices.
-
-Whether query or indexing performance dominates the runtime depends on the
-documents being reindexed and cluster resources.
-
-[float]
-==== Reindexing many indices
-If you have many indices to reindex it is generally better to reindex them
-one at a time rather than using a glob pattern to pick up many indices. That
-way you can resume the process if there are any errors by removing the
-partially completed index and starting over at that index. It also makes
-parallelizing the process fairly simple: split the list of indices to reindex
-and run each list in parallel.
-
-One-off bash scripts seem to work nicely for this:
-
-[source,bash]
-----------------------------------------------------------------
-for index in i1 i2 i3 i4 i5; do
-  curl -HContent-Type:application/json -XPOST localhost:9200/_reindex?pretty -d'{
-    "source": {
-      "index": "'$index'"
-    },
-    "dest": {
-      "index": "'$index'-reindexed"
-    }
-  }'
-done
-----------------------------------------------------------------
-// NOTCONSOLE
-
-[float]
-==== Reindex daily indices
-
-Notwithstanding the above advice, you can use `_reindex` in combination with
-<<modules-scripting-painless, Painless>> to reindex daily indices to apply
-a new template to the existing documents.
-
-Assuming you have indices consisting of documents as follows:
-
-[source,js]
-----------------------------------------------------------------
-PUT metricbeat-2016.05.30/_doc/1?refresh
-{"system.cpu.idle.pct": 0.908}
-PUT metricbeat-2016.05.31/_doc/1?refresh
-{"system.cpu.idle.pct": 0.105}
-----------------------------------------------------------------
-// CONSOLE
-
-The new template for the `metricbeat-*` indices is already loaded into Elasticsearch,
-but it applies only to the newly created indices. Painless can be used to reindex
-the existing documents and apply the new template.
-
-The script below extracts the date from the index name and creates a new index
-with `-1` appended. All data from `metricbeat-2016.05.31` will be reindexed
-into `metricbeat-2016.05.31-1`.
-
-[source,js]
-----------------------------------------------------------------
-POST _reindex
-{
-  "source": {
-    "index": "metricbeat-*"
-  },
-  "dest": {
-    "index": "metricbeat"
-  },
-  "script": {
-    "lang": "painless",
-    "source": "ctx._index = 'metricbeat-' + (ctx._index.substring('metricbeat-'.length(), ctx._index.length())) + '-1'"
-  }
-}
-----------------------------------------------------------------
-// CONSOLE
-// TEST[continued]
-
-All documents from the previous metricbeat indices can now be found in the `*-1` indices.
-
-[source,js]
-----------------------------------------------------------------
-GET metricbeat-2016.05.30-1/_doc/1
-GET metricbeat-2016.05.31-1/_doc/1
-----------------------------------------------------------------
-// CONSOLE
-// TEST[continued]
-
-The previous method can also be used in conjunction with <<docs-reindex-change-name, changing a field name>>
-to load only the existing data into the new index and rename any fields if needed.
-
-[float]
-==== Extracting a random subset of an index
-
-`_reindex` can be used to extract a random subset of an index for testing:
-
-[source,js]
-----------------------------------------------------------------
-POST _reindex
-{
-  "max_docs": 10,
-  "source": {
-    "index": "twitter",
-    "query": {
-      "function_score" : {
-        "query" : { "match_all": {} },
-        "random_score" : {}
-      }
-    },
-    "sort": "_score"    <1>
-  },
-  "dest": {
-    "index": "random_twitter"
-  }
-}
-----------------------------------------------------------------
-// CONSOLE
-// TEST[setup:big_twitter]
-
-<1> `_reindex` defaults to sorting by `_doc` so `random_score` will not have any
-effect unless you override the sort to `_score`.

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -767,13 +767,14 @@ daily indices to apply a new template to the existing documents.
 
 Assuming you have indices that contain documents like:
 
-[source,console]
+[source,js]
 ----------------------------------------------------------------
 PUT metricbeat-2016.05.30/_doc/1?refresh
 {"system.cpu.idle.pct": 0.908}
 PUT metricbeat-2016.05.31/_doc/1?refresh
 {"system.cpu.idle.pct": 0.105}
 ----------------------------------------------------------------
+// CONSOLE
 
 The new template for the `metricbeat-*` indices is already loaded into Elasticsearch,
 but it applies only to the newly created indices. Painless can be used to reindex
@@ -783,7 +784,7 @@ The script below extracts the date from the index name and creates a new index
 with `-1` appended. All data from `metricbeat-2016.05.31` will be reindexed
 into `metricbeat-2016.05.31-1`.
 
-[source,console]
+[source,js]
 ----------------------------------------------------------------
 POST _reindex
 {
@@ -799,15 +800,17 @@ POST _reindex
   }
 }
 ----------------------------------------------------------------
+// CONSOLE
 // TEST[continued]
 
 All documents from the previous metricbeat indices can now be found in the `*-1` indices.
 
-[source,console]
+[source,js]
 ----------------------------------------------------------------
 GET metricbeat-2016.05.30-1/_doc/1
 GET metricbeat-2016.05.31-1/_doc/1
 ----------------------------------------------------------------
+// CONSOLE
 // TEST[continued]
 
 The previous method can also be used in conjunction with <<docs-reindex-change-name, changing a field name>>

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -701,7 +701,7 @@ POST _reindex
 `_reindex` can be used to build a copy of an index with renamed fields. Say you
 create an index containing documents that look like this:
 
-[source,console]
+[source,js]
 --------------------------------------------------
 POST test/_doc/1?refresh
 {
@@ -709,6 +709,7 @@ POST test/_doc/1?refresh
   "flag": "foo"
 }
 --------------------------------------------------
+// CONSOLE
 
 but you don't like the name `flag` and want to replace it with `tag`.
 `_reindex` can create the other index for you:

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -125,7 +125,6 @@ for index in i1 i2 i3 i4 i5; do
   }'
 done
 ----------------------------------------------------------------
-// NOTCONSOLE
 
 [[docs-reindex-throttle]]
 ===== Throttling
@@ -229,7 +228,7 @@ POST new_twitter/_search?size=0&filter_path=hits.total
 
 which results in a sensible `total` like this one:
 
-[source,console-result]
+[source,js]
 ----------------------------------------------------------------
 {
   "hits": {
@@ -240,6 +239,7 @@ which results in a sensible `total` like this one:
   }
 }
 ----------------------------------------------------------------
+// TESTRESPONSE
 
 [[docs-reindex-automatic-slice]]
 ====== Automatic slicing
@@ -271,7 +271,7 @@ POST new_twitter/_search?size=0&filter_path=hits.total
 
 which results in a sensible `total` like this one:
 
-[source,console-result]
+[source,js]
 ----------------------------------------------------------------
 {
   "hits": {
@@ -282,6 +282,7 @@ which results in a sensible `total` like this one:
   }
 }
 ----------------------------------------------------------------
+// TESTRESPONSE
 
 Setting `slices` to `auto` will let Elasticsearch choose the number of slices
 to use. This setting will use one slice per shard, up to a certain limit. If

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -16,7 +16,7 @@ Reindex does not copy the settings from the source index.
 Mappings, shard counts, replicas, and so on must be configured ahead of time.
 =================================================
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _reindex
 {
@@ -28,12 +28,11 @@ POST _reindex
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:big_twitter]
 
 ////
 
-[source,js]
+[source,console]
 --------------------------------------------------
 {
   "took" : 147,
@@ -158,7 +157,7 @@ starting the next set. This is "bursty" instead of "smooth".
 The value of `requests_per_second` can be changed on a running reindex using
 the `_rethrottle` API:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _reindex/r1A2WoRbTwKZ516z6NEs5A:36619/_rethrottle?requests_per_second=-1
 --------------------------------------------------
@@ -356,7 +355,7 @@ For example, you can use the following request to copy all documents from
 the `source` index with the company name `cat` into the `dest` index with
 routing set to `cat`.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _reindex
 {
@@ -374,7 +373,6 @@ POST _reindex
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[s/^/PUT source\n/]
 
 
@@ -382,7 +380,7 @@ POST _reindex
 By default `_reindex` uses scroll batches of 1000. You can change the
 batch size with the `size` field in the `source` element:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _reindex
 {
@@ -396,13 +394,12 @@ POST _reindex
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[s/^/PUT source\n/]
 
 Reindex can also use the <<ingest>> feature by specifying a
 `pipeline` like this:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _reindex
 {
@@ -415,7 +412,6 @@ POST _reindex
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[s/^/PUT source\n/]
 
 [[docs-reindex-api-query-params]]
@@ -587,7 +583,7 @@ the `conflicts` option to prevent reindex from aborting on version conflicts.
 You can limit the documents by adding a query to the `source`.
 For example, the following request only copies tweets made by `kimchy` into `new_twitter`:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _reindex
 {
@@ -634,7 +630,7 @@ If possible, it's better to use a more selective query instead of `max_docs` and
 
 For example, following request copies 10000 documents from `twitter` into `new_twitter`:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _reindex
 {
@@ -657,7 +653,7 @@ The `index` attribute in `source` can be a list, allowing you to copy from lots
 of sources in one request. This will copy documents from the
 `twitter` and `blog` indices:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _reindex
 {
@@ -696,7 +692,6 @@ POST _reindex
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 [[docs-reindex-change-name]]
@@ -705,7 +700,7 @@ POST _reindex
 `_reindex` can be used to build a copy of an index with renamed fields. Say you
 create an index containing documents that look like this:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST test/_doc/1?refresh
 {
@@ -713,12 +708,11 @@ POST test/_doc/1?refresh
   "flag": "foo"
 }
 --------------------------------------------------
-// CONSOLE
 
 but you don't like the name `flag` and want to replace it with `tag`.
 `_reindex` can create the other index for you:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 POST _reindex
 {
@@ -733,21 +727,19 @@ POST _reindex
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 Now you can get the new document:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET test2/_doc/1
 --------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 which will return:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 {
   "found": true,
@@ -789,7 +781,7 @@ The script below extracts the date from the index name and creates a new index
 with `-1` appended. All data from `metricbeat-2016.05.31` will be reindexed
 into `metricbeat-2016.05.31-1`.
 
-[source,js]
+[source,console]
 ----------------------------------------------------------------
 POST _reindex
 {
@@ -809,12 +801,11 @@ POST _reindex
 
 All documents from the previous metricbeat indices can now be found in the `*-1` indices.
 
-[source,js]
+[source,console]
 ----------------------------------------------------------------
 GET metricbeat-2016.05.30-1/_doc/1
 GET metricbeat-2016.05.31-1/_doc/1
 ----------------------------------------------------------------
-// CONSOLE
 // TEST[continued]
 
 The previous method can also be used in conjunction with <<docs-reindex-change-name, changing a field name>>
@@ -825,7 +816,7 @@ to load only the existing data into the new index and rename any fields if neede
 
 `_reindex` can be used to extract a random subset of an index for testing:
 
-[source,js]
+[source,console]
 ----------------------------------------------------------------
 POST _reindex
 {
@@ -845,7 +836,6 @@ POST _reindex
   }
 }
 ----------------------------------------------------------------
-// CONSOLE
 // TEST[setup:big_twitter]
 
 <1> `_reindex` defaults to sorting by `_doc` so `random_score` will not have any

--- a/docs/reference/docs/termvectors.asciidoc
+++ b/docs/reference/docs/termvectors.asciidoc
@@ -1,10 +1,10 @@
 [[docs-termvectors]]
-=== Term Vectors
+=== Term vectors API
+++++
+<titleabbrev>Term vectors</titleabbrev>
+++++
 
-Returns information and statistics on terms in the fields of a particular
-document. The document could be stored in the index or artificially provided
-by the user. Term vectors are <<realtime,realtime>> by default, not near
-realtime. This can be changed by setting `realtime` parameter to `false`.
+Retrieves information and statistics for terms in the fields of a particular document. 
 
 [source,js]
 --------------------------------------------------
@@ -13,8 +13,19 @@ GET /twitter/_termvectors/1
 // CONSOLE
 // TEST[setup:twitter]
 
-Optionally, you can specify the fields for which the information is
-retrieved either with a parameter in the url
+[[docs-termvectors-api-request]]
+==== {api-request-title}
+
+`GET /<index>/_termvectors/<_id>`
+
+[[docs-termvectors-api-desc]]
+==== {api-description-title}
+
+You can retrieve term vectors for documents stored in the index or 
+for _artificial_ documents passed in the body of the request. 
+
+You can specify the fields you are interested in through the `fields` parameter,
+or by adding the fields to the request body. 
 
 [source,js]
 --------------------------------------------------
@@ -23,18 +34,16 @@ GET /twitter/_termvectors/1?fields=message
 // CONSOLE
 // TEST[setup:twitter]
 
-or by adding the requested fields in the request body (see
-example below). Fields can also be specified with wildcards
-in similar way to the <<query-dsl-multi-match-query,multi match query>>
+Fields can be specified using wildcards, similar to the <<query-dsl-multi-match-query,multi match query>>.
 
-[float]
-==== Return values
+Term vectors are <<realtime,real-time>> by default, not near real-time. 
+This can be changed by setting `realtime` parameter to `false`.
 
-Three types of values can be requested: _term information_, _term statistics_
+You can request three types of values: _term information_, _term statistics_
 and _field statistics_. By default, all term information and field
-statistics are returned for all fields but no term statistics.
+statistics are returned for all fields but term statistics are excluded.
 
-[float]
+[[docs-termvectors-api-term-info]]
 ===== Term information
 
  * term frequency in the field (always returned)
@@ -54,7 +63,7 @@ should make sure that the string you are taking a sub-string of is also encoded
 using UTF-16.
 ======
 
-[float]
+[[docs-termvectors-api-term-stats]]
 ===== Term statistics
 
 Setting `term_statistics` to `true` (default is `false`) will
@@ -67,7 +76,7 @@ return
 By default these values are not returned since term statistics can
 have a serious performance impact.
 
-[float]
+[[docs-termvectors-api-field-stats]]
 ===== Field statistics
 
 Setting `field_statistics` to `false` (default is `true`) will
@@ -79,8 +88,8 @@ omit :
  * sum of total term frequencies (the sum of total term frequencies of
    each term in this field)
 
-[float]
-===== Terms Filtering
+[[docs-termvectors-api-terms-filtering]]
+===== Terms filtering
 
 With the parameter `filter`, the terms returned could also be filtered based
 on their tf-idf scores. This could be useful in order find out a good
@@ -107,7 +116,7 @@ The following sub-parameters are supported:
 `max_word_length`::
   The maximum word length above which words will be ignored. Defaults to unbounded (`0`).
 
-[float]
+[[docs-termvectors-api-behavior]]
 ==== Behaviour
 
 The term and field statistics are not accurate. Deleted documents
@@ -118,8 +127,45 @@ whereas the absolute numbers have no meaning in this context. By default,
 when requesting term vectors of artificial documents, a shard to get the statistics
 from is randomly selected. Use `routing` only to hit a particular shard.
 
-[float]
-===== Example: Returning stored term vectors
+[[docs-termvectors-api-path-params]]
+==== {api-path-parms-title}
+
+`<index>`::
+(Required, string) Name of the index that contains the document.
+
+`<_id>`::
+(Optional, string) Unique identifier of the document.
+
+[[docs-termvectors-api-query-params]]
+==== {api-query-parms-title}
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=fields]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=field_statistics]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=offsets]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=payloads]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=positions]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=preference]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=routing]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=realtime]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=term_statistics]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=version]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=version_type]
+
+[[docs-termvectors-api-example]]
+==== {api-examples-title}
+
+[[docs-termvectors-api-stored-termvectors]]
+===== Returning stored term vectors
 
 First, we create an index that stores term vectors, payloads etc. :
 
@@ -265,8 +311,8 @@ Response:
 // TEST[continued]
 // TESTRESPONSE[s/"took": 6/"took": "$body.took"/]
 
-[float]
-===== Example: Generating term vectors on the fly
+[[docs-termvectors-api-generate-termvectors]]
+===== Generating term vectors on the fly
 
 Term vectors which are not explicitly stored in the index are automatically
 computed on the fly. The following request returns all information and statistics for the
@@ -288,8 +334,7 @@ GET /twitter/_termvectors/1
 // TEST[continued]
 
 [[docs-termvectors-artificial-doc]]
-[float]
-===== Example: Artificial documents
+===== Artificial documents
 
 Term vectors can also be generated for artificial documents,
 that is for documents not present in the index.  For example, the following request would
@@ -312,7 +357,6 @@ GET /twitter/_termvectors
 // TEST[continued]
 
 [[docs-termvectors-per-field-analyzer]]
-[float]
 ====== Per-field analyzer
 
 Additionally, a different analyzer than the one at the field may be provided
@@ -379,8 +423,7 @@ Response:
 
 
 [[docs-termvectors-terms-filtering]]
-[float]
-===== Example: Terms filtering
+===== Terms filtering
 
 Finally, the terms returned could be filtered based on their tf-idf scores. In
 the example below we obtain the three most "interesting" keywords from the

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -135,6 +135,13 @@ Wildcard expressions are not accepted.
 --
 end::expand-wildcards[]
 
+tag::field_statistics[]
+`field_statistics`::
+(Optional, boolean) If `true`, the response includes the document count, sum of document frequencies, 
+and sum of total term frequencies.
+Defaults to `true`.
+end::field_statistics[]
+
 tag::fielddata-fields[]
 `fielddata_fields`::
 (Optional, string)
@@ -227,7 +234,7 @@ end::cat-h[]
 
 tag::help[]
 `help`::
-(Optional, boolean) If `true`, the response returns help information. Defaults
+(Optional, boolean) If `true`, the response includes help information. Defaults
 to `false`.
 end::help[]
 
@@ -449,6 +456,12 @@ Comma-separated list of node IDs or names
 used to limit returned information.
 end::node-id-query-parm[]
 
+tag::offsets[]
+`<offsets>`::
+(Optional, boolean) If `true`, the response includes term offsets.
+Defaults to `true`.
+end::offsets[]
+
 tag::parent-task-id[]
 `parent_task_id`::
 +
@@ -474,6 +487,18 @@ tag::path-pipeline[]
 used to limit the request.
 end::path-pipeline[]
 
+tag::payloads[]
+`payloads`::
+(Optional, boolean) If `true`, the response includes term payloads.
+Defaults to `true`.
+end::payloads[]
+
+tag::positions[]
+`positions`::
+(Optional, boolean) If `true`, the response includes term positions.
+Defaults to `true`.
+end::positions[]
+
 tag::preference[]
 `preference`::
 (Optional, string) Specifies the node or shard the operation should be 
@@ -491,6 +516,12 @@ tag::query[]
 <<query-dsl,Query DSL>>.
 end::query[]
 
+tag::realtime[]
+`realtime`::
+(Optional, boolean) If `true`, the request is real-time as opposed to near-real-time. 
+Defaults to `true`. See <<realtime>>.
+end::realtime[]
+
 tag::refresh[]
 `refresh`::
 (Optional, enum) If `true`, {es} refreshes the affected shards to make this
@@ -501,8 +532,8 @@ end::refresh[]
 
 tag::request_cache[]
 `request_cache`::
-(Optional, boolean) Specifies if the request cache should be used for this
-request. Defaults to the index-level setting.
+(Optional, boolean) If `true`, the request cache is used for this request. 
+Defaults to the index-level setting.
 end::request_cache[]
 
 tag::requests_per_second[]
@@ -621,6 +652,12 @@ tag::stats[]
 purposes.
 end::stats[]
 
+tag::stored_fields[]
+`stored_fields`::
+(Optional, boolean) If `true`, retrieves the document fields stored in the
+index rather than the document `_source`. Defaults to `false`.
+end::stored_fields[]
+
 tag::target-index[]
 `<target-index>`::
 +
@@ -637,6 +674,12 @@ tag::task-id[]
 (Optional, string) ID of the task to return
 (`node_id:task_number`).
 end::task-id[]
+
+tag::term_statistics[]
+`term_statistics`::
+(Optional, boolean) If `true`, the response includes term frequency and document frequency. 
+Defaults to `false`.
+end::term_statistics[]
 
 tag::terminate_after[]
 `terminate_after`::
@@ -671,8 +714,8 @@ end::type[]
 
 tag::cat-v[]
 `v`::
-(Optional, boolean) If `true`, the response includes column headings. Defaults
-to `false`.
+(Optional, boolean) If `true`, the response includes column headings. 
+Defaults to `false`.
 end::cat-v[]
 
 tag::version[]
@@ -712,6 +755,6 @@ end::wait_for_active_shards[]
 
 tag::wait_for_completion[]
 `wait_for_completion`::
-(Optional, boolean) Should the request block until the operation is 
-complete. Defaults to `true`.
+(Optional, boolean) If `true`, the request blocks until the operation is complete. 
+Defaults to `true`.
 end::wait_for_completion[]


### PR DESCRIPTION
* [DOCS] Reformats bulk API. (#47479)

* Reformats bulk API.

* Update docs/reference/docs/bulk.asciidoc

Co-Authored-By: James Rodewig <james.rodewig@elastic.co>

* Reformats mget API (#47477)

* Reformats mget API

* Update docs/reference/docs/get.asciidoc

Co-Authored-By: James Rodewig <james.rodewig@elastic.co>

* Incorporated feedback.

* Reformats reindex API (#47483)

* Reformats reindex API

* Incorporated review feedback.

* Reformats term vectors APIs (#47484)

* Reformat termvectors APIs

* Reformats mtermvectors

* Apply suggestions from code review

Co-Authored-By: James Rodewig <james.rodewig@elastic.co>

* Incorporated review feedback.
