### PR TITLE
Move binding member field generation to Painless semantic pass

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Globals.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Globals.java
@@ -28,8 +28,6 @@ import java.util.Map;
  */
 public class Globals {
     private final Map<String,Constant> constantInitializers = new HashMap<>();
-    private final Map<String,Class<?>> classBindings = new HashMap<>();
-    private final Map<Object,String> instanceBindings = new HashMap<>();
     private final BitSet statements;
     
     /** Create a new Globals from the set of statement boundaries */
@@ -44,32 +42,9 @@ public class Globals {
         }
     }
 
-    /** Adds a new class binding to be written as a local variable */
-    public String addClassBinding(Class<?> type) {
-        String name = "$class_binding$" + classBindings.size();
-        classBindings.put(name, type);
-
-        return name;
-    }
-
-    /** Adds a new binding to be written as a local variable */
-    public String addInstanceBinding(Object instance) {
-        return instanceBindings.computeIfAbsent(instance, key -> "$instance_binding$" + instanceBindings.size());
-    }
-    
     /** Returns the current initializers */
     public Map<String,Constant> getConstantInitializers() {
         return constantInitializers;
-    }
-
-    /** Returns the current bindings */
-    public Map<String,Class<?>> getClassBindings() {
-        return classBindings;
-    }
-
-    /** Returns the current bindings */
-    public Map<Object,String> getInstanceBindings() {
-        return instanceBindings;
     }
 
     /** Returns the set of statement boundaries */

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SField.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SField.java
@@ -30,6 +30,9 @@ import org.objectweb.asm.Type;
 
 import java.util.Set;
 
+/**
+ * Represents a member field for its parent class (internal only).
+ */
 public class SField extends ANode {
 
     private final int access;
@@ -37,6 +40,14 @@ public class SField extends ANode {
     private final Class<?> type;
     private final Object instance;
 
+    /**
+     * Standard constructor.
+     * @param location original location in the source
+     * @param access asm constants for field modifiers
+     * @param name name of the field
+     * @param type type of the field
+     * @param instance initial value for the field
+     */
     public SField(Location location, int access, String name, Class<?> type, Object instance) {
         super(location);
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SField.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SField.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.painless.node;
+
+import org.elasticsearch.painless.ClassWriter;
+import org.elasticsearch.painless.CompilerSettings;
+import org.elasticsearch.painless.Globals;
+import org.elasticsearch.painless.Locals;
+import org.elasticsearch.painless.Location;
+import org.elasticsearch.painless.MethodWriter;
+import org.elasticsearch.painless.ScriptRoot;
+import org.objectweb.asm.Type;
+
+import java.util.Set;
+
+public class SField extends ANode {
+
+    private final int access;
+    private final String name;
+    private final Class<?> type;
+    private final Object instance;
+
+    public SField(Location location, int access, String name, Class<?> type, Object instance) {
+        super(location);
+
+        this.access = access;
+        this.name = name;
+        this.type = type;
+        this.instance = instance;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Object getInstance() {
+        return instance;
+    }
+
+    @Override
+    void storeSettings(CompilerSettings settings) {
+        throw createError(new UnsupportedOperationException("unexpected node"));
+    }
+
+    @Override
+    void extractVariables(Set<String> variables) {
+        throw createError(new UnsupportedOperationException("unexpected node"));
+    }
+
+    @Override
+    void analyze(ScriptRoot scriptRoot, Locals locals) {
+        throw createError(new UnsupportedOperationException("unexpected node"));
+    }
+
+    @Override
+    void write(ClassWriter classWriter, MethodWriter methodWriter, Globals globals) {
+        throw createError(new UnsupportedOperationException("unexpected node"));
+    }
+
+    void write(ClassWriter classWriter) {
+        classWriter.getClassVisitor().visitField(access, name, Type.getType(type).getDescriptor(), null, null).visitEnd();
+    }
+
+    @Override
+    public String toString() {
+        return singleLineToString(name, type);
+    }
+}


### PR DESCRIPTION
This adds an SField node that operates similarly to SFunction as a top level node meant only for use in an SClass node. Member fields are generated for both class bindings and instance bindings using the new SField node during the semantic pass, and information is no longer passed through Globals for this during the write pass.