### PR TITLE
Upgrade to build scan plugin 2.4.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ import org.gradle.util.GradleVersion
 import static org.elasticsearch.gradle.tool.Boilerplate.maybeConfigure
 
 plugins {
-    id 'com.gradle.build-scan' version '2.4'
+    id 'com.gradle.build-scan' version '2.4.2'
     id 'lifecycle-base'
     id 'elasticsearch.global-build-info'
     id "com.diffplug.gradle.spotless" version "3.24.2" apply false


### PR DESCRIPTION
Upgrade to latest build scan plugin, which is 2.4.2. This release includes some reliability fixes so is probably worth the bump. 