### PR TITLE
[DOCS] Added the voting node.role value

### DIFF
--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -43,7 +43,7 @@ Valid columns are:
 
 `node.role`, `r`, `role`, `nodeRole`::
 (Default) Roles of the node. Returned values include `m` (master-eligible node),
-`d` (data node), `i` (ingest node), and `-` (coordinating node only).
+`d` (data node), `i` (ingest node), `v` (voting node), and `-` (coordinating node only).
 +
 For example, `mdi` indicates a master-eligible data and ingest node.
 

--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -43,7 +43,7 @@ Valid columns are:
 
 `node.role`, `r`, `role`, `nodeRole`::
 (Default) Roles of the node. Returned values include `m` (master-eligible node),
-`d` (data node), `i` (ingest node), `v` (voting node), and `-` (coordinating node only).
+`d` (data node), `i` (ingest node), `v` (voting-only node), and `-` (coordinating node only).
 +
 For example, `mdi` indicates a master-eligible data and ingest node.
 


### PR DESCRIPTION
With the elasticsearch.yml option "node.voting_only: true", if you perform a "_cat/nodes" there is a new option for `v` that will display if the node is a voting node.

![cat-nodes_voting](https://user-images.githubusercontent.com/29664630/66957622-93ca8700-f034-11e9-86cc-eed21f9f3bea.png)

