### PR TITLE
[DOCS] Extends the analyzed_fields description in the PUT DFA API docs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -61,19 +61,22 @@ and mappings.
 ==== {api-request-body-title}
 
 `analysis`::
-  (Required, object) Defines the type of {dfanalytics} you want to perform on your source 
-  index. For example: `outlier_detection`. See <<dfanalytics-types>>.
+  (Required, object) Defines the type of {dfanalytics} you want to perform on 
+  your source index. For example: `outlier_detection`. See 
+  <<dfanalytics-types>>.
   
 `analyzed_fields`::
   (Optional, object) You can specify both `includes` and/or `excludes` patterns. 
   If `analyzed_fields` is not set, only the relevant fields will be included. 
-  For example, all the numeric fields for {oldetection}.
+  For example, all the numeric fields for {oldetection}. For the potential field 
+  type limitations, see 
+  {stack-ov}/ml-dfa-limitations.html[{dfanalytics limitations}].
   
-  `analyzed_fields.includes`:::
+  `includes`:::
     (Optional, array) An array of strings that defines the fields that will be 
     included in the analysis.
     
-  `analyzed_fields.excludes`:::
+  `excludes`:::
     (Optional, array) An array of strings that defines the fields that will be 
     excluded from the analysis.
 

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -70,7 +70,7 @@ and mappings.
   If `analyzed_fields` is not set, only the relevant fields will be included. 
   For example, all the numeric fields for {oldetection}. For the potential field 
   type limitations, see 
-  {stack-ov}/ml-dfa-limitations.html[{dfanalytics limitations}].
+  {stack-ov}/ml-dfa-limitations.html[{dfanalytics} limitations].
   
   `includes`:::
     (Optional, array) An array of strings that defines the fields that will be 


### PR DESCRIPTION
This pull request adds a link to the description of the `analyzed_fields` variable and simplifies the names of the `includes` and `excludes` variables in the PUT data frame analytics API documentation.

Related issue: https://github.com/elastic/ml-team/issues/187#issuecomment-539669270

Preview is available here: http://elasticsearch_47791.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-dfanalytics.html