### PR TITLE
Fix BulkProcessor deadlock when bulk requests fail (#47599)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkProcessor.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkProcessor.java
@@ -204,6 +204,7 @@ public class BulkProcessor implements Closeable {
         Objects.requireNonNull(consumer, "consumer");
         Objects.requireNonNull(listener, "listener");
         final ScheduledThreadPoolExecutor scheduledThreadPoolExecutor = Scheduler.initScheduler(Settings.EMPTY);
+        scheduledThreadPoolExecutor.setCorePoolSize(2);
         return new Builder(consumer, listener,
             buildScheduler(scheduledThreadPoolExecutor),
                 () -> Scheduler.terminate(scheduledThreadPoolExecutor, 10, TimeUnit.SECONDS));

--- a/server/src/test/java/org/elasticsearch/action/bulk/RetryTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/RetryTests.java
@@ -41,7 +41,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 public class RetryTests extends ESTestCase {
-    // no need to wait fof a long time in tests
+    // no need to wait for a long time in tests
     private static final TimeValue DELAY = TimeValue.timeValueMillis(1L);
     private static final int CALLS_TO_FAIL = 5;
 


### PR DESCRIPTION
In #47599 we known that if the BulkProcessor results in failed bulk requests, they will be retried via the RetryHandler. In versions of Elasticsearch prior to 7.3.0 this can result in a deadlock. 

It seems that there is a similar deadlock problem in the Elasticsearch version after 7.3.0.
Different from #46790, here we first execute the `Flush` logic ,then the shared thread pool `Scheduler` cannot execute the retry logic, so the flush logic cannot be ended. Causes the ReentrantLock cannot be obtained by the user thread in `internalAdd` method.