### PR TITLE
[7.x] Add FIPS 140 mode to XPack Usage API (#47278)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
@@ -27,6 +27,7 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
     private static final String AUDIT_XFIELD = "audit";
     private static final String IP_FILTER_XFIELD = "ipfilter";
     private static final String ANONYMOUS_XFIELD = "anonymous";
+    private static final String FIPS_140_XFIELD = "fips_140";
 
     private Map<String, Object> realmsUsage;
     private Map<String, Object> rolesStoreUsage;
@@ -37,6 +38,7 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
     private Map<String, Object> ipFilterUsage;
     private Map<String, Object> anonymousUsage;
     private Map<String, Object> roleMappingStoreUsage;
+    private Map<String, Object> fips140Usage;
 
     public SecurityFeatureSetUsage(StreamInput in) throws IOException {
         super(in);
@@ -55,13 +57,17 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
         }
         anonymousUsage = in.readMap();
         roleMappingStoreUsage = in.readMap();
+        if (in.getVersion().onOrAfter(Version.V_7_5_0)) {
+            fips140Usage = in.readMap();
+        }
     }
 
     public SecurityFeatureSetUsage(boolean available, boolean enabled, Map<String, Object> realmsUsage,
                                    Map<String, Object> rolesStoreUsage, Map<String, Object> roleMappingStoreUsage,
                                    Map<String, Object> sslUsage, Map<String, Object> auditUsage,
                                    Map<String, Object> ipFilterUsage, Map<String, Object> anonymousUsage,
-                                   Map<String, Object> tokenServiceUsage, Map<String, Object> apiKeyServiceUsage) {
+                                   Map<String, Object> tokenServiceUsage, Map<String, Object> apiKeyServiceUsage,
+                                   Map<String, Object> fips140Usage) {
         super(XPackField.SECURITY, available, enabled);
         this.realmsUsage = realmsUsage;
         this.rolesStoreUsage = rolesStoreUsage;
@@ -72,6 +78,7 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
         this.auditUsage = auditUsage;
         this.ipFilterUsage = ipFilterUsage;
         this.anonymousUsage = anonymousUsage;
+        this.fips140Usage = fips140Usage;
     }
 
     @Override
@@ -92,6 +99,9 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
         }
         out.writeMap(anonymousUsage);
         out.writeMap(roleMappingStoreUsage);
+        if (out.getVersion().onOrAfter(Version.V_7_5_0)) {
+            out.writeMap(fips140Usage);
+        }
     }
 
     @Override
@@ -107,6 +117,7 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
             builder.field(AUDIT_XFIELD, auditUsage);
             builder.field(IP_FILTER_XFIELD, ipFilterUsage);
             builder.field(ANONYMOUS_XFIELD, anonymousUsage);
+            builder.field(FIPS_140_XFIELD, fips140Usage);
         } else if (sslUsage.isEmpty() == false) {
             // A trial (or basic) license can have SSL without security.
             // This is because security defaults to disabled on that license, but that dynamic-default does not disable SSL.

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityFeatureSet.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityFeatureSet.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.xpack.core.XPackSettings.API_KEY_SERVICE_ENABLED_SETTING;
+import static org.elasticsearch.xpack.core.XPackSettings.FIPS_MODE_ENABLED;
 import static org.elasticsearch.xpack.core.XPackSettings.HTTP_SSL_ENABLED;
 import static org.elasticsearch.xpack.core.XPackSettings.TOKEN_SERVICE_ENABLED_SETTING;
 import static org.elasticsearch.xpack.core.XPackSettings.TRANSPORT_SSL_ENABLED;
@@ -95,6 +96,7 @@ public class SecurityFeatureSet implements XPackFeatureSet {
         Map<String, Object> auditUsage = auditUsage(settings);
         Map<String, Object> ipFilterUsage = ipFilterUsage(ipFilter);
         Map<String, Object> anonymousUsage = singletonMap("enabled", AnonymousUser.isAnonymousEnabled(settings));
+        Map<String, Object> fips140Usage = fips140Usage(settings);
 
         final AtomicReference<Map<String, Object>> rolesUsageRef = new AtomicReference<>();
         final AtomicReference<Map<String, Object>> roleMappingUsageRef = new AtomicReference<>();
@@ -104,7 +106,7 @@ public class SecurityFeatureSet implements XPackFeatureSet {
             if (countDown.countDown()) {
                 listener.onResponse(new SecurityFeatureSetUsage(available(), enabled(), realmsUsageRef.get(), rolesUsageRef.get(),
                         roleMappingUsageRef.get(), sslUsage, auditUsage, ipFilterUsage, anonymousUsage, tokenServiceUsage,
-                        apiKeyServiceUsage));
+                        apiKeyServiceUsage, fips140Usage));
             }
         };
 
@@ -184,4 +186,7 @@ public class SecurityFeatureSet implements XPackFeatureSet {
         return ipFilter.usageStats();
     }
 
+    static Map<String, Object> fips140Usage(Settings settings) {
+        return singletonMap("enabled", FIPS_MODE_ENABLED.get(settings));
+    }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityFeatureSetTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityFeatureSetTests.java
@@ -149,6 +149,10 @@ public class SecurityFeatureSetTests extends ESTestCase {
         if (anonymousEnabled) {
             settings.put(AnonymousUser.ROLES_SETTING.getKey(), "foo");
         }
+        final boolean fips140Enabled = randomBoolean();
+        if (fips140Enabled) {
+            settings.put("xpack.security.fips_mode.enabled", true);
+        }
 
         SecurityFeatureSet featureSet = new SecurityFeatureSet(settings.build(), licenseState,
                 realms, rolesStore, roleMappingStore, ipFilter);
@@ -216,6 +220,9 @@ public class SecurityFeatureSetTests extends ESTestCase {
 
                 // anonymous
                 assertThat(source.getValue("anonymous.enabled"), is(anonymousEnabled));
+
+                // FIPS 140
+                assertThat(source.getValue("fips_140.enabled"), is(fips140Enabled));
             } else {
                 assertThat(source.getValue("realms"), is(nullValue()));
                 assertThat(source.getValue("ssl"), is(nullValue()));


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add FIPS 140 mode to XPack Usage API (#47278)