### PR TITLE
[Docs] Fix testing docs regarding --debug-jvm

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -44,7 +44,7 @@ supports a remote debugging option:
 ---------------------------------------------------------------------------
 
 This will instruct all JVMs (including any that run cli tools such as creating the keyring or adding users)
-to suspend and initiate a debug connection on port incrementing from  5005.
+to suspend and initiate a debug connection on port incrementing from `5005`.
 As such the IDE needs to be instructed to listen for connections on this port.
 Since we might run multiple JVMs as part of configuring and starting the cluster it's
 recommended to have the option to aut restart checked.


### PR DESCRIPTION
Remove extra whitespace and highlight the starting port number.

Follows: #48188
