### PR TITLE
Add builder for distance_feature to QueryBuilders

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.index.query.DistanceFeatureQueryBuilder.Origin;
 import org.elasticsearch.index.query.MoreLikeThisQueryBuilder.Item;
 import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
@@ -98,6 +99,16 @@ public final class QueryBuilders {
      */
     public static DisMaxQueryBuilder disMaxQuery() {
         return new DisMaxQueryBuilder();
+    }
+
+    /**
+     * A query to boost scores based on their proximity to the given origin for date, date_nanos and geo_point field types.
+     * @param name The field name
+     * @param origin The origin of the distance calculation. Can be a long, string or {@link GeoPoint}, depending on field type.
+     * @param pivot The distance from the origin at which relevance scores receive half of the boost value.
+     */
+    public static DistanceFeatureQueryBuilder distanceFeatureQuery(String name, Origin origin, String pivot) {
+        return new DistanceFeatureQueryBuilder(name, origin, pivot);
     }
 
     /**


### PR DESCRIPTION
The QueryBuilders convenience class is currently missing a shortcut to construct
a DistanceFeatureQueryBuilder, which is added here.

Closes #47767