### PR TITLE
Deprecate the sparse_vector field type.

### DIFF
--- a/docs/reference/mapping/types/sparse-vector.asciidoc
+++ b/docs/reference/mapping/types/sparse-vector.asciidoc
@@ -6,6 +6,7 @@
 <titleabbrev>Sparse vector</titleabbrev>
 ++++
 
+deprecated[7.6, The `sparse_vector` type is deprecated and will be removed in 8.0.]
 experimental[]
 
 A `sparse_vector` field stores sparse vectors of float values.
@@ -38,7 +39,11 @@ PUT my_index
     }
   }
 }
+--------------------------------------------------
+// TEST[warning:The [sparse_vector] field type is deprecated and will be removed in 8.0.]
 
+[source,console]
+--------------------------------------------------
 PUT my_index/_doc/1
 {
   "my_text" : "text1",
@@ -50,8 +55,8 @@ PUT my_index/_doc/2
   "my_text" : "text2",
   "my_vector" : {"103": 0.5, "4": -0.5,  "5": 1, "11" : 1.2}
 }
-
 --------------------------------------------------
+// TEST[continued]
 
 Internally, each document's sparse vector is encoded as a binary
 doc value. Its size in bytes is equal to

--- a/docs/reference/vectors/vector-functions.asciidoc
+++ b/docs/reference/vectors/vector-functions.asciidoc
@@ -5,16 +5,14 @@
 
 experimental[]
 
-These functions are used for
-for <<dense-vector,`dense_vector`>>  and
-<<sparse-vector,`sparse_vector`>> fields.
-
 NOTE: During vector functions' calculation, all matched documents are
-linearly scanned. Thus, expect the query time grow linearly 
+linearly scanned. Thus, expect the query time grow linearly
 with the number of matched documents. For this reason, we recommend
 to limit the number of matched documents with a `query` parameter.
 
-Let's create an index with the following mapping and index a couple
+====== `dense_vector` functions
+
+Let's create an index with a `dense_vector` mapping and index a couple
 of documents into it.
 
 [source,console]
@@ -27,9 +25,6 @@ PUT my_index
         "type": "dense_vector",
         "dims": 3
       },
-      "my_sparse_vector" : {
-        "type" : "sparse_vector"
-      },
       "status" : {
         "type" : "keyword"
       }
@@ -40,21 +35,21 @@ PUT my_index
 PUT my_index/_doc/1
 {
   "my_dense_vector": [0.5, 10, 6],
-  "my_sparse_vector": {"2": 1.5, "15" : 2, "50": -1.1, "4545": 1.1},
   "status" : "published"
 }
 
 PUT my_index/_doc/2
 {
   "my_dense_vector": [-0.5, 10, 10],
-  "my_sparse_vector": {"2": 2.5, "10" : 1.3, "55": -2.3, "113": 1.6},
   "status" : "published"
 }
+
+POST my_index/_refresh
 
 --------------------------------------------------
 // TESTSETUP
 
-For dense_vector fields, `cosineSimilarity` calculates the measure of
+The `cosineSimilarity` function calculates the measure of
 cosine similarity between a given query vector and document vectors.
 
 [source,console]
@@ -90,36 +85,7 @@ GET my_index/_search
 NOTE: If a document's dense vector field has a number of dimensions
 different from the query's vector, an error will be thrown.
 
-Similarly, for sparse_vector fields, `cosineSimilaritySparse` calculates cosine similarity
-between a given query vector and document vectors.
-
-[source,console]
---------------------------------------------------
-GET my_index/_search
-{
-  "query": {
-    "script_score": {
-      "query" : {
-        "bool" : {
-          "filter" : {
-            "term" : {
-              "status" : "published"
-            }
-          }
-        }
-      },
-      "script": {
-        "source": "cosineSimilaritySparse(params.query_vector, doc['my_sparse_vector']) + 1.0",
-        "params": {
-          "query_vector": {"2": 0.5, "10" : 111.3, "50": -1.3, "113": 14.8, "4545": 156.0}
-        }
-      }
-    }
-  }
-}
---------------------------------------------------
-
-For dense_vector fields, `dotProduct` calculates the measure of
+The `dotProduct` function calculates the measure of
 dot product between a given query vector and document vectors.
 
 [source,console]
