### PR TITLE
Update forbiddenapis to v2.7

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -117,7 +117,7 @@ dependencies {
   compile 'org.apache.rat:apache-rat:0.11'
   compile "org.elasticsearch:jna:4.5.1"
   compile 'com.github.jengelman.gradle.plugins:shadow:4.0.3'
-  compile 'de.thetaphi:forbiddenapis:2.6'
+  compile 'de.thetaphi:forbiddenapis:2.7'
   compile 'com.avast.gradle:gradle-docker-compose-plugin:0.8.12'
   testCompile "junit:junit:${props.getProperty('junit')}"
   testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${props.getProperty('randomizedrunner')}"

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
@@ -43,7 +43,7 @@ class PrecommitTasks {
     public static TaskProvider create(Project project, boolean includeDependencyLicenses) {
         project.configurations.create("forbiddenApisCliJar")
         project.dependencies {
-            forbiddenApisCliJar('de.thetaphi:forbiddenapis:2.6')
+            forbiddenApisCliJar('de.thetaphi:forbiddenapis:2.7')
         }
 
         Configuration jarHellConfig = project.configurations.create("jarHell")
@@ -149,13 +149,16 @@ class PrecommitTasks {
             doFirst {
                 // we need to defer this configuration since we don't know the runtime java version until execution time
                 targetCompatibility = project.runtimeJavaVersion.getMajorVersion()
-                if (project.runtimeJavaVersion > JavaVersion.VERSION_11) {
+                /*
+                TODO: Reenable once Gradle supports Java 13 or later!
+                if (project.runtimeJavaVersion > JavaVersion.VERSION_13) {
                     project.logger.info(
-                            "Forbidden APIs does not support java version past 11. Will use the signatures from 11 for ",
+                            "Forbidden APIs does not support java version past 13. Will use the signatures from 13 for ",
                             project.runtimeJavaVersion
                     )
-                    targetCompatibility = JavaVersion.VERSION_11.getMajorVersion()
+                    targetCompatibility = JavaVersion.VERSION_13.getMajorVersion()
                 }
+                */
             }
             bundledSignatures = [
                     "jdk-unsafe", "jdk-deprecated", "jdk-non-portable", "jdk-system-out"

--- a/buildSrc/src/testKit/thirdPartyAudit/build.gradle
+++ b/buildSrc/src/testKit/thirdPartyAudit/build.gradle
@@ -23,7 +23,7 @@ repositories {
 configurations.create("forbiddenApisCliJar")
 
 dependencies {
-    forbiddenApisCliJar 'de.thetaphi:forbiddenapis:2.6'
+    forbiddenApisCliJar 'de.thetaphi:forbiddenapis:2.7'
     compileOnly "org.${project.properties.compileOnlyGroup}:${project.properties.compileOnlyVersion}"
     compile "org.${project.properties.compileGroup}:${project.properties.compileVersion}"
 }


### PR DESCRIPTION
This PR just updates forbiddenapis to 2.7. This new version supports 12 and Java 13.

Features:
- Java 12 signatures
- Java 13 signatures
- allows usage of `FileReader` and `FileWriter` since Java 11 (new constructor with charset available)

I commented the code about maximum runtime java version, as Gradle currently only supports Java 12, so forbiddenapis is always able to apply signatures.

Nevertheless, I don't understand the logic here. targetVersion should be identical to the targetVersion used during compile (Java 11), it makes no sense to use a newer version as this makes builds not reproducible. But this is a different issue, so somebody should explain to me why this is done. The correct way is to set `forbidden.targetCompatiblity := javac.targetCompatibility`