### PR TITLE
Remove type parameter from ESIntegTestCase sugar methods

### DIFF
--- a/modules/repository-url/src/test/java/org/elasticsearch/repositories/url/URLSnapshotRestoreTests.java
+++ b/modules/repository-url/src/test/java/org/elasticsearch/repositories/url/URLSnapshotRestoreTests.java
@@ -65,7 +65,7 @@ public class URLSnapshotRestoreTests extends ESIntegTestCase {
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            index("test-idx", "doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx", Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         assertThat(client.prepareSearch("test-idx").setSize(0).get().getHits().getTotalHits().value, equalTo(100L));

--- a/plugins/store-smb/src/test/java/org/elasticsearch/index/store/AbstractAzureFsTestCase.java
+++ b/plugins/store-smb/src/test/java/org/elasticsearch/index/store/AbstractAzureFsTestCase.java
@@ -40,7 +40,7 @@ public abstract  class AbstractAzureFsTestCase extends ESIntegTestCase {
         createIndex("test");
         long nbDocs = randomIntBetween(10, 1000);
         for (long i = 0; i < nbDocs; i++) {
-            index("test", "doc", "" + i, "foo", "bar");
+            indexDoc("test", "" + i, "foo", "bar");
         }
         refresh();
         SearchResponse response = client().prepareSearch("test").get();

--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/DeprecationHttpIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/DeprecationHttpIT.java
@@ -99,7 +99,7 @@ public class DeprecationHttpIT extends HttpSmokeTestCase {
             int randomDocCount = randomIntBetween(1, 2);
 
             for (int j = 0; j < randomDocCount; ++j) {
-                index(indices[i], "type", Integer.toString(j), "{\"field\":" + j + "}");
+                index(indices[i], Integer.toString(j), "{\"field\":" + j + "}");
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
@@ -1200,7 +1200,7 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
 
     private void indexData() {
         for (int i = 0; i < 10; i++) {
-            index("idx", "t", Integer.toString(i), Collections.singletonMap("f1", Integer.toString(i)));
+            index("idx", Integer.toString(i), Collections.singletonMap("f1", Integer.toString(i)));
         }
         flushAndRefresh("idx");
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
@@ -134,7 +134,7 @@ public class ClusterStatsIT extends ESIntegTestCase {
         // add another node, replicas should get assigned
         internalCluster().startNode();
         ensureGreen();
-        index("test1", "type", "1", "f", "f");
+        indexDoc("test1", "1", "f", "f");
         refresh(); // make the doc visible
         response = client().admin().cluster().prepareClusterStats().get();
         assertThat(response.getStatus(), Matchers.equalTo(ClusterHealthStatus.GREEN));
@@ -164,7 +164,7 @@ public class ClusterStatsIT extends ESIntegTestCase {
 
     public void testValuesSmokeScreen() throws IOException, ExecutionException, InterruptedException {
         internalCluster().startNodes(randomIntBetween(1, 3));
-        index("test1", "type", "1", "f", "f");
+        indexDoc("test1", "1", "f", "f");
 
         ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
         String msg = response.toString();

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
@@ -40,7 +40,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -88,7 +87,7 @@ public class RolloverIT extends ESIntegTestCase {
     public void testRollover() throws Exception {
         long beforeTime = client().threadPool().absoluteTimeInMillis() - 1000L;
         assertAcked(prepareCreate("test_index-2").addAlias(new Alias("test_alias")).get());
-        index("test_index-2", "type1", "1", "field", "value");
+        indexDoc("test_index-2", "1", "field", "value");
         flush("test_index-2");
         final RolloverResponse response = client().admin().indices().prepareRolloverIndex("test_alias").get();
         assertThat(response.getOldIndex(), equalTo("test_index-2"));
@@ -111,7 +110,7 @@ public class RolloverIT extends ESIntegTestCase {
     public void testRolloverWithExplicitWriteIndex() throws Exception {
         long beforeTime = client().threadPool().absoluteTimeInMillis() - 1000L;
         assertAcked(prepareCreate("test_index-2").addAlias(new Alias("test_alias").writeIndex(true)).get());
-        index("test_index-2", "type1", "1", "field", "value");
+        indexDoc("test_index-2", "1", "field", "value");
         flush("test_index-2");
         final RolloverResponse response = client().admin().indices().prepareRolloverIndex("test_alias").get();
         assertThat(response.getOldIndex(), equalTo("test_index-2"));
@@ -151,7 +150,7 @@ public class RolloverIT extends ESIntegTestCase {
             testAlias.writeIndex(true);
         }
         assertAcked(prepareCreate("test_index-2").addAlias(testAlias).get());
-        index("test_index-2", "type1", "1", "field", "value");
+        indexDoc("test_index-2", "1", "field", "value");
         flush("test_index-2");
         final Settings settings = Settings.builder()
             .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
@@ -181,7 +180,7 @@ public class RolloverIT extends ESIntegTestCase {
 
     public void testRolloverDryRun() throws Exception {
         assertAcked(prepareCreate("test_index-1").addAlias(new Alias("test_alias")).get());
-        index("test_index-1", "type1", "1", "field", "value");
+        indexDoc("test_index-1", "1", "field", "value");
         flush("test_index-1");
         final RolloverResponse response = client().admin().indices().prepareRolloverIndex("test_alias").dryRun(true).get();
         assertThat(response.getOldIndex(), equalTo("test_index-1"));
@@ -203,7 +202,7 @@ public class RolloverIT extends ESIntegTestCase {
             testAlias.writeIndex(true);
         }
         assertAcked(prepareCreate("test_index-0").addAlias(testAlias).get());
-        index("test_index-0", "type1", "1", "field", "value");
+        indexDoc("test_index-0", "1", "field", "value");
         flush("test_index-0");
         final RolloverResponse response = client().admin().indices().prepareRolloverIndex("test_alias")
             .addMaxIndexSizeCondition(new ByteSizeValue(10, ByteSizeUnit.MB))
@@ -238,7 +237,7 @@ public class RolloverIT extends ESIntegTestCase {
             testAlias.writeIndex(true);
         }
         assertAcked(prepareCreate("test_index").addAlias(testAlias).get());
-        index("test_index", "type1", "1", "field", "value");
+        indexDoc("test_index", "1", "field", "value");
         flush("test_index");
         final RolloverResponse response = client().admin().indices().prepareRolloverIndex("test_alias")
             .setNewIndexName("test_new_index").get();
@@ -261,9 +260,9 @@ public class RolloverIT extends ESIntegTestCase {
 
     public void testRolloverOnExistingIndex() throws Exception {
         assertAcked(prepareCreate("test_index-0").addAlias(new Alias("test_alias")).get());
-        index("test_index-0", "type1", "1", "field", "value");
+        indexDoc("test_index-0", "1", "field", "value");
         assertAcked(prepareCreate("test_index-000001").get());
-        index("test_index-000001", "type1", "1", "field", "value");
+        indexDoc("test_index-000001", "1", "field", "value");
         flush("test_index-0", "test_index-000001");
         try {
             client().admin().indices().prepareRolloverIndex("test_alias").get();
@@ -321,7 +320,7 @@ public class RolloverIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test-1").addAlias(new Alias("test_alias")).get());
         int numDocs = randomIntBetween(10, 20);
         for (int i = 0; i < numDocs; i++) {
-            index("test-1", "doc", Integer.toString(i), "field", "foo-" + i);
+            indexDoc("test-1", Integer.toString(i), "field", "foo-" + i);
         }
         flush("test-1");
         refresh("test_alias");
@@ -392,9 +391,9 @@ public class RolloverIT extends ESIntegTestCase {
         assertAcked(prepareCreate(closedIndex).addAlias(new Alias(aliasName)).get());
         assertAcked(prepareCreate(writeIndexPrefix + "000001").addAlias(new Alias(aliasName).writeIndex(true)).get());
 
-        index(closedIndex, SINGLE_MAPPING_NAME, null, "{\"foo\": \"bar\"}");
-        index(aliasName, SINGLE_MAPPING_NAME, null, "{\"foo\": \"bar\"}");
-        index(aliasName, SINGLE_MAPPING_NAME, null, "{\"foo\": \"bar\"}");
+        index(closedIndex, null, "{\"foo\": \"bar\"}");
+        index(aliasName, null, "{\"foo\": \"bar\"}");
+        index(aliasName, null, "{\"foo\": \"bar\"}");
         refresh(aliasName);
 
         assertAcked(client().admin().indices().prepareClose(closedIndex).get());
@@ -416,9 +415,9 @@ public class RolloverIT extends ESIntegTestCase {
         assertAcked(prepareCreate(closedIndex).addAlias(new Alias(aliasName)).get());
         assertAcked(prepareCreate(writeIndexPrefix + "000001").addAlias(new Alias(aliasName).writeIndex(true)).get());
 
-        index(closedIndex, SINGLE_MAPPING_NAME, null, "{\"foo\": \"bar\"}");
-        index(aliasName, SINGLE_MAPPING_NAME, null, "{\"foo\": \"bar\"}");
-        index(aliasName, SINGLE_MAPPING_NAME, null, "{\"foo\": \"bar\"}");
+        index(closedIndex, null, "{\"foo\": \"bar\"}");
+        index(aliasName, null, "{\"foo\": \"bar\"}");
+        index(aliasName, null, "{\"foo\": \"bar\"}");
         refresh(aliasName);
 
         assertAcked(client().admin().indices().prepareClose(closedIndex).get());

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
@@ -457,7 +457,7 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
 
     public void testFailingVersionedUpdatedOnBulk() throws Exception {
         createIndex("test");
-        index("test", "type", "1", "field", "1");
+        indexDoc("test", "1", "field", "1");
         final BulkResponse[] responses = new BulkResponse[30];
         final CyclicBarrier cyclicBarrier = new CyclicBarrier(responses.length);
         Thread[] threads = new Thread[responses.length];
@@ -630,7 +630,7 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
         createIndex(indexName, Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1).build());
         internalCluster().ensureAtLeastNumDataNodes(2);
         ensureGreen(indexName);
-        IndexResponse doc = index(indexName, "_doc", "1", Map.of("user", "xyz"));
+        IndexResponse doc = index(indexName, "1", Map.of("user", "xyz"));
         assertThat(doc.getShardInfo().getSuccessful(), equalTo(2));
         final BulkResponse bulkResponse = client().prepareBulk()
             .add(new UpdateRequest().index(indexName).id("1").detectNoop(true).doc("user", "xyz")) // noop update

--- a/server/src/test/java/org/elasticsearch/action/termvectors/AbstractTermVectorsTestCase.java
+++ b/server/src/test/java/org/elasticsearch/action/termvectors/AbstractTermVectorsTestCase.java
@@ -127,7 +127,6 @@ public abstract class AbstractTermVectorsTestCase extends ESIntegTestCase {
         public final String[] fieldContent;
         public String index = "test";
         public String alias = "alias";
-        public String type = "type1";
 
         public TestDoc(String id, TestFieldSetting[] fieldSettings, String[] fieldContent) {
             this.id = id;
@@ -149,7 +148,7 @@ public abstract class AbstractTermVectorsTestCase extends ESIntegTestCase {
         @Override
         public String toString() {
 
-            StringBuilder sb = new StringBuilder("index:").append(index).append(" type:").append(type).append(" id:").append(id);
+            StringBuilder sb = new StringBuilder("index:").append(index).append(" id:").append(id);
             for (int i = 0; i < fieldSettings.length; i++) {
                 TestFieldSetting f = fieldSettings[i];
                 sb.append("\n").append("Field: ").append(f).append("\n  content:").append(fieldContent[i]);
@@ -236,7 +235,7 @@ public abstract class AbstractTermVectorsTestCase extends ESIntegTestCase {
             }
             final String id = routingKeyForShard(index, i);
             TestDoc doc = new TestDoc(id, fieldSettings, contentArray.clone());
-            index(doc.index, doc.type, doc.id, docSource);
+            index(doc.index, doc.id, docSource);
             testDocs[i] = doc;
         }
 

--- a/server/src/test/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
@@ -83,9 +83,9 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
 
     @Before
     public void indexData() throws Exception {
-        index("foo", "bar", "1", XContentFactory.jsonBuilder().startObject().field("foo", "foo").endObject());
-        index("fuu", "buu", "1", XContentFactory.jsonBuilder().startObject().field("fuu", "fuu").endObject());
-        index("baz", "baz", "1", XContentFactory.jsonBuilder().startObject().field("baz", "baz").endObject());
+        index("foo", "1", XContentFactory.jsonBuilder().startObject().field("foo", "foo").endObject());
+        index("fuu", "1", XContentFactory.jsonBuilder().startObject().field("fuu", "fuu").endObject());
+        index("baz", "1", XContentFactory.jsonBuilder().startObject().field("baz", "baz").endObject());
         refresh();
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/RareClusterStateIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/RareClusterStateIT.java
@@ -159,7 +159,7 @@ public class RareClusterStateIT extends ESIntegTestCase {
         BlockClusterStateProcessing disruption = new BlockClusterStateProcessing(dataNode, random());
         internalCluster().setDisruptionScheme(disruption);
         logger.info("--> indexing a doc");
-        index("test", "type", "1");
+        indexDoc("test", "1");
         refresh();
         disruption.startDisrupting();
         logger.info("--> delete index and recreate it");

--- a/server/src/test/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
@@ -513,14 +513,14 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         logger.info("--> Indexing with gap in seqno to ensure that some operations will be replayed in resync");
         long numDocs = scaledRandomIntBetween(5, 50);
         for (int i = 0; i < numDocs; i++) {
-            IndexResponse indexResult = index("test", "doc", Long.toString(i));
+            IndexResponse indexResult = indexDoc("test", Long.toString(i));
             assertThat(indexResult.getShardInfo().getSuccessful(), equalTo(numberOfReplicas + 1));
         }
         final IndexShard oldPrimaryShard = internalCluster().getInstance(IndicesService.class, oldPrimary).getShardOrNull(shardId);
         EngineTestCase.generateNewSeqNo(IndexShardTestCase.getEngine(oldPrimaryShard)); // Make gap in seqno.
         long moreDocs = scaledRandomIntBetween(1, 10);
         for (int i = 0; i < moreDocs; i++) {
-            IndexResponse indexResult = index("test", "doc", Long.toString(numDocs + i));
+            IndexResponse indexResult = indexDoc("test", Long.toString(numDocs + i));
             assertThat(indexResult.getShardInfo().getSuccessful(), equalTo(numberOfReplicas + 1));
         }
         final Set<String> replicasSide1 = Sets.newHashSet(randomSubsetOf(between(1, numberOfReplicas - 1), replicaNodes));

--- a/server/src/test/java/org/elasticsearch/discovery/MasterDisruptionIT.java
+++ b/server/src/test/java/org/elasticsearch/discovery/MasterDisruptionIT.java
@@ -246,7 +246,7 @@ public class MasterDisruptionIT extends AbstractDisruptionTestCase {
         .build());
 
         // create one field
-        index("test", "doc", "1", "{ \"f\": 1 }");
+        index("test", "1", "{ \"f\": 1 }");
 
         ensureGreen();
 

--- a/server/src/test/java/org/elasticsearch/gateway/MetaDataWriteDataNodesIT.java
+++ b/server/src/test/java/org/elasticsearch/gateway/MetaDataWriteDataNodesIT.java
@@ -49,7 +49,7 @@ public class MetaDataWriteDataNodesIT extends ESIntegTestCase {
         String masterNode = internalCluster().startMasterOnlyNode(Settings.EMPTY);
         String dataNode = internalCluster().startDataOnlyNode(Settings.EMPTY);
         assertAcked(prepareCreate("test").setSettings(Settings.builder().put("index.number_of_replicas", 0)));
-        index("test", "_doc", "1", jsonBuilder().startObject().field("text", "some text").endObject());
+        index("test", "1", jsonBuilder().startObject().field("text", "some text").endObject());
         ensureGreen("test");
         assertIndexInMetaState(dataNode, "test");
         assertIndexInMetaState(masterNode, "test");
@@ -65,7 +65,7 @@ public class MetaDataWriteDataNodesIT extends ESIntegTestCase {
         String index = "index";
         assertAcked(prepareCreate(index).setSettings(Settings.builder().put("index.number_of_replicas", 0)
             .put(IndexMetaData.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + "_name", node1)));
-        index(index, "_doc", "1", jsonBuilder().startObject().field("text", "some text").endObject());
+        index(index, "1", jsonBuilder().startObject().field("text", "some text").endObject());
         ensureGreen();
         assertIndexInMetaState(node1, index);
         Index resolveIndex = resolveIndex(index);

--- a/server/src/test/java/org/elasticsearch/gateway/RecoveryFromGatewayIT.java
+++ b/server/src/test/java/org/elasticsearch/gateway/RecoveryFromGatewayIT.java
@@ -196,12 +196,12 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
         for (int i = 0; i < 1 + randomInt(100); i++) {
             for (int id = 0; id < Math.max(value1Docs, value2Docs); id++) {
                 if (id < value1Docs) {
-                    index("test", "type1", "1_" + id,
+                    index("test", "1_" + id,
                         jsonBuilder().startObject().field("field", "value1").startArray("num").value(14).value(179).endArray().endObject()
                     );
                 }
                 if (id < value2Docs) {
-                    index("test", "type1", "2_" + id,
+                    index("test", "2_" + id,
                         jsonBuilder().startObject().field("field", "value2").startArray("num").value(14).endArray().endObject()
                     );
                 }
@@ -545,7 +545,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test").setSettings(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1)));
         final Index index = resolveIndex("test");
         final ShardId shardId = new ShardId(index, 0);
-        index("test", "type", "1");
+        indexDoc("test", "1");
         flush("test");
 
         final boolean corrupt = randomBoolean();

--- a/server/src/test/java/org/elasticsearch/get/GetActionIT.java
+++ b/server/src/test/java/org/elasticsearch/get/GetActionIT.java
@@ -663,7 +663,7 @@ public class GetActionIT extends ESIntegTestCase {
                 "  }\n" +
                 "}";
 
-        index("test", "_doc", "1", doc);
+        index("test", "1", doc);
         String[] fieldsList = {"suggest"};
         // before refresh - document is only in translog
         assertGetFieldsAlwaysNull(indexOrAlias(), "1", fieldsList);
@@ -780,7 +780,7 @@ public class GetActionIT extends ESIntegTestCase {
                 "  \"text1\": \"some text.\"\n," +
                 "  \"text2\": \"more text.\"\n" +
                 "}\n";
-        index("test", "_doc", "1", doc);
+        index("test", "1", doc);
     }
 
     private void assertGetFieldsAlwaysWorks(String index, String docId, String[] fields) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/ExternalValuesMapperIntegrationIT.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ExternalValuesMapperIntegrationIT.java
@@ -49,7 +49,7 @@ public class ExternalValuesMapperIntegrationIT extends ESIntegTestCase {
                 .endObject()
                 .endObject().endObject()).execute().get();
 
-        index("test-idx", "type", "1", XContentFactory.jsonBuilder()
+        index("test-idx", "1", XContentFactory.jsonBuilder()
             .startObject()
             .field("field", "Every day is exactly the same")
             .endObject());
@@ -98,7 +98,7 @@ public class ExternalValuesMapperIntegrationIT extends ESIntegTestCase {
                 .endObject()
             .endObject().endObject()).execute().get();
 
-        index("test-idx", "type", "1", XContentFactory.jsonBuilder()
+        index("test-idx", "1", XContentFactory.jsonBuilder()
                 .startObject()
                     .field("field", "1234")
                 .endObject());
@@ -146,7 +146,7 @@ public class ExternalValuesMapperIntegrationIT extends ESIntegTestCase {
                 .endObject()
                 .endObject().endObject().endObject()).execute().get();
 
-        index("test-idx", "_doc", "1", "f", "This is my text");
+        indexDoc("test-idx", "1", "f", "This is my text");
         refresh();
 
         SearchResponse response = client().prepareSearch("test-idx")

--- a/server/src/test/java/org/elasticsearch/index/suggest/stats/SuggestStatsIT.java
+++ b/server/src/test/java/org/elasticsearch/index/suggest/stats/SuggestStatsIT.java
@@ -76,7 +76,7 @@ public class SuggestStatsIT extends ESIntegTestCase {
         ensureGreen();
 
         for (int i = 0; i < randomIntBetween(20, 100); i++) {
-            index("test" + ((i % 2) + 1), "type", "" + i, "f", "test" + i);
+            indexDoc("test" + ((i % 2) + 1), "" + i, "f", "test" + i);
         }
         refresh();
 

--- a/server/src/test/java/org/elasticsearch/indexing/IndexActionIT.java
+++ b/server/src/test/java/org/elasticsearch/indexing/IndexActionIT.java
@@ -153,7 +153,7 @@ public class IndexActionIT extends ESIntegTestCase {
                 @Override
                 public Void call() throws Exception {
                     int docId = random.nextInt(docCount);
-                    IndexResponse indexResponse = index("test", "type", Integer.toString(docId), "field1", "value");
+                    IndexResponse indexResponse = indexDoc("test", Integer.toString(docId), "field1", "value");
                     if (indexResponse.getResult() == DocWriteResponse.Result.CREATED) {
                         createdCounts.incrementAndGet(docId);
                     }

--- a/server/src/test/java/org/elasticsearch/indices/analysis/PreBuiltAnalyzerIntegrationIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/analysis/PreBuiltAnalyzerIntegrationIT.java
@@ -90,7 +90,7 @@ public class PreBuiltAnalyzerIntegrationIT extends ESIntegTestCase {
             Map<String, Object> data = new HashMap<>();
             data.put("foo", randomAlphaOfLength(scaledRandomIntBetween(5, 50)));
 
-            index(randomIndex, "type", randomId, data);
+            index(randomIndex, randomId, data);
         }
 
         refresh();

--- a/server/src/test/java/org/elasticsearch/indices/flush/FlushIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/flush/FlushIT.java
@@ -294,7 +294,7 @@ public class FlushIT extends ESIntegTestCase {
         final ShardId shardId = new ShardId(index, 0);
         final int numDocs = between(1, 10);
         for (int i = 0; i < numDocs; i++) {
-            index("test", "doc", Integer.toString(i));
+            indexDoc("test", Integer.toString(i));
         }
         final List<IndexShard> indexShards = internalCluster().nodesInclude("test").stream()
             .map(node -> internalCluster().getInstance(IndicesService.class, node).getShardOrNull(shardId))
@@ -337,7 +337,7 @@ public class FlushIT extends ESIntegTestCase {
         final ShardId shardId = new ShardId(index, 0);
         final int numDocs = between(1, 10);
         for (int i = 0; i < numDocs; i++) {
-            index("test", "doc", Integer.toString(i));
+            indexDoc("test", Integer.toString(i));
         }
         final ShardsSyncedFlushResult firstSeal = SyncedFlushUtil.attemptSyncedFlush(logger, internalCluster(), shardId);
         assertThat(firstSeal.successfulShards(), equalTo(numberOfReplicas + 1));
@@ -348,7 +348,7 @@ public class FlushIT extends ESIntegTestCase {
         // Shards were updated, renew synced flush.
         final int moreDocs = between(1, 10);
         for (int i = 0; i < moreDocs; i++) {
-            index("test", "doc", "more-" + i);
+            indexDoc("test", "more-" + i);
         }
         final ShardsSyncedFlushResult thirdSeal = SyncedFlushUtil.attemptSyncedFlush(logger, internalCluster(), shardId);
         assertThat(thirdSeal.successfulShards(), equalTo(numberOfReplicas + 1));

--- a/server/src/test/java/org/elasticsearch/indices/state/ReopenWhileClosingIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/state/ReopenWhileClosingIT.java
@@ -124,7 +124,7 @@ public class ReopenWhileClosingIT extends ESIntegTestCase {
             Settings.builder().put(indexSettings()).put("index.routing.allocation.include._name", String.join(",", dataOnlyNodes)).build());
         final int nbDocs =  scaledRandomIntBetween(1, 100);
         for (int i = 0; i < nbDocs; i++) {
-            index(indexName, "_doc", String.valueOf(i), "num", i);
+            indexDoc(indexName, String.valueOf(i), "num", i);
         }
         assertIndexIsOpened(indexName);
     }

--- a/server/src/test/java/org/elasticsearch/indices/stats/IndexStatsIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/stats/IndexStatsIT.java
@@ -600,7 +600,7 @@ public class IndexStatsIT extends ESIntegTestCase {
         NumShards test1 = getNumShards("test_index");
 
         for (int i = 0; i < 100; i++) {
-            index("test_index", "_doc", Integer.toString(i), "field", "value");
+            indexDoc("test_index", Integer.toString(i), "field", "value");
         }
 
         IndicesStatsResponse stats = client().admin().indices().prepareStats().setSegments(true).get();

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
@@ -906,12 +906,12 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 .endObject().endObject().endObject()));
         ensureGreen();
 
-        index("test", "type1", "1",
+        indexDoc("test", "1",
                 "foo", "running with scissors");
-        index("test", "type1", "2",
+        indexDoc("test", "2",
                 "foo", "cat cat junk junk junk junk junk junk junk cats junk junk",
                 "bar", "cat cat junk junk junk junk junk junk junk cats junk junk");
-        index("test", "type1", "3",
+        indexDoc("test", "3",
                 "foo", "weird",
                 "bar", "result");
         refresh();
@@ -1483,7 +1483,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         createIndex("test");
         ensureGreen();
 
-        index("test", "type1", "1", "field1", "The <b>quick<b> brown fox", "field2", "The <b>slow<b> brown fox");
+        indexDoc("test", "1", "field1", "The <b>quick<b> brown fox", "field2", "The <b>slow<b> brown fox");
         refresh();
 
         SearchResponse response = client().prepareSearch("test")
@@ -1503,7 +1503,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 "field2", "type=text,term_vector=with_positions_offsets"));
         ensureGreen();
 
-        index("test", "type1", "1", "field1", "The <b>quick<b> brown fox", "field2", "The <b>slow<b> brown fox");
+        indexDoc("test", "1", "field1", "The <b>quick<b> brown fox", "field2", "The <b>slow<b> brown fox");
         refresh();
 
         SearchResponse response = client().prepareSearch("test")
@@ -1589,7 +1589,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 "type=text," + randomStoreField() + "term_vector=with_positions_offsets,index_options=offsets"));
         ensureGreen();
 
-        index("test", "type1", "1", "text", "Testing the highlight query feature");
+        indexDoc("test", "1", "text", "Testing the highlight query feature");
         refresh();
 
         for (String type : ALL_TYPES) {
@@ -1631,7 +1631,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         ensureGreen();
 
         String text = "I am pretty long so some of me should get cut off. Second sentence";
-        index("test", "type1", "1", "text", text);
+        indexDoc("test", "1", "text", text);
         refresh();
 
         // When you don't set noMatchSize you don't get any results if there isn't anything to highlight.
@@ -1741,7 +1741,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
 
         String text1 = "I am pretty long so some of me should get cut off. We'll see how that goes.";
         String text2 = "I am short";
-        index("test", "type1", "1", "text", new String[] {text1, text2});
+        indexDoc("test", "1", "text", new String[] {text1, text2});
         refresh();
 
         // The no match fragment should come from the first value of a multi-valued field
@@ -1762,7 +1762,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         assertHighlight(response, 0, "text", 0, 1, equalTo("I am pretty long so some"));
 
         // And noMatchSize returns nothing when the first entry is empty string!
-        index("test", "type1", "2", "text", new String[] {"", text2});
+        indexDoc("test", "2", "text", new String[] {"", text2});
         refresh();
 
         IdsQueryBuilder idsQueryBuilder = QueryBuilders.idsQuery().addIds("2");
@@ -1786,7 +1786,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         assertHighlight(response, 0, "text", 0, 1, equalTo("I am short"));
 
         // But if the field was actually empty then you should get no highlighting field
-        index("test", "type1", "3", "text", new String[] {});
+        indexDoc("test", "3", "text", new String[] {});
         refresh();
         idsQueryBuilder = QueryBuilders.idsQuery().addIds("3");
         field.highlighterType("plain");
@@ -1808,7 +1808,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         assertNotHighlighted(response, 0, "text");
 
         // Same for if the field doesn't even exist on the document
-        index("test", "type1", "4");
+        indexDoc("test", "4");
         refresh();
 
         idsQueryBuilder = QueryBuilders.idsQuery().addIds("4");
@@ -1854,7 +1854,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         String text1 = "This is the first sentence. This is the second sentence." + HighlightUtils.PARAGRAPH_SEPARATOR;
         String text2 = "This is the third sentence. This is the fourth sentence.";
         String text3 = "This is the fifth sentence";
-        index("test", "type1", "1", "text", new String[] {text1, text2, text3});
+        indexDoc("test", "1", "text", new String[] {text1, text2, text3});
         refresh();
 
         // The no match fragment should come from the first value of a multi-valued field
@@ -1964,7 +1964,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()).get());
         ensureGreen();
 
-        index("test", "type1", "1",
+        indexDoc("test", "1",
                 "field1", "The <b>quick<b> brown fox. Second sentence.",
                 "field2", "The <b>slow<b> brown fox. Second sentence.");
         refresh();
@@ -2527,7 +2527,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         for (int i = 0; i<10; i++) {
             text.append("junk junk junk junk junk junk junk junk junk junk junk junk junk junk junk junk junk junk junk junk\n");
         }
-        index("test", "type1", "1", "field1", text.toString());
+        indexDoc("test", "1", "field1", text.toString());
         refresh();
 
         // Match queries

--- a/server/src/test/java/org/elasticsearch/search/fields/SearchFieldsIT.java
+++ b/server/src/test/java/org/elasticsearch/search/fields/SearchFieldsIT.java
@@ -1024,7 +1024,7 @@ public class SearchFieldsIT extends ESIntegTestCase {
         DateTime date = new DateTime(1990, 12, 29, 0, 0, DateTimeZone.UTC);
         org.joda.time.format.DateTimeFormatter formatter = DateTimeFormat.forPattern("yyyy-MM-dd");
 
-        index("test", "type", "1", "text_field", "foo", "date_field", formatter.print(date));
+        indexDoc("test", "1", "text_field", "foo", "date_field", formatter.print(date));
         refresh("test");
 
         SearchRequestBuilder builder = client().prepareSearch().setQuery(matchAllQuery())
@@ -1087,7 +1087,7 @@ public class SearchFieldsIT extends ESIntegTestCase {
         DateTime date = new DateTime(1990, 12, 29, 0, 0, DateTimeZone.UTC);
         org.joda.time.format.DateTimeFormatter formatter = DateTimeFormat.forPattern("yyyy-MM-dd");
 
-        index("test", "type", "1", "text_field", "foo", "date_field", formatter.print(date));
+        indexDoc("test", "1", "text_field", "foo", "date_field", formatter.print(date));
         refresh("test");
 
         SearchRequestBuilder builder = client().prepareSearch().setQuery(matchAllQuery())
@@ -1143,7 +1143,7 @@ public class SearchFieldsIT extends ESIntegTestCase {
         .endObject();
         assertAcked(prepareCreate("test").addMapping("type", mapping));
 
-        index("test", "type", "1", "field1", "value1", "field2", "value2");
+        indexDoc("test", "1", "field1", "value1", "field2", "value2");
         refresh("test");
 
         SearchResponse searchResponse = client().prepareSearch()
@@ -1187,7 +1187,7 @@ public class SearchFieldsIT extends ESIntegTestCase {
         .endObject();
         assertAcked(prepareCreate("test").addMapping("type", mapping));
 
-        index("test", "type", "1", "field1", "value1", "field2", "value2");
+        indexDoc("test", "1", "field1", "value1", "field2", "value2");
         refresh("test");
 
         SearchResponse searchResponse = client().prepareSearch()

--- a/server/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreIT.java
+++ b/server/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreIT.java
@@ -89,7 +89,7 @@ public class FunctionScoreIT extends ESIntegTestCase {
 
     public void testScriptScoresNested() throws IOException {
         createIndex(INDEX);
-        index(INDEX, TYPE, "1", jsonBuilder().startObject().field("dummy_field", 1).endObject());
+        index(INDEX, "1", jsonBuilder().startObject().field("dummy_field", 1).endObject());
         refresh();
 
         Script scriptOne = new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "1", Collections.emptyMap());
@@ -113,7 +113,7 @@ public class FunctionScoreIT extends ESIntegTestCase {
 
     public void testScriptScoresWithAgg() throws IOException {
         createIndex(INDEX);
-        index(INDEX, TYPE, "1", jsonBuilder().startObject().field("dummy_field", 1).endObject());
+        index(INDEX, "1", jsonBuilder().startObject().field("dummy_field", 1).endObject());
         refresh();
 
         Script script = new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "get score value", Collections.emptyMap());
@@ -134,7 +134,7 @@ public class FunctionScoreIT extends ESIntegTestCase {
     public void testMinScoreFunctionScoreBasic() throws IOException {
         float score = randomValueOtherThanMany((f) -> Float.compare(f, 0) < 0, ESTestCase::randomFloat);
         float minScore = randomValueOtherThanMany((f) -> Float.compare(f, 0) < 0, ESTestCase::randomFloat);
-        index(INDEX, TYPE, jsonBuilder().startObject()
+        index(INDEX, jsonBuilder().startObject()
             .field("num", 2)
             .field("random_score", score) // Pass the random score as a document field so that it can be extracted in the script
             .endObject());
@@ -208,7 +208,7 @@ public class FunctionScoreIT extends ESIntegTestCase {
     /** make sure min_score works if functions is empty, see https://github.com/elastic/elasticsearch/issues/10253 */
     public void testWithEmptyFunctions() throws IOException, ExecutionException, InterruptedException {
         assertAcked(prepareCreate("test"));
-        index("test", "testtype", "1", jsonBuilder().startObject().field("text", "test text").endObject());
+        index("test", "1", jsonBuilder().startObject().field("text", "test text").endObject());
         refresh();
 
         SearchResponse termQuery = client().search(

--- a/server/src/test/java/org/elasticsearch/search/functionscore/RandomScoreFunctionIT.java
+++ b/server/src/test/java/org/elasticsearch/search/functionscore/RandomScoreFunctionIT.java
@@ -97,7 +97,7 @@ public class RandomScoreFunctionIT extends ESIntegTestCase {
         ensureGreen(); // make sure we are done otherwise preference could change?
         int docCount = randomIntBetween(100, 200);
         for (int i = 0; i < docCount; i++) {
-            index("test", "type", "" + i, jsonBuilder().startObject().field("foo", i).endObject());
+            index("test", "" + i, jsonBuilder().startObject().field("foo", i).endObject());
         }
         flush();
         refresh();
@@ -142,7 +142,7 @@ public class RandomScoreFunctionIT extends ESIntegTestCase {
                 int numDocsToChange = randomIntBetween(20, 50);
                 while (numDocsToChange > 0) {
                     int doc = randomInt(docCount-1);// watch out this is inclusive the max values!
-                    index("test", "type", "" + doc, jsonBuilder().startObject().field("foo", doc).endObject());
+                    index("test", "" + doc, jsonBuilder().startObject().field("foo", doc).endObject());
                     --numDocsToChange;
                 }
                 flush();
@@ -251,7 +251,7 @@ public class RandomScoreFunctionIT extends ESIntegTestCase {
     public void testSeedReportedInExplain() throws Exception {
         createIndex("test");
         ensureGreen();
-        index("test", "type", "1", jsonBuilder().startObject().endObject());
+        index("test", "1", jsonBuilder().startObject().endObject());
         flush();
         refresh();
 
@@ -291,7 +291,7 @@ public class RandomScoreFunctionIT extends ESIntegTestCase {
         int docCount = randomIntBetween(100, 200);
         for (int i = 0; i < docCount; i++) {
             String id = randomRealisticUnicodeOfCodepointLengthBetween(1, 50);
-            index("test", "type", id, jsonBuilder().startObject().endObject());
+            index("test", id, jsonBuilder().startObject().endObject());
         }
         flush();
         refresh();
@@ -314,7 +314,7 @@ public class RandomScoreFunctionIT extends ESIntegTestCase {
         ensureGreen();
         final int docCount = randomIntBetween(100, 200);
         for (int i = 0; i < docCount; i++) {
-            index("test", "type", "" + i, jsonBuilder().startObject().endObject());
+            index("test", "" + i, jsonBuilder().startObject().endObject());
         }
         flushAndRefresh();
 
@@ -342,7 +342,7 @@ public class RandomScoreFunctionIT extends ESIntegTestCase {
         ensureGreen();
 
         for (int i = 0; i < count; i++) {
-            index("test", "type", "" + i, jsonBuilder().startObject().endObject());
+            index("test", "" + i, jsonBuilder().startObject().endObject());
         }
 
         flush();

--- a/server/src/test/java/org/elasticsearch/search/morelikethis/MoreLikeThisIT.java
+++ b/server/src/test/java/org/elasticsearch/search/morelikethis/MoreLikeThisIT.java
@@ -406,8 +406,8 @@ public class MoreLikeThisIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test").addMapping("_doc", mapping));
         ensureGreen();
 
-        index("test", "_doc", "1", "text", "lucene");
-        index("test", "_doc", "2", "text", "lucene release");
+        indexDoc("test", "1", "text", "lucene");
+        indexDoc("test", "2", "text", "lucene release");
         refresh();
 
         Item item = new Item("test", "1");

--- a/server/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
+++ b/server/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
@@ -1725,7 +1725,7 @@ public class SearchQueryIT extends ESIntegTestCase {
             .endObject()
         .endObject();
 
-        index("index", "_doc", "1", source);
+        index("index", "1", source);
         refresh();
 
         QueryBuilder nestedQuery = QueryBuilders.nestedQuery("section",

--- a/server/src/test/java/org/elasticsearch/search/sort/FieldSortIT.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/FieldSortIT.java
@@ -209,13 +209,13 @@ public class FieldSortIT extends ESIntegTestCase {
         assertAcked(client().admin().indices().prepareCreate("test")
                 .addMapping("type1", "svalue", "type=keyword").get());
         ensureGreen();
-        index("test", "type1", jsonBuilder().startObject()
+        index("test", jsonBuilder().startObject()
                 .field("id", "1")
                 .field("svalue", "aaa")
                 .field("ivalue", 100)
                 .field("dvalue", 0.1)
                 .endObject());
-        index("test", "type1", jsonBuilder().startObject()
+        index("test", jsonBuilder().startObject()
                 .field("id", "2")
                 .field("svalue", "bbb")
                 .field("ivalue", 200)

--- a/server/src/test/java/org/elasticsearch/search/source/MetadataFetchingIT.java
+++ b/server/src/test/java/org/elasticsearch/search/source/MetadataFetchingIT.java
@@ -116,7 +116,7 @@ public class MetadataFetchingIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test"));
         ensureGreen();
 
-        index("test", "type1", "1", "field", "value");
+        indexDoc("test", "1", "field", "value");
         refresh();
 
         {

--- a/server/src/test/java/org/elasticsearch/search/source/SourceFetchingIT.java
+++ b/server/src/test/java/org/elasticsearch/search/source/SourceFetchingIT.java
@@ -31,7 +31,7 @@ public class SourceFetchingIT extends ESIntegTestCase {
         createIndex("test");
         ensureGreen();
 
-        index("test", "type1", "1", "field", "value");
+        indexDoc("test", "1", "field", "value");
         refresh();
 
         SearchResponse response = client().prepareSearch("test").get();

--- a/server/src/test/java/org/elasticsearch/search/suggest/SuggestSearchIT.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/SuggestSearchIT.java
@@ -86,10 +86,10 @@ public class SuggestSearchIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test").addMapping("type1", "text", "type=text"));
         ensureGreen();
 
-        index("test", "type1", "1", "text", "abcd");
-        index("test", "type1", "2", "text", "aacd");
-        index("test", "type1", "3", "text", "abbd");
-        index("test", "type1", "4", "text", "abcc");
+        indexDoc("test", "1", "text", "abcd");
+        indexDoc("test", "2", "text", "aacd");
+        indexDoc("test", "3", "text", "abbd");
+        indexDoc("test", "4", "text", "abcc");
         refresh();
 
         TermSuggestionBuilder termSuggest = termSuggestion("text")
@@ -100,10 +100,10 @@ public class SuggestSearchIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test_1").addMapping("type1", "text", "type=text"));
         ensureGreen();
 
-        index("test_1", "type1", "1", "text", "ab cd");
-        index("test_1", "type1", "2", "text", "aa cd");
-        index("test_1", "type1", "3", "text", "ab bd");
-        index("test_1", "type1", "4", "text", "ab cc");
+        indexDoc("test_1", "1", "text", "ab cd");
+        indexDoc("test_1", "2", "text", "aa cd");
+        indexDoc("test_1", "3", "text", "ab bd");
+        indexDoc("test_1", "4", "text", "ab cc");
         refresh();
         termSuggest = termSuggestion("text")
                 .suggestMode(SuggestMode.ALWAYS) // Always, otherwise the results can vary between requests.
@@ -121,14 +121,14 @@ public class SuggestSearchIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test_2").addMapping("type1", mapping));
         ensureGreen();
 
-        index("test_2", "type1", "1", "text", "ab cd");
-        index("test_2", "type1", "2", "text", "aa cd");
-        index("test_2", "type1", "3", "text", "ab bd");
-        index("test_2", "type1", "4", "text", "ab cc");
-        index("test_2", "type1", "1", "text", "abcd");
-        index("test_2", "type1", "2", "text", "aacd");
-        index("test_2", "type1", "3", "text", "abbd");
-        index("test_2", "type1", "4", "text", "abcc");
+        indexDoc("test_2", "1", "text", "ab cd");
+        indexDoc("test_2", "2", "text", "aa cd");
+        indexDoc("test_2", "3", "text", "ab bd");
+        indexDoc("test_2", "4", "text", "ab cc");
+        indexDoc("test_2", "1", "text", "abcd");
+        indexDoc("test_2", "2", "text", "aacd");
+        indexDoc("test_2", "3", "text", "abbd");
+        indexDoc("test_2", "4", "text", "abcc");
         refresh();
 
         termSuggest = termSuggestion("text")
@@ -197,9 +197,9 @@ public class SuggestSearchIT extends ESIntegTestCase {
         ensureGreen();
 
 
-        index("test", "type1", "1", "name", "I like iced tea");
-        index("test", "type1", "2", "name", "I like tea.");
-        index("test", "type1", "3", "name", "I like ice cream.");
+        indexDoc("test", "1", "name", "I like iced tea");
+        indexDoc("test", "2", "name", "I like tea.");
+        indexDoc("test", "3", "name", "I like ice cream.");
         refresh();
 
         DirectCandidateGeneratorBuilder generator = candidateGenerator("name").prefixLength(0).minWordLength(0).suggestMode("always")
@@ -231,7 +231,7 @@ public class SuggestSearchIT extends ESIntegTestCase {
         ensureGreen();
 
         for (int i = 0; i < 15; i++) {
-            index("test", "type1", Integer.toString(i), "text", "abc" + i);
+            indexDoc("test", Integer.toString(i), "text", "abc" + i);
         }
         refresh();
 
@@ -305,10 +305,10 @@ public class SuggestSearchIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test").addMapping("type1", "text", "type=text"));
         ensureGreen();
 
-        index("test", "type1", "1", "text", "abcd");
-        index("test", "type1", "2", "text", "aacd");
-        index("test", "type1", "3", "text", "abbd");
-        index("test", "type1", "4", "text", "abcc");
+        indexDoc("test", "1", "text", "abcd");
+        indexDoc("test", "2", "text", "aacd");
+        indexDoc("test", "3", "text", "abbd");
+        indexDoc("test", "4", "text", "abcc");
         refresh();
 
         SearchResponse search = client().prepareSearch().setQuery(matchQuery("text", "spellcecker")).get();
@@ -330,7 +330,7 @@ public class SuggestSearchIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test").addMapping("type1", "text", "type=text"));
         ensureGreen();
 
-        index("test", "type1", "1", "text", "bar");
+        indexDoc("test", "1", "text", "bar");
         refresh();
 
         TermSuggestionBuilder termSuggest = termSuggestion("text")
@@ -361,7 +361,7 @@ public class SuggestSearchIT extends ESIntegTestCase {
         assertSuggestionSize(suggest, 0, 0, "test");
         assertThat(suggest.getSuggestion("test").getEntries().get(0).getText().string(), equalTo("abcd"));
 
-        index("test", "type1", "1", "text", "bar");
+        indexDoc("test", "1", "text", "bar");
         refresh();
 
         suggest = searchSuggest("test", termSuggest);
@@ -377,10 +377,10 @@ public class SuggestSearchIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test").addMapping("typ1", "field1", "type=text", "field2", "type=text"));
         ensureGreen();
 
-        index("test", "typ1", "1", "field1", "prefix_abcd", "field2", "prefix_efgh");
-        index("test", "typ1", "2", "field1", "prefix_aacd", "field2", "prefix_eeeh");
-        index("test", "typ1", "3", "field1", "prefix_abbd", "field2", "prefix_efff");
-        index("test", "typ1", "4", "field1", "prefix_abcc", "field2", "prefix_eggg");
+        indexDoc("test", "1", "field1", "prefix_abcd", "field2", "prefix_efgh");
+        indexDoc("test", "2", "field1", "prefix_aacd", "field2", "prefix_eeeh");
+        indexDoc("test", "3", "field1", "prefix_abbd", "field2", "prefix_efff");
+        indexDoc("test", "4", "field1", "prefix_abcc", "field2", "prefix_eggg");
         refresh();
 
         Map<String, SuggestionBuilder<?>> suggestions = new HashMap<>();
@@ -422,7 +422,7 @@ public class SuggestSearchIT extends ESIntegTestCase {
 
         for (Entry<String, Integer> entry : termsAndDocCount.entrySet()) {
             for (int i = 0; i < entry.getValue(); i++) {
-                index("test", "type1", entry.getKey() + i, "field1", entry.getKey());
+                indexDoc("test", entry.getKey() + i, "field1", entry.getKey());
             }
         }
         refresh();
@@ -459,7 +459,7 @@ public class SuggestSearchIT extends ESIntegTestCase {
                         .putList("index.analysis.analyzer.stopwd.filter", "stop")
         ));
         ensureGreen();
-        index("test", "typ1", "1", "body", "this is a test");
+        indexDoc("test", "1", "body", "this is a test");
         refresh();
 
         Suggest searchSuggest = searchSuggest( "a an the", "simple_phrase",
@@ -489,9 +489,9 @@ public class SuggestSearchIT extends ESIntegTestCase {
         assertAcked(builder.addMapping("type1", mapping));
         ensureGreen();
 
-        index("test", "type1", "1", "body", "hello world");
-        index("test", "type1", "2", "body", "hello world");
-        index("test", "type1", "3", "body", "hello words");
+        indexDoc("test", "1", "body", "hello world");
+        indexDoc("test", "2", "body", "hello world");
+        indexDoc("test", "3", "body", "hello words");
         refresh();
 
         Suggest searchSuggest = searchSuggest( "hello word", "simple_phrase",
@@ -554,7 +554,7 @@ public class SuggestSearchIT extends ESIntegTestCase {
             "Police sergeant who stops the film",
         };
         for (String line : strings) {
-            index("test", "type1", line, "body", line, "bigram", line);
+            indexDoc("test", line, "body", line, "bigram", line);
         }
         refresh();
 
@@ -671,9 +671,9 @@ public class SuggestSearchIT extends ESIntegTestCase {
         ensureGreen();
 
         String line = "xorr the god jewel";
-        index("test", "type1", "1", "body", line, "bigram", line);
+        indexDoc("test", "1", "body", line, "bigram", line);
         line = "I got it this time";
-        index("test", "type1", "2", "body", line, "bigram", line);
+        indexDoc("test", "2", "body", line, "bigram", line);
         refresh();
 
         PhraseSuggestionBuilder phraseSuggestion = phraseSuggestion("bigram")
@@ -732,13 +732,13 @@ public class SuggestSearchIT extends ESIntegTestCase {
         assertAcked(builder.addMapping("type2", mapping));
         ensureGreen();
 
-        index("test", "type2", "1", "foo", "bar");
-        index("test", "type2", "2", "foo", "bar");
-        index("test", "type2", "3", "foo", "bar");
-        index("test", "type2", "4", "foo", "bar");
-        index("test", "type2", "5", "foo", "bar");
-        index("test", "type2", "1", "name", "Just testing the suggestions api");
-        index("test", "type2", "2", "name", "An other title about equal length");
+        indexDoc("test", "1", "foo", "bar");
+        indexDoc("test", "2", "foo", "bar");
+        indexDoc("test", "3", "foo", "bar");
+        indexDoc("test", "4", "foo", "bar");
+        indexDoc("test", "5", "foo", "bar");
+        indexDoc("test", "1", "name", "Just testing the suggestions api");
+        indexDoc("test", "2", "name", "An other title about equal length");
         // Note that the last document has to have about the same length as the other or cutoff rechecking will remove the useful suggestion
         refresh();
 
@@ -798,9 +798,9 @@ public class SuggestSearchIT extends ESIntegTestCase {
         assertThat(suggest.getSuggestion("did_you_mean").getEntries().get(0).getText().string(), equalTo("tetsting sugestion"));
 
 
-        index("test", "type1", "11", "foo", "bar");
-        index("test", "type1", "12", "foo", "bar");
-        index("test", "type1", "2", "name", "An other title about equal length");
+        indexDoc("test", "11", "foo", "bar");
+        indexDoc("test", "12", "foo", "bar");
+        indexDoc("test", "2", "name", "An other title about equal length");
         refresh();
 
         // test phrase suggestion but nothing matches
@@ -817,7 +817,7 @@ public class SuggestSearchIT extends ESIntegTestCase {
         assertThat(suggest.getSuggestion("did_you_mean").getEntries().get(0).getText().string(), equalTo("tetsting sugestion"));
 
         // finally indexing a document that will produce some meaningful suggestion
-        index("test", "type1", "1", "name", "Just testing the suggestions api");
+        indexDoc("test", "1", "name", "Just testing the suggestions api");
         refresh();
 
         searchResponse = client().prepareSearch()
@@ -876,7 +876,7 @@ public class SuggestSearchIT extends ESIntegTestCase {
             phrases.add("chaff" + i);
         }
         for (String phrase: phrases) {
-            index("test", "type1", phrase, "body", phrase);
+            indexDoc("test", phrase, "body", phrase);
         }
         refresh();
 

--- a/server/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -388,7 +388,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            index("test-idx", "doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx", Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         assertThat(client.prepareSearch("test-idx").setSize(0).get().getHits().getTotalHits().value, equalTo(100L));
@@ -440,7 +440,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            index("test-idx", "doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx", Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         assertThat(client.prepareSearch("test-idx").setSize(0).get().getHits().getTotalHits().value, equalTo(100L));
@@ -519,7 +519,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
 
         logger.info("--> indexing some data into test-idx-some");
         for (int i = 0; i < 100; i++) {
-            index("test-idx-some", "doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx-some", Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         assertThat(client().prepareSearch("test-idx-some").setSize(0).get().getHits().getTotalHits().value, equalTo(100L));
@@ -540,8 +540,8 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
                                                                           .put("number_of_replicas", 0)));
         logger.info("--> indexing some data into test-idx-all");
         for (int i = 0; i < 100; i++) {
-            index("test-idx-all", "doc", Integer.toString(i), "foo", "bar" + i);
-            index("test-idx-closed", "doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx-all", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx-closed", Integer.toString(i), "foo", "bar" + i);
         }
         refresh("test-idx-closed", "test-idx-all"); // don't refresh test-idx-some it will take 30 sec until it times out...
         assertThat(client().prepareSearch("test-idx-all").setSize(0).get().getHits().getTotalHits().value, equalTo(100L));
@@ -688,7 +688,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
 
         logger.info("--> indexing some data into test-idx");
         for (int i = 0; i < 100; i++) {
-            index("test-idx", "doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx", Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         assertThat(client().prepareSearch("test-idx").setSize(0).get().getHits().getTotalHits().value, equalTo(100L));

--- a/server/src/test/java/org/elasticsearch/snapshots/MinThreadsSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/MinThreadsSnapshotRestoreIT.java
@@ -66,7 +66,7 @@ public class MinThreadsSnapshotRestoreIT extends AbstractSnapshotIntegTestCase {
         final String index = "test-idx1";
         assertAcked(prepareCreate(index, 1, Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0)));
         for (int i = 0; i < 10; i++) {
-            index(index, "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc(index, Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         final String snapshot1 = "test-snap1";
@@ -74,7 +74,7 @@ public class MinThreadsSnapshotRestoreIT extends AbstractSnapshotIntegTestCase {
         final String index2 = "test-idx2";
         assertAcked(prepareCreate(index2, 1, Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0)));
         for (int i = 0; i < 10; i++) {
-            index(index2, "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc(index2, Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         final String snapshot2 = "test-snap2";
@@ -120,7 +120,7 @@ public class MinThreadsSnapshotRestoreIT extends AbstractSnapshotIntegTestCase {
         final String index = "test-idx";
         assertAcked(prepareCreate(index, 1, Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0)));
         for (int i = 0; i < 10; i++) {
-            index(index, "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc(index, Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         final String snapshot1 = "test-snap1";
@@ -166,7 +166,7 @@ public class MinThreadsSnapshotRestoreIT extends AbstractSnapshotIntegTestCase {
         final String index = "test-idx";
         assertAcked(prepareCreate(index, 1, Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0)));
         for (int i = 0; i < 10; i++) {
-            index(index, "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc(index, Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         final String snapshot1 = "test-snap1";
@@ -174,7 +174,7 @@ public class MinThreadsSnapshotRestoreIT extends AbstractSnapshotIntegTestCase {
         final String index2 = "test-idx2";
         assertAcked(prepareCreate(index2, 1, Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0)));
         for (int i = 0; i < 10; i++) {
-            index(index2, "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc(index2, Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         final String snapshot2 = "test-snap2";

--- a/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -186,9 +186,9 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            index("test-idx-1", "_doc", Integer.toString(i), "foo", "bar" + i);
-            index("test-idx-2", "_doc", Integer.toString(i), "foo", "baz" + i);
-            index("test-idx-3", "_doc", Integer.toString(i), "foo", "baz" + i);
+            indexDoc("test-idx-1", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx-2", Integer.toString(i), "foo", "baz" + i);
+            indexDoc("test-idx-3", Integer.toString(i), "foo", "baz" + i);
         }
         refresh();
         assertHitCount(client.prepareSearch("test-idx-1").setSize(0).get(), 100L);
@@ -331,7 +331,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         Client client = client();
         // Write a document
         String docId = Integer.toString(randomInt());
-        index(indexName, "_doc", docId, "value", expectedValue);
+        indexDoc(indexName, docId, "value", expectedValue);
 
         logger.info("-->  creating repository");
         assertAcked(client.admin().cluster().preparePutRepository(repoName)
@@ -737,7 +737,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            index("test-idx", "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx", Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         assertThat(client.prepareSearch("test-idx").setSize(0).get().getHits().getTotalHits().value, equalTo(100L));
@@ -800,7 +800,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            index("test-idx", "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx", Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         assertThat(client.prepareSearch("test-idx").setSize(0).get().getHits().getTotalHits().value, equalTo(100L));
@@ -858,7 +858,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            index("test-idx", "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx", Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         assertThat(client.prepareSearch("test-idx").setSize(0).get().getHits().getTotalHits().value, equalTo(100L));
@@ -927,7 +927,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            index("test-idx", "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx", Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         assertThat(client.prepareSearch("test-idx").setSize(0).get().getHits().getTotalHits().value, equalTo(100L));
@@ -990,7 +990,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            index("test-idx", "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx", Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         assertThat(client.prepareSearch("test-idx").setSize(0).get().getHits().getTotalHits().value, equalTo(100L));
@@ -1098,7 +1098,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         // index some documents
         final int nbDocs = scaledRandomIntBetween(10, 100);
         for (int i = 0; i < nbDocs; i++) {
-            index(indexName, "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc(indexName, Integer.toString(i), "foo", "bar" + i);
         }
         flushAndRefresh(indexName);
         assertThat(client().prepareSearch(indexName).setSize(0).get().getHits().getTotalHits().value, equalTo((long) nbDocs));
@@ -1191,7 +1191,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            index("test-idx", "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx", Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         assertThat(client.prepareSearch("test-idx").setSize(0).get().getHits().getTotalHits().value, equalTo(100L));
@@ -1285,7 +1285,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         logger.info("--> creating {} snapshots ", numberOfSnapshots);
         for (int i = 0; i < numberOfSnapshots; i++) {
             for (int j = 0; j < 10; j++) {
-                index("test-idx", "_doc", Integer.toString(i * 10 + j), "foo", "bar" + i * 10 + j);
+                indexDoc("test-idx", Integer.toString(i * 10 + j), "foo", "bar" + i * 10 + j);
             }
             refresh();
             logger.info("--> snapshot {}", i);
@@ -1351,7 +1351,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         assertAcked(prepareCreate(indexName));
         ensureGreen();
         for (int i = 0; i < 10; i++) {
-            index(indexName, "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc(indexName, Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
 
@@ -1713,8 +1713,8 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            index("test-idx-1", "_doc", Integer.toString(i), "foo", "bar" + i);
-            index("test-idx-2", "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx-1", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx-2", Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         assertThat(client.prepareSearch("test-idx-1").setSize(0).get().getHits().getTotalHits().value, equalTo(100L));
@@ -1835,7 +1835,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            index("test-idx", "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx", Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         assertThat(client.prepareSearch("test-idx").setSize(0).get().getHits().getTotalHits().value, equalTo(100L));
@@ -1901,7 +1901,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            index("test-idx", "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx", Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         assertThat(client.prepareSearch("test-idx").setSize(0).get().getHits().getTotalHits().value, equalTo(100L));
@@ -1983,7 +1983,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            index("test-idx", "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx", Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
 
@@ -2050,7 +2050,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            index("test-idx", "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx", Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         assertThat(client.prepareSearch("test-idx").setSize(0).get().getHits().getTotalHits().value, equalTo(100L));
@@ -2109,7 +2109,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            index("test-idx", "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx", Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         assertThat(client.prepareSearch("test-idx").setSize(0).get().getHits().getTotalHits().value, equalTo(100L));
@@ -2231,7 +2231,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            index("test-idx", "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx", Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         assertThat(client.prepareSearch("test-idx").setSize(0).get().getHits().getTotalHits().value, equalTo(100L));
@@ -2561,9 +2561,9 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            index("test-idx-1", "_doc", Integer.toString(i), "foo", "bar" + i);
-            index("test-idx-2", "_doc", Integer.toString(i), "foo", "baz" + i);
-            index("test-idx-3", "_doc", Integer.toString(i), "foo", "baz" + i);
+            indexDoc("test-idx-1", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx-2", Integer.toString(i), "foo", "baz" + i);
+            indexDoc("test-idx-3", Integer.toString(i), "foo", "baz" + i);
         }
         refresh();
         assertThat(client.prepareSearch("test-idx-1").setSize(0).get().getHits().getTotalHits().value, equalTo(100L));
@@ -2622,8 +2622,8 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            index("test-idx-1", "_doc", Integer.toString(i), "foo", "bar" + i);
-            index("test-idx-2", "_doc", Integer.toString(i), "foo", "baz" + i);
+            indexDoc("test-idx-1", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx-2", Integer.toString(i), "foo", "baz" + i);
         }
         refresh();
         assertThat(client.prepareSearch("test-idx-1").setSize(0).get().getHits().getTotalHits().value, equalTo(100L));
@@ -2685,7 +2685,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            index(indexName, "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc(indexName, Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         assertThat(client.prepareSearch(indexName).setSize(0).get().getHits().getTotalHits().value, equalTo(100L));
@@ -3070,7 +3070,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         createIndex(indexName);
         ensureGreen();
         for (int i = 0; i < 10; i++) {
-            index(indexName, "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc(indexName, Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
 
@@ -3087,7 +3087,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         logger.info("--> index more documents");
         for (int i = 10; i < 20; i++) {
-            index(indexName, "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc(indexName, Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
 
@@ -3153,7 +3153,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         assertAcked(prepareCreate(indexName, 1, Settings.builder().put("number_of_replicas", 0)));
         ensureGreen();
         for (int i = 0; i < 10; i++) {
-            index(indexName, "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc(indexName, Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
 
@@ -3194,7 +3194,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         logger.info("--> take another snapshot to be in-progress");
         // add documents so there are data files to block on
         for (int i = 10; i < 20; i++) {
-            index(indexName, "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc(indexName, Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
 
@@ -3284,7 +3284,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         logger.info("--> indexing some data");
         for (int i = 0; i < numDocs; i++) {
-            index(index, "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc(index, Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
 
@@ -3349,7 +3349,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         ensureGreen();
         final int numDocs = randomIntBetween(1, 5);
         for (int i = 0; i < numDocs; i++) {
-            index("test-idx", "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx", Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
         assertThat(client.prepareSearch("test-idx").setSize(0).get().getHits().getTotalHits().value, equalTo((long) numDocs));
@@ -3405,7 +3405,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         ensureGreen();
         final int numDocs = randomIntBetween(1, 5);
         for (int i = 0; i < numDocs; i++) {
-            index("test-idx-good", "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx-good", Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
 
@@ -3484,7 +3484,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                 if (randomBoolean()) {
                     final int numDocs = randomIntBetween(1, 5);
                     for (int k = 0; k < numDocs; k++) {
-                        index("test-idx-" + j, "_doc", Integer.toString(k), "foo", "bar" + k);
+                        indexDoc("test-idx-" + j, Integer.toString(k), "foo", "bar" + k);
                     }
                     refresh();
                 }
@@ -3562,7 +3562,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         createIndex(indexName, settings);
         ensureGreen();
         for (int i = 0; i < 5; i++) {
-            index(indexName, "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc(indexName, Integer.toString(i), "foo", "bar" + i);
         }
 
         final Index index = resolveIndex(indexName);
@@ -3571,7 +3571,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         EngineTestCase.generateNewSeqNo(getEngineFromShard(primary));
 
         for (int i = 5; i < 10; i++) {
-            index(indexName, "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc(indexName, Integer.toString(i), "foo", "bar" + i);
         }
 
         refresh();
@@ -3598,7 +3598,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         assertThat(shardStats.getSeqNoStats().getGlobalCheckpoint(), equalTo(10L));
         logger.info("--> indexing some more");
         for (int i = 10; i < 15; i++) {
-            index(indexName, "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc(indexName, Integer.toString(i), "foo", "bar" + i);
         }
         client().admin().indices().prepareFlush(indexName).setForce(true).setWaitIfOngoing(true).get();
 
@@ -3625,10 +3625,10 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         Client client = client();
         // Write a document
         String docId = Integer.toString(randomInt());
-        index(indexName1, "_doc", docId, "value", expectedValue);
+        indexDoc(indexName1, docId, "value", expectedValue);
 
         String docId2 = Integer.toString(randomInt());
-        index(indexName2, "_doc", docId2, "value", expectedValue);
+        indexDoc(indexName2, docId2, "value", expectedValue);
 
         logger.info("-->  creating repository");
         assertAcked(client.admin().cluster().preparePutRepository(repoName)
@@ -3686,10 +3686,10 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         Client client = client();
         // Write a document
         String docId = Integer.toString(randomInt());
-        index(indexName1, "_doc", docId, "value", expectedValue);
+        indexDoc(indexName1, docId, "value", expectedValue);
 
         String docId2 = Integer.toString(randomInt());
-        index(indexName2, "_doc", docId2, "value", expectedValue);
+        indexDoc(indexName2, docId2, "value", expectedValue);
 
         logger.info("-->  creating repository");
         assertAcked(client.admin().cluster().preparePutRepository(repoName)
@@ -3784,7 +3784,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         logger.info("--> indexing some documents");
         final int docCount = initialShardCount * randomIntBetween(1, 10);
         for (int i = 0; i < docCount; i++) {
-            index(indexName, "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc(indexName, Integer.toString(i), "foo", "bar" + i);
         }
 
         logger.info("-->  creating repository");
@@ -3808,7 +3808,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         logger.info("--> indexing some documents");
         final int newDocCount = newShardCount * randomIntBetween(1, 10);
         for (int i = 0; i < newDocCount; i++) {
-            index(indexName, "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc(indexName, Integer.toString(i), "foo", "bar" + i);
         }
 
         logger.info("--> snapshot with [{}] shards", newShardCount);

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotShardsServiceIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotShardsServiceIT.java
@@ -65,7 +65,7 @@ public class SnapshotShardsServiceIT extends AbstractSnapshotIntegTestCase {
         ensureGreen();
         final int numDocs = scaledRandomIntBetween(50, 100);
         for (int i = 0; i < numDocs; i++) {
-            index("test-index", "doc", Integer.toString(i));
+            indexDoc("test-index", Integer.toString(i));
         }
 
         logger.info("--> blocking repository");

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
@@ -58,9 +58,9 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            index("test-idx-1", "_doc", Integer.toString(i), "foo", "bar" + i);
-            index("test-idx-2", "_doc", Integer.toString(i), "foo", "baz" + i);
-            index("test-idx-3", "_doc", Integer.toString(i), "foo", "baz" + i);
+            indexDoc("test-idx-1", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx-2", Integer.toString(i), "foo", "baz" + i);
+            indexDoc("test-idx-3", Integer.toString(i), "foo", "baz" + i);
         }
         refresh();
 
@@ -98,7 +98,7 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            index("test-idx-1", "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx-1", Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
 
@@ -153,7 +153,7 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            index("test-idx-1", "_doc", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx-1", Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
 

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
@@ -222,9 +222,9 @@ public abstract class ESBlobStoreRepositoryIntegTestCase extends ESIntegTestCase
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 20; i++) {
-            index("test-idx-1", "doc", Integer.toString(i), "foo", "bar" + i);
-            index("test-idx-2", "doc", Integer.toString(i), "foo", "baz" + i);
-            index("test-idx-3", "doc", Integer.toString(i), "foo", "baz" + i);
+            indexDoc("test-idx-1", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx-2", Integer.toString(i), "foo", "baz" + i);
+            indexDoc("test-idx-3", Integer.toString(i), "foo", "baz" + i);
         }
         refresh();
 
@@ -235,9 +235,9 @@ public abstract class ESBlobStoreRepositoryIntegTestCase extends ESIntegTestCase
 
         logger.info("--> indexing more data");
         for (int i = 20; i < 40; i++) {
-            index("test-idx-1", "doc", Integer.toString(i), "foo", "bar" + i);
-            index("test-idx-2", "doc", Integer.toString(i), "foo", "baz" + i);
-            index("test-idx-3", "doc", Integer.toString(i), "foo", "baz" + i);
+            indexDoc("test-idx-1", Integer.toString(i), "foo", "bar" + i);
+            indexDoc("test-idx-2", Integer.toString(i), "foo", "baz" + i);
+            indexDoc("test-idx-3", Integer.toString(i), "foo", "baz" + i);
         }
 
         logger.info("--> take another snapshot with only 2 of the 3 indices");

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -1091,53 +1091,53 @@ public abstract class ESIntegTestCase extends ESTestCase {
     /**
      * Syntactic sugar for:
      * <pre>
-     *   client().prepareIndex(index, type).setSource(source).execute().actionGet();
+     *   client().prepareIndex(index).setSource(source).execute().actionGet();
      * </pre>
      */
-    protected final IndexResponse index(String index, String type, XContentBuilder source) {
+    protected final IndexResponse index(String index, XContentBuilder source) {
         return client().prepareIndex(index).setSource(source).execute().actionGet();
     }
 
     /**
      * Syntactic sugar for:
      * <pre>
-     *   client().prepareIndex(index, type).setSource(source).execute().actionGet();
+     *   client().prepareIndex(index).setSource(source).execute().actionGet();
      * </pre>
      */
-    protected final IndexResponse index(String index, String type, String id, Map<String, Object> source) {
-        return client().prepareIndex(index, type, id).setSource(source).execute().actionGet();
+    protected final IndexResponse index(String index, String id, Map<String, Object> source) {
+        return client().prepareIndex(index).setId(id).setSource(source).execute().actionGet();
     }
 
     /**
      * Syntactic sugar for:
      * <pre>
-     *   return client().prepareIndex(index, type, id).setSource(source).execute().actionGet();
+     *   return client().prepareIndex(index).setId(id).setSource(source).execute().actionGet();
      * </pre>
      */
-    protected final IndexResponse index(String index, String type, String id, XContentBuilder source) {
-        return client().prepareIndex(index, type, id).setSource(source).execute().actionGet();
+    protected final IndexResponse index(String index, String id, XContentBuilder source) {
+        return client().prepareIndex(index).setId(id).setSource(source).execute().actionGet();
     }
 
     /**
      * Syntactic sugar for:
      * <pre>
-     *   return client().prepareIndex(index, type, id).setSource(source).execute().actionGet();
+     *   return client().prepareIndex(index).setId(id).setSource(source).execute().actionGet();
      * </pre>
      */
-    protected final IndexResponse index(String index, String type, String id, Object... source) {
-        return client().prepareIndex(index, type, id).setSource(source).execute().actionGet();
+    protected final IndexResponse indexDoc(String index, String id, Object... source) {
+        return client().prepareIndex(index).setId(id).setSource(source).execute().actionGet();
     }
 
     /**
      * Syntactic sugar for:
      * <pre>
-     *   return client().prepareIndex(index, type, id).setSource(source).execute().actionGet();
+     *   return client().prepareIndex(index).setId(id).setSource(source).execute().actionGet();
      * </pre>
      * <p>
      * where source is a JSON String.
      */
-    protected final IndexResponse index(String index, String type, String id, String source) {
-        return client().prepareIndex(index, type, id).setSource(source, XContentType.JSON).execute().actionGet();
+    protected final IndexResponse index(String index, String id, String source) {
+        return client().prepareIndex(index).setId(id).setSource(source, XContentType.JSON).execute().actionGet();
     }
 
     /**

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
@@ -83,7 +83,7 @@ public class SLMSnapshotBlockingIntegTests extends ESIntegTestCase {
         final String policyName = "test-policy";
         int docCount = 20;
         for (int i = 0; i < docCount; i++) {
-            index(indexName, "_doc", i + "", Collections.singletonMap("foo", "bar"));
+            index(indexName, i + "", Collections.singletonMap("foo", "bar"));
         }
 
         // Create a snapshot repo
@@ -131,7 +131,7 @@ public class SLMSnapshotBlockingIntegTests extends ESIntegTestCase {
         final String policyId = "slm-policy";
         int docCount = 20;
         for (int i = 0; i < docCount; i++) {
-            index(indexName, "_doc", null, Collections.singletonMap("foo", "bar"));
+            index(indexName, null, Collections.singletonMap("foo", "bar"));
         }
 
         initializeRepo(REPO);
@@ -166,7 +166,7 @@ public class SLMSnapshotBlockingIntegTests extends ESIntegTestCase {
 
         logger.info("--> indexing more docs to force new segment files");
         for (int i = 0; i < docCount; i++) {
-            index(indexName, "_doc", null, Collections.singletonMap("foo", "bar"));
+            index(indexName, null, Collections.singletonMap("foo", "bar"));
         }
         refresh(indexName);
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/integration/MultipleIndicesPermissionsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/integration/MultipleIndicesPermissionsTests.java
@@ -116,14 +116,14 @@ public class MultipleIndicesPermissionsTests extends SecurityIntegTestCase {
     }
 
     public void testSingleRole() throws Exception {
-        IndexResponse indexResponse = index("test", "type", jsonBuilder()
+        IndexResponse indexResponse = index("test", jsonBuilder()
                 .startObject()
                 .field("name", "value")
                 .endObject());
         assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
 
 
-        indexResponse = index("test1", "type", jsonBuilder()
+        indexResponse = index("test1", jsonBuilder()
                 .startObject()
                 .field("name", "value1")
                 .endObject());
@@ -174,19 +174,19 @@ public class MultipleIndicesPermissionsTests extends SecurityIntegTestCase {
 
     public void testMonitorRestrictedWildcards() throws Exception {
 
-        IndexResponse indexResponse = index("foo", "type", jsonBuilder()
+        IndexResponse indexResponse = index("foo", jsonBuilder()
                 .startObject()
                 .field("name", "value")
                 .endObject());
         assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
 
-        indexResponse = index("foobar", "type", jsonBuilder()
+        indexResponse = index("foobar", jsonBuilder()
                 .startObject()
                 .field("name", "value")
                 .endObject());
         assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
 
-        indexResponse = index("foobarfoo", "type", jsonBuilder()
+        indexResponse = index("foobarfoo", jsonBuilder()
                 .startObject()
                 .field("name", "value")
                 .endObject());
@@ -227,7 +227,7 @@ public class MultipleIndicesPermissionsTests extends SecurityIntegTestCase {
         assertThat(indicesRecoveryResponse.shardRecoveryStates().size(), is(3));
         assertThat(indicesRecoveryResponse.shardRecoveryStates().keySet(), containsInAnyOrder("foo", "foobar", "foobarfoo"));
 
-        // test _cat/indices with wildcards that cover unauthorized indices (".security" in this case)  
+        // test _cat/indices with wildcards that cover unauthorized indices (".security" in this case)
         RequestOptions.Builder optionsBuilder = RequestOptions.DEFAULT.toBuilder();
         optionsBuilder.addHeader("Authorization", UsernamePasswordToken.basicAuthHeaderValue("user_monitor", USERS_PASSWD));
         RequestOptions options = optionsBuilder.build();
@@ -238,13 +238,13 @@ public class MultipleIndicesPermissionsTests extends SecurityIntegTestCase {
     }
 
     public void testMultipleRoles() throws Exception {
-        IndexResponse indexResponse = index("a", "type", jsonBuilder()
+        IndexResponse indexResponse = index("a", jsonBuilder()
                 .startObject()
                 .field("name", "value_a")
                 .endObject());
         assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
 
-        indexResponse = index("b", "type", jsonBuilder()
+        indexResponse = index("b", jsonBuilder()
                 .startObject()
                 .field("name", "value_b")
                 .endObject());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/integration/SecurityCachePermissionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/integration/SecurityCachePermissionTests.java
@@ -46,8 +46,8 @@ public class SecurityCachePermissionTests extends SecurityIntegTestCase {
 
     @Before
     public void loadData() {
-        index("data", "a", "1", "{ \"name\": \"John\", \"token\": \"token1\" }");
-        index("tokens", "tokens", "1", "{ \"group\": \"1\", \"tokens\": [\"token1\", \"token2\"] }");
+        index("data", "1", "{ \"name\": \"John\", \"token\": \"token1\" }");
+        index("tokens", "1", "{ \"group\": \"1\", \"tokens\": [\"token1\", \"token2\"] }");
         refresh();
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/license/LicensingTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/license/LicensingTests.java
@@ -129,14 +129,14 @@ public class LicensingTests extends SecurityIntegTestCase {
     }
 
     public void testEnableDisableBehaviour() throws Exception {
-        IndexResponse indexResponse = index("test", "type", jsonBuilder()
+        IndexResponse indexResponse = index("test", jsonBuilder()
                 .startObject()
                 .field("name", "value")
                 .endObject());
         assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
 
 
-        indexResponse = index("test1", "type", jsonBuilder()
+        indexResponse = index("test1", jsonBuilder()
                 .startObject()
                 .field("name", "value1")
                 .endObject());

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateSearchInputMappingsTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateSearchInputMappingsTests.java
@@ -38,7 +38,7 @@ public class HistoryTemplateSearchInputMappingsTests extends AbstractWatcherInte
         String index = "the-index";
         String type = "the-type";
         createIndex(index);
-        index(index, type, "{}");
+        indexDoc(index, "{}");
         flush();
         refresh();
 

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/HistoryIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/HistoryIntegrationTests.java
@@ -51,7 +51,7 @@ public class HistoryIntegrationTests extends AbstractWatcherIntegrationTestCase 
     public void testThatHistoryIsWrittenWithChainedInput() throws Exception {
         XContentBuilder xContentBuilder = jsonBuilder().startObject().startObject("inner").field("date", "2015-06-06").endObject()
                 .endObject();
-        index("foo", "bar", "1", xContentBuilder);
+        index("foo", "1", xContentBuilder);
         refresh();
 
         WatchSourceBuilder builder = watchBuilder()

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transform/TransformIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transform/TransformIntegrationTests.java
@@ -159,7 +159,7 @@ public class TransformIntegrationTests extends AbstractWatcherIntegrationTestCas
         createIndex("my-condition-index", "my-payload-index");
         ensureGreen("my-condition-index", "my-payload-index");
 
-        index("my-payload-index", "payload", "mytestresult");
+        indexDoc("my-payload-index", "mytestresult");
         refresh();
 
         WatcherSearchTemplateRequest inputRequest = templateRequest(searchSource().query(matchAllQuery()), "my-condition-index");


### PR DESCRIPTION
ESIntegTestCase has a number of sugar `index` methods that prepare and execute
index requests.  Now that index requests no longer use types, we can remove the
`type` parameter from each of these.

To prevent issues when re-compiling against the test framework, the method
`index(String index, String id, Object... source)` is renamed to `indexDoc`
so that e.g. `index(index, type, id, field1, field2, field3)` does not get re-interpreted
as an index request with an id of `type`.