### PR TITLE
[DOCS][Transform] document limitation regarding rolling upgrade with 7.2, 7.3

### DIFF
--- a/docs/reference/transform/limitations.asciidoc
+++ b/docs/reference/transform/limitations.asciidoc
@@ -35,12 +35,12 @@ nodes have been upgraded to the newer version before using the {transforms} UI.
 
 [float]
 [[transform-rolling-upgrade-limitation]]
-==== {transforms-cap} Transforms suspended during a rolling upgrade from 7.2 and 7.3
+==== {transforms-cap} Transforms reassignment suspended during a rolling upgrade from 7.2 and 7.3
 
 If your cluster contains mixed version nodes, for example during a rolling
-upgrade from 7.2, 7.3 to a newer version, transforms are suspended for the time of
-the upgrade. Once the upgrade is done, transforms will resume automatically, there is
-no action required.
+upgrade from 7.2, 7.3 to a newer version, transforms whose nodes are stopped will
+not be reassigned until the upgrade is complete. Once the upgrade is done, transforms
+will resume automatically, there is no action required.
 
 [float]
 [[transform-datatype-limitations]]

--- a/docs/reference/transform/limitations.asciidoc
+++ b/docs/reference/transform/limitations.asciidoc
@@ -33,6 +33,14 @@ upgrade from 7.2 to a newer version, and {transforms} have been created in 7.2,
 the {transforms} UI (earler {dataframe} UI) will not work. Please wait until all 
 nodes have been upgraded to the newer version before using the {transforms} UI.
 
+[float]
+[[transform-rolling-upgrade-limitation]]
+==== {transforms-cap} Transforms suspended during a rolling upgrade from 7.2 and 7.3
+
+If your cluster contains mixed version nodes, for example during a rolling
+upgrade from 7.2, 7.3 to a newer version, transforms are suspended for the time of
+the upgrade. Once the upgrade is done, transforms will resume automatically, there is
+no action required.
 
 [float]
 [[transform-datatype-limitations]]
@@ -181,9 +189,9 @@ for the {transform} checkpoint to complete.
 
 [float]
 [[transform-scheduling-limitations]]
-==== {cdataframe-cap} scheduling limitations
+==== {ctransform-cap} scheduling limitations
 
-A {cdataframe} periodically checks for changes to source data. The functionality 
+A {ctransform} periodically checks for changes to source data. The functionality
 of the scheduler is currently limited to a basic periodic timer which can be 
 within the `frequency` range from 1s to 1h. The default is 1m. This is designed 
 to run little and often. When choosing a `frequency` for this timer consider 
@@ -206,7 +214,7 @@ When using the API to delete a failed {transform}, first stop it using
 
 [float]
 [[transform-availability-limitations]]
-==== {cdataframes-cap} may give incorrect results if documents are not yet available to search
+==== {ctransforms-cap} may give incorrect results if documents are not yet available to search
 
 After a document is indexed, there is a very small delay until it is available 
 to search.

--- a/docs/reference/transform/limitations.asciidoc
+++ b/docs/reference/transform/limitations.asciidoc
@@ -38,7 +38,7 @@ nodes have been upgraded to the newer version before using the {transforms} UI.
 ==== {transforms-cap} reassignment suspended during a rolling upgrade from 7.2 and 7.3
 
 If your cluster contains mixed version nodes, for example during a rolling
-upgrade from 7.2, 7.3 to a newer version, transforms whose nodes are stopped will
+upgrade from 7.2 or 7.3 to a newer version, {transforms} whose nodes are stopped will
 not be reassigned until the upgrade is complete. After the upgrade is done, {transforms}
 resume automatically; no action is required.
 

--- a/docs/reference/transform/limitations.asciidoc
+++ b/docs/reference/transform/limitations.asciidoc
@@ -39,7 +39,7 @@ nodes have been upgraded to the newer version before using the {transforms} UI.
 
 If your cluster contains mixed version nodes, for example during a rolling
 upgrade from 7.2, 7.3 to a newer version, transforms whose nodes are stopped will
-not be reassigned until the upgrade is complete. Once the upgrade is done, transforms
+not be reassigned until the upgrade is complete. After the upgrade is done, {transforms}
 will resume automatically, there is no action required.
 
 [float]

--- a/docs/reference/transform/limitations.asciidoc
+++ b/docs/reference/transform/limitations.asciidoc
@@ -35,7 +35,7 @@ nodes have been upgraded to the newer version before using the {transforms} UI.
 
 [float]
 [[transform-rolling-upgrade-limitation]]
-==== {transforms-cap} Transforms reassignment suspended during a rolling upgrade from 7.2 and 7.3
+==== {transforms-cap} reassignment suspended during a rolling upgrade from 7.2 and 7.3
 
 If your cluster contains mixed version nodes, for example during a rolling
 upgrade from 7.2, 7.3 to a newer version, transforms whose nodes are stopped will

--- a/docs/reference/transform/limitations.asciidoc
+++ b/docs/reference/transform/limitations.asciidoc
@@ -40,7 +40,7 @@ nodes have been upgraded to the newer version before using the {transforms} UI.
 If your cluster contains mixed version nodes, for example during a rolling
 upgrade from 7.2, 7.3 to a newer version, transforms whose nodes are stopped will
 not be reassigned until the upgrade is complete. After the upgrade is done, {transforms}
-will resume automatically, there is no action required.
+resume automatically; no action is required.
 
 [float]
 [[transform-datatype-limitations]]


### PR DESCRIPTION
adds a limitation about rolling upgrade, see #48019

also fixes a problem with renamed preferences

Preview: http://elasticsearch_48118.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/transform-limitations.html