### PR TITLE
Reenable BwC Tests after #48371

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -206,8 +206,8 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
-final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/48371" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = true
+final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -118,7 +118,7 @@ import static org.elasticsearch.cluster.SnapshotsInProgress.completed;
  */
 public class SnapshotsService extends AbstractLifecycleComponent implements ClusterStateApplier {
 
-    public static final Version SHARD_GEN_IN_REPO_DATA_VERSION = Version.V_8_0_0;
+    public static final Version SHARD_GEN_IN_REPO_DATA_VERSION = Version.V_7_6_0;
 
     private static final Logger logger = LogManager.getLogger(SnapshotsService.class);
 


### PR DESCRIPTION
#48371 has been merged -> reenabling tests

NOTE: I will remove the BwC logic that has become obsolete with the
backporting of relevant changes to 7.6 in a follow-up as it
is quite a bit of code that goes away and I didn't want to
delay BwC tests.
