### PR TITLE
Add a packagingTask for every os project

### DIFF
--- a/qa/os/build.gradle
+++ b/qa/os/build.gradle
@@ -62,13 +62,8 @@ processTestResources {
 }
 
 subprojects { Project platformProject ->
-
-  // TODO: remove this property lookup once CI is switched to use an explicit task for the sample tests
-  boolean allBoxes = (project.findProperty('vagrant.boxes') ?: '') == 'all'
-  if (allBoxes || ['centos-7', 'ubuntu-1604'].contains(platformProject.name)) {
-    tasks.register('packagingTest') {
-      dependsOn 'distroTest', 'batsTest.oss', 'batsTest.default'
-    }
+  tasks.register('packagingTest') {
+    dependsOn 'distroTest', 'batsTest.oss', 'batsTest.default'
   }
 
   vagrant {


### PR DESCRIPTION
We no longer run the sample tests in CI, so it's safe to create a task
for every project.
This will make it easier to set them up in a matrix like fashion.


