### PR TITLE
Fix --debug-jvm Gradle Arg

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
@@ -23,7 +23,7 @@ public class RunTask extends DefaultTestClustersTask {
         description = "Enable debugging configuration, to allow attaching a debugger to elasticsearch."
     )
     public void setDebug(boolean enabled) {
-        this.debug = debug;
+        this.debug = enabled;
     }
 
     @Input


### PR DESCRIPTION
This fixes the `--debug-jvm` arg to work again for
the `run` task.
Seems a recent refactoring of `RunTask` introduced
this obvious type.
