### PR TITLE
Filter out special gradle threads from leak control

### DIFF
--- a/buildSrc/src/test/java/org/elasticsearch/gradle/test/GradleThreadsFilter.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/test/GradleThreadsFilter.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle.test;
+
+import com.carrotsearch.randomizedtesting.ThreadFilter;
+
+/**
+ * Filter out threads controlled by gradle that may be created during unit tests.
+ *
+ * Currently this is only the pooled threads for Exec.
+ */
+public class GradleThreadsFilter implements ThreadFilter {
+
+    @Override
+    public boolean reject(Thread t) {
+        return t.getName().startsWith("Exec process");
+    }
+}

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/test/GradleUnitTestCase.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/test/GradleUnitTestCase.java
@@ -3,12 +3,16 @@ package org.elasticsearch.gradle.test;
 import com.carrotsearch.randomizedtesting.JUnit4MethodProvider;
 import com.carrotsearch.randomizedtesting.RandomizedRunner;
 import com.carrotsearch.randomizedtesting.annotations.TestMethodProviders;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import org.junit.runner.RunWith;
 
 @RunWith(RandomizedRunner.class)
 @TestMethodProviders({
     JUnit4MethodProvider.class,
     JUnit3MethodProvider.class
+})
+@ThreadLeakFilters(defaultFilters = true, filters = {
+    GradleThreadsFilter.class
 })
 public abstract class GradleUnitTestCase extends BaseTestCase  {
 }


### PR DESCRIPTION
This commit adds a thread filter for gradle unit tests which omits
threads gradle may create that we have no control over shutting down.
The current example of this is for project.exec which gradle pools.

closes #47417