### PR TITLE
Search - add “partial_results” summary flag to SearchResponse

### DIFF
--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/SearchTemplateResponseTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/SearchTemplateResponseTests.java
@@ -181,6 +181,7 @@ public class SearchTemplateResponseTests extends AbstractXContentTestCase<Search
             .startObject()
                 .field("took", 0)
                 .field("timed_out", false)
+                .field("partial_results", false)
                 .startObject("_shards")
                     .field("total", 0)
                     .field("successful", 0)

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -63,6 +63,7 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
     private static final ParseField SCROLL_ID = new ParseField("_scroll_id");
     private static final ParseField TOOK = new ParseField("took");
     private static final ParseField TIMED_OUT = new ParseField("timed_out");
+    private static final ParseField PARTIAL = new ParseField("partial_results");
     private static final ParseField TERMINATED_EARLY = new ParseField("terminated_early");
     private static final ParseField NUM_REDUCE_PHASES = new ParseField("num_reduce_phases");
 
@@ -133,6 +134,15 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
      */
     public boolean isTimedOut() {
         return internalResponse.timedOut();
+    }
+    
+    /**
+     * Are the search results potentially missing some data?
+     */
+    public boolean isPartial() {
+        int unavailableOrFailedShards = getTotalShards() - (getSuccessfulShards() + getSkippedShards());
+        return isTimedOut() || unavailableOrFailedShards > 0 || 
+                (isTerminatedEarly() != null && isTerminatedEarly()) ;
     }
 
     /**
@@ -237,6 +247,7 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
         }
         builder.field(TOOK.getPreferredName(), tookInMillis);
         builder.field(TIMED_OUT.getPreferredName(), isTimedOut());
+        builder.field(PARTIAL.getPreferredName(), isPartial());
         if (isTerminatedEarly() != null) {
             builder.field(TERMINATED_EARLY.getPreferredName(), isTerminatedEarly());
         }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -140,7 +140,7 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
      * Are the search results potentially missing some data?
      */
     public boolean isPartial() {
-        int unavailableOrFailedShards = getTotalShards() - (getSuccessfulShards() + getSkippedShards());
+        int unavailableOrFailedShards = getTotalShards() - getSuccessfulShards();
         return isTimedOut() || unavailableOrFailedShards > 0 || 
                 (isTerminatedEarly() != null && isTerminatedEarly()) ;
     }

