### PR TITLE
Use an env var for the classpath of jar hell task

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/JarHellTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/JarHellTask.java
@@ -42,7 +42,7 @@ public class JarHellTask extends PrecommitTask {
     @TaskAction
     public void runJarHellCheck() {
         LoggedExec.javaexec(getProject(), spec -> {
-            spec.classpath(getClasspath());
+            spec.environment("CLASSPATH", getClasspath().getAsPath());
             spec.setMain("org.elasticsearch.bootstrap.JarHell");
         });
     }


### PR DESCRIPTION
The classpath for some project could outgrow the max allowed command
line on Windows. Using an env var is not fault proof, but give more
breathing room

Closes #47953