### PR TITLE
Improve resiliency to auto-formatting in libs, modules

### DIFF
--- a/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/SslConfigurationLoader.java
+++ b/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/SslConfigurationLoader.java
@@ -69,30 +69,95 @@ public abstract class SslConfigurationLoader {
     static final List<String> DEFAULT_PROTOCOLS = List.of("TLSv1.3", "TLSv1.2", "TLSv1.1");
 
     private static final List<String> JDK11_CIPHERS = List.of(
-        "TLS_AES_256_GCM_SHA384", "TLS_AES_128_GCM_SHA256", // TLSv1.3 cipher has PFS, AEAD, hardware support
-        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", // PFS, AEAD, hardware support
-        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", // PFS, AEAD, hardware support
-        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",  "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256", // PFS, hardware support
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256", // PFS, hardware support
-        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA", "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA", // PFS, hardware support
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", // PFS, hardware support
-        "TLS_RSA_WITH_AES_256_GCM_SHA384", "TLS_RSA_WITH_AES_128_GCM_SHA256", // AEAD, hardware support
-        "TLS_RSA_WITH_AES_256_CBC_SHA256", "TLS_RSA_WITH_AES_128_CBC_SHA256", // hardware support
-        "TLS_RSA_WITH_AES_256_CBC_SHA", "TLS_RSA_WITH_AES_128_CBC_SHA"); // hardware support
+        // TLSv1.3 cipher has PFS, AEAD, hardware support
+        "TLS_AES_256_GCM_SHA384",
+        "TLS_AES_128_GCM_SHA256",
+
+        // PFS, AEAD, hardware support
+        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+
+        // PFS, AEAD, hardware support
+        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+
+        // PFS, hardware support
+        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+        "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+
+        // PFS, hardware support
+        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+
+        // PFS, hardware support
+        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+        "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+
+        // PFS, hardware support
+        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+
+        // AEAD, hardware support
+        "TLS_RSA_WITH_AES_256_GCM_SHA384",
+        "TLS_RSA_WITH_AES_128_GCM_SHA256",
+
+        // hardware support
+        "TLS_RSA_WITH_AES_256_CBC_SHA256",
+        "TLS_RSA_WITH_AES_128_CBC_SHA256",
+
+        // hardware support
+        "TLS_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_RSA_WITH_AES_128_CBC_SHA"
+    );
 
     private static final List<String> JDK12_CIPHERS = List.of(
-        "TLS_AES_256_GCM_SHA384", "TLS_AES_128_GCM_SHA256", // TLSv1.3 cipher has PFS, AEAD, hardware support
-        "TLS_CHACHA20_POLY1305_SHA256", // TLSv1.3 cipher has PFS, AEAD
-        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", // PFS, AEAD, hardware support
-        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", // PFS, AEAD, hardware support
-        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256", "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256", // PFS, AEAD
-        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",  "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256", // PFS, hardware support
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256", // PFS, hardware support
-        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA", "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA", // PFS, hardware support
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", // PFS, hardware support
-        "TLS_RSA_WITH_AES_256_GCM_SHA384", "TLS_RSA_WITH_AES_128_GCM_SHA256", // AEAD, hardware support
-        "TLS_RSA_WITH_AES_256_CBC_SHA256", "TLS_RSA_WITH_AES_128_CBC_SHA256", // hardware support
-        "TLS_RSA_WITH_AES_256_CBC_SHA", "TLS_RSA_WITH_AES_128_CBC_SHA"); // hardware support
+        // TLSv1.3 cipher has PFS, AEAD, hardware support
+        "TLS_AES_256_GCM_SHA384",
+        "TLS_AES_128_GCM_SHA256",
+
+        // TLSv1.3 cipher has PFS, AEAD
+        "TLS_CHACHA20_POLY1305_SHA256",
+
+        // PFS, AEAD, hardware support
+        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+
+        // PFS, AEAD, hardware support
+        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+
+        // PFS, AEAD
+        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+
+        // PFS, hardware support
+        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+        "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+
+        // PFS, hardware support
+        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+
+        // PFS, hardware support
+        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+        "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+
+        // PFS, hardware support
+        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+
+        // AEAD, hardware support
+        "TLS_RSA_WITH_AES_256_GCM_SHA384",
+        "TLS_RSA_WITH_AES_128_GCM_SHA256",
+
+        // hardware support
+        "TLS_RSA_WITH_AES_256_CBC_SHA256",
+        "TLS_RSA_WITH_AES_128_CBC_SHA256",
+
+        // hardware support
+        "TLS_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_RSA_WITH_AES_128_CBC_SHA"
+    );
 
     static final List<String> DEFAULT_CIPHERS =
         JavaVersion.current().compareTo(JavaVersion.parse("12")) > -1 ? JDK12_CIPHERS : JDK11_CIPHERS;

