### PR TITLE
MappingMetaData routing can be a simple boolean

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -543,7 +543,7 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
     public void process(Version indexCreatedVersion, @Nullable MappingMetaData mappingMd, String concreteIndex) {
         if (mappingMd != null) {
             // might as well check for routing here
-            if (mappingMd.routing().required() && routing == null) {
+            if (mappingMd.routingRequired() && routing == null) {
                 throw new RoutingMissingException(concreteIndex, id);
             }
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeBooleanValue;
 
@@ -45,46 +46,16 @@ public class MappingMetaData extends AbstractDiffable<MappingMetaData> {
 
     public static final MappingMetaData EMPTY_MAPPINGS = new MappingMetaData("_doc", Collections.emptyMap());
 
-    public static class Routing {
-
-        public static final Routing EMPTY = new Routing(false);
-
-        private final boolean required;
-
-        public Routing(boolean required) {
-            this.required = required;
-        }
-
-        public boolean required() {
-            return required;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            Routing routing = (Routing) o;
-
-            return required == routing.required;
-        }
-
-        @Override
-        public int hashCode() {
-            return getClass().hashCode() + (required ? 1 : 0);
-        }
-    }
-
     private final String type;
 
     private final CompressedXContent source;
 
-    private final Routing routing;
+    private final boolean routingRequired;
 
     public MappingMetaData(DocumentMapper docMapper) {
         this.type = docMapper.type();
         this.source = docMapper.mappingSource();
-        this.routing = new Routing(docMapper.routingFieldMapper().required());
+        this.routingRequired = docMapper.routingFieldMapper().required();
     }
 
     @SuppressWarnings("unchecked")
@@ -95,7 +66,7 @@ public class MappingMetaData extends AbstractDiffable<MappingMetaData> {
             throw new IllegalStateException("Can't derive type from mapping, no root type: " + mapping.string());
         }
         this.type = mappingMap.keySet().iterator().next();
-        this.routing = initRouting((Map<String, Object>) mappingMap.get(this.type));
+        this.routingRequired = routingRequired((Map<String, Object>) mappingMap.get(this.type));
     }
 
     @SuppressWarnings("unchecked")
@@ -112,13 +83,13 @@ public class MappingMetaData extends AbstractDiffable<MappingMetaData> {
         if (mapping.size() == 1 && mapping.containsKey(type)) {
             withoutType = (Map<String, Object>) mapping.get(type);
         }
-        this.routing = initRouting(withoutType);
+        this.routingRequired = routingRequired(withoutType);
     }
 
     @SuppressWarnings("unchecked")
-    private Routing initRouting(Map<String, Object> withoutType) {
+    private boolean routingRequired(Map<String, Object> withoutType) {
+        boolean required = false;
         if (withoutType.containsKey("_routing")) {
-            boolean required = false;
             Map<String, Object> routingNode = (Map<String, Object>) withoutType.get("_routing");
             for (Map.Entry<String, Object> entry : routingNode.entrySet()) {
                 String fieldName = entry.getKey();
@@ -132,10 +103,8 @@ public class MappingMetaData extends AbstractDiffable<MappingMetaData> {
                     }
                 }
             }
-            return new Routing(required);
-        } else {
-            return Routing.EMPTY;
         }
+        return required;
     }
 
     public String type() {
@@ -165,8 +134,8 @@ public class MappingMetaData extends AbstractDiffable<MappingMetaData> {
         return sourceAsMap();
     }
 
-    public Routing routing() {
-        return this.routing;
+    public boolean routingRequired() {
+        return this.routingRequired;
     }
 
     @Override
@@ -174,7 +143,7 @@ public class MappingMetaData extends AbstractDiffable<MappingMetaData> {
         out.writeString(type());
         source().writeTo(out);
         // routing
-        out.writeBoolean(routing().required());
+        out.writeBoolean(routingRequired);
     }
 
     @Override
@@ -184,7 +153,7 @@ public class MappingMetaData extends AbstractDiffable<MappingMetaData> {
 
         MappingMetaData that = (MappingMetaData) o;
 
-        if (!routing.equals(that.routing)) return false;
+        if (!Objects.equals(this.routingRequired, that.routingRequired)) return false;
         if (!source.equals(that.source)) return false;
         if (!type.equals(that.type)) return false;
 
@@ -193,17 +162,13 @@ public class MappingMetaData extends AbstractDiffable<MappingMetaData> {
 
     @Override
     public int hashCode() {
-        int result = type.hashCode();
-        result = 31 * result + source.hashCode();
-        result = 31 * result + routing.hashCode();
-        return result;
+        return Objects.hash(type, source, routingRequired);
     }
 
     public MappingMetaData(StreamInput in) throws IOException {
         type = in.readString();
         source = CompressedXContent.readCompressedString(in);
-        // routing
-        routing = new Routing(in.readBoolean());
+        routingRequired = in.readBoolean();
     }
 
     public static Diff<MappingMetaData> readDiffFrom(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -696,7 +696,7 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, To
         if (indexMetaData != null) {
             MappingMetaData mappingMetaData = indexMetaData.mapping();
             if (mappingMetaData != null) {
-                return mappingMetaData.routing().required();
+                return mappingMetaData.routingRequired();
             }
         }
         return false;

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
@@ -93,8 +93,8 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
 
         logger.info("--> verify meta _routing required exists");
         MappingMetaData mappingMd = client().admin().cluster().prepareState().execute().actionGet().getState().metaData()
-            .index("test").getMappings().get("type1");
-        assertThat(mappingMd.routing().required(), equalTo(true));
+            .index("test").mapping();
+        assertThat(mappingMd.routingRequired(), equalTo(true));
 
         logger.info("--> restarting nodes...");
         internalCluster().fullRestart();
@@ -103,9 +103,8 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         ensureYellow();
 
         logger.info("--> verify meta _routing required exists");
-        mappingMd = client().admin().cluster().prepareState().execute().actionGet().getState().metaData().index("test").getMappings()
-                .get("type1");
-        assertThat(mappingMd.routing().required(), equalTo(true));
+        mappingMd = client().admin().cluster().prepareState().execute().actionGet().getState().metaData().index("test").mapping();
+        assertThat(mappingMd.routingRequired(), equalTo(true));
     }
 
     public void testSimpleOpenClose() throws Exception {


### PR DESCRIPTION
MappingMetaData contains a Routing class, which ultimately delegates down to a 
simple boolean (does this mapping require a routing key or not).  At some point in the
past this may have been necessary to distinguish between unconfigured and configured
states, but this is no longer required and so the class can be removed.