### PR TITLE
[DOCS] Expand `updated` response parm in reindex API docs

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -524,7 +524,7 @@ reindex timed out.
 `updated`::
 +
 --
-(integer) The number of documents that were successfully updated.
+(integer) The number of documents that were successfully updated, i.e., a document with same id already existed prior to reindex updating it.
 
 This number includes:
 

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -522,19 +522,8 @@ reindex timed out.
 (integer) The number of documents that were successfully processed.
 
 `updated`::
-+
---
-(integer) The number of documents that were successfully updated, i.e., a document with same id already existed prior to reindex updating it.
-
-This number includes:
-
-* Documents overwritten during the reindex. This can occur when documents in the
-source and destination indices have the same ID.
-
-* Documents indexed more than once during the reindex. This can occur when {es}
-mistakenly marks a successful attempt to index a document as a failure. In this
-case, {es} indexes the document again, causing a document update.
---
+(integer) The number of documents that were successfully updated,
+i.e. a document with same ID already existed prior to reindex updating it.
 
 `created`::
 

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -522,8 +522,19 @@ reindex timed out.
 (integer) The number of documents that were successfully processed.
 
 `updated`::
-
++
+--
 (integer) The number of documents that were successfully updated.
+
+This number includes:
+
+* Documents overwritten during the reindex. This can occur when documents in the
+source and destination indices have the same ID.
+
+* Documents indexed more than once during the reindex. This can occur when {es}
+mistakenly marks a successful attempt to index a document as a failure. In this
+case, {es} indexes the document again, causing a document update.
+--
 
 `created`::
 


### PR DESCRIPTION
The reindex API documentation's current `updated` response parameter definition doesn't explain what is happening when documents show as "updated" in a reindex.

This expands the parameter definition to capture the cases in which a document would be counted as `updated`.

Closes #46438.