### PR TITLE
[7.4] [DOCS] Extends analyzed.fields description in DFA resources

### DIFF
--- a/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
@@ -16,17 +16,18 @@
   <<dfanalytics-types>>.
   
 `analyzed_fields`::
-  (object) You can specify both `includes` and/or `excludes` patterns. If 
-  `analyzed_fields` is not set, only the relevant fields will be included. For 
-  example all the numeric fields for {oldetection}.
+  (object) You can specify both `includes` and/or `excludes` patterns. 
+  If `analyzed_fields` is not set, only the relevant fields will be included. 
+  For example, all the numeric fields for {oldetection}. For the supported field 
+  types, see <<ml-put-dfanalytics-supported-fields>>.
   
-  `analyzed_fields.includes`:::
-    (array) An array of strings that defines the fields that will be included in 
-    the analysis.
+  `includes`:::
+    (array) An array of strings that defines the fields that will be 
+    included in the analysis.
     
-  `analyzed_fields.excludes`:::
-    (array) An array of strings that defines the fields that will be excluded 
-    from the analysis.
+  `excludes`:::
+    (array) An array of strings that defines the fields that will be 
+    excluded from the analysis.
   
 
 [source,js]


### PR DESCRIPTION
This PR extends the `analyzed_fields` variable description in the DFA resources section to be in line with the description in the PUT DFA API docs.