### PR TITLE
[DOCS] Note clause limit in `index.mapping.total_fields.limit` docs

### DIFF
--- a/docs/reference/mapping.asciidoc
+++ b/docs/reference/mapping.asciidoc
@@ -80,6 +80,13 @@ causing a mapping explosion:
 `index.mapping.total_fields.limit`::
     The maximum number of fields in an index. Field and object mappings, as well as
     field aliases count towards this limit. The default value is `1000`.
++
+[IMPORTANT]
+====
+If you increase this setting, we recommend you also increase the
+<<search-settings,`indices.query.bool.max_clause_count`>> setting, which
+limits the maximum number of <<query-dsl-bool-query,boolean clauses>> in a query.
+====
 
 `index.mapping.depth.limit`::
     The maximum depth for a field, which is measured as the number of inner
@@ -93,13 +100,6 @@ causing a mapping explosion:
 `index.mapping.nested_objects.limit`::
     The maximum number of `nested` JSON objects within a single document across
     all nested types, defaults to 10000.
-+
-[IMPORTANT]
-====
-If you increase this setting, we recommend you also increase the
-<<search-settings,`indices.query.bool.max_clause_count`>> setting, which
-limits the maximum number of <<query-dsl-bool-query,boolean clauses>> in a query.
-====
 
 `index.mapping.field_name_length.limit`::
     Setting for the maximum length of a field name. The default value is

--- a/docs/reference/mapping.asciidoc
+++ b/docs/reference/mapping.asciidoc
@@ -93,6 +93,13 @@ causing a mapping explosion:
 `index.mapping.nested_objects.limit`::
     The maximum number of `nested` JSON objects within a single document across
     all nested types, defaults to 10000.
++
+[IMPORTANT]
+====
+If you increase this setting, we recommend you also increase the
+<<search-settings,`indices.query.bool.max_clause_count`>> setting, which
+limits the maximum number of <<query-dsl-bool-query,boolean clauses>> in a query.
+====
 
 `index.mapping.field_name_length.limit`::
     Setting for the maximum length of a field name. The default value is

--- a/docs/reference/mapping.asciidoc
+++ b/docs/reference/mapping.asciidoc
@@ -83,6 +83,10 @@ causing a mapping explosion:
 +
 [IMPORTANT]
 ====
+The limit is in place to prevent mappings and searches from becoming too
+large. Higher values can lead to performance degradations and memory issues,
+especially in clusters with a high load or few resources.
+
 If you increase this setting, we recommend you also increase the
 <<search-settings,`indices.query.bool.max_clause_count`>> setting, which
 limits the maximum number of <<query-dsl-bool-query,boolean clauses>> in a query.


### PR DESCRIPTION
Notes that you should increase the `indices.query.bool.max_clause_count`setting if you increase the `index.mapping.nested_objects.limit` setting.

Closes #46928.