--- a/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/ConstructingObjectParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/ConstructingObjectParserTests.java
@@ -91,10 +91,7 @@ public class ConstructingObjectParserTests extends ESTestCase {
     }
 
     public void testMissingAllConstructorArgs() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\n"
-                + "  \"mineral\": 1\n"
-                + "}");
+        XContentParser parser = createParser(JsonXContent.jsonXContent, "{ \"mineral\": 1 }");
         ConstructingObjectParser<HasCtorArguments, Void> objectParser = randomBoolean() ? HasCtorArguments.PARSER
                 : HasCtorArguments.PARSER_VEGETABLE_OPTIONAL;
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> objectParser.apply(parser, null));
@@ -106,31 +103,20 @@ public class ConstructingObjectParserTests extends ESTestCase {
     }
 
     public void testMissingAllConstructorArgsButNotRequired() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                "{\n"
-              + "  \"mineral\": 1\n"
-              + "}");
+        XContentParser parser = createParser(JsonXContent.jsonXContent, "{ \"mineral\": 1 }");
         HasCtorArguments parsed = HasCtorArguments.PARSER_ALL_OPTIONAL.apply(parser, null);
         assertEquals(1, parsed.mineral);
     }
 
     public void testMissingSecondConstructorArg() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\n"
-                + "  \"mineral\": 1,\n"
-                + "  \"animal\": \"cat\"\n"
-                + "}");
+        XContentParser parser = createParser(JsonXContent.jsonXContent, "{ \"mineral\": 1, \"animal\": \"cat\" }");
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                 () -> HasCtorArguments.PARSER.apply(parser, null));
         assertEquals("Required [vegetable]", e.getMessage());
     }
 
     public void testMissingSecondConstructorArgButNotRequired() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                "{\n"
-              + "  \"mineral\": 1,\n"
-              + "  \"animal\": \"cat\"\n"
-              + "}");
+        XContentParser parser = createParser(JsonXContent.jsonXContent, "{ \"mineral\": 1, \"animal\": \"cat\" }");
         @SuppressWarnings("unchecked")
         HasCtorArguments parsed = randomFrom(HasCtorArguments.PARSER_VEGETABLE_OPTIONAL, HasCtorArguments.PARSER_ALL_OPTIONAL).apply(parser,
                 null);
@@ -139,11 +125,7 @@ public class ConstructingObjectParserTests extends ESTestCase {
     }
 
     public void testMissingFirstConstructorArg() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\n"
-                + "  \"mineral\": 1,\n"
-                + "  \"vegetable\": 2\n"
-                + "}");
+        XContentParser parser = createParser(JsonXContent.jsonXContent, "{ \"mineral\": 1, \"vegetable\": 2 }");
         @SuppressWarnings("unchecked")
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                 () -> randomFrom(HasCtorArguments.PARSER, HasCtorArguments.PARSER_VEGETABLE_OPTIONAL).apply(parser, null));
@@ -151,23 +133,19 @@ public class ConstructingObjectParserTests extends ESTestCase {
     }
 
     public void testMissingFirstConstructorArgButNotRequired() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                "{\n"
