### PR TITLE
Force flush in translog retention test

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardIT.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardIT.java
@@ -855,7 +855,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
         }
     }
 
-    public void testLimitNumberOfRetainingTranslogFiles() throws Exception {
+    public void testLimitNumberOfRetainedTranslogFiles() throws Exception {
         String indexName = "test";
         int translogRetentionTotalFiles = randomIntBetween(0, 50);
         Settings.Builder settings = Settings.builder()
@@ -888,7 +888,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
                 shard.rollTranslogGeneration();
             }
         }
-        client().admin().indices().prepareFlush(indexName).get();
+        client().admin().indices().prepareFlush(indexName).setForce(true).setWaitIfOngoing(true).get();
         checkTranslog.run();
     }
 


### PR DESCRIPTION
If we roll translog but do not index, then a flush without force is a noop. In this case, the number of retained translog files will be higher than the value specified by the retention policy.

Closes #47597
Relates #47414