### PR TITLE
Create test superuser when launching elasticsearch via 'run' task

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -434,6 +434,7 @@ testClusters {
       setting 'xpack.sql.enabled', 'true'
       setting 'xpack.rollup.enabled', 'true'
       keystore 'bootstrap.password', 'password'
+      user username: 'elastic-admin', password: 'elastic-password', role: 'superuser'
     }
   }
 }


### PR DESCRIPTION
When removing `ClusterFormationTasks` as part of #47572 the creation of the test admin user on the `run` task [here](https://github.com/elastic/elasticsearch/pull/47572/files#diff-aca91c70bd1a1ddea7d98a11bdb2b291L429) looks to have been lost. This PR simply adds that test user back when launching elasticsearch via `./gradlew run` for testing purposes.