### PR TITLE
[ML][Transforms] signal listener early on task _stop failure

### DIFF
--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransportStopTransformActionTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransportStopTransformActionTests.java
@@ -5,12 +5,15 @@
  */
 package org.elasticsearch.xpack.transform.action;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.TaskOperationFailure;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.core.transform.TransformMessages;
@@ -18,8 +21,10 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformTaskParams;
 import org.elasticsearch.xpack.core.transform.transforms.TransformState;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskState;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static org.elasticsearch.rest.RestStatus.CONFLICT;
 import static org.hamcrest.Matchers.equalTo;
@@ -89,6 +94,69 @@ public class TransportStopTransformActionTests extends ESTestCase {
             equalTo(TransformMessages.getMessage(TransformMessages.CANNOT_STOP_FAILED_TRANSFORM,
                 "failed-task",
                 "task has failed")));
+    }
+
+    public void testFirstNotOKStatus() {
+        List<ElasticsearchException> nodeFailures = new ArrayList<>();
+        List<TaskOperationFailure> taskOperationFailures = new ArrayList<>();
+
+        nodeFailures.add(new ElasticsearchException("nodefailure",
+            new ElasticsearchStatusException("failure", RestStatus.UNPROCESSABLE_ENTITY)));
+        taskOperationFailures.add(new TaskOperationFailure("node",
+            1,
+            new ElasticsearchStatusException("failure", RestStatus.BAD_REQUEST)));
+
+        assertThat(TransportStopTransformAction.firstNotOKStatus(Collections.emptyList(), Collections.emptyList()),
+            equalTo(RestStatus.INTERNAL_SERVER_ERROR));
+
+        assertThat(TransportStopTransformAction.firstNotOKStatus(taskOperationFailures, Collections.emptyList()),
+            equalTo(RestStatus.BAD_REQUEST));
+        assertThat(TransportStopTransformAction.firstNotOKStatus(taskOperationFailures, nodeFailures),
+            equalTo(RestStatus.BAD_REQUEST));
+        assertThat(TransportStopTransformAction.firstNotOKStatus(taskOperationFailures,
+            Collections.singletonList(new ElasticsearchException(new ElasticsearchStatusException("not failure", RestStatus.OK)))),
+            equalTo(RestStatus.BAD_REQUEST));
+
+        assertThat(TransportStopTransformAction.firstNotOKStatus(
+            Collections.singletonList(new TaskOperationFailure(
+                "node",
+                1,
+                new ElasticsearchStatusException("not failure", RestStatus.OK))),
+            nodeFailures),
+            equalTo(RestStatus.INTERNAL_SERVER_ERROR));
+
+        assertThat(TransportStopTransformAction.firstNotOKStatus(
+            Collections.emptyList(),
+            nodeFailures),
+            equalTo(RestStatus.INTERNAL_SERVER_ERROR));
+    }
+
+    public void testBuildException() {
+        List<ElasticsearchException> nodeFailures = new ArrayList<>();
+        List<TaskOperationFailure> taskOperationFailures = new ArrayList<>();
+
+        nodeFailures.add(new ElasticsearchException("node failure"));
+        taskOperationFailures.add(new TaskOperationFailure("node",
+            1,
+            new ElasticsearchStatusException("task failure", RestStatus.BAD_REQUEST)));
+
+        RestStatus status = CONFLICT;
+        ElasticsearchStatusException statusException =
+            TransportStopTransformAction.buildException(taskOperationFailures, nodeFailures, status);
+
+        assertThat(statusException.status(), equalTo(status));
+        assertThat(statusException.getMessage(), equalTo(taskOperationFailures.get(0).getCause().getMessage()));
+        assertThat(statusException.getSuppressed().length, equalTo(1));
+
+        statusException = TransportStopTransformAction.buildException(Collections.emptyList(), nodeFailures, status);
+        assertThat(statusException.status(), equalTo(status));
+        assertThat(statusException.getMessage(), equalTo(nodeFailures.get(0).getMessage()));
+        assertThat(statusException.getSuppressed().length, equalTo(0));
+
+        statusException = TransportStopTransformAction.buildException(taskOperationFailures, Collections.emptyList(), status);
+        assertThat(statusException.status(), equalTo(status));
+        assertThat(statusException.getMessage(), equalTo(taskOperationFailures.get(0).getCause().getMessage()));
+        assertThat(statusException.getSuppressed().length, equalTo(0));
     }
 
 }


### PR DESCRIPTION
If there is some failure in the `stop` call, we don't handle it. Consequently, the listener could just spin forever waiting for a task to be removed when it never will be.

This adds some logic to signal back to the listener if some node failures or task failures occurred.

This is particularly troublesome on tests where a `_stop` fails as `waitForPersistentTasksCondition` is only ever fired on cluster state updates, and if no updates occur, it will simply sit there indefinitely. 