### PR TITLE
[7.x][Transform] add BWC alias for internal index

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndex.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndex.java
@@ -82,6 +82,8 @@ public final class TransformInternalIndex {
                         .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "0-1"))
                 // todo: remove type
                 .putMapping(MapperService.SINGLE_MAPPING_NAME, Strings.toString(mappings()))
+                // BWC: for mixed clusters with nodes < 7.5, we need the alias to make new docs visible for them
+                .putAlias(AliasMetaData.builder(".data-frame-internal-3"))
                 .build();
         return transformTemplate;
     }


### PR DESCRIPTION
create an alias for old nodes to retrieve new documents in the internal index as they do not know the new index pattern

Found via upgrade tests: https://gradle-enterprise.elastic.co/s/7fix7wtsrc3yi

Notes: 
 - this is not going to master as upgrading happens from `7.last` to `8.0`
 - non-issue: fixes an unreleased issue