### PR TITLE
Reenable BWC tests and adapt BWC layer for Pause/Resume auto-follower API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -205,8 +205,8 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
-final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/47904" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = true
+final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/x-pack/plugin/ccr/qa/rest/src/test/resources/rest-api-spec/test/ccr/auto_follow.yml
+++ b/x-pack/plugin/ccr/qa/rest/src/test/resources/rest-api-spec/test/ccr/auto_follow.yml
@@ -56,8 +56,8 @@
 ---
 "Test pause and resume auto follow pattern":
   - skip:
-      version: " - 7.9.99"
-      reason: "pause/resume auto-follow patterns is supported since 8.0"
+      version: " - 7.4.99"
+      reason: "pause/resume auto-follow patterns is supported since 7.5.0"
 
   - do:
       cluster.state: {}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowMetadata.java
@@ -233,7 +233,7 @@ public class AutoFollowMetadata extends AbstractNamedDiffable<MetaData.Custom> i
             this.remoteCluster = remoteCluster;
             this.leaderIndexPatterns = leaderIndexPatterns;
             this.followIndexPattern = followIndexPattern;
-            if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            if (in.getVersion().onOrAfter(Version.V_7_5_0)) {
                 this.active = in.readBoolean();
             } else {
                 this.active = true;
@@ -270,7 +270,7 @@ public class AutoFollowMetadata extends AbstractNamedDiffable<MetaData.Custom> i
             out.writeStringCollection(leaderIndexPatterns);
             out.writeOptionalString(followIndexPattern);
             super.writeTo(out);
-            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            if (out.getVersion().onOrAfter(Version.V_7_5_0)) {
                 out.writeBoolean(active);
             }
         }


### PR DESCRIPTION
This commit reenabled bwc tests and adapts the bwc serialization layer for #47904 