### PR TITLE
Deprecate Pooled Direct Netty Buffers

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
@@ -47,6 +47,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
@@ -84,6 +85,8 @@ import static org.elasticsearch.common.util.concurrent.EsExecutors.daemonThreadF
  */
 public class Netty4Transport extends TcpTransport {
     private static final Logger logger = LogManager.getLogger(Netty4Transport.class);
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(logger);
 
     public static final Setting<Integer> WORKER_COUNT =
         new Setting<>("transport.netty.worker_count",
@@ -220,6 +223,8 @@ public class Netty4Transport extends TcpTransport {
         // channels of type CopyBytesSocketChannel. CopyBytesSocketChannel pool a single direct buffer
         // per-event-loop thread to be used for IO operations.
         if (ByteBufAllocator.DEFAULT.isDirectBufferPooled()) {
+            deprecationLogger.deprecated("Using pooled direct Netty buffers is deprecated and may destabilize your cluster. " +
+                "Add `-Dio.netty.allocator.numDirectArenas=0` to your jvm.options to disable pooled direct buffers.");
             serverBootstrap.channel(NioServerSocketChannel.class);
         } else {
             serverBootstrap.channel(CopyBytesServerSocketChannel.class);


### PR DESCRIPTION
Pooled direct Netty buffers can destabilize
ES easily starting in v7.4.0 due to the move
to Netty 4.1.38 which uses direct buffers for
all IO allocations by default.
If you don't have direct buffer pooling disabled
you won't run the new IO path from #44837 and
large messages (e.g. huge bulk requests) will cause
allocation of unpooled direct byte buffers of the
size of the message and will often lead to the
cluster slowly going OOM.

People who upgrade their ES cluster but keep their old
jvm.options file won't have the now default `-Dio.netty.allocator.numDirectArenas=0`
set and might run into memory trouble.

See this discuss issue for example of bad behavior with direct buffers in `7.4`: https://discuss.elastic.co/t/cluster-constantly-crashing-after-upgrade-to-7-4/202580