### PR TITLE
Geo: implement proper handling of out of bounds geo points

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeIndexer.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeIndexer.java
@@ -50,6 +50,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.apache.lucene.geo.GeoUtils.orient;
 import static org.elasticsearch.common.geo.GeoUtils.normalizeLat;
 import static org.elasticsearch.common.geo.GeoUtils.normalizeLon;
+import static org.elasticsearch.common.geo.GeoUtils.normalizePoint;
 
 /**
  * Utility class that converts geometries into Lucene-compatible form
@@ -160,8 +161,9 @@ public final class GeoShapeIndexer implements AbstractGeometryFieldMapper.Indexe
 
             @Override
             public Geometry visit(Point point) {
-                //TODO: Just remove altitude for now. We need to add normalization later
-                return new Point(point.getX(), point.getY());
+                double[] latlon = new double[]{point.getX(), point.getY()};
+                normalizePoint(latlon);
+                return new Point(latlon[0], latlon[1]);
             }
 
             @Override

--- a/server/src/test/java/org/elasticsearch/common/geo/GeometryIndexerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeometryIndexerTests.java
@@ -137,6 +137,15 @@ public class GeometryIndexerTests extends ESTestCase {
 
         point = new Point(2, 1, 3);
         assertEquals(indexed, indexer.prepareForIndexing(point));
+
+        point = new Point(362, 1);
+        assertEquals(indexed, indexer.prepareForIndexing(point));
+
+        point = new Point(-178, 179);
+        assertEquals(indexed, indexer.prepareForIndexing(point));
+
+        point = new Point(180, 180);
+        assertEquals(new Point(0, 0), indexer.prepareForIndexing(point));
     }
 
     public void testMultiPoint() {


### PR DESCRIPTION
This is the first iteration in improving of handling of out of
bounds geopoints with a latitude outside of the -90 - +90 range
and a longitude outside of the -180 - +180 range.

Relates to #43916
