### PR TITLE
Update docs around querying on the _index field.

### DIFF
--- a/docs/reference/mapping/fields/index-field.asciidoc
+++ b/docs/reference/mapping/fields/index-field.asciidoc
@@ -4,18 +4,11 @@
 When performing queries across multiple indexes, it is sometimes desirable to
 add query clauses that are associated with documents of only certain indexes.
 The `_index` field allows matching on the index a document was indexed into.
-Its value is accessible in `term`, or `terms` queries, aggregations,
-scripts, and when sorting:
-
-NOTE: The `_index` is exposed as a virtual field -- it is not added to the
-Lucene index as a real field.  This means that you can use the `_index` field
-in a `term` or `terms` query (or any query that is rewritten to a `term`
-query, such as the `match`,  `query_string` or `simple_query_string` query),
-but it does not support `prefix`, `wildcard`, `regexp`, or `fuzzy` queries.
+Its value is accessible in certain queries and aggregations, and when sorting
+or scripting:
 
 [source,console]
 --------------------------
-# Example documents
 PUT index_1/_doc/1
 {
   "text": "Document in index 1"
@@ -63,3 +56,20 @@ GET index_1,index_2/_search
 <2> Aggregating on the `_index` field
 <3> Sorting on the `_index` field
 <4> Accessing the `_index` field in scripts
+
+The `_index` field is exposed virtually -- it is not added to the Lucene index
+as a real field.  This means that you can use the `_index` field in a `term` or
+`terms` query (or any query that is rewritten to a `term` query, such as the
+`match`,  `query_string` or `simple_query_string` query), as well as `prefix`
+and `wildcard` queries. However, it does not support `regexp` and `fuzzy`
+queries.
+
+Queries on the `_index` field accept index aliases in addition to concrete
+index names.
+
+NOTE: When specifying a remote index name such as `cluster_1:index_3`, the
+query must contain the separator character `:`. For example, a `wildcard` query
+on `cluster_*:index_3` would match documents from the remote index. However, a
+query on `cluster*index_1` is only matched against local indices, since no
+separator is present. This behavior aligns with the usual resolution rules for
+remote index names.


### PR DESCRIPTION
This PR makes the following changes:
* Update the supported query types to include `prefix` and `wildcard`.
* Specify that queries accept index aliases.
* Clarify that when querying on a remote index name, the separator `:` must be
  present.

Follow-up to #46640.