### PR TITLE
[7.3] [DOCS] Adds supported fields section to the PUT DFA API description

### DIFF
--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -47,6 +47,18 @@ it possible to set up the destination index in advance with custom settings
 and mappings.
 
 
+[[ml-put-dfanalytics-supported-fields]]
+===== Supported fields
+
+====== {oldetection-cap}
+
+{oldetection-cap} requires numeric or boolean data to analyze. The algorithms 
+don't support missing values therefore fields that have data types other than 
+numeric or boolean are ignored. Documents where included fields contain missing 
+values, null values, or an array are also ignored. Therefore the `dest` index 
+may contain documents that don't have an {olscore}.
+
+
 [[ml-put-dfanalytics-path-params]]
 ==== {api-path-parms-title}
 
@@ -68,9 +80,8 @@ and mappings.
 `analyzed_fields`::
   (Optional, object) You can specify both `includes` and/or `excludes` patterns. 
   If `analyzed_fields` is not set, only the relevant fields will be included. 
-  For example, all the numeric fields for {oldetection}. For the potential field 
-  type limitations, see 
-  {stack-ov}/ml-dfa-limitations.html[{dfanalytics} limitations].
+  For example, all the numeric fields for {oldetection}. For the supported field 
+  types, see <<ml-put-dfanalytics-supported-fields>>.
   
   `includes`:::
     (Optional, array) An array of strings that defines the fields that will be 


### PR DESCRIPTION
This PR adds the Supported fields section to the PUT data frame analytics API description that lists the supported fields and field restrictions of the outlier detection analysis.

Related PR: [DOCS] Adds supported fields section to the PUT DFA API description #47842

Related issue: https://github.com/elastic/ml-team/issues/187#issuecomment-539669270