### PR TITLE
[DOCS] Add #46860 to 7.4 release notes

### DIFF
--- a/docs/reference/release-notes/7.4.asciidoc
+++ b/docs/reference/release-notes/7.4.asciidoc
@@ -47,6 +47,7 @@ Geo::
 * Geo: add Geometry-based query builders to QueryBuilders {pull}45058[#45058] (issues: {issue}44715[#44715], {issue}45048[#45048])
 
 Infra/Core::
+* Bundle AdoptOpenJDK 13 {pull}46860[#46860]
 * Add deprecation check for pidfile setting {pull}45939[#45939] (issues: {issue}45938[#45938], {issue}45940[#45940])
 * Deprecate the pidfile setting {pull}45938[#45938]
 * Add node.processors setting in favor of processors {pull}45855[#45855]


### PR DESCRIPTION
Adds PR #46860 to the 7.4 release notes.

#46860 switched Elasticsearch from Oracle OpenJDK 13 to AdoptOpenJDK 13 for bundling the JDK.