-              + "  \"mineral\": 1,\n"
-              + "  \"vegetable\": 2\n"
-              + "}");
+        XContentParser parser = createParser(JsonXContent.jsonXContent, "{ \"mineral\": 1, \"vegetable\": 2 }");
         HasCtorArguments parsed = HasCtorArguments.PARSER_ALL_OPTIONAL.apply(parser, null);
         assertEquals(1, parsed.mineral);
         assertEquals((Integer) 2, parsed.vegetable);
     }
 
     public void testBadParam() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\n"
-                + "  \"animal\": \"cat\",\n"
-                + "  \"vegetable\": 2,\n"
-                + "  \"a\": \"supercalifragilisticexpialidocious\"\n"
-                + "}");
+        XContentParser parser = createParser(
+            JsonXContent.jsonXContent,
+            // The following JSON needs to include newlines, in order to affect the line numbers
+            // included in the exception
+            "{\n" + "  \"animal\": \"cat\",\n" + "  \"vegetable\": 2,\n" + "  \"a\": \"supercalifragilisticexpialidocious\"\n" + "}"
+        );
         XContentParseException e = expectThrows(XContentParseException.class,
                 () -> randomFrom(HasCtorArguments.ALL_PARSERS).apply(parser, null));
         assertThat(e.getMessage(), containsString("[has_required_arguments] failed to parse field [a]"));
@@ -177,12 +155,12 @@ public class ConstructingObjectParserTests extends ESTestCase {
     }
 
     public void testBadParamBeforeObjectBuilt() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\n"
-                + "  \"a\": \"supercalifragilisticexpialidocious\",\n"
-                + "  \"animal\": \"cat\"\n,"
-                + "  \"vegetable\": 2\n"
-                + "}");
+        XContentParser parser = createParser(
+            JsonXContent.jsonXContent,
+            // The following JSON needs to include newlines, in order to affect the line numbers
+            // included in the exception
+            "{\n" + "  \"a\": \"supercalifragilisticexpialidocious\",\n" + "  \"animal\": \"cat\"\n," + "  \"vegetable\": 2\n" + "}"
+        );
         XContentParseException e = expectThrows(XContentParseException.class,
                 () -> randomFrom(HasCtorArguments.ALL_PARSERS).apply(parser, null));
         assertThat(e.getMessage(), containsString("[has_required_arguments] failed to parse field [vegetable]"));
@@ -238,40 +216,25 @@ public class ConstructingObjectParserTests extends ESTestCase {
         parser.declareString(ctorArgOptional ? optionalConstructorArg() : constructorArg(), new ParseField("yeah"));
 
         // ctor arg first so we can test for the bug we found one time
-        XContentParser xcontent = createParser(JsonXContent.jsonXContent,
-                "{\n"
-              + "  \"yeah\": \"!\",\n"
-              + "  \"foo\": \"foo\"\n"
-              + "}");
+        XContentParser xcontent = createParser(JsonXContent.jsonXContent, "{ \"yeah\": \"!\", \"foo\": \"foo\" }");
         CalledOneTime result = parser.apply(xcontent, null);
         assertTrue(result.fooSet);
 
         // and ctor arg second just in case
-        xcontent = createParser(JsonXContent.jsonXContent,
-                "{\n"
-              + "  \"foo\": \"foo\",\n"
-              + "  \"yeah\": \"!\"\n"
-              + "}");
+        xcontent = createParser(JsonXContent.jsonXContent, "{ \"foo\": \"foo\",  \"yeah\": \"!\" }");
         result = parser.apply(xcontent, null);
         assertTrue(result.fooSet);
 
         if (ctorArgOptional) {
             // and without the constructor arg if we've made it optional
-            xcontent = createParser(JsonXContent.jsonXContent,
-                    "{\n"
-                  + "  \"foo\": \"foo\"\n"
-                  + "}");
+            xcontent = createParser(JsonXContent.jsonXContent, "{ \"foo\": \"foo\" }");
             result = parser.apply(xcontent, null);
         }
         assertTrue(result.fooSet);
     }
 
     public void testIgnoreUnknownFields() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\n"
