### PR TITLE
[DOCS] Sort cluster API docs alphabetically

### DIFF
--- a/docs/reference/cluster.asciidoc
+++ b/docs/reference/cluster.asciidoc
@@ -79,32 +79,32 @@ GET /_nodes/ra*:2
 GET /_nodes/ra*:2*
 --------------------------------------------------
 
+include::cluster/allocation-explain.asciidoc[]
+
+include::cluster/get-settings.asciidoc[]
+
 include::cluster/health.asciidoc[]
+
+include::cluster/reroute.asciidoc[]
 
 include::cluster/state.asciidoc[]
 
 include::cluster/stats.asciidoc[]
 
-include::cluster/pending.asciidoc[]
-
-include::cluster/reroute.asciidoc[]
-
 include::cluster/update-settings.asciidoc[]
 
-include::cluster/get-settings.asciidoc[]
+include::cluster/nodes-usage.asciidoc[]
 
-include::cluster/nodes-stats.asciidoc[]
+include::cluster/nodes-hot-threads.asciidoc[]
 
 include::cluster/nodes-info.asciidoc[]
 
-include::cluster/nodes-usage.asciidoc[]
+include::cluster/nodes-stats.asciidoc[]
+
+include::cluster/pending.asciidoc[]
 
 include::cluster/remote-info.asciidoc[]
 
 include::cluster/tasks.asciidoc[]
-
-include::cluster/nodes-hot-threads.asciidoc[]
-
-include::cluster/allocation-explain.asciidoc[]
 
 include::cluster/voting-exclusions.asciidoc[]

--- a/docs/reference/cluster/allocation-explain.asciidoc
+++ b/docs/reference/cluster/allocation-explain.asciidoc
@@ -1,5 +1,8 @@
 [[cluster-allocation-explain]]
-=== Cluster Allocation Explain API
+=== Cluster allocation explain API
+++++
+<titleabbrev>Cluster allocation explain</titleabbrev>
+++++
 
 Provides explanations for shard allocations in the cluster.
 

--- a/docs/reference/cluster/get-settings.asciidoc
+++ b/docs/reference/cluster/get-settings.asciidoc
@@ -1,5 +1,8 @@
 [[cluster-get-settings]]
-=== Cluster Get Settings
+=== Cluster get settings API
+++++
+<titleabbrev>Cluster get settings</titleabbrev>
+++++
 
 Returns cluster-wide settings.
 

--- a/docs/reference/cluster/health.asciidoc
+++ b/docs/reference/cluster/health.asciidoc
@@ -1,5 +1,8 @@
 [[cluster-health]]
-=== Cluster Health
+=== Cluster health API
+++++
+<titleabbrev>Cluster health</titleabbrev>
+++++
 
 Returns the health status of a cluster.
 

--- a/docs/reference/cluster/nodes-hot-threads.asciidoc
+++ b/docs/reference/cluster/nodes-hot-threads.asciidoc
@@ -1,5 +1,8 @@
 [[cluster-nodes-hot-threads]]
-=== Nodes hot_threads
+=== Nodes hot threads API
+++++
+<titleabbrev>Nodes hot threads</titleabbrev>
+++++
 
 Returns the hot threads on each selected node in the cluster.
 

--- a/docs/reference/cluster/nodes-info.asciidoc
+++ b/docs/reference/cluster/nodes-info.asciidoc
@@ -1,5 +1,8 @@
 [[cluster-nodes-info]]
-=== Nodes Info
+=== Nodes info API
+++++
+<titleabbrev>Nodes info</titleabbrev>
+++++
 
 Returns cluster nodes information.
 

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1,5 +1,8 @@
 [[cluster-nodes-stats]]
-=== Nodes Stats
+=== Nodes stats API
+++++
+<titleabbrev>Nodes stats</titleabbrev>
+++++
 
 Returns cluster nodes statistics.
 

--- a/docs/reference/cluster/nodes-usage.asciidoc
+++ b/docs/reference/cluster/nodes-usage.asciidoc
@@ -1,5 +1,8 @@
 [[cluster-nodes-usage]]
-=== Nodes Feature Usage
+=== Nodes feature usage API
+++++
+<titleabbrev>Nodes feature usage</titleabbrev>
+++++
 
 Returns information on the usage of features.
 

--- a/docs/reference/cluster/pending.asciidoc
+++ b/docs/reference/cluster/pending.asciidoc
@@ -1,5 +1,8 @@
 [[cluster-pending]]
-=== Pending cluster tasks
+=== Pending cluster tasks API
+++++
+<titleabbrev>Pending cluster tasks</titleabbrev>
+++++
 
 Returns cluster-level changes that have not yet been executed.
 

--- a/docs/reference/cluster/remote-info.asciidoc
+++ b/docs/reference/cluster/remote-info.asciidoc
@@ -1,5 +1,8 @@
 [[cluster-remote-info]]
-=== Remote Cluster Info
+=== Remote cluster info API
+++++
+<titleabbrev>Remote cluster info</titleabbrev>
+++++
 
 Returns configured remote cluster information.
 

--- a/docs/reference/cluster/reroute.asciidoc
+++ b/docs/reference/cluster/reroute.asciidoc
@@ -1,5 +1,8 @@
 [[cluster-reroute]]
-=== Cluster Reroute
+=== Cluster reroute API
+++++
+<titleabbrev>Cluster reroute</titleabbrev>
+++++
 
 Changes the allocation of shards in a cluster.
 

--- a/docs/reference/cluster/state.asciidoc
+++ b/docs/reference/cluster/state.asciidoc
@@ -1,5 +1,8 @@
 [[cluster-state]]
-=== Cluster State
+=== Cluster state API
+++++
+<titleabbrev>Cluster state</titleabbrev>
+++++
 
 Returns metadata about the state of the cluster.
 

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -1,5 +1,8 @@
 [[cluster-stats]]
-=== Cluster Stats
+=== Cluster stats API
+++++
+<titleabbrev>Cluster stats</titleabbrev>
+++++
 
 Returns cluster statistics.
 

--- a/docs/reference/cluster/update-settings.asciidoc
+++ b/docs/reference/cluster/update-settings.asciidoc
@@ -1,5 +1,8 @@
 [[cluster-update-settings]]
-=== Cluster Update Settings
+=== Cluster update settings API
+++++
+<titleabbrev>Cluster update settings</titleabbrev>
+++++
 
 Updates cluster-wide settings. 
 

--- a/docs/reference/cluster/voting-exclusions.asciidoc
+++ b/docs/reference/cluster/voting-exclusions.asciidoc
@@ -1,7 +1,7 @@
 [[voting-config-exclusions]]
 === Voting configuration exclusions API
 ++++
-<titleabbrev>Voting Configuration Exclusions</titleabbrev>
+<titleabbrev>Voting configuration exclusions</titleabbrev>
 ++++
 
 Adds or removes master-eligible nodes from the


### PR DESCRIPTION
Also ensures titles and title abbrevations are in sentence case and consistent.