### PR TITLE
watcher - re-enable test

### DIFF
--- a/x-pack/qa/smoke-test-watcher/src/test/resources/rest-api-spec/test/painless/10_basic.yml
+++ b/x-pack/qa/smoke-test-watcher/src/test/resources/rest-api-spec/test/painless/10_basic.yml
@@ -1,8 +1,5 @@
 ---
 "Test execute watch api":
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/45585"
 
   - do:
       cluster.health:


### PR DESCRIPTION
This test is believed to be fixed by #43939

Closes #45585
-----

This test is currently only muted master. 

Timeline of events:

Aug 14 - muted in master
Aug 16 - #43939 committed to master
Aug 22 - #43939 back-ported to 7.x
Aug 23 - last recorded failure (against 7.x)