### PR TITLE
[7.x][Transform] Transform rolling cluster upgrade test failure

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_data_frame_jobs_crud.yml
@@ -156,7 +156,9 @@
         transform_id: "mixed-simple-continuous-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-simple-continuous-transform" }
-  - match: { transforms.0.state: "/started|indexing/" }
+  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we cannot
+  # assert on state in the mixed cluster as it could be state at the top level or state.task_state
+  #- match: { transforms.0.state: "/started|indexing/" }
 
   - do:
       data_frame_transform_deprecated.stop_transform:
@@ -169,7 +171,9 @@
         transform_id: "mixed-simple-continuous-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-simple-continuous-transform" }
-  - match: { transforms.0.state: "stopped" }
+  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we cannot
+  # assert on state in the mixed cluster as it could be state at the top level or state.task_state
+  #- match: { transforms.0.state: "stopped" }
 
 ---
 "Test GET, start, and stop old cluster batch transforms":
@@ -282,7 +286,9 @@
         transform_id: "old-simple-continuous-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-continuous-transform" }
-  - match: { transforms.0.state: "/started|indexing/" }
+  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we cannot
+  # assert on state in the mixed cluster as it could be state at the top level or state.task_state
+  #- match: { transforms.0.state: "/started|indexing/" }
 
   - do:
       data_frame_transform_deprecated.stop_transform:
@@ -295,4 +301,6 @@
         transform_id: "old-simple-continuous-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-continuous-transform" }
-  - match: { transforms.0.state: "stopped" }
+  # Since we are breaking the stats format between 7.3 and 7.4 (allowed because we're beta) we cannot
+  # assert on state in the mixed cluster as it could be state at the top level or state.task_state
+  #- match: { transforms.0.state: "stopped" }


### PR DESCRIPTION
do not assert on state in mixed cluster due to endpoint differences between 7.3 and 7.4

regression #46452
fixes #47693 