### PR TITLE
Ensure random timestamps are within search boundary (#38753)

### DIFF
--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
@@ -452,7 +452,6 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
         });
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/34762")
     public void testRandomizedDateHisto() throws Exception {
         String rollupIndex = randomAlphaOfLengthBetween(5, 10);
 
@@ -468,7 +467,9 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
         final List<Map<String, Object>> dataset = new ArrayList<>();
         int numDocs = randomIntBetween(1,100);
         for (int i = 0; i < numDocs; i++) {
-            long timestamp = new DateTime().minusHours(randomIntBetween(1,100)).getMillis();
+            // Make sure the timestamp is sufficiently in the past that we don't get bitten
+            // by internal rounding, causing no docs to match
+            long timestamp = new DateTime().minusDays(2).minusHours(randomIntBetween(11,100)).getMillis();
             dataset.add(asMap(timestampField, timestamp, valueField, randomLongBetween(1, 100)));
         }
         executeTestCase(dataset, job, System.currentTimeMillis(), (resp) -> {


### PR DESCRIPTION
Backport of #38753 to 7.x where the test is still mutes, I thinkt it was just forgotten.

The random timestamps were landing too close to the current time,
so an unlucky rollup interval would round such that the doc wasn't
included in the search range (and thus not "rolled up") which
would then fail the test.

The fix is to make sure the timestamp of all docs is sufficiently behind
'now' that the possible rounding intervals will always include them.
