### PR TITLE
Stop Resolving Fallback IndexId (#48141)

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -255,15 +255,7 @@ public final class RepositoryData {
      * throwing an exception if the index could not be resolved.
      */
     public IndexId resolveIndexId(final String indexName) {
-        if (indices.containsKey(indexName)) {
-            return indices.get(indexName);
-        } else {
-            // on repositories created before 5.0, there was no indices information in the index
-            // blob, so if the repository hasn't been updated with new snapshots, no new index blob
-            // would have been written, so we only have old snapshots without the index information.
-            // in this case, the index id is just the index name
-            return new IndexId(indexName, indexName);
-        }
+        return Objects.requireNonNull(indices.get(indexName), () -> "Tried to resolve unknown index [" + indexName + "]");
     }
 
     /**
@@ -352,31 +344,23 @@ public final class RepositoryData {
                 if (SNAPSHOTS.equals(field)) {
                     if (parser.nextToken() == XContentParser.Token.START_ARRAY) {
                         while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
-                            final SnapshotId snapshotId;
-                            // the new format from 5.0 which contains the snapshot name and uuid
-                            if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
-                                String name = null;
-                                String uuid = null;
-                                SnapshotState state = null;
-                                while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
-                                    String currentFieldName = parser.currentName();
-                                    parser.nextToken();
-                                    if (NAME.equals(currentFieldName)) {
-                                        name = parser.text();
-                                    } else if (UUID.equals(currentFieldName)) {
-                                        uuid = parser.text();
-                                    } else if (STATE.equals(currentFieldName)) {
-                                        state = SnapshotState.fromValue(parser.numberValue().byteValue());
-                                    }
+                            String name = null;
+                            String uuid = null;
+                            SnapshotState state = null;
+                            while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+                                String currentFieldName = parser.currentName();
+                                parser.nextToken();
+                                if (NAME.equals(currentFieldName)) {
+                                    name = parser.text();
+                                } else if (UUID.equals(currentFieldName)) {
+                                    uuid = parser.text();
+                                } else if (STATE.equals(currentFieldName)) {
+                                    state = SnapshotState.fromValue(parser.numberValue().byteValue());
                                 }
-                                snapshotId = new SnapshotId(name, uuid);
-                                if (state != null) {
-                                    snapshotStates.put(uuid, state);
-                                }
-                            } else {
-                                // the old format pre 5.0 that only contains the snapshot name, use the name as the uuid too
-                                final String name = parser.text();
-                                snapshotId = new SnapshotId(name, name);
+                            }
+                            final SnapshotId snapshotId = new SnapshotId(name, uuid);
+                            if (state != null) {
+                                snapshotStates.put(uuid, state);
                             }
                             snapshots.put(snapshotId.getUUID(), snapshotId);
                         }

--- a/server/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
@@ -158,9 +158,6 @@ public class RepositoryDataTests extends ESTestCase {
         String indexName = indexNames.iterator().next();
         IndexId indexId = indices.get(indexName);
         assertEquals(indexId, repositoryData.resolveIndexId(indexName));
-        String notInRepoData = randomAlphaOfLength(5);
-        assertFalse(indexName.contains(notInRepoData));
-        assertEquals(new IndexId(notInRepoData, notInRepoData), repositoryData.resolveIndexId(notInRepoData));
     }
 
     public void testGetSnapshotState() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/SourceOnlySnapshotShardTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/SourceOnlySnapshotShardTests.java
@@ -222,7 +222,7 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
         ShardRouting shardRouting = TestShardRouting.newShardRouting(new ShardId("index", "_na_", 0), randomAlphaOfLength(10), true,
             ShardRoutingState.INITIALIZING,
             new RecoverySource.SnapshotRecoverySource(
-                UUIDs.randomBase64UUID(), new Snapshot("src_only", snapshotId), Version.CURRENT, indexId.getId()));
+                UUIDs.randomBase64UUID(), new Snapshot("src_only", snapshotId), Version.CURRENT, indexId.getName()));
         IndexMetaData metaData = runAsSnapshot(threadPool, () -> repository.getSnapshotIndexMetaData(snapshotId, indexId));
         IndexShard restoredShard = newShard(
             shardRouting, metaData, null, SourceOnlySnapshotRepository.getEngineFactory(), () -> {}, RetentionLeaseSyncer.EMPTY);


### PR DESCRIPTION
There is no reason to still resolve the
fallback `IndexId` here. It only applies to
`2.x` repos and those we can't read anymore
anyway because they use an `/index` instead of
an `/index-N` blob at the repo root for which
at least 7.x+ does not contain the logic to find
it.


backport of #48141 