### PR TITLE
Fix ILM HLRC Javadoc->Documentation links (#48083)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndexLifecycleClient.java
@@ -120,8 +120,11 @@ public class IndexLifecycleClient {
 
     /**
      * Delete a lifecycle definition
-     * See <a href="https://fix-me-when-we-have-docs.com">
-     * the docs</a> for more.
+     * See <pre>
+     *  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/
+     *  java-rest-high-ilm-ilm-delete-lifecycle-policy.html
+     * </pre>
+     * for more.
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -135,8 +138,11 @@ public class IndexLifecycleClient {
 
     /**
      * Asynchronously delete a lifecycle definition
-     * See <a href="https://fix-me-when-we-have-docs.com">
-     * the docs</a> for more.
+     * See <pre>
+     *  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/
+     *  java-rest-high-ilm-ilm-delete-lifecycle-policy.html
+     * </pre>
+     * for more.
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -151,8 +157,11 @@ public class IndexLifecycleClient {
 
     /**
      * Remove the index lifecycle policy for an index
-     * See <a href="https://fix-me-when-we-have-docs.com">
-     * the docs</a> for more.
+     * See <pre>
+     *  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/
+     *  java-rest-high-ilm-ilm-remove-lifecycle-policy-from-index.html
+     * </pre>
+     * for more.
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -166,8 +175,11 @@ public class IndexLifecycleClient {
 
     /**
      * Asynchronously remove the index lifecycle policy for an index
-     * See <a href="https://fix-me-when-we-have-docs.com">
-     * the docs</a> for more.
+     * See <pre>
+     *  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/
+     *  java-rest-high-ilm-ilm-remove-lifecycle-policy-from-index.html
+     * </pre>
+     * for more.
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -182,8 +194,11 @@ public class IndexLifecycleClient {
 
     /**
      * Start the Index Lifecycle Management feature.
-     * See <a href="https://fix-me-when-we-have-docs.com">
-     * the docs</a> for more.
+     * See <pre>
+     *  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/
+     *  java-rest-high-ilm-ilm-start-ilm.html
+     * </pre>
+     * for more.
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -196,8 +211,11 @@ public class IndexLifecycleClient {
 
     /**
      * Asynchronously start the Index Lifecycle Management feature.
-     * See <a href="https://fix-me-when-we-have-docs.com">
-     * the docs</a> for more.
+     * See <pre>
+     *  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/
+     *  java-rest-high-ilm-ilm-start-ilm.html
+     * </pre>
+     * for more.
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -210,8 +228,11 @@ public class IndexLifecycleClient {
 
     /**
      * Stop the Index Lifecycle Management feature.
-     * See <a href="https://fix-me-when-we-have-docs.com">
-     * the docs</a> for more.
+     * See <pre>
+     *  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/
+     *  java-rest-high-ilm-ilm-stop-ilm.html
+     * </pre>
+     * for more.
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -223,9 +244,29 @@ public class IndexLifecycleClient {
     }
 
     /**
+     * Asynchronously stop the Index Lifecycle Management feature.
+     * See <pre>
+     *  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/
+     *  java-rest-high-ilm-ilm-stop-ilm.html
+     * </pre>
+     * for more.
+     * @param request the request
+     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
+     * @param listener the listener to be notified upon request completion
+     * @return cancellable that may be used to cancel the request
+     */
+    public Cancellable stopILMAsync(StopILMRequest request, RequestOptions options, ActionListener<AcknowledgedResponse> listener) {
+        return restHighLevelClient.performRequestAsyncAndParseEntity(request, IndexLifecycleRequestConverters::stopILM, options,
+            AcknowledgedResponse::fromXContent, listener, emptySet());
+    }
+
+    /**
      * Get the status of index lifecycle management
-     * See <a href="https://fix-me-when-we-have-docs.com">
-     * the docs</a> for more.
+     * See <pre>
+     *  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/
+     *  java-rest-high-ilm-ilm-status.html
+     * </pre>
+     * for more.
      *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
@@ -238,8 +279,11 @@ public class IndexLifecycleClient {
 
     /**
      * Asynchronously get the status of index lifecycle management
-     * See <a href="https://fix-me-when-we-have-docs.com">
-     * the docs</a> for more.
+     * See <pre>
+     *  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/
+     *  java-rest-high-ilm-ilm-status.html
+     * </pre>
+     * for more.
      * @param request  the request
      * @param options  the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -253,23 +297,12 @@ public class IndexLifecycleClient {
     }
 
     /**
-     * Asynchronously stop the Index Lifecycle Management feature.
-     * See <a href="https://fix-me-when-we-have-docs.com">
-     * the docs</a> for more.
-     * @param request the request
-     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
-     * @param listener the listener to be notified upon request completion
-     * @return cancellable that may be used to cancel the request
-     */
-    public Cancellable stopILMAsync(StopILMRequest request, RequestOptions options, ActionListener<AcknowledgedResponse> listener) {
-        return restHighLevelClient.performRequestAsyncAndParseEntity(request, IndexLifecycleRequestConverters::stopILM, options,
-                AcknowledgedResponse::fromXContent, listener, emptySet());
-    }
-
-    /**
      * Explain the lifecycle state for an index
-     * See <a href="https://fix-me-when-we-have-docs.com">
-     * the docs</a> for more.
+     * See <pre>
+     *  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/
+     *  java-rest-high-ilm-ilm-explain-lifecycle.html
+     * </pre>
+     * for more.
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -282,8 +315,11 @@ public class IndexLifecycleClient {
 
     /**
      * Asynchronously explain the lifecycle state for an index
-     * See <a href="https://fix-me-when-we-have-docs.com">
-     * the docs</a> for more.
+     * See <pre>
+     *  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/
+     *  java-rest-high-ilm-ilm-explain-lifecycle.html
+     * </pre>
+     * for more.
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -297,8 +333,11 @@ public class IndexLifecycleClient {
 
     /**
      * Retry lifecycle step for given indices
-     * See <a href="https://fix-me-when-we-have-docs.com">
-     * the docs</a> for more.
+     * See <pre>
+     *  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/
+     *  java-rest-high-ilm-ilm-retry-lifecycle-policy.html
+     * </pre>
+     * for more.
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -311,8 +350,11 @@ public class IndexLifecycleClient {
 
     /**
      * Asynchronously retry the lifecycle step for given indices
-     * See <a href="https://fix-me-when-we-have-docs.com">
-     * the docs</a> for more.
+     * See <pre>
+     *  https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/
+     *  java-rest-high-ilm-ilm-retry-lifecycle-policy.html
+     * </pre>
+     * for more.
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion


### PR DESCRIPTION
Backports the following commits to 7.5:
 - Fix ILM HLRC Javadoc->Documentation links  (#48083)
