### PR TITLE
[7.x] [ML] Add logistic_regression output aggregator (#48238)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/MlInferenceNamedXContentProvider.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/MlInferenceNamedXContentProvider.java
@@ -20,6 +20,7 @@ package org.elasticsearch.client.ml.inference;
 
 import org.elasticsearch.client.ml.inference.trainedmodel.TrainedModel;
 import org.elasticsearch.client.ml.inference.trainedmodel.ensemble.Ensemble;
+import org.elasticsearch.client.ml.inference.trainedmodel.ensemble.LogisticRegression;
 import org.elasticsearch.client.ml.inference.trainedmodel.ensemble.OutputAggregator;
 import org.elasticsearch.client.ml.inference.trainedmodel.ensemble.WeightedMode;
 import org.elasticsearch.client.ml.inference.trainedmodel.ensemble.WeightedSum;
@@ -60,6 +61,9 @@ public class MlInferenceNamedXContentProvider implements NamedXContentProvider {
         namedXContent.add(new NamedXContentRegistry.Entry(OutputAggregator.class,
             new ParseField(WeightedSum.NAME),
             WeightedSum::fromXContent));
+        namedXContent.add(new NamedXContentRegistry.Entry(OutputAggregator.class,
+            new ParseField(LogisticRegression.NAME),
+            LogisticRegression::fromXContent));
 
         return namedXContent;
     }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/trainedmodel/ensemble/LogisticRegression.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/trainedmodel/ensemble/LogisticRegression.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.client.ml.inference.trainedmodel.ensemble;
+
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+
+public class LogisticRegression implements OutputAggregator {
+
+    public static final String NAME = "logistic_regression";
+    public static final ParseField WEIGHTS = new ParseField("weights");
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<LogisticRegression, Void> PARSER = new ConstructingObjectParser<>(
+        NAME,
+        true,
+        a -> new LogisticRegression((List<Double>)a[0]));
+    static {
+        PARSER.declareDoubleArray(ConstructingObjectParser.optionalConstructorArg(), WEIGHTS);
+    }
+
+    public static LogisticRegression fromXContent(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+
+    private final List<Double> weights;
+
+    public LogisticRegression(List<Double> weights) {
+        this.weights = weights;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        if (weights != null) {
+            builder.field(WEIGHTS.getPreferredName(), weights);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LogisticRegression that = (LogisticRegression) o;
+        return Objects.equals(weights, that.weights);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(weights);
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
@@ -68,6 +68,7 @@ import org.elasticsearch.client.ml.dataframe.evaluation.softclassification.Confu
 import org.elasticsearch.client.ml.dataframe.evaluation.softclassification.PrecisionMetric;
 import org.elasticsearch.client.ml.dataframe.evaluation.softclassification.RecallMetric;
 import org.elasticsearch.client.ml.inference.trainedmodel.ensemble.Ensemble;
+import org.elasticsearch.client.ml.inference.trainedmodel.ensemble.LogisticRegression;
 import org.elasticsearch.client.ml.inference.trainedmodel.ensemble.WeightedMode;
 import org.elasticsearch.client.ml.inference.trainedmodel.ensemble.WeightedSum;
 import org.elasticsearch.client.ml.inference.trainedmodel.tree.Tree;
@@ -686,7 +687,7 @@ public class RestHighLevelClientTests extends ESTestCase {
 
     public void testProvidedNamedXContents() {
         List<NamedXContentRegistry.Entry> namedXContents = RestHighLevelClient.getProvidedNamedXContents();
-        assertEquals(48, namedXContents.size());
+        assertEquals(49, namedXContents.size());
         Map<Class<?>, Integer> categories = new HashMap<>();
         List<String> names = new ArrayList<>();
         for (NamedXContentRegistry.Entry namedXContent : namedXContents) {
@@ -750,9 +751,9 @@ public class RestHighLevelClientTests extends ESTestCase {
         assertThat(names, hasItems(FrequencyEncoding.NAME, OneHotEncoding.NAME, TargetMeanEncoding.NAME));
         assertEquals(Integer.valueOf(2), categories.get(org.elasticsearch.client.ml.inference.trainedmodel.TrainedModel.class));
         assertThat(names, hasItems(Tree.NAME, Ensemble.NAME));
-        assertEquals(Integer.valueOf(2),
+        assertEquals(Integer.valueOf(3),
             categories.get(org.elasticsearch.client.ml.inference.trainedmodel.ensemble.OutputAggregator.class));
-        assertThat(names, hasItems(WeightedMode.NAME, WeightedSum.NAME));
+        assertThat(names, hasItems(WeightedMode.NAME, WeightedSum.NAME, LogisticRegression.NAME));
     }
 
     public void testApiNamingConventions() throws Exception {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/inference/trainedmodel/ensemble/EnsembleTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/inference/trainedmodel/ensemble/EnsembleTests.java
@@ -68,7 +68,7 @@ public class EnsembleTests extends AbstractXContentTestCase<Ensemble> {
         OutputAggregator outputAggregator = null;
         if (randomBoolean()) {
             List<Double> weights = Stream.generate(ESTestCase::randomDouble).limit(numberOfModels).collect(Collectors.toList());
-            outputAggregator = randomFrom(new WeightedMode(weights), new WeightedSum(weights));
+            outputAggregator = randomFrom(new WeightedMode(weights), new WeightedSum(weights), new LogisticRegression(weights));
         }
         List<String> categoryLabels = null;
         if (randomBoolean()) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/inference/trainedmodel/ensemble/LogisticRegressionTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/inference/trainedmodel/ensemble/LogisticRegressionTests.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.client.ml.inference.trainedmodel.ensemble;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractXContentTestCase;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+
+public class LogisticRegressionTests extends AbstractXContentTestCase<LogisticRegression> {
+
+    LogisticRegression createTestInstance(int numberOfWeights) {
+        return new LogisticRegression(Stream.generate(ESTestCase::randomDouble).limit(numberOfWeights).collect(Collectors.toList()));
+    }
+
+    @Override
+    protected LogisticRegression doParseInstance(XContentParser parser) throws IOException {
+        return LogisticRegression.fromXContent(parser);
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return true;
+    }
+
+    @Override
+    protected LogisticRegression createTestInstance() {
+        return randomBoolean() ? new LogisticRegression(null) : createTestInstance(randomIntBetween(1, 100));
+    }
+
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
@@ -158,6 +158,11 @@ import org.elasticsearch.xpack.core.ml.inference.preprocessing.OneHotEncoding;
 import org.elasticsearch.xpack.core.ml.inference.preprocessing.PreProcessor;
 import org.elasticsearch.xpack.core.ml.inference.preprocessing.TargetMeanEncoding;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TrainedModel;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ensemble.Ensemble;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ensemble.LogisticRegression;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ensemble.OutputAggregator;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ensemble.WeightedMode;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ensemble.WeightedSum;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.tree.Tree;
 import org.elasticsearch.xpack.core.ml.job.config.JobTaskState;
 import org.elasticsearch.xpack.core.monitoring.MonitoringFeatureSetUsage;
@@ -507,6 +512,13 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
                 new NamedWriteableRegistry.Entry(PreProcessor.class, TargetMeanEncoding.NAME.getPreferredName(), TargetMeanEncoding::new),
                 // ML - Inference models
                 new NamedWriteableRegistry.Entry(TrainedModel.class, Tree.NAME.getPreferredName(), Tree::new),
+                new NamedWriteableRegistry.Entry(TrainedModel.class, Ensemble.NAME.getPreferredName(), Ensemble::new),
+                // ML - Inference aggregators
+                new NamedWriteableRegistry.Entry(OutputAggregator.class, WeightedSum.NAME.getPreferredName(), WeightedSum::new),
+                new NamedWriteableRegistry.Entry(OutputAggregator.class, WeightedMode.NAME.getPreferredName(), WeightedMode::new),
+                new NamedWriteableRegistry.Entry(OutputAggregator.class,
+                    LogisticRegression.NAME.getPreferredName(),
+                    LogisticRegression::new),
 
                 // monitoring
                 new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.MONITORING, MonitoringFeatureSetUsage::new),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/MlInferenceNamedXContentProvider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/MlInferenceNamedXContentProvider.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TrainedModel;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.StrictlyParsedTrainedModel;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ensemble.Ensemble;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ensemble.LenientlyParsedOutputAggregator;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ensemble.LogisticRegression;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ensemble.OutputAggregator;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ensemble.StrictlyParsedOutputAggregator;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ensemble.WeightedMode;
@@ -61,6 +62,9 @@ public class MlInferenceNamedXContentProvider implements NamedXContentProvider {
         namedXContent.add(new NamedXContentRegistry.Entry(LenientlyParsedOutputAggregator.class,
             WeightedSum.NAME,
             WeightedSum::fromXContentLenient));
+        namedXContent.add(new NamedXContentRegistry.Entry(LenientlyParsedOutputAggregator.class,
+            LogisticRegression.NAME,
+            LogisticRegression::fromXContentLenient));
 
         // Model Strict
         namedXContent.add(new NamedXContentRegistry.Entry(StrictlyParsedTrainedModel.class, Tree.NAME, Tree::fromXContentStrict));
@@ -73,6 +77,9 @@ public class MlInferenceNamedXContentProvider implements NamedXContentProvider {
         namedXContent.add(new NamedXContentRegistry.Entry(StrictlyParsedOutputAggregator.class,
             WeightedSum.NAME,
             WeightedSum::fromXContentStrict));
+        namedXContent.add(new NamedXContentRegistry.Entry(StrictlyParsedOutputAggregator.class,
+            LogisticRegression.NAME,
+            LogisticRegression::fromXContentStrict));
 
         return namedXContent;
     }
@@ -99,6 +106,9 @@ public class MlInferenceNamedXContentProvider implements NamedXContentProvider {
         namedWriteables.add(new NamedWriteableRegistry.Entry(OutputAggregator.class,
             WeightedMode.NAME.getPreferredName(),
             WeightedMode::new));
+        namedWriteables.add(new NamedWriteableRegistry.Entry(OutputAggregator.class,
+            LogisticRegression.NAME.getPreferredName(),
+            LogisticRegression::new));
 
         return namedWriteables;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/LogisticRegression.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/LogisticRegression.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ml.inference.trainedmodel.ensemble;
+
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.IntStream;
+
+import static org.elasticsearch.xpack.core.ml.inference.utils.Statistics.sigmoid;
+
+public class LogisticRegression implements StrictlyParsedOutputAggregator, LenientlyParsedOutputAggregator {
+
+    public static final ParseField NAME = new ParseField("logistic_regression");
+    public static final ParseField WEIGHTS = new ParseField("weights");
+
+    private static final ConstructingObjectParser<LogisticRegression, Void> LENIENT_PARSER = createParser(true);
+    private static final ConstructingObjectParser<LogisticRegression, Void> STRICT_PARSER = createParser(false);
+
+    @SuppressWarnings("unchecked")
+    private static ConstructingObjectParser<LogisticRegression, Void> createParser(boolean lenient) {
+        ConstructingObjectParser<LogisticRegression, Void> parser = new ConstructingObjectParser<>(
+            NAME.getPreferredName(),
+            lenient,
+            a -> new LogisticRegression((List<Double>)a[0]));
+        parser.declareDoubleArray(ConstructingObjectParser.optionalConstructorArg(), WEIGHTS);
+        return parser;
+    }
+
+    public static LogisticRegression fromXContentStrict(XContentParser parser) {
+        return STRICT_PARSER.apply(parser, null);
+    }
+
+    public static LogisticRegression fromXContentLenient(XContentParser parser) {
+        return LENIENT_PARSER.apply(parser, null);
+    }
+
+    private final List<Double> weights;
+
+    LogisticRegression() {
+        this((List<Double>) null);
+    }
+
+    public LogisticRegression(List<Double> weights) {
+        this.weights = weights == null ? null : Collections.unmodifiableList(weights);
+    }
+
+    public LogisticRegression(StreamInput in) throws IOException {
+        if (in.readBoolean()) {
+            this.weights = Collections.unmodifiableList(in.readList(StreamInput::readDouble));
+        } else {
+            this.weights = null;
+        }
+    }
+
+    @Override
+    public Integer expectedValueSize() {
+        return this.weights == null ? null : this.weights.size();
+    }
+
+    @Override
+    public List<Double> processValues(List<Double> values) {
+        Objects.requireNonNull(values, "values must not be null");
+        if (weights != null && values.size() != weights.size()) {
+            throw new IllegalArgumentException("values must be the same length as weights.");
+        }
+        double summation = weights == null ?
+            values.stream().mapToDouble(Double::valueOf).sum() :
+            IntStream.range(0, weights.size()).mapToDouble(i -> values.get(i) * weights.get(i)).sum();
+        double probOfClassOne = sigmoid(summation);
+        assert 0.0 <= probOfClassOne && probOfClassOne <= 1.0;
+        return Arrays.asList(1.0 - probOfClassOne, probOfClassOne);
+    }
+
+    @Override
+    public double aggregate(List<Double> values) {
+        Objects.requireNonNull(values, "values must not be null");
+        assert values.size() == 2;
+        int bestValue = 0;
+        double bestProb = Double.NEGATIVE_INFINITY;
+        for (int i = 0; i < values.size(); i++) {
+            if (values.get(i) == null) {
+                throw new IllegalArgumentException("values must not contain null values");
+            }
+            if (values.get(i) > bestProb) {
+                bestProb = values.get(i);
+                bestValue = i;
+            }
+        }
+        return bestValue;
+    }
+
+    @Override
+    public String getName() {
+        return NAME.getPreferredName();
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME.getPreferredName();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeBoolean(weights != null);
+        if (weights != null) {
+            out.writeCollection(weights, StreamOutput::writeDouble);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        if (weights != null) {
+            builder.field(WEIGHTS.getPreferredName(), weights);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LogisticRegression that = (LogisticRegression) o;
+        return Objects.equals(weights, that.weights);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(weights);
+    }
+
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/utils/Statistics.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/utils/Statistics.java
@@ -45,6 +45,10 @@ public final class Statistics {
         return exps;
     }
 
+    public static double sigmoid(double value) {
+        return 1/(1 + Math.exp(-value));
+    }
+
     public static boolean isInvalid(Double v) {
         return v == null || Double.isInfinite(v) || Double.isNaN(v);
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/EnsembleTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/EnsembleTests.java
@@ -71,7 +71,9 @@ public class EnsembleTests extends AbstractSerializingTestCase<Ensemble> {
         List<Double> weights = randomBoolean() ?
             null :
             Stream.generate(ESTestCase::randomDouble).limit(numberOfModels).collect(Collectors.toList());
-        OutputAggregator outputAggregator = randomFrom(new WeightedMode(weights), new WeightedSum(weights));
+        OutputAggregator outputAggregator = randomFrom(new WeightedMode(weights),
+            new WeightedSum(weights),
+            new LogisticRegression(weights));
         List<String> categoryLabels = null;
         if (randomBoolean()) {
             categoryLabels = Arrays.asList(generateRandomStringArray(randomIntBetween(1, 10), randomIntBetween(1, 10), false, false));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/LogisticRegressionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/LogisticRegressionTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ml.inference.trainedmodel.ensemble;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class LogisticRegressionTests extends WeightedAggregatorTests<LogisticRegression> {
+
+    @Override
+    LogisticRegression createTestInstance(int numberOfWeights) {
+        List<Double> weights = Stream.generate(ESTestCase::randomDouble).limit(numberOfWeights).collect(Collectors.toList());
+        return new LogisticRegression(weights);
+    }
+
+    @Override
+    protected LogisticRegression doParseInstance(XContentParser parser) throws IOException {
+        return lenient ? LogisticRegression.fromXContentLenient(parser) : LogisticRegression.fromXContentStrict(parser);
+    }
+
+    @Override
+    protected LogisticRegression createTestInstance() {
+        return randomBoolean() ? new LogisticRegression() : createTestInstance(randomIntBetween(1, 100));
+    }
+
+    @Override
+    protected Writeable.Reader<LogisticRegression> instanceReader() {
+        return LogisticRegression::new;
+    }
+
+    public void testAggregate() {
+        List<Double> ones = Arrays.asList(1.0, 1.0, 1.0, 1.0, 1.0);
+        List<Double> values = Arrays.asList(1.0, 2.0, 2.0, 3.0, 5.0);
+
+        LogisticRegression logisticRegression = new LogisticRegression(ones);
+        assertThat(logisticRegression.aggregate(logisticRegression.processValues(values)), equalTo(1.0));
+
+        List<Double> variedWeights = Arrays.asList(.01, -1.0, .1, 0.0, 0.0);
+
+        logisticRegression = new LogisticRegression(variedWeights);
+        assertThat(logisticRegression.aggregate(logisticRegression.processValues(values)), equalTo(0.0));
+
+        logisticRegression = new LogisticRegression();
+        assertThat(logisticRegression.aggregate(logisticRegression.processValues(values)), equalTo(1.0));
+    }
+
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/utils/StatisticsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/utils/StatisticsTests.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.core.ml.inference.utils;
 
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Arrays;
@@ -28,6 +29,22 @@ public class StatisticsTests extends ESTestCase {
     public void testSoftMaxWithNoValidValues() {
         List<Double> values = Arrays.asList(Double.NEGATIVE_INFINITY, null, Double.NaN, Double.POSITIVE_INFINITY);
         expectThrows(IllegalArgumentException.class, () -> Statistics.softMax(values));
+    }
+
+    public void testSigmoid() {
+        double eps = 0.000001;
+        List<Tuple<Double, Double>> paramsAndExpectedReturns = Arrays.asList(
+            Tuple.tuple(0.0, 0.5),
+            Tuple.tuple(0.5, 0.62245933),
+            Tuple.tuple(1.0, 0.73105857),
+            Tuple.tuple(10000.0, 1.0),
+            Tuple.tuple(-0.5, 0.3775406),
+            Tuple.tuple(-1.0, 0.2689414),
+            Tuple.tuple(-10000.0, 0.0)
+        );
+        for (Tuple<Double, Double> expectation : paramsAndExpectedReturns) {
+            assertThat(Statistics.sigmoid(expectation.v1()), closeTo(expectation.v2(), eps));
+        }
     }
 
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] Add logistic_regression output aggregator  (#48238)