### PR TITLE
Fix AutoFollowCoordinatorTests

### DIFF
--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinatorTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinatorTests.java
@@ -1088,7 +1088,7 @@ public class AutoFollowCoordinatorTests extends ESTestCase {
             .build();
 
         ClusterState remoteState = null;
-        final int nbLeaderIndices = randomInt(15);
+        final int nbLeaderIndices = randomIntBetween(1, 15);
         for (int i = 0; i < nbLeaderIndices; i++) {
             String indexName = "docs-" + i;
             if (remoteState == null) {


### PR DESCRIPTION
A stupid test bug make it through the tests in #47721 and will trigger CI failures with NPEs.