### PR TITLE
Typo in HAVING section

### DIFF
--- a/docs/reference/sql/language/syntax/commands/select.asciidoc
+++ b/docs/reference/sql/language/syntax/commands/select.asciidoc
@@ -235,7 +235,7 @@ The `HAVING` clause can be used _only_ along aggregate functions (and thus `GROU
 
 [source, sql]
 ----
-GROUP BY condition
+HAVING condition
 ----
 
 where:


### PR DESCRIPTION
`HAVING` section code states `GROUP BY`  instead of the appropriate keyword.
