### PR TITLE
[7.6][Transform] blacklist continuous transform tests if upgraded from 7.2.x

### DIFF
--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -199,7 +199,10 @@ for (Version bwcVersion : bwcVersions.wireCompatible) {
             toBlackList << 'upgraded_cluster/80_data_frame_jobs_crud/Get start, stop, and delete old cluster batch data frame transforms'
             toBlackList << 'upgraded_cluster/80_data_frame_jobs_crud/Test GET, stop, delete, old continuous transforms'
         }
-
+        // continuous Dataframe transforms were not added until 7.3.0
+        if (bwcVersion.before('7.3.0')) {
+            toBlackList << 'upgraded_cluster/80_data_frame_jobs_crud/Test GET, stop, delete, old continuous transforms'
+        }
         // transform in mixed cluster is effectively disabled till 7.4, see gh#48019
         if (bwcVersion.before('7.4.0')) {
             toBlackList << 'upgraded_cluster/80_data_frame_jobs_crud/Get start, stop mixed cluster batch data frame transforms'

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -197,7 +197,6 @@ for (Version bwcVersion : bwcVersions.wireCompatible) {
         // Dataframe transforms were not added until 7.2.0
         if (bwcVersion.before('7.2.0')) {
             toBlackList << 'upgraded_cluster/80_data_frame_jobs_crud/Get start, stop, and delete old cluster batch data frame transforms'
-            toBlackList << 'upgraded_cluster/80_data_frame_jobs_crud/Test GET, stop, delete, old continuous transforms'
         }
         // continuous Dataframe transforms were not added until 7.3.0
         if (bwcVersion.before('7.3.0')) {


### PR DESCRIPTION
blacklist continuous transform tests if upgraded from 7.2.x

fixes #48336 