### PR TITLE
Ensure SLM stats does not block an in-place upgrade from 7.4

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleMetadata.java
@@ -62,7 +62,7 @@ public class SnapshotLifecycleMetadata implements XPackMetaDataCustom {
                 throw new IllegalArgumentException("ordered " + POLICIES_FIELD.getPreferredName() + " are not supported");
             }, POLICIES_FIELD);
         PARSER.declareString(ConstructingObjectParser.constructorArg(), OPERATION_MODE_FIELD);
-        PARSER.declareObject(ConstructingObjectParser.constructorArg(), (v, o) -> SnapshotLifecycleStats.parse(v), STATS_FIELD);
+        PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), (v, o) -> SnapshotLifecycleStats.parse(v), STATS_FIELD);
     }
 
     private final Map<String, SnapshotLifecyclePolicyMetadata> snapshotConfigurations;
@@ -74,7 +74,7 @@ public class SnapshotLifecycleMetadata implements XPackMetaDataCustom {
                                      SnapshotLifecycleStats slmStats) {
         this.snapshotConfigurations = new HashMap<>(snapshotConfigurations);
         this.operationMode = operationMode;
-        this.slmStats = slmStats;
+        this.slmStats = slmStats != null ? slmStats : new SnapshotLifecycleStats();
     }
 
     public SnapshotLifecycleMetadata(StreamInput in) throws IOException {

--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -12,7 +12,11 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ObjectPath;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.document.RestGetAction;
@@ -21,6 +25,7 @@ import org.elasticsearch.rest.action.search.RestSearchAction;
 import org.elasticsearch.test.StreamsUtils;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.upgrades.AbstractFullClusterRestartTestCase;
+import org.elasticsearch.xpack.slm.SnapshotLifecycleStats;
 import org.hamcrest.Matcher;
 import org.junit.Before;
 
@@ -435,6 +440,21 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
         assertEquals(400, e.getResponse().getStatusLine().getStatusCode());
         assertThat(e.getMessage(), containsString(
             "[testsqlfailsonindexwithtwotypes] contains more than one type [type1, type2] so it is incompatible with sql"));
+    }
+
+    public void testSlmStats() throws IOException {
+        //need to stop and start ILM to ensure that SLM metadata is written to cluster state
+        if (isRunningAgainstOldCluster()) {
+            client().performRequest(new Request("POST", "_ilm/stop"));
+            client().performRequest(new Request("POST", "_ilm/start"));
+        } else {
+            Response response = client().performRequest(new Request("GET", "_slm/stats"));
+            XContentType xContentType = XContentType.fromMediaTypeOrFormat(response.getEntity().getContentType().getValue());
+             try (XContentParser parser = xContentType.xContent().createParser(NamedXContentRegistry.EMPTY,
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION, response.getEntity().getContent())) {
+                assertEquals(new SnapshotLifecycleStats(), SnapshotLifecycleStats.parse(parser));
+            }
+        }
     }
 
     private String loadWatch(String watch) throws IOException {


### PR DESCRIPTION
7.5+ for SLM requires [stats] object to exist in the cluster state.
When doing an in-place upgrade from 7.4 to 7.5+ [stats] does not exist
in cluster state, result in an exception on startup [1].

This commit moves the [stats] to be an optional object in the parser
and if not found will default to an empty stats object.

[1] Caused by: java.lang.IllegalArgumentException: Required [stats]

----------

Note - this is was not caught by normal full cluster state restart tests since by default there is no SLM data in cluster state. Stopping and restarting ILM is one way to force SLM cluster state to be written (hence the custom test)

Note - this does not need to merged to master/8.0, however, we may need a follow up PR in 7.x to ensure that SLM is eagerly written to cluster state. 

Below is the full error when the test is run without the fix:
```
./gradlew :x-pack:qa:full-cluster-restart:v7.4.0#bwc -Dtests.class=org.elasticsearch.xpack.restart.FullClusterRestartIT -Dtests.method="testSlmStats"

> Task :printGlobalBuildInfo UP-TO-DATE
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 5.6.2
  OS Info               : Mac OS X 10.14.6 (x86_64)
  JDK Version           : 12 (Oracle Corporation 12.0.1 [Java HotSpot(TM) 64-Bit Server VM 12.0.1+12])
  JAVA_HOME             : /Users/jakelandis/workspace/java/jdk-12.0.1.jdk/Contents/Home
  Random Testing Seed   : DFEA8712EB526FEE
=======================================

> Task :x-pack:plugin:core:compileJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :x-pack:qa:full-cluster-restart:v7.4.0#upgradedClusterTest

=== Standard output of node `node{:x-pack:qa:full-cluster-restart:v7.4.0-0}` ===

»    ↓ errors and warnings from /Users/jakelandis/workspace/7x/elasticsearch/x-pack/qa/full-cluster-restart/build/testclusters/v7.4.0-0/logs/es.stdout.log ↓
» WARN ][o.e.d.FileBasedSeedHostsProvider] [v7.4.0-0] expected, but did not find, a dynamic hosts list at [/Users/jakelandis/workspace/7x/elasticsearch/x-pack/qa/full-cluster-restart/build/testclusters/v7.4.0-0/config/unicast_hosts.txt]
»   ↑ repeated 4 times ↑
» ERROR][o.e.g.GatewayMetaState   ] [v7.4.0-0] failed to read or upgrade local state, exiting...
»  org.elasticsearch.ElasticsearchException: java.io.IOException: failed to read /Users/jakelandis/workspace/7x/elasticsearch/x-pack/qa/full-cluster-restart/build/testclusters/v7.4.0-0/data/nodes/0/_state/global-22.st
»       at org.elasticsearch.ExceptionsHelper.maybeThrowRuntimeAndSuppress(ExceptionsHelper.java:167) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.gateway.MetaDataStateFormat.loadGeneration(MetaDataStateFormat.java:414) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.gateway.MetaStateService.loadFullState(MetaStateService.java:81) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.gateway.GatewayMetaState.upgradeMetaData(GatewayMetaState.java:154) [elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.gateway.GatewayMetaState.start(GatewayMetaState.java:90) [elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.node.Node.start(Node.java:697) [elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.bootstrap.Bootstrap.start(Bootstrap.java:273) [elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:358) [elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:159) [elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.bootstrap.Elasticsearch.execute(Elasticsearch.java:150) [elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:86) [elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:125) [elasticsearch-cli-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.cli.Command.main(Command.java:90) [elasticsearch-cli-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:115) [elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:92) [elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»  Caused by: java.io.IOException: failed to read /Users/jakelandis/workspace/7x/elasticsearch/x-pack/qa/full-cluster-restart/build/testclusters/v7.4.0-0/data/nodes/0/_state/global-22.st
»       at org.elasticsearch.gateway.MetaDataStateFormat.loadGeneration(MetaDataStateFormat.java:408) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       ... 13 more
»  Caused by: java.lang.IllegalArgumentException: Required [stats]
»       at org.elasticsearch.common.xcontent.ConstructingObjectParser$Target.finish(ConstructingObjectParser.java:446) ~[elasticsearch-x-content-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.common.xcontent.ConstructingObjectParser$Target.access$000(ConstructingObjectParser.java:350) ~[elasticsearch-x-content-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.common.xcontent.ConstructingObjectParser.parse(ConstructingObjectParser.java:169) ~[elasticsearch-x-content-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.xpack.ilm.IndexLifecycle.lambda$getNamedXContent$5(IndexLifecycle.java:222) ~[?:?]
»       at org.elasticsearch.common.xcontent.NamedXContentRegistry$Entry.lambda$new$0(NamedXContentRegistry.java:63) ~[elasticsearch-x-content-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.common.xcontent.NamedXContentRegistry.parseNamedObject(NamedXContentRegistry.java:141) ~[elasticsearch-x-content-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.common.xcontent.support.AbstractXContentParser.namedObject(AbstractXContentParser.java:385) ~[elasticsearch-x-content-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.cluster.metadata.MetaData$Builder.fromXContent(MetaData.java:1403) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.cluster.metadata.MetaData$1.fromXContent(MetaData.java:1448) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.cluster.metadata.MetaData$1.fromXContent(MetaData.java:1439) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.gateway.MetaDataStateFormat.read(MetaDataStateFormat.java:302) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.gateway.MetaDataStateFormat.loadGeneration(MetaDataStateFormat.java:404) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       ... 13 more
» WARN ][o.e.b.ElasticsearchUncaughtExceptionHandler] [v7.4.0-0] uncaught exception in thread [main]
»  org.elasticsearch.bootstrap.StartupException: ElasticsearchException[java.io.IOException: failed to read /Users/jakelandis/workspace/7x/elasticsearch/x-pack/qa/full-cluster-restart/build/testclusters/v7.4.0-0/data/nodes/0/_state/global-22.st]; nested: IOException[failed to read /Users/jakelandis/workspace/7x/elasticsearch/x-pack/qa/full-cluster-restart/build/testclusters/v7.4.0-0/data/nodes/0/_state/global-22.st]; nested: IllegalArgumentException[Required [stats]];
»       at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:163) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.bootstrap.Elasticsearch.execute(Elasticsearch.java:150) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:86) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:125) ~[elasticsearch-cli-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.cli.Command.main(Command.java:90) ~[elasticsearch-cli-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:115) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:92) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»  Caused by: org.elasticsearch.ElasticsearchException: java.io.IOException: failed to read /Users/jakelandis/workspace/7x/elasticsearch/x-pack/qa/full-cluster-restart/build/testclusters/v7.4.0-0/data/nodes/0/_state/global-22.st
»       at org.elasticsearch.ExceptionsHelper.maybeThrowRuntimeAndSuppress(ExceptionsHelper.java:167) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.gateway.MetaDataStateFormat.loadGeneration(MetaDataStateFormat.java:414) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.gateway.MetaStateService.loadFullState(MetaStateService.java:81) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.gateway.GatewayMetaState.upgradeMetaData(GatewayMetaState.java:154) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.gateway.GatewayMetaState.start(GatewayMetaState.java:90) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.node.Node.start(Node.java:697) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.bootstrap.Bootstrap.start(Bootstrap.java:273) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:358) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:159) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       ... 6 more
»  Caused by: java.io.IOException: failed to read /Users/jakelandis/workspace/7x/elasticsearch/x-pack/qa/full-cluster-restart/build/testclusters/v7.4.0-0/data/nodes/0/_state/global-22.st
»       at org.elasticsearch.gateway.MetaDataStateFormat.loadGeneration(MetaDataStateFormat.java:408) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.gateway.MetaStateService.loadFullState(MetaStateService.java:81) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.gateway.GatewayMetaState.upgradeMetaData(GatewayMetaState.java:154) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.gateway.GatewayMetaState.start(GatewayMetaState.java:90) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.node.Node.start(Node.java:697) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.bootstrap.Bootstrap.start(Bootstrap.java:273) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:358) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:159) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       ... 6 more
»  Caused by: java.lang.IllegalArgumentException: Required [stats]
»       at org.elasticsearch.common.xcontent.ConstructingObjectParser$Target.finish(ConstructingObjectParser.java:446) ~[elasticsearch-x-content-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.common.xcontent.ConstructingObjectParser$Target.access$000(ConstructingObjectParser.java:350) ~[elasticsearch-x-content-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.common.xcontent.ConstructingObjectParser.parse(ConstructingObjectParser.java:169) ~[elasticsearch-x-content-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.xpack.ilm.IndexLifecycle.lambda$getNamedXContent$5(IndexLifecycle.java:222) ~[?:?]
»       at org.elasticsearch.common.xcontent.NamedXContentRegistry$Entry.lambda$new$0(NamedXContentRegistry.java:63) ~[elasticsearch-x-content-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.common.xcontent.NamedXContentRegistry.parseNamedObject(NamedXContentRegistry.java:141) ~[elasticsearch-x-content-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.common.xcontent.support.AbstractXContentParser.namedObject(AbstractXContentParser.java:385) ~[elasticsearch-x-content-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.cluster.metadata.MetaData$Builder.fromXContent(MetaData.java:1403) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.cluster.metadata.MetaData$1.fromXContent(MetaData.java:1448) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.cluster.metadata.MetaData$1.fromXContent(MetaData.java:1439) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.gateway.MetaDataStateFormat.read(MetaDataStateFormat.java:302) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.gateway.MetaDataStateFormat.loadGeneration(MetaDataStateFormat.java:404) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.gateway.MetaStateService.loadFullState(MetaStateService.java:81) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.gateway.GatewayMetaState.upgradeMetaData(GatewayMetaState.java:154) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.gateway.GatewayMetaState.start(GatewayMetaState.java:90) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.node.Node.start(Node.java:697) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.bootstrap.Bootstrap.start(Bootstrap.java:273) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:358) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:159) ~[elasticsearch-7.6.0-SNAPSHOT.jar:7.6.0-SNAPSHOT]
»       ... 6 more
```