### PR TITLE
Also validate source index at put enrich policy time.

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/EnrichDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/EnrichDocumentationIT.java
@@ -58,6 +58,10 @@ public class EnrichDocumentationIT extends ESRestHighLevelClientTestCase {
 
     public void testPutPolicy() throws Exception {
         RestHighLevelClient client = highLevelClient();
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest("users")
+            .mapping(Map.of("properties", Map.of("email", Map.of("type", "keyword"))));
+        client.indices().create(createIndexRequest, RequestOptions.DEFAULT);
+
         // tag::enrich-put-policy-request
         PutPolicyRequest putPolicyRequest = new PutPolicyRequest(
             "users-policy", "match", List.of("users"),
@@ -104,6 +108,10 @@ public class EnrichDocumentationIT extends ESRestHighLevelClientTestCase {
         RestHighLevelClient client = highLevelClient();
 
         {
+            CreateIndexRequest createIndexRequest = new CreateIndexRequest("users")
+                .mapping(Map.of("properties", Map.of("email", Map.of("type", "keyword"))));
+            client.indices().create(createIndexRequest, RequestOptions.DEFAULT);
+
             // Add a policy, so that it can be deleted:
             PutPolicyRequest putPolicyRequest = new PutPolicyRequest(
                 "users-policy", "match", List.of("users"),
@@ -154,6 +162,10 @@ public class EnrichDocumentationIT extends ESRestHighLevelClientTestCase {
 
     public void testGetPolicy() throws Exception {
         RestHighLevelClient client = highLevelClient();
+
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest("users")
+            .mapping(Map.of("properties", Map.of("email", Map.of("type", "keyword"))));
+        client.indices().create(createIndexRequest, RequestOptions.DEFAULT);
 
         PutPolicyRequest putPolicyRequest = new PutPolicyRequest(
             "users-policy", "match", List.of("users"),

--- a/docs/reference/ingest/apis/enrich/delete-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/delete-enrich-policy.asciidoc
@@ -12,6 +12,13 @@ Deletes an existing enrich policy and its enrich index.
 [source,console]
 ----
 PUT /users
+{
+    "mappings" : {
+        "properties" : {
+            "email" : { "type" : "keyword" }
+        }
+    }
+}
 
 PUT /_enrich/policy/my-policy
 {

--- a/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
@@ -12,6 +12,13 @@ Returns information about an enrich policy.
 [source,console]
 ----
 PUT /users
+{
+    "mappings" : {
+        "properties" : {
+            "email" : { "type" : "keyword" }
+        }
+    }
+}
 
 PUT /_enrich/policy/my-policy
 {

--- a/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
@@ -12,6 +12,13 @@ Creates an enrich policy.
 [source,console]
 ----
 PUT /users
+{
+    "mappings" : {
+        "properties" : {
+            "email" : { "type" : "keyword" }
+        }
+    }
+}
 ----
 ////
 

--- a/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
+++ b/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
@@ -10,6 +10,7 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -38,6 +39,15 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
         for (Map<?, ?> entry: policies) {
             client().performRequest(new Request("DELETE", "/_enrich/policy/" +
                 XContentMapValues.extractValue("config.match.name", entry)));
+
+            List<?> sourceIndices = (List<?>) XContentMapValues.extractValue("config.match.indices", entry);
+            for (Object sourceIndex : sourceIndices) {
+                try {
+                    client().performRequest(new Request("DELETE", "/" + sourceIndex));
+                } catch (ResponseException e) {
+                    // and that is ok
+                }
+            }
         }
     }
 
@@ -48,6 +58,8 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
     }
 
     private void setupGenericLifecycleTest(boolean deletePipeilne) throws Exception {
+        // Create source index:
+        createSourceIndex("my-source-index");
         // Create the policy:
         Request putPolicyRequest = new Request("PUT", "/_enrich/policy/my_policy");
         putPolicyRequest.setJsonEntity(generatePolicySource("my-source-index"));
@@ -99,6 +111,7 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
     }
 
     public void testImmutablePolicy() throws IOException {
+        createSourceIndex("my-source-index");
         Request putPolicyRequest = new Request("PUT", "/_enrich/policy/my_policy");
         putPolicyRequest.setJsonEntity(generatePolicySource("my-source-index"));
         assertOK(client().performRequest(putPolicyRequest));
@@ -108,6 +121,7 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
     }
 
     public void testDeleteIsCaseSensitive() throws Exception {
+        createSourceIndex("my-source-index");
         Request putPolicyRequest = new Request("PUT", "/_enrich/policy/my_policy");
         putPolicyRequest.setJsonEntity(generatePolicySource("my-source-index"));
         assertOK(client().performRequest(putPolicyRequest));
@@ -153,6 +167,20 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
         }
         source.endObject().endObject();
         return Strings.toString(source);
+    }
+
+    public static void createSourceIndex(String index) throws IOException {
+        String mapping = createSourceIndexMapping();
+        createIndex(index, Settings.EMPTY, mapping);
+    }
+
+    public static String createSourceIndexMapping() {
+        return "\"properties\":" +
+            "{\"host\": {\"type\":\"keyword\"}," +
+            "\"globalRank\":{\"type\":\"keyword\"}," +
+            "\"tldRank\":{\"type\":\"keyword\"}," +
+            "\"tld\":{\"type\":\"keyword\"}" +
+            "}";
     }
 
     private static Map<String, Object> toMap(Response response) throws IOException {

--- a/x-pack/plugin/enrich/qa/rest-with-security/src/test/java/org/elasticsearch/xpack/enrich/EnrichSecurityIT.java
+++ b/x-pack/plugin/enrich/qa/rest-with-security/src/test/java/org/elasticsearch/xpack/enrich/EnrichSecurityIT.java
@@ -36,6 +36,9 @@ public class EnrichSecurityIT extends CommonEnrichRestTestCase {
     public void testInsufficientPermissionsOnNonExistentIndex() throws Exception {
         // This test is here because it requires a valid user that has permission to execute policy PUTs but should fail if the user
         // does not have access to read the backing indices used to enrich the data.
+        Request request = new Request("PUT", "/some-other-index");
+        request.setJsonEntity("{\n \"mappings\" : {" + createSourceIndexMapping() + "} }");
+        adminClient().performRequest(request);
         Request putPolicyRequest = new Request("PUT", "/_enrich/policy/my_policy");
         putPolicyRequest.setJsonEntity(generatePolicySource("some-other-index"));
         ResponseException exc = expectThrows(ResponseException.class, () -> client().performRequest(putPolicyRequest));

--- a/x-pack/plugin/enrich/qa/rest/src/test/resources/rest-api-spec/test/enrich/10_basic.yml
+++ b/x-pack/plugin/enrich/qa/rest/src/test/resources/rest-api-spec/test/enrich/10_basic.yml
@@ -2,6 +2,20 @@
 "Test enrich crud apis":
 
   - do:
+      indices.create:
+        index: bar
+        body:
+          mappings:
+            properties:
+              baz:
+                type: keyword
+              a:
+                type: keyword
+              b:
+                type: keyword
+  - is_true: acknowledged
+
+  - do:
       enrich.put_policy:
         name: policy-crud
         body:

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
@@ -136,27 +136,34 @@ public class EnrichPolicyRunner implements Runnable {
         logger.debug("Policy [{}]: Validating [{}] source mappings", policyName, sourceIndices);
         for (String sourceIndex : sourceIndices) {
             Map<String, Object> mapping = getMappings(getIndexResponse, sourceIndex);
-            // First ensure mapping is set
-            if (mapping.get("properties") == null) {
-                throw new ElasticsearchException(
-                    "Enrich policy execution for [{}] failed. Could not read mapping for source [{}] included by pattern [{}]",
-                    policyName, sourceIndex, policy.getIndices());
-            }
-            // Validate the key and values
-            try {
-                validateField(mapping, policy.getMatchField(), true);
-                for (String valueFieldName : policy.getEnrichFields()) {
-                    validateField(mapping, valueFieldName, false);
-                }
-            } catch (ElasticsearchException e) {
-                throw new ElasticsearchException(
-                        "Enrich policy execution for [{}] failed while validating field mappings for index [{}]",
-                        e, policyName, sourceIndex);
-            }
+            validateMappings(policyName, policy, sourceIndex, mapping);
         }
     }
 
-    private void validateField(Map<?, ?> properties, String fieldName, boolean fieldRequired) {
+    static void validateMappings(final String policyName,
+                                 final EnrichPolicy policy,
+                                 final String sourceIndex,
+                                 final Map<String, Object> mapping) {
+        // First ensure mapping is set
+        if (mapping.get("properties") == null) {
+            throw new ElasticsearchException(
+                "Enrich policy execution for [{}] failed. Could not read mapping for source [{}] included by pattern [{}]",
+                policyName, sourceIndex, policy.getIndices());
+        }
+        // Validate the key and values
+        try {
+            validateField(mapping, policy.getMatchField(), true);
+            for (String valueFieldName : policy.getEnrichFields()) {
+                validateField(mapping, valueFieldName, false);
+            }
+        } catch (ElasticsearchException e) {
+            throw new ElasticsearchException(
+                "Enrich policy execution for [{}] failed while validating field mappings for index [{}]",
+                e, policyName, sourceIndex);
+        }
+    }
+
+    private static void validateField(Map<?, ?> properties, String fieldName, boolean fieldRequired) {
         assert Strings.isEmpty(fieldName) == false: "Field name cannot be null or empty";
         String[] fieldParts = fieldName.split("\\.");
         StringBuilder parent = new StringBuilder();

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportPutEnrichPolicyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportPutEnrichPolicyAction.java
@@ -103,7 +103,7 @@ public class TransportPutEnrichPolicyAction extends TransportMasterNodeAction<Pu
     }
 
     private void putPolicy(PutEnrichPolicyAction.Request request, ActionListener<AcknowledgedResponse> listener ) {
-        EnrichStore.putPolicy(request.getName(), request.getPolicy(), clusterService, e -> {
+        EnrichStore.putPolicy(request.getName(), request.getPolicy(), clusterService, indexNameExpressionResolver, e -> {
             if (e == null) {
                 listener.onResponse(new AcknowledgedResponse(true));
             } else {

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/AbstractEnrichTestCase.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/AbstractEnrichTestCase.java
@@ -5,6 +5,10 @@
  */
 package org.elasticsearch.xpack.enrich;
 
+import org.elasticsearch.ResourceAlreadyExistsException;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
@@ -24,9 +28,13 @@ public abstract class AbstractEnrichTestCase extends ESSingleNodeTestCase {
 
     protected AtomicReference<Exception> saveEnrichPolicy(String name, EnrichPolicy policy,
                                                           ClusterService clusterService) throws InterruptedException {
+        if (policy != null) {
+            createSourceIndices(policy);
+        }
+        IndexNameExpressionResolver resolver = new IndexNameExpressionResolver();
         CountDownLatch latch = new CountDownLatch(1);
         AtomicReference<Exception> error = new AtomicReference<>();
-        EnrichStore.putPolicy(name, policy, clusterService, e -> {
+        EnrichStore.putPolicy(name, policy, clusterService, resolver, e -> {
             error.set(e);
             latch.countDown();
         });
@@ -44,6 +52,22 @@ public abstract class AbstractEnrichTestCase extends ESSingleNodeTestCase {
         latch.await();
         if (error.get() != null){
             throw error.get();
+        }
+    }
+
+    protected void createSourceIndices(EnrichPolicy policy) {
+        createSourceIndices(client(), policy);
+    }
+
+    protected static void createSourceIndices(Client client, EnrichPolicy policy) {
+        for (String sourceIndex : policy.getIndices()) {
+            CreateIndexRequest createIndexRequest = new CreateIndexRequest(sourceIndex);
+            createIndexRequest.mapping("_doc", policy.getMatchField(), "type=keyword");
+            try {
+                client.admin().indices().create(createIndexRequest).actionGet();
+            } catch (ResourceAlreadyExistsException e) {
+                // and that is okay
+            }
         }
     }
 }

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyMaintenanceServiceTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyMaintenanceServiceTests.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Phaser;
@@ -23,6 +24,7 @@ import org.elasticsearch.action.admin.indices.alias.get.GetAliasesResponse;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -33,6 +35,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 
 import static org.elasticsearch.xpack.core.enrich.EnrichPolicy.MATCH_TYPE;
+import static org.elasticsearch.xpack.enrich.AbstractEnrichTestCase.createSourceIndices;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 
@@ -113,12 +116,15 @@ public class EnrichPolicyMaintenanceServiceTests extends ESSingleNodeTestCase {
         for (int i = 0; i < randomIntBetween(1, 3); i++) {
             enrichKeys.add(randomAlphaOfLength(10));
         }
-        return new EnrichPolicy(MATCH_TYPE, null, List.of(randomAlphaOfLength(10)), randomAlphaOfLength(10), enrichKeys);
+        String sourceIndex = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        return new EnrichPolicy(MATCH_TYPE, null, List.of(sourceIndex), randomAlphaOfLength(10), enrichKeys);
     }
 
     private void addPolicy(String policyName, EnrichPolicy policy) throws InterruptedException {
+        IndexNameExpressionResolver resolver = new IndexNameExpressionResolver();
+        createSourceIndices(client(), policy);
         doSyncronously((clusterService, exceptionConsumer) ->
-            EnrichStore.putPolicy(policyName, policy, clusterService, exceptionConsumer));
+            EnrichStore.putPolicy(policyName, policy, clusterService, resolver, exceptionConsumer));
     }
 
     private void removePolicy(String policyName) throws InterruptedException {

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyTests.java
@@ -22,6 +22,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
+import java.util.Locale;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
@@ -59,7 +61,9 @@ public class EnrichPolicyTests extends AbstractSerializingTestCase<EnrichPolicy>
             return new EnrichPolicy(
                 randomFrom(EnrichPolicy.SUPPORTED_POLICY_TYPES),
                 randomBoolean() ? querySource : null,
-                Arrays.asList(generateRandomStringArray(8, 4, false, false)),
+                Arrays.stream(generateRandomStringArray(8, 4, false, false))
+                    .map(s -> s.toLowerCase(Locale.ROOT))
+                    .collect(Collectors.toList()),
                 randomAlphaOfLength(4),
                 Arrays.asList(generateRandomStringArray(8, 4, false, false))
             );

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyUpdateTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyUpdateTests.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.xpack.enrich.AbstractEnrichTestCase.createSourceIndices;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -40,6 +41,7 @@ public class EnrichPolicyUpdateTests extends ESSingleNodeTestCase {
 
         EnrichPolicy instance1 =
             new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, List.of("index"), "key1", List.of("field1"));
+        createSourceIndices(client(), instance1);
         PutEnrichPolicyAction.Request putPolicyRequest = new PutEnrichPolicyAction.Request("my_policy", instance1);
         assertAcked(client().execute(PutEnrichPolicyAction.INSTANCE, putPolicyRequest).actionGet());
         assertThat("Execute failed", client().execute(ExecuteEnrichPolicyAction.INSTANCE,
@@ -53,7 +55,8 @@ public class EnrichPolicyUpdateTests extends ESSingleNodeTestCase {
         assertThat(pipelineInstance1.getProcessors().get(0), instanceOf(MatchProcessor.class));
 
         EnrichPolicy instance2 =
-            new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, List.of("index"), "key2", List.of("field2"));
+            new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, List.of("index2"), "key2", List.of("field2"));
+        createSourceIndices(client(), instance2);
         ResourceAlreadyExistsException exc = expectThrows(ResourceAlreadyExistsException.class, () ->
             client().execute(PutEnrichPolicyAction.INSTANCE, new PutEnrichPolicyAction.Request("my_policy", instance2)).actionGet());
         assertTrue(exc.getMessage().contains("policy [my_policy] already exists"));

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichRestartIT.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichRestartIT.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
+import static org.elasticsearch.xpack.enrich.AbstractEnrichTestCase.createSourceIndices;
 import static org.elasticsearch.xpack.enrich.EnrichMultiNodeIT.DECORATE_FIELDS;
 import static org.elasticsearch.xpack.enrich.EnrichMultiNodeIT.MATCH_FIELD;
 import static org.elasticsearch.xpack.enrich.EnrichMultiNodeIT.POLICY_NAME;
@@ -37,6 +38,7 @@ public class EnrichRestartIT extends ESIntegTestCase {
 
         EnrichPolicy enrichPolicy =
             new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, List.of(SOURCE_INDEX_NAME), MATCH_FIELD, List.of(DECORATE_FIELDS));
+        createSourceIndices(client(), enrichPolicy);
         for (int i = 0; i < numPolicies; i++) {
             String policyName = POLICY_NAME + i;
             PutEnrichPolicyAction.Request request = new PutEnrichPolicyAction.Request(policyName, enrichPolicy);

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/TransportDeleteEnrichPolicyActionTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/TransportDeleteEnrichPolicyActionTests.java
@@ -32,7 +32,7 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 public class TransportDeleteEnrichPolicyActionTests extends AbstractEnrichTestCase {
 
     @After
-    private void cleanupPolicy() {
+    public void cleanupPolicy() {
         ClusterService clusterService = getInstanceFromNode(ClusterService.class);
         String name = "my-policy";
 
@@ -57,7 +57,7 @@ public class TransportDeleteEnrichPolicyActionTests extends AbstractEnrichTestCa
         final TransportDeleteEnrichPolicyAction transportAction = node().injector().getInstance(TransportDeleteEnrichPolicyAction.class);
         ActionTestUtils.execute(transportAction, null,
             new DeleteEnrichPolicyAction.Request(fakeId),
-            new ActionListener<AcknowledgedResponse>() {
+            new ActionListener<>() {
                 @Override
                 public void onResponse(AcknowledgedResponse acknowledgedResponse) {
                     fail();
@@ -91,7 +91,7 @@ public class TransportDeleteEnrichPolicyActionTests extends AbstractEnrichTestCa
         final TransportDeleteEnrichPolicyAction transportAction = node().injector().getInstance(TransportDeleteEnrichPolicyAction.class);
         ActionTestUtils.execute(transportAction, null,
             new DeleteEnrichPolicyAction.Request(name),
-            new ActionListener<AcknowledgedResponse>() {
+            new ActionListener<>() {
                 @Override
                 public void onResponse(AcknowledgedResponse acknowledgedResponse) {
                     reference.set(acknowledgedResponse);
@@ -132,7 +132,7 @@ public class TransportDeleteEnrichPolicyActionTests extends AbstractEnrichTestCa
         final TransportDeleteEnrichPolicyAction transportAction = node().injector().getInstance(TransportDeleteEnrichPolicyAction.class);
         ActionTestUtils.execute(transportAction, null,
             new DeleteEnrichPolicyAction.Request(name),
-            new ActionListener<AcknowledgedResponse>() {
+            new ActionListener<>() {
                 @Override
                 public void onResponse(AcknowledgedResponse acknowledgedResponse) {
                     reference.set(acknowledgedResponse);
@@ -179,7 +179,7 @@ public class TransportDeleteEnrichPolicyActionTests extends AbstractEnrichTestCa
             final AtomicReference<Exception> reference = new AtomicReference<>();
             ActionTestUtils.execute(transportAction, null,
                 new DeleteEnrichPolicyAction.Request(name),
-                new ActionListener<AcknowledgedResponse>() {
+                new ActionListener<>() {
                     @Override
                     public void onResponse(AcknowledgedResponse acknowledgedResponse) {
                         fail();
@@ -205,7 +205,7 @@ public class TransportDeleteEnrichPolicyActionTests extends AbstractEnrichTestCa
 
             ActionTestUtils.execute(transportAction, null,
                 new DeleteEnrichPolicyAction.Request(name),
-                new ActionListener<AcknowledgedResponse>() {
+                new ActionListener<>() {
                     @Override
                     public void onResponse(AcknowledgedResponse acknowledgedResponse) {
                         reference.set(acknowledgedResponse);

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/TransportGetEnrichPolicyActionTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/TransportGetEnrichPolicyActionTests.java
@@ -27,7 +27,7 @@ import static org.hamcrest.Matchers.nullValue;
 public class TransportGetEnrichPolicyActionTests extends AbstractEnrichTestCase {
 
     @After
-    private void cleanupPolicies() throws InterruptedException {
+    public void cleanupPolicies() throws InterruptedException {
         ClusterService clusterService = getInstanceFromNode(ClusterService.class);
 
         final CountDownLatch latch = new CountDownLatch(1);
@@ -35,7 +35,7 @@ public class TransportGetEnrichPolicyActionTests extends AbstractEnrichTestCase 
         final TransportGetEnrichPolicyAction transportAction = node().injector().getInstance(TransportGetEnrichPolicyAction.class);
         ActionTestUtils.execute(transportAction, null,
             new GetEnrichPolicyAction.Request(),
-            new ActionListener<GetEnrichPolicyAction.Response>() {
+            new ActionListener<>() {
                 @Override
                 public void onResponse(GetEnrichPolicyAction.Response response) {
                     reference.set(response);
@@ -108,7 +108,7 @@ public class TransportGetEnrichPolicyActionTests extends AbstractEnrichTestCase 
         final TransportGetEnrichPolicyAction transportAction = node().injector().getInstance(TransportGetEnrichPolicyAction.class);
         ActionTestUtils.execute(transportAction, null,
             new GetEnrichPolicyAction.Request(),
-            new ActionListener<GetEnrichPolicyAction.Response>() {
+            new ActionListener<>() {
                 @Override
                 public void onResponse(GetEnrichPolicyAction.Response response) {
                     reference.set(response);
@@ -144,7 +144,7 @@ public class TransportGetEnrichPolicyActionTests extends AbstractEnrichTestCase 
         final TransportGetEnrichPolicyAction transportAction = node().injector().getInstance(TransportGetEnrichPolicyAction.class);
         ActionTestUtils.execute(transportAction, null,
             new GetEnrichPolicyAction.Request(new String[]{name}),
-            new ActionListener<GetEnrichPolicyAction.Response>() {
+            new ActionListener<>() {
                 @Override
                 public void onResponse(GetEnrichPolicyAction.Response response) {
                     reference.set(response);
@@ -187,7 +187,7 @@ public class TransportGetEnrichPolicyActionTests extends AbstractEnrichTestCase 
         final TransportGetEnrichPolicyAction transportAction = node().injector().getInstance(TransportGetEnrichPolicyAction.class);
         ActionTestUtils.execute(transportAction, null,
             new GetEnrichPolicyAction.Request(new String[]{name, anotherName}),
-            new ActionListener<GetEnrichPolicyAction.Response>() {
+            new ActionListener<>() {
                 @Override
                 public void onResponse(GetEnrichPolicyAction.Response response) {
                     reference.set(response);
@@ -218,7 +218,7 @@ public class TransportGetEnrichPolicyActionTests extends AbstractEnrichTestCase 
         final TransportGetEnrichPolicyAction transportAction = node().injector().getInstance(TransportGetEnrichPolicyAction.class);
         ActionTestUtils.execute(transportAction, null,
             new GetEnrichPolicyAction.Request(new String[]{"non-exists"}),
-            new ActionListener<GetEnrichPolicyAction.Response>() {
+            new ActionListener<>() {
                 @Override
                 public void onResponse(GetEnrichPolicyAction.Response response) {
                     reference.set(response);


### PR DESCRIPTION
This changes tests to be changed to create a valid
source index prior to creating the enrich policy.