### PR TITLE
GlobalBuildInfo plugin should search packed references for commit IDs (#47464)

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
@@ -26,7 +26,10 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class GlobalBuildInfoPlugin implements Plugin<Project> {
     private static final String GLOBAL_INFO_EXTENSION_NAME = "globalInfo";
@@ -247,7 +250,23 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             }
             final String ref = readFirstLine(head);
             if (ref.startsWith("ref:")) {
-                revision = readFirstLine(gitDir.resolve(ref.substring("ref:".length()).trim()));
+                String refName = ref.substring("ref:".length()).trim();
+                Path refFile = gitDir.resolve(refName);
+                if (Files.exists(refFile)) {
+                    revision = readFirstLine(refFile);
+                } else if (Files.exists(dotGit.resolve("packed-refs"))) {
+                    // Check packed references for commit ID
+                    Pattern p = Pattern.compile("^([a-f0-9]{40}) " + refName + "$");
+                    try (Stream<String> lines = Files.lines(dotGit.resolve("packed-refs"))) {
+                        revision = lines.map(p::matcher)
+                            .filter(Matcher::matches)
+                            .map(m -> m.group(1))
+                            .findFirst()
+                            .orElseThrow(() -> new IOException("Packed reference not found for refName " + refName));
+                    }
+                } else {
+                    throw new GradleException("Can't find revision for refName " + refName);
+                }
             } else {
                 // we are in detached HEAD state
                 revision = ref;
@@ -260,9 +279,13 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
     }
 
     private static String readFirstLine(final Path path) throws IOException {
-        return Files.lines(path, StandardCharsets.UTF_8)
-            .findFirst()
-            .orElseThrow(() -> new IOException("file [" + path + "] is empty"));
+        String firstLine;
+        try (Stream<String> lines = Files.lines(path, StandardCharsets.UTF_8)) {
+            firstLine = lines
+                .findFirst()
+                .orElseThrow(() -> new IOException("file [" + path + "] is empty"));
+        }
+        return firstLine;
     }
 
 }


### PR DESCRIPTION
* GlobalBuildInfo plugin searches packed references

In recent versions of Git, references may be packed in a packed-refs
file. If this happens, Gradle will need to look in that file to find
build information.