### PR TITLE
Add 'javadoc' task to CI lifecycle check tasks

### DIFF
--- a/buildSrc/reaper/src/main/java/org/elasticsearch/gradle/reaper/Reaper.java
+++ b/buildSrc/reaper/src/main/java/org/elasticsearch/gradle/reaper/Reaper.java
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
  * Since how to reap a given service is platform and service dependent, this tool
  * operates on system commands to execute. It takes a single argument, a directory
  * that will contain files with reaping commands. Each line in each file will be
- * executed with {@link Runtime#getRuntime()#exec}.
+ * executed with {@link Runtime#exec(String)}.
  *
  * The main method will wait indefinitely on the parent process (Gradle) by
  * reading from stdin. When Gradle shuts down, whether normally or abruptly, the

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -676,6 +676,10 @@ class BuildPlugin implements Plugin<Project> {
              */
             (javadoc.options as CoreJavadocOptions).addBooleanOption('html5', true)
         }
+        // ensure javadoc task is run with 'check'
+        project.pluginManager.withPlugin('lifecycle-base') {
+            project.tasks.getByName(LifecycleBasePlugin.CHECK_TASK_NAME).dependsOn(project.tasks.withType(Javadoc))
+        }
         configureJavadocJar(project)
     }
 


### PR DESCRIPTION
The PR ensures that the `javadoc` task is run when we run `check` since often times malformed JavaDocs can cause failure down the road. Essentially, we should consider generating JavaDocs to be part of project verification.

Closes #47795