### PR TITLE
Default "prediction_field_name" to (dependent_variable + "_prediction")

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
@@ -126,8 +126,8 @@ import org.elasticsearch.client.ml.dataframe.OutlierDetection;
 import org.elasticsearch.client.ml.dataframe.PhaseProgress;
 import org.elasticsearch.client.ml.dataframe.QueryConfig;
 import org.elasticsearch.client.ml.dataframe.evaluation.classification.Classification;
-import org.elasticsearch.client.ml.dataframe.evaluation.regression.MeanSquaredErrorMetric;
 import org.elasticsearch.client.ml.dataframe.evaluation.classification.MulticlassConfusionMatrixMetric;
+import org.elasticsearch.client.ml.dataframe.evaluation.regression.MeanSquaredErrorMetric;
 import org.elasticsearch.client.ml.dataframe.evaluation.regression.RSquaredMetric;
 import org.elasticsearch.client.ml.dataframe.evaluation.regression.Regression;
 import org.elasticsearch.client.ml.dataframe.evaluation.softclassification.AucRocMetric;
@@ -1267,6 +1267,7 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
                 .setIndex("put-test-dest-index")
                 .build())
             .setAnalysis(org.elasticsearch.client.ml.dataframe.Regression.builder("my_dependent_variable")
+                .setPredictionFieldName("my_dependent_variable_prediction")
                 .setTrainingPercent(80.0)
                 .build())
             .setDescription("this is a regression")
@@ -1301,6 +1302,7 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
                 .setIndex("put-test-dest-index")
                 .build())
             .setAnalysis(org.elasticsearch.client.ml.dataframe.Classification.builder("my_dependent_variable")
+                .setPredictionFieldName("my_dependent_variable_prediction")
                 .setTrainingPercent(80.0)
                 .setNumTopClasses(1)
                 .build())

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
@@ -90,7 +90,7 @@ public class Classification implements DataFrameAnalysis {
         }
         this.dependentVariable = ExceptionsHelper.requireNonNull(dependentVariable, DEPENDENT_VARIABLE);
         this.boostedTreeParams = ExceptionsHelper.requireNonNull(boostedTreeParams, BoostedTreeParams.NAME);
-        this.predictionFieldName = predictionFieldName;
+        this.predictionFieldName = predictionFieldName == null ? dependentVariable + "_prediction" : predictionFieldName;
         this.numTopClasses = numTopClasses == null ? DEFAULT_NUM_TOP_CLASSES : numTopClasses;
         this.trainingPercent = trainingPercent == null ? 100.0 : trainingPercent;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
@@ -111,6 +111,10 @@ public class Classification implements DataFrameAnalysis {
         return dependentVariable;
     }
 
+    public String getPredictionFieldName() {
+        return predictionFieldName;
+    }
+
     public int getNumTopClasses() {
         return numTopClasses;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
@@ -70,7 +70,7 @@ public class Regression implements DataFrameAnalysis {
         }
         this.dependentVariable = ExceptionsHelper.requireNonNull(dependentVariable, DEPENDENT_VARIABLE);
         this.boostedTreeParams = ExceptionsHelper.requireNonNull(boostedTreeParams, BoostedTreeParams.NAME);
-        this.predictionFieldName = predictionFieldName;
+        this.predictionFieldName = predictionFieldName == null ? dependentVariable + "_prediction" : predictionFieldName;
         this.trainingPercent = trainingPercent == null ? 100.0 : trainingPercent;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
@@ -89,6 +89,10 @@ public class Regression implements DataFrameAnalysis {
         return dependentVariable;
     }
 
+    public String getPredictionFieldName() {
+        return predictionFieldName;
+    }
+
     public double getTrainingPercent() {
         return trainingPercent;
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/ClassificationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/ClassificationTests.java
@@ -73,6 +73,14 @@ public class ClassificationTests extends AbstractSerializingTestCase<Classificat
         assertThat(e.getMessage(), equalTo("[num_top_classes] must be an integer in [0, 1000]"));
     }
 
+    public void testGetPredictionFieldName() {
+        Classification classification = new Classification("foo", BOOSTED_TREE_PARAMS, "result", 3, 50.0);
+        assertThat(classification.getPredictionFieldName(), equalTo("result"));
+
+        classification = new Classification("foo", BOOSTED_TREE_PARAMS, null, 3, 50.0);
+        assertThat(classification.getPredictionFieldName(), equalTo("foo_prediction"));
+    }
+
     public void testGetNumTopClasses() {
         Classification classification = new Classification("foo", BOOSTED_TREE_PARAMS, "result", 7, 1.0);
         assertThat(classification.getNumTopClasses(), equalTo(7));

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
@@ -1470,6 +1470,7 @@ setup:
       "eta": 0.5,
       "maximum_number_trees": 400,
       "feature_bag_fraction": 0.3,
+      "prediction_field_name": "foo_prediction",
       "training_percent": 60.3
     }
   }}
@@ -1809,6 +1810,7 @@ setup:
       "eta": 0.5,
       "maximum_number_trees": 400,
       "feature_bag_fraction": 0.3,
+      "prediction_field_name": "foo_prediction",
       "training_percent": 60.3,
       "num_top_classes": 2
     }
@@ -1844,6 +1846,7 @@ setup:
   - match: { analysis: {
     "regression":{
       "dependent_variable": "foo",
+      "prediction_field_name": "foo_prediction",
       "training_percent": 100.0
     }
   }}

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/90_ml_data_frame_analytics_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/90_ml_data_frame_analytics_crud.yml
@@ -58,7 +58,8 @@
   - match: { data_frame_analytics.0.source.index: ["bwc_ml_regression_job_source"] }
   - match: { data_frame_analytics.0.source.query: {"term": { "user": "Kimchy" }} }
   - match: { data_frame_analytics.0.dest.index: "old_cluster_regression_job_results" }
-  - match: { data_frame_analytics.0.analysis: {"regression":{ "dependent_variable": "foo", "training_percent": 100.0 }} }
+  - match: { data_frame_analytics.0.analysis.regression.dependent_variable: "foo" }
+  - match: { data_frame_analytics.0.analysis.regression.training_percent: 100.0 }
 
 ---
 "Get old regression job stats":

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/90_ml_data_frame_analytics_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/90_ml_data_frame_analytics_crud.yml
@@ -38,7 +38,8 @@
   - match: { data_frame_analytics.0.source.index: ["bwc_ml_regression_job_source"] }
   - match: { data_frame_analytics.0.source.query: {"term": { "user": "Kimchy" }} }
   - match: { data_frame_analytics.0.dest.index: "old_cluster_regression_job_results" }
-  - match: { data_frame_analytics.0.analysis: {"regression":{ "dependent_variable": "foo", "training_percent": 100.0 }} }
+  - match: { data_frame_analytics.0.analysis.regression.dependent_variable: "foo" }
+  - match: { data_frame_analytics.0.analysis.regression.training_percent: 100.0 }
 
 ---
 "Get old cluster regression job stats":


### PR DESCRIPTION
In line with how are defaults handled in other places (see e.g: `DataFrameAnalyticsDest.resultsField`) this PR sets the default value of `prediction_field_name` upon `Classification` and `Regression` objects creation.

This way the value of `prediction_field_name` is directly available to the API user / UI.

Relates https://github.com/elastic/elasticsearch/issues/46735