-                + "  \"test\" : \"foo\",\n"
-                + "  \"junk\" : 2\n"
-                + "}");
+        XContentParser parser = createParser(JsonXContent.jsonXContent, "{ \"test\" : \"foo\", \"junk\" : 2 }");
         class TestStruct {
             public final String test;
             TestStruct(String test) {
@@ -286,11 +249,7 @@ public class ConstructingObjectParserTests extends ESTestCase {
     }
 
     public void testConstructObjectUsingContext() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-            "{\n"
-                + "  \"animal\": \"dropbear\",\n"
-                + "  \"mineral\": -8\n"
-                + "}");
+        XContentParser parser = createParser(JsonXContent.jsonXContent, "{ \"animal\": \"dropbear\", \"mineral\": -8 }");
         HasCtorArguments parsed = HasCtorArguments.PARSER_INT_CONTEXT.apply(parser, 42);
         assertEquals(Integer.valueOf(42), parsed.vegetable);
         assertEquals("dropbear", parsed.animal);
@@ -410,12 +369,10 @@ public class ConstructingObjectParserTests extends ESTestCase {
     }
 
     public void testParseNamedObject() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\"named\": {\n"
-                + "  \"a\": {}"
-                + "},\"named_in_constructor\": {\n"
-                + "  \"b\": {}"
-                + "}}");
+        XContentParser parser = createParser(
+            JsonXContent.jsonXContent,
+            "{\"named\": { \"a\": {} }, \"named_in_constructor\": { \"b\": {} } }"
+        );
         NamedObjectHolder h = NamedObjectHolder.PARSER.apply(parser, null);
         assertThat(h.named, hasSize(1));
         assertEquals("a", h.named.get(0).name);
@@ -425,12 +382,10 @@ public class ConstructingObjectParserTests extends ESTestCase {
     }
 
     public void testParseNamedObjectInOrder() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\"named\": [\n"
-                + "  {\"a\": {}}"
-                + "],\"named_in_constructor\": [\n"
-                + "  {\"b\": {}}"
-                + "]}");
+        XContentParser parser = createParser(
+            JsonXContent.jsonXContent,
+            "{\"named\": [ {\"a\": {}} ], \"named_in_constructor\": [ {\"b\": {}} ]}"
+        );
         NamedObjectHolder h = NamedObjectHolder.PARSER.apply(parser, null);
         assertThat(h.named, hasSize(1));
         assertEquals("a", h.named.get(0).name);
@@ -440,12 +395,10 @@ public class ConstructingObjectParserTests extends ESTestCase {
     }
 
     public void testParseNamedObjectTwoFieldsInArray() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\"named\": [\n"
