### PR TITLE
Fix SLMSnapshotBlockingIntegTest

### DIFF
--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
@@ -37,7 +37,6 @@ import org.elasticsearch.xpack.core.slm.action.ExecuteSnapshotRetentionAction;
 import org.elasticsearch.xpack.core.slm.action.GetSnapshotLifecycleAction;
 import org.elasticsearch.xpack.core.slm.action.PutSnapshotLifecycleAction;
 import org.elasticsearch.xpack.ilm.IndexLifecycle;
-import org.junit.After;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -63,23 +62,6 @@ import static org.hamcrest.Matchers.greaterThan;
 public class SLMSnapshotBlockingIntegTests extends ESIntegTestCase {
 
     static final String REPO = "my-repo";
-
-    @After
-    public void resetSLMSettings() throws Exception {
-        // Cancel/delete all snapshots
-        assertBusy(() -> {
-            logger.info("--> wiping all snapshots after test");
-            client().admin().cluster().prepareGetSnapshots(REPO).get().getSnapshots(REPO)
-                .forEach(snapshotInfo -> {
-                    try {
-                        client().admin().cluster().prepareDeleteSnapshot(REPO, snapshotInfo.snapshotId().getName()).get();
-                    } catch (Exception e) {
-                        logger.warn("exception cleaning up snapshot " + snapshotInfo.snapshotId().getName(), e);
-                        fail("exception cleanup up snapshot");
-                    }
-                });
-        });
-    }
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.xpack.core.slm.action.ExecuteSnapshotRetentionAction;
 import org.elasticsearch.xpack.core.slm.action.GetSnapshotLifecycleAction;
 import org.elasticsearch.xpack.core.slm.action.PutSnapshotLifecycleAction;
 import org.elasticsearch.xpack.ilm.IndexLifecycle;
+import org.junit.Before;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -62,6 +63,14 @@ import static org.hamcrest.Matchers.greaterThan;
 public class SLMSnapshotBlockingIntegTests extends ESIntegTestCase {
 
     static final String REPO = "my-repo";
+
+    @Before
+    public void ensureClusterNodes() {
+        logger.info("--> starting enough nodes to ensure we have enough to safely stop for tests");
+        internalCluster().startMasterOnlyNodes(2);
+        internalCluster().startDataOnlyNodes(2);
+        ensureGreen();
+    }
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
@@ -226,7 +226,6 @@ public class SLMSnapshotBlockingIntegTests extends ESIntegTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/47937")
     public void testBasicFailureRetention() throws Exception {
         final String indexName = "test-idx";
         final String policyId = "test-policy";


### PR DESCRIPTION
The after snapshot action is interfering with SLM deleting snapshots
here it seems, causing concurrent delete exceptions.
Since these tests are now test-scoped there is no reason to run
snapshot deletes after each test so we can remove them to avoid this issue.

Closes #47937
