### PR TITLE
Differentiate base paths in repository integration tests

### DIFF
--- a/plugins/repository-azure/qa/microsoft-azure-storage/build.gradle
+++ b/plugins/repository-azure/qa/microsoft-azure-storage/build.gradle
@@ -54,7 +54,7 @@ task azureStorageFixture(type: AntFixture) {
 
 Map<String, Object> expansions = [
         'container': azureContainer,
-        'base_path': azureBasePath
+        'base_path': azureBasePath + "_integration_tests"
 ]
 
 processTestResources {

--- a/plugins/repository-gcs/qa/google-cloud-storage/build.gradle
+++ b/plugins/repository-gcs/qa/google-cloud-storage/build.gradle
@@ -79,7 +79,7 @@ task createServiceAccountFile() {
 
 Map<String, Object> expansions = [
         'bucket': gcsBucket,
-        'base_path': gcsBasePath
+        'base_path': gcsBasePath + "_integration_tests"
 ]
 
 processTestResources {

--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -244,9 +244,9 @@ task s3Fixture(type: AntFixture) {
 
 Map<String, Object> expansions = [
   'permanent_bucket': s3PermanentBucket,
-  'permanent_base_path': s3PermanentBasePath,
+  'permanent_base_path': s3PermanentBasePath + "_integration_tests",
   'temporary_bucket': s3TemporaryBucket,
-  'temporary_base_path': s3TemporaryBasePath,
+  'temporary_base_path': s3TemporaryBasePath + "_integration_tests",
   'ec2_bucket': s3EC2Bucket,
   'ec2_base_path': s3EC2BasePath,
   'ecs_bucket': s3ECSBucket,


### PR DESCRIPTION
Abstract third party tests do not exist on 6.8 but we can still differentiate base paths in repository integration tests like we did for other branches (#47284).

Relates https://github.com/elastic/elasticsearch/pull/47284#issuecomment-543723620