### PR TITLE
SQL: Fix issue with negative literels and parentheses

### DIFF
--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/TestUtils.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/TestUtils.java
@@ -13,16 +13,18 @@ import org.elasticsearch.xpack.sql.session.Configuration;
 import org.elasticsearch.xpack.sql.util.DateUtils;
 
 import java.time.ZoneId;
+import java.util.StringJoiner;
 
 import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
 import static org.elasticsearch.test.ESTestCase.randomBoolean;
 import static org.elasticsearch.test.ESTestCase.randomFrom;
+import static org.elasticsearch.test.ESTestCase.randomInt;
 import static org.elasticsearch.test.ESTestCase.randomIntBetween;
 import static org.elasticsearch.test.ESTestCase.randomNonNegativeLong;
 import static org.elasticsearch.test.ESTestCase.randomZone;
 
 
-public class TestUtils {
+public final class TestUtils {
 
     private TestUtils() {}
 
@@ -58,4 +60,11 @@ public class TestUtils {
                 randomBoolean());
     }
 
+    public static String randomWhitespaces() {
+        StringJoiner sj = new StringJoiner("");
+        for (int i = 0; i < randomInt(10); i++) {
+            sj.add(randomFrom(" ", "\t", "\r", "\n"));
+        }
+        return sj.toString();
+    }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/parser/EscapedFunctionsTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/parser/EscapedFunctionsTests.java
@@ -22,10 +22,10 @@ import org.junit.Assert;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.StringJoiner;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static org.elasticsearch.xpack.sql.TestUtils.randomWhitespaces;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -34,14 +34,6 @@ import static org.hamcrest.Matchers.matchesPattern;
 public class EscapedFunctionsTests extends ESTestCase {
 
     private final SqlParser parser = new SqlParser();
-
-    private String randomWhitespaces() {
-        StringJoiner sj = new StringJoiner("");
-        for (int i = 0; i < randomInt(10); i++) {
-            sj.add(randomFrom(" ", "\t", "\r", "\n"));
-        }
-        return sj.toString();
-    }
 
     private String buildExpression(String escape, String pattern, Object value) {
         return format(Locale.ROOT, "{" + randomWhitespaces() + escape + " " + randomWhitespaces() +

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/parser/ExpressionTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/parser/ExpressionTests.java
@@ -202,10 +202,18 @@ public class ExpressionTests extends ESTestCase {
         Expression expr = parser.createExpression("- 6");
         assertEquals(Literal.class, expr.getClass());
         assertEquals("- 6", expr.sourceText());
+
+        expr = parser.createExpression("- ( 6 )");
+        assertEquals(Literal.class, expr.getClass());
+        assertEquals("- ( 6 )", expr.sourceText());
+
+        expr = parser.createExpression("- ( ( (1.25) )    )");
+        assertEquals(Literal.class, expr.getClass());
+        assertEquals("- ( ( (1.25) )    )", expr.sourceText());
     }
 
     public void testComplexArithmetic() {
-        String sql = "-(((a-2)-(-3))+b)";
+        String sql = "-(((a-2)- (( - ( (  3)  )) )  )+ b)";
         Expression expr = parser.createExpression(sql);
         assertEquals(Neg.class, expr.getClass());
         Neg neg = (Neg) expr;
@@ -213,15 +221,15 @@ public class ExpressionTests extends ESTestCase {
         assertEquals(1, neg.children().size());
         assertEquals(Add.class, neg.children().get(0).getClass());
         Add add = (Add) neg.children().get(0);
-        assertEquals("((a-2)-(-3))+b", add.sourceText());
+        assertEquals("((a-2)- (( - ( (  3)  )) )  )+ b", add.sourceText());
         assertEquals(2, add.children().size());
         assertEquals("?b", add.children().get(1).toString());
         assertEquals(Sub.class, add.children().get(0).getClass());
         Sub sub1 = (Sub) add.children().get(0);
-        assertEquals("(a-2)-(-3)", sub1.sourceText());
+        assertEquals("(a-2)- (( - ( (  3)  )) )", sub1.sourceText());
         assertEquals(2, sub1.children().size());
         assertEquals(Literal.class, sub1.children().get(1).getClass());
-        assertEquals("-3", sub1.children().get(1).sourceText());
+        assertEquals("- ( (  3)  )", sub1.children().get(1).sourceText());
         assertEquals(Sub.class, sub1.children().get(0).getClass());
         Sub sub2 = (Sub) sub1.children().get(0);
         assertEquals(2, sub2.children().size());


### PR DESCRIPTION
Previously, when a numeric literal was enclosed in parentheses and then
negated, the negation was lost and the number was considered positive, e.g.:
`-(5)` was considered as `5` instead of `-5`
`- ( (1.28) )` was considered as `1.28` instead of `-1.28`

Fixes: #48009
