### PR TITLE
Add a known issue to the release notes of 7.4.0

### DIFF
--- a/docs/reference/release-notes/7.4.asciidoc
+++ b/docs/reference/release-notes/7.4.asciidoc
@@ -8,6 +8,14 @@ coming[7.4.1]
 
 Also see <<breaking-changes-7.4,Breaking changes in 7.4>>.
 
+[float]
+=== Known issues
+
+* Activating the <<search-slow-log, search slow log>> should be avoided in this version.
+Any attempt to log a slow search can throw an AIOOBE due to a bug that
+performs concurrent modifications on a shared byte array.
+(issue: {issue}/48358[#48358])
+
 [[breaking-7.4.0]]
 [float]
 === Breaking changes


### PR DESCRIPTION
A [bug](https://github.com/elastic/elasticsearch/issues/48358) in 7.4.0 prevents the activation of the search slow log. 
This change adds an entry in the release notes to warn users to not activate it in this version.

Relates #48358