### PR TITLE
Remove Support for pre-5.x Indices in Restore (#48181)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
@@ -46,7 +46,6 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
      * Information about snapshotted file
      */
     public static class FileInfo {
-        private static final String UNKNOWN_CHECKSUM = "_na_";
 
         private final String name;
         private final ByteSizeValue partSize;
@@ -226,14 +225,6 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
             return metadata.isSame(fileInfo.metadata);
         }
 
-        /**
-         * Checks if the checksum for the file is unknown. This only is possible on an empty shard's
-         * segments_N file which was created in older Lucene versions.
-         */
-        public boolean hasUnknownChecksum() {
-            return metadata.checksum().equals(UNKNOWN_CHECKSUM);
-        }
-
         static final String NAME = "name";
         static final String PHYSICAL_NAME = "physical_name";
         static final String LENGTH = "length";
@@ -254,9 +245,7 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
             builder.field(NAME, file.name);
             builder.field(PHYSICAL_NAME, file.metadata.name());
             builder.field(LENGTH, file.metadata.length());
-            if (file.metadata.checksum().equals(UNKNOWN_CHECKSUM) == false) {
-                builder.field(CHECKSUM, file.metadata.checksum());
-            }
+            builder.field(CHECKSUM, file.metadata.checksum());
             if (file.partSize != null) {
                 builder.field(PART_SIZE, file.partSize.getBytes());
             }

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/FileRestoreContext.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/FileRestoreContext.java
@@ -85,26 +85,10 @@ public abstract class FileRestoreContext {
     /**
      * Performs restore operation
      */
-    public void restore(SnapshotFiles snapshotFiles, Store store) throws IOException {
+    public void restore(SnapshotFiles snapshotFiles, Store store) {
         store.incRef();
         try {
             logger.debug("[{}] [{}] restoring to [{}] ...", snapshotId, repositoryName, shardId);
-
-            if (snapshotFiles.indexFiles().size() == 1
-                && snapshotFiles.indexFiles().get(0).physicalName().startsWith("segments_")
-                && snapshotFiles.indexFiles().get(0).hasUnknownChecksum()) {
-                // If the shard has no documents, it will only contain a single segments_N file for the
-                // shard's snapshot.  If we are restoring a snapshot created by a previous supported version,
-                // it is still possible that in that version, an empty shard has a segments_N file with an unsupported
-                // version (and no checksum), because we don't know the Lucene version to assign segments_N until we
-                // have written some data.  Since the segments_N for an empty shard could have an incompatible Lucene
-                // version number and no checksum, even though the index itself is perfectly fine to restore, this
-                // empty shard would cause exceptions to be thrown.  Since there is no data to restore from an empty
-                // shard anyway, we just create the empty shard here and then exit.
-                store.createEmpty(store.indexSettings().getIndexVersionCreated().luceneVersion);
-                return;
-            }
-
             Store.MetadataSnapshot recoveryTargetMetadata;
             try {
                 // this will throw an IOException if the store has no segments infos file. The

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -469,7 +469,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
             this.throttleListener = throttleListener;
         }
 
-        void restoreFiles(Store store) throws IOException {
+        void restoreFiles(Store store) {
             ArrayList<FileInfo> fileInfos = new ArrayList<>();
             for (StoreFileMetaData fileMetaData : sourceMetaData) {
                 ByteSizeValue fileSize = new ByteSizeValue(fileMetaData.length());


### PR DESCRIPTION
The logic for handling empty segment files has been
unnecessary ever since #24021 which removes the support
for these files in 6.x -> we can safely remove the
support for restoring these from 7.x+ to simplify the code.

back port of #48181 