### PR TITLE
[DOCS] Document ingest pipeline and processor node stats

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -490,7 +490,7 @@ parameter to `ingest` and use the
 
 [source,console]
 --------------------------------------------------
-GET /_nodes/stats/metric?filter_path=nodes.*.ingest
+GET /_nodes/stats/ingest?filter_path=nodes.*.ingest
 --------------------------------------------------
 
 You can use the `metric` and `filter_path` query parameters to get the same

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -135,6 +135,9 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=include-segment-file-sizes]
 [[cluster-nodes-stats-api-response-body]]
 ==== {api-response-body-title}
 
+[[cluster-nodes-stats-api-response-body-fs]]
+===== `fs` section
+
 The `fs` flag can be set to retrieve information that concern the file system:
 
 `fs.timestamp`::
@@ -219,6 +222,10 @@ The `fs` flag can be set to retrieve information that concern the file system:
 `fs.io_stats.write_kilobytes` (Linux only)::
     The total number of kilobytes written across all devices used by {es} since 
     starting {es}.
+
+
+[[cluster-nodes-stats-api-response-body-os]]
+===== `os` section
 
 The `os` flag can be set to retrieve statistics that concern
 the operating system:
@@ -317,6 +324,10 @@ NOTE: For the cgroup stats to be visible, cgroups must be compiled into the
 kernel, the `cpu` and `cpuacct` cgroup subsystems must be configured and stats 
 must be readable from `/sys/fs/cgroup/cpu` and `/sys/fs/cgroup/cpuacct`.
 
+
+[[cluster-nodes-stats-api-response-body-process]]
+===== `process` section
+
 The `process` flag can be set to retrieve statistics that concern
 the current running process:
 
@@ -342,24 +353,60 @@ the current running process:
     Size in bytes of virtual memory that is guaranteed to be available to the 
     running process.
 
+
+[[cluster-nodes-stats-api-response-body-ingest]]
+===== `ingest` section
+
 The `ingest` flag can be set to retrieve statistics that concern ingest:
 
 `ingest.total.count`::
-    The total number of document ingested during the lifetime of this node
+    (integer)
+    Total number of documents ingested during the lifetime of this node.
 
 `ingest.total.time_in_millis`::
-    The total time spent on ingest preprocessing documents during the lifetime 
-    of this node.
+    (integer)
+    Total time spent preprocessing ingest documents during the lifetime of this
+    node.
 
 `ingest.total.current`::
-    The total number of documents currently being ingested.
+    (integer)
+    Total number of documents currently being ingested.
 
 `ingest.total.failed`::
-    The total number ingest preprocessing operations failed during the lifetime 
-    of this node.
+    (integer)
+    Total number of failed ingest operations during the lifetime of this node.
 
-On top of these overall ingest statistics, these statistics are also provided on 
-a per pipeline basis.
+`ingest.pipelines.<pipeline-id>.count`::
+    (integer)
+    Number of documents preprocessed by the ingest pipeline.
+
+`ingest.pipelines.<pipeline-id>.time_in_millis`::
+    (integer)
+    Total time spent preprocessing documents in the ingest pipeline.
+
+`ingest.pipelines.<pipeline-id>.failed`::
+    (integer)
+    Total number of failed operations for the ingest pipeline.
+
+`ingest.pipelines.<pipeline-id>.<processor>.count`::
+    (integer)
+    Number of documents transformed by the processor.
+
+`ingest.pipelines.<pipeline-id>.<processor>.time_in_millis`::
+    (integer)
+    Time spent by the processor transforming documents.
+
+`ingest.pipelines.<pipeline-id>.<processor>.current`::
+    (integer)
+    Number of documents currently being transformed by the processor.
+
+`ingest.pipelines.<pipeline-id>.<processor>.failed`::
+    (integer)
+    Number of failed operations for the processor.
+
+
+[[cluster-nodes-stats-api-response-body-adaptive-selection]]
+===== `adaptive_selection` section
 
 The `adaptive_selection` flag can be set to retrieve statistics that concern
 <<search-adaptive-replica,adaptive replica selection>>. These statistics are
@@ -432,4 +479,32 @@ GET /_nodes/stats?groups=_all
 
 # Some groups from just the indices stats
 GET /_nodes/stats/indices?groups=foo,bar
+--------------------------------------------------
+
+[[cluster-nodes-stats-ingest-ex]]
+===== Retrieve ingest statistics only
+
+To return only ingest-related node statistics, set the `<metric>` path
+parameter to `ingest` and use the
+<<common-options-response-filtering,`filter_path`>> query parameter.
+
+[source,console]
+--------------------------------------------------
+GET /_nodes/stats/metric?filter_path=nodes.*.ingest
+--------------------------------------------------
+
+You can use the `metric` and `filter_path` query parameters to get the same
+response.
+
+[source,console]
+--------------------------------------------------
+GET /_nodes/stats?metric=ingest&filter_path=nodes.*.ingest
+--------------------------------------------------
+
+To further refine the response, change the `filter_path` value.
+For example, the following request only returns ingest pipeline statistics.
+
+[source,console]
+--------------------------------------------------
+GET /_nodes/stats?metric=ingest&filter_path=nodes.*.ingest.pipelines
 --------------------------------------------------


### PR DESCRIPTION
### Changes
- Explicitly documents ingest pipeline and processor stats returned by the node stats API.
- Adds some examples for filtering the response to only include ingest-related stats.
- Adds section headings for each metric group. I'd eventually like to put these in collapsible sections, but that's not possible for now.

Closes #40063.

It also relates to #47524, which is a broader effort to document the node stats response body and make it consistent.