### PR TITLE
[7.5] Default "prediction_field_name" to (dependent_variable + "_prediction") (#48232)

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
@@ -126,8 +126,8 @@ import org.elasticsearch.client.ml.dataframe.OutlierDetection;
 import org.elasticsearch.client.ml.dataframe.PhaseProgress;
 import org.elasticsearch.client.ml.dataframe.QueryConfig;
 import org.elasticsearch.client.ml.dataframe.evaluation.classification.Classification;
-import org.elasticsearch.client.ml.dataframe.evaluation.regression.MeanSquaredErrorMetric;
 import org.elasticsearch.client.ml.dataframe.evaluation.classification.MulticlassConfusionMatrixMetric;
+import org.elasticsearch.client.ml.dataframe.evaluation.regression.MeanSquaredErrorMetric;
 import org.elasticsearch.client.ml.dataframe.evaluation.regression.RSquaredMetric;
 import org.elasticsearch.client.ml.dataframe.evaluation.regression.Regression;
 import org.elasticsearch.client.ml.dataframe.evaluation.softclassification.AucRocMetric;
@@ -1297,6 +1297,7 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
                 .setIndex("put-test-dest-index")
                 .build())
             .setAnalysis(org.elasticsearch.client.ml.dataframe.Regression.builder("my_dependent_variable")
+                .setPredictionFieldName("my_dependent_variable_prediction")
                 .setTrainingPercent(80.0)
                 .build())
             .setDescription("this is a regression")
@@ -1331,6 +1332,7 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
                 .setIndex("put-test-dest-index")
                 .build())
             .setAnalysis(org.elasticsearch.client.ml.dataframe.Classification.builder("my_dependent_variable")
+                .setPredictionFieldName("my_dependent_variable_prediction")
                 .setTrainingPercent(80.0)
                 .setNumTopClasses(1)
                 .build())

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
@@ -92,7 +92,7 @@ public class Classification implements DataFrameAnalysis {
         }
         this.dependentVariable = ExceptionsHelper.requireNonNull(dependentVariable, DEPENDENT_VARIABLE);
         this.boostedTreeParams = ExceptionsHelper.requireNonNull(boostedTreeParams, BoostedTreeParams.NAME);
-        this.predictionFieldName = predictionFieldName;
+        this.predictionFieldName = predictionFieldName == null ? dependentVariable + "_prediction" : predictionFieldName;
         this.numTopClasses = numTopClasses == null ? DEFAULT_NUM_TOP_CLASSES : numTopClasses;
         this.trainingPercent = trainingPercent == null ? 100.0 : trainingPercent;
     }
@@ -111,6 +111,10 @@ public class Classification implements DataFrameAnalysis {
 
     public String getDependentVariable() {
         return dependentVariable;
+    }
+
+    public String getPredictionFieldName() {
+        return predictionFieldName;
     }
 
     public int getNumTopClasses() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
@@ -70,7 +70,7 @@ public class Regression implements DataFrameAnalysis {
         }
         this.dependentVariable = ExceptionsHelper.requireNonNull(dependentVariable, DEPENDENT_VARIABLE);
         this.boostedTreeParams = ExceptionsHelper.requireNonNull(boostedTreeParams, BoostedTreeParams.NAME);
-        this.predictionFieldName = predictionFieldName;
+        this.predictionFieldName = predictionFieldName == null ? dependentVariable + "_prediction" : predictionFieldName;
         this.trainingPercent = trainingPercent == null ? 100.0 : trainingPercent;
     }
 
@@ -87,6 +87,10 @@ public class Regression implements DataFrameAnalysis {
 
     public String getDependentVariable() {
         return dependentVariable;
+    }
+
+    public String getPredictionFieldName() {
+        return predictionFieldName;
     }
 
     public double getTrainingPercent() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/ClassificationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/ClassificationTests.java
@@ -73,6 +73,14 @@ public class ClassificationTests extends AbstractSerializingTestCase<Classificat
         assertThat(e.getMessage(), equalTo("[num_top_classes] must be an integer in [0, 1000]"));
     }
 
+    public void testGetPredictionFieldName() {
+        Classification classification = new Classification("foo", BOOSTED_TREE_PARAMS, "result", 3, 50.0);
+        assertThat(classification.getPredictionFieldName(), equalTo("result"));
+
+        classification = new Classification("foo", BOOSTED_TREE_PARAMS, null, 3, 50.0);
+        assertThat(classification.getPredictionFieldName(), equalTo("foo_prediction"));
+    }
+
     public void testGetNumTopClasses() {
         Classification classification = new Classification("foo", BOOSTED_TREE_PARAMS, "result", 7, 1.0);
         assertThat(classification.getNumTopClasses(), equalTo(7));

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
@@ -1470,6 +1470,7 @@ setup:
       "eta": 0.5,
       "maximum_number_trees": 400,
       "feature_bag_fraction": 0.3,
+      "prediction_field_name": "foo_prediction",
       "training_percent": 60.3
     }
   }}
@@ -1809,6 +1810,7 @@ setup:
       "eta": 0.5,
       "maximum_number_trees": 400,
       "feature_bag_fraction": 0.3,
+      "prediction_field_name": "foo_prediction",
       "training_percent": 60.3,
       "num_top_classes": 2
     }
@@ -1844,6 +1846,7 @@ setup:
   - match: { analysis: {
     "regression":{
       "dependent_variable": "foo",
+      "prediction_field_name": "foo_prediction",
       "training_percent": 100.0
     }
   }}


### PR DESCRIPTION
Backports the following commits to 7.5:
 - Default "prediction_field_name" to (dependent_variable + "_prediction")  (#48232)