### PR TITLE
SLM Start/Stop HLRC and docs

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleClient.java
@@ -43,6 +43,9 @@ import org.elasticsearch.client.slm.GetSnapshotLifecyclePolicyResponse;
 import org.elasticsearch.client.slm.GetSnapshotLifecycleStatsRequest;
 import org.elasticsearch.client.slm.GetSnapshotLifecycleStatsResponse;
 import org.elasticsearch.client.slm.PutSnapshotLifecyclePolicyRequest;
+import org.elasticsearch.client.slm.SnapshotLifecycleManagementStatusRequest;
+import org.elasticsearch.client.slm.StartSLMRequest;
+import org.elasticsearch.client.slm.StopSLMRequest;
 
 import java.io.IOException;
 
@@ -540,5 +543,91 @@ public class IndexLifecycleClient {
                                                       ActionListener<GetSnapshotLifecycleStatsResponse> listener) {
         return restHighLevelClient.performRequestAsyncAndParseEntity(request, IndexLifecycleRequestConverters::getSnapshotLifecycleStats,
             options, GetSnapshotLifecycleStatsResponse::fromXContent, listener, emptySet());
+    }
+
+    /**
+     * Start the Snapshot Lifecycle Management feature.
+     * See <a href="https://fix-me-when-we-have-docs.com">
+     * the docs</a> for more.
+     * @param request the request
+     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @return the response
+     * @throws IOException in case there is a problem sending the request or parsing back the response
+     */
+    public AcknowledgedResponse startSLM(StartSLMRequest request, RequestOptions options) throws IOException {
+        return restHighLevelClient.performRequestAndParseEntity(request, IndexLifecycleRequestConverters::startSLM, options,
+            AcknowledgedResponse::fromXContent, emptySet());
+    }
+
+    /**
+     * Asynchronously start the Snapshot Lifecycle Management feature.
+     * See <a href="https://fix-me-when-we-have-docs.com">
+     * the docs</a> for more.
+     * @param request the request
+     * @param listener the listener to be notified upon request completion
+     * @return cancellable that may be used to cancel the request
+     */
+    public Cancellable startSLMAsync(StartSLMRequest request, RequestOptions options, ActionListener<AcknowledgedResponse> listener) {
+        return restHighLevelClient.performRequestAsyncAndParseEntity(request, IndexLifecycleRequestConverters::startSLM, options,
+            AcknowledgedResponse::fromXContent, listener, emptySet());
+    }
+
+    /**
+     * Stop the Snapshot Lifecycle Management feature.
+     * See <a href="https://fix-me-when-we-have-docs.com">
+     * the docs</a> for more.
+     * @param request the request
+     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @return the response
+     * @throws IOException in case there is a problem sending the request or parsing back the response
+     */
+    public AcknowledgedResponse stopSLM(StopSLMRequest request, RequestOptions options) throws IOException {
+        return restHighLevelClient.performRequestAndParseEntity(request, IndexLifecycleRequestConverters::stopSLM, options,
+            AcknowledgedResponse::fromXContent, emptySet());
+    }
+
+    /**
+     * Asynchronously stop the Snapshot Lifecycle Management feature.
+     * See <a href="https://fix-me-when-we-have-docs.com">
+     * the docs</a> for more.
+     * @param request the request
+     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @param listener the listener to be notified upon request completion
+     * @return cancellable that may be used to cancel the request
+     */
+    public Cancellable stopSLMAsync(StopSLMRequest request, RequestOptions options, ActionListener<AcknowledgedResponse> listener) {
+        return restHighLevelClient.performRequestAsyncAndParseEntity(request, IndexLifecycleRequestConverters::stopSLM, options,
+            AcknowledgedResponse::fromXContent, listener, emptySet());
+    }
+
+    /**
+     * Stop the Snapshot Lifecycle Management feature.
+     * See <a href="https://fix-me-when-we-have-docs.com">
+     * the docs</a> for more.
+     * @param request the request
+     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @return the response
+     * @throws IOException in case there is a problem sending the request or parsing back the response
+     */
+    public LifecycleManagementStatusResponse snapshotLifecycleManagementStatus(SnapshotLifecycleManagementStatusRequest request,
+                                                                               RequestOptions options) throws IOException {
+        return restHighLevelClient.performRequestAndParseEntity(request, IndexLifecycleRequestConverters::snapshotLifecycleManagementStatus,
+            options, LifecycleManagementStatusResponse::fromXContent, emptySet());
+    }
+
+    /**
+     * Asynchronously stop the Snapshot Lifecycle Management feature.
+     * See <a href="https://fix-me-when-we-have-docs.com">
+     * the docs</a> for more.
+     * @param request the request
+     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @param listener the listener to be notified upon request completion
+     * @return cancellable that may be used to cancel the request
+     */
+    public Cancellable snapshotLifecycleManagementStatusAsync(SnapshotLifecycleManagementStatusRequest request, RequestOptions options,
+                                    ActionListener<LifecycleManagementStatusResponse> listener) {
+        return restHighLevelClient.performRequestAsyncAndParseEntity(request,
+            IndexLifecycleRequestConverters::snapshotLifecycleManagementStatus, options, LifecycleManagementStatusResponse::fromXContent,
+            listener, emptySet());
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleClient.java
@@ -547,8 +547,10 @@ public class IndexLifecycleClient {
 
     /**
      * Start the Snapshot Lifecycle Management feature.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-start.html">
-     * the docs</a> for more.
+     * See <pre>
+     *  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/
+     *  java-rest-high-ilm-slm-start-slm.html
+     * </pre> for more.
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -561,8 +563,10 @@ public class IndexLifecycleClient {
 
     /**
      * Asynchronously start the Snapshot Lifecycle Management feature.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-start.html">
-     * the docs</a> for more.
+     * See <pre>
+     *  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/
+     *  java-rest-high-ilm-slm-start-slm.html
+     * </pre> for more.
      * @param request the request
      * @param listener the listener to be notified upon request completion
      * @return cancellable that may be used to cancel the request
@@ -574,8 +578,10 @@ public class IndexLifecycleClient {
 
     /**
      * Stop the Snapshot Lifecycle Management feature.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-stop.html">
-     * the docs</a> for more.
+     * See <pre>
+     *  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/
+     *  java-rest-high-ilm-slm-stop-slm.html
+     * </pre> for more.
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -588,8 +594,10 @@ public class IndexLifecycleClient {
 
     /**
      * Asynchronously stop the Snapshot Lifecycle Management feature.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-stop.html">
-     * the docs</a> for more.
+     * See <pre>
+     *  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/
+     *  java-rest-high-ilm-slm-stop-slm.html
+     * </pre> for more.
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -602,8 +610,10 @@ public class IndexLifecycleClient {
 
     /**
      * Stop the Snapshot Lifecycle Management feature.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-get-status.html">
-     * the docs</a> for more.
+     * See <pre>
+     *  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/
+     *  java-rest-high-ilm-slm-status.html
+     * </pre> for more.
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -617,8 +627,10 @@ public class IndexLifecycleClient {
 
     /**
      * Asynchronously stop the Snapshot Lifecycle Management feature.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-get-status.html">
-     * the docs</a> for more.
+     * See <pre>
+     *  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/
+     *  java-rest-high-ilm-slm-status.html
+     * </pre> for more.
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleClient.java
@@ -619,8 +619,8 @@ public class IndexLifecycleClient {
      * @return the response
      * @throws IOException in case there is a problem sending the request or parsing back the response
      */
-    public LifecycleManagementStatusResponse snapshotLifecycleManagementStatus(SnapshotLifecycleManagementStatusRequest request,
-                                                                               RequestOptions options) throws IOException {
+    public LifecycleManagementStatusResponse getSLMStatus(SnapshotLifecycleManagementStatusRequest request,
+                                                          RequestOptions options) throws IOException {
         return restHighLevelClient.performRequestAndParseEntity(request, IndexLifecycleRequestConverters::snapshotLifecycleManagementStatus,
             options, LifecycleManagementStatusResponse::fromXContent, emptySet());
     }
@@ -636,8 +636,8 @@ public class IndexLifecycleClient {
      * @param listener the listener to be notified upon request completion
      * @return cancellable that may be used to cancel the request
      */
-    public Cancellable snapshotLifecycleManagementStatusAsync(SnapshotLifecycleManagementStatusRequest request, RequestOptions options,
-                                    ActionListener<LifecycleManagementStatusResponse> listener) {
+    public Cancellable getSLMStatusAsync(SnapshotLifecycleManagementStatusRequest request, RequestOptions options,
+                                         ActionListener<LifecycleManagementStatusResponse> listener) {
         return restHighLevelClient.performRequestAsyncAndParseEntity(request,
             IndexLifecycleRequestConverters::snapshotLifecycleManagementStatus, options, LifecycleManagementStatusResponse::fromXContent,
             listener, emptySet());

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleClient.java
@@ -609,7 +609,7 @@ public class IndexLifecycleClient {
     }
 
     /**
-     * Stop the Snapshot Lifecycle Management feature.
+     * Get the status of Snapshot Lifecycle Management.
      * See <pre>
      *  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/
      *  java-rest-high-ilm-slm-status.html
@@ -626,7 +626,7 @@ public class IndexLifecycleClient {
     }
 
     /**
-     * Asynchronously stop the Snapshot Lifecycle Management feature.
+     * Asynchronously get the status of Snapshot Lifecycle Management.
      * See <pre>
      *  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/
      *  java-rest-high-ilm-slm-status.html

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleClient.java
@@ -547,7 +547,7 @@ public class IndexLifecycleClient {
 
     /**
      * Start the Snapshot Lifecycle Management feature.
-     * See <a href="https://fix-me-when-we-have-docs.com">
+     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-start.html">
      * the docs</a> for more.
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
@@ -561,7 +561,7 @@ public class IndexLifecycleClient {
 
     /**
      * Asynchronously start the Snapshot Lifecycle Management feature.
-     * See <a href="https://fix-me-when-we-have-docs.com">
+     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-start.html">
      * the docs</a> for more.
      * @param request the request
      * @param listener the listener to be notified upon request completion
@@ -574,7 +574,7 @@ public class IndexLifecycleClient {
 
     /**
      * Stop the Snapshot Lifecycle Management feature.
-     * See <a href="https://fix-me-when-we-have-docs.com">
+     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-stop.html">
      * the docs</a> for more.
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
@@ -588,7 +588,7 @@ public class IndexLifecycleClient {
 
     /**
      * Asynchronously stop the Snapshot Lifecycle Management feature.
-     * See <a href="https://fix-me-when-we-have-docs.com">
+     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-stop.html">
      * the docs</a> for more.
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
@@ -602,7 +602,7 @@ public class IndexLifecycleClient {
 
     /**
      * Stop the Snapshot Lifecycle Management feature.
-     * See <a href="https://fix-me-when-we-have-docs.com">
+     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-get-status.html">
      * the docs</a> for more.
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
@@ -617,7 +617,7 @@ public class IndexLifecycleClient {
 
     /**
      * Asynchronously stop the Snapshot Lifecycle Management feature.
-     * See <a href="https://fix-me-when-we-have-docs.com">
+     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-get-status.html">
      * the docs</a> for more.
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleRequestConverters.java
@@ -38,6 +38,9 @@ import org.elasticsearch.client.slm.ExecuteSnapshotLifecycleRetentionRequest;
 import org.elasticsearch.client.slm.GetSnapshotLifecyclePolicyRequest;
 import org.elasticsearch.client.slm.GetSnapshotLifecycleStatsRequest;
 import org.elasticsearch.client.slm.PutSnapshotLifecyclePolicyRequest;
+import org.elasticsearch.client.slm.SnapshotLifecycleManagementStatusRequest;
+import org.elasticsearch.client.slm.StartSLMRequest;
+import org.elasticsearch.client.slm.StopSLMRequest;
 import org.elasticsearch.common.Strings;
 
 import java.io.IOException;
@@ -236,6 +239,45 @@ final class IndexLifecycleRequestConverters {
         RequestConverters.Params params = new RequestConverters.Params();
         params.withMasterTimeout(getSnapshotLifecycleStatsRequest.masterNodeTimeout());
         params.withTimeout(getSnapshotLifecycleStatsRequest.timeout());
+        request.addParameters(params.asMap());
+        return request;
+    }
+
+    static Request snapshotLifecycleManagementStatus(SnapshotLifecycleManagementStatusRequest snapshotLifecycleManagementStatusRequest){
+        Request request = new Request(HttpGet.METHOD_NAME,
+            new RequestConverters.EndpointBuilder()
+                .addPathPartAsIs("_slm")
+                .addPathPartAsIs("status")
+                .build());
+        RequestConverters.Params params = new RequestConverters.Params();
+        params.withMasterTimeout(snapshotLifecycleManagementStatusRequest.masterNodeTimeout());
+        params.withTimeout(snapshotLifecycleManagementStatusRequest.timeout());
+        request.addParameters(params.asMap());
+        return request;
+    }
+
+    static Request startSLM(StartSLMRequest startSLMRequest) {
+        Request request = new Request(HttpPost.METHOD_NAME,
+            new RequestConverters.EndpointBuilder()
+                .addPathPartAsIs("_slm")
+                .addPathPartAsIs("start")
+                .build());
+        RequestConverters.Params params = new RequestConverters.Params();
+        params.withMasterTimeout(startSLMRequest.masterNodeTimeout());
+        params.withTimeout(startSLMRequest.timeout());
+        request.addParameters(params.asMap());
+        return request;
+    }
+
+    static Request stopSLM(StopSLMRequest stopSLMRequest) {
+        Request request = new Request(HttpPost.METHOD_NAME,
+            new RequestConverters.EndpointBuilder()
+                .addPathPartAsIs("_slm")
+                .addPathPartAsIs("stop")
+                .build());
+        RequestConverters.Params params = new RequestConverters.Params();
+        params.withMasterTimeout(stopSLMRequest.masterNodeTimeout());
+        params.withTimeout(stopSLMRequest.timeout());
         request.addParameters(params.asMap());
         return request;
     }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/slm/SnapshotLifecycleManagementStatusRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/slm/SnapshotLifecycleManagementStatusRequest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.slm;
+
+import org.elasticsearch.client.TimedRequest;
+
+public class SnapshotLifecycleManagementStatusRequest extends TimedRequest {
+}

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/slm/StartSLMRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/slm/StartSLMRequest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.slm;
+
+import org.elasticsearch.client.TimedRequest;
+
+public class StartSLMRequest extends TimedRequest {
+}

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/slm/StopSLMRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/slm/StopSLMRequest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.slm;
+
+import org.elasticsearch.client.TimedRequest;
+
+public class StopSLMRequest extends TimedRequest {
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/ILMDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/ILMDocumentationIT.java
@@ -779,7 +779,7 @@ public class ILMDocumentationIT extends ESRestHighLevelClientTestCase {
         assertTrue(response.isAcknowledged());
 
         //////// PUT
-        // tag::slm-put-snapshot-lifecycle-policy
+        // tag::slm-put-snapshot-lifecycle-policy-request
         Map<String, Object> config = new HashMap<>();
         config.put("indices", Collections.singletonList("idx"));
         SnapshotRetentionConfiguration retention =
@@ -789,7 +789,7 @@ public class ILMDocumentationIT extends ESRestHighLevelClientTestCase {
             "my_repository", config, retention);
         PutSnapshotLifecyclePolicyRequest request =
             new PutSnapshotLifecyclePolicyRequest(policy);
-        // end::slm-put-snapshot-lifecycle-policy
+        // end::slm-put-snapshot-lifecycle-policy-request
 
         // tag::slm-put-snapshot-lifecycle-policy-execute
         AcknowledgedResponse resp = client.indexLifecycle()
@@ -818,16 +818,16 @@ public class ILMDocumentationIT extends ESRestHighLevelClientTestCase {
 
         // tag::slm-put-snapshot-lifecycle-policy-execute-async
         client.indexLifecycle().putSnapshotLifecyclePolicyAsync(request,
-            RequestOptions.DEFAULT, putListener);
+            RequestOptions.DEFAULT, putListener); // <1>
         // end::slm-put-snapshot-lifecycle-policy-execute-async
 
         //////// GET
-        // tag::slm-get-snapshot-lifecycle-policy
+        // tag::slm-get-snapshot-lifecycle-policy-request
         GetSnapshotLifecyclePolicyRequest getAllRequest =
             new GetSnapshotLifecyclePolicyRequest(); // <1>
         GetSnapshotLifecyclePolicyRequest getRequest =
             new GetSnapshotLifecyclePolicyRequest("policy_id"); // <2>
-        // end::slm-get-snapshot-lifecycle-policy
+        // end::slm-get-snapshot-lifecycle-policy-request
 
         // tag::slm-get-snapshot-lifecycle-policy-execute
         GetSnapshotLifecyclePolicyResponse getResponse =
@@ -854,7 +854,7 @@ public class ILMDocumentationIT extends ESRestHighLevelClientTestCase {
 
         // tag::slm-get-snapshot-lifecycle-policy-execute-async
         client.indexLifecycle().getSnapshotLifecyclePolicyAsync(getRequest,
-            RequestOptions.DEFAULT, getListener);
+            RequestOptions.DEFAULT, getListener); // <1>
         // end::slm-get-snapshot-lifecycle-policy-execute-async
 
         assertThat(getResponse.getPolicies().size(), equalTo(1));
@@ -882,10 +882,10 @@ public class ILMDocumentationIT extends ESRestHighLevelClientTestCase {
         createIndex("idx", Settings.builder().put("index.number_of_shards", 1).build());
 
         //////// EXECUTE
-        // tag::slm-execute-snapshot-lifecycle-policy
+        // tag::slm-execute-snapshot-lifecycle-policy-request
         ExecuteSnapshotLifecyclePolicyRequest executeRequest =
             new ExecuteSnapshotLifecyclePolicyRequest("policy_id"); // <1>
-        // end::slm-execute-snapshot-lifecycle-policy
+        // end::slm-execute-snapshot-lifecycle-policy-request
 
         // tag::slm-execute-snapshot-lifecycle-policy-execute
         ExecuteSnapshotLifecyclePolicyResponse executeResponse =
@@ -940,7 +940,7 @@ public class ILMDocumentationIT extends ESRestHighLevelClientTestCase {
         // tag::slm-execute-snapshot-lifecycle-policy-execute-async
         client.indexLifecycle()
             .executeSnapshotLifecyclePolicyAsync(executeRequest,
-                RequestOptions.DEFAULT, executeListener);
+                RequestOptions.DEFAULT, executeListener); // <1>
         // end::slm-execute-snapshot-lifecycle-policy-execute-async
         latch.await(5, TimeUnit.SECONDS);
 
@@ -961,42 +961,49 @@ public class ILMDocumentationIT extends ESRestHighLevelClientTestCase {
             greaterThanOrEqualTo(1L));
 
         //////// DELETE
-        // tag::slm-delete-snapshot-lifecycle-policy
+        // tag::slm-delete-snapshot-lifecycle-policy-request
         DeleteSnapshotLifecyclePolicyRequest deleteRequest =
             new DeleteSnapshotLifecyclePolicyRequest("policy_id"); // <1>
-        // end::slm-delete-snapshot-lifecycle-policy
+        // end::slm-delete-snapshot-lifecycle-policy-request
 
         // tag::slm-delete-snapshot-lifecycle-policy-execute
         AcknowledgedResponse deleteResp = client.indexLifecycle()
             .deleteSnapshotLifecyclePolicy(deleteRequest, RequestOptions.DEFAULT);
         // end::slm-delete-snapshot-lifecycle-policy-execute
+
+        // tag::slm-delete-snapshot-lifecycle-policy-response
+        boolean deleteAcknowledged = deleteResp.isAcknowledged(); // <1>
+        // end::slm-delete-snapshot-lifecycle-policy-response
+
         assertTrue(deleteResp.isAcknowledged());
 
+        // tag::slm-delete-snapshot-lifecycle-policy-execute-listener
         ActionListener<AcknowledgedResponse> deleteListener = new ActionListener<>() {
             @Override
             public void onResponse(AcknowledgedResponse resp) {
-                // no-op
+                boolean deleteAcknowledged = resp.isAcknowledged(); // <1>
             }
 
             @Override
             public void onFailure(Exception e) {
-                // no-op
+                // <2>
             }
         };
+        // end::slm-delete-snapshot-lifecycle-policy-execute-listener
 
         // tag::slm-delete-snapshot-lifecycle-policy-execute-async
         client.indexLifecycle()
             .deleteSnapshotLifecyclePolicyAsync(deleteRequest,
-                RequestOptions.DEFAULT, deleteListener);
+                RequestOptions.DEFAULT, deleteListener); // <1>
         // end::slm-delete-snapshot-lifecycle-policy-execute-async
 
         assertTrue(deleteResp.isAcknowledged());
 
         //////// EXECUTE RETENTION
-        // tag::slm-execute-snapshot-lifecycle-retention
+        // tag::slm-execute-snapshot-lifecycle-retention-request
         ExecuteSnapshotLifecycleRetentionRequest req =
             new ExecuteSnapshotLifecycleRetentionRequest();
-        // end::slm-execute-snapshot-lifecycle-retention
+        // end::slm-execute-snapshot-lifecycle-retention-request
 
         // tag::slm-execute-snapshot-lifecycle-retention-execute
         AcknowledgedResponse retentionResp =
@@ -1009,7 +1016,7 @@ public class ILMDocumentationIT extends ESRestHighLevelClientTestCase {
         final boolean acked = retentionResp.isAcknowledged();
         // end::slm-execute-snapshot-lifecycle-retention-response
 
-        // tag::slm-execute-snapshot-lifecycle-policy-execute-listener
+        // tag::slm-execute-snapshot-lifecycle-retention-execute-listener
         ActionListener<AcknowledgedResponse> retentionListener =
             new ActionListener<>() {
                 @Override
@@ -1027,7 +1034,7 @@ public class ILMDocumentationIT extends ESRestHighLevelClientTestCase {
         // tag::slm-execute-snapshot-lifecycle-retention-execute-async
         client.indexLifecycle()
             .executeSnapshotLifecycleRetentionAsync(req,
-                RequestOptions.DEFAULT, retentionListener);
+                RequestOptions.DEFAULT, retentionListener); // <1>
         // end::slm-execute-snapshot-lifecycle-retention-execute-async
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/ILMDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/ILMDocumentationIT.java
@@ -1077,7 +1077,7 @@ public class ILMDocumentationIT extends ESRestHighLevelClientTestCase {
             // tag::slm-status-execute
             LifecycleManagementStatusResponse response =
                 client.indexLifecycle()
-                    .snapshotLifecycleManagementStatus(request, RequestOptions.DEFAULT);
+                    .getSLMStatus(request, RequestOptions.DEFAULT);
             // end::slm-status-execute
 
             // tag::slm-status-response
@@ -1110,7 +1110,7 @@ public class ILMDocumentationIT extends ESRestHighLevelClientTestCase {
         listener = new LatchedActionListener<>(listener, latch);
 
         // tag::slm-status-execute-async
-        client.indexLifecycle().snapshotLifecycleManagementStatusAsync(request,
+        client.indexLifecycle().getSLMStatusAsync(request,
             RequestOptions.DEFAULT, listener); // <1>
         // end::slm-status-execute-async
         assertTrue(latch.await(30L, TimeUnit.SECONDS));
@@ -1118,7 +1118,7 @@ public class ILMDocumentationIT extends ESRestHighLevelClientTestCase {
         // Check that SLM is running again
         LifecycleManagementStatusResponse response =
             client.indexLifecycle()
-                .snapshotLifecycleManagementStatus(request, RequestOptions.DEFAULT);
+                .getSLMStatus(request, RequestOptions.DEFAULT);
 
         OperationMode operationMode = response.getOperationMode();
         assertEquals(OperationMode.RUNNING, operationMode);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/ILMDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/ILMDocumentationIT.java
@@ -978,17 +978,18 @@ public class ILMDocumentationIT extends ESRestHighLevelClientTestCase {
         assertTrue(deleteResp.isAcknowledged());
 
         // tag::slm-delete-snapshot-lifecycle-policy-execute-listener
-        ActionListener<AcknowledgedResponse> deleteListener = new ActionListener<>() {
-            @Override
-            public void onResponse(AcknowledgedResponse resp) {
-                boolean deleteAcknowledged = resp.isAcknowledged(); // <1>
-            }
+        ActionListener<AcknowledgedResponse> deleteListener =
+            new ActionListener<>() {
+                @Override
+                public void onResponse(AcknowledgedResponse resp) {
+                    boolean deleteAcknowledged = resp.isAcknowledged(); // <1>
+                }
 
-            @Override
-            public void onFailure(Exception e) {
-                // <2>
-            }
-        };
+                @Override
+                public void onFailure(Exception e) {
+                    // <2>
+                }
+            };
         // end::slm-delete-snapshot-lifecycle-policy-execute-listener
 
         // tag::slm-delete-snapshot-lifecycle-policy-execute-async

--- a/docs/java-rest/high-level/ilm/snapshot_lifecycle_management_status.asciidoc
+++ b/docs/java-rest/high-level/ilm/snapshot_lifecycle_management_status.asciidoc
@@ -1,0 +1,36 @@
+--
+:api: slm-status
+:request: SnapshotLifecycleManagementStatusRequest
+:response: AcknowledgedResponse
+--
+[role="xpack"]
+[id="{upid}-{api}"]
+=== Snapshot Lifecycle Management Status API
+
+
+[id="{upid}-{api}-request"]
+==== Request
+
+The Snapshot Lifecycle Management Status API allows you to retrieve the status
+of Snapshot Lifecycle Management
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests-file}[{api}-request]
+--------------------------------------------------
+
+
+[id="{upid}-{api}-response"]
+==== Response
+
+The returned +{response}+ indicates the status of Snapshot Lifecycle Management.
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests-file}[{api}-response]
+--------------------------------------------------
+<1> The returned status can be `RUNNING`, `STOPPING`, or `STOPPED`.
+
+include::../execution.asciidoc[]
+
+

--- a/docs/java-rest/high-level/ilm/start_snapshot_lifecycle_management.asciidoc
+++ b/docs/java-rest/high-level/ilm/start_snapshot_lifecycle_management.asciidoc
@@ -1,0 +1,36 @@
+--
+:api: slm-start-slm
+:request: StartSLMRequest
+:response: AcknowledgedResponse
+--
+[role="xpack"]
+[id="{upid}-{api}"]
+=== Start Snapshot Lifecycle Management API
+
+
+[id="{upid}-{api}-request"]
+==== Request
+
+The Start Snapshot Lifecycle Management API allows you to start Snapshot
+Lifecycle Management if it has previously been stopped.
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests-file}[{api}-request]
+--------------------------------------------------
+
+
+[id="{upid}-{api}-response"]
+==== Response
+
+The returned +{response}+ indicates if the request to start Snapshot Lifecycle
+Management was received.
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests-file}[{api}-response]
+--------------------------------------------------
+<1> Whether or not the request to start Snapshot Lifecycle Management was
+acknowledged.
+
+include::../execution.asciidoc[]

--- a/docs/java-rest/high-level/ilm/stop_snapshot_lifecycle_management.asciidoc
+++ b/docs/java-rest/high-level/ilm/stop_snapshot_lifecycle_management.asciidoc
@@ -1,0 +1,38 @@
+--
+:api: slm-stop-slm
+:request: StopSLMRequest
+:response: AcknowledgedResponse
+--
+[role="xpack"]
+[id="{upid}-{api}"]
+=== Stop Snapshot Lifecycle Management API
+
+
+[id="{upid}-{api}-request"]
+==== Request
+
+The Stop Snapshot Management API allows you to stop Snapshot Lifecycle
+Management temporarily.
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests-file}[{api}-request]
+--------------------------------------------------
+
+
+[id="{upid}-{api}-response"]
+==== Response
+
+The returned +{response}+ indicates if the request to stop Snapshot
+Lifecycle Management was received.
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests-file}[{api}-response]
+--------------------------------------------------
+<1> Whether or not the request to stop Snapshot Lifecycle Management was
+acknowledged.
+
+include::../execution.asciidoc[]
+
+

--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -576,6 +576,35 @@ include::ilm/retry_lifecycle_policy.asciidoc[]
 include::ilm/remove_lifecycle_policy_from_index.asciidoc[]
 
 [role="xpack"]
+== Snapshot Lifecycle Management APIs
+
+:upid: {mainid}-ilm
+:doc-tests-file: {doc-tests}/ILMDocumentationIT.java
+
+The Java High Level REST Client supports the following Snapshot Lifecycle
+Management APIs:
+
+* <<{upid}-slm-put-snapshot-lifecycle-policy>>
+* <<{upid}-slm-delete-snapshot-lifecycle-policy>>
+* <<{upid}-ilm-get-lifecycle-policy>>
+* <<{upid}-slm-start-slm>>
+* <<{upid}-slm-stop-slm>>
+* <<{upid}-slm-status>>
+* <<{upid}-slm-execute-snapshot-lifecycle-policy>>
+* <<{upid}-slm-execute-snapshot-lifecycle-retention>>
+
+
+include::ilm/put_snapshot_lifecycle_policy.asciidoc[]
+include::ilm/delete_snapshot_lifecycle_policy.asciidoc[]
+include::ilm/get_snapshot_lifecycle_policy.asciidoc[]
+include::ilm/start_snapshot_lifecycle_management.asciidoc[]
+include::ilm/stop_snapshot_lifecycle_management.asciidoc[]
+include::ilm/snapshot_lifecycle_management_status.asciidoc[]
+include::ilm/execute_snapshot_lifecycle_policy.asciidoc[]
+include::ilm/execute_snapshot_lifecycle_retention.asciidoc[]
+
+
+[role="xpack"]
 [[transform_apis]]
 == {transform-cap} APIs
 

--- a/docs/reference/ilm/apis/slm-api.asciidoc
+++ b/docs/reference/ilm/apis/slm-api.asciidoc
@@ -670,11 +670,13 @@ background:
 
 Stop the Snapshot Lifecycle Management (SLM) plugin.
 
-==== Request
+[[slm-stop-request]]
+==== {api-request-title}
 
 `POST /_ilm/stop`
 
-==== Description
+[[slm-stop-desc]]
+==== {api-description-title}
 
 Halts all snapshot lifecycle management operations and stops the SLM plugin.
 This is useful when you are performing maintenance on the cluster and need to
@@ -695,9 +697,10 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 You must have the `manage_slm` cluster privilege to use this API.
 For more information, see <<security-privileges>>.
 
-==== Examples
+[[slm-stop-example]]
+==== {api-examples-title}
 
-The following example stops the SLM plugin.
+Stops the SLM plugin.
 
 [source,console]
 --------------------------------------------------
@@ -724,11 +727,13 @@ If the request does not encounter errors, you receive the following result:
 
 Start the Snapshot Lifecycle Management (SLM) plugin.
 
-==== Request
+[[slm-start-request]]
+==== {api-request-title}
 
 `POST /_slm/start`
 
-==== Description
+[[slm-start-desc]]
+==== {api-description-title}
 
 Starts the SLM plugin if it is currently stopped. SLM is started
 automatically when the cluster is formed. Restarting SLM is only
@@ -743,9 +748,10 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 You must have the `manage_slm` cluster privilege to use this API.
 For more information, see <<security-privileges>>.
 
-==== Examples
+[[slm-start-example]]
+==== {api-examples-title}
 
-The following example starts the SLM plugin.
+Starts the SLM plugin.
 
 [source,console]
 --------------------------------------------------
@@ -772,11 +778,13 @@ If the request succeeds, you receive the following result:
 
 Retrieves the current Snapshot Lifecycle Management (SLM) status.
 
-==== Request
+[[slm-get-status-request]]
+==== {api-request-title}
 
 `GET /_slm/status`
 
-==== Description
+[[slm-get-status-desc]]
+==== {api-description-title}
 
 Returns the status of the SLM plugin. The `operation_mode` field in the
 response shows one of three states: `STARTED`, `STOPPING`,
@@ -792,9 +800,10 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 You must have the `manage_slm` or `read_slm` or both cluster privileges to use this API.
 For more information, see <<security-privileges>>.
 
-==== Examples
+[[slm-get-status-example]]
+==== {api-examples-title}
 
-The following example gets the SLM plugin status.
+Gets the SLM plugin status.
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/ilm/apis/slm-api.asciidoc
+++ b/docs/reference/ilm/apis/slm-api.asciidoc
@@ -631,7 +631,7 @@ The following example stops the SLM plugin.
 
 [source,console]
 --------------------------------------------------
-POST _ilm/stop
+POST _slm/stop
 --------------------------------------------------
 // TEST[continued]
 

--- a/docs/reference/ilm/apis/slm-api.asciidoc
+++ b/docs/reference/ilm/apis/slm-api.asciidoc
@@ -15,10 +15,9 @@ SLM policy management is split into three different CRUD APIs, a way to put or u
 policies, a way to retrieve policies, and a way to delete unwanted policies, as
 well as a separate API for immediately invoking a snapshot based on a policy.
 
-Since SLM falls under the same category as ILM, it is stopped and started by
-using the <<start-stop-ilm,start and stop>> ILM APIs. It is, however, managed
-by a different enable setting. To disable SLM's functionality, set the cluster
-setting `xpack.slm.enabled` to `false` in elasticsearch.yml.
+SLM can be stopped temporarily and restarted using the <<slm-stop,Stop SLM>> and
+<<slm-start,Start SLM>> APIs. To disable SLM's functionality entirely, set the
+cluster setting `xpack.slm.enabled` to `false` in elasticsearch.yml.
 
 [[slm-api-put]]
 === Put snapshot lifecycle policy API
@@ -591,3 +590,152 @@ This API will immediately return, as retention will be run asynchronously in the
 }
 --------------------------------------------------
 
+[[slm-stop]]
+=== Stop Snapshot Lifecycle Management API
+
+[subs="attributes"]
+++++
+<titleabbrev>Stop Snapshot Lifecycle Management</titleabbrev>
+++++
+
+Stop the Snapshot Lifecycle Management (SLM) plugin.
+
+==== Request
+
+`POST /_ilm/stop`
+
+==== Description
+
+Halts all snapshot lifecycle management operations and stops the SLM plugin.
+This is useful when you are performing maintenance on the cluster and need to
+prevent SLM from performing any actions on your indices. Note that this API does
+not stop any snapshots that are currently in progress.
+
+The API returns as soon as the stop request has been acknowledged, but the
+plugin might continue to run until in-progress operations complete and the plugin
+can be safely stopped. Use the  <<slm-get-status, Get SLM Status>> API to see
+if SLM is running. 
+
+==== Request Parameters
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+
+==== Authorization
+
+You must have the `manage_slm` cluster privilege to use this API.
+For more information, see <<security-privileges>>.
+
+==== Examples
+
+The following example stops the SLM plugin.
+
+[source,console]
+--------------------------------------------------
+POST _ilm/stop
+--------------------------------------------------
+// TEST[continued]
+
+If the request does not encounter errors, you receive the following result:
+
+[source,console-result]
+--------------------------------------------------
+{
+  "acknowledged": true
+}
+--------------------------------------------------
+
+[[slm-start]]
+=== Start Snapshot Lifecycle Management API
+
+[subs="attributes"]
+++++
+<titleabbrev>Start Snapshot Lifecycle Management</titleabbrev>
+++++
+
+Start the Snapshot Lifecycle Management (SLM) plugin.
+
+==== Request
+
+`POST /_slm/start`
+
+==== Description
+
+Starts the SLM plugin if it is currently stopped. SLM is started
+automatically when the cluster is formed. Restarting SLM is only
+necessary if it has been stopped using the <<slm-stop, Stop SLM API>>.
+
+==== Request Parameters
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+
+==== Authorization
+
+You must have the `manage_slm` cluster privilege to use this API.
+For more information, see <<security-privileges>>.
+
+==== Examples
+
+The following example starts the SLM plugin.
+
+[source,console]
+--------------------------------------------------
+POST _slm/start
+--------------------------------------------------
+// TEST[continued]
+
+If the request succeeds, you receive the following result:
+
+[source,console-result]
+--------------------------------------------------
+{
+  "acknowledged": true
+}
+--------------------------------------------------
+
+[[slm-get-status]]
+=== Get Snapshot Lifecycle Management status API
+
+[subs="attributes"]
+++++
+<titleabbrev>Get Snapshot Lifecycle Management status</titleabbrev>
+++++
+
+Retrieves the current Snapshot Lifecycle Management (SLM) status.
+
+==== Request
+
+`GET /_slm/status`
+
+==== Description
+
+Returns the status of the SLM plugin. The `operation_mode` field in the
+response shows one of three states: `STARTED`, `STOPPING`,
+or `STOPPED`. You can change the status of the SLM plugin with the
+<<slm-start, Start SLM>> and <<slm-stop, Stop SLM>> APIs.
+
+==== Request Parameters
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+
+==== Authorization
+
+You must have the `manage_slm` or `read_slm` or both cluster privileges to use this API.
+For more information, see <<security-privileges>>.
+
+==== Examples
+
+The following example gets the SLM plugin status.
+
+[source,console]
+--------------------------------------------------
+GET _slm/status
+--------------------------------------------------
+
+If the request succeeds, the body of the response shows the operation mode:
+
+[source,console-result]
+--------------------------------------------------
+{
+  "operation_mode": "RUNNING"
+}
+--------------------------------------------------

--- a/docs/reference/ilm/apis/slm-api.asciidoc
+++ b/docs/reference/ilm/apis/slm-api.asciidoc
@@ -681,7 +681,9 @@ Stop the Snapshot Lifecycle Management (SLM) plugin.
 Halts all snapshot lifecycle management operations and stops the SLM plugin.
 This is useful when you are performing maintenance on the cluster and need to
 prevent SLM from performing any actions on your indices. Note that this API does
-not stop any snapshots that are currently in progress.
+not stop any snapshots that are currently in progress, and that snapshots can
+still be taken manually via the <<slm-api-execute,Execute Policy API>> even
+when SLM is stopped.
 
 The API returns as soon as the stop request has been acknowledged, but the
 plugin might continue to run until in-progress operations complete and the plugin


### PR DESCRIPTION
This commit adds HLRC support and documentation for the SLM Start and
Stop APIs, as well as updating existing documentation where appropriate.

Relates to https://github.com/elastic/elasticsearch/issues/43663 and https://github.com/elastic/elasticsearch/pull/47710