### PR TITLE
Allow integer types for classification's dependent variable

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
@@ -9,6 +9,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -20,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
@@ -148,8 +150,17 @@ public class Classification implements DataFrameAnalysis {
     }
 
     @Override
+    public Set<String> getAllowedCategoricalTypes(String fieldName) {
+        if (dependentVariable.equals(fieldName)) {
+            return Sets.union(Types.categorical(), Types.booleanAndDiscreteNumerical());
+        }
+        return Types.categorical();
+    }
+
+    @Override
     public List<RequiredField> getRequiredFields() {
-        return Collections.singletonList(new RequiredField(dependentVariable, Types.categorical()));
+        return Collections.singletonList(
+            new RequiredField(dependentVariable, Sets.union(Types.categorical(), Types.booleanAndDiscreteNumerical())));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
@@ -10,6 +10,7 @@ import org.elasticsearch.common.xcontent.ToXContentObject;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface DataFrameAnalysis extends ToXContentObject, NamedWriteable {
 
@@ -22,6 +23,12 @@ public interface DataFrameAnalysis extends ToXContentObject, NamedWriteable {
      * @return {@code true} if this analysis supports fields with categorical values (i.e. text, keyword, ip)
      */
     boolean supportsCategoricalFields();
+
+    /**
+     * @param fieldName field for which the allowed categorical types should be returned
+     * @return The types treated as categorical for the given field
+     */
+    Set<String> getAllowedCategoricalTypes(String fieldName);
 
     /**
      * @return The names and types of the fields that analyzed documents must have for the analysis to operate

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 public class OutlierDetection implements DataFrameAnalysis {
 
@@ -211,6 +212,11 @@ public class OutlierDetection implements DataFrameAnalysis {
     @Override
     public boolean supportsCategoricalFields() {
         return false;
+    }
+
+    @Override
+    public Set<String> getAllowedCategoricalTypes(String fieldName) {
+        return Collections.emptySet();
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
@@ -132,6 +133,11 @@ public class Regression implements DataFrameAnalysis {
     @Override
     public boolean supportsCategoricalFields() {
         return true;
+    }
+
+    @Override
+    public Set<String> getAllowedCategoricalTypes(String fieldName) {
+        return Types.categorical();
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Types.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Types.java
@@ -11,6 +11,7 @@ import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 
+import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -30,11 +31,12 @@ public final class Types {
         Stream.concat(Stream.of(NumberType.values()).map(NumberType::typeName), Stream.of("scaled_float"))
             .collect(Collectors.toUnmodifiableSet());
 
-    private static final Set<String> BOOLEAN_AND_DISCRETE_NUMERICAL_TYPES =
-        Stream.concat(
-                Stream.of(NumberType.BYTE, NumberType.SHORT, NumberType.INTEGER, NumberType.LONG).map(NumberType::typeName),
-                Stream.of(BooleanFieldMapper.CONTENT_TYPE))
+    private static final Set<String> DISCRETE_NUMERICAL_TYPES =
+        Stream.of(NumberType.BYTE, NumberType.SHORT, NumberType.INTEGER, NumberType.LONG)
+            .map(NumberType::typeName)
             .collect(Collectors.toUnmodifiableSet());
+
+    private static final Set<String> BOOL_TYPES = Collections.singleton(BooleanFieldMapper.CONTENT_TYPE);
 
     public static Set<String> categorical() {
         return CATEGORICAL_TYPES;
@@ -44,7 +46,11 @@ public final class Types {
         return NUMERICAL_TYPES;
     }
 
-    public static Set<String> booleanAndDiscreteNumerical() {
-        return BOOLEAN_AND_DISCRETE_NUMERICAL_TYPES;
+    public static Set<String> discreteNumerical() {
+        return DISCRETE_NUMERICAL_TYPES;
+    }
+
+    public static Set<String> bool() {
+        return BOOL_TYPES;
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Types.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Types.java
@@ -5,9 +5,12 @@
  */
 package org.elasticsearch.xpack.core.ml.dataframe.analyses;
 
-import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.index.mapper.BooleanFieldMapper;
+import org.elasticsearch.index.mapper.IpFieldMapper;
+import org.elasticsearch.index.mapper.KeywordFieldMapper;
+import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
+import org.elasticsearch.index.mapper.TextFieldMapper;
 
-import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -20,16 +23,18 @@ public final class Types {
     private Types() {}
 
     private static final Set<String> CATEGORICAL_TYPES =
-        Collections.unmodifiableSet(
-            Stream.of("text", "keyword", "ip")
-                .collect(Collectors.toSet()));
+        Stream.of(TextFieldMapper.CONTENT_TYPE, KeywordFieldMapper.CONTENT_TYPE, IpFieldMapper.CONTENT_TYPE)
+            .collect(Collectors.toUnmodifiableSet());
 
     private static final Set<String> NUMERICAL_TYPES =
-        Collections.unmodifiableSet(
-            Stream.concat(
-                    Stream.of(NumberFieldMapper.NumberType.values()).map(NumberFieldMapper.NumberType::typeName),
-                    Stream.of("scaled_float"))
-                .collect(Collectors.toSet()));
+        Stream.concat(Stream.of(NumberType.values()).map(NumberType::typeName), Stream.of("scaled_float"))
+            .collect(Collectors.toUnmodifiableSet());
+
+    private static final Set<String> BOOLEAN_AND_DISCRETE_NUMERICAL_TYPES =
+        Stream.concat(
+                Stream.of(NumberType.BYTE, NumberType.SHORT, NumberType.INTEGER, NumberType.LONG).map(NumberType::typeName),
+                Stream.of(BooleanFieldMapper.CONTENT_TYPE))
+            .collect(Collectors.toUnmodifiableSet());
 
     public static Set<String> categorical() {
         return CATEGORICAL_TYPES;
@@ -37,5 +42,9 @@ public final class Types {
 
     public static Set<String> numerical() {
         return NUMERICAL_TYPES;
+    }
+
+    public static Set<String> booleanAndDiscreteNumerical() {
+        return BOOLEAN_AND_DISCRETE_NUMERICAL_TYPES;
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractor.java
@@ -23,7 +23,7 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.fetch.StoredFieldsContext;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.xpack.core.ClientHelper;
-import org.elasticsearch.xpack.core.ml.dataframe.analyses.Types;
+import org.elasticsearch.xpack.core.ml.dataframe.analyses.DataFrameAnalysis;
 import org.elasticsearch.xpack.ml.datafeed.extractor.fields.ExtractedField;
 import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsIndex;
 
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -265,15 +264,11 @@ public class DataFrameDataExtractor {
             .setTrackTotalHits(true);
     }
 
-    public Set<String> getCategoricalFields() {
-        Set<String> categoricalFields = new HashSet<>();
-        for (ExtractedField extractedField : context.extractedFields.getAllFields()) {
-            String fieldName = extractedField.getName();
-            if (Types.categorical().containsAll(extractedField.getTypes())) {
-                categoricalFields.add(fieldName);
-            }
-        }
-        return categoricalFields;
+    public Set<String> getCategoricalFields(DataFrameAnalysis analysis) {
+        return context.extractedFields.getAllFields().stream()
+            .filter(extractedField -> analysis.getAllowedCategoricalTypes(extractedField.getName()).containsAll(extractedField.getTypes()))
+            .map(ExtractedField::getName)
+            .collect(Collectors.toUnmodifiableSet());
     }
 
     public static class DataSummary {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManager.java
@@ -367,7 +367,7 @@ public class AnalyticsProcessManager {
 
         private AnalyticsProcessConfig createProcessConfig(DataFrameAnalyticsConfig config, DataFrameDataExtractor dataExtractor) {
             DataFrameDataExtractor.DataSummary dataSummary = dataExtractor.collectDataSummary();
-            Set<String> categoricalFields = dataExtractor.getCategoricalFields();
+            Set<String> categoricalFields = dataExtractor.getCategoricalFields(config.getAnalysis());
             AnalyticsProcessConfig processConfig = new AnalyticsProcessConfig(config.getId(), dataSummary.rows, dataSummary.cols,
                 config.getModelMemoryLimit(), 1, config.getDest().getResultsField(), categoricalFields, config.getAnalysis());
             return processConfig;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/MemoryUsageEstimationProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/MemoryUsageEstimationProcessManager.java
@@ -57,7 +57,7 @@ public class MemoryUsageEstimationProcessManager {
                                                DataFrameDataExtractorFactory dataExtractorFactory) {
         DataFrameDataExtractor dataExtractor = dataExtractorFactory.newExtractor(false);
         DataFrameDataExtractor.DataSummary dataSummary = dataExtractor.collectDataSummary();
-        Set<String> categoricalFields = dataExtractor.getCategoricalFields();
+        Set<String> categoricalFields = dataExtractor.getCategoricalFields(config.getAnalysis());
         if (dataSummary.rows == 0) {
             return new MemoryUsageEstimationResult(ByteSizeValue.ZERO, ByteSizeValue.ZERO);
         }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorTests.java
@@ -24,6 +24,9 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ml.dataframe.analyses.Classification;
+import org.elasticsearch.xpack.core.ml.dataframe.analyses.OutlierDetectionTests;
+import org.elasticsearch.xpack.core.ml.dataframe.analyses.Regression;
 import org.elasticsearch.xpack.ml.datafeed.extractor.fields.ExtractedField;
 import org.elasticsearch.xpack.ml.datafeed.extractor.fields.ExtractedFields;
 import org.elasticsearch.xpack.ml.test.SearchHitBuilder;
@@ -41,7 +44,9 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -382,6 +387,36 @@ public class DataFrameDataExtractorTests extends ESTestCase {
         rows = dataExtractor.next();
         assertThat(rows.isEmpty(), is(true));
         assertThat(dataExtractor.hasNext(), is(false));
+    }
+
+    public void testGetCategoricalFields() {
+        extractedFields = new ExtractedFields(Arrays.asList(
+            ExtractedField.newField("field_boolean", Collections.singleton("boolean"), ExtractedField.ExtractionMethod.DOC_VALUE),
+            ExtractedField.newField("field_float", Collections.singleton("float"), ExtractedField.ExtractionMethod.DOC_VALUE),
+            ExtractedField.newField("field_double", Collections.singleton("double"), ExtractedField.ExtractionMethod.DOC_VALUE),
+            ExtractedField.newField("field_byte", Collections.singleton("byte"), ExtractedField.ExtractionMethod.DOC_VALUE),
+            ExtractedField.newField("field_short", Collections.singleton("short"), ExtractedField.ExtractionMethod.DOC_VALUE),
+            ExtractedField.newField("field_integer", Collections.singleton("integer"), ExtractedField.ExtractionMethod.DOC_VALUE),
+            ExtractedField.newField("field_long", Collections.singleton("long"), ExtractedField.ExtractionMethod.DOC_VALUE),
+            ExtractedField.newField("field_keyword", Collections.singleton("keyword"), ExtractedField.ExtractionMethod.DOC_VALUE),
+            ExtractedField.newField("field_text", Collections.singleton("text"), ExtractedField.ExtractionMethod.SOURCE)));
+        TestExtractor dataExtractor = createExtractor(true, true);
+
+        assertThat(dataExtractor.getCategoricalFields(OutlierDetectionTests.createRandom()), empty());
+
+        assertThat(dataExtractor.getCategoricalFields(new Regression("field_double")), containsInAnyOrder("field_keyword", "field_text"));
+        assertThat(dataExtractor.getCategoricalFields(new Regression("field_long")), containsInAnyOrder("field_keyword", "field_text"));
+        assertThat(dataExtractor.getCategoricalFields(new Regression("field_boolean")), containsInAnyOrder("field_keyword", "field_text"));
+
+        assertThat(
+            dataExtractor.getCategoricalFields(new Classification("field_keyword")),
+            containsInAnyOrder("field_keyword", "field_text"));
+        assertThat(
+            dataExtractor.getCategoricalFields(new Classification("field_long")),
+            containsInAnyOrder("field_keyword", "field_text", "field_long"));
+        assertThat(
+            dataExtractor.getCategoricalFields(new Classification("field_boolean")),
+            containsInAnyOrder("field_keyword", "field_text", "field_boolean"));
     }
 
     private TestExtractor createExtractor(boolean includeSource, boolean includeRowsWithMissingValues) {


### PR DESCRIPTION
Some users may want to encode their labels as booleans (true, false). Others may want to use integers (0, 1, 2, 3, etc.).
Classification API should allow for dependent variable being treated as categorical even if its type is boolean or discrete numeric.

Relates https://github.com/elastic/elasticsearch/issues/46735