### PR TITLE
[DOCS] Reformat ASCII folding token filter docs

### DIFF
--- a/docs/reference/analysis/tokenfilters/apostrophe-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/apostrophe-tokenfilter.asciidoc
@@ -8,7 +8,7 @@ Strips all characters after an apostrophe, including the apostrophe itself.
 
 This filter is included in {es}'s built-in <<turkish-analyzer,Turkish language
 analyzer>>. It uses Lucene's
-https://lucene.apache.org/core/4_8_0/analyzers-common/org/apache/lucene/analysis/tr/ApostropheFilter.html[ApostropheFilter],
+https://lucene.apache.org/core/{lucene_version_path}/analyzers-common/org/apache/lucene/analysis/tr/ApostropheFilter.html[ApostropheFilter],
 which was built for the Turkish language.
 
 

--- a/docs/reference/analysis/tokenfilters/asciifolding-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/asciifolding-tokenfilter.asciidoc
@@ -5,7 +5,7 @@
 ++++
 
 Converts alphabetic, numeric, and symbolic Unicode characters which are not in
-the first 127 ASCII characters (the "Basic Latin" Unicode block) into their
+the first 127 ASCII characters (the Basic Latin Unicode block) into their
 ASCII equivalents, if one exists. For example, the filter changes `à` to `a`.
 
 This filter uses Lucene's
@@ -14,8 +14,8 @@ https://lucene.apache.org/core/{lucene_version_path}/analyzers-common/org/apache
 [[analysis-asciifolding-tokenfilter-analyze-ex]]
 ==== Example
 
-The following <<indices-analyze,analyze API>> request demonstrates how the
-ASCII folding token filter works.
+The following <<indices-analyze,analyze API>> request uses the asciifolding
+filter to drop the diacritical marks in `açaí à la carte`:
 
 [source,console]
 --------------------------------------------------
@@ -76,7 +76,7 @@ The filter produces the following tokens:
 ==== Add to an analyzer
 
 The following <<indices-create-index,create index API>> request uses the
-ASCII folding token filter to configure a new 
+`asciifolding` filter to configure a new 
 <<analysis-custom-analyzer,custom analyzer>>.
 
 [source,console]
@@ -101,15 +101,18 @@ PUT /asciifold_example
 
 `preserve_original`::
 (Optional, boolean)
-If `true`, keep the original tokens and emit folded tokens.
+If `true`, emit both original tokens and folded tokens.
 Defaults to `false`.
 
 [[analysis-asciifolding-tokenfilter-customize]]
 ==== Customize
 
-To customize the ASCII folding token filter, duplicate it to create the basis
+To customize the `asciifolding` filter, duplicate it to create the basis
 for a new custom token filter. You can modify the filter using its configurable
 parameters.
+
+For example, the following request creates a custom `asciifolding` filter with
+`preserve_original` set to true:
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/analysis/tokenfilters/asciifolding-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/asciifolding-tokenfilter.asciidoc
@@ -14,7 +14,7 @@ https://lucene.apache.org/core/{lucene_version_path}/analyzers-common/org/apache
 [[analysis-asciifolding-tokenfilter-analyze-ex]]
 ==== Example
 
-The following <<indices-analyze,analyze API>> request uses the asciifolding
+The following <<indices-analyze,analyze API>> request uses the `asciifolding`
 filter to drop the diacritical marks in `açaí à la carte`:
 
 [source,console]

--- a/docs/reference/analysis/tokenfilters/asciifolding-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/asciifolding-tokenfilter.asciidoc
@@ -109,7 +109,7 @@ Defaults to `false`.
 ==== Customize
 
 To customize the ASCII folding token filter, duplicate it to create the basis
-for a new custom token filter. You can modify the filter using its configure
+for a new custom token filter. You can modify the filter using its configurable
 parameters.
 
 [source,console]

--- a/docs/reference/analysis/tokenfilters/asciifolding-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/asciifolding-tokenfilter.asciidoc
@@ -1,10 +1,84 @@
 [[analysis-asciifolding-tokenfilter]]
-=== ASCII Folding Token Filter
+=== ASCII folding token filter
+++++
+<titleabbrev>ASCII folding</titleabbrev>
+++++
 
