### PR TITLE
[Transform] separate old and mixed rolling upgrade tests

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_data_frame_jobs_crud.yml
@@ -162,7 +162,7 @@ setup:
   - do:
       transform.delete_transform:
         transform_id: "mixed-complex-transform"
-   - do:
+  - do:
       transform.get_transform_stats:
         transform_id: "mixed-simple-transform,mixed-complex-transform"
   - match: { count: 0 }

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_data_frame_jobs_crud.yml
@@ -79,6 +79,10 @@ setup:
   - do:
       transform.delete_transform:
         transform_id: "old-simple-transform"
+  - do:
+      transform.get_transform_stats:
+        transform_id: "old-simple-transform"
+  - match: { count: 0 }
 
 ---
 "Get start, stop mixed cluster batch data frame transforms":
@@ -158,11 +162,9 @@ setup:
   - do:
       transform.delete_transform:
         transform_id: "mixed-complex-transform"
----
-"Test old, mixed transform deleted":
-  - do:
+   - do:
       transform.get_transform_stats:
-        transform_id: "old-simple-transform,mixed-simple-transform,mixed-complex-transform"
+        transform_id: "mixed-simple-transform,mixed-complex-transform"
   - match: { count: 0 }
 
 ---

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_data_frame_jobs_crud.yml
@@ -6,7 +6,7 @@ setup:
         # wait for long enough that we give delayed unassigned shards to stop being delayed
         timeout: 70s
 ---
-"Get start, stop, and delete old and mixed cluster batch data frame transforms":
+"Get start, stop, and delete old cluster batch data frame transforms":
   # Simple and complex OLD transforms
   - do:
       transform.get_transform:
@@ -75,7 +75,13 @@ setup:
   - match: { count: 1 }
   - match: { transforms.0.id: "old-complex-transform" }
   - match: { transforms.0.state: "stopped" }
+  # Delete old transform
+  - do:
+      transform.delete_transform:
+        transform_id: "old-simple-transform"
 
+---
+"Get start, stop mixed cluster batch data frame transforms":
   # Simple and complex Mixed cluster transforms
   - do:
       transform.get_transform:
@@ -145,23 +151,22 @@ setup:
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-complex-transform" }
   - match: { transforms.0.state: "stopped" }
-
-# Delete all old and mixed transforms
-  - do:
-      transform.delete_transform:
-        transform_id: "old-simple-transform"
-
+  # Delete mixed transform
   - do:
       transform.delete_transform:
         transform_id: "mixed-simple-transform"
-
+  - do:
+      transform.delete_transform:
+        transform_id: "mixed-complex-transform"
+---
+"Test old, mixed transform deleted":
   - do:
       transform.get_transform_stats:
-        transform_id: "old-simple-transform,mixed-simple-transform"
+        transform_id: "old-simple-transform,mixed-simple-transform,mixed-complex-transform"
   - match: { count: 0 }
 
 ---
-"Test GET, stop, delete, old and mixed continuous transforms":
+"Test GET, stop, delete, old continuous transforms":
   - do:
       transform.get_transform:
         transform_id: "old-simple-continuous-transform"
@@ -206,7 +211,8 @@ setup:
   - do:
       transform.delete_transform:
         transform_id: "old-simple-continuous-transform"
-
+---
+"Test GET, mixed continuous transforms":
   - do:
       transform.get_transform:
         transform_id: "mixed-simple-continuous-transform"


### PR DESCRIPTION
separates rolling upgrade tests for transforms created on old and mixed clusters.

Prerequisite to disable tests for transforms in mixed clusters created with 7.2, 7.3, see  #48019 and #48247