### PR TITLE
[DOCS] Adds missing references to oidc realms

### DIFF
--- a/x-pack/docs/en/security/authentication/oidc-guide.asciidoc
+++ b/x-pack/docs/en/security/authentication/oidc-guide.asciidoc
@@ -85,7 +85,7 @@ the authentication chain for {es}.
 
 This realm has a few mandatory settings, and a number of optional settings.
 The available settings are described in detail in
-<<ref-oidc-settings. This
+<<ref-oidc-settings>>. This
 guide will explore the most common settings.
 
 Create an OpenID Connect (the realm type is `oidc`) realm in your `elasticsearch.yml` file

--- a/x-pack/docs/en/security/authentication/overview.asciidoc
+++ b/x-pack/docs/en/security/authentication/overview.asciidoc
@@ -16,9 +16,9 @@ integrate with external user management systems such as LDAP and Active
 Directory.
 
 The {stack-security-features} provide built-in realms such as `native`,`ldap`,
-`active_directory`, `pki`, `file`, and `saml`. If none of the built-in realms
-meet your needs, you can also build your own custom realm and plug it into the
-{stack}. 
+`active_directory`, `pki`, `file`, `saml`, and `oidc`. If none of the built-in
+realms meet your needs, you can also build your own custom realm and plug it
+into the {stack}. 
 
 When {security-features} are enabled, depending on the realms you've configured,
 you must attach your user credentials to the requests sent to {es}. For example,

--- a/x-pack/docs/en/security/authentication/realms.asciidoc
+++ b/x-pack/docs/en/security/authentication/realms.asciidoc
@@ -45,6 +45,9 @@ _kerberos_::
 A realm that authenticates a user using Kerberos authentication. Users are
 authenticated on the basis of Kerberos tickets. See <<kerberos-realm>>.
 
+_oidc_::
+A realm that facilitates authentication using OpenID Connect. It enables {es} to serve as an OpenID Connect Relying Party (RP) and provide single sign-on (SSO) support in {kib}. See <<oidc-guide>>.
+
 The {security-features} also support custom realms. If you need to integrate
 with another authentication system, you can build a custom realm plugin. For
 more information, see <<custom-realms>>.


### PR DESCRIPTION
OpenID Connect realms are described in https://www.elastic.co/guide/en/elasticsearch/reference/master/oidc-guide-authentication.html#oidc-create-realm, but they're missing from the list of realms in https://www.elastic.co/guide/en/elasticsearch/reference/master/realms.html and https://www.elastic.co/guide/en/elasticsearch/reference/master/setting-up-authentication.html

The changes can be previewed here:

http://elasticsearch_48224.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/realms.html
http://elasticsearch_48224.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/setting-up-authentication.html