### PR TITLE
Download jdk to a temp file to make sure retries work

### DIFF
--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -16,7 +16,9 @@ FROM centos:7 AS builder
 ENV PATH /usr/share/elasticsearch/bin:$PATH
 ENV JAVA_HOME /opt/jdk-${jdkVersion}
 
-RUN curl -L --retry 8 -s ${jdkUrl} | tar -C /opt -zxf -
+RUN curl -L --retry 8 -s ${jdkUrl} --continue-at - --output /tmp/jdk.tar.gz && \
+    tar -C /opt -zxf /tmp/jdk.tar.gz && \
+    rm -Rf /tmp/jdk.tar.gz
 
 # Replace OpenJDK's built-in CA certificate keystore with the one from the OS
 # vendor. The latter is superior in several ways.

--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -16,7 +16,7 @@ FROM centos:7 AS builder
 ENV PATH /usr/share/elasticsearch/bin:$PATH
 ENV JAVA_HOME /opt/jdk-${jdkVersion}
 
-RUN curl -L --retry 8 -s ${jdkUrl} --continue-at - --output /tmp/jdk.tar.gz && \
+RUN curl -L --retry 8 -s -S ${jdkUrl} --continue-at - --output /tmp/jdk.tar.gz && \
     tar -C /opt -zxf /tmp/jdk.tar.gz && \
     rm -Rf /tmp/jdk.tar.gz
 


### PR DESCRIPTION
Note that retries will not work if the connection is refused.
The version of curl in the base image does not support `--retry-connrefused`

Closes #48129 
