### PR TITLE
[DOCS] Reformat apostrophe token filter docs

### DIFF
--- a/docs/reference/analysis/tokenfilters/apostrophe-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/apostrophe-tokenfilter.asciidoc
@@ -70,7 +70,7 @@ The filter produces the following tokens:
 ==== Add to an analyzer
 
 The following <<indices-create-index,create index API>> request adds the
-apostrophe token filter to an analyzer.
+apostrophe token filter to a <<analysis-custom-analyzer,custom analyzer>>.
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/analysis/tokenfilters/apostrophe-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/apostrophe-tokenfilter.asciidoc
@@ -1,5 +1,84 @@
 [[analysis-apostrophe-tokenfilter]]
-=== Apostrophe Token Filter
+=== Apostrophe token filter
+++++
+<titleabbrev>Apostrophe</titleabbrev>
+++++
 
-The `apostrophe` token filter strips all characters after an apostrophe,
-including the apostrophe itself.
+Strips all characters after an apostrophe, including the apostrophe itself.
+
+[[analysis-apostrophe-tokenfilter-analyze-ex]]
+==== Example
+
+The following <<indices-analyze,analyze API>> request demonstrates how the
+apostrophe token filter works.
+
+[source,console]
+--------------------------------------------------
+GET /_analyze
+{
+  "tokenizer" : "standard",
+  "filter" : ["apostrophe"],
+  "text" : "Istanbul'a veya Istanbul'dan"
+}
+--------------------------------------------------
+
+The `apostrophe` token filter produces the following tokens:
+
+[source,text]
+---------------------------
+[ Istanbul, veya, Istanbul ]
+---------------------------
+
+/////////////////////
+[source,console-result]
+--------------------------------------------------
+{
+  "tokens" : [
+    {
+      "token" : "Istanbul",
+      "start_offset" : 0,
+      "end_offset" : 10,
+      "type" : "<ALPHANUM>",
+      "position" : 0
+    },
+    {
+      "token" : "veya",
+      "start_offset" : 11,
+      "end_offset" : 15,
+      "type" : "<ALPHANUM>",
+      "position" : 1
+    },
+    {
+      "token" : "Istanbul",
+      "start_offset" : 16,
+      "end_offset" : 28,
+      "type" : "<ALPHANUM>",
+      "position" : 2
+    }
+  ]
+}
+--------------------------------------------------
+/////////////////////
+
+[[analysis-apostrophe-tokenfilter-analyzer-ex]]
+==== Add to an analyzer
+
+The following <<indices-create-index,create index API>> request adds the
+`apostrophe` token filter to an analyzer.
+
+[source,console]
+--------------------------------------------------
+PUT /apostrophe_example
+{
+    "settings" : {
+        "analysis" : {
+            "analyzer" : {
+                "default" : {
+                    "tokenizer" : "standard",
+                    "filter" : ["apostrophe"]
+                }
+            }
+        }
+    }
+}
+--------------------------------------------------

--- a/docs/reference/analysis/tokenfilters/apostrophe-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/apostrophe-tokenfilter.asciidoc
@@ -31,9 +31,9 @@ GET /_analyze
 The filter produces the following tokens:
 
 [source,text]
----------------------------
+--------------------------------------------------
 [ Istanbul, veya, Istanbul ]
----------------------------
+--------------------------------------------------
 
 /////////////////////
 [source,console-result]

--- a/docs/reference/analysis/tokenfilters/apostrophe-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/apostrophe-tokenfilter.asciidoc
@@ -69,8 +69,9 @@ The filter produces the following tokens:
 [[analysis-apostrophe-tokenfilter-analyzer-ex]]
 ==== Add to an analyzer
 
-The following <<indices-create-index,create index API>> request adds the
-apostrophe token filter to a <<analysis-custom-analyzer,custom analyzer>>.
+The following <<indices-create-index,create index API>> request uses the
+apostrophe token filter to configure a new 
+<<analysis-custom-analyzer,custom analyzer>>.
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/analysis/tokenfilters/apostrophe-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/apostrophe-tokenfilter.asciidoc
@@ -6,6 +6,12 @@
 
 Strips all characters after an apostrophe, including the apostrophe itself.
 
+This filter is included in {es}'s built-in <<turkish-analyzer,Turkish language
+analyzer>>. It uses Lucene's
+https://lucene.apache.org/core/4_8_0/analyzers-common/org/apache/lucene/analysis/tr/ApostropheFilter.html[ApostropheFilter],
+which was built for the Turkish language.
+
+
 [[analysis-apostrophe-tokenfilter-analyze-ex]]
 ==== Example
 
@@ -22,7 +28,7 @@ GET /_analyze
 }
 --------------------------------------------------
 
-The `apostrophe` token filter produces the following tokens:
+The filter produces the following tokens:
 
 [source,text]
 ---------------------------
@@ -64,7 +70,7 @@ The `apostrophe` token filter produces the following tokens:
 ==== Add to an analyzer
 
 The following <<indices-create-index,create index API>> request adds the
-`apostrophe` token filter to an analyzer.
+apostrophe token filter to an analyzer.
 
 [source,console]
 --------------------------------------------------
@@ -73,7 +79,7 @@ PUT /apostrophe_example
     "settings" : {
         "analysis" : {
             "analyzer" : {
-                "default" : {
+                "standard_apostrophe" : {
                     "tokenizer" : "standard",
                     "filter" : ["apostrophe"]
                 }


### PR DESCRIPTION
Reformats the `apostrophe` token filter docs. This PR adds:

* A title abbreviation
* An analyze API example with resulting tokens
* An example adding the token filter to an analyzer

I hope to re-use this format for other token filter docs. All feedback is welcome!