-A token filter of type `asciifolding` that converts alphabetic, numeric,
-and symbolic Unicode characters which are not in the first 127 ASCII
-characters (the "Basic Latin" Unicode block) into their ASCII
-equivalents, if one exists.  Example:
+Converts alphabetic, numeric, and symbolic Unicode characters which are not in
+the first 127 ASCII characters (the "Basic Latin" Unicode block) into their
+ASCII equivalents, if one exists. For example, the filter changes `à` to `a`.
+
+This filter uses Lucene's
+https://lucene.apache.org/core/{lucene_version_path}/analyzers-common/org/apache/lucene/analysis/miscellaneous/ASCIIFoldingFilter.html[ASCIIFoldingFilter].
+
+
+[[analysis-asciifolding-tokenfilter-analyze-ex]]
+==== Example
+
+The following <<indices-analyze,analyze API>> request demonstrates how the
+ASCII folding token filter works.
+
+[source,console]
+--------------------------------------------------
+GET /_analyze
+{
+  "tokenizer" : "standard",
+  "filter" : ["asciifolding"],
+  "text" : "açaí à la carte"
+}
+--------------------------------------------------
+
+The filter produces the following tokens:
+
+[source,text]
+--------------------------------------------------
+[ acai, a, la, carte ]
+--------------------------------------------------
+
+/////////////////////
+[source,console-result]
+--------------------------------------------------
+{
+  "tokens" : [
+    {
+      "token" : "acai",
+      "start_offset" : 0,
+      "end_offset" : 4,
+      "type" : "<ALPHANUM>",
+      "position" : 0
+    },
+    {
+      "token" : "a",
+      "start_offset" : 5,
+      "end_offset" : 6,
+      "type" : "<ALPHANUM>",
+      "position" : 1
+    },
+    {
+      "token" : "la",
+      "start_offset" : 7,
+      "end_offset" : 9,
+      "type" : "<ALPHANUM>",
+      "position" : 2
+    },
+    {
+      "token" : "carte",
+      "start_offset" : 10,
+      "end_offset" : 15,
+      "type" : "<ALPHANUM>",
+      "position" : 3
+    }
+  ]
+}
+--------------------------------------------------
+/////////////////////
+
+[[analysis-asciifolding-tokenfilter-analyzer-ex]]
+==== Add to an analyzer
+
+The following <<indices-create-index,create index API>> request uses the
+ASCII folding token filter to configure a new 
+<<analysis-custom-analyzer,custom analyzer>>.
 
 [source,console]
 --------------------------------------------------
@@ -13,7 +87,7 @@ PUT /asciifold_example
     "settings" : {
         "analysis" : {
             "analyzer" : {
-                "default" : {
+                "standard_asciifolding" : {
                     "tokenizer" : "standard",
                     "filter" : ["asciifolding"]
                 }
@@ -23,9 +97,20 @@ PUT /asciifold_example
 }
 --------------------------------------------------
 
-Accepts `preserve_original` setting which defaults to false but if true
-will keep the original token as well as emit the folded token.  For
-example:
+[[analysis-asciifolding-tokenfilter-configure-parms]]
+==== Configurable parameters
+
+`preserve_original`::
+(Optional, boolean)
+If `true`, keep the original tokens and emit folded tokens.
+Defaults to `false`.
+
+[[analysis-asciifolding-tokenfilter-customize]]
+==== Customize
+
+To customize the ASCII folding token filter, duplicate it to create the basis
+for a new custom token filter. You can modify the filter using its configure
+parameters.
 
 [source,console]
 --------------------------------------------------
@@ -34,7 +119,7 @@ PUT /asciifold_example
     "settings" : {
         "analysis" : {
             "analyzer" : {
-                "default" : {
+                "standard_asciifolding" : {
                     "tokenizer" : "standard",
                     "filter" : ["my_ascii_folding"]
                 }

--- a/docs/reference/analysis/tokenfilters/asciifolding-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/asciifolding-tokenfilter.asciidoc
@@ -11,7 +11,6 @@ ASCII equivalents, if one exists. For example, the filter changes `à` to `a`.
 This filter uses Lucene's
 https://lucene.apache.org/core/{lucene_version_path}/analyzers-common/org/apache/lucene/analysis/miscellaneous/ASCIIFoldingFilter.html[ASCIIFoldingFilter].
 
-
 [[analysis-asciifolding-tokenfilter-analyze-ex]]
 ==== Example
 

--- a/docs/reference/analysis/tokenfilters/asciifolding-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/asciifolding-tokenfilter.asciidoc
@@ -4,9 +4,9 @@
 <titleabbrev>ASCII folding</titleabbrev>
 ++++
 
-Converts alphabetic, numeric, and symbolic Unicode characters which are not in
-the first 127 ASCII characters (the Basic Latin Unicode block) into their
-ASCII equivalents, if one exists. For example, the filter changes `à` to `a`.
+Converts alphabetic, numeric, and symbolic characters that are not in the Basic
+Latin Unicode block (first 127 ASCII characters) to their ASCII equivalent, if
+one exists. For example, the filter changes `à` to `a`.
 
 This filter uses Lucene's
 https://lucene.apache.org/core/{lucene_version_path}/analyzers-common/org/apache/lucene/analysis/miscellaneous/ASCIIFoldingFilter.html[ASCIIFoldingFilter].


### PR DESCRIPTION
Reformats the ASCII folding token filter docs:

* Adds a title abbreviation
* Updates the description with a short example and Lucene link
* Adds an analyze API example with resulting tokens
* Updates the example adding the token filter to an analyzer
* Updates the parameter docs and custom token filter example
* Updates the Lucene link in the apostrophe token filter docs

The `configurable parameters` and `customize` sections build on the template in the existing [simple analyzer](https://www.elastic.co/guide/en/elasticsearch/reference/master/analysis-simple-analyzer.html)  and [apostrophe token filter](https://www.elastic.co/guide/en/elasticsearch/reference/master/analysis-apostrophe-tokenfilter.html) docs.

I hope to re-use this format for other token filter docs. All feedback is welcome!