### PR TITLE
[DOCS] Fix errors in rollover index API docs

### DIFF
--- a/docs/reference/indices/rollover-index.asciidoc
+++ b/docs/reference/indices/rollover-index.asciidoc
@@ -42,19 +42,34 @@ NOTE: To roll over an index, a condition must be met *when you call the API*.
 automatically roll over indices when a condition is met, you can use {es}'s
 <<index-lifecycle-management, index lifecycle management (ILM) policies>>.
 
-The API accepts a single alias name and a list of `conditions`. The alias must point to a write index for
-a Rollover request to be valid. There are two ways this can be achieved, and depending on the configuration, the
-alias metadata will be updated differently. The two scenarios are as follows:
+The rollover index API accepts a single alias name
+and a list of `conditions`.
+To request a rollover,
+the specified alias must point to a write index,
+indicated by the `is_write_index` value.
+Depending on this value,
+the rollover request updates the alias metadata as follows:
 
- - The alias only points to a single index with `is_write_index` not configured (defaults to `null`).
+. The alias points to a single index
+with an unconfigured `is_write_index` value,
+which defaults to `null`.
++
+In this scenario,
+the rollover request adds the alias
+to the newly created target index
+and removes the alias
+from the rolled over index.
 
-In this scenario, the original index will have their rollover alias will be added to the newly created index, and removed
-from the original (rolled-over) index.
-
- - The alias points to one or more indices with `is_write_index` set to `true` on the index to be rolled over (the write index).
-
-In this scenario, the write index will have its rollover alias' `is_write_index` set to `false`, while the newly created index
-will now have the rollover alias pointing to it as the write index with `is_write_index` as `true`.
+. The alias points to one or more indices
+with an `is_write_index` value of `true`.
++
+In this scenario,
+the rollover request adds the alias
+to the newly created target index
+and assigns that index
+an `is_write_index` value of `true`.
+The request assigns rolled over indices
+an `is_write_index` value of `false`.
 
 
 [[rollover-wait-active-shards]]

--- a/docs/reference/indices/rollover-index.asciidoc
+++ b/docs/reference/indices/rollover-index.asciidoc
@@ -45,13 +45,14 @@ automatically roll over indices when a condition is met, you can use {es}'s
 The rollover index API accepts a single alias name
 and a list of `conditions`.
 To request a rollover,
-the specified alias must point to a write index,
-indicated by the `is_write_index` value.
+the specified alias must point to an index
+with an `is_write_index` flag
+that is unconfigured (`null`) or `true`.
 Depending on this value,
 the rollover request updates the alias metadata as follows:
 
 . The alias points to a single index
-with an unconfigured `is_write_index` value,
+with an unconfigured `is_write_index` flag,
 which defaults to `null`.
 +
 In this scenario,
@@ -62,19 +63,19 @@ from the rolled over index.
 
 . The alias points to one or more indices.
 Only one of these indices
-has an `is_write_index` value of `true`.
+has an `is_write_index` flag of `true`.
 +
 In this scenario,
 the rollover request treats the index
-with an `is_write_index` value of `true`
+with an `is_write_index` flag of `true`
 as the rolled over index.
 +
 The request adds the alias
 to the newly created target index
 and assigns the target index
-an `is_write_index` value of `true`.
+an `is_write_index` flag of `true`.
 The request assigns the rolled over index
-an `is_write_index` value of `false`.
+an `is_write_index` flag of `false`.
 
 
 [[rollover-wait-active-shards]]

--- a/docs/reference/indices/rollover-index.asciidoc
+++ b/docs/reference/indices/rollover-index.asciidoc
@@ -66,7 +66,7 @@ has an `is_write_index` value of `true`.
 +
 In this scenario,
 the rollover request treats the index
-with a `is_write_index` value of `true`
+with an `is_write_index` value of `true`
 as the rolled over index.
 +
 The request adds the alias

--- a/docs/reference/indices/rollover-index.asciidoc
+++ b/docs/reference/indices/rollover-index.asciidoc
@@ -60,8 +60,9 @@ to the newly created target index
 and removes the alias
 from the rolled over index.
 
-. The alias points to one or more indices
-with an `is_write_index` value of `true`.
+. The alias points to one or more indices.
+Only one of these indices
+has an `is_write_index` value of `true`.
 +
 In this scenario,
 the rollover request adds the alias

--- a/docs/reference/indices/rollover-index.asciidoc
+++ b/docs/reference/indices/rollover-index.asciidoc
@@ -58,8 +58,8 @@ In this case,
 the rollover request:
 
 . Creates a new index
-. Sets `is_write_index` to `true` for the new index.
-. Sets `is_write_index` to `false` for the original index.
+. Sets `is_write_index` to `true` for the new index
+. Sets `is_write_index` to `false` for the original index
 
 
 [[rollover-wait-active-shards]]

--- a/docs/reference/indices/rollover-index.asciidoc
+++ b/docs/reference/indices/rollover-index.asciidoc
@@ -65,11 +65,15 @@ Only one of these indices
 has an `is_write_index` value of `true`.
 +
 In this scenario,
-the rollover request adds the alias
+the rollover request treats the index
+with a `is_write_index` value of `true`
+as the rolled over index.
++
+The request adds the alias
 to the newly created target index
-and assigns that index
+and assigns the target index
 an `is_write_index` value of `true`.
-The request assigns rolled over indices
+The request assigns the rolled over index
 an `is_write_index` value of `false`.
 
 

--- a/docs/reference/indices/rollover-index.asciidoc
+++ b/docs/reference/indices/rollover-index.asciidoc
@@ -44,38 +44,22 @@ automatically roll over indices when a condition is met, you can use {es}'s
 
 The rollover index API accepts a single alias name
 and a list of `conditions`.
-To request a rollover,
-the specified alias must point to an index
-with an `is_write_index` flag
-that is unconfigured (`null`) or `true`.
-Depending on this value,
-the rollover request updates the alias metadata as follows:
 
-. The alias points to a single index
-with an unconfigured `is_write_index` flag,
-which defaults to `null`.
-+
-In this scenario,
-the rollover request adds the alias
-to the newly created target index
-and removes the alias
-from the rolled over index.
+If the specified alias points to a single index,
+the rollover request:
 
-. The alias points to one or more indices.
-Only one of these indices
-has an `is_write_index` flag of `true`.
-+
-In this scenario,
-the rollover request treats the index
-with an `is_write_index` flag of `true`
-as the rolled over index.
-+
-The request adds the alias
-to the newly created target index
-and assigns the target index
-an `is_write_index` flag of `true`.
-The request assigns the rolled over index
-an `is_write_index` flag of `false`.
+. Creates a new index
+. Adds the alias to the new index
+. Removes the alias from the original index
+
+If the specified alias points to multiple indices,
+one of these indices must have `is_write_index` set to `true`.
+In this case,
+the rollover request:
+
+. Creates a new index
+. Sets `is_write_index` to `true` for the new index.
+. Sets `is_write_index` to `false` for the original index.
 
 
 [[rollover-wait-active-shards]]


### PR DESCRIPTION
Fixes some awkward wording and errors in the rollover index API docs.

Closes #37145