### PR TITLE
Automatically detect and ignore type at root of mapping json

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
@@ -21,12 +21,9 @@ package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.compress.CompressedXContent;
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.query.QueryShardContext;
@@ -72,15 +69,33 @@ public class DocumentMapperParser {
     public DocumentMapper parse(@Nullable String type, CompressedXContent source) throws MapperParsingException {
         Map<String, Object> mapping = null;
         if (source != null) {
-            Map<String, Object> root = XContentHelper.convertToMap(source.compressedReference(), true, XContentType.JSON).v2();
-            Tuple<String, Map<String, Object>> t = extractMapping(type, root);
-            type = t.v1();
-            mapping = t.v2();
+            mapping = XContentHelper.convertToMap(source.compressedReference(), true, XContentType.JSON).v2();
         }
         if (mapping == null) {
             mapping = new HashMap<>();
         }
-        return parse(type, mapping);
+        // We try this twice, once with the parsed Map, and if that fails we then see if there's a type name
+        // at the root, extract the mapping from one level down and try again.
+        // TODO: Remove in 9.0 once no types are stored in mappings
+        try {
+            return parse(type, mapping);
+        }
+        catch (MapperParsingException e) {
+            mapping = extractTypedNode(mapping);
+            if (mapping == null) {
+                throw e;
+            }
+            return parse(type, mapping);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> extractTypedNode(Map<String, Object> root) {
+        if (root.size() == 1) {
+            String rootName = root.keySet().iterator().next();
+            return (Map<String, Object>) root.get(rootName);
+        }
+        return null;
     }
 
     @SuppressWarnings({"unchecked"})
@@ -154,50 +169,6 @@ public class DocumentMapperParser {
             remainingFields.append(" [").append(key).append(" : ").append(map.get(key)).append("]");
         }
         return remainingFields.toString();
-    }
-
-    private Tuple<String, Map<String, Object>> extractMapping(String type, String source) throws MapperParsingException {
-        Map<String, Object> root;
-        try (XContentParser parser = XContentType.JSON.xContent()
-                .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, source)) {
-            root = parser.mapOrdered();
-        } catch (Exception e) {
-            throw new MapperParsingException("failed to parse mapping definition", e);
-        }
-        return extractMapping(type, root);
-    }
-
-    /**
-     * Given an optional type name and mapping definition, returns the type and a normalized form of the mappings.
-     *
-     * The provided mapping definition may or may not contain the type name as the root key in the map. This method
-     * attempts to unwrap the mappings, so that they no longer contain a type name at the root. If no type name can
-     * be found, through either the 'type' parameter or by examining the provided mappings, then an exception will be
-     * thrown.
-     *
-     * @param type An optional type name.
-     * @param root The mapping definition.
-     *
-     * @return A tuple of the form (type, normalized mappings).
-     */
-    @SuppressWarnings({"unchecked"})
-    private Tuple<String, Map<String, Object>> extractMapping(String type, Map<String, Object> root) throws MapperParsingException {
-        if (root.size() == 0) {
-            if (type != null) {
-                return new Tuple<>(type, root);
-            } else {
-                throw new MapperParsingException("malformed mapping, no type name found");
-            }
-        }
-
-        String rootName = root.keySet().iterator().next();
-        Tuple<String, Map<String, Object>> mapping;
-        if (type == null || type.equals(rootName) || mapperService.resolveDocumentType(type).equals(rootName)) {
-            mapping = new Tuple<>(rootName, (Map<String, Object>) root.get(rootName));
-        } else {
-            mapping = new Tuple<>(type, root);
-        }
-        return mapping;
     }
 
     NamedXContentRegistry getXContentRegistry() {


### PR DESCRIPTION
We currently have logic that checks if a mapping json representation has a single root
field that matches the type of the mapping, and if so then we load mappings from one
level down.  This commit changes the logic slightly to ignore the type value; we now 
attempt to parse at the top level, and if this fails we check if the top has a single entry and
if so then re-attempt parsing one level down.  This will allow us to stop passing type 
names when building and merging mappings in a subsequent commit.

Relates to #41059 