### PR TITLE
Allow more time for restart tests to reach yellow state.

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -404,7 +404,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
     private void waitForYellow(String indexName) throws IOException {
         Request request = new Request("GET", "/_cluster/health/" + indexName);
         request.addParameter("wait_for_status", "yellow");
-        request.addParameter("timeout", "30s");
+        request.addParameter("timeout", "60s");
         request.addParameter("wait_for_no_relocating_shards", "true");
         request.addParameter("wait_for_no_initializing_shards", "true");
         Map<String, Object> response = entityAsMap(client().performRequest(request));


### PR DESCRIPTION
The testWatcher method will on occasion timeout waiting for
a yellow cluster state. This change increases the timeout
to 60s.

---------

As part of re-enabling via https://github.com/elastic/elasticsearch/pull/47950 this test was run for 24+ hours without failure on a dedicated node. I believe that this timeout is an environmental issue and 60s should be plenty of time. 