### PR TITLE
Use `/api/security/saml/callback` as Kibana ACS URL.

### DIFF
--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -906,8 +906,8 @@ URI. We recommend that you use the base URL of your Kibana instance. For example
 
 `sp.acs`::
 The URL of the Assertion Consumer Service within {kib}. Typically this is the 
-"api/security/v1/saml" endpoint of your Kibana server. For example, 
-`https://kibana.example.com/api/security/v1/saml`. 
+"api/security/saml/callback" endpoint of your Kibana server. For example,
+`https://kibana.example.com/api/security/saml/callback`.
 
 `sp.logout`::
 The URL of the Single Logout service within {kib}. Typically this is the 

--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -57,7 +57,7 @@ testClusters.integTest {
     setting 'xpack.security.authc.realms.saml.saml1.idp.entity_id', 'https://my-idp.org'
     setting 'xpack.security.authc.realms.saml.saml1.idp.metadata.path', 'idp-docs-metadata.xml'
     setting 'xpack.security.authc.realms.saml.saml1.sp.entity_id', 'https://kibana.org'
-    setting 'xpack.security.authc.realms.saml.saml1.sp.acs', 'https://kibana.org/api/security/v1/saml'
+    setting 'xpack.security.authc.realms.saml.saml1.sp.acs', 'https://kibana.org/api/security/saml/callback'
     setting 'xpack.security.authc.realms.saml.saml1.attributes.principal', 'uid'
     setting 'xpack.security.authc.realms.saml.saml1.attributes.name', 'urn:oid:2.5.4.3'
     user username: 'test_admin'

--- a/x-pack/docs/en/rest-api/security/saml-prepare-authentication-api.asciidoc
+++ b/x-pack/docs/en/rest-api/security/saml-prepare-authentication-api.asciidoc
@@ -75,13 +75,13 @@ POST /_security/saml/prepare
 --------------------------------------------------
 
 The following example generates a SAML authentication request for the SAML realm with an Assertion
-Consuming Service URL matching `https://kibana.org/api/security/v1/saml
+Consuming Service URL matching `https://kibana.org/api/security/saml/callback
 
 [source,console]
 --------------------------------------------------
 POST /_security/saml/prepare
 {
-  "acs" : "https://kibana.org/api/security/v1/saml"
+  "acs" : "https://kibana.org/api/security/saml/callback"
 }
 --------------------------------------------------
 

--- a/x-pack/docs/en/security/authentication/configuring-saml-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-saml-realm.asciidoc
@@ -90,7 +90,7 @@ xpack.security.authc.realms:
       idp.metadata.path: saml/idp-metadata.xml <4>
       idp.entity_id: "https://sso.example.com/" <5>
       sp.entity_id:  "https://kibana.example.com/" <6>
-      sp.acs: "https://kibana.example.com/api/security/v1/saml" <7>
+      sp.acs: "https://kibana.example.com/api/security/saml/callback" <7>
       sp.logout: "https://kibana.example.com/logout" <8>
 ------------------------------------------------------------
 <1> The realm must be within the `xpack.security.authc.realms.saml` namespace.
@@ -114,7 +114,7 @@ SAML HTTP-POST binding only. It must be a URL that is accessible from the web
 browser of the user who is attempting to login to {kib}; it does not need to be 
 directly accessible by {es} or the IdP. The correct value can vary depending on 
 how you have installed {kib} and whether there are any proxies involved, but it 
-is typically +$\{kibana-url}/api/security/v1/saml+ where _$\{kibana-url}_ is the 
+is typically +$\{kibana-url}/api/security/saml/callback+ where _$\{kibana-url}_ is the
 base URL for your {kib} instance.
 <8> This is the URL within {kib} that accepts logout messages from the IdP.
 Like the `sp.acs` URL, it must be accessible from the web browser, but does

--- a/x-pack/docs/en/security/authentication/saml-guide.asciidoc
+++ b/x-pack/docs/en/security/authentication/saml-guide.asciidoc
@@ -125,7 +125,7 @@ xpack.security.authc.realms.saml.saml1:
   idp.metadata.path: saml/idp-metadata.xml
   idp.entity_id: "https://sso.example.com/"
   sp.entity_id:  "https://kibana.example.com/"
-  sp.acs: "https://kibana.example.com/api/security/v1/saml"
+  sp.acs: "https://kibana.example.com/api/security/saml/callback"
   sp.logout: "https://kibana.example.com/logout"
   attributes.principal: "urn:oid:0.9.2342.19200300.100.1.1"
   attributes.groups: "urn:oid:1.3.6.1.4.1.5923.1.5.1."
@@ -172,7 +172,7 @@ sp.acs::
     or the IdP.
     The correct value may vary depending on how you have installed {kib} and
     whether there are any proxies involved, but it will typically be
-    +$\{kibana-url}/api/security/v1/saml+ where _$\{kibana-url}_ is the base URL for
+    +$\{kibana-url}/api/security/saml/callback+ where _$\{kibana-url}_ is the base URL for
     your {kib} instance.
 
 sp.logout::
@@ -292,7 +292,7 @@ xpack.security.authc.realms.saml.saml1:
   idp.metadata.path: saml/idp-metadata.xml
   idp.entity_id: "https://sso.example.com/"
   sp.entity_id:  "https://kibana.example.com/"
-  sp.acs: "https://kibana.example.com/api/security/v1/saml"
+  sp.acs: "https://kibana.example.com/api/security/saml/callback"
   attributes.principal: "nameid:persistent"
   attributes.groups: "roles"
 ------------------------------------------------------------
@@ -337,7 +337,7 @@ xpack.security.authc.realms.saml.saml1:
   idp.metadata.path: saml/idp-metadata.xml
   idp.entity_id: "https://sso.example.com/"
   sp.entity_id:  "https://kibana.example.com/"
-  sp.acs: "https://kibana.example.com/api/security/v1/saml"
+  sp.acs: "https://kibana.example.com/api/security/saml/callback"
   attributes.principal: "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
   attribute_patterns.principal: "^([^@]+)@staff\\.example\\.com$"
 ------------------------------------------------------------
@@ -744,7 +744,7 @@ The three additional settings that are required for SAML support are shown below
 ------------------------------------------------------------
 xpack.security.authc.providers: [saml]
 xpack.security.authc.saml.realm: saml1
-server.xsrf.whitelist: [/api/security/v1/saml]
+server.xsrf.whitelist: [/api/security/saml/callback]
 ------------------------------------------------------------
 
 The configuration values used in the example above are:
@@ -816,7 +816,7 @@ xpack.security.authc.realms.saml.saml_finance:
   idp.metadata.path: saml/idp-metadata.xml
   idp.entity_id: "https://sso.example.com/"
   sp.entity_id:  "https://kibana.finance.example.com/"
-  sp.acs: "https://kibana.finance.example.com/api/security/v1/saml"
+  sp.acs: "https://kibana.finance.example.com/api/security/saml/callback"
   sp.logout: "https://kibana.finance.example.com/logout"
   attributes.principal: "urn:oid:0.9.2342.19200300.100.1.1"
   attributes.groups: "urn:oid:1.3.6.1.4.1.5923.1.5.1."
@@ -825,7 +825,7 @@ xpack.security.authc.realms.saml.saml_sales:
   idp.metadata.path: saml/idp-metadata.xml
   idp.entity_id: "https://sso.example.com/"
   sp.entity_id:  "https://kibana.sales.example.com/"
-  sp.acs: "https://kibana.sales.example.com/api/security/v1/saml"
+  sp.acs: "https://kibana.sales.example.com/api/security/saml/callback"
   sp.logout: "https://kibana.sales.example.com/logout"
   attributes.principal: "urn:oid:0.9.2342.19200300.100.1.1"
   attributes.groups: "urn:oid:1.3.6.1.4.1.5923.1.5.1."
@@ -834,7 +834,7 @@ xpack.security.authc.realms.saml.saml_eng:
   idp.metadata.path: saml/idp-external.xml
   idp.entity_id: "https://engineering.sso.example.net/"
   sp.entity_id:  "https://kibana.engineering.example.com/"
-  sp.acs: "https://kibana.engineering.example.com/api/security/v1/saml"
+  sp.acs: "https://kibana.engineering.example.com/api/security/saml/callback"
   sp.logout: "https://kibana.engineering.example.com/logout"
   attributes.principal: "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"
 ------------------------------------------------------------

--- a/x-pack/docs/en/security/troubleshooting.asciidoc
+++ b/x-pack/docs/en/security/troubleshooting.asciidoc
@@ -444,7 +444,7 @@ logs:
 
 ....
 Cannot find any matching realm for [SamlPrepareAuthenticationRequest{realmName=saml1,
-assertionConsumerServiceURL=https://my.kibana.url/api/security/v1/saml}]
+assertionConsumerServiceURL=https://my.kibana.url/api/security/saml/callback}]
 ....
 
 *Resolution:*


### PR DESCRIPTION
In https://github.com/elastic/kibana/pull/47929 Kibana dropped `/api/security/v1/saml` (deprecated since 7.5) route in favor of `/api/security/saml/callback` (in 8.0+). In this PR I'm just updating all references to already deprecated `/api/security/v1/saml` Kibana ACS URL.