### PR TITLE
Fix incorrect opType options in IndexRequest docs.

### DIFF
--- a/docs/java-rest/high-level/document/index.asciidoc
+++ b/docs/java-rest/high-level/document/index.asciidoc
@@ -85,7 +85,7 @@ include-tagged::{doc-tests-file}[{api}-request-version-type]
 include-tagged::{doc-tests-file}[{api}-request-op-type]
 --------------------------------------------------
 <1> Operation type provided as an `DocWriteRequest.OpType` value
-<2> Operation type provided as a `String`: can be `create` or `update` (default)
+<2> Operation type provided as a `String`: can be `create` or `index` (default)
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------


### PR DESCRIPTION
IndexRequest can be either `create` or `index` as can be seen in https://github.com/elastic/elasticsearch/blob/master/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java#L427-L437

Furthermore, the default is `index` as can be seen in https://github.com/elastic/elasticsearch/blob/master/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java#L93