### PR TITLE
Resolve more Gradle task validation warnings

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
@@ -58,7 +58,7 @@ class RestTestsFromSnippetsTask extends SnippetsTask {
     @OutputDirectory
     File testRoot = project.file('build/rest')
 
-    Set<String> names = new HashSet<>()
+    private Set<String> names = new HashSet<>()
 
     RestTestsFromSnippetsTask() {
         project.afterEvaluate {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
@@ -23,6 +23,7 @@ import groovy.transform.PackageScope
 import org.elasticsearch.gradle.doc.SnippetsTask.Snippet
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 
 import java.nio.file.Files
@@ -58,7 +59,8 @@ class RestTestsFromSnippetsTask extends SnippetsTask {
     @OutputDirectory
     File testRoot = project.file('build/rest')
 
-    private Set<String> names = new HashSet<>()
+    @Internal
+    Set<String> names = new HashSet<>()
 
     RestTestsFromSnippetsTask() {
         project.afterEvaluate {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
@@ -104,6 +104,7 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
         }
     }
 
+    @Internal
     ElasticsearchNode getFirstNode() {
         return nodes.getAt(clusterName + "-0");
     }


### PR DESCRIPTION
This PR is a follow up to #47538 to resolve a few more task input validation warnings.

https://gradle-enterprise.elastic.co/s/yic3k5ijfphce/console-log?task=:buildSrc:validateTaskProperties