### PR TITLE
Fail with a better error when if there are no ingest nodes

### DIFF
--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportExecuteEnrichPolicyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportExecuteEnrichPolicyAction.java
@@ -62,6 +62,12 @@ public class TransportExecuteEnrichPolicyAction
     @Override
     protected void masterOperation(Task task, ExecuteEnrichPolicyAction.Request request, ClusterState state,
                                    ActionListener<ExecuteEnrichPolicyAction.Response> listener) {
+        if (state.getNodes().getIngestNodes().isEmpty()) {
+            // if we don't fail here then reindex will fail with a more complicated error.
+            // (EnrichPolicyRunner uses a pipeline with reindex)
+            throw new IllegalStateException("no ingest nodes in this cluster");
+        }
+
         if (request.isWaitForCompletion()) {
             executor.runPolicy(request, new ActionListener<>() {
                 @Override

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichMultiNodeIT.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichMultiNodeIT.java
@@ -119,6 +119,19 @@ public class EnrichMultiNodeIT extends ESIntegTestCase {
         enrich(keys, ingestOnlyNode);
     }
 
+    public void testEnrichNoIngestNodes() {
+        Settings settings = Settings.builder()
+            .put(Node.NODE_MASTER_SETTING.getKey(), true)
+            .put(Node.NODE_DATA_SETTING.getKey(), true)
+            .put(Node.NODE_INGEST_SETTING.getKey(), false)
+            .build();
+        internalCluster().startNode(settings);
+
+        createSourceIndex(64);
+        Exception e = expectThrows(IllegalStateException.class, EnrichMultiNodeIT::createAndExecutePolicy);
+        assertThat(e.getMessage(), equalTo("no ingest nodes in this cluster"));
+    }
+
     private static void enrich(List<String> keys, String coordinatingNode) {
         int numDocs = 256;
         BulkRequest bulkRequest = new BulkRequest("my-index");


### PR DESCRIPTION
when executing enrich execute policy api.
