### PR TITLE
Cache all rest tests tasks so long as they don't use shared clusters

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/RestTestRunnerTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/RestTestRunnerTask.java
@@ -5,9 +5,8 @@ import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.testing.Test;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
-
-import static org.elasticsearch.gradle.testclusters.TestDistribution.INTEG_TEST;
 
 /**
  * Customized version of Gradle {@link Test} task which tracks a collection of {@link ElasticsearchCluster} as a task input. We must do this
@@ -20,9 +19,17 @@ public class RestTestRunnerTask extends Test implements TestClustersAware {
     private Collection<ElasticsearchCluster> clusters = new HashSet<>();
 
     public RestTestRunnerTask() {
-        super();
-        this.getOutputs().doNotCacheIf("Build cache is only enabled for tests against clusters using the 'integ-test' distribution",
-            task -> clusters.stream().flatMap(c -> c.getNodes().stream()).anyMatch(n -> n.getTestDistribution() != INTEG_TEST));
+        this.getOutputs().doNotCacheIf("Caching disabled for this task since it uses a cluster shared by other tasks",
+            /*
+             * Look for any other tasks which use the same cluster as this task. Since tests often have side effects for the cluster they
+             * execute against, this state can cause issues when trying to cache tests results of tasks that share a cluster. To avoid any
+             * undesired behavior we simply disable the cache if we detect that this task uses a cluster shared between multiple tasks.
+             */
+            t -> getProject().getTasks().withType(RestTestRunnerTask.class)
+                .stream()
+                .filter(task -> task != this)
+                .anyMatch(task -> Collections.disjoint(task.getClusters(), getClusters()) == false)
+        );
     }
 
     @Override


### PR DESCRIPTION
This is a follow up to #46952 which was an attempt to enable caching on _all_ rest integration tests. As discussed in that PR, certain QA projects that ran a set of ordered suites against a single cluster are problematic to cache because of side-effects and cluster state. There are potentially some solutions there but for now we are just going to effectively exclude those problematic projects.

This pull request removes the restriction that only tests using the `integ-test` distribution can be cached. It replaced this with a condition that any rest integration test task can be cached, so long as it targets a cluster that is not used by any other tasks. We cannot guarantee that another task using a cluster doesn't have side-effects that cause undesired behavior when caching so we just punt in those scenarios. This should still give us decent benefit, as many of our `x-pack` tests use the default distribution, and we can avoid running those tests in cases where we don't change production code. For example, when a commit contains only test code changes, or just documentation changes.