### PR TITLE
Add build scan tag for all pull request builds

### DIFF
--- a/gradle/build-scan.gradle
+++ b/gradle/build-scan.gradle
@@ -1,4 +1,3 @@
-import nebula.plugin.info.scm.ScmInfoExtension
 import org.elasticsearch.gradle.OS
 
 buildScan {
@@ -37,6 +36,7 @@ buildScan {
             value 'Git Branch', System.getenv('ghprbTargetBranch')
             tag System.getenv('ghprbTargetBranch')
             tag "pr/${System.getenv('ghprbPullId')}"
+            tag 'pull-request'
             link 'Source', "https://github.com/elastic/elasticsearch/tree/${System.getenv('ghprbActualCommit')}"
             link 'Pull Request', System.getenv('ghprbPullLink')
         } else {


### PR DESCRIPTION
It's sometimes helpful when doing some build analysis with Gradle Enterprise to filter for, or exclude certain categories of builds. This PR adds a 'pull-request' tag to all pull request builds making it simple to include/exclude PR builds for analysis.