### PR TITLE
Fix download of 6.x rpm and deb packages

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
@@ -227,7 +227,13 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
                 classifier = "";
             }
         } else if (distribution.getType() == Type.DEB) {
-            classifier = ":amd64";
+            if (distroVersion.onOrAfter("7.0.0")) {
+                classifier = ":amd64";
+            } else {
+                classifier = "";
+            }
+        } else if (distribution.getType() == Type.RPM && distroVersion.before("7.0.0")) {
+            classifier = "";
         }
         String flavor = "";
         if (distribution.getFlavor() == Flavor.OSS && distroVersion.onOrAfter("6.3.0")) {


### PR DESCRIPTION
These packages don't have a classifier and are failing the ci worker image builds: 
 https://infra-ci.elastic.co/job/elastic+infra+master+packer-builder-elasticsearch-ci-linux/