### PR TITLE
[7.x] Fix build failures when docker-compose is unavailable

### DIFF
--- a/x-pack/snapshot-tool/build.gradle
+++ b/x-pack/snapshot-tool/build.gradle
@@ -81,6 +81,8 @@ task s3ThirdPartyTests {
 if (useFixture) {
   apply plugin: 'elasticsearch.test.fixtures'
 
+  testFixtures.useFixture()
+
   task writeDockerFile {
     File minioDockerfile = new File("${project.buildDir}/minio-docker/Dockerfile")
     outputs.file(minioDockerfile)


### PR DESCRIPTION
This PR addresses #42829. This includes some build config that didn't make it during the backport of #46780 due to slight differences in the build between `master` and `7.x`.

Closes #42829.