@@ -153,39 +119,7 @@ GET my_index/_search
 
 <1> Using the standard sigmoid function prevents scores from being negative.
 
-Similarly, for sparse_vector fields, `dotProductSparse` calculates dot product
-between a given query vector and document vectors.
-
-[source,console]
---------------------------------------------------
-GET my_index/_search
-{
-  "query": {
-    "script_score": {
-      "query" : {
-        "bool" : {
-          "filter" : {
-            "term" : {
-              "status" : "published"
-            }
-          }
-        }
-      },
-      "script": {
-        "source": """
-          double value = dotProductSparse(params.query_vector, doc['my_sparse_vector']);
-          return sigmoid(1, Math.E, -value);
-        """,
-         "params": {
-          "query_vector": {"2": 0.5, "10" : 111.3, "50": -1.3, "113": 14.8, "4545": 156.0}
-        }
-      }
-    }
-  }
-}
---------------------------------------------------
-
-For dense_vector fields, `l1norm` calculates L^1^ distance
+The `l1norm` function calculates L^1^ distance
 (Manhattan distance) between a given query vector and
 document vectors.
 
@@ -224,36 +158,7 @@ we reversed the output from `l1norm` and `l2norm`. Also, to avoid
 division by 0 when a document vector matches the query exactly,
 we added `1` in the denominator.
 
-For sparse_vector fields, `l1normSparse` calculates L^1^ distance
-between a given query vector and document vectors.
-
-[source,console]
---------------------------------------------------
-GET my_index/_search
-{
-  "query": {
-    "script_score": {
-      "query" : {
-        "bool" : {
-          "filter" : {
-            "term" : {
-              "status" : "published"
-            }
-          }
-        }
-      },
-      "script": {
-        "source": "1 / (1 + l1normSparse(params.queryVector, doc['my_sparse_vector']))",
-        "params": {
-          "queryVector": {"2": 0.5, "10" : 111.3, "50": -1.3, "113": 14.8, "4545": 156.0}
-        }
-      }
-    }
-  }
-}
---------------------------------------------------
-
-For dense_vector fields, `l2norm` calculates L^2^ distance
+The `l2norm` function calculates L^2^ distance
 (Euclidean distance) between a given query vector and
 document vectors.
 
@@ -283,12 +188,163 @@ GET my_index/_search
 }
 --------------------------------------------------
 
-Similarly, for sparse_vector fields, `l2normSparse` calculates L^2^ distance
+NOTE: If a document doesn't have a value for a vector field on which
+a vector function is executed, an error will be thrown.
+
+You can check if a document has a value for the field `my_vector` by
+`doc['my_vector'].size() == 0`. Your overall script can look like this:
+
+[source,js]
+--------------------------------------------------
+"source": "doc['my_vector'].size() == 0 ? 0 : cosineSimilarity(params.queryVector, doc['my_vector'])"
+--------------------------------------------------
+// NOTCONSOLE
+
+====== `sparse_vector` functions
+
+deprecated[7.6, The `sparse_vector` type is deprecated and will be removed in 8.0.]
+
+Let's create an index with a `sparse_vector` mapping and index a couple
+of documents into it.
+
+[source,console]
+--------------------------------------------------
+PUT my_sparse_index
+{
+  "mappings": {
+    "properties": {
+      "my_sparse_vector": {
+        "type": "sparse_vector"
+      },
+      "status" : {
+        "type" : "keyword"
+      }
+    }
+  }
+}
+--------------------------------------------------
+// TEST[warning:The [sparse_vector] field type is deprecated and will be removed in 8.0.]
+
+[source,console]
+--------------------------------------------------
+PUT my_sparse_index/_doc/1
+{
+  "my_sparse_vector": {"2": 1.5, "15" : 2, "50": -1.1, "4545": 1.1},
+  "status" : "published"
+}
+
+PUT my_sparse_index/_doc/2
+{
+  "my_sparse_vector": {"2": 2.5, "10" : 1.3, "55": -2.3, "113": 1.6},
+  "status" : "published"
+}
+
+POST my_sparse_index/_refresh
+--------------------------------------------------
+// TEST[continued]
+
+The `cosineSimilaritySparse` function calculates cosine similarity
 between a given query vector and document vectors.
 
 [source,console]
 --------------------------------------------------
