### PR TITLE
[DOCS] Expands GET role mappings API description

### DIFF
--- a/x-pack/docs/en/rest-api/security/get-role-mappings.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-role-mappings.asciidoc
@@ -7,6 +7,7 @@
 
 Retrieves role mappings.
 
+
 [[security-api-get-role-mapping-request]]
 ==== {api-request-title}
 
@@ -14,16 +15,23 @@ Retrieves role mappings.
 
 `GET /_security/role_mapping/<name>` 
 
+
 [[security-api-get-role-mapping-prereqs]]
 ==== {api-prereq-title}
 
-* To use this API, you must have at least the `manage_security` cluster privilege.
+* To use this API, you must have at least the `manage_security` cluster 
+privilege.
+
 
 [[security-api-get-role-mapping-desc]]
 ==== {api-description-title}
 
 Role mappings define which roles are assigned to each user. For more information, 
-see <<mapping-roles>>. 
+see <<mapping-roles>>. The API cannot retrieve role mappings that are defined
+in role mapping files. The <<security-api-put-role-mapping>> is the preferred 
+way to manage role mappings rather than using 
+{stack-ov}/mapping-roles.html#mapping-roles-file[role mapping files].
+
 
 [[security-api-get-role-mapping-path-params]]
 ==== {api-path-parms-title}
@@ -35,6 +43,7 @@ see <<mapping-roles>>.
   mapping names as a comma-separated list. If you do not specify this
   parameter, the API returns information about all role mappings. 
 
+
 [[security-api-get-role-mapping-response-body]]
 ==== {api-response-body-title}
 
@@ -42,6 +51,7 @@ A successful call retrieves an object, where the keys are the
 names of the request mappings, and the values are the JSON representation of 
 those mappings. For more information, see 
 <<role-mapping-resources>>.
+
 
 [[security-api-get-role-mapping-response-codes]]
 ==== {api-response-codes-title}


### PR DESCRIPTION
This PR adds a note that indicates that `GET /_security/role_mapping` returns only the role mappings configured via the API and not the roles configured through files.

Related issue: https://github.com/elastic/elasticsearch/issues/46905

[docs issue triage]