### PR TITLE
API call wrongly referred to shrink rather than split

### DIFF
--- a/docs/reference/indices/split-index.asciidoc
+++ b/docs/reference/indices/split-index.asciidoc
@@ -21,9 +21,9 @@ POST /twitter/_split/split-twitter-index
 [[split-index-api-request]]
 ==== {api-request-title}
 
-`POST /<index>/_shrink/<target-index>`
+`POST /<index>/_split/<target-index>`
 
-`PUT /<index>/_shrink/<target-index>`
+`PUT /<index>/_split/<target-index>`
 
 
 [[split-index-api-prereqs]]


### PR DESCRIPTION
Please review and confirm that there are no other wrong mentions.
