### PR TITLE
Track GlobalOrds TermEnum's in breaker

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
@@ -75,12 +75,12 @@ public enum GlobalOrdinalsBuilder {
             );
         }
         return new GlobalOrdinalsIndexFieldData(indexSettings, indexFieldData.getFieldName(),
-                atomicFD, ordinalMap, memorySizeInBytes, scriptFunction
+                atomicFD, ordinalMap, memorySizeInBytes, scriptFunction, breakerService
         );
     }
 
     public static IndexOrdinalsFieldData buildEmpty(IndexSettings indexSettings, final IndexReader indexReader,
-            IndexOrdinalsFieldData indexFieldData) throws IOException {
+            IndexOrdinalsFieldData indexFieldData, CircuitBreakerService breakerService) throws IOException {
         assert indexReader.leaves().size() > 1;
 
         final AtomicOrdinalsFieldData[] atomicFD = new AtomicOrdinalsFieldData[indexReader.leaves().size()];
@@ -110,7 +110,7 @@ public enum GlobalOrdinalsBuilder {
         }
         final OrdinalMap ordinalMap = OrdinalMap.build(null, subs, PackedInts.DEFAULT);
         return new GlobalOrdinalsIndexFieldData(indexSettings, indexFieldData.getFieldName(),
-                atomicFD, ordinalMap, 0, AbstractAtomicOrdinalsFieldData.DEFAULT_SCRIPT_FUNCTION
+                atomicFD, ordinalMap, 0, AbstractAtomicOrdinalsFieldData.DEFAULT_SCRIPT_FUNCTION, breakerService
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexOrdinalsFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexOrdinalsFieldData.java
@@ -89,7 +89,7 @@ public abstract class AbstractIndexOrdinalsFieldData extends AbstractIndexFieldD
             // so if a field doesn't exist then we don't cache it and just return an empty field data instance.
             // The next time the field is found, we do cache.
             try {
-                return GlobalOrdinalsBuilder.buildEmpty(indexSettings, indexReader, this);
+                return GlobalOrdinalsBuilder.buildEmpty(indexSettings, indexReader, this, breakerService);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVOrdinalsIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVOrdinalsIndexFieldData.java
@@ -121,7 +121,7 @@ public class SortedSetDVOrdinalsIndexFieldData extends DocValuesIndexFieldData i
             // so if a field doesn't exist then we don't cache it and just return an empty field data instance.
             // The next time the field is found, we do cache.
             try {
-                return GlobalOrdinalsBuilder.buildEmpty(indexSettings, indexReader, this);
+                return GlobalOrdinalsBuilder.buildEmpty(indexSettings, indexReader, this, breakerService);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
Term enums hold a considerable amount of memory, and even though we cache them for repeated use they can have a large impact on overall memory availability.  This tracks their usage in the FieldData breaker (similar to the ordinal map).  In particular, I believe most of the untracked memory is the `BytesRef` in the `TermsDict`, which seems to be sized to the largest term.

I'm not convinced this does what I think it does, so we may just close this PR if I'm way off base :)