### PR TITLE
Change policy_id to list type in slm.get_lifecycle

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_lifecycle.json
@@ -13,7 +13,7 @@
           ],
           "parts":{
             "policy_id":{
-              "type":"string",
+              "type":"list",
               "description":"Comma-separated list of snapshot lifecycle policies to retrieve"
             }
           }


### PR DESCRIPTION
This commit changes the REST API spec slm.get_lifecycle's polict_id url part to be of type "list", in line with other REST API specs that accept a comma-separated list of values.

Closes #47765