### PR TITLE
Switch stored script example to script_score query

### DIFF
--- a/docs/reference/scripting/using.asciidoc
+++ b/docs/reference/scripting/using.asciidoc
@@ -153,6 +153,7 @@ POST _scripts/calculate-score
   }
 }
 -----------------------------------
+// TEST[setup:twitter]
 
 This same script can be retrieved with:
 
@@ -166,10 +167,15 @@ Stored scripts can be used by specifying the `id` parameters as follows:
 
 [source,console]
 --------------------------------------------------
-GET _search
+GET twitter/_search
 {
   "query": {
-    "script": {
+    "script_score": {
+      "query": {
+        "match": {
+            "message": "some message"
+        }
+      },
       "script": {
         "id": "calculate-score",
         "params": {


### PR DESCRIPTION
The example use of a scoring script was incorrectly using a filter
script query, which has no scoring, and thus no _score variable
avialable. This commit converts the example doc to using the newer
script_score query.