### PR TITLE
[DOCS] Re-enable code snippet testing in close anomaly detection job API

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -1038,6 +1038,29 @@ buildRestTests.setups['server_metrics_job'] = buildRestTests.setups['server_metr
             }
           }
 '''
+buildRestTests.setups['server_metrics_job-raw'] = buildRestTests.setups['server_metrics_data'] + '''
+  - do:
+      raw:
+        method: PUT
+        path: _ml/anomaly_detectors/total-requests
+        body:  >
+          {
+            "description" : "Total sum of requests",
+            "analysis_config" : {
+              "bucket_span":"10m",
+              "detectors" :[
+              {
+                "detector_description": "Sum of total",
+                "function": "sum",
+                "field_name": "total"
+              }
+            ]},
+            "data_description" : {
+              "time_field":"timestamp",
+              "time_format": "epoch_ms"
+            }
+          }
+'''
 buildRestTests.setups['server_metrics_datafeed'] = buildRestTests.setups['server_metrics_job'] + '''
   - do:
       ml.put_datafeed:
@@ -1048,10 +1071,27 @@ buildRestTests.setups['server_metrics_datafeed'] = buildRestTests.setups['server
           "indexes":"server-metrics"
           }
 '''
+buildRestTests.setups['server_metrics_datafeed-raw'] = buildRestTests.setups['server_metrics_job-raw'] + '''
+  - do:
+      raw:
+        method: PUT
+        path: _ml/datafeeds/datafeed-total-requests
+        body:  >
+          {
+          "job_id":"total-requests",
+          "indexes":"server-metrics"
+          }
+'''
 buildRestTests.setups['server_metrics_openjob'] = buildRestTests.setups['server_metrics_datafeed'] + '''
   - do:
       ml.open_job:
         job_id: "total-requests"
+'''
+buildRestTests.setups['server_metrics_openjob-raw'] = buildRestTests.setups['server_metrics_datafeed-raw'] + '''
+  - do:
+      raw:
+        method: POST 
+        path: _ml/anomaly_detectors/total-requests/_open
 '''
 buildRestTests.setups['server_metrics_startdf'] = buildRestTests.setups['server_metrics_openjob'] + '''
   - do:

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -972,12 +972,11 @@ buildRestTests.setups['server_metrics_index'] = '''
               number_of_shards: 1
               number_of_replicas: 0
             mappings:
-              metric:
-                properties:
-                  timestamp:
-                    type: date
-                  total:
-                    type: long
+              properties:
+                timestamp:
+                  type: date
+                total:
+                  type: long
 '''
 buildRestTests.setups['server_metrics_data'] = buildRestTests.setups['server_metrics_index'] + '''
   - do:

--- a/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
@@ -102,7 +102,7 @@ The following example closes the `total-requests` job:
 --------------------------------------------------
 POST _ml/anomaly_detectors/total-requests/_close
 --------------------------------------------------
-// TEST[skip:setup:server_metrics_openjob]
+// TEST[setup:server_metrics_openjob-raw]
 
 When the job is closed, you receive the following results:
 


### PR DESCRIPTION
The current code snippet tests in the documentation do not seem to support the use of non-OSS APIs and result in "rest api xxx doesn't exist in the rest spec" failures. This PR therefore tries to use "raw" methods in the build.gradle to re-enable testing in a machine learning API, similar to what is done for rollup and transform APIs (https://github.com/elastic/elasticsearch/pull/45154).