### PR TITLE
Remove type from Watcher IndexAction

### DIFF
--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/ActionBuilders.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/ActionBuilders.java
@@ -33,14 +33,6 @@ public final class ActionBuilders {
         return EmailAction.builder(email);
     }
 
-    /**
-     * Types are deprecated and should not be used. use {@link #indexAction(String)}
-     */
-    @Deprecated
-    public static IndexAction.Builder indexAction(String index, String type) {
-        return IndexAction.builder(index, type);
-    }
-
     public static IndexAction.Builder indexAction(String index) {
         return IndexAction.builder(index);
     }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/index/ExecutableIndexAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/index/ExecutableIndexAction.java
@@ -17,7 +17,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.watcher.actions.Action;
 import org.elasticsearch.xpack.core.watcher.actions.Action.Result.Status;
@@ -92,7 +91,7 @@ public class ExecutableIndexAction extends ExecutableAction<IndexAction> {
         }
 
         if (ctx.simulateAction(actionId)) {
-            return new IndexAction.Simulated(indexRequest.index(), MapperService.SINGLE_MAPPING_NAME, indexRequest.id(),
+            return new IndexAction.Simulated(indexRequest.index(), indexRequest.id(),
                 action.refreshPolicy, new XContentSource(indexRequest.source(), XContentType.JSON));
         }
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/index/IndexAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/index/IndexAction.java
@@ -5,12 +5,10 @@
  */
 package org.elasticsearch.xpack.watcher.actions.index;
 
-import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -29,7 +27,6 @@ public class IndexAction implements Action {
 
     public static final String TYPE = "index";
 
-    @Nullable @Deprecated final String docType;
     @Nullable final String index;
     @Nullable final String docId;
     @Nullable final String executionTimeField;
@@ -37,23 +34,10 @@ public class IndexAction implements Action {
     @Nullable final ZoneId dynamicNameTimeZone;
     @Nullable final RefreshPolicy refreshPolicy;
 
-    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(IndexAction.class));
-    public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Specifying types in a watcher index action is deprecated.";
-
     public IndexAction(@Nullable String index, @Nullable String docId,
                        @Nullable String executionTimeField,
                        @Nullable TimeValue timeout, @Nullable ZoneId dynamicNameTimeZone, @Nullable RefreshPolicy refreshPolicy) {
-        this(index, null, docId, executionTimeField, timeout, dynamicNameTimeZone, refreshPolicy);
-    }
-    /**
-     * Document types are deprecated, use constructor without docType
-     */
-    @Deprecated
-    public IndexAction(@Nullable String index, @Nullable String docType, @Nullable String docId,
-                       @Nullable String executionTimeField,
-                       @Nullable TimeValue timeout, @Nullable ZoneId dynamicNameTimeZone, @Nullable RefreshPolicy refreshPolicy) {
         this.index = index;
-        this.docType = docType;
         this.docId = docId;
         this.executionTimeField = executionTimeField;
         this.timeout = timeout;
@@ -68,10 +52,6 @@ public class IndexAction implements Action {
 
     public String getIndex() {
         return index;
-    }
-
-    public String getDocType() {
-        return docType;
     }
 
     public String getDocId() {
@@ -97,7 +77,7 @@ public class IndexAction implements Action {
 
         IndexAction that = (IndexAction) o;
 
-        return Objects.equals(index, that.index) && Objects.equals(docType, that.docType) && Objects.equals(docId, that.docId)
+        return Objects.equals(index, that.index) && Objects.equals(docId, that.docId)
                 && Objects.equals(executionTimeField, that.executionTimeField)
                 && Objects.equals(timeout, that.timeout)
                 && Objects.equals(dynamicNameTimeZone, that.dynamicNameTimeZone)
@@ -106,7 +86,7 @@ public class IndexAction implements Action {
 
     @Override
     public int hashCode() {
-        return Objects.hash(index, docType, docId, executionTimeField, timeout, dynamicNameTimeZone, refreshPolicy);
+        return Objects.hash(index, docId, executionTimeField, timeout, dynamicNameTimeZone, refreshPolicy);
     }
 
     @Override
@@ -114,9 +94,6 @@ public class IndexAction implements Action {
         builder.startObject();
         if (index != null) {
             builder.field(Field.INDEX.getPreferredName(), index);
-        }
-        if (docType != null) {
-            builder.field(Field.DOC_TYPE.getPreferredName(), docType);
         }
         if (docId != null) {
             builder.field(Field.DOC_ID.getPreferredName(), docId);
@@ -138,7 +115,6 @@ public class IndexAction implements Action {
 
     public static IndexAction parse(String watchId, String actionId, XContentParser parser) throws IOException {
         String index = null;
-        String docType = null;
         String docId = null;
         String executionTimeField = null;
         TimeValue timeout = null;
@@ -165,10 +141,7 @@ public class IndexAction implements Action {
                             watchId, actionId, currentFieldName);
                 }
             } else if (token == XContentParser.Token.VALUE_STRING) {
-                if (Field.DOC_TYPE.match(currentFieldName, parser.getDeprecationHandler())) {
-                    deprecationLogger.deprecatedAndMaybeLog("watcher_index_action", TYPES_DEPRECATION_MESSAGE);
-                    docType = parser.text();
-                } else if (Field.DOC_ID.match(currentFieldName, parser.getDeprecationHandler())) {
+                if (Field.DOC_ID.match(currentFieldName, parser.getDeprecationHandler())) {
                     docId = parser.text();
                 } else if (Field.EXECUTION_TIME_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     executionTimeField = parser.text();
@@ -194,15 +167,7 @@ public class IndexAction implements Action {
             }
         }
 
-        return new IndexAction(index, docType, docId, executionTimeField, timeout, dynamicNameTimeZone, refreshPolicy);
-    }
-
-    /**
-     * Document types are deprecated, use {@link #builder(java.lang.String)}
-     */
-    @Deprecated
-    public static Builder builder(String index, String docType) {
-        return new Builder(index, docType);
+        return new IndexAction(index, docId, executionTimeField, timeout, dynamicNameTimeZone, refreshPolicy);
     }
 
     public static Builder builder(String index) {
@@ -233,16 +198,14 @@ public class IndexAction implements Action {
     static class Simulated extends Action.Result {
 
         private final String index;
-        private final String docType;
         @Nullable private final String docId;
         @Nullable private final RefreshPolicy refreshPolicy;
         private final XContentSource source;
 
-        protected Simulated(String index, String docType, @Nullable String docId, @Nullable RefreshPolicy refreshPolicy,
+        protected Simulated(String index, @Nullable String docId, @Nullable RefreshPolicy refreshPolicy,
                             XContentSource source) {
             super(TYPE, Status.SIMULATED);
             this.index = index;
-            this.docType = docType;
             this.docId = docId;
             this.source = source;
             this.refreshPolicy = refreshPolicy;
@@ -250,10 +213,6 @@ public class IndexAction implements Action {
 
         public String index() {
             return index;
-        }
-
-        public String docType() {
-            return docType;
         }
 
         public String docId() {
@@ -268,8 +227,7 @@ public class IndexAction implements Action {
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject(type)
                        .startObject(Field.REQUEST.getPreferredName())
-                            .field(Field.INDEX.getPreferredName(), index)
-                            .field(Field.DOC_TYPE.getPreferredName(), docType);
+                            .field(Field.INDEX.getPreferredName(), index);
 
             if (docId != null) {
                 builder.field(Field.DOC_ID.getPreferredName(), docId);
@@ -288,25 +246,14 @@ public class IndexAction implements Action {
     public static class Builder implements Action.Builder<IndexAction> {
 
         final String index;
-        final String docType;
         String docId;
         String executionTimeField;
         TimeValue timeout;
         ZoneId dynamicNameTimeZone;
         RefreshPolicy refreshPolicy;
 
-        /**
-         * Document types are deprecated and should not be used. Use: {@link Builder#Builder(java.lang.String)}
-         */
-        @Deprecated
-        private Builder(String index, String docType) {
-            this.index = index;
-            this.docType = docType;
-        }
-
         private Builder(String index) {
             this.index = index;
-            this.docType = null;
         }
 
         public Builder setDocId(String docId) {
@@ -336,13 +283,12 @@ public class IndexAction implements Action {
 
         @Override
         public IndexAction build() {
-            return new IndexAction(index, docType, docId, executionTimeField, timeout, dynamicNameTimeZone, refreshPolicy);
+            return new IndexAction(index, docId, executionTimeField, timeout, dynamicNameTimeZone, refreshPolicy);
         }
     }
 
     interface Field {
         ParseField INDEX = new ParseField("index");
-        ParseField DOC_TYPE = new ParseField("doc_type");
         ParseField DOC_ID = new ParseField("doc_id");
         ParseField EXECUTION_TIME_FIELD = new ParseField("execution_time_field");
         ParseField SOURCE = new ParseField("source");

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherConcreteIndexTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherConcreteIndexTests.java
@@ -38,7 +38,7 @@ public class WatcherConcreteIndexTests extends AbstractWatcherIntegrationTestCas
             .trigger(schedule(interval("3s")))
             .input(noneInput())
             .condition(InternalAlwaysCondition.INSTANCE)
-            .addAction("indexer", indexAction(watchResultsIndex, "_doc")))
+            .addAction("indexer", indexAction(watchResultsIndex)))
             .get();
 
         assertTrue(putWatchResponse.isCreated());

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/ActionErrorIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/ActionErrorIntegrationTests.java
@@ -40,7 +40,7 @@ public class ActionErrorIntegrationTests extends AbstractWatcherIntegrationTestC
                         // adding an action that throws an error and is associated with a 60 minute throttle period
                         // with such a period, on successful execution we other executions of the watch will be
                         // throttled within the hour... but on failed execution there should be no throttling
-                .addAction("_action", TimeValue.timeValueMinutes(60), IndexAction.builder("foo", "bar")))
+                .addAction("_action", TimeValue.timeValueMinutes(60), IndexAction.builder("foo")))
                 .get();
 
         assertThat(putWatchResponse.isCreated(), is(true));

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/throttler/ActionThrottleTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/throttler/ActionThrottleTests.java
@@ -394,7 +394,7 @@ public class ActionThrottleTests extends AbstractWatcherIntegrationTestCase {
         INDEX {
             @Override
             public Action.Builder<IndexAction> action() throws Exception {
-                return IndexAction.builder("test_index", "test_type");
+                return IndexAction.builder("test_index");
             }
 
             @Override

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/execution/ExecuteWatchQueuedStatsTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/execution/ExecuteWatchQueuedStatsTests.java
@@ -69,7 +69,7 @@ public class ExecuteWatchQueuedStatsTests extends AbstractWatcherIntegrationTest
                                 .addAction(
                                         "action",
                                         TimeValue.timeValueSeconds(1),
-                                        IndexAction.builder("test_index", "acknowledgement").setDocId("id")))
+                                        IndexAction.builder("test_index").setDocId("id")))
                 .get();
 
         final int numberOfIterations = 128 - scaledRandomIntBetween(0, 128);

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transform/TransformIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transform/TransformIntegrationTests.java
@@ -170,7 +170,7 @@ public class TransformIntegrationTests extends AbstractWatcherIntegrationTestCas
                                 .trigger(schedule(interval("5s")))
                                 .input(searchInput(inputRequest))
                                 .transform(searchTransform(transformRequest))
-                                .addAction("_id", indexAction("output1", "result"))
+                                .addAction("_id", indexAction("output1"))
                 ).get();
         assertThat(putWatchResponse.isCreated(), is(true));
         putWatchResponse = new PutWatchRequestBuilder(client(), "_id2")

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/watch/WatchTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/watch/WatchTests.java
@@ -585,14 +585,14 @@ public class WatchTests extends ESTestCase {
                     randomFrom(DataAttachment.JSON, DataAttachment.YAML), EmailAttachments.EMPTY_ATTACHMENTS);
             list.add(new ActionWrapper("_email_" + randomAlphaOfLength(8), randomThrottler(),
                     AlwaysConditionTests.randomCondition(scriptService), randomTransform(),
-                    new ExecutableEmailAction(action, logger, emailService, templateEngine, htmlSanitizer, 
+                    new ExecutableEmailAction(action, logger, emailService, templateEngine, htmlSanitizer,
                             Collections.emptyMap()), null, null));
         }
         if (randomBoolean()) {
             ZoneOffset timeZone = randomBoolean() ? ZoneOffset.UTC : null;
             TimeValue timeout = randomBoolean() ? timeValueSeconds(between(1, 10000)) : null;
             WriteRequest.RefreshPolicy refreshPolicy = randomBoolean() ? null : randomFrom(WriteRequest.RefreshPolicy.values());
-            IndexAction action = new IndexAction("_index", null, randomBoolean() ? "123" : null, null, timeout, timeZone,
+            IndexAction action = new IndexAction("_index", randomBoolean() ? "123" : null, null, timeout, timeZone,
                     refreshPolicy);
             list.add(new ActionWrapper("_index_" + randomAlphaOfLength(8), randomThrottler(),
                     AlwaysConditionTests.randomCondition(scriptService),  randomTransform(),


### PR DESCRIPTION
Type information is ignored at index time, so is no longer required in Watcher.  This
commit removes the deprecated IndexAction constructors and builders that take types.

Relates to #41059