### PR TITLE
[7.5] fix incorrect comparison (#48208)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/core/TermVectorsResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/core/TermVectorsResponse.java
@@ -149,7 +149,7 @@ public class TermVectorsResponse {
             && Objects.equals(id, other.id)
             && docVersion == other.docVersion
             && found == other.found
-            && tookInMillis == tookInMillis
+            && tookInMillis == other.tookInMillis
             && Objects.equals(termVectorList, other.termVectorList);
     }
 


### PR DESCRIPTION
Backports the following commits to 7.5:
 - fix incorrect comparison  (#48208)