### PR TITLE
[Transform] wait for deprecated index shards to get active

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutor.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutor.java
@@ -109,7 +109,8 @@ public class TransformPersistentTasksExecutor extends PersistentTasksExecutor<Tr
         IndexNameExpressionResolver resolver = new IndexNameExpressionResolver();
         String[] indices = resolver.concreteIndexNames(clusterState,
             IndicesOptions.lenientExpandOpen(),
-            TransformInternalIndexConstants.INDEX_NAME_PATTERN);
+            TransformInternalIndexConstants.INDEX_NAME_PATTERN,
+            TransformInternalIndexConstants.INDEX_NAME_PATTERN_DEPRECATED);
         List<String> unavailableIndices = new ArrayList<>(indices.length);
         for (String index : indices) {
             IndexRoutingTable routingTable = clusterState.getRoutingTable().index(index);


### PR DESCRIPTION
wait for deprecated index shards to get active

relates #47943

non-issue: this is due to the yet unreleased rename of transform