-                + "  {\"a\": {}, \"b\": {}}"
-                + "],\"named_in_constructor\": [\n"
-                + "  {\"c\": {}}"
-                + "]}");
+        XContentParser parser = createParser(
+            JsonXContent.jsonXContent,
+            "{\"named\": [ {\"a\": {}, \"b\": {}}], \"named_in_constructor\": [ {\"c\": {}} ]}"
+        );
         XContentParseException e = expectThrows(XContentParseException.class, () -> NamedObjectHolder.PARSER.apply(parser, null));
         assertThat(e.getMessage(), containsString("[named_object_holder] failed to parse field [named]"));
         assertThat(e.getCause().getMessage(),
@@ -454,12 +407,10 @@ public class ConstructingObjectParserTests extends ESTestCase {
     }
 
     public void testParseNamedObjectTwoFieldsInArrayConstructorArg() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\"named\": [\n"
-                + "  {\"a\": {}}"
-                + "],\"named_in_constructor\": [\n"
-                + "  {\"c\": {}, \"d\": {}}"
-                + "]}");
+        XContentParser parser = createParser(
+            JsonXContent.jsonXContent,
+            "{\"named\": [ {\"a\": {}}], \"named_in_constructor\": [ {\"c\": {}, \"d\": {}} ]}"
+        );
         XContentParseException e = expectThrows(XContentParseException.class, () -> NamedObjectHolder.PARSER.apply(parser, null));
         assertThat(e.getMessage(), containsString("[named_object_holder] failed to parse field [named_in_constructor]"));
         assertThat(e.getCause().getMessage(),
@@ -468,12 +419,7 @@ public class ConstructingObjectParserTests extends ESTestCase {
     }
 
     public void testParseNamedObjectNoFieldsInArray() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\"named\": [\n"
-                + "  {}"
-                + "],\"named_in_constructor\": [\n"
-                + "  {\"a\": {}}"
-                + "]}");
+        XContentParser parser = createParser(JsonXContent.jsonXContent, "{\"named\": [ {} ], \"named_in_constructor\": [ {\"a\": {}} ]}");
         XContentParseException e = expectThrows(XContentParseException.class, () -> NamedObjectHolder.PARSER.apply(parser, null));
         assertThat(e.getMessage(), containsString("[named_object_holder] failed to parse field [named]"));
         assertThat(e.getCause().getMessage(),
@@ -482,12 +428,7 @@ public class ConstructingObjectParserTests extends ESTestCase {
     }
 
     public void testParseNamedObjectNoFieldsInArrayConstructorArg() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\"named\": [\n"
-                + "  {\"a\": {}}"
-                + "],\"named_in_constructor\": [\n"
-                + "  {}"
-                + "]}");
+        XContentParser parser = createParser(JsonXContent.jsonXContent, "{\"named\": [ {\"a\": {}} ], \"named_in_constructor\": [ {} ]}");
         XContentParseException e = expectThrows(XContentParseException.class, () -> NamedObjectHolder.PARSER.apply(parser, null));
         assertThat(e.getMessage(), containsString("[named_object_holder] failed to parse field [named_in_constructor]"));
         assertThat(e.getCause().getMessage(),
@@ -496,12 +437,10 @@ public class ConstructingObjectParserTests extends ESTestCase {
     }
 
     public void testParseNamedObjectJunkInArray() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\"named\": [\n"
-                + "  \"junk\""
-                + "],\"named_in_constructor\": [\n"
-                + " {\"a\": {}}"
-                + "]}");
+        XContentParser parser = createParser(
+            JsonXContent.jsonXContent,
+            "{\"named\": [ \"junk\" ], \"named_in_constructor\": [ {\"a\": {}} ]}"
+        );
         XContentParseException e = expectThrows(XContentParseException.class, () -> NamedObjectHolder.PARSER.apply(parser, null));
         assertThat(e.getMessage(), containsString("[named_object_holder] failed to parse field [named]"));
         assertThat(e.getCause().getMessage(),
@@ -510,12 +449,10 @@ public class ConstructingObjectParserTests extends ESTestCase {
     }
 
     public void testParseNamedObjectJunkInArrayConstructorArg() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\"named\": [\n"
-                + "  {\"a\": {}}"
-                + "],\"named_in_constructor\": [\n"
-                + "  \"junk\""
-                + "]}");
+        XContentParser parser = createParser(
+            JsonXContent.jsonXContent,
+            "{\"named\": [ {\"a\": {}} ], \"named_in_constructor\": [ \"junk\" ]}"
+        );
         XContentParseException e = expectThrows(XContentParseException.class, () -> NamedObjectHolder.PARSER.apply(parser, null));
         assertThat(e.getMessage(), containsString("[named_object_holder] failed to parse field [named_in_constructor]"));
         assertThat(e.getCause().getMessage(),
@@ -524,11 +461,10 @@ public class ConstructingObjectParserTests extends ESTestCase {
     }
 
     public void testParseNamedObjectInOrderNotSupported() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\"named\": [\n"
-                + "  {\"a\": {}}"
-                + "],\"named_in_constructor\": {\"b\": {}}"
-                + "}");
+        XContentParser parser = createParser(
+            JsonXContent.jsonXContent,
+            "{\"named\": [\n" + "  {\"a\": {}}" + "],\"named_in_constructor\": {\"b\": {}}" + "}"
+        );
 
         // Create our own parser for this test so we can disable support for the "ordered" mode specified by the array above
         @SuppressWarnings("unchecked")
@@ -545,11 +481,10 @@ public class ConstructingObjectParserTests extends ESTestCase {
     }
 
     public void testParseNamedObjectInOrderNotSupportedConstructorArg() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\"named\": {\"a\": {}}"
-                + ",\"named_in_constructor\": [\n"
-                + "  {\"b\": {}}"
-                + "]}");
+        XContentParser parser = createParser(
+            JsonXContent.jsonXContent,
+            "{\"named\": {\"a\": {}}, \"named_in_constructor\": [ {\"b\": {}} ]}"
+        );
 
         // Create our own parser for this test so we can disable support for the "ordered" mode specified by the array above
         @SuppressWarnings("unchecked")

--- a/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/ObjectParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/ObjectParserTests.java
@@ -44,12 +44,10 @@ import static org.hamcrest.Matchers.hasSize;
 public class ObjectParserTests extends ESTestCase {
 
     public void testBasics() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\n"
-                + "  \"test\" : \"foo\",\n"
-                + "  \"test_number\" : 2,\n"
-                + "  \"test_array\":  [1,2,3,4]\n"
-                + "}");
+        XContentParser parser = createParser(
+            JsonXContent.jsonXContent,
+            "{ \"test\" : \"foo\", \"test_number\" : 2, \"test_array\": [1,2,3,4] }"
+        );
         class TestStruct {
             public String test;
             int testNumber;
@@ -176,8 +174,10 @@ public class ObjectParserTests extends ESTestCase {
                 }
             }
         }
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                "{\"url\" : { \"host\": \"http://foobar\", \"port\" : 80}, \"name\" : \"foobarbaz\"}");
+        XContentParser parser = createParser(
+            JsonXContent.jsonXContent,
+            "{\"url\" : { \"host\": \"http://foobar\", \"port\" : 80}, \"name\" : \"foobarbaz\"}"
+        );
         ObjectParser<Foo, CustomParseContext> objectParser = new ObjectParser<>("foo");
         objectParser.declareString(Foo::setName, new ParseField("name"));
         objectParser.declareObjectOrDefault(Foo::setURI, (p, s) -> s.parseURI(p), () -> null, new ParseField("url"));
@@ -449,10 +449,7 @@ public class ObjectParserTests extends ESTestCase {
     }
 
     public void testParseNamedObject() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\"named\": {\n"
-                + "  \"a\": {}"
-                + "}}");
+        XContentParser parser = createParser(JsonXContent.jsonXContent, "{\"named\": { \"a\": {} }}");
         NamedObjectHolder h = NamedObjectHolder.PARSER.apply(parser, null);
         assertThat(h.named, hasSize(1));
         assertEquals("a", h.named.get(0).name);
@@ -460,10 +457,7 @@ public class ObjectParserTests extends ESTestCase {
     }
 
     public void testParseNamedObjectInOrder() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\"named\": [\n"
-                + "  {\"a\": {}}"
-                + "]}");
+        XContentParser parser = createParser(JsonXContent.jsonXContent, "{\"named\": [ {\"a\": {}} ] }");
         NamedObjectHolder h = NamedObjectHolder.PARSER.apply(parser, null);
         assertThat(h.named, hasSize(1));
         assertEquals("a", h.named.get(0).name);
@@ -471,10 +465,7 @@ public class ObjectParserTests extends ESTestCase {
     }
 
     public void testParseNamedObjectTwoFieldsInArray() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\"named\": [\n"
-                + "  {\"a\": {}, \"b\": {}}"
-                + "]}");
+        XContentParser parser = createParser(JsonXContent.jsonXContent, "{\"named\": [ {\"a\": {}, \"b\": {}}]}");
         XContentParseException e = expectThrows(XContentParseException.class, () -> NamedObjectHolder.PARSER.apply(parser, null));
         assertThat(e.getMessage(), containsString("[named_object_holder] failed to parse field [named]"));
         assertThat(e.getCause().getMessage(),
@@ -483,10 +474,7 @@ public class ObjectParserTests extends ESTestCase {
     }
 
     public void testParseNamedObjectNoFieldsInArray() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\"named\": [\n"
-                + "  {}"
-                + "]}");
+        XContentParser parser = createParser(JsonXContent.jsonXContent, "{\"named\": [ {} ]}");
         XContentParseException e = expectThrows(XContentParseException.class, () -> NamedObjectHolder.PARSER.apply(parser, null));
         assertThat(e.getMessage(), containsString("[named_object_holder] failed to parse field [named]"));
         assertThat(e.getCause().getMessage(),
@@ -495,10 +483,7 @@ public class ObjectParserTests extends ESTestCase {
     }
 
     public void testParseNamedObjectJunkInArray() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\"named\": [\n"
-                + "  \"junk\""
-                + "]}");
+        XContentParser parser = createParser(JsonXContent.jsonXContent, "{\"named\": [ \"junk\" ] }");
         XContentParseException e = expectThrows(XContentParseException.class, () -> NamedObjectHolder.PARSER.apply(parser, null));
         assertThat(e.getMessage(), containsString("[named_object_holder] failed to parse field [named]"));
         assertThat(e.getCause().getMessage(),
@@ -507,10 +492,7 @@ public class ObjectParserTests extends ESTestCase {
     }
 
     public void testParseNamedObjectInOrderNotSupported() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-                  "{\"named\": [\n"
-                + "  {\"a\": {}}"
-                + "]}");
+        XContentParser parser = createParser(JsonXContent.jsonXContent, "{\"named\": [ {\"a\": {}} ] }");
 
         // Create our own parser for this test so we can disable support for the "ordered" mode specified by the array above
         ObjectParser<NamedObjectHolder, Void> objectParser = new ObjectParser<>("named_object_holder",
@@ -601,11 +583,10 @@ public class ObjectParserTests extends ESTestCase {
     }
 
     public void testArraysOfGenericValues() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent,
-            "{\n"
-                + "  \"test_array\":  [ 1, null, \"3\", 4.2],\n"
-                + "  \"int_array\":  [ 1, 2, 3]\n"
-                + "}");
+        XContentParser parser = createParser(
+            JsonXContent.jsonXContent,
+            "{ \"test_array\": [ 1, null, \"3\", 4.2], \"int_array\":  [ 1, 2, 3] }"
+        );
         class TestStruct {
             List<Object> testArray = new ArrayList<>();
 

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonAnalysisPlugin.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonAnalysisPlugin.java
@@ -408,8 +408,8 @@ public class CommonAnalysisPlugin extends Plugin implements AnalysisPlugin, Scri
         filters.add(PreConfiguredTokenFilter.singleton("indic_normalization", true, IndicNormalizationFilter::new));
         filters.add(PreConfiguredTokenFilter.singleton("keyword_repeat", false, false, KeywordRepeatFilter::new));
         filters.add(PreConfiguredTokenFilter.singleton("kstem", false, KStemFilter::new));
-        filters.add(PreConfiguredTokenFilter.singleton("length", false, input ->
-                new LengthFilter(input, 0, Integer.MAX_VALUE)));  // TODO this one seems useless
+        // TODO this one seems useless
+        filters.add(PreConfiguredTokenFilter.singleton("length", false, input -> new LengthFilter(input, 0, Integer.MAX_VALUE)));
         filters.add(PreConfiguredTokenFilter.singleton("limit", false, input ->
                 new LimitTokenCountFilter(input,
                         LimitTokenCountFilterFactory.DEFAULT_MAX_TOKEN_COUNT,


### PR DESCRIPTION
Make a number of changes so that code in the `libs` and `modules` directories are more resilient to automatic formatting. This covers:

* Format cipher lists vertically, instead of horizontally
* Remove string concatenation where JSON fits on a single line
* Move some comments around to they aren't auto-formatted to a strange
  place