### PR TITLE
Fix executing enrich policies stats

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/ExecuteEnrichPolicyAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/ExecuteEnrichPolicyAction.java
@@ -68,12 +68,6 @@ public class ExecuteEnrichPolicyAction extends ActionType<ExecuteEnrichPolicyAct
             return null;
         }
 
-        // This will be displayed in tasks api and allows stats api to figure out which policies are being executed.
-        @Override
-        public String getDescription() {
-            return name;
-        }
-
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyExecutor.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyExecutor.java
@@ -29,6 +29,8 @@ import org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyStatus;
 
 public class EnrichPolicyExecutor {
 
+    public static final String TASK_ACTION = "policy_execution";
+
     private final ClusterService clusterService;
     private final Client client;
     private final TaskManager taskManager;
@@ -165,7 +167,7 @@ public class EnrichPolicyExecutor {
 
     private Task runPolicyTask(final ExecuteEnrichPolicyAction.Request request, EnrichPolicy policy,
                                BiConsumer<Task, ExecuteEnrichPolicyStatus> onResponse, BiConsumer<Task, Exception> onFailure) {
-        Task asyncTask = taskManager.register("enrich", "policy_execution", new TaskAwareRequest() {
+        Task asyncTask = taskManager.register("enrich", TASK_ACTION, new TaskAwareRequest() {
             @Override
             public void setParentTask(TaskId taskId) {
                 request.setParentTask(taskId);

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportEnrichStatsAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportEnrichStatsAction.java
@@ -23,7 +23,7 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.enrich.action.EnrichStatsAction;
 import org.elasticsearch.xpack.core.enrich.action.EnrichStatsAction.Response.CoordinatorStats;
 import org.elasticsearch.xpack.core.enrich.action.EnrichStatsAction.Response.ExecutingPolicy;
-import org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyAction;
+import org.elasticsearch.xpack.enrich.EnrichPolicyExecutor;
 
 import java.io.IOException;
 import java.util.Comparator;
@@ -80,7 +80,7 @@ public class TransportEnrichStatsAction extends TransportMasterNodeAction<Enrich
                     .sorted(Comparator.comparing(CoordinatorStats::getNodeId))
                     .collect(Collectors.toList());
                 List<ExecutingPolicy> policyExecutionTasks = taskManager.getTasks().values().stream()
-                    .filter(t -> t.getAction().equals(ExecuteEnrichPolicyAction.NAME))
+                    .filter(t -> t.getAction().equals(EnrichPolicyExecutor.TASK_ACTION))
                     .map(t -> t.taskInfo(clusterService.localNode().getId(), true))
                     .map(t -> new ExecutingPolicy(t.getDescription(), t))
                     .sorted(Comparator.comparing(ExecutingPolicy::getName))


### PR DESCRIPTION
The enrich stats api picked the wrong task to be displayed
in the executing stats section.

In case `wait_for_completion` was set to `false` then no task
was being displayed and if that param was set to `true` then
the wrong task was being displayed (transport action task instead
of enrich policy executor task).