### PR TITLE
Fix tag in the search request timeout option docs

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -569,8 +569,9 @@ end::scroll_size[]
 
 tag::search_timeout[]
 `search_timeout`::
-(Optional, <<time-units, time units>> Explicit timeout for each search 
-request. Defaults to no timeout.
+(Optional, <<time-units, time units>>)
+Explicit timeout for each search request.
+Defaults to no timeout.
 end::search_timeout[]
 
 tag::search_type[]

--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -73,7 +73,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=search_type]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=terminate_after]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeout]
+include::{docdir}/rest-api/common-parms.asciidoc[tag=search_timeout]
 
 
 Out of the above, the `search_type`, `request_cache` and the 


### PR DESCRIPTION
This change fixes the link to the search request timeout documentation.

Relates #47716