### PR TITLE
[7.x] Require that the dependent variable column has at most 2 distinct values in classfication analysis. (#47858)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
@@ -153,6 +153,12 @@ public class Classification implements DataFrameAnalysis {
     }
 
     @Override
+    public Map<String, Long> getFieldCardinalityLimits() {
+        // This restriction is due to the fact that currently the C++ backend only supports binomial classification.
+        return Collections.singletonMap(dependentVariable, 2L);
+    }
+
+    @Override
     public boolean supportsMissingValues() {
         return true;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
@@ -29,6 +29,11 @@ public interface DataFrameAnalysis extends ToXContentObject, NamedWriteable {
     List<RequiredField> getRequiredFields();
 
     /**
+     * @return {@link Map} containing cardinality limits for the selected (analysis-specific) fields
+     */
+    Map<String, Long> getFieldCardinalityLimits();
+
+    /**
      * @return {@code true} if this analysis supports data frame rows with missing values
      */
     boolean supportsMissingValues();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
@@ -219,6 +219,11 @@ public class OutlierDetection implements DataFrameAnalysis {
     }
 
     @Override
+    public Map<String, Long> getFieldCardinalityLimits() {
+        return Collections.emptyMap();
+    }
+
+    @Override
     public boolean supportsMissingValues() {
         return false;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
@@ -140,6 +140,11 @@ public class Regression implements DataFrameAnalysis {
     }
 
     @Override
+    public Map<String, Long> getFieldCardinalityLimits() {
+        return Collections.emptyMap();
+    }
+
+    @Override
     public boolean supportsMissingValues() {
         return true;
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/ClassificationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/ClassificationTests.java
@@ -13,6 +13,9 @@ import org.elasticsearch.test.AbstractSerializingTestCase;
 import java.io.IOException;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
 public class ClassificationTests extends AbstractSerializingTestCase<Classification> {
 
@@ -64,5 +67,9 @@ public class ClassificationTests extends AbstractSerializingTestCase<Classificat
             () -> new Classification("foo", new BoostedTreeParams(0.0, 0.0, 0.5, 500, 1.0), "result", 3, 100.0001));
 
         assertThat(e.getMessage(), equalTo("[training_percent] must be a double in [1, 100]"));
+    }
+
+    public void testFieldCardinalityLimitsIsNonNull() {
+        assertThat(createTestInstance().getFieldCardinalityLimits(), is(not(nullValue())));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetectionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetectionTests.java
@@ -15,6 +15,8 @@ import java.util.Map;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
 public class OutlierDetectionTests extends AbstractSerializingTestCase<OutlierDetection> {
 
@@ -80,6 +82,10 @@ public class OutlierDetectionTests extends AbstractSerializingTestCase<OutlierDe
         assertThat((Double) params.get(OutlierDetection.OUTLIER_FRACTION.getPreferredName()),
             is(closeTo(0.9, 1E-9)));
         assertThat(params.get(OutlierDetection.STANDARDIZATION_ENABLED.getPreferredName()), is(false));
+    }
+
+    public void testFieldCardinalityLimitsIsNonNull() {
+        assertThat(createTestInstance().getFieldCardinalityLimits(), is(not(nullValue())));
     }
 
     public void testGetStateDocId() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/RegressionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/RegressionTests.java
@@ -14,6 +14,8 @@ import java.io.IOException;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
 public class RegressionTests extends AbstractSerializingTestCase<Regression> {
 
@@ -64,6 +66,10 @@ public class RegressionTests extends AbstractSerializingTestCase<Regression> {
             () -> new Regression("foo", new BoostedTreeParams(0.0, 0.0, 0.5, 500, 1.0), "result", 100.0001));
 
         assertThat(e.getMessage(), equalTo("[training_percent] must be a double in [1, 100]"));
+    }
+
+    public void testFieldCardinalityLimitsIsNonNull() {
+        assertThat(createTestInstance().getFieldCardinalityLimits(), is(not(nullValue())));
     }
 
     public void testGetStateDocId() {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/start_data_frame_analytics.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/start_data_frame_analytics.yml
@@ -69,7 +69,7 @@
         body:
           mappings:
             properties:
-              long_field: { "type": "long" }
+              long_field: { type: "long" }
 
   - do:
       ml.put_data_frame_analytics:
@@ -140,3 +140,52 @@
       catch: /dest index \[non-empty-dest\] must be empty/
       ml.start_data_frame_analytics:
         id: "start_given_empty_dest_index"
+
+---
+"Test start classification analysis when the dependent variable cardinality is too high":
+  - do:
+      indices.create:
+        index: index-with-dep-var-with-too-high-card
+        body:
+          mappings:
+            properties:
+              numeric_field: { type: "long" }
+              keyword_field: { type: "keyword" }
+
+  - do:
+      index:
+        index: index-with-dep-var-with-too-high-card
+        body: { numeric_field: 1.0, keyword_field: "class_a" }
+
+  - do:
+      index:
+        index: index-with-dep-var-with-too-high-card
+        body: { numeric_field: 2.0, keyword_field: "class_b" }
+
+  - do:
+      index:
+        index: index-with-dep-var-with-too-high-card
+        body: { numeric_field: 3.0, keyword_field: "class_c" }
+
+  - do:
+      indices.refresh:
+        index: index-with-dep-var-with-too-high-card
+
+  - do:
+      ml.put_data_frame_analytics:
+        id: "too-high-card"
+        body: >
+          {
+            "source": {
+              "index": "index-with-dep-var-with-too-high-card"
+            },
+            "dest": {
+              "index": "index-with-dep-var-with-too-high-card-dest"
+            },
+            "analysis": { "classification": { "dependent_variable": "keyword_field" } }
+          }
+
+  - do:
+      catch: /Field \[keyword_field\] must have at most \[2\] distinct values but there were at least \[3\]/
+      ml.start_data_frame_analytics:
+        id: "too-high-card"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Require that the dependent variable column has at most 2 distinct values in classfication analysis.  (#47858)