### PR TITLE
Clarify mapping types that support ignore_malformed

### DIFF
--- a/docs/reference/mapping/params/ignore-malformed.asciidoc
+++ b/docs/reference/mapping/params/ignore-malformed.asciidoc
@@ -48,12 +48,12 @@ PUT my_index/_doc/2
 
 The `ignore_malformed` setting is currently supported by the following <<mapping-types,mapping types>>:
 
-* <<number>>::         `long`, `integer`, `short`, `byte`, `double`, `float`, `half_float`, `scaled_float`
-* <<date>>::           `date`
-* <<date_nanos>>::     `date_nanos`
-* <<geo-point>>::     `geo_point` for lat/lon points
-* <<geo-shape>>::     `geo_shape` for complex shapes like polygons
-* <<ip>>::            `ip` for IPv4 and IPv6 addresses
+<<number>>::         `long`, `integer`, `short`, `byte`, `double`, `float`, `half_float`, `scaled_float`
+<<date>>::           `date`
+<<date_nanos>>::     `date_nanos`
+<<geo-point>>::     `geo_point` for lat/lon points
+<<geo-shape>>::     `geo_shape` for complex shapes like polygons
+<<ip>>::            `ip` for IPv4 and IPv6 addresses
 
 TIP: The `ignore_malformed` setting value can be updated on
 existing fields using the <<indices-put-mapping,PUT mapping API>>.

--- a/docs/reference/mapping/params/ignore-malformed.asciidoc
+++ b/docs/reference/mapping/params/ignore-malformed.asciidoc
@@ -7,7 +7,7 @@ user may send a `login` field that is a <<date,`date`>>, and another sends a
 
 Trying to index the wrong datatype into a field throws an exception by
 default, and rejects the whole document.  The `ignore_malformed` parameter, if
-set to `true`, allows the exception to be ignored.  The malformed field is not
+set to `true`, allows the exception to be ignored. The malformed field is not
 indexed, but other fields in the document are processed normally.
 
 For example:
@@ -46,15 +46,23 @@ PUT my_index/_doc/2
 <1> This document will have the `text` field indexed, but not the `number_one` field.
 <2> This document will be rejected because `number_two` does not allow malformed values.
 
+The `ignore_malformed` setting is currently supported by the following <<mapping-types,mapping types>>:
+* <<number>>::         `long`, `integer`, `short`, `byte`, `double`, `float`, `half_float`, `scaled_float`
+* <<date>>::           `date`
+* <<date_nanos>>::     `date_nanos`
+* <<geo-point>>::     `geo_point` for lat/lon points
+* <<geo-shape>>::     `geo_shape` for complex shapes like polygons
+* <<ip>>::            `ip` for IPv4 and IPv6 addresses
+
 TIP: The `ignore_malformed` setting value can be updated on
 existing fields using the <<indices-put-mapping,PUT mapping API>>.
-
 
 [[ignore-malformed-setting]]
 ==== Index-level default
 
 The `index.mapping.ignore_malformed` setting can be set on the index level to
-allow to ignore malformed content globally across all mapping types.
+allow to ignore malformed content globally across all mapping types that allow it.
+Mapping types that don't support the setting will ignore it if set on the index level.
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/mapping/params/ignore-malformed.asciidoc
+++ b/docs/reference/mapping/params/ignore-malformed.asciidoc
@@ -47,6 +47,7 @@ PUT my_index/_doc/2
 <2> This document will be rejected because `number_two` does not allow malformed values.
 
 The `ignore_malformed` setting is currently supported by the following <<mapping-types,mapping types>>:
+
 * <<number>>::         `long`, `integer`, `short`, `byte`, `double`, `float`, `half_float`, `scaled_float`
 * <<date>>::           `date`
 * <<date_nanos>>::     `date_nanos`
@@ -61,7 +62,7 @@ existing fields using the <<indices-put-mapping,PUT mapping API>>.
 ==== Index-level default
 
 The `index.mapping.ignore_malformed` setting can be set on the index level to
-allow to ignore malformed content globally across all mapping types that allow it.
+ignore malformed content globally across all allowed mapping types.
 Mapping types that don't support the setting will ignore it if set on the index level.
 
 [source,console]


### PR DESCRIPTION
The `ignore_malformed` setting only works on selected mapping types, otherwise
we throw an mapper_parsing_exception. We should add a list of all the mapping
types that support it, since the number of types not supporting it seems larger.

Closes #47166