### PR TITLE
Fix TreeNode's Builder wrong nodeIndex assignment

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/trainedmodel/tree/TreeNode.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/trainedmodel/tree/TreeNode.java
@@ -206,7 +206,7 @@ public class TreeNode implements ToXContentObject {
         private Integer rightChild;
 
         public Builder(int nodeIndex) {
-            nodeIndex = nodeIndex;
+            this.nodeIndex = nodeIndex;
         }
 
         private Builder() {


### PR DESCRIPTION
The `nodeIndex` argument was being assigned to itself.