### PR TITLE
Add an assert-busy section to YAML REST tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/AssertBusySection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/AssertBusySection.java
@@ -1,0 +1,112 @@
+package org.elasticsearch.test.rest.yaml.section;
+
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentLocation;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestExecutionContext;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents an assert_busy section:
+ *
+ *   - assert_busy:
+ *     - max_wait_time: "30s"
+ *     - do:
+ *         cluster.remote_info: {}
+ *     - is_true: local.connected
+ *     - match: { local.num_nodes_connected: 1}
+ *
+ */
+public class AssertBusySection implements ExecutableSection {
+
+    private static final TimeValue DEFAULT_MAX_WAIT_TIME = TimeValue.timeValueSeconds(10L);
+
+    public static AssertBusySection parse(final XContentParser parser) throws IOException {
+        final XContentLocation location = parser.getTokenLocation();
+        if (parser.nextToken() != XContentParser.Token.START_ARRAY) {
+            throw new IllegalArgumentException("expected [" + XContentParser.Token.START_ARRAY + "], " +
+                "found [" + parser.currentToken() + "], the assert_busy section is not properly indented");
+        }
+
+        TimeValue maxWaitTime = DEFAULT_MAX_WAIT_TIME;
+        DoSection doSection = null;
+        final List<Assertion> assertions = new ArrayList<>();
+        while (parser.currentToken() != XContentParser.Token.END_ARRAY) {
+            ParserUtils.advanceToFieldName(parser);
+            if ("max_wait_time".equals(parser.currentName())) {
+                if (parser.nextToken() != XContentParser.Token.VALUE_STRING) {
+                    throw new IllegalArgumentException("expected [" + XContentParser.Token.VALUE_STRING + "], " +
+                        "found [" + parser.currentToken() + "], the max_wait_time value has a wrong type");
+                }
+                maxWaitTime = TimeValue.parseTimeValue(parser.textOrNull(), DEFAULT_MAX_WAIT_TIME, parser.currentName());
+                parser.nextToken();
+            } else if ("do".equals(parser.currentName())) {
+                doSection = DoSection.parse(parser);
+            } else {
+                ExecutableSection assertion = parser.namedObject(ExecutableSection.class, parser.currentName(), null);
+                if (assertion instanceof Assertion) {
+                    if (assertion instanceof AssertBusySection) {
+                        throw new IllegalArgumentException("section [assert_busy] not supported within assert_busy section");
+                    }
+                    assertions.add((Assertion) assertion);
+                }
+            }
+            parser.nextToken();
+        }
+        parser.nextToken();
+        return new AssertBusySection(location, maxWaitTime, doSection, assertions);
+    }
+
+    private final TimeValue maxWaitTime;
+    private final XContentLocation location;
+    private final DoSection doSection;
+    private final List<Assertion> assertions;
+
+    private AssertBusySection(XContentLocation location, TimeValue maxWaitTime, DoSection doSection, List<Assertion> assertions) {
+        this.maxWaitTime = Objects.requireNonNull(maxWaitTime);
+        this.location = Objects.requireNonNull(location);
+        this.doSection = Objects.requireNonNull(doSection);
+        this.assertions = Objects.requireNonNull(assertions);
+        if (assertions.isEmpty()) {
+            throw new IllegalArgumentException("Missing assertions in assert_busy section");
+        }
+    }
+
+    @Override
+    public XContentLocation getLocation() {
+        return location;
+    }
+
+    TimeValue getMaxWaitTime() {
+        return maxWaitTime;
+    }
+
+    DoSection getDoSection() {
+        return doSection;
+    }
+
+    List<Assertion> getAssertions() {
+        return assertions;
+    }
+
+    @Override
+    public void execute(final ClientYamlTestExecutionContext executionContext) throws IOException {
+        try {
+            ESTestCase.assertBusy(() -> {
+                doSection.execute(executionContext);
+                for (Assertion assertion : assertions) {
+                    assertion.execute(executionContext);
+                }
+            }, maxWaitTime.duration(), maxWaitTime.timeUnit());
+        } catch (Exception e) {
+            throw new IOException("Fail to execute assert_busy section", e);
+        } catch (AssertionError e) {
+            throw new AssertionError("assert_busy section timed out after [" + maxWaitTime + "]", e);
+        }
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/ExecutableSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/ExecutableSection.java
@@ -46,7 +46,8 @@ public interface ExecutableSection {
             new NamedXContentRegistry.Entry(ExecutableSection.class, new ParseField("lt"), LessThanAssertion::parse),
             new NamedXContentRegistry.Entry(ExecutableSection.class, new ParseField("lte"), LessThanOrEqualToAssertion::parse),
             new NamedXContentRegistry.Entry(ExecutableSection.class, new ParseField("contains"), ContainsAssertion::parse),
-            new NamedXContentRegistry.Entry(ExecutableSection.class, new ParseField("length"), LengthAssertion::parse));
+            new NamedXContentRegistry.Entry(ExecutableSection.class, new ParseField("length"), LengthAssertion::parse),
+            new NamedXContentRegistry.Entry(ExecutableSection.class, new ParseField("assert_busy"), AssertBusySection::parse));
 
     /**
      * {@link NamedXContentRegistry} that parses the default list of

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/AssertBusySectionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/AssertBusySectionTests.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.rest.yaml.section;
+
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.yaml.YamlXContent;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class AssertBusySectionTests extends AbstractClientYamlTestFragmentParserTestCase {
+
+    public void testParseAssertBusySection() throws Exception {
+        parser = createParser(YamlXContent.yamlXContent,
+            "  - max_wait_time: \"12s\"\n" +
+            "  - do:\n" +
+            "      index1:\n" +
+            "        index:  test_1\n" +
+            "        type:   test\n" +
+            "        id:     1\n" +
+            "        body:   { \"include\": { \"field1\": \"v1\", \"field2\": \"v2\" }, \"count\": 1 }\n" +
+            "  - match: { field: 10 }\n" +
+            "  - lt: { field: 10 }\n" +
+            "  - lte: { field: 9 }\n" +
+            "  - gt: { field: 8 }\n" +
+            "  - gte: { field: 7 }\n" +
+            "  - is_true: field1\n" +
+            "  - is_false: field2\n"
+        );
+
+        AssertBusySection assertBusySection = AssertBusySection.parse(parser);
+
+        assertThat(assertBusySection, notNullValue());
+        assertThat(assertBusySection.getLocation(), notNullValue());
+        assertThat(assertBusySection.getMaxWaitTime(), equalTo(TimeValue.timeValueSeconds(12L)));
+        assertThat(assertBusySection.getDoSection(), instanceOf(DoSection.class));
+        assertThat(assertBusySection.getDoSection().getApiCallSection().getApi(), equalTo("index1"));
+        assertThat(assertBusySection.getAssertions().size(), equalTo(7));
+        assertThat(assertBusySection.getAssertions().get(0), instanceOf(MatchAssertion.class));
+        assertThat(assertBusySection.getAssertions().get(1), instanceOf(LessThanAssertion.class));
+        assertThat(assertBusySection.getAssertions().get(2), instanceOf(LessThanOrEqualToAssertion.class));
+        assertThat(assertBusySection.getAssertions().get(3), instanceOf(GreaterThanAssertion.class));
+        assertThat(assertBusySection.getAssertions().get(4), instanceOf(GreaterThanEqualToAssertion.class));
+        assertThat(assertBusySection.getAssertions().get(5), instanceOf(IsTrueAssertion.class));
+        assertThat(assertBusySection.getAssertions().get(6), instanceOf(IsFalseAssertion.class));
+    }
+}

--- a/x-pack/plugin/ccr/qa/rest/src/test/resources/rest-api-spec/test/ccr/auto_follow.yml
+++ b/x-pack/plugin/ccr/qa/rest/src/test/resources/rest-api-spec/test/ccr/auto_follow.yml
@@ -19,6 +19,13 @@
 
   - match: {transient: {cluster.remote.local.seeds: $local_ip}}
 
+  - assert_busy:
+    - max_wait_time: "30s"
+    - do:
+        cluster.remote_info: {}
+    - is_true: local.connected
+    - match: { local.num_nodes_connected: 1}
+
   - do:
       ccr.put_auto_follow_pattern:
         name: my_pattern


### PR DESCRIPTION
This pull request is a proposal to add a new `assertBusy()` like section to our YAML REST tests. I agree we should not add too many `assert_busy` sections in our tests but I think having such a section would have helped in many situations (waiting for a template to be automatically created, waiting for a remote cluster connection to be active etc).

The `assert_busy` section is composed of a single `do` section and one or more assertions:
```yaml
- assert_busy:
    - max_wait_time: "30s"
    - do:
        cluster.remote_info: {}
    - is_true: local.connected
    - match: { local.num_nodes_connected: 1}
```