### PR TITLE
Add sparse vector deprecation to 7.6 migration docs.

### DIFF
--- a/docs/reference/migration/index.asciidoc
+++ b/docs/reference/migration/index.asciidoc
@@ -11,6 +11,7 @@ For information about how to upgrade your cluster, see <<setup-upgrade>>.
 
 --
 
+include::migrate_7_6.asciidoc[]
 include::migrate_7_5.asciidoc[]
 include::migrate_7_4.asciidoc[]
 include::migrate_7_3.asciidoc[]

--- a/docs/reference/migration/migrate_7_6.asciidoc
+++ b/docs/reference/migration/migrate_7_6.asciidoc
@@ -1,0 +1,31 @@
+[[breaking-changes-7.6]]
+== Breaking changes in 7.6
+++++
+<titleabbrev>7.6</titleabbrev>
+++++
+
+This section discusses the changes that you need to be aware of when migrating
+your application to Elasticsearch 7.6.
+
+See also <<release-highlights>> and <<es-release-notes>>.
+
+coming[7.6.0]
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+
+//end::notable-breaking-changes[]
+
+[discrete]
+[[breaking_76_search_changes]]
+=== Search Changes
+
+[discrete]
+==== Deprecation of sparse vector fields
+The `sparse_vector` field type has been deprecated and will be removed in 8.0.
+We have not seen much interest in this experimental field type, and don't see
+a clear use case as it's currently designed. If you have feedback or
+suggestions around sparse vector functionality, please let us know through
+GitHub or the 'discuss' forums.


### PR DESCRIPTION
This note was accidentally omitted from #48368.