-GET my_index/_search
+GET my_sparse_index/_search
+{
+  "query": {
+    "script_score": {
+      "query" : {
+        "bool" : {
+          "filter" : {
+            "term" : {
+              "status" : "published"
+            }
+          }
+        }
+      },
+      "script": {
+        "source": "cosineSimilaritySparse(params.query_vector, doc['my_sparse_vector']) + 1.0",
+        "params": {
+          "query_vector": {"2": 0.5, "10" : 111.3, "50": -1.3, "113": 14.8, "4545": 156.0}
+        }
+      }
+    }
+  }
+}
+--------------------------------------------------
+// TEST[continued]
+// TEST[warning:The [sparse_vector] field type is deprecated and will be removed in 8.0.]
+
+The `dotProductSparse` function calculates dot product
+between a given query vector and document vectors.
+
+[source,console]
+--------------------------------------------------
+GET my_sparse_index/_search
+{
+  "query": {
+    "script_score": {
+      "query" : {
+        "bool" : {
+          "filter" : {
+            "term" : {
+              "status" : "published"
+            }
+          }
+        }
+      },
+      "script": {
+        "source": """
+          double value = dotProductSparse(params.query_vector, doc['my_sparse_vector']);
+          return sigmoid(1, Math.E, -value);
+        """,
+         "params": {
+          "query_vector": {"2": 0.5, "10" : 111.3, "50": -1.3, "113": 14.8, "4545": 156.0}
+        }
+      }
+    }
+  }
+}
+--------------------------------------------------
+// TEST[continued]
+// TEST[warning:The [sparse_vector] field type is deprecated and will be removed in 8.0.]
+
+The `l1normSparse` function calculates L^1^ distance
+between a given query vector and document vectors.
+
+[source,console]
+--------------------------------------------------
+GET my_sparse_index/_search
+{
+  "query": {
+    "script_score": {
+      "query" : {
+        "bool" : {
+          "filter" : {
+            "term" : {
+              "status" : "published"
+            }
+          }
+        }
+      },
+      "script": {
+        "source": "1 / (1 + l1normSparse(params.queryVector, doc['my_sparse_vector']))",
+        "params": {
+          "queryVector": {"2": 0.5, "10" : 111.3, "50": -1.3, "113": 14.8, "4545": 156.0}
+        }
+      }
+    }
+  }
+}
+--------------------------------------------------
+// TEST[continued]
+// TEST[warning:The [sparse_vector] field type is deprecated and will be removed in 8.0.]
+
+The `l2normSparse` function calculates L^2^ distance
+between a given query vector and document vectors.
+
+[source,console]
+--------------------------------------------------
+GET my_sparse_index/_search
 {
   "query": {
     "script_score": {
@@ -311,15 +367,5 @@ GET my_index/_search
   }
 }
 --------------------------------------------------
-
-NOTE: If a document doesn't have a value for a vector field on which
-a vector function is executed, an error will be thrown.
-
-You can check if a document has a value for the field `my_vector` by
-`doc['my_vector'].size() == 0`. Your overall script can look like this:
-
-[source,js]
---------------------------------------------------
-"source": "doc['my_vector'].size() == 0 ? 0 : cosineSimilarity(params.queryVector, doc['my_vector'])"
---------------------------------------------------
-// NOTCONSOLE
+// TEST[continued]
+// TEST[warning:The [sparse_vector] field type is deprecated and will be removed in 8.0.]

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/30_sparse_vector_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/30_sparse_vector_basic.yml
@@ -1,10 +1,12 @@
 setup:
   - skip:
-      features: headers
+      features: [headers, warnings]
       version: " - 7.2.99"
       reason: "sparse_vector functions were introduced in 7.3.0"
 
   - do:
+      warnings:
+        - The [sparse_vector] field type is deprecated and will be removed in 8.0.
       indices.create:
         include_type_name: false
         index: test-index
@@ -44,6 +46,8 @@ setup:
 - do:
     headers:
       Content-Type: application/json
+    warnings:
+      - The [sparse_vector] field type is deprecated and will be removed in 8.0.
     search:
       rest_total_hits_as_int: true
       body:
@@ -74,6 +78,8 @@ setup:
 - do:
     headers:
       Content-Type: application/json
+    warnings:
+      - The [sparse_vector] field type is deprecated and will be removed in 8.0.
     search:
       rest_total_hits_as_int: true
       body:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/35_sparse_vector_l1l2.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/35_sparse_vector_l1l2.yml
@@ -1,10 +1,12 @@
 setup:
   - skip:
-      features: headers
+      features: [headers, warnings]
       version: " - 7.3.99"
       reason: "l1norm and l2norm functions were added from 7.4"
 
   - do:
+      warnings:
+        - The [sparse_vector] field type is deprecated and will be removed in 8.0.
       indices.create:
         include_type_name: false
         index: test-index
@@ -44,6 +46,8 @@ setup:
   - do:
       headers:
         Content-Type: application/json
+      warnings:
+        - The [sparse_vector] field type is deprecated and will be removed in 8.0.
       search:
         rest_total_hits_as_int: true
         body:
@@ -75,6 +79,8 @@ setup:
   - do:
       headers:
         Content-Type: application/json
+      warnings:
+        - The [sparse_vector] field type is deprecated and will be removed in 8.0.
       search:
         rest_total_hits_as_int: true
         body:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/40_sparse_vector_special_cases.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/40_sparse_vector_special_cases.yml
@@ -1,10 +1,12 @@
 setup:
   - skip:
-      features: headers
+      features: [headers, warnings]
       version: " - 7.3.99"
       reason: "sparse_vector functions check on empty values was added from 7.4"
 
   - do:
+      warnings:
+        - The [sparse_vector] field type is deprecated and will be removed in 8.0.
       indices.create:
         include_type_name: false
         index: test-index
@@ -50,6 +52,8 @@ setup:
   - do:
       headers:
         Content-Type: application/json
+      warnings:
+        - The [sparse_vector] field type is deprecated and will be removed in 8.0.
       search:
         rest_total_hits_as_int: true
         body:
@@ -70,6 +74,8 @@ setup:
   - do:
       headers:
         Content-Type: application/json
+      warnings:
+        - The [sparse_vector] field type is deprecated and will be removed in 8.0.
       search:
         rest_total_hits_as_int: true
         body:
@@ -96,6 +102,8 @@ setup:
         my_sparse_vector: {"1": 10}
 
 - do:
+    warnings:
+      - The [sparse_vector] field type is deprecated and will be removed in 8.0.
     index:
       index: test-index
       id: 2
@@ -110,6 +118,8 @@ setup:
     catch: bad_request
     headers:
       Content-Type: application/json
+    warnings:
+      - The [sparse_vector] field type is deprecated and will be removed in 8.0.
     search:
       rest_total_hits_as_int: true
       body:
@@ -126,6 +136,8 @@ setup:
 - do:
     headers:
       Content-Type: application/json
+    warnings:
+      - The [sparse_vector] field type is deprecated and will be removed in 8.0.
     search:
       rest_total_hits_as_int: true
       body:
@@ -173,6 +185,8 @@ setup:
 - do:
     headers:
       Content-Type: application/json
+    warnings:
+      - The [sparse_vector] field type is deprecated and will be removed in 8.0.
     search:
       rest_total_hits_as_int: true
       body:
@@ -249,6 +263,8 @@ setup:
 - do:
     headers:
       Content-Type: application/json
+    warnings:
+      - The [sparse_vector] field type is deprecated and will be removed in 8.0.
     search:
       rest_total_hits_as_int: true
       body:
@@ -278,6 +294,8 @@ setup:
 - do:
     headers:
       Content-Type: application/json
+    warnings:
+      - The [sparse_vector] field type is deprecated and will be removed in 8.0.
     search:
       rest_total_hits_as_int: true
       body:
@@ -306,6 +324,8 @@ setup:
 - do:
     headers:
       Content-Type: application/json
+    warnings:
+      - The [sparse_vector] field type is deprecated and will be removed in 8.0.
     search:
       rest_total_hits_as_int: true
       body:
@@ -331,6 +351,8 @@ setup:
 - do:
     headers:
       Content-Type: application/json
+    warnings:
+      - The [sparse_vector] field type is deprecated and will be removed in 8.0.
     search:
       rest_total_hits_as_int: true
       body:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/50_vector_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/50_vector_stats.yml
@@ -1,6 +1,6 @@
 setup:
   - skip:
-      features: headers
+      features: [headers, warnings]
       version: " - 7.3.99"
       reason: "vector stats was added from 7.4"
 
@@ -27,6 +27,8 @@ setup:
                 dims: 30
 
   - do:
+      warnings:
+        - The [sparse_vector] field type is deprecated and will be removed in 8.0.
       indices.create:
         index: test-index2
         body:

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapper.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapper.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.vectors.mapper;
 
+import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
@@ -14,6 +15,7 @@ import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.index.fielddata.IndexFieldData;
@@ -23,8 +25,8 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.query.QueryShardContext;
-import org.elasticsearch.xpack.vectors.query.VectorDVIndexFieldData;
 import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.xpack.vectors.query.VectorDVIndexFieldData;
 
 import java.io.IOException;
 import java.time.ZoneId;
@@ -41,6 +43,9 @@ public class SparseVectorFieldMapper extends FieldMapper {
     public static final String CONTENT_TYPE = "sparse_vector";
     public static short MAX_DIMS_COUNT = 1024; //maximum allowed number of dimensions
     public static int MAX_DIMS_NUMBER = 65535; //maximum allowed dimension's number
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(SparseVectorFieldMapper.class));
+    public static final String DEPRECATION_MESSAGE = "The [sparse_vector] field type is deprecated and will be removed in 8.0.";
 
     public static class Defaults {
         public static final MappedFieldType FIELD_TYPE = new SparseVectorFieldType();
@@ -78,6 +83,7 @@ public class SparseVectorFieldMapper extends FieldMapper {
     public static class TypeParser implements Mapper.TypeParser {
         @Override
         public Mapper.Builder<?,?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            deprecationLogger.deprecatedAndMaybeLog("sparse_vector", DEPRECATION_MESSAGE);
             SparseVectorFieldMapper.Builder builder = new SparseVectorFieldMapper.Builder(name);
             return builder;
         }

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/ScoreScriptUtils.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/ScoreScriptUtils.java
@@ -7,9 +7,12 @@
 
 package org.elasticsearch.xpack.vectors.query;
 
+import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.script.ScoreScript;
+import org.elasticsearch.xpack.vectors.mapper.SparseVectorFieldMapper;
 import org.elasticsearch.xpack.vectors.mapper.VectorEncoderDecoder;
 
 import java.nio.ByteBuffer;
@@ -173,6 +176,8 @@ public class ScoreScriptUtils {
     // per script execution for all documents.
 
     public static class SparseVectorFunction {
+        static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(SparseVectorFunction.class));
+
         final ScoreScript scoreScript;
         final float[] queryValues;
         final int[] queryDims;
@@ -197,6 +202,8 @@ public class ScoreScriptUtils {
             }
             // Sort dimensions in the ascending order and sort values in the same order as their corresponding dimensions
             sortSparseDimsFloatValues(queryDims, queryValues, n);
+
+            deprecationLogger.deprecatedAndMaybeLog("sparse_vector_function", SparseVectorFieldMapper.DEPRECATION_MESSAGE);
         }
 
         public void validateDocVector(BytesRef vector) {

--- a/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapperTests.java
+++ b/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapperTests.java
@@ -115,6 +115,8 @@ public class SparseVectorFieldMapperTests extends ESSingleNodeTestCase {
         );
         float decodedMagnitude = VectorEncoderDecoder.decodeVectorMagnitude(indexVersion, vectorBR);
         assertEquals(expectedMagnitude, decodedMagnitude, 0.001f);
+
+        assertWarnings(SparseVectorFieldMapper.DEPRECATION_MESSAGE);
     }
 
     public void testAddDocumentsToIndexBefore_V_7_5_0() throws Exception {
@@ -168,6 +170,8 @@ public class SparseVectorFieldMapperTests extends ESSingleNodeTestCase {
             decodedValues,
             0.001f
         );
+
+        assertWarnings(SparseVectorFieldMapper.DEPRECATION_MESSAGE);
     }
 
     public void testDimensionNumberValidation() {
@@ -230,6 +234,8 @@ public class SparseVectorFieldMapperTests extends ESSingleNodeTestCase {
         assertThat(e.getCause(), instanceOf(IllegalArgumentException.class));
         assertThat(e.getCause().getMessage(), containsString(
             "takes an object that maps a dimension number to a float, but got unexpected token [START_ARRAY]"));
+
+        assertWarnings(SparseVectorFieldMapper.DEPRECATION_MESSAGE);
     }
 
       public void testDimensionLimit() throws IOException {
@@ -254,6 +260,8 @@ public class SparseVectorFieldMapperTests extends ESSingleNodeTestCase {
         MapperParsingException e = expectThrows(MapperParsingException.class, () -> mapper.parse(
             new SourceToParse("test-index", "_doc", "1", invalidDoc, XContentType.JSON)));
         assertThat(e.getDetailedMessage(), containsString("has exceeded the maximum allowed number of dimensions"));
+
+        assertWarnings(SparseVectorFieldMapper.DEPRECATION_MESSAGE);
     }
 
 }

--- a/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/query/ScoreScriptUtilsTests.java
+++ b/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/query/ScoreScriptUtilsTests.java
@@ -10,6 +10,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
 import org.elasticsearch.script.ScoreScript;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.vectors.mapper.SparseVectorFieldMapper;
 import org.elasticsearch.xpack.vectors.mapper.VectorEncoderDecoder;
 import org.elasticsearch.xpack.vectors.query.ScoreScriptUtils.CosineSimilarity;
 import org.elasticsearch.xpack.vectors.query.ScoreScriptUtils.CosineSimilaritySparse;
@@ -132,6 +133,8 @@ public class ScoreScriptUtilsTests extends ESTestCase {
         L2NormSparse l2Norm = new L2NormSparse(scoreScript, queryVector);
         double result4 = l2Norm.l2normSparse(dvs);
         assertEquals("l2normSparse result is not equal to the expected value!", 301.361, result4, 0.001);
+
+        assertWarnings(SparseVectorFieldMapper.DEPRECATION_MESSAGE);
     }
 
     public void testSparseVectorMissingDimensions1() {
@@ -172,6 +175,8 @@ public class ScoreScriptUtilsTests extends ESTestCase {
         L2NormSparse l2Norm = new L2NormSparse(scoreScript, queryVector);
         double result4 = l2Norm.l2normSparse(dvs);
         assertEquals("l2normSparse result is not equal to the expected value!", 302.277, result4, 0.001);
+
+        assertWarnings(SparseVectorFieldMapper.DEPRECATION_MESSAGE);
     }
 
     public void testSparseVectorMissingDimensions2() {
@@ -212,5 +217,7 @@ public class ScoreScriptUtilsTests extends ESTestCase {
         L2NormSparse l2Norm = new L2NormSparse(scoreScript, queryVector);
         double result4 = l2Norm.l2normSparse(dvs);
         assertEquals("l2normSparse result is not equal to the expected value!", 302.277, result4, 0.001);
+
+        assertWarnings(SparseVectorFieldMapper.DEPRECATION_MESSAGE);
     }
 }


### PR DESCRIPTION
Backport of #48315, opening a PR to run a full build.