### PR TITLE
Fix refresh optimization for realtime get in mixed cluster

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -455,9 +455,15 @@ public class RecoveryIT extends AbstractRollingTestCase {
                 updates.put(docId, value);
             }
         }
-        client().performRequest(new Request("POST", index + "/_refresh"));
+        boolean refreshed = randomBoolean();
+        if (refreshed) {
+            client().performRequest(new Request("POST", index + "/_refresh"));
+        }
         for (int docId : updates.keySet()) {
             Request get = new Request("GET", index + "/test/" + docId);
+            if (refreshed && randomBoolean()) {
+                get.addParameter("realtime", "false");
+            }
             Map<String, Object> doc = entityAsMap(client().performRequest(get));
             assertThat(XContentMapValues.extractValue("_source.updated_field", doc), equalTo(updates.get(docId)));
         }

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -675,8 +675,12 @@ public class InternalEngine extends Engine {
                             trackTranslogLocation.set(true);
                         }
                     }
-                    assert versionValue.seqNo >= 0 : versionValue;
-                    refreshIfNeeded("realtime_get", versionValue.seqNo);
+                    if (versionValue.seqNo != SequenceNumbers.UNASSIGNED_SEQ_NO) {
+                        assert versionValue.seqNo >= 0 : versionValue;
+                        refreshIfNeeded("realtime_get", versionValue.seqNo);
+                    } else {
+                        refresh("realtime_get", SearcherScope.INTERNAL);
+                    }
                 }
                 scope = SearcherScope.INTERNAL;
             } else {


### PR DESCRIPTION
We might not have sequence numbers in a mixed cluster between 6.8 and 5.6. In this case, we should refresh unconditionally; otherwise, we can apply the refresh optimization. An alternative is to use translog locations instead of the local checkpoint for this optimization. 

Closes #48114