### PR TITLE
[DOCS] Extends analyzed_fields description in PUT DFA API docs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -89,7 +89,9 @@ that don’t contain a results field are not included in the {reganalysis}.
   (Optional, object) You can specify both `includes` and/or `excludes` patterns. 
   If `analyzed_fields` is not set, only the relevant fields will be included. 
   For example, all the numeric fields for {oldetection}. For the supported field 
-  types, see <<ml-put-dfanalytics-supported-fields>>.
+  types, see <<ml-put-dfanalytics-supported-fields>>. If you specify fields – 
+  either in `includes` or in `excludes` – that have a data type that is not 
+  supported, an error occurs.
   
   `includes`:::
     (Optional, array) An array of strings that defines the fields that will be 
@@ -97,7 +99,9 @@ that don’t contain a results field are not included in the {reganalysis}.
     
   `excludes`:::
     (Optional, array) An array of strings that defines the fields that will be 
-    excluded from the analysis.
+    excluded from the analysis. You do not need to add fields with unsupported 
+    data types to `excludes`, these fields are excluded from the analysis 
+    automatically.
 
 `description`::
   (Optional, string) A description of the job.


### PR DESCRIPTION
This PR extends the `analyzed_fields` description in the PUT DFA API docs.

Related issue: https://github.com/elastic/ml-team/issues/187#issuecomment-543624966