### PR TITLE
Fix bug in ingest node documentation (#45589)

### DIFF
--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -518,6 +518,7 @@ PUT _ingest/pipeline/logs_pipeline
     },
     {
       "fail": {
+        "if": "ctx.service?.name != 'apache_httpd' && ctx.service?.name != 'syslog'",
         "message": "This pipeline requires service.name to be either `syslog` or `apache_httpd`"
       }
     }


### PR DESCRIPTION
The "Conditionals with the Pipeline Processor" incorrectly documents
how to create a pipeline of pipelines with a failure condition. The 
example as-is will always execute the fail processor. The change here
updates the documentation to correct guard the fail processor with an
if condition.
