### PR TITLE
Re-enable Watcher rest tests

### DIFF
--- a/x-pack/qa/smoke-test-watcher/src/test/resources/rest-api-spec/test/painless/50_update_scripts.yml
+++ b/x-pack/qa/smoke-test-watcher/src/test/resources/rest-api-spec/test/painless/50_update_scripts.yml
@@ -3,8 +3,7 @@
 ---
 "Test transform scripts are updated on execution":
   - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/43975"
+      features: warnings
 
   - do:
       cluster.health:
@@ -80,8 +79,6 @@
 "Test condition scripts are updated on execution":
   - skip:
       features: warnings
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/45582"
 
   - do:
       cluster.health:


### PR DESCRIPTION
These tests are believed to be fixed by #43939

closes #45582 and #43975

-------

These tests are currently only muted master.

Jul 23 - muted in master (Test transform scripts are updated on execution)
Aug 14 - muted in master (Test condition scripts are updated on execution)
Aug 15 - last recorded failure (from either test on any branch)
Aug 16 - #43939 commited to master
Aug 22 - #43939 backported to 7.x
