### PR TITLE
[Docs] Fix typo for truststores in configuring TLS

### DIFF
--- a/x-pack/docs/en/security/securing-communications/tls-transport.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/tls-transport.asciidoc
@@ -35,7 +35,7 @@ CA certificate as a trusted certificate entry. This allows for the keystore to
 also be used as a truststore. In this case, the path value should match
 the `keystore.path` value.
 Note, however, that this is not the general rule. There are keystores that cannot be
-used as trustores, only 
+used as truststores, only 
 {ref}/security-settings.html#pkcs12-truststore-note[specifically crafted ones can]
 --
 


### PR DESCRIPTION
Changes `trustores` to `truststores` in the "Encrypting communications between nodes in a cluster" section.