### PR TITLE
Handle Concurrent Repo Modification to Fix Test

### DIFF
--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
@@ -215,6 +215,10 @@ public class SLMSnapshotBlockingIntegTests extends ESIntegTestCase {
                     SnapshotsStatusResponse s =
                         client().admin().cluster().prepareSnapshotStatus(REPO).setSnapshots(completedSnapshotName).get();
                     assertNull("expected no snapshot but one was returned", s.getSnapshots().get(0));
+                } catch (RepositoryException e) {
+                    // Concurrent status calls and write operations may lead to failures in determining the current repository generation
+                    // TODO: Remove this hack once tracking the current repository generation has been made consistent
+                    throw new AssertionError(e);
                 } catch (SnapshotMissingException e) {
                     // Great, we wanted it to be deleted!
                 }


### PR DESCRIPTION
Just like #48329 (and using the changes) in that PR
we can run into a concurrent repo modification that we
will throw on and must retry until consistent handling of
this situation is implemented.

Closes #47834
