### PR TITLE
[7.x] Enable ResolverStyle.STRICT for java formatters (#46675)

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateFormat.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateFormat.java
@@ -98,9 +98,9 @@ enum DateFormat {
             final DateFormatter formatter = dateFormatter;
             return text -> {
                 TemporalAccessor accessor = formatter.parse(text);
-                // if there is no year, we fall back to the current one and
+                // if there is no year nor year-of-era, we fall back to the current one and
                 // fill the rest of the date up with the parsed date
-                if (accessor.isSupported(ChronoField.YEAR) == false) {
+                if (accessor.isSupported(ChronoField.YEAR) == false && accessor.isSupported(ChronoField.YEAR_OF_ERA) == false ) {
                     int year = LocalDate.now(ZoneOffset.UTC).getYear();
                     ZonedDateTime newTime = Instant.EPOCH.atZone(ZoneOffset.UTC).withYear(year);
                     for (ChronoField field : FIELDS) {

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateFormatTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateFormatTests.java
@@ -44,8 +44,16 @@ public class DateFormatTests extends ESTestCase {
                 equalTo("11 24 01:29:01"));
     }
 
-    public void testParseJavaWithTimeZone() {
+    public void testParseYearOfEraJavaWithTimeZone() {
         Function<String, ZonedDateTime> javaFunction = DateFormat.Java.getFunction("yyyy-MM-dd'T'HH:mm:ss.SSSZZ",
+            ZoneOffset.UTC, Locale.ROOT);
+        ZonedDateTime datetime = javaFunction.apply("2018-02-05T13:44:56.657+0100");
+        String expectedDateTime = DateFormatter.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").withZone(ZoneOffset.UTC).format(datetime);
+        assertThat(expectedDateTime, is("2018-02-05T12:44:56.657Z"));
+    }
+
+    public void testParseYearJavaWithTimeZone() {
+        Function<String, ZonedDateTime> javaFunction = DateFormat.Java.getFunction("uuuu-MM-dd'T'HH:mm:ss.SSSZZ",
             ZoneOffset.UTC, Locale.ROOT);
         ZonedDateTime datetime = javaFunction.apply("2018-02-05T13:44:56.657+0100");
         String expectedDateTime = DateFormatter.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").withZone(ZoneOffset.UTC).format(datetime);

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -1893,7 +1893,7 @@ public class DateFormatters {
      * when YearOfEra was used instead of Year.
      * This is to make it compatible with Joda behaviour
      */
-    static final TemporalQuery<LocalDate> LOCAL_DATE_QUERY = new TemporalQuery<>() {
+    static final TemporalQuery<LocalDate> LOCAL_DATE_QUERY = new TemporalQuery<LocalDate>() {
         @Override
         public LocalDate queryFrom(TemporalAccessor temporal) {
             if (temporal.isSupported(ChronoField.EPOCH_DAY)) {

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -39,6 +39,7 @@ import java.time.temporal.IsoFields;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalAdjusters;
 import java.time.temporal.TemporalQueries;
+import java.time.temporal.TemporalQuery;
 import java.time.temporal.WeekFields;
 import java.util.Locale;
 
@@ -55,7 +56,8 @@ public class DateFormatters {
 
     private static final DateTimeFormatter TIME_ZONE_FORMATTER_NO_COLON = new DateTimeFormatterBuilder()
         .appendOffset("+HHmm", "Z")
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter STRICT_YEAR_MONTH_DAY_FORMATTER = new DateTimeFormatterBuilder()
         .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
@@ -67,7 +69,9 @@ public class DateFormatters {
         .appendValue(DAY_OF_MONTH, 2, 2, SignStyle.NOT_NEGATIVE)
         .optionalEnd()
         .optionalEnd()
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
+
 
     private static final DateTimeFormatter STRICT_HOUR_MINUTE_SECOND_FORMATTER = new DateTimeFormatterBuilder()
         .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NOT_NEGATIVE)
@@ -75,7 +79,8 @@ public class DateFormatters {
         .appendValue(MINUTE_OF_HOUR, 2, 2, SignStyle.NOT_NEGATIVE)
         .appendLiteral(':')
         .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter STRICT_DATE_OPTIONAL_TIME_PRINTER = new DateTimeFormatterBuilder()
         .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
@@ -97,7 +102,8 @@ public class DateFormatters {
         .optionalEnd()
         .optionalEnd()
         .optionalEnd()
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter STRICT_DATE_OPTIONAL_TIME_FORMATTER = new DateTimeFormatterBuilder()
         .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
@@ -128,7 +134,8 @@ public class DateFormatters {
         .optionalEnd()
         .optionalEnd()
         .optionalEnd()
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     /**
      * Returns a generic ISO datetime parser where the date is mandatory and the time is optional.
@@ -155,7 +162,8 @@ public class DateFormatters {
         .append(TIME_ZONE_FORMATTER_NO_COLON)
         .optionalEnd()
         .optionalEnd()
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter STRICT_DATE_OPTIONAL_TIME_PRINTER_NANOS = new DateTimeFormatterBuilder()
         .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
@@ -177,7 +185,8 @@ public class DateFormatters {
         .optionalEnd()
         .optionalEnd()
         .optionalEnd()
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     /**
      * Returns a generic ISO datetime parser where the date is mandatory and the time is optional with nanosecond resolution.
@@ -220,7 +229,8 @@ public class DateFormatters {
             .append(TIME_ZONE_FORMATTER_NO_COLON)
             .optionalEnd()
             .optionalEnd()
-            .toFormatter(Locale.ROOT));
+            .toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT));
 
     /////////////////////////////////////////
     //
@@ -235,16 +245,22 @@ public class DateFormatters {
         .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NOT_NEGATIVE)
         .appendValue(MINUTE_OF_HOUR, 2, 2, SignStyle.NOT_NEGATIVE)
         .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     /*
      * Returns a basic formatter for a two digit hour of day, two digit minute
      * of hour, two digit second of minute, and time zone offset (HHmmssZ).
      */
     private static final DateFormatter BASIC_TIME_NO_MILLIS = new JavaDateFormatter("basic_time_no_millis",
-        new DateTimeFormatterBuilder().append(BASIC_TIME_NO_MILLIS_BASE).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().append(BASIC_TIME_NO_MILLIS_BASE).appendZoneOrOffsetId().toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().append(BASIC_TIME_NO_MILLIS_BASE).append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+        new DateTimeFormatterBuilder().append(BASIC_TIME_NO_MILLIS_BASE).appendOffset("+HH:MM", "Z")
+                                      .toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().append(BASIC_TIME_NO_MILLIS_BASE).appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().append(BASIC_TIME_NO_MILLIS_BASE).append(TIME_ZONE_FORMATTER_NO_COLON)
+                                      .toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     private static final DateTimeFormatter BASIC_TIME_FORMATTER = new DateTimeFormatterBuilder()
@@ -252,14 +268,16 @@ public class DateFormatters {
         .appendValue(MINUTE_OF_HOUR, 2, 2, SignStyle.NOT_NEGATIVE)
         .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
         .appendFraction(NANO_OF_SECOND, 1, 9, true)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter BASIC_TIME_PRINTER = new DateTimeFormatterBuilder()
         .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NOT_NEGATIVE)
         .appendValue(MINUTE_OF_HOUR, 2, 2, SignStyle.NOT_NEGATIVE)
         .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
         .appendFraction(NANO_OF_SECOND, 3, 3, true)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     /*
      * Returns a basic formatter for a two digit hour of day, two digit minute
@@ -267,16 +285,23 @@ public class DateFormatters {
      * offset (HHmmss.SSSZ).
      */
     private static final DateFormatter BASIC_TIME = new JavaDateFormatter("basic_time",
-        new DateTimeFormatterBuilder().append(BASIC_TIME_PRINTER).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().append(BASIC_TIME_FORMATTER).appendZoneOrOffsetId().toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().append(BASIC_TIME_FORMATTER).append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+        new DateTimeFormatterBuilder().append(BASIC_TIME_PRINTER).appendOffset("+HH:MM", "Z")
+                                      .toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().append(BASIC_TIME_FORMATTER).appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().append(BASIC_TIME_FORMATTER).append(TIME_ZONE_FORMATTER_NO_COLON)
+                                      .toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     private static final DateTimeFormatter BASIC_T_TIME_PRINTER =
-        new DateTimeFormatterBuilder().appendLiteral("T").append(BASIC_TIME_PRINTER).toFormatter(Locale.ROOT);
+        new DateTimeFormatterBuilder().appendLiteral("T").append(BASIC_TIME_PRINTER).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter BASIC_T_TIME_FORMATTER =
-        new DateTimeFormatterBuilder().appendLiteral("T").append(BASIC_TIME_FORMATTER).toFormatter(Locale.ROOT);
+        new DateTimeFormatterBuilder().appendLiteral("T").append(BASIC_TIME_FORMATTER).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT);
 
     /*
      * Returns a basic formatter for a two digit hour of day, two digit minute
@@ -284,9 +309,12 @@ public class DateFormatters {
      * offset prefixed by 'T' ('T'HHmmss.SSSZ).
      */
     private static final DateFormatter BASIC_T_TIME = new JavaDateFormatter("basic_t_time",
-        new DateTimeFormatterBuilder().append(BASIC_T_TIME_PRINTER).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().append(BASIC_T_TIME_FORMATTER).appendZoneOrOffsetId().toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().append(BASIC_T_TIME_FORMATTER).append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+        new DateTimeFormatterBuilder().append(BASIC_T_TIME_PRINTER).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().append(BASIC_T_TIME_FORMATTER).appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().append(BASIC_T_TIME_FORMATTER).append(TIME_ZONE_FORMATTER_NO_COLON).
+            toFormatter(Locale.ROOT)
     );
 
     /*
@@ -296,86 +324,107 @@ public class DateFormatters {
      */
     private static final DateFormatter BASIC_T_TIME_NO_MILLIS = new JavaDateFormatter("basic_t_time_no_millis",
         new DateTimeFormatterBuilder().appendLiteral("T").append(BASIC_TIME_NO_MILLIS_BASE)
-                                      .appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().appendLiteral("T").append(BASIC_TIME_NO_MILLIS_BASE).appendZoneOrOffsetId().toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().appendLiteral("T").append(BASIC_TIME_NO_MILLIS_BASE).append(TIME_ZONE_FORMATTER_NO_COLON)
-            .toFormatter(Locale.ROOT)
+                                      .appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().appendLiteral("T").append(BASIC_TIME_NO_MILLIS_BASE)
+                                      .appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().appendLiteral("T").append(BASIC_TIME_NO_MILLIS_BASE)
+                                      .append(TIME_ZONE_FORMATTER_NO_COLON)
+                                      .toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     private static final DateTimeFormatter BASIC_YEAR_MONTH_DAY_FORMATTER = new DateTimeFormatterBuilder()
         .appendValue(ChronoField.YEAR, 4, 4, SignStyle.NORMAL)
         .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NOT_NEGATIVE)
         .appendValue(DAY_OF_MONTH, 2, 2, SignStyle.NOT_NEGATIVE)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter BASIC_DATE_TIME_FORMATTER = new DateTimeFormatterBuilder()
         .append(BASIC_YEAR_MONTH_DAY_FORMATTER)
         .append(BASIC_T_TIME_FORMATTER)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter BASIC_DATE_TIME_PRINTER = new DateTimeFormatterBuilder()
         .append(BASIC_YEAR_MONTH_DAY_FORMATTER)
         .append(BASIC_T_TIME_PRINTER)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     /*
      * Returns a basic formatter that combines a basic date and time, separated
-     * by a 'T' (yyyyMMdd'T'HHmmss.SSSZ).
+     * by a 'T' (uuuuMMdd'T'HHmmss.SSSZ).
      */
     private static final DateFormatter BASIC_DATE_TIME = new JavaDateFormatter("basic_date_time",
-        new DateTimeFormatterBuilder().append(BASIC_DATE_TIME_PRINTER).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().append(BASIC_DATE_TIME_FORMATTER).appendZoneOrOffsetId().toFormatter(Locale.ROOT),
+        new DateTimeFormatterBuilder().append(BASIC_DATE_TIME_PRINTER).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().append(BASIC_DATE_TIME_FORMATTER).appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(BASIC_DATE_TIME_FORMATTER).append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     private static final DateTimeFormatter BASIC_DATE_T =
-        new DateTimeFormatterBuilder().append(BASIC_YEAR_MONTH_DAY_FORMATTER).appendLiteral("T").toFormatter(Locale.ROOT);
+        new DateTimeFormatterBuilder().append(BASIC_YEAR_MONTH_DAY_FORMATTER).appendLiteral("T").toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT);
 
     /*
      * Returns a basic formatter that combines a basic date and time without millis,
-     * separated by a 'T' (yyyyMMdd'T'HHmmssZ).
+     * separated by a 'T' (uuuuMMdd'T'HHmmssZ).
      */
     private static final DateFormatter BASIC_DATE_TIME_NO_MILLIS = new JavaDateFormatter("basic_date_time_no_millis",
         new DateTimeFormatterBuilder().append(BASIC_DATE_T).append(BASIC_TIME_NO_MILLIS_BASE)
-            .appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
+                                      .appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(BASIC_DATE_T).append(BASIC_TIME_NO_MILLIS_BASE)
-            .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
+                                      .appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(BASIC_DATE_T).append(BASIC_TIME_NO_MILLIS_BASE)
-            .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /*
      * Returns a formatter for a full ordinal date, using a four
-     * digit year and three digit dayOfYear (yyyyDDD).
+     * digit year and three digit dayOfYear (uuuuDDD).
      */
     private static final DateFormatter BASIC_ORDINAL_DATE = new JavaDateFormatter("basic_ordinal_date",
-        DateTimeFormatter.ofPattern("yyyyDDD", Locale.ROOT));
+        DateTimeFormatter.ofPattern("uuuuDDD", Locale.ROOT));
 
     /*
      * Returns a formatter for a full ordinal date and time, using a four
-     * digit year and three digit dayOfYear (yyyyDDD'T'HHmmss.SSSZ).
+     * digit year and three digit dayOfYear (uuuuDDD'T'HHmmss.SSSZ).
      */
     private static final DateFormatter BASIC_ORDINAL_DATE_TIME = new JavaDateFormatter("basic_ordinal_date_time",
         new DateTimeFormatterBuilder().appendPattern("yyyyDDD").append(BASIC_T_TIME_PRINTER)
-            .appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
+                                      .appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().appendPattern("yyyyDDD").append(BASIC_T_TIME_FORMATTER)
-            .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
+                                      .appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().appendPattern("yyyyDDD").append(BASIC_T_TIME_FORMATTER)
-            .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
 
     );
 
     /*
      * Returns a formatter for a full ordinal date and time without millis,
-     * using a four digit year and three digit dayOfYear (yyyyDDD'T'HHmmssZ).
+     * using a four digit year and three digit dayOfYear (uuuuDDD'T'HHmmssZ).
      */
     private static final DateFormatter BASIC_ORDINAL_DATE_TIME_NO_MILLIS = new JavaDateFormatter("basic_ordinal_date_time_no_millis",
-        new DateTimeFormatterBuilder().appendPattern("yyyyDDD").appendLiteral("T").append(BASIC_TIME_NO_MILLIS_BASE)
-            .appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().appendPattern("yyyyDDD").appendLiteral("T").append(BASIC_TIME_NO_MILLIS_BASE)
-            .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().appendPattern("yyyyDDD").appendLiteral("T").append(BASIC_TIME_NO_MILLIS_BASE)
-            .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+        new DateTimeFormatterBuilder().appendPattern("uuuuDDD").appendLiteral("T").append(BASIC_TIME_NO_MILLIS_BASE)
+                                      .appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().appendPattern("uuuuDDD").appendLiteral("T").append(BASIC_TIME_NO_MILLIS_BASE)
+                                      .appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().appendPattern("uuuuDDD").appendLiteral("T").append(BASIC_TIME_NO_MILLIS_BASE)
+                                      .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     private static final DateTimeFormatter BASIC_WEEK_DATE_FORMATTER = new DateTimeFormatterBuilder()
@@ -383,7 +432,8 @@ public class DateFormatters {
         .appendLiteral("W")
         .appendValue(IsoFields.WEEK_OF_WEEK_BASED_YEAR, 1, 2, SignStyle.NEVER)
         .appendValue(ChronoField.DAY_OF_WEEK)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     /////////////////////////////////////////
     //
@@ -402,7 +452,8 @@ public class DateFormatters {
         .appendLiteral("W")
         .appendValue(IsoFields.WEEK_OF_WEEK_BASED_YEAR, 1, 2, SignStyle.NEVER)
         .appendValue(ChronoField.DAY_OF_WEEK)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter STRICT_BASIC_WEEK_DATE_PRINTER = new DateTimeFormatterBuilder()
         .parseStrict()
@@ -410,7 +461,8 @@ public class DateFormatters {
         .appendLiteral("W")
         .appendValue(IsoFields.WEEK_OF_WEEK_BASED_YEAR, 2, 2, SignStyle.NEVER)
         .appendValue(ChronoField.DAY_OF_WEEK)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     /*
      * Returns a basic formatter for a full date as four digit weekyear, two
@@ -432,7 +484,8 @@ public class DateFormatters {
                 .appendValue(MINUTE_OF_HOUR, 2, 2, SignStyle.NOT_NEGATIVE)
                 .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
                 .appendOffset("+HH:MM", "Z")
-                .toFormatter(Locale.ROOT),
+                .toFormatter(Locale.ROOT)
+                .withResolverStyle(ResolverStyle.STRICT),
             new DateTimeFormatterBuilder()
                 .append(STRICT_BASIC_WEEK_DATE_PRINTER)
                 .appendLiteral("T")
@@ -440,7 +493,8 @@ public class DateFormatters {
                 .appendValue(MINUTE_OF_HOUR, 2, 2, SignStyle.NOT_NEGATIVE)
                 .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
                 .appendZoneOrOffsetId()
-                .toFormatter(Locale.ROOT),
+                .toFormatter(Locale.ROOT)
+                .withResolverStyle(ResolverStyle.STRICT),
             new DateTimeFormatterBuilder()
                 .append(STRICT_BASIC_WEEK_DATE_PRINTER)
                 .appendLiteral("T")
@@ -449,6 +503,7 @@ public class DateFormatters {
                 .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
                 .append(TIME_ZONE_FORMATTER_NO_COLON)
                 .toFormatter(Locale.ROOT)
+                .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /*
@@ -457,9 +512,10 @@ public class DateFormatters {
      */
     private static final DateFormatter STRICT_BASIC_WEEK_DATE_TIME = new JavaDateFormatter("strict_basic_week_date_time",
         new DateTimeFormatterBuilder()
-        .append(STRICT_BASIC_WEEK_DATE_PRINTER)
-        .append(DateTimeFormatter.ofPattern("'T'HHmmss.SSSX", Locale.ROOT))
-        .toFormatter(Locale.ROOT),
+            .append(STRICT_BASIC_WEEK_DATE_PRINTER)
+            .append(DateTimeFormatter.ofPattern("'T'HHmmss.SSSX", Locale.ROOT))
+            .toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder()
             .append(STRICT_BASIC_WEEK_DATE_FORMATTER)
             .appendLiteral("T")
@@ -468,7 +524,8 @@ public class DateFormatters {
             .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
             .appendFraction(NANO_OF_SECOND, 1, 9, true)
             .appendZoneOrOffsetId()
-            .toFormatter(Locale.ROOT),
+            .toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder()
             .append(STRICT_BASIC_WEEK_DATE_FORMATTER)
             .appendLiteral("T")
@@ -478,6 +535,7 @@ public class DateFormatters {
             .appendFraction(NANO_OF_SECOND, 1, 9, true)
             .append(TIME_ZONE_FORMATTER_NO_COLON)
             .toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /*
@@ -490,13 +548,13 @@ public class DateFormatters {
      * A date formatter that formats or parses a date plus an hour without an offset, such as '2011-12-03T01'.
      */
     private static final DateFormatter STRICT_DATE_HOUR = new JavaDateFormatter("strict_date_hour",
-        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH", Locale.ROOT));
+        DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH", Locale.ROOT));
 
     /*
      * A date formatter that formats or parses a date plus an hour/minute without an offset, such as '2011-12-03T01:10'.
      */
     private static final DateFormatter STRICT_DATE_HOUR_MINUTE = new JavaDateFormatter("strict_date_hour_minute",
-        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm", Locale.ROOT));
+        DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm", Locale.ROOT));
 
     /*
      * A strict date formatter that formats or parses a date without an offset, such as '2011-12-03'.
@@ -509,17 +567,19 @@ public class DateFormatters {
      */
     private static final DateFormatter STRICT_YEAR_MONTH = new JavaDateFormatter("strict_year_month",
         new DateTimeFormatterBuilder()
-        .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
-        .appendLiteral("-")
-        .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NOT_NEGATIVE)
-        .toFormatter(Locale.ROOT));
+            .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+            .appendLiteral("-")
+            .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NOT_NEGATIVE)
+            .toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT));
 
     /*
      * A strict formatter that formats or parses a year, such as '2011'.
      */
     private static final DateFormatter STRICT_YEAR = new JavaDateFormatter("strict_year", new DateTimeFormatterBuilder()
         .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
-        .toFormatter(Locale.ROOT));
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT));
 
     /*
      * A strict formatter that formats or parses a hour, minute and second, such as '09:43:25'.
@@ -533,7 +593,8 @@ public class DateFormatters {
         .append(STRICT_HOUR_MINUTE_SECOND_FORMATTER)
         .appendFraction(NANO_OF_SECOND, 3, 9, true)
         .appendOffset("+HH:MM", "Z")
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter STRICT_DATE_FORMATTER = new DateTimeFormatterBuilder()
         .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
@@ -542,15 +603,19 @@ public class DateFormatters {
         .optionalStart()
         .appendFraction(NANO_OF_SECOND, 1, 9, true)
         .optionalEnd()
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     /*
      * Returns a formatter that combines a full date and time, separated by a 'T'
-     * (yyyy-MM-dd'T'HH:mm:ss.SSSZZ).
+     * (uuuu-MM-dd'T'HH:mm:ss.SSSZZ).
      */
     private static final DateFormatter STRICT_DATE_TIME = new JavaDateFormatter("strict_date_time", STRICT_DATE_PRINTER,
-        new DateTimeFormatterBuilder().append(STRICT_DATE_FORMATTER).appendZoneOrOffsetId().toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().append(STRICT_DATE_FORMATTER).append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+        new DateTimeFormatterBuilder().append(STRICT_DATE_FORMATTER).appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().append(STRICT_DATE_FORMATTER).append(TIME_ZONE_FORMATTER_NO_COLON)
+                                      .toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     private static final DateTimeFormatter STRICT_ORDINAL_DATE_TIME_NO_MILLIS_BASE = new DateTimeFormatterBuilder()
@@ -559,50 +624,60 @@ public class DateFormatters {
         .appendValue(DAY_OF_YEAR, 3, 3, SignStyle.NOT_NEGATIVE)
         .appendLiteral('T')
         .append(STRICT_HOUR_MINUTE_SECOND_FORMATTER)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     /*
      * Returns a formatter for a full ordinal date and time without millis,
-     * using a four digit year and three digit dayOfYear (yyyy-DDD'T'HH:mm:ssZZ).
+     * using a four digit year and three digit dayOfYear (uuuu-DDD'T'HH:mm:ssZZ).
      */
     private static final DateFormatter STRICT_ORDINAL_DATE_TIME_NO_MILLIS = new JavaDateFormatter("strict_ordinal_date_time_no_millis",
         new DateTimeFormatterBuilder().append(STRICT_ORDINAL_DATE_TIME_NO_MILLIS_BASE)
-            .appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
+                                      .appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(STRICT_ORDINAL_DATE_TIME_NO_MILLIS_BASE)
-            .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
+                                      .appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(STRICT_ORDINAL_DATE_TIME_NO_MILLIS_BASE)
-            .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     private static final DateTimeFormatter STRICT_DATE_TIME_NO_MILLIS_FORMATTER = new DateTimeFormatterBuilder()
         .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
         .appendLiteral('T')
         .append(STRICT_HOUR_MINUTE_SECOND_FORMATTER)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     /*
      * Returns a formatter that combines a full date and time without millis,
-     * separated by a 'T' (yyyy-MM-dd'T'HH:mm:ssZZ).
+     * separated by a 'T' (uuuu-MM-dd'T'HH:mm:ssZZ).
      */
     private static final DateFormatter STRICT_DATE_TIME_NO_MILLIS = new JavaDateFormatter("strict_date_time_no_millis",
         new DateTimeFormatterBuilder().append(STRICT_DATE_TIME_NO_MILLIS_FORMATTER)
-            .appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
+                                      .appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(STRICT_DATE_TIME_NO_MILLIS_FORMATTER)
-            .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
+                                      .appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(STRICT_DATE_TIME_NO_MILLIS_FORMATTER)
-            .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     // NOTE: this is not a strict formatter to retain the joda time based behaviour, even though it's named like this
     private static final DateTimeFormatter STRICT_HOUR_MINUTE_SECOND_MILLIS_FORMATTER = new DateTimeFormatterBuilder()
         .append(STRICT_HOUR_MINUTE_SECOND_FORMATTER)
         .appendFraction(NANO_OF_SECOND, 1, 9, true)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter STRICT_HOUR_MINUTE_SECOND_MILLIS_PRINTER = new DateTimeFormatterBuilder()
         .append(STRICT_HOUR_MINUTE_SECOND_FORMATTER)
         .appendFraction(NANO_OF_SECOND, 3, 3, true)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     /*
      * Returns a formatter for a two digit hour of day, two digit minute of
@@ -623,7 +698,7 @@ public class DateFormatters {
     /*
      * Returns a formatter that combines a full date, two digit hour of day,
      * two digit minute of hour, two digit second of minute, and three digit
-     * fraction of second (yyyy-MM-dd'T'HH:mm:ss.SSS).
+     * fraction of second (uuuu-MM-dd'T'HH:mm:ss.SSS).
      */
     private static final DateFormatter STRICT_DATE_HOUR_MINUTE_SECOND_FRACTION = new JavaDateFormatter(
         "strict_date_hour_minute_second_fraction",
@@ -631,7 +706,8 @@ public class DateFormatters {
             .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
             .appendLiteral("T")
             .append(STRICT_HOUR_MINUTE_SECOND_MILLIS_PRINTER)
-            .toFormatter(Locale.ROOT),
+            .toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder()
             .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
             .appendLiteral("T")
@@ -639,6 +715,7 @@ public class DateFormatters {
             // this one here is lenient as well to retain joda time based bwc compatibility
             .appendFraction(NANO_OF_SECOND, 1, 9, true)
             .toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT)
     );
 
     private static final DateFormatter STRICT_DATE_HOUR_MINUTE_SECOND_MILLIS = new JavaDateFormatter(
@@ -647,7 +724,8 @@ public class DateFormatters {
             .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
             .appendLiteral("T")
             .append(STRICT_HOUR_MINUTE_SECOND_MILLIS_PRINTER)
-            .toFormatter(Locale.ROOT),
+            .toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder()
             .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
             .appendLiteral("T")
@@ -655,6 +733,7 @@ public class DateFormatters {
             //  this one here is lenient as well to retain joda time based bwc compatibility
             .appendFraction(NANO_OF_SECOND, 1, 9, true)
             .toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /*
@@ -681,7 +760,8 @@ public class DateFormatters {
         .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
         .appendFraction(NANO_OF_SECOND, 3, 9, true)
         .optionalEnd()
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter STRICT_ORDINAL_DATE_TIME_FORMATTER_BASE = new DateTimeFormatterBuilder()
         .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
@@ -694,19 +774,23 @@ public class DateFormatters {
         .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
         .appendFraction(NANO_OF_SECOND, 1, 9, true)
         .optionalEnd()
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     /*
      * Returns a formatter for a full ordinal date and time, using a four
-     * digit year and three digit dayOfYear (yyyy-DDD'T'HH:mm:ss.SSSZZ).
+     * digit year and three digit dayOfYear (uuuu-DDD'T'HH:mm:ss.SSSZZ).
      */
     private static final DateFormatter STRICT_ORDINAL_DATE_TIME = new JavaDateFormatter("strict_ordinal_date_time",
         new DateTimeFormatterBuilder().append(STRICT_ORDINAL_DATE_TIME_PRINTER)
-            .appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
+                                      .appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(STRICT_ORDINAL_DATE_TIME_FORMATTER_BASE)
-            .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
+                                      .appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(STRICT_ORDINAL_DATE_TIME_FORMATTER_BASE)
-            .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     // Note: milliseconds parsing is not strict, others are
@@ -717,7 +801,8 @@ public class DateFormatters {
         .appendLiteral(':')
         .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
         .appendFraction(NANO_OF_SECOND, 1, 9, true)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter STRICT_TIME_PRINTER = new DateTimeFormatterBuilder()
         .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NOT_NEGATIVE)
@@ -726,7 +811,8 @@ public class DateFormatters {
         .appendLiteral(':')
         .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
         .appendFraction(NANO_OF_SECOND, 3, 3, true)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     /*
      * Returns a formatter for a two digit hour of day, two digit minute of
@@ -734,9 +820,13 @@ public class DateFormatters {
      * time zone offset (HH:mm:ss.SSSZZ).
      */
     private static final DateFormatter STRICT_TIME = new JavaDateFormatter("strict_time",
-        new DateTimeFormatterBuilder().append(STRICT_TIME_PRINTER).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().append(STRICT_TIME_FORMATTER_BASE).appendZoneOrOffsetId().toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().append(STRICT_TIME_FORMATTER_BASE).append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+        new DateTimeFormatterBuilder().append(STRICT_TIME_PRINTER).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().append(STRICT_TIME_FORMATTER_BASE).appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().append(STRICT_TIME_FORMATTER_BASE).append(TIME_ZONE_FORMATTER_NO_COLON)
+                                      .toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /*
@@ -745,11 +835,16 @@ public class DateFormatters {
      * time zone offset prefixed by 'T' ('T'HH:mm:ss.SSSZZ).
      */
     private static final DateFormatter STRICT_T_TIME = new JavaDateFormatter("strict_t_time",
-        new DateTimeFormatterBuilder().appendLiteral('T').append(STRICT_TIME_PRINTER).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
+        new DateTimeFormatterBuilder().appendLiteral('T').append(STRICT_TIME_PRINTER)
+                                      .appendOffset("+HH:MM", "Z")
+                                      .toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().appendLiteral('T').append(STRICT_TIME_FORMATTER_BASE)
-            .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
+                                      .appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().appendLiteral('T').append(STRICT_TIME_FORMATTER_BASE)
-            .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     private static final DateTimeFormatter STRICT_TIME_NO_MILLIS_BASE = new DateTimeFormatterBuilder()
@@ -758,16 +853,22 @@ public class DateFormatters {
         .appendValue(MINUTE_OF_HOUR, 2, 2, SignStyle.NOT_NEGATIVE)
         .appendLiteral(':')
         .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     /*
      * Returns a formatter for a two digit hour of day, two digit minute of
      * hour, two digit second of minute, and time zone offset (HH:mm:ssZZ).
      */
     private static final DateFormatter STRICT_TIME_NO_MILLIS = new JavaDateFormatter("strict_time_no_millis",
-        new DateTimeFormatterBuilder().append(STRICT_TIME_NO_MILLIS_BASE).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().append(STRICT_TIME_NO_MILLIS_BASE).appendZoneOrOffsetId().toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().append(STRICT_TIME_NO_MILLIS_BASE).append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+        new DateTimeFormatterBuilder().append(STRICT_TIME_NO_MILLIS_BASE).appendOffset("+HH:MM", "Z")
+                                      .toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().append(STRICT_TIME_NO_MILLIS_BASE).appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().append(STRICT_TIME_NO_MILLIS_BASE).append(TIME_ZONE_FORMATTER_NO_COLON)
+                                      .toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /*
@@ -777,26 +878,31 @@ public class DateFormatters {
      */
     private static final DateFormatter STRICT_T_TIME_NO_MILLIS = new JavaDateFormatter("strict_t_time_no_millis",
         new DateTimeFormatterBuilder().appendLiteral("T").append(STRICT_TIME_NO_MILLIS_BASE)
-            .appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
+                                      .appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().appendLiteral("T").append(STRICT_TIME_NO_MILLIS_BASE)
-            .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
+                                      .appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().appendLiteral("T").append(STRICT_TIME_NO_MILLIS_BASE)
-            .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     private static final DateTimeFormatter ISO_WEEK_DATE = new DateTimeFormatterBuilder()
-            .parseCaseInsensitive()
-            .appendValue(IsoFields.WEEK_BASED_YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
-            .appendLiteral("-W")
-            .appendValue(IsoFields.WEEK_OF_WEEK_BASED_YEAR, 2)
-            .appendLiteral('-')
-            .appendValue(DAY_OF_WEEK, 1)
-            .toFormatter(Locale.ROOT);
+        .parseCaseInsensitive()
+        .appendValue(IsoFields.WEEK_BASED_YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+        .appendLiteral("-W")
+        .appendValue(IsoFields.WEEK_OF_WEEK_BASED_YEAR, 2)
+        .appendLiteral('-')
+        .appendValue(DAY_OF_WEEK, 1)
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter ISO_WEEK_DATE_T = new DateTimeFormatterBuilder()
-            .append(ISO_WEEK_DATE)
-            .appendLiteral('T')
-            .toFormatter(Locale.ROOT);
+        .append(ISO_WEEK_DATE)
+        .appendLiteral('T')
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     /*
      * Returns a formatter for a full date as four digit weekyear, two digit
@@ -810,11 +916,14 @@ public class DateFormatters {
      */
     private static final DateFormatter STRICT_WEEK_DATE_TIME_NO_MILLIS = new JavaDateFormatter("strict_week_date_time_no_millis",
         new DateTimeFormatterBuilder().append(ISO_WEEK_DATE_T)
-            .append(STRICT_TIME_NO_MILLIS_BASE).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
+                                      .append(STRICT_TIME_NO_MILLIS_BASE).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(ISO_WEEK_DATE_T)
-            .append(STRICT_TIME_NO_MILLIS_BASE).appendZoneOrOffsetId().toFormatter(Locale.ROOT),
+                                      .append(STRICT_TIME_NO_MILLIS_BASE).appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(ISO_WEEK_DATE_T)
-            .append(STRICT_TIME_NO_MILLIS_BASE).append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .append(STRICT_TIME_NO_MILLIS_BASE).append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /*
@@ -823,11 +932,14 @@ public class DateFormatters {
      */
     private static final DateFormatter STRICT_WEEK_DATE_TIME = new JavaDateFormatter("strict_week_date_time",
         new DateTimeFormatterBuilder().append(ISO_WEEK_DATE_T)
-                                      .append(STRICT_TIME_PRINTER).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
+                                      .append(STRICT_TIME_PRINTER).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(ISO_WEEK_DATE_T).append(STRICT_TIME_FORMATTER_BASE)
-            .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
+                                      .appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(ISO_WEEK_DATE_T).append(STRICT_TIME_FORMATTER_BASE)
-            .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /*
@@ -835,13 +947,15 @@ public class DateFormatters {
      */
     private static final DateFormatter STRICT_WEEKYEAR = new JavaDateFormatter("strict_weekyear", new DateTimeFormatterBuilder()
         .appendValue(WeekFields.ISO.weekBasedYear(), 4, 10, SignStyle.EXCEEDS_PAD)
-        .toFormatter(Locale.ROOT));
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT));
 
     private static final DateTimeFormatter STRICT_WEEKYEAR_WEEK_FORMATTER = new DateTimeFormatterBuilder()
         .appendValue(WeekFields.ISO.weekBasedYear(), 4, 10, SignStyle.EXCEEDS_PAD)
         .appendLiteral("-W")
         .appendValue(WeekFields.ISO.weekOfWeekBasedYear(), 2, 2, SignStyle.NOT_NEGATIVE)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     /*
      * Returns a formatter for a four digit weekyear and two digit week of
@@ -856,34 +970,37 @@ public class DateFormatters {
      */
     private static final DateFormatter STRICT_WEEKYEAR_WEEK_DAY = new JavaDateFormatter("strict_weekyear_week_day",
         new DateTimeFormatterBuilder()
-        .append(STRICT_WEEKYEAR_WEEK_FORMATTER)
-        .appendLiteral("-")
-        .appendValue(WeekFields.ISO.dayOfWeek())
-        .toFormatter(Locale.ROOT));
+            .append(STRICT_WEEKYEAR_WEEK_FORMATTER)
+            .appendLiteral("-")
+            .appendValue(WeekFields.ISO.dayOfWeek())
+            .toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT));
 
     /*
      * Returns a formatter that combines a full date, two digit hour of day,
      * two digit minute of hour, and two digit second of
-     * minute. (yyyy-MM-dd'T'HH:mm:ss)
+     * minute. (uuuu-MM-dd'T'HH:mm:ss)
      */
     private static final DateFormatter STRICT_DATE_HOUR_MINUTE_SECOND = new JavaDateFormatter("strict_date_hour_minute_second",
-        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss", Locale.ROOT));
+        DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss", Locale.ROOT));
 
     /*
      * A basic formatter for a full date as four digit year, two digit
-     * month of year, and two digit day of month (yyyyMMdd).
+     * month of year, and two digit day of month (uuuuMMdd).
      */
     private static final DateFormatter BASIC_DATE = new JavaDateFormatter("basic_date",
         new DateTimeFormatterBuilder()
             .appendValue(ChronoField.YEAR, 4, 4, SignStyle.NORMAL)
             .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NOT_NEGATIVE)
             .appendValue(DAY_OF_MONTH, 2, 2, SignStyle.NOT_NEGATIVE)
-            .toFormatter(Locale.ROOT).withZone(ZoneOffset.UTC),
+            .toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT).withZone(ZoneOffset.UTC),
         new DateTimeFormatterBuilder()
             .appendValue(ChronoField.YEAR, 1, 4, SignStyle.NORMAL)
             .appendValue(MONTH_OF_YEAR, 1, 2, SignStyle.NOT_NEGATIVE)
             .appendValue(DAY_OF_MONTH, 1, 2, SignStyle.NOT_NEGATIVE)
-            .toFormatter(Locale.ROOT).withZone(ZoneOffset.UTC)
+            .toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT).withZone(ZoneOffset.UTC)
     );
 
     private static final DateTimeFormatter STRICT_ORDINAL_DATE_FORMATTER = new DateTimeFormatterBuilder()
@@ -892,11 +1009,12 @@ public class DateFormatters {
         .appendLiteral('-')
         .appendValue(DAY_OF_YEAR, 3)
         .optionalStart()
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     /*
      * Returns a formatter for a full ordinal date, using a four
-     * digit year and three digit dayOfYear (yyyy-DDD).
+     * digit year and three digit dayOfYear (uuuu-DDD).
      */
     private static final DateFormatter STRICT_ORDINAL_DATE = new JavaDateFormatter("strict_ordinal_date", STRICT_ORDINAL_DATE_FORMATTER);
 
@@ -922,17 +1040,18 @@ public class DateFormatters {
         .appendValue(DAY_OF_MONTH, 1, 2, SignStyle.NOT_NEGATIVE)
         .optionalEnd()
         .optionalEnd()
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter HOUR_MINUTE_FORMATTER = new DateTimeFormatterBuilder()
         .appendValue(HOUR_OF_DAY, 1, 2, SignStyle.NOT_NEGATIVE)
         .appendLiteral(':')
         .appendValue(MINUTE_OF_HOUR, 1, 2, SignStyle.NOT_NEGATIVE)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT).withResolverStyle(ResolverStyle.STRICT);
 
     /*
      * a date formatter with optional time, being very lenient, format is
-     * yyyy-MM-dd'T'HH:mm:ss.SSSZ
+     * uuuu-MM-dd'T'HH:mm:ss.SSSZ
      */
     private static final DateFormatter DATE_OPTIONAL_TIME = new JavaDateFormatter("date_optional_time",
         STRICT_DATE_OPTIONAL_TIME_PRINTER,
@@ -961,13 +1080,14 @@ public class DateFormatters {
             .optionalEnd()
             .optionalEnd()
             .optionalEnd()
-            .toFormatter(Locale.ROOT));
+            .toFormatter(Locale.ROOT).withResolverStyle(ResolverStyle.STRICT));
 
     private static final DateTimeFormatter HOUR_MINUTE_SECOND_FORMATTER = new DateTimeFormatterBuilder()
         .append(HOUR_MINUTE_FORMATTER)
         .appendLiteral(":")
         .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter HOUR_MINUTE_SECOND_MILLIS_FORMATTER = new DateTimeFormatterBuilder()
         .appendValue(HOUR_OF_DAY, 1, 2, SignStyle.NOT_NEGATIVE)
@@ -976,7 +1096,8 @@ public class DateFormatters {
         .appendLiteral(':')
         .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
         .appendFraction(NANO_OF_SECOND, 1, 3, true)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter HOUR_MINUTE_SECOND_FRACTION_FORMATTER = new DateTimeFormatterBuilder()
         .appendValue(HOUR_OF_DAY, 1, 2, SignStyle.NOT_NEGATIVE)
@@ -985,23 +1106,26 @@ public class DateFormatters {
         .appendLiteral(':')
         .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
         .appendFraction(NANO_OF_SECOND, 1, 9, true)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter ORDINAL_DATE_FORMATTER = new DateTimeFormatterBuilder()
         .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
         .appendLiteral('-')
         .appendValue(DAY_OF_YEAR, 1, 3, SignStyle.NOT_NEGATIVE)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter ORDINAL_DATE_PRINTER = new DateTimeFormatterBuilder()
         .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
         .appendLiteral('-')
         .appendValue(DAY_OF_YEAR, 3, 3, SignStyle.NOT_NEGATIVE)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     /*
      * Returns a formatter for a full ordinal date, using a four
-     * digit year and three digit dayOfYear (yyyy-DDD).
+     * digit year and three digit dayOfYear (uuuu-DDD).
      */
     private static final DateFormatter ORDINAL_DATE =
         new JavaDateFormatter("ordinal_date", ORDINAL_DATE_PRINTER, ORDINAL_DATE_FORMATTER);
@@ -1012,15 +1136,18 @@ public class DateFormatters {
         .appendValue(MINUTE_OF_HOUR, 1, 2, SignStyle.NOT_NEGATIVE)
         .appendLiteral(':')
         .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter T_TIME_NO_MILLIS_FORMATTER =
-        new DateTimeFormatterBuilder().appendLiteral("T").append(TIME_NO_MILLIS_FORMATTER).toFormatter(Locale.ROOT);
+        new DateTimeFormatterBuilder().appendLiteral("T").append(TIME_NO_MILLIS_FORMATTER).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter TIME_PREFIX = new DateTimeFormatterBuilder()
         .append(TIME_NO_MILLIS_FORMATTER)
         .appendFraction(NANO_OF_SECOND, 1, 9, true)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter WEEK_DATE_FORMATTER = new DateTimeFormatterBuilder()
         .appendValue(IsoFields.WEEK_BASED_YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
@@ -1028,36 +1155,40 @@ public class DateFormatters {
         .appendValue(IsoFields.WEEK_OF_WEEK_BASED_YEAR, 1, 2, SignStyle.NOT_NEGATIVE)
         .appendLiteral('-')
         .appendValue(DAY_OF_WEEK, 1)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     /*
      * Returns a formatter for a four digit weekyear. (YYYY)
      */
     private static final DateFormatter WEEK_YEAR = new JavaDateFormatter("week_year",
-        new DateTimeFormatterBuilder().appendValue(WeekFields.ISO.weekBasedYear()).toFormatter(Locale.ROOT));
+        new DateTimeFormatterBuilder().appendValue(WeekFields.ISO.weekBasedYear()).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT));
 
     /*
      * Returns a formatter for a four digit year. (uuuu)
      */
     private static final DateFormatter YEAR = new JavaDateFormatter("year",
-        new DateTimeFormatterBuilder().appendValue(ChronoField.YEAR).toFormatter(Locale.ROOT));
+        new DateTimeFormatterBuilder().appendValue(ChronoField.YEAR).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT));
 
     /*
      * Returns a formatter that combines a full date and two digit hour of
-     * day. (yyyy-MM-dd'T'HH)
+     * day. (uuuu-MM-dd'T'HH)
      */
     private static final DateFormatter DATE_HOUR = new JavaDateFormatter("date_hour",
-        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH", Locale.ROOT),
+        DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH", Locale.ROOT),
         new DateTimeFormatterBuilder()
             .append(DATE_FORMATTER)
             .appendLiteral("T")
             .appendValue(HOUR_OF_DAY, 1, 2, SignStyle.NOT_NEGATIVE)
-            .toFormatter(Locale.ROOT));
+            .toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT));
 
     /*
      * Returns a formatter that combines a full date, two digit hour of day,
      * two digit minute of hour, two digit second of minute, and three digit
-     * fraction of second (yyyy-MM-dd'T'HH:mm:ss.SSS).
+     * fraction of second (uuuu-MM-dd'T'HH:mm:ss.SSS).
      */
     private static final DateFormatter DATE_HOUR_MINUTE_SECOND_MILLIS =
         new JavaDateFormatter("date_hour_minute_second_millis",
@@ -1065,12 +1196,14 @@ public class DateFormatters {
                 .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
                 .appendLiteral("T")
                 .append(STRICT_HOUR_MINUTE_SECOND_MILLIS_PRINTER)
-                .toFormatter(Locale.ROOT),
+                .toFormatter(Locale.ROOT)
+                .withResolverStyle(ResolverStyle.STRICT),
             new DateTimeFormatterBuilder()
                 .append(DATE_FORMATTER)
                 .appendLiteral("T")
                 .append(HOUR_MINUTE_SECOND_MILLIS_FORMATTER)
-                .toFormatter(Locale.ROOT));
+                .toFormatter(Locale.ROOT)
+                .withResolverStyle(ResolverStyle.STRICT));
 
     private static final DateFormatter DATE_HOUR_MINUTE_SECOND_FRACTION =
         new JavaDateFormatter("date_hour_minute_second_fraction",
@@ -1078,37 +1211,41 @@ public class DateFormatters {
                 .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
                 .appendLiteral("T")
                 .append(STRICT_HOUR_MINUTE_SECOND_MILLIS_PRINTER)
-                .toFormatter(Locale.ROOT),
+                .toFormatter(Locale.ROOT)
+                .withResolverStyle(ResolverStyle.STRICT),
             new DateTimeFormatterBuilder()
                 .append(DATE_FORMATTER)
                 .appendLiteral("T")
                 .append(HOUR_MINUTE_SECOND_FRACTION_FORMATTER)
-                .toFormatter(Locale.ROOT));
+                .toFormatter(Locale.ROOT)
+                .withResolverStyle(ResolverStyle.STRICT));
 
     /*
      * Returns a formatter that combines a full date, two digit hour of day,
-     * and two digit minute of hour. (yyyy-MM-dd'T'HH:mm)
+     * and two digit minute of hour. (uuuu-MM-dd'T'HH:mm)
      */
     private static final DateFormatter DATE_HOUR_MINUTE = new JavaDateFormatter("date_hour_minute",
-        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm", Locale.ROOT),
+        DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm", Locale.ROOT),
         new DateTimeFormatterBuilder()
             .append(DATE_FORMATTER)
             .appendLiteral("T")
             .append(HOUR_MINUTE_FORMATTER)
-            .toFormatter(Locale.ROOT));
+            .toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT));
 
     /*
      * Returns a formatter that combines a full date, two digit hour of day,
      * two digit minute of hour, and two digit second of
-     * minute. (yyyy-MM-dd'T'HH:mm:ss)
+     * minute. (uuuu-MM-dd'T'HH:mm:ss)
      */
     private static final DateFormatter DATE_HOUR_MINUTE_SECOND = new JavaDateFormatter("date_hour_minute_second",
-        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss", Locale.ROOT),
+        DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss", Locale.ROOT),
         new DateTimeFormatterBuilder()
             .append(DATE_FORMATTER)
             .appendLiteral("T")
             .append(HOUR_MINUTE_SECOND_FORMATTER)
-            .toFormatter(Locale.ROOT));
+            .toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT));
 
     private static final DateTimeFormatter DATE_TIME_FORMATTER = new DateTimeFormatterBuilder()
         .append(DATE_FORMATTER)
@@ -1119,16 +1256,21 @@ public class DateFormatters {
         .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
         .appendFraction(NANO_OF_SECOND, 1, 9, true)
         .optionalEnd()
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     /*
      * Returns a formatter that combines a full date and time, separated by a 'T'
-     * (yyyy-MM-dd'T'HH:mm:ss.SSSZZ).
+     * (uuuu-MM-dd'T'HH:mm:ss.SSSZZ).
      */
     private static final DateFormatter DATE_TIME = new JavaDateFormatter("date_time",
         STRICT_DATE_OPTIONAL_TIME_PRINTER,
-        new DateTimeFormatterBuilder().append(DATE_TIME_FORMATTER).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().append(DATE_TIME_FORMATTER).append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+        new DateTimeFormatterBuilder().append(DATE_TIME_FORMATTER).appendOffset("+HH:MM", "Z")
+                                      .toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().append(DATE_TIME_FORMATTER).append(TIME_ZONE_FORMATTER_NO_COLON)
+                                      .toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /*
@@ -1140,10 +1282,10 @@ public class DateFormatters {
 
     /*
      * Returns a formatter for a full date as four digit year, two digit month
-     * of year, and two digit day of month (yyyy-MM-dd).
+     * of year, and two digit day of month (uuuu-MM-dd).
      */
     private static final DateFormatter DATE = new JavaDateFormatter("date",
-        DateTimeFormatter.ISO_LOCAL_DATE.withResolverStyle(ResolverStyle.LENIENT),
+        DateTimeFormatter.ISO_LOCAL_DATE.withResolverStyle(ResolverStyle.STRICT),
         DATE_FORMATTER);
 
     // only the formatter, nothing optional here
@@ -1154,7 +1296,8 @@ public class DateFormatters {
         .appendLiteral(':')
         .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
         .appendZoneId()
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter DATE_TIME_PREFIX = new DateTimeFormatterBuilder()
         .append(DATE_FORMATTER)
@@ -1164,20 +1307,26 @@ public class DateFormatters {
         .appendLiteral(':')
         .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
         .optionalEnd()
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     /*
      * Returns a formatter that combines a full date and time without millis, but with a timezone that can be optional
-     * separated by a 'T' (yyyy-MM-dd'T'HH:mm:ssZ).
+     * separated by a 'T' (uuuu-MM-dd'T'HH:mm:ssZ).
      */
     private static final DateFormatter DATE_TIME_NO_MILLIS = new JavaDateFormatter("date_time_no_millis",
         DATE_TIME_NO_MILLIS_PRINTER,
-        new DateTimeFormatterBuilder().append(DATE_TIME_PREFIX).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().append(DATE_TIME_PREFIX).append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT),
+        new DateTimeFormatterBuilder().append(DATE_TIME_PREFIX).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().append(DATE_TIME_PREFIX).append(TIME_ZONE_FORMATTER_NO_COLON)
+                                      .toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(DATE_TIME_PREFIX)
-            .optionalStart().appendZoneOrOffsetId().optionalEnd().toFormatter(Locale.ROOT),
+                                      .optionalStart().appendZoneOrOffsetId().optionalEnd().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(DATE_TIME_PREFIX)
-            .optionalStart().append(TIME_ZONE_FORMATTER_NO_COLON).optionalEnd().toFormatter(Locale.ROOT)
+                                      .optionalStart().append(TIME_ZONE_FORMATTER_NO_COLON).optionalEnd().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /*
@@ -1208,6 +1357,7 @@ public class DateFormatters {
             .appendLiteral(":")
             .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
             .toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /*
@@ -1216,6 +1366,7 @@ public class DateFormatters {
     private static final DateFormatter HOUR = new JavaDateFormatter("hour",
         DateTimeFormatter.ofPattern("HH", Locale.ROOT),
         new DateTimeFormatterBuilder().appendValue(HOUR_OF_DAY, 1, 2, SignStyle.NOT_NEGATIVE).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     private static final DateTimeFormatter ORDINAL_DATE_TIME_FORMATTER_BASE = new DateTimeFormatterBuilder()
@@ -1227,38 +1378,46 @@ public class DateFormatters {
         .appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NOT_NEGATIVE)
         .appendFraction(NANO_OF_SECOND, 1, 9, true)
         .optionalEnd()
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     /*
      * Returns a formatter for a full ordinal date and time, using a four
-     * digit year and three digit dayOfYear (yyyy-DDD'T'HH:mm:ss.SSSZZ).
+     * digit year and three digit dayOfYear (uuuu-DDD'T'HH:mm:ss.SSSZZ).
      */
     private static final DateFormatter ORDINAL_DATE_TIME = new JavaDateFormatter("ordinal_date_time",
         new DateTimeFormatterBuilder().append(STRICT_ORDINAL_DATE_TIME_PRINTER)
-            .appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
+                                      .appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(ORDINAL_DATE_TIME_FORMATTER_BASE)
-            .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
+                                      .appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(ORDINAL_DATE_TIME_FORMATTER_BASE)
-            .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     private static final DateTimeFormatter ORDINAL_DATE_TIME_NO_MILLIS_BASE = new DateTimeFormatterBuilder()
         .append(ORDINAL_DATE_FORMATTER)
         .appendLiteral('T')
         .append(HOUR_MINUTE_SECOND_FORMATTER)
-        .toFormatter(Locale.ROOT);
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
 
     /*
      * Returns a formatter for a full ordinal date and time without millis,
-     * using a four digit year and three digit dayOfYear (yyyy-DDD'T'HH:mm:ssZZ).
+     * using a four digit year and three digit dayOfYear (uuuu-DDD'T'HH:mm:ssZZ).
      */
     private static final DateFormatter ORDINAL_DATE_TIME_NO_MILLIS = new JavaDateFormatter("ordinal_date_time_no_millis",
         new DateTimeFormatterBuilder().append(STRICT_ORDINAL_DATE_TIME_NO_MILLIS_BASE)
-            .appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
+                                      .appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(ORDINAL_DATE_TIME_NO_MILLIS_BASE)
-            .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
+                                      .appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(ORDINAL_DATE_TIME_NO_MILLIS_BASE)
-            .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /*
@@ -1267,11 +1426,14 @@ public class DateFormatters {
      */
     private static final DateFormatter WEEK_DATE_TIME = new JavaDateFormatter("week_date_time",
         new DateTimeFormatterBuilder().append(ISO_WEEK_DATE_T)
-                                      .append(STRICT_TIME_PRINTER).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
+                                      .append(STRICT_TIME_PRINTER).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(WEEK_DATE_FORMATTER).appendLiteral("T").append(TIME_PREFIX)
-            .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
+                                      .appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(WEEK_DATE_FORMATTER).appendLiteral("T").append(TIME_PREFIX)
-            .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /*
@@ -1280,11 +1442,14 @@ public class DateFormatters {
      */
     private static final DateFormatter WEEK_DATE_TIME_NO_MILLIS = new JavaDateFormatter("week_date_time_no_millis",
         new DateTimeFormatterBuilder().append(ISO_WEEK_DATE_T)
-            .append(STRICT_TIME_NO_MILLIS_BASE).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
+                                      .append(STRICT_TIME_NO_MILLIS_BASE).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(WEEK_DATE_FORMATTER).append(T_TIME_NO_MILLIS_FORMATTER)
-            .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
+                                      .appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(WEEK_DATE_FORMATTER).append(T_TIME_NO_MILLIS_FORMATTER)
-            .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /*
@@ -1295,11 +1460,14 @@ public class DateFormatters {
         new DateTimeFormatterBuilder()
             .append(STRICT_BASIC_WEEK_DATE_PRINTER)
             .append(DateTimeFormatter.ofPattern("'T'HHmmss.SSSX", Locale.ROOT))
-            .toFormatter(Locale.ROOT),
+            .toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(BASIC_WEEK_DATE_FORMATTER).append(BASIC_T_TIME_FORMATTER)
-            .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
+                                      .appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(BASIC_WEEK_DATE_FORMATTER).append(BASIC_T_TIME_FORMATTER)
-            .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /*
@@ -1309,11 +1477,14 @@ public class DateFormatters {
     private static final DateFormatter BASIC_WEEK_DATE_TIME_NO_MILLIS = new JavaDateFormatter("basic_week_date_time_no_millis",
         new DateTimeFormatterBuilder()
             .append(STRICT_BASIC_WEEK_DATE_PRINTER).append(DateTimeFormatter.ofPattern("'T'HHmmssX", Locale.ROOT))
-            .toFormatter(Locale.ROOT),
+            .toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(BASIC_WEEK_DATE_FORMATTER).appendLiteral("T").append(BASIC_TIME_NO_MILLIS_BASE)
-            .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
+                                      .appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(BASIC_WEEK_DATE_FORMATTER).appendLiteral("T").append(BASIC_TIME_NO_MILLIS_BASE)
-            .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /*
@@ -1322,9 +1493,12 @@ public class DateFormatters {
      * time zone offset (HH:mm:ss.SSSZZ).
      */
     private static final DateFormatter TIME = new JavaDateFormatter("time",
-        new DateTimeFormatterBuilder().append(STRICT_TIME_PRINTER).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().append(TIME_PREFIX).appendZoneOrOffsetId().toFormatter(Locale.ROOT),
+        new DateTimeFormatterBuilder().append(STRICT_TIME_PRINTER).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().append(TIME_PREFIX).appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(TIME_PREFIX).append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /*
@@ -1332,9 +1506,14 @@ public class DateFormatters {
      * hour, two digit second of minute, andtime zone offset (HH:mm:ssZZ).
      */
     private static final DateFormatter TIME_NO_MILLIS = new JavaDateFormatter("time_no_millis",
-        new DateTimeFormatterBuilder().append(STRICT_TIME_NO_MILLIS_BASE).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().append(TIME_NO_MILLIS_FORMATTER).appendZoneOrOffsetId().toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().append(TIME_NO_MILLIS_FORMATTER).append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+        new DateTimeFormatterBuilder().append(STRICT_TIME_NO_MILLIS_BASE).appendOffset("+HH:MM", "Z")
+                                      .toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().append(TIME_NO_MILLIS_FORMATTER).appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().append(TIME_NO_MILLIS_FORMATTER).append(TIME_ZONE_FORMATTER_NO_COLON)
+                                      .toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /*
@@ -1343,11 +1522,15 @@ public class DateFormatters {
      * time zone offset prefixed by 'T' ('T'HH:mm:ss.SSSZZ).
      */
     private static final DateFormatter T_TIME = new JavaDateFormatter("t_time",
-        new DateTimeFormatterBuilder().appendLiteral('T').append(STRICT_TIME_PRINTER).appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
+        new DateTimeFormatterBuilder().appendLiteral('T').append(STRICT_TIME_PRINTER).appendOffset("+HH:MM", "Z")
+                                      .toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().appendLiteral("T").append(TIME_PREFIX)
-            .appendZoneOrOffsetId().toFormatter(Locale.ROOT),
+                                      .appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().appendLiteral("T").append(TIME_PREFIX)
-            .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /*
@@ -1357,9 +1540,13 @@ public class DateFormatters {
      */
     private static final DateFormatter T_TIME_NO_MILLIS = new JavaDateFormatter("t_time_no_millis",
         new DateTimeFormatterBuilder().appendLiteral("T").append(STRICT_TIME_NO_MILLIS_BASE)
-                                      .appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().append(T_TIME_NO_MILLIS_FORMATTER).appendZoneOrOffsetId().toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().append(T_TIME_NO_MILLIS_FORMATTER).append(TIME_ZONE_FORMATTER_NO_COLON).toFormatter(Locale.ROOT)
+                                      .appendOffset("+HH:MM", "Z").toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().append(T_TIME_NO_MILLIS_FORMATTER).appendZoneOrOffsetId().toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().append(T_TIME_NO_MILLIS_FORMATTER).append(TIME_ZONE_FORMATTER_NO_COLON)
+                                      .toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /*
@@ -1370,8 +1557,11 @@ public class DateFormatters {
             .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
             .appendLiteral("-")
             .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NOT_NEGATIVE)
-            .toFormatter(Locale.ROOT),
-        new DateTimeFormatterBuilder().appendValue(ChronoField.YEAR).appendLiteral("-").appendValue(MONTH_OF_YEAR).toFormatter(Locale.ROOT)
+            .toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().appendValue(ChronoField.YEAR).appendLiteral("-").appendValue(MONTH_OF_YEAR)
+                                      .toFormatter(Locale.ROOT)
+                                      .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /*
@@ -1386,6 +1576,7 @@ public class DateFormatters {
             .appendLiteral("-")
             .appendValue(DAY_OF_MONTH)
             .toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /*
@@ -1404,6 +1595,7 @@ public class DateFormatters {
             .appendLiteral("-W")
             .appendValue(WeekFields.ISO.weekOfWeekBasedYear())
             .toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /*
@@ -1415,7 +1607,8 @@ public class DateFormatters {
             .append(STRICT_WEEKYEAR_WEEK_FORMATTER)
             .appendLiteral("-")
             .appendValue(WeekFields.ISO.dayOfWeek())
-            .toFormatter(Locale.ROOT),
+            .toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder()
             .appendValue(WeekFields.ISO.weekBasedYear())
             .appendLiteral("-W")
@@ -1423,6 +1616,7 @@ public class DateFormatters {
             .appendLiteral("-")
             .appendValue(WeekFields.ISO.dayOfWeek())
             .toFormatter(Locale.ROOT)
+            .withResolverStyle(ResolverStyle.STRICT)
     );
 
     /////////////////////////////////////////
@@ -1439,170 +1633,173 @@ public class DateFormatters {
             throw new IllegalArgumentException("No date pattern provided");
         }
 
-        if (FormatNames.ISO8601.matches(input)) {
+        if ("iso8601".equals(input)) {
             return ISO_8601;
-        } else if (FormatNames.BASIC_DATE.matches(input) ) {
+        } else if ("basicDate".equals(input) || "basic_date".equals(input)) {
             return BASIC_DATE;
-        } else if (FormatNames.BASIC_DATE_TIME.matches(input) ) {
+        } else if ("basicDateTime".equals(input) || "basic_date_time".equals(input)) {
             return BASIC_DATE_TIME;
-        } else if (FormatNames.BASIC_DATE_TIME_NO_MILLIS.matches(input) ) {
+        } else if ("basicDateTimeNoMillis".equals(input) || "basic_date_time_no_millis".equals(input)) {
             return BASIC_DATE_TIME_NO_MILLIS;
-        } else if (FormatNames.BASIC_ORDINAL_DATE.matches(input) ) {
+        } else if ("basicOrdinalDate".equals(input) || "basic_ordinal_date".equals(input)) {
             return BASIC_ORDINAL_DATE;
-        } else if (FormatNames.BASIC_ORDINAL_DATE_TIME.matches(input) ) {
+        } else if ("basicOrdinalDateTime".equals(input) || "basic_ordinal_date_time".equals(input)) {
             return BASIC_ORDINAL_DATE_TIME;
-        } else if (FormatNames.BASIC_ORDINAL_DATE_TIME_NO_MILLIS.matches(input) ) {
+        } else if ("basicOrdinalDateTimeNoMillis".equals(input) || "basic_ordinal_date_time_no_millis".equals(input)) {
             return BASIC_ORDINAL_DATE_TIME_NO_MILLIS;
-        } else if (FormatNames.BASIC_TIME.matches(input) ) {
+        } else if ("basicTime".equals(input) || "basic_time".equals(input)) {
             return BASIC_TIME;
-        } else if (FormatNames.BASIC_TIME_NO_MILLIS.matches(input) ) {
+        } else if ("basicTimeNoMillis".equals(input) || "basic_time_no_millis".equals(input)) {
             return BASIC_TIME_NO_MILLIS;
-        } else if (FormatNames.BASIC_T_TIME.matches(input) ) {
+        } else if ("basicTTime".equals(input) || "basic_t_time".equals(input)) {
             return BASIC_T_TIME;
-        } else if (FormatNames.BASIC_T_TIME_NO_MILLIS.matches(input) ) {
+        } else if ("basicTTimeNoMillis".equals(input) || "basic_t_time_no_millis".equals(input)) {
             return BASIC_T_TIME_NO_MILLIS;
-        } else if (FormatNames.BASIC_WEEK_DATE.matches(input) ) {
+        } else if ("basicWeekDate".equals(input) || "basic_week_date".equals(input)) {
             return BASIC_WEEK_DATE;
-        } else if (FormatNames.BASIC_WEEK_DATE_TIME.matches(input) ) {
+        } else if ("basicWeekDateTime".equals(input) || "basic_week_date_time".equals(input)) {
             return BASIC_WEEK_DATE_TIME;
-        } else if (FormatNames.BASIC_WEEK_DATE_TIME_NO_MILLIS.matches(input) ) {
+        } else if ("basicWeekDateTimeNoMillis".equals(input) || "basic_week_date_time_no_millis".equals(input)) {
             return BASIC_WEEK_DATE_TIME_NO_MILLIS;
-        } else if (FormatNames.DATE.matches(input)) {
+        } else if ("date".equals(input)) {
             return DATE;
-        } else if (FormatNames.DATE_HOUR.matches(input) ) {
+        } else if ("dateHour".equals(input) || "date_hour".equals(input)) {
             return DATE_HOUR;
-        } else if (FormatNames.DATE_HOUR_MINUTE.matches(input) ) {
+        } else if ("dateHourMinute".equals(input) || "date_hour_minute".equals(input)) {
             return DATE_HOUR_MINUTE;
-        } else if (FormatNames.DATE_HOUR_MINUTE_SECOND.matches(input) ) {
+        } else if ("dateHourMinuteSecond".equals(input) || "date_hour_minute_second".equals(input)) {
             return DATE_HOUR_MINUTE_SECOND;
-        } else if (FormatNames.DATE_HOUR_MINUTE_SECOND_FRACTION.matches(input) ) {
+        } else if ("dateHourMinuteSecondFraction".equals(input) || "date_hour_minute_second_fraction".equals(input)) {
             return DATE_HOUR_MINUTE_SECOND_FRACTION;
-        } else if (FormatNames.DATE_HOUR_MINUTE_SECOND_MILLIS.matches(input) ) {
+        } else if ("dateHourMinuteSecondMillis".equals(input) || "date_hour_minute_second_millis".equals(input)) {
             return DATE_HOUR_MINUTE_SECOND_MILLIS;
-        } else if (FormatNames.DATE_OPTIONAL_TIME.matches(input) ) {
+        } else if ("dateOptionalTime".equals(input) || "date_optional_time".equals(input)) {
             return DATE_OPTIONAL_TIME;
-        } else if (FormatNames.DATE_TIME.matches(input) ) {
+        } else if ("dateTime".equals(input) || "date_time".equals(input)) {
             return DATE_TIME;
-        } else if (FormatNames.DATE_TIME_NO_MILLIS.matches(input) ) {
+        } else if ("dateTimeNoMillis".equals(input) || "date_time_no_millis".equals(input)) {
             return DATE_TIME_NO_MILLIS;
-        } else if (FormatNames.HOUR.matches(input)) {
+        } else if ("hour".equals(input)) {
             return HOUR;
-        } else if (FormatNames.HOUR_MINUTE.matches(input) ) {
+        } else if ("hourMinute".equals(input) || "hour_minute".equals(input)) {
             return HOUR_MINUTE;
-        } else if (FormatNames.HOUR_MINUTE_SECOND.matches(input) ) {
+        } else if ("hourMinuteSecond".equals(input) || "hour_minute_second".equals(input)) {
             return HOUR_MINUTE_SECOND;
-        } else if (FormatNames.HOUR_MINUTE_SECOND_FRACTION.matches(input) ) {
+        } else if ("hourMinuteSecondFraction".equals(input) || "hour_minute_second_fraction".equals(input)) {
             return HOUR_MINUTE_SECOND_FRACTION;
-        } else if (FormatNames.HOUR_MINUTE_SECOND_MILLIS.matches(input) ) {
+        } else if ("hourMinuteSecondMillis".equals(input) || "hour_minute_second_millis".equals(input)) {
             return HOUR_MINUTE_SECOND_MILLIS;
-        } else if (FormatNames.ORDINAL_DATE.matches(input) ) {
+        } else if ("ordinalDate".equals(input) || "ordinal_date".equals(input)) {
             return ORDINAL_DATE;
-        } else if (FormatNames.ORDINAL_DATE_TIME.matches(input) ) {
+        } else if ("ordinalDateTime".equals(input) || "ordinal_date_time".equals(input)) {
             return ORDINAL_DATE_TIME;
-        } else if (FormatNames.ORDINAL_DATE_TIME_NO_MILLIS.matches(input) ) {
+        } else if ("ordinalDateTimeNoMillis".equals(input) || "ordinal_date_time_no_millis".equals(input)) {
             return ORDINAL_DATE_TIME_NO_MILLIS;
-        } else if (FormatNames.TIME.matches(input)) {
+        } else if ("time".equals(input)) {
             return TIME;
-        } else if (FormatNames.TIME_NO_MILLIS.matches(input) ) {
+        } else if ("timeNoMillis".equals(input) || "time_no_millis".equals(input)) {
             return TIME_NO_MILLIS;
-        } else if (FormatNames.T_TIME.matches(input) ) {
+        } else if ("tTime".equals(input) || "t_time".equals(input)) {
             return T_TIME;
-        } else if (FormatNames.T_TIME_NO_MILLIS.matches(input) ) {
+        } else if ("tTimeNoMillis".equals(input) || "t_time_no_millis".equals(input)) {
             return T_TIME_NO_MILLIS;
-        } else if (FormatNames.WEEK_DATE.matches(input) ) {
+        } else if ("weekDate".equals(input) || "week_date".equals(input)) {
             return WEEK_DATE;
-        } else if (FormatNames.WEEK_DATE_TIME.matches(input) ) {
+        } else if ("weekDateTime".equals(input) || "week_date_time".equals(input)) {
             return WEEK_DATE_TIME;
-        } else if (FormatNames.WEEK_DATE_TIME_NO_MILLIS.matches(input) ) {
+        } else if ("weekDateTimeNoMillis".equals(input) || "week_date_time_no_millis".equals(input)) {
             return WEEK_DATE_TIME_NO_MILLIS;
-        } else if (FormatNames.WEEK_YEAR.matches(input) ) {
+        } else if ("weekyear".equals(input) || "week_year".equals(input)) {
             return WEEK_YEAR;
-        } else if (FormatNames.WEEK_YEAR_WEEK.matches(input) ) {
+        } else if ("weekyearWeek".equals(input) || "weekyear_week".equals(input)) {
             return WEEKYEAR_WEEK;
-        } else if (FormatNames.WEEKYEAR_WEEK_DAY.matches(input) ) {
+        } else if ("weekyearWeekDay".equals(input) || "weekyear_week_day".equals(input)) {
             return WEEKYEAR_WEEK_DAY;
-        } else if (FormatNames.YEAR.matches(input)) {
+        } else if ("year".equals(input)) {
             return YEAR;
-        } else if (FormatNames.YEAR_MONTH.matches(input) ) {
+        } else if ("yearMonth".equals(input) || "year_month".equals(input)) {
             return YEAR_MONTH;
-        } else if (FormatNames.YEAR_MONTH_DAY.matches(input) ) {
+        } else if ("yearMonthDay".equals(input) || "year_month_day".equals(input)) {
             return YEAR_MONTH_DAY;
-        } else if (FormatNames.EPOCH_SECOND.matches(input)) {
+        } else if ("epoch_second".equals(input)) {
             return EpochTime.SECONDS_FORMATTER;
-        } else if (FormatNames.EPOCH_MILLIS.matches(input)) {
+        } else if ("epoch_millis".equals(input)) {
             return EpochTime.MILLIS_FORMATTER;
-            // strict date formats here, must be at least 4 digits for year and two for months and two for day
-        } else if (FormatNames.STRICT_BASIC_WEEK_DATE.matches(input) ) {
+        // strict date formats here, must be at least 4 digits for year and two for months and two for day
+        } else if ("strictBasicWeekDate".equals(input) || "strict_basic_week_date".equals(input)) {
             return STRICT_BASIC_WEEK_DATE;
-        } else if (FormatNames.STRICT_BASIC_WEEK_DATE_TIME.matches(input) ) {
+        } else if ("strictBasicWeekDateTime".equals(input) || "strict_basic_week_date_time".equals(input)) {
             return STRICT_BASIC_WEEK_DATE_TIME;
-        } else if (FormatNames.STRICT_BASIC_WEEK_DATE_TIME_NO_MILLIS.matches(input) ) {
+        } else if ("strictBasicWeekDateTimeNoMillis".equals(input) || "strict_basic_week_date_time_no_millis".equals(input)) {
             return STRICT_BASIC_WEEK_DATE_TIME_NO_MILLIS;
-        } else if (FormatNames.STRICT_DATE.matches(input) ) {
+        } else if ("strictDate".equals(input) || "strict_date".equals(input)) {
             return STRICT_DATE;
-        } else if (FormatNames.STRICT_DATE_HOUR.matches(input) ) {
+        } else if ("strictDateHour".equals(input) || "strict_date_hour".equals(input)) {
             return STRICT_DATE_HOUR;
-        } else if (FormatNames.STRICT_DATE_HOUR_MINUTE.matches(input) ) {
+        } else if ("strictDateHourMinute".equals(input) || "strict_date_hour_minute".equals(input)) {
             return STRICT_DATE_HOUR_MINUTE;
-        } else if (FormatNames.STRICT_DATE_HOUR_MINUTE_SECOND.matches(input) ) {
+        } else if ("strictDateHourMinuteSecond".equals(input) || "strict_date_hour_minute_second".equals(input)) {
             return STRICT_DATE_HOUR_MINUTE_SECOND;
-        } else if (FormatNames.STRICT_DATE_HOUR_MINUTE_SECOND_FRACTION.matches(input) ) {
+        } else if ("strictDateHourMinuteSecondFraction".equals(input) || "strict_date_hour_minute_second_fraction".equals(input)) {
             return STRICT_DATE_HOUR_MINUTE_SECOND_FRACTION;
-        } else if (FormatNames.STRICT_DATE_HOUR_MINUTE_SECOND_MILLIS.matches(input) ) {
+        } else if ("strictDateHourMinuteSecondMillis".equals(input) || "strict_date_hour_minute_second_millis".equals(input)) {
             return STRICT_DATE_HOUR_MINUTE_SECOND_MILLIS;
-        } else if (FormatNames.STRICT_DATE_OPTIONAL_TIME.matches(input) ) {
+        } else if ("strictDateOptionalTime".equals(input) || "strict_date_optional_time".equals(input)) {
             return STRICT_DATE_OPTIONAL_TIME;
-        } else if (FormatNames.STRICT_DATE_OPTIONAL_TIME_NANOS.matches(input) ) {
+        } else if ("strictDateOptionalTimeNanos".equals(input) || "strict_date_optional_time_nanos".equals(input)) {
             return STRICT_DATE_OPTIONAL_TIME_NANOS;
-        } else if (FormatNames.STRICT_DATE_TIME.matches(input) ) {
+        } else if ("strictDateTime".equals(input) || "strict_date_time".equals(input)) {
             return STRICT_DATE_TIME;
-        } else if (FormatNames.STRICT_DATE_TIME_NO_MILLIS.matches(input) ) {
+        } else if ("strictDateTimeNoMillis".equals(input) || "strict_date_time_no_millis".equals(input)) {
             return STRICT_DATE_TIME_NO_MILLIS;
-        } else if (FormatNames.STRICT_HOUR.matches(input) ) {
+        } else if ("strictHour".equals(input) || "strict_hour".equals(input)) {
             return STRICT_HOUR;
-        } else if (FormatNames.STRICT_HOUR_MINUTE.matches(input) ) {
+        } else if ("strictHourMinute".equals(input) || "strict_hour_minute".equals(input)) {
             return STRICT_HOUR_MINUTE;
-        } else if (FormatNames.STRICT_HOUR_MINUTE_SECOND.matches(input) ) {
+        } else if ("strictHourMinuteSecond".equals(input) || "strict_hour_minute_second".equals(input)) {
             return STRICT_HOUR_MINUTE_SECOND;
-        } else if (FormatNames.STRICT_HOUR_MINUTE_SECOND_FRACTION.matches(input) ) {
+        } else if ("strictHourMinuteSecondFraction".equals(input) || "strict_hour_minute_second_fraction".equals(input)) {
             return STRICT_HOUR_MINUTE_SECOND_FRACTION;
-        } else if (FormatNames.STRICT_HOUR_MINUTE_SECOND_MILLIS.matches(input) ) {
+        } else if ("strictHourMinuteSecondMillis".equals(input) || "strict_hour_minute_second_millis".equals(input)) {
             return STRICT_HOUR_MINUTE_SECOND_MILLIS;
-        } else if (FormatNames.STRICT_ORDINAL_DATE.matches(input) ) {
+        } else if ("strictOrdinalDate".equals(input) || "strict_ordinal_date".equals(input)) {
             return STRICT_ORDINAL_DATE;
-        } else if (FormatNames.STRICT_ORDINAL_DATE_TIME.matches(input) ) {
+        } else if ("strictOrdinalDateTime".equals(input) || "strict_ordinal_date_time".equals(input)) {
             return STRICT_ORDINAL_DATE_TIME;
-        } else if (FormatNames.STRICT_ORDINAL_DATE_TIME_NO_MILLIS.matches(input) ) {
+        } else if ("strictOrdinalDateTimeNoMillis".equals(input) || "strict_ordinal_date_time_no_millis".equals(input)) {
             return STRICT_ORDINAL_DATE_TIME_NO_MILLIS;
-        } else if (FormatNames.STRICT_TIME.matches(input) ) {
+        } else if ("strictTime".equals(input) || "strict_time".equals(input)) {
             return STRICT_TIME;
-        } else if (FormatNames.STRICT_TIME_NO_MILLIS.matches(input) ) {
+        } else if ("strictTimeNoMillis".equals(input) || "strict_time_no_millis".equals(input)) {
             return STRICT_TIME_NO_MILLIS;
-        } else if (FormatNames.STRICT_T_TIME.matches(input) ) {
+        } else if ("strictTTime".equals(input) || "strict_t_time".equals(input)) {
             return STRICT_T_TIME;
-        } else if (FormatNames.STRICT_T_TIME_NO_MILLIS.matches(input) ) {
+        } else if ("strictTTimeNoMillis".equals(input) || "strict_t_time_no_millis".equals(input)) {
             return STRICT_T_TIME_NO_MILLIS;
-        } else if (FormatNames.STRICT_WEEK_DATE.matches(input) ) {
+        } else if ("strictWeekDate".equals(input) || "strict_week_date".equals(input)) {
             return STRICT_WEEK_DATE;
-        } else if (FormatNames.STRICT_WEEK_DATE_TIME.matches(input) ) {
+        } else if ("strictWeekDateTime".equals(input) || "strict_week_date_time".equals(input)) {
             return STRICT_WEEK_DATE_TIME;
-        } else if (FormatNames.STRICT_WEEK_DATE_TIME_NO_MILLIS.matches(input) ) {
+        } else if ("strictWeekDateTimeNoMillis".equals(input) || "strict_week_date_time_no_millis".equals(input)) {
             return STRICT_WEEK_DATE_TIME_NO_MILLIS;
-        } else if (FormatNames.STRICT_WEEKYEAR.matches(input) ) {
+        } else if ("strictWeekyear".equals(input) || "strict_weekyear".equals(input)) {
             return STRICT_WEEKYEAR;
-        } else if (FormatNames.STRICT_WEEKYEAR_WEEK.matches(input) ) {
+        } else if ("strictWeekyearWeek".equals(input) || "strict_weekyear_week".equals(input)) {
             return STRICT_WEEKYEAR_WEEK;
-        } else if (FormatNames.STRICT_WEEKYEAR_WEEK_DAY.matches(input) ) {
+        } else if ("strictWeekyearWeekDay".equals(input) || "strict_weekyear_week_day".equals(input)) {
             return STRICT_WEEKYEAR_WEEK_DAY;
-        } else if (FormatNames.STRICT_YEAR.matches(input) ) {
+        } else if ("strictYear".equals(input) || "strict_year".equals(input)) {
             return STRICT_YEAR;
-        } else if (FormatNames.STRICT_YEAR_MONTH.matches(input) ) {
+        } else if ("strictYearMonth".equals(input) || "strict_year_month".equals(input)) {
             return STRICT_YEAR_MONTH;
-        } else if (FormatNames.STRICT_YEAR_MONTH_DAY.matches(input) ) {
+        } else if ("strictYearMonthDay".equals(input) || "strict_year_month_day".equals(input)) {
             return STRICT_YEAR_MONTH_DAY;
         } else {
             try {
-                return new JavaDateFormatter(input, new DateTimeFormatterBuilder().appendPattern(input).toFormatter(Locale.ROOT));
+                return new JavaDateFormatter(input, new DateTimeFormatterBuilder()
+                    .appendPattern(input)
+                    .toFormatter(Locale.ROOT)
+                    .withResolverStyle(ResolverStyle.STRICT));
             } catch (IllegalArgumentException e) {
                 throw new IllegalArgumentException("Invalid format: [" + input + "]: " + e.getMessage(), e);
             }
@@ -1648,7 +1845,7 @@ public class DateFormatters {
             zoneId = ZoneOffset.UTC;
         }
 
-        LocalDate localDate = accessor.query(TemporalQueries.localDate());
+        LocalDate localDate = accessor.query(LOCAL_DATE_QUERY);
         LocalTime localTime = accessor.query(TemporalQueries.localTime());
         boolean isLocalDateSet = localDate != null;
         boolean isLocalTimeSet = localTime != null;
@@ -1662,11 +1859,12 @@ public class DateFormatters {
             return localDate.atStartOfDay(zoneId);
         } else if (isLocalTimeSet) {
             return of(getLocaldate(accessor), localTime, zoneId);
-        } else if (accessor.isSupported(ChronoField.YEAR)) {
+        } else if (accessor.isSupported(ChronoField.YEAR) || accessor.isSupported(ChronoField.YEAR_OF_ERA) ) {
             if (accessor.isSupported(MONTH_OF_YEAR)) {
                 return getFirstOfMonth(accessor).atStartOfDay(zoneId);
             } else {
-                return Year.of(accessor.get(ChronoField.YEAR)).atDay(1).atStartOfDay(zoneId);
+                int year = getYear(accessor);
+                return Year.of(year).atDay(1).atStartOfDay(zoneId);
             }
         } else if (accessor.isSupported(MONTH_OF_YEAR)) {
             // missing year, falling back to the epoch and then filling
@@ -1690,16 +1888,54 @@ public class DateFormatters {
         throw new IllegalArgumentException("temporal accessor [" + accessor + "] cannot be converted to zoned date time");
     }
 
+    /**
+     * extending the java.time.temporal.TemporalQueries.LOCAL_DATE implementation to also create local dates
+     * when YearOfEra was used instead of Year.
+     * This is to make it compatible with Joda behaviour
+     */
+    static final TemporalQuery<LocalDate> LOCAL_DATE_QUERY = new TemporalQuery<>() {
+        @Override
+        public LocalDate queryFrom(TemporalAccessor temporal) {
+            if (temporal.isSupported(ChronoField.EPOCH_DAY)) {
+                return LocalDate.ofEpochDay(temporal.getLong(ChronoField.EPOCH_DAY));
+            } else if( temporal.isSupported(ChronoField.YEAR_OF_ERA) || temporal.isSupported(ChronoField.YEAR)) {
+                int year = getYear(temporal);
+                if(temporal.isSupported(ChronoField.MONTH_OF_YEAR) && temporal.isSupported(ChronoField.DAY_OF_MONTH)){
+                    return LocalDate.of(year, temporal.get(ChronoField.MONTH_OF_YEAR), temporal.get(ChronoField.DAY_OF_MONTH));
+                } else if (temporal.isSupported(DAY_OF_YEAR)) {
+                    return LocalDate.ofYearDay(year, temporal.get(DAY_OF_YEAR));
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public String toString() {
+            return "LocalDate";
+        }
+    };
+
     private static LocalDate getLocaldate(TemporalAccessor accessor) {
+        int year = getYear(accessor);
         if (accessor.isSupported(MONTH_OF_YEAR)) {
             if (accessor.isSupported(DAY_OF_MONTH)) {
-                return LocalDate.of(1970, accessor.get(MONTH_OF_YEAR), accessor.get(DAY_OF_MONTH));
+                return LocalDate.of(year, accessor.get(MONTH_OF_YEAR), accessor.get(DAY_OF_MONTH));
             } else {
-                return LocalDate.of(1970, accessor.get(MONTH_OF_YEAR), 1);
+                return LocalDate.of(year, accessor.get(MONTH_OF_YEAR), 1);
             }
         }
 
         return LOCALDATE_EPOCH;
+    }
+
+    private static int getYear(TemporalAccessor accessor) {
+        if(accessor.isSupported(ChronoField.YEAR)){
+            return accessor.get(ChronoField.YEAR);
+        }
+        if(accessor.isSupported(ChronoField.YEAR_OF_ERA)){
+            return accessor.get(ChronoField.YEAR_OF_ERA);
+        }
+        return 1970;
     }
 
     @SuppressForbidden(reason = "ZonedDateTime.of is fine here")
@@ -1709,6 +1945,6 @@ public class DateFormatters {
 
     @SuppressForbidden(reason = "LocalDate.of is fine here")
     private static LocalDate getFirstOfMonth(TemporalAccessor accessor) {
-        return LocalDate.of(accessor.get(ChronoField.YEAR), accessor.get(MONTH_OF_YEAR), 1);
+        return LocalDate.of(getYear(accessor), accessor.get(MONTH_OF_YEAR), 1);
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
@@ -872,6 +872,10 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
         assertSameDate("2018-10-10T10:11:12,123+05:30", format, jodaFormatter, javaFormatter);
     }
 
+    public void testParsingLocalDateFromYearOfEra(){
+        //with strict resolving, YearOfEra expect an era, otherwise it won't resolve to a date
+        assertSameDate("2018363","yyyyDDD",Joda.forPattern("YYYYDDD"),DateFormatter.forPattern("uuuuDDD"));
+    }
     public void testParsingMissingTimezone() {
         long millisJava = DateFormatter.forPattern("8yyyy-MM-dd HH:mm:ss").parseMillis("2018-02-18 17:47:17");
         long millisJoda = DateFormatter.forPattern("yyyy-MM-dd HH:mm:ss").parseMillis("2018-02-18 17:47:17");

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/DateDerivativeIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/DateDerivativeIT.java
@@ -198,7 +198,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
         List<IndexRequestBuilder> builders = new ArrayList<>();
 
         ZoneId timezone = ZoneId.of("CET");
-        DateFormatter formatter = DateFormatter.forPattern("yyyy-MM-dd'T'HH:mm:ss").withZone(timezone);
+        DateFormatter formatter = DateFormatter.forPattern("uuuu-MM-dd'T'HH:mm:ss").withZone(timezone);
         // epoch millis: 1332547200000
         addNTimes(1, IDX_DST_START, DateFormatters.from(formatter.parse("2012-03-24T01:00:00")), builders);
         // day with dst shift, only 23h long
@@ -223,7 +223,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
         List<? extends Bucket> buckets = deriv.getBuckets();
         assertThat(buckets.size(), equalTo(4));
 
-        DateFormatter dateFormatter = DateFormatter.forPattern("yyyy-MM-dd");
+        DateFormatter dateFormatter = DateFormatter.forPattern("uuuu-MM-dd");
         ZonedDateTime expectedKeyFirstBucket =
             LocalDate.from(dateFormatter.parse("2012-03-24")).atStartOfDay(timezone).withZoneSameInstant(ZoneOffset.UTC);
         assertBucket(buckets.get(0), expectedKeyFirstBucket, 1L, nullValue(), null, null);
@@ -250,7 +250,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
         ZoneId timezone = ZoneId.of("CET");
         List<IndexRequestBuilder> builders = new ArrayList<>();
 
-        DateFormatter formatter = DateFormatter.forPattern("yyyy-MM-dd'T'HH:mm:ss").withZone(timezone);
+        DateFormatter formatter = DateFormatter.forPattern("uuuu-MM-dd'T'HH:mm:ss").withZone(timezone);
         addNTimes(1, IDX_DST_END, DateFormatters.from(formatter.parse("2012-10-27T01:00:00")), builders);
         // day with dst shift -1h, 25h long
         addNTimes(2, IDX_DST_END, DateFormatters.from(formatter.parse("2012-10-28T01:00:00")), builders);
@@ -274,7 +274,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
         List<? extends Bucket> buckets = deriv.getBuckets();
         assertThat(buckets.size(), equalTo(4));
 
-        DateFormatter dateFormatter = DateFormatter.forPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC);
+        DateFormatter dateFormatter = DateFormatter.forPattern("uuuu-MM-dd").withZone(ZoneOffset.UTC);
 
         ZonedDateTime expectedKeyFirstBucket =
             LocalDate.from(dateFormatter.parse("2012-10-27")).atStartOfDay(timezone).withZoneSameInstant(ZoneOffset.UTC);
@@ -303,7 +303,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
         ZoneId timezone = ZoneId.of("Asia/Kathmandu");
         List<IndexRequestBuilder> builders = new ArrayList<>();
 
-        DateFormatter formatter = DateFormatter.forPattern("yyyy-MM-dd'T'HH:mm:ss").withZone(timezone);
+        DateFormatter formatter = DateFormatter.forPattern("uuuu-MM-dd'T'HH:mm:ss").withZone(timezone);
         addNTimes(1, IDX_DST_KATHMANDU, DateFormatters.from(formatter.parse("1985-12-31T22:30:00")), builders);
         // the shift happens during the next bucket, which includes the 45min that do not start on the full hour
         addNTimes(2, IDX_DST_KATHMANDU, DateFormatters.from(formatter.parse("1985-12-31T23:30:00")), builders);
@@ -327,7 +327,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
         List<? extends Bucket> buckets = deriv.getBuckets();
         assertThat(buckets.size(), equalTo(4));
 
-        DateFormatter dateFormatter = DateFormatter.forPattern("yyyy-MM-dd'T'HH:mm:ss").withZone(ZoneOffset.UTC);
+        DateFormatter dateFormatter = DateFormatter.forPattern("uuuu-MM-dd'T'HH:mm:ss").withZone(ZoneOffset.UTC);
 
         ZonedDateTime expectedKeyFirstBucket =
             LocalDateTime.from(dateFormatter.parse("1985-12-31T22:00:00")).atZone(timezone).withZoneSameInstant(ZoneOffset.UTC);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleOriginationDateParser.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleOriginationDateParser.java
@@ -17,7 +17,7 @@ import static org.elasticsearch.xpack.core.ilm.LifecycleSettings.LIFECYCLE_PARSE
 
 public class IndexLifecycleOriginationDateParser {
 
-    private static final DateFormatter DATE_FORMATTER = DateFormatter.forPattern("yyyy.MM.dd");
+    private static final DateFormatter DATE_FORMATTER = DateFormatter.forPattern("uuuu.MM.dd");
     private static final String INDEX_NAME_REGEX = "^.*-(\\d{4}.\\d{2}.\\d{2})(-[\\d]+)?$";
     private static final Pattern INDEX_NAME_PATTERN = Pattern.compile(INDEX_NAME_REGEX);
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleOriginationDateParserTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleOriginationDateParserTests.java
@@ -17,7 +17,7 @@ import static org.hamcrest.Matchers.is;
 
 public class IndexLifecycleOriginationDateParserTests extends ESTestCase {
 
-    private static final DateFormatter dateFormatter = DateFormatter.forPattern("yyyy.MM.dd");
+    private static final DateFormatter dateFormatter = DateFormatter.forPattern("uuuu.MM.dd");
 
     public void testShouldParseIndexNameReturnsFalseWhenOriginationDateIsSet() {
         Settings settings = Settings.builder()


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Enable ResolverStyle.STRICT for java formatters (#46675)