### PR TITLE
Re-enable Watcher rest tests

### DIFF
--- a/x-pack/qa/smoke-test-watcher/src/test/resources/rest-api-spec/test/painless/10_basic.yml
+++ b/x-pack/qa/smoke-test-watcher/src/test/resources/rest-api-spec/test/painless/10_basic.yml
@@ -127,9 +127,6 @@
 
 ---
 "Test execute watch api with rest_total_hits_as_int":
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/43889"
 
   - do:
       cluster.health:


### PR DESCRIPTION
This test is believed to be fixed by #43939

closes #43889

--------

This test is currently only muted master.

Jul 10 - muted in master
Aug 16 - #43939 commited to master
Aug 22 - #43939 backported to 7.x
Aug 23 - last recorded failure (on any branch)