--- a/server/src/test/java/org/elasticsearch/action/search/AbstractSearchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/AbstractSearchAsyncActionTests.java
@@ -185,6 +185,7 @@ public class AbstractSearchAsyncActionTests extends ESTestCase {
         assertSame(searchResponse.getSuggest(), internalSearchResponse.suggest());
         assertSame(searchResponse.getProfileResults(), internalSearchResponse.profile());
         assertSame(searchResponse.getHits(), internalSearchResponse.hits());
+        assertThat(searchResponse.isPartial(), equalTo(true));
     }
 
     public void testSendSearchResponseDisallowPartialFailures() {

--- a/server/src/test/java/org/elasticsearch/action/search/SearchResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchResponseTests.java
@@ -221,6 +221,7 @@ public class SearchResponseTests extends ESTestCase {
             {
                 expectedString.append("\"took\":0,");
                 expectedString.append("\"timed_out\":false,");
+                expectedString.append("\"partial_results\":false,");
                 expectedString.append("\"_shards\":");
                 {
                     expectedString.append("{\"total\":0,");
@@ -250,6 +251,7 @@ public class SearchResponseTests extends ESTestCase {
             {
                 expectedString.append("\"took\":0,");
                 expectedString.append("\"timed_out\":false,");
+                expectedString.append("\"partial_results\":false,");
                 expectedString.append("\"_shards\":");
                 {
                     expectedString.append("{\"total\":0,");

--- a/server/src/test/java/org/elasticsearch/search/SearchCancellationIT.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchCancellationIT.java
@@ -132,6 +132,7 @@ public class SearchCancellationIT extends ESIntegTestCase {
             SearchResponse response = searchResponse.actionGet();
             logger.info("Search response {}", response);
             assertNotEquals("At least one shard should have failed", 0, response.getFailedShards());
+            assertThat(response.isPartial(), equalTo(true));                    
             return response;
         } catch (SearchPhaseExecutionException ex) {
             logger.info("All shards failed with", ex);

--- a/server/src/test/java/org/elasticsearch/search/SearchTimeoutIT.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchTimeoutIT.java
@@ -65,6 +65,7 @@ public class SearchTimeoutIT extends ESIntegTestCase {
                 .setAllowPartialSearchResults(true)
                 .get();
         assertThat(searchResponse.isTimedOut(), equalTo(true));
+        assertThat(searchResponse.isPartial(), equalTo(true));
     }
 
     public void testPartialResultsIntolerantTimeout() throws Exception {

--- a/server/src/test/java/org/elasticsearch/search/basic/SearchRedStateIndexIT.java
+++ b/server/src/test/java/org/elasticsearch/search/basic/SearchRedStateIndexIT.java
@@ -56,6 +56,7 @@ public class SearchRedStateIndexIT extends ESIntegTestCase {
         assertThat("Expect no shards skipped", searchResponse.getSkippedShards(), equalTo(0));
         assertThat("Expect subset of shards successful", searchResponse.getSuccessfulShards(), lessThan(numShards));
         assertThat("Expected total shards", searchResponse.getTotalShards(), equalTo(numShards));
+        assertThat(searchResponse.isPartial(), equalTo(true));        
     }
 
     public void testClusterAllowPartialsWithRedState() throws Exception {
@@ -70,6 +71,7 @@ public class SearchRedStateIndexIT extends ESIntegTestCase {
         assertThat("Expect no shards skipped", searchResponse.getSkippedShards(), equalTo(0));
         assertThat("Expect subset of shards successful", searchResponse.getSuccessfulShards(), lessThan(numShards));
         assertThat("Expected total shards", searchResponse.getTotalShards(), equalTo(numShards));
+        assertThat(searchResponse.isPartial(), equalTo(true));        
     }
     
     

--- a/server/src/test/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
+++ b/server/src/test/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
@@ -311,11 +311,13 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
         assertFailures(searchResponse);
         assertHitCount(searchResponse, 1L);
         assertSearchHits(searchResponse, "1");
+        assertThat(searchResponse.isPartial(), equalTo(true));                    
 
         searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo").field("field").lenient(true)).get();
         assertNoFailures(searchResponse);
         assertHitCount(searchResponse, 1L);
         assertSearchHits(searchResponse, "1");
+        assertThat(searchResponse.isPartial(), equalTo(false));                    
     }
 
     // Issue #7967

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -305,6 +305,7 @@ public class ElasticsearchAssertions {
         //we can either run into partial or total failures depending on the current number of shards
         try {
             SearchResponse searchResponse = searchRequestBuilder.get();
+            assertThat(searchResponse.isPartial(), equalTo(true));
             assertThat("Expected shard failures, got none", searchResponse.getShardFailures().length, greaterThan(0));
             for (ShardSearchFailure shardSearchFailure : searchResponse.getShardFailures()) {
                 assertThat(shardSearchFailure.status(), equalTo(restStatus));
@@ -336,6 +337,8 @@ public class ElasticsearchAssertions {
         assertNoFailures(response);
         assertThat("Expected all shards successful",
                 response.getSuccessfulShards(), equalTo(response.getTotalShards()));
+        // Is this a valid assumption for all tests? Do some test assume "success" when there's timeouts or red state?
+        assertThat(response.isPartial(), equalTo(false));
     }
 
     public static void assertHighlight(SearchResponse resp, int hit, String field, int fragment, Matcher<String> matcher) {


### PR DESCRIPTION
We have a multitude of flags and conditions that indicate partial failure in our search responses.

These make it hard for clients to answer the most basic question:
> "Can I trust these results?"

To aid with that, this PR proposes a simple new "partial_results" boolean in the response which summarises all the reasons for incomplete data (timed out, unavailable shards, cancellations, failures). Client applications should pay close attention to this summary flag and warn users if it is set to true. 

Of course, setting the existing `allow_partial_search_results` flag to false is a way to avoid returning any incomplete data in the first place but this is currently not the default setting and clients need a simple way to understand if they are missing any data.

Relates to #47700 