### PR TITLE
[DOCS] Expand on default limits in 'limit token count' token filter desc

### DIFF
--- a/docs/reference/analysis/tokenfilters/limit-token-count-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/limit-token-count-tokenfilter.asciidoc
@@ -1,13 +1,19 @@
 [[analysis-limit-token-count-tokenfilter]]
 === Limit Token Count Token Filter
 
-Limits the number of tokens that are indexed per document and field.
+Limits the number of tokens indexed per document field.
+
+By default, <<analysis,analysis>> does not limit tokens indexed to document
+fields. You can use this filter to set a maximum number of tokens per field that
+fits your use case.
+
+
 
 [cols="<,<",options="header",]
 |=======================================================================
 |Setting |Description
 |`max_token_count` |The maximum number of tokens that should be indexed
-per document and field. The default is `1`
+per document field. The default is `1`.
 
 |`consume_all_tokens` |If set to `true` the filter exhaust the stream
 even if `max_token_count` tokens have been consumed already. The default


### PR DESCRIPTION
By default, analysis does not limit the number of tokens indexed per document field. This documents that behavior in the description of the 'limit token count' token filter.

Closes #46011.