### PR TITLE
Backport: Include enrich into the info api as feature

### DIFF
--- a/docs/reference/rest-api/info.asciidoc
+++ b/docs/reference/rest-api/info.asciidoc
@@ -71,6 +71,10 @@ Example response:
           "available" : true,
           "enabled" : true
       },
+      "enrich" : {
+          "available" : true,
+          "enabled" : true
+      },
       "flattened" : {
          "available" : true,
          "enabled" : true

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
@@ -43,6 +43,7 @@ import org.elasticsearch.xpack.core.ccr.AutoFollowMetadata;
 import org.elasticsearch.xpack.core.ccr.CCRFeatureSet;
 import org.elasticsearch.xpack.core.analytics.AnalyticsFeatureSetUsage;
 import org.elasticsearch.xpack.core.deprecation.DeprecationInfoAction;
+import org.elasticsearch.xpack.core.enrich.EnrichFeatureSet;
 import org.elasticsearch.xpack.core.enrich.action.DeleteEnrichPolicyAction;
 import org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyAction;
 import org.elasticsearch.xpack.core.enrich.action.GetEnrichPolicyAction;
@@ -580,7 +581,9 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
                 // Spatial
                 new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.SPATIAL, SpatialFeatureSetUsage::new),
                 // analytics
-                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.ANALYTICS, AnalyticsFeatureSetUsage::new)
+                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.ANALYTICS, AnalyticsFeatureSetUsage::new),
+                // Enrich
+                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.ENRICH, EnrichFeatureSet.Usage::new)
         );
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackField.java
@@ -49,6 +49,8 @@ public final class XPackField {
     public static final String SPATIAL = "spatial";
     /** Name constant for the analytics plugin. */
     public static final String ANALYTICS = "analytics";
+    /** Name constant for the enrich plugin. */
+    public static final String ENRICH = "enrich";
 
     private XPackField() {}
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichFeatureSet.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichFeatureSet.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.enrich;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.xpack.core.XPackFeatureSet;
+import org.elasticsearch.xpack.core.XPackField;
+import org.elasticsearch.xpack.core.XPackSettings;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class EnrichFeatureSet implements XPackFeatureSet {
+
+    private final boolean enabled;
+    private final XPackLicenseState licenseState;
+
+    @Inject
+    public EnrichFeatureSet(Settings settings, @Nullable XPackLicenseState licenseState) {
+        this.enabled = XPackSettings.ENRICH_ENABLED_SETTING.get(settings);
+        this.licenseState = licenseState;
+    }
+
+    @Override
+    public String name() {
+        return XPackField.ENRICH;
+    }
+
+    @Override
+    public boolean available() {
+        return licenseState.isEnrichAllowed();
+    }
+
+    @Override
+    public boolean enabled() {
+        return enabled;
+    }
+
+    @Override
+    public Map<String, Object> nativeCodeInfo() {
+        return null;
+    }
+
+    @Override
+    public void usage(ActionListener<XPackFeatureSet.Usage> listener) {
+        listener.onResponse(new Usage(available(), enabled()));
+    }
+
+    public static class Usage extends XPackFeatureSet.Usage {
+
+        Usage(boolean available, boolean enabled) {
+            super(XPackField.ENRICH, available, enabled);
+        }
+
+        public Usage(StreamInput input) throws IOException {
+            super(input);
+        }
+    }
+}

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPlugin.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPlugin.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
@@ -42,6 +43,7 @@ import org.elasticsearch.xpack.core.enrich.action.GetEnrichPolicyAction;
 import org.elasticsearch.xpack.core.enrich.action.PutEnrichPolicyAction;
 import org.elasticsearch.xpack.enrich.action.EnrichCoordinatorProxyAction;
 import org.elasticsearch.xpack.enrich.action.EnrichCoordinatorStatsAction;
+import org.elasticsearch.xpack.core.enrich.EnrichFeatureSet;
 import org.elasticsearch.xpack.enrich.action.EnrichShardMultiSearchAction;
 import org.elasticsearch.xpack.enrich.action.TransportDeleteEnrichPolicyAction;
 import org.elasticsearch.xpack.enrich.action.TransportEnrichStatsAction;
@@ -174,6 +176,15 @@ public class EnrichPlugin extends Plugin implements ActionPlugin, IngestPlugin {
     }
 
     @Override
+    public Collection<Module> createGuiceModules() {
+        if (transportClientMode) {
+            return Collections.emptyList();
+        }
+
+        return Collections.singleton(b -> XPackPlugin.bindFeatureSet(b, EnrichFeatureSet.class));
+    }
+
+    @Override
     public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
         return Arrays.asList(
             new NamedWriteableRegistry.Entry(MetaData.Custom.class, EnrichMetadata.TYPE, EnrichMetadata::new),
@@ -191,6 +202,7 @@ public class EnrichPlugin extends Plugin implements ActionPlugin, IngestPlugin {
     @Override
     public List<Setting<?>> getSettings() {
         return Arrays.asList(
+            ENRICH_ENABLED_SETTING,
             ENRICH_FETCH_SIZE_SETTING,
             ENRICH_MAX_CONCURRENT_POLICY_EXECUTIONS,
             ENRICH_CLEANUP_PERIOD,

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichDisabledIT.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichDisabledIT.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.enrich;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.protocol.xpack.XPackInfoRequest;
+import org.elasticsearch.protocol.xpack.XPackInfoResponse;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.xpack.core.XPackField;
+import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.action.XPackInfoAction;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+
+import static org.hamcrest.Matchers.is;
+
+public class EnrichDisabledIT extends ESSingleNodeTestCase {
+
+    public void testEnrichAvailableButNotEnabled() {
+        ensureGreen();
+
+        XPackInfoRequest infoRequest = new XPackInfoRequest();
+        infoRequest.setCategories(EnumSet.of(XPackInfoRequest.Category.FEATURES));
+        XPackInfoResponse infoResponse = client().execute(XPackInfoAction.INSTANCE, infoRequest).actionGet();
+        assertThat(infoResponse.getFeatureSetsInfo().getFeatureSets().get(XPackField.ENRICH).available(), is(true));
+        assertThat(infoResponse.getFeatureSetsInfo().getFeatureSets().get(XPackField.ENRICH).enabled(), is(false));
+    }
+
+    @Override
+    protected Settings nodeSettings() {
+        return Settings.builder()
+            .put(XPackSettings.ENRICH_ENABLED_SETTING.getKey(), false)
+            .build();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return Collections.singleton(LocalStateEnrich.class);
+    }
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/xpack/15_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/xpack/15_basic.yml
@@ -81,6 +81,8 @@
   - is_true:    features.monitoring.available
   - is_true:    features.analytics.enabled
   - is_true:    features.analytics.available
+  - is_true:    features.enrich.available
+  - is_true:    features.enrich.enabled
   - is_true:    tagline
 
   - do:


### PR DESCRIPTION
Backport of #48109

This commit also fixes a bug, the enrich enabled setting
was not included in the list of settings.