### PR TITLE
Bootstrap check for PKI realms with no trust config

### DIFF
--- a/docs/changelog/48455.yaml
+++ b/docs/changelog/48455.yaml
@@ -1,0 +1,5 @@
+pr: 48455
+summary: Bootstrap check for PKI realms with no trust config
+area: Authentication
+type: enhancement
+issues: []


### PR DESCRIPTION
PKI realms without delegation enabled can work without any trust configuration. But in this case they rely on the certificate verification on the network layer (HTTP or transport). However, client authentication on the network layer can be toggled without also enabling certificate verification. In this case any valid certificate - key pair can be used to authenticate against the PKI realm.

This commit introduces a bootstrap check that fails if there is at least one PKI realm with no trust config and at least one network layer with client authentication enabled but no verification mode.

Obviates https://github.com/elastic/elasticsearch/pull/45590 , see https://github.com/elastic/elasticsearch/pull/45590#issuecomment-544300716


