### PR TITLE
Always use last properly persisted metadata as previous state

### DIFF
--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -276,7 +276,7 @@ public class GatewayMetaState {
                     incrementalClusterStateWriter.setCurrentTerm(event.state().term());
                 }
 
-                incrementalClusterStateWriter.updateClusterState(event.state(), event.previousState());
+                incrementalClusterStateWriter.updateClusterState(event.state());
                 incrementalClusterStateWriter.setIncrementalWrite(true);
             } catch (WriteStateException e) {
                 logger.warn("Exception occurred when storing new meta data", e);
@@ -318,9 +318,9 @@ public class GatewayMetaState {
         @Override
         public void setLastAcceptedState(ClusterState clusterState) {
             try {
-                final ClusterState previousClusterState = incrementalClusterStateWriter.getPreviousClusterState();
-                incrementalClusterStateWriter.setIncrementalWrite(previousClusterState.term() == clusterState.term());
-                incrementalClusterStateWriter.updateClusterState(clusterState, previousClusterState);
+                incrementalClusterStateWriter.setIncrementalWrite(
+                    incrementalClusterStateWriter.getPreviousClusterState().term() == clusterState.term());
+                incrementalClusterStateWriter.updateClusterState(clusterState);
             } catch (WriteStateException e) {
                 logger.error(new ParameterizedMessage("Failed to set last accepted state with version {}", clusterState.version()), e);
                 e.rethrowAsErrorOrUncheckedException();

--- a/server/src/test/java/org/elasticsearch/gateway/IncrementalClusterStateWriterTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/IncrementalClusterStateWriterTests.java
@@ -510,7 +510,7 @@ public class IncrementalClusterStateWriterTests extends ESAllocationTestCase {
         Loggers.addAppender(classLogger, mockAppender);
 
         try {
-            incrementalClusterStateWriter.updateClusterState(clusterState, clusterState);
+            incrementalClusterStateWriter.updateClusterState(clusterState);
         } finally {
             Loggers.removeAppender(classLogger, mockAppender);
             mockAppender.stop();


### PR DESCRIPTION
On data-only nodes we were not using the last persisted cluster state as base point to compute what needed storage, but the last applied cluster state (but not necessarily properly persisted) instead.