### PR TITLE
Un-mute locale depending mapping tests

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/180_locale_dependent_mapping.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/180_locale_dependent_mapping.yml
@@ -1,8 +1,8 @@
 ---
 "Test Index and Search locale dependent mappings / dates":
   - skip:
-      version: "all"
-      reason: "Awaits fix: https://github.com/elastic/elasticsearch/issues/39981(Previously: JDK9 only supports this with a special sysproperty added in 6.2.0.)"
+      version: " - 6.1.99"
+      reason: JDK9 only supports this with a special sysproperty added in 6.2.0
   - do:
       indices.create:
           index: test_index


### PR DESCRIPTION
Reverts 71968c92a2366c66fd6476ea117ce5b524ec646a. The underlying
issue which was related to the bouncycastle security provider
permissions was resolved in
https://github.com/elastic/infra/pull/14995

resolves: https://github.com/elastic/elasticsearch/issues/39981