### PR TITLE
[7.6][Transform] separate old and mixed rolling upgrade tests

### DIFF
--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -196,10 +196,16 @@ for (Version bwcVersion : bwcVersions.wireCompatible) {
         def toBlackList = []
         // Dataframe transforms were not added until 7.2.0
         if (bwcVersion.before('7.2.0')) {
-            toBlackList << 'upgraded_cluster/80_data_frame_jobs_crud/Get start, stop, and delete old and mixed cluster batch data frame transforms'
-            toBlackList << 'upgraded_cluster/80_data_frame_jobs_crud/Test GET, stop, delete, old and mixed continuous transforms'
-
+            toBlackList << 'upgraded_cluster/80_data_frame_jobs_crud/Get start, stop, and delete old cluster batch data frame transforms'
+            toBlackList << 'upgraded_cluster/80_data_frame_jobs_crud/Test GET, stop, delete, old continuous transforms'
         }
+
+        // transform in mixed cluster is effectively disabled till 7.4, see gh#48019
+        if (bwcVersion.before('7.4.0')) {
+            toBlackList << 'upgraded_cluster/80_data_frame_jobs_crud/Get start, stop mixed cluster batch data frame transforms'
+            toBlackList << 'upgraded_cluster/80_data_frame_jobs_crud/Test GET, mixed continuous transforms'
+        }
+
         if (!toBlackList.empty) {
             systemProperty 'tests.rest.blacklist', toBlackList.join(',')
         }

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_data_frame_jobs_crud.yml
@@ -1,8 +1,5 @@
 ---
 "Test put batch data frame transforms on mixed cluster":
-  - skip:
-      version: "all"
-      reason: "https://github.com/elastic/elasticsearch/issues/47943"
   - do:
       cluster.health:
         index: "transform-airline-data"
@@ -114,9 +111,6 @@
 
 ---
 "Test put continuous data frame transform on mixed cluster":
-  - skip:
-      version: "all"
-      reason: "https://github.com/elastic/elasticsearch/issues/47943"
   - do:
       cluster.health:
         index: "transform-airline-data-cont"
@@ -183,9 +177,6 @@
 
 ---
 "Test GET, start, and stop old cluster batch transforms":
-  - skip:
-      version: "all"
-      reason: "https://github.com/elastic/elasticsearch/issues/47943"
   - do:
       cluster.health:
         index: "transform-airline-data"
@@ -270,9 +261,6 @@
 
 ---
 "Test GET, stop, start, old continuous transforms":
-  - skip:
-      version: "all"
-      reason: "https://github.com/elastic/elasticsearch/issues/47943"
   - do:
       cluster.health:
         index: "transform-airline-data-cont"

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_data_frame_jobs_crud.yml
@@ -7,9 +7,6 @@ setup:
         timeout: 70s
 ---
 "Get start, stop, and delete old cluster batch data frame transforms":
-  - skip:
-      version: "all"
-      reason: "https://github.com/elastic/elasticsearch/issues/47943"
   # Simple and complex OLD transforms
   - do:
       transform.get_transform:
@@ -170,9 +167,6 @@ setup:
 
 ---
 "Test GET, stop, delete, old continuous transforms":
-  - skip:
-      version: "all"
-      reason: "https://github.com/elastic/elasticsearch/issues/47943"
   - do:
       transform.get_transform:
         transform_id: "old-simple-continuous-transform"
@@ -265,9 +259,6 @@ setup:
         transform_id: "mixed-simple-continuous-transform"
 ---
 "Test index mappings for latest internal index":
-  - skip:
-      version: "all"
-      reason: "https://github.com/elastic/elasticsearch/issues/47943"
   - do:
       transform.put_transform:
         transform_id: "upgraded-simple-transform"

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_data_frame_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_data_frame_jobs_crud.yml
@@ -6,7 +6,7 @@ setup:
         # wait for long enough that we give delayed unassigned shards to stop being delayed
         timeout: 70s
 ---
-"Get start, stop, and delete old and mixed cluster batch data frame transforms":
+"Get start, stop, and delete old cluster batch data frame transforms":
   - skip:
       version: "all"
       reason: "https://github.com/elastic/elasticsearch/issues/47943"
@@ -77,7 +77,17 @@ setup:
   - match: { count: 1 }
   - match: { transforms.0.id: "old-complex-transform" }
   - match: { transforms.0.state: "stopped" }
+  # Delete old transform
+  - do:
+      transform.delete_transform:
+        transform_id: "old-simple-transform"
+  - do:
+      transform.get_transform_stats:
+        transform_id: "old-simple-transform"
+  - match: { count: 0 }
 
+---
+"Get start, stop mixed cluster batch data frame transforms":
   # Simple and complex Mixed cluster transforms
   - do:
       transform.get_transform:
@@ -146,23 +156,20 @@ setup:
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-complex-transform" }
   - match: { transforms.0.state: "stopped" }
-
-# Delete all old and mixed transforms
-  - do:
-      transform.delete_transform:
-        transform_id: "old-simple-transform"
-
+  # Delete mixed transform
   - do:
       transform.delete_transform:
         transform_id: "mixed-simple-transform"
-
+  - do:
+      transform.delete_transform:
+        transform_id: "mixed-complex-transform"
   - do:
       transform.get_transform_stats:
-        transform_id: "old-simple-transform,mixed-simple-transform"
+        transform_id: "mixed-simple-transform,mixed-complex-transform"
   - match: { count: 0 }
 
 ---
-"Test GET, stop, delete, old and mixed continuous transforms":
+"Test GET, stop, delete, old continuous transforms":
   - skip:
       version: "all"
       reason: "https://github.com/elastic/elasticsearch/issues/47943"
@@ -210,7 +217,8 @@ setup:
   - do:
       transform.delete_transform:
         transform_id: "old-simple-continuous-transform"
-
+---
+"Test GET, mixed continuous transforms":
   - do:
       transform.get_transform:
         transform_id: "mixed-simple-continuous-transform"


### PR DESCRIPTION
separates rolling upgrade tests for transforms created on old and mixed clusters and disable
testing transforms on mixed clusters for <7.4.

backport of #48275