### PR TITLE
Remove deprecated include-type methods from HLRC indices client

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesClient.java
@@ -149,50 +149,6 @@ public final class IndicesClient {
     }
 
     /**
-     * Creates an index using the Create Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html">
-     * Create Index API on elastic.co</a>
-     * @param createIndexRequest the request
-     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
-     * @return the response
-     * @throws IOException in case there is a problem sending the request or parsing back the response
-     *
-     * @deprecated This method uses an old request object which still refers to types, a deprecated feature. The
-     * method {@link #create(CreateIndexRequest, RequestOptions)} should be used instead, which accepts a new
-     * request object.
-     */
-    @Deprecated
-    public org.elasticsearch.action.admin.indices.create.CreateIndexResponse create(
-            org.elasticsearch.action.admin.indices.create.CreateIndexRequest createIndexRequest,
-            RequestOptions options) throws IOException {
-        return restHighLevelClient.performRequestAndParseEntity(createIndexRequest,
-            IndicesRequestConverters::createIndex, options,
-            org.elasticsearch.action.admin.indices.create.CreateIndexResponse::fromXContent, emptySet());
-    }
-
-    /**
-     * Asynchronously creates an index using the Create Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html">
-     * Create Index API on elastic.co</a>
-     * @param createIndexRequest the request
-     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
-     * @param listener the listener to be notified upon request completion
-     *
-     * @deprecated This method uses an old request object which still refers to types, a deprecated feature. The
-     * method {@link #createAsync(CreateIndexRequest, RequestOptions, ActionListener)} should be used instead,
-     * which accepts a new request object.
-     * @return cancellable that may be used to cancel the request
-     */
-    @Deprecated
-    public Cancellable createAsync(org.elasticsearch.action.admin.indices.create.CreateIndexRequest createIndexRequest,
-                                   RequestOptions options,
-                                   ActionListener<org.elasticsearch.action.admin.indices.create.CreateIndexResponse> listener) {
-        return restHighLevelClient.performRequestAsyncAndParseEntity(createIndexRequest,
-            IndicesRequestConverters::createIndex, options,
-            org.elasticsearch.action.admin.indices.create.CreateIndexResponse::fromXContent, listener, emptySet());
-    }
-
-    /**
      * Updates the mappings on an index using the Put Mapping API.
      * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html">
      * Put Mapping API on elastic.co</a>
@@ -216,46 +172,6 @@ public final class IndicesClient {
      * @return cancellable that may be used to cancel the request
      */
     public Cancellable putMappingAsync(PutMappingRequest putMappingRequest, RequestOptions options,
-                                       ActionListener<AcknowledgedResponse> listener) {
-        return restHighLevelClient.performRequestAsyncAndParseEntity(putMappingRequest, IndicesRequestConverters::putMapping, options,
-            AcknowledgedResponse::fromXContent, listener, emptySet());
-    }
-
-    /**
-     * Updates the mappings on an index using the Put Mapping API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html">
-     * Put Mapping API on elastic.co</a>
-     * @param putMappingRequest the request
-     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
-     * @return the response
-     * @throws IOException in case there is a problem sending the request or parsing back the response
-     *
-     * @deprecated This method uses an old request object which still refers to types, a deprecated feature. The method
-     * {@link #putMapping(PutMappingRequest, RequestOptions)} should be used instead, which accepts a new request object.
-     */
-    @Deprecated
-    public AcknowledgedResponse putMapping(org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest putMappingRequest,
-                                           RequestOptions options) throws IOException {
-        return restHighLevelClient.performRequestAndParseEntity(putMappingRequest, IndicesRequestConverters::putMapping, options,
-            AcknowledgedResponse::fromXContent, emptySet());
-    }
-
-    /**
-     * Asynchronously updates the mappings on an index using the Put Mapping API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html">
-     * Put Mapping API on elastic.co</a>
-     * @param putMappingRequest the request
-     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
-     * @param listener the listener to be notified upon request completion
-     *
-     * @deprecated This method uses an old request object which still refers to types, a deprecated feature. The
-     * method {@link #putMappingAsync(PutMappingRequest, RequestOptions, ActionListener)} should be used instead,
-     * which accepts a new request object.
-     * @return cancellable that may be used to cancel the request
-     */
-    @Deprecated
-    public Cancellable putMappingAsync(org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest putMappingRequest,
-                                       RequestOptions options,
                                        ActionListener<AcknowledgedResponse> listener) {
         return restHighLevelClient.performRequestAsyncAndParseEntity(putMappingRequest, IndicesRequestConverters::putMapping, options,
             AcknowledgedResponse::fromXContent, listener, emptySet());
@@ -295,51 +211,6 @@ public final class IndicesClient {
             GetMappingsResponse::fromXContent,
             listener,
             emptySet());
-    }
-
-    /**
-     * Retrieves the field mappings on an index or indices using the Get Field Mapping API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-field-mapping.html">
-     * Get Field Mapping API on elastic.co</a>
-     * @param getFieldMappingsRequest the request
-     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
-     * @return the response
-     * @throws IOException in case there is a problem sending the request or parsing back the response
-     *
-     * @deprecated This method uses old request and response objects which still refer to types, a deprecated feature.
-     * The method {@link #getFieldMapping(GetFieldMappingsRequest, RequestOptions)} should be used instead, which
-     * accepts a new request object.
-     */
-    @Deprecated
-    public org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse getFieldMapping(
-            org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsRequest getFieldMappingsRequest,
-            RequestOptions options) throws IOException {
-        return restHighLevelClient.performRequestAndParseEntity(getFieldMappingsRequest, IndicesRequestConverters::getFieldMapping,
-            options, org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse::fromXContent, emptySet());
-    }
-
-    /**
-     * Asynchronously retrieves the field mappings on an index on indices using the Get Field Mapping API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-field-mapping.html">
-     * Get Field Mapping API on elastic.co</a>
-     * @param getFieldMappingsRequest the request
-     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
-     * @param listener the listener to be notified upon request completion
-     *
-     * @deprecated This method uses old request and response objects which still refer to types, a deprecated feature.
-     * The method {@link #getFieldMappingAsync(GetFieldMappingsRequest, RequestOptions, ActionListener)} should be
-     * used instead, which accepts a new request object.
-     * @return cancellable that may be used to cancel the request
-     */
-    @Deprecated
-    public Cancellable getFieldMappingAsync(
-        org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsRequest getFieldMappingsRequest,
-        RequestOptions options,
-        ActionListener<org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse> listener) {
-        return restHighLevelClient.performRequestAsyncAndParseEntity(getFieldMappingsRequest,
-            IndicesRequestConverters::getFieldMapping, options,
-            org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse::fromXContent,
-            listener, emptySet());
     }
 
     /**
@@ -762,52 +633,6 @@ public final class IndicesClient {
     }
 
     /**
-     * Checks if the index (indices) exists or not.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-exists.html">
-     * Indices Exists API on elastic.co</a>
-     * @param request the request
-     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
-     * @return the response
-     * @throws IOException in case there is a problem sending the request
-     * @deprecated This method uses an old request object which still refers to types, a deprecated feature. The method
-     * {@link #exists(GetIndexRequest, RequestOptions)} should be used instead, which accepts a new request object.
-     */
-    @Deprecated
-    public boolean exists(org.elasticsearch.action.admin.indices.get.GetIndexRequest request, RequestOptions options) throws IOException {
-        return restHighLevelClient.performRequest(
-            request,
-            IndicesRequestConverters::indicesExist,
-            options,
-            RestHighLevelClient::convertExistsResponse,
-            Collections.emptySet()
-        );
-    }
-
-    /**
-     * Asynchronously checks if the index (indices) exists or not.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-exists.html">
-     * Indices Exists API on elastic.co</a>
-     * @param request the request
-     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
-     * @param listener the listener to be notified upon request completion
-     * @deprecated This method uses an old request object which still refers to types, a deprecated feature. The method
-     * {@link #existsAsync(GetIndexRequest, RequestOptions, ActionListener)} should be used instead, which accepts a new request object.
-     * @return cancellable that may be used to cancel the request
-     */
-    @Deprecated
-    public Cancellable existsAsync(org.elasticsearch.action.admin.indices.get.GetIndexRequest request, RequestOptions options,
-                                   ActionListener<Boolean> listener) {
-        return restHighLevelClient.performRequestAsync(
-                request,
-                IndicesRequestConverters::indicesExist,
-                options,
-                RestHighLevelClient::convertExistsResponse,
-                listener,
-                Collections.emptySet()
-        );
-    }
-
-    /**
      * Shrinks an index using the Shrink Index API.
      * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-shrink-index.html">
      * Shrink Index API on elastic.co</a>
@@ -919,48 +744,6 @@ public final class IndicesClient {
                 RolloverResponse::fromXContent, listener, emptySet());
     }
 
-
-    /**
-     * Rolls over an index using the Rollover Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-rollover-index.html">
-     * Rollover Index API on elastic.co</a>
-     * @param rolloverRequest the request
-     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
-     * @return the response
-     * @throws IOException in case there is a problem sending the request or parsing back the response
-     *
-     * @deprecated This method uses deprecated request and response objects.
-     * The method {@link #rollover(RolloverRequest, RequestOptions)} should be used instead, which accepts a new request object.
-     */
-    @Deprecated
-    public org.elasticsearch.action.admin.indices.rollover.RolloverResponse rollover(
-            org.elasticsearch.action.admin.indices.rollover.RolloverRequest rolloverRequest,
-            RequestOptions options) throws IOException {
-        return restHighLevelClient.performRequestAndParseEntity(rolloverRequest, IndicesRequestConverters::rollover, options,
-            org.elasticsearch.action.admin.indices.rollover.RolloverResponse::fromXContent, emptySet());
-    }
-
-    /**
-     * Asynchronously rolls over an index using the Rollover Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-rollover-index.html">
-     * Rollover Index API on elastic.co</a>
-     * @param rolloverRequest the request
-     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
-     * @param listener the listener to be notified upon request completion
-     *
-     * @deprecated This method uses deprecated request and response objects.
-     * The method {@link #rolloverAsync(RolloverRequest, RequestOptions, ActionListener)} should be used instead, which
-     * accepts a new request object.
-     * @return cancellable that may be used to cancel the request
-     */
-    @Deprecated
-    public Cancellable rolloverAsync(org.elasticsearch.action.admin.indices.rollover.RolloverRequest rolloverRequest,
-            RequestOptions options,
-            ActionListener<org.elasticsearch.action.admin.indices.rollover.RolloverResponse> listener) {
-        return restHighLevelClient.performRequestAsyncAndParseEntity(rolloverRequest, IndicesRequestConverters::rollover, options,
-            org.elasticsearch.action.admin.indices.rollover.RolloverResponse::fromXContent, listener, emptySet());
-    }
-
     /**
      * Gets one or more aliases using the Get Index Aliases API.
      * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html"> Indices Aliases API on
@@ -1020,48 +803,6 @@ public final class IndicesClient {
             IndicesRequestConverters::indexPutSettings, options,
             AcknowledgedResponse::fromXContent, listener, emptySet());
     }
-
-
-    /**
-     * Puts an index template using the Index Templates API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html"> Index Templates API
-     * on elastic.co</a>
-     * @param putIndexTemplateRequest the request
-     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
-     * @return the response
-     * @throws IOException in case there is a problem sending the request or parsing back the response
-     * @deprecated This old form of request allows types in mappings. Use {@link #putTemplate(PutIndexTemplateRequest, RequestOptions)}
-     * instead which introduces a new request object without types.
-     */
-    @Deprecated
-    public AcknowledgedResponse putTemplate(
-            org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest putIndexTemplateRequest,
-            RequestOptions options) throws IOException {
-        return restHighLevelClient.performRequestAndParseEntity(putIndexTemplateRequest, IndicesRequestConverters::putTemplate, options,
-            AcknowledgedResponse::fromXContent, emptySet());
-    }
-
-    /**
-     * Asynchronously puts an index template using the Index Templates API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html"> Index Templates API
-     * on elastic.co</a>
-     * @param putIndexTemplateRequest the request
-     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
-     * @param listener the listener to be notified upon request completion
-     * @deprecated This old form of request allows types in mappings.
-     * Use {@link #putTemplateAsync(PutIndexTemplateRequest, RequestOptions, ActionListener)}
-     * instead which introduces a new request object without types.
-     * @return cancellable that may be used to cancel the request
-     */
-    @Deprecated
-    public Cancellable putTemplateAsync(
-                org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest putIndexTemplateRequest,
-                RequestOptions options, ActionListener<AcknowledgedResponse> listener) {
-        return restHighLevelClient.performRequestAsyncAndParseEntity(putIndexTemplateRequest,
-            IndicesRequestConverters::putTemplate, options,
-            AcknowledgedResponse::fromXContent, listener, emptySet());
-    }
-
 
     /**
      * Puts an index template using the Index Templates API.
@@ -1130,27 +871,6 @@ public final class IndicesClient {
     }
 
     /**
-     * Gets index templates using the Index Templates API. The mappings will be returned in a legacy deprecated format, where the
-     * mapping definition is nested under the type name.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html"> Index Templates API
-     * on elastic.co</a>
-     * @param getIndexTemplatesRequest the request
-     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
-     * @return the response
-     * @throws IOException in case there is a problem sending the request or parsing back the response
-     * @deprecated This method uses an old response object which still refers to types, a deprecated feature. Use
-     * {@link #getIndexTemplate(GetIndexTemplatesRequest, RequestOptions)} instead which returns a new response object
-     */
-    @Deprecated
-    public org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse getTemplate(
-            GetIndexTemplatesRequest getIndexTemplatesRequest, RequestOptions options) throws IOException {
-        return restHighLevelClient.performRequestAndParseEntity(getIndexTemplatesRequest,
-            IndicesRequestConverters::getTemplatesWithDocumentTypes,
-            options,
-            org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse::fromXContent, emptySet());
-    }
-
-    /**
      * Gets index templates using the Index Templates API
      * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html"> Index Templates API
      * on elastic.co</a>
@@ -1164,28 +884,6 @@ public final class IndicesClient {
         return restHighLevelClient.performRequestAndParseEntity(getIndexTemplatesRequest,
             IndicesRequestConverters::getTemplates,
             options, GetIndexTemplatesResponse::fromXContent, emptySet());
-    }
-
-    /**
-     * Asynchronously gets index templates using the Index Templates API. The mappings will be returned in a legacy deprecated format,
-     * where the mapping definition is nested under the type name.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html"> Index Templates API
-     * on elastic.co</a>
-     * @param getIndexTemplatesRequest the request
-     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
-     * @param listener the listener to be notified upon request completion
-     * @deprecated This method uses an old response object which still refers to types, a deprecated feature. Use
-     * {@link #getIndexTemplateAsync(GetIndexTemplatesRequest, RequestOptions, ActionListener)} instead which returns a new response object
-     * @return cancellable that may be used to cancel the request
-     */
-    @Deprecated
-    public Cancellable getTemplateAsync(GetIndexTemplatesRequest getIndexTemplatesRequest, RequestOptions options,
-            ActionListener<org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse> listener) {
-        return restHighLevelClient.performRequestAsyncAndParseEntity(getIndexTemplatesRequest,
-            IndicesRequestConverters::getTemplatesWithDocumentTypes,
-            options,
-            org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse::fromXContent,
-            listener, emptySet());
     }
 
     /**

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
@@ -58,8 +58,6 @@ import org.elasticsearch.common.Strings;
 import java.io.IOException;
 import java.util.Locale;
 
-import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
-
 final class IndicesRequestConverters {
 
     private IndicesRequestConverters() {}
@@ -115,21 +113,6 @@ final class IndicesRequestConverters {
         return request;
     }
 
-    static Request createIndex(org.elasticsearch.action.admin.indices.create.CreateIndexRequest createIndexRequest)
-            throws IOException {
-        String endpoint = RequestConverters.endpoint(createIndexRequest.indices());
-        Request request = new Request(HttpPut.METHOD_NAME, endpoint);
-
-        RequestConverters.Params parameters = new RequestConverters.Params();
-        parameters.withTimeout(createIndexRequest.timeout());
-        parameters.withMasterTimeout(createIndexRequest.masterNodeTimeout());
-        parameters.withWaitForActiveShards(createIndexRequest.waitForActiveShards());
-        parameters.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
-        request.addParameters(parameters.asMap());
-        request.setEntity(RequestConverters.createEntity(createIndexRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
-        return request;
-    }
-
     static Request updateAliases(IndicesAliasesRequest indicesAliasesRequest) throws IOException {
         Request request = new Request(HttpPost.METHOD_NAME, "/_aliases");
 
@@ -148,29 +131,6 @@ final class IndicesRequestConverters {
         RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(putMappingRequest.timeout());
         parameters.withMasterTimeout(putMappingRequest.masterNodeTimeout());
-        request.addParameters(parameters.asMap());
-        request.setEntity(RequestConverters.createEntity(putMappingRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
-        return request;
-    }
-
-    /**
-     * converter for the legacy server-side {@link org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest} that still supports
-     * types
-     */
-    @Deprecated
-    static Request putMapping(org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest putMappingRequest) throws IOException {
-        // The concreteIndex is an internal concept, not applicable to requests made over the REST API.
-        if (putMappingRequest.getConcreteIndex() != null) {
-            throw new IllegalArgumentException("concreteIndex cannot be set on PutMapping requests made over the REST API");
-        }
-
-        Request request = new Request(HttpPut.METHOD_NAME, RequestConverters.endpoint(putMappingRequest.indices(),
-            "_mapping", putMappingRequest.type()));
-
-        RequestConverters.Params parameters = new RequestConverters.Params();
-        parameters.withTimeout(putMappingRequest.timeout());
-        parameters.withMasterTimeout(putMappingRequest.masterNodeTimeout());
-        parameters.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
         request.addParameters(parameters.asMap());
         request.setEntity(RequestConverters.createEntity(putMappingRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;
@@ -206,28 +166,6 @@ final class IndicesRequestConverters {
         parameters.withIndicesOptions(getFieldMappingsRequest.indicesOptions());
         parameters.withIncludeDefaults(getFieldMappingsRequest.includeDefaults());
         parameters.withLocal(getFieldMappingsRequest.local());
-        request.addParameters(parameters.asMap());
-        return request;
-    }
-
-    @Deprecated
-    static Request getFieldMapping(org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsRequest getFieldMappingsRequest) {
-        String[] indices = getFieldMappingsRequest.indices() == null ? Strings.EMPTY_ARRAY : getFieldMappingsRequest.indices();
-        String[] types = getFieldMappingsRequest.types() == null ? Strings.EMPTY_ARRAY : getFieldMappingsRequest.types();
-        String[] fields = getFieldMappingsRequest.fields() == null ? Strings.EMPTY_ARRAY : getFieldMappingsRequest.fields();
-
-        String endpoint = new RequestConverters.EndpointBuilder().addCommaSeparatedPathParts(indices)
-            .addPathPartAsIs("_mapping").addCommaSeparatedPathParts(types)
-            .addPathPartAsIs("field").addCommaSeparatedPathParts(fields)
-            .build();
-
-        Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-
-        RequestConverters.Params parameters = new RequestConverters.Params();
-        parameters.withIndicesOptions(getFieldMappingsRequest.indicesOptions());
-        parameters.withIncludeDefaults(getFieldMappingsRequest.includeDefaults());
-        parameters.withLocal(getFieldMappingsRequest.local());
-        parameters.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
         request.addParameters(parameters.asMap());
         return request;
     }
@@ -360,25 +298,6 @@ final class IndicesRequestConverters {
         return request;
     }
 
-    @Deprecated
-    static Request rollover(org.elasticsearch.action.admin.indices.rollover.RolloverRequest rolloverRequest) throws IOException {
-        String endpoint = new RequestConverters.EndpointBuilder().addPathPart(rolloverRequest.getAlias()).addPathPartAsIs("_rollover")
-            .addPathPart(rolloverRequest.getNewIndexName()).build();
-        Request request = new Request(HttpPost.METHOD_NAME, endpoint);
-
-        RequestConverters.Params params = new RequestConverters.Params();
-        params.withTimeout(rolloverRequest.timeout());
-        params.withMasterTimeout(rolloverRequest.masterNodeTimeout());
-        params.withWaitForActiveShards(rolloverRequest.getCreateIndexRequest().waitForActiveShards());
-        if (rolloverRequest.isDryRun()) {
-            params.putParam("dry_run", Boolean.TRUE.toString());
-        }
-        params.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
-        request.setEntity(RequestConverters.createEntity(rolloverRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
-        request.addParameters(params.asMap());
-        return request;
-    }
-
     static Request getSettings(GetSettingsRequest getSettingsRequest) {
         String[] indices = getSettingsRequest.indices() == null ? Strings.EMPTY_ARRAY : getSettingsRequest.indices();
         String[] names = getSettingsRequest.names() == null ? Strings.EMPTY_ARRAY : getSettingsRequest.names();
@@ -395,28 +314,6 @@ final class IndicesRequestConverters {
         return request;
     }
 
-    /**
-     * converter for the legacy server-side {@link org.elasticsearch.action.admin.indices.get.GetIndexRequest} that
-     * still supports types
-     */
-    @Deprecated
-    static Request getIndex(org.elasticsearch.action.admin.indices.get.GetIndexRequest getIndexRequest) {
-        String[] indices = getIndexRequest.indices() == null ? Strings.EMPTY_ARRAY : getIndexRequest.indices();
-
-        String endpoint = RequestConverters.endpoint(indices);
-        Request request = new Request(HttpGet.METHOD_NAME, endpoint);
-
-        RequestConverters.Params params = new RequestConverters.Params();
-        params.withIndicesOptions(getIndexRequest.indicesOptions());
-        params.withLocal(getIndexRequest.local());
-        params.withIncludeDefaults(getIndexRequest.includeDefaults());
-        params.withHuman(getIndexRequest.humanReadable());
-        params.withMasterTimeout(getIndexRequest.masterNodeTimeout());
-        params.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
-        request.addParameters(params.asMap());
-        return request;
-    }
-
     static Request getIndex(GetIndexRequest getIndexRequest) {
         String[] indices = getIndexRequest.indices() == null ? Strings.EMPTY_ARRAY : getIndexRequest.indices();
 
@@ -429,28 +326,6 @@ final class IndicesRequestConverters {
         params.withIncludeDefaults(getIndexRequest.includeDefaults());
         params.withHuman(getIndexRequest.humanReadable());
         params.withMasterTimeout(getIndexRequest.masterNodeTimeout());
-        request.addParameters(params.asMap());
-        return request;
-    }
-
-    /**
-     * converter for the legacy server-side {@link org.elasticsearch.action.admin.indices.get.GetIndexRequest} that
-     * still supports types
-     */
-    @Deprecated
-    static Request indicesExist(org.elasticsearch.action.admin.indices.get.GetIndexRequest getIndexRequest) {
-        if (getIndexRequest.indices() == null || getIndexRequest.indices().length == 0) {
-            throw new IllegalArgumentException("indices are mandatory");
-        }
-        String endpoint = RequestConverters.endpoint(getIndexRequest.indices(), "");
-        Request request = new Request(HttpHead.METHOD_NAME, endpoint);
-
-        RequestConverters.Params params = new RequestConverters.Params();
-        params.withLocal(getIndexRequest.local());
-        params.withHuman(getIndexRequest.humanReadable());
-        params.withIndicesOptions(getIndexRequest.indicesOptions());
-        params.withIncludeDefaults(getIndexRequest.includeDefaults());
-        params.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
         request.addParameters(params.asMap());
         return request;
     }
@@ -482,30 +357,6 @@ final class IndicesRequestConverters {
         parameters.withPreserveExisting(updateSettingsRequest.isPreserveExisting());
         request.addParameters(parameters.asMap());
         request.setEntity(RequestConverters.createEntity(updateSettingsRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
-        return request;
-    }
-
-    /**
-     * @deprecated This uses the old form of PutIndexTemplateRequest which uses types.
-     * Use (@link {@link #putTemplate(PutIndexTemplateRequest)} instead
-     */
-    @Deprecated
-    static Request putTemplate(org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest putIndexTemplateRequest)
-            throws IOException {
-        String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_template")
-            .addPathPart(putIndexTemplateRequest.name()).build();
-        Request request = new Request(HttpPut.METHOD_NAME, endpoint);
-        RequestConverters.Params params = new RequestConverters.Params();
-        params.withMasterTimeout(putIndexTemplateRequest.masterNodeTimeout());
-        if (putIndexTemplateRequest.create()) {
-            params.putParam("create", Boolean.TRUE.toString());
-        }
-        if (Strings.hasText(putIndexTemplateRequest.cause())) {
-            params.putParam("cause", putIndexTemplateRequest.cause());
-        }
-        params.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
-        request.addParameters(params.asMap());
-        request.setEntity(RequestConverters.createEntity(putIndexTemplateRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
         return request;
     }
 
@@ -552,16 +403,7 @@ final class IndicesRequestConverters {
         return request;
     }
 
-    @Deprecated
-    static Request getTemplatesWithDocumentTypes(GetIndexTemplatesRequest getIndexTemplatesRequest) {
-        return getTemplates(getIndexTemplatesRequest, true);
-    }
-
     static Request getTemplates(GetIndexTemplatesRequest getIndexTemplatesRequest) {
-        return getTemplates(getIndexTemplatesRequest, false);
-    }
-
-    private static Request getTemplates(GetIndexTemplatesRequest getIndexTemplatesRequest, boolean includeTypeName) {
         final String endpoint = new RequestConverters.EndpointBuilder()
             .addPathPartAsIs("_template")
             .addCommaSeparatedPathParts(getIndexTemplatesRequest.names())
@@ -570,9 +412,6 @@ final class IndicesRequestConverters {
         final RequestConverters.Params params = new RequestConverters.Params();
         params.withLocal(getIndexTemplatesRequest.isLocal());
         params.withMasterTimeout(getIndexTemplatesRequest.getMasterNodeTimeout());
-        if (includeTypeName) {
-            params.putParam(INCLUDE_TYPE_NAME_PARAMETER, "true");
-        }
         request.addParameters(params.asMap());
         return request;
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -94,14 +94,9 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.rest.action.admin.indices.RestCreateIndexAction;
-import org.elasticsearch.rest.action.admin.indices.RestGetIndexTemplateAction;
-import org.elasticsearch.rest.action.admin.indices.RestPutIndexTemplateAction;
-import org.elasticsearch.rest.action.admin.indices.RestRolloverIndexAction;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -181,19 +176,6 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         }
     }
 
-    public void testIndicesExistsWithTypes() throws IOException {
-        // Index present
-        String indexName = "test_index_exists_index_present";
-        createIndex(indexName, Settings.EMPTY);
-
-        org.elasticsearch.action.admin.indices.get.GetIndexRequest request
-            = new org.elasticsearch.action.admin.indices.get.GetIndexRequest();
-        request.indices(indexName);
-
-        boolean response = execute(request, highLevelClient().indices()::exists, highLevelClient().indices()::existsAsync);
-        assertTrue(response);
-    }
-
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void testCreateIndex() throws IOException {
         {
@@ -240,70 +222,6 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
 
             Map<String, Object> aliasData =
                     (Map<String, Object>)XContentMapValues.extractValue(indexName + ".aliases.alias_name", getIndexResponse);
-            assertNotNull(aliasData);
-            assertEquals("1", aliasData.get("index_routing"));
-            Map<String, Object> filter = (Map) aliasData.get("filter");
-            Map<String, Object> term = (Map) filter.get("term");
-            assertEquals(2016, term.get("year"));
-
-            assertEquals("text", XContentMapValues.extractValue(indexName + ".mappings.properties.field.type", getIndexResponse));
-        }
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    public void testCreateIndexWithTypes() throws IOException {
-        {
-            // Create index
-            String indexName = "plain_index";
-            assertFalse(indexExists(indexName));
-
-            org.elasticsearch.action.admin.indices.create.CreateIndexRequest createIndexRequest =
-                new org.elasticsearch.action.admin.indices.create.CreateIndexRequest(indexName);
-
-            org.elasticsearch.action.admin.indices.create.CreateIndexResponse createIndexResponse = execute(
-                createIndexRequest,
-                highLevelClient().indices()::create,
-                highLevelClient().indices()::createAsync,
-                expectWarnings(RestCreateIndexAction.TYPES_DEPRECATION_MESSAGE));
-            assertTrue(createIndexResponse.isAcknowledged());
-
-            assertTrue(indexExists(indexName));
-        }
-        {
-            // Create index with mappings, aliases and settings
-            String indexName = "rich_index";
-            assertFalse(indexExists(indexName));
-
-            org.elasticsearch.action.admin.indices.create.CreateIndexRequest createIndexRequest =
-                new org.elasticsearch.action.admin.indices.create.CreateIndexRequest(indexName);
-
-            Alias alias = new Alias("alias_name");
-            alias.filter("{\"term\":{\"year\":2016}}");
-            alias.routing("1");
-            createIndexRequest.alias(alias);
-
-            Settings.Builder settings = Settings.builder();
-            settings.put(SETTING_NUMBER_OF_REPLICAS, 2);
-            createIndexRequest.settings(settings);
-
-            XContentBuilder mappingBuilder = JsonXContent.contentBuilder();
-            mappingBuilder.startObject().startObject("properties").startObject("field");
-            mappingBuilder.field("type", "text");
-            mappingBuilder.endObject().endObject().endObject();
-            createIndexRequest.mapping(MapperService.SINGLE_MAPPING_NAME, mappingBuilder);
-
-            org.elasticsearch.action.admin.indices.create.CreateIndexResponse createIndexResponse = execute(
-                createIndexRequest,
-                highLevelClient().indices()::create,
-                highLevelClient().indices()::createAsync,
-                expectWarnings(RestCreateIndexAction.TYPES_DEPRECATION_MESSAGE));
-            assertTrue(createIndexResponse.isAcknowledged());
-
-            Map<String, Object> getIndexResponse = getAsMap(indexName);
-            assertEquals("2", XContentMapValues.extractValue(indexName + ".settings.index.number_of_replicas", getIndexResponse));
-
-            Map<String, Object> aliasData =
-                (Map<String, Object>)XContentMapValues.extractValue(indexName + ".aliases.alias_name", getIndexResponse);
             assertNotNull(aliasData);
             assertEquals("1", aliasData.get("index_routing"));
             Map<String, Object> filter = (Map) aliasData.get("filter");
@@ -1080,31 +998,6 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         }
     }
 
-    public void testRolloverWithTypes() throws IOException {
-        highLevelClient().indices().create(new CreateIndexRequest("test").alias(new Alias("alias")), RequestOptions.DEFAULT);
-        highLevelClient().index(new IndexRequest("test").id("1").source("field", "value"), RequestOptions.DEFAULT);
-        highLevelClient().index(new IndexRequest("test").id("2").source("field", "value")
-            .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL), RequestOptions.DEFAULT);
-
-        org.elasticsearch.action.admin.indices.rollover.RolloverRequest rolloverRequest =
-            new org.elasticsearch.action.admin.indices.rollover.RolloverRequest("alias", "test_new");
-        rolloverRequest.addMaxIndexDocsCondition(1);
-        rolloverRequest.getCreateIndexRequest().mapping("_doc", "field2", "type=keyword");
-
-        org.elasticsearch.action.admin.indices.rollover.RolloverResponse rolloverResponse = execute(
-            rolloverRequest,
-            highLevelClient().indices()::rollover,
-            highLevelClient().indices()::rolloverAsync,
-            expectWarnings(RestRolloverIndexAction.TYPES_DEPRECATION_MESSAGE)
-        );
-        assertTrue(rolloverResponse.isRolledOver());
-        assertFalse(rolloverResponse.isDryRun());
-        Map<String, Boolean> conditionStatus = rolloverResponse.getConditionStatus();
-        assertTrue(conditionStatus.get("[max_docs: 1]"));
-        assertEquals("test", rolloverResponse.getOldIndex());
-        assertEquals("test_new", rolloverResponse.getNewIndex());
-    }
-
     public void testGetAlias() throws IOException {
         {
             createIndex("index1", Settings.EMPTY);
@@ -1391,36 +1284,6 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    public void testPutTemplateWithTypes() throws Exception {
-        org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest putTemplateRequest =
-            new org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest()
-            .name("my-template")
-            .patterns(Arrays.asList("pattern-1", "name-*"))
-            .order(10)
-            .create(randomBoolean())
-            .settings(Settings.builder().put("number_of_shards", "3").put("number_of_replicas", "0"))
-            .mapping("doc", "host_name", "type=keyword", "description", "type=text")
-            .alias(new Alias("alias-1").indexRouting("abc")).alias(new Alias("{index}-write").searchRouting("xyz"));
-
-        AcknowledgedResponse putTemplateResponse = execute(putTemplateRequest,
-            highLevelClient().indices()::putTemplate, highLevelClient().indices()::putTemplateAsync,
-            expectWarnings(RestPutIndexTemplateAction.TYPES_DEPRECATION_MESSAGE)
-            );
-        assertThat(putTemplateResponse.isAcknowledged(), equalTo(true));
-
-        Map<String, Object> templates = getAsMap("/_template/my-template");
-        assertThat(templates.keySet(), hasSize(1));
-        assertThat(extractValue("my-template.order", templates), equalTo(10));
-        assertThat(extractRawValues("my-template.index_patterns", templates), contains("pattern-1", "name-*"));
-        assertThat(extractValue("my-template.settings.index.number_of_shards", templates), equalTo("3"));
-        assertThat(extractValue("my-template.settings.index.number_of_replicas", templates), equalTo("0"));
-        assertThat(extractValue("my-template.mappings.properties.host_name.type", templates), equalTo("keyword"));
-        assertThat(extractValue("my-template.mappings.properties.description.type", templates), equalTo("text"));
-        assertThat((Map<String, String>) extractValue("my-template.aliases.alias-1", templates), hasEntry("index_routing", "abc"));
-        assertThat((Map<String, String>) extractValue("my-template.aliases.{index}-write", templates), hasEntry("search_routing", "xyz"));
-    }
-
-    @SuppressWarnings("unchecked")
     public void testPutTemplate() throws Exception {
         PutIndexTemplateRequest putTemplateRequest = new PutIndexTemplateRequest("my-template", List.of("pattern-1", "name-*"))
             .order(10)
@@ -1467,43 +1330,6 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
                         highLevelClient().indices()::putTemplate, highLevelClient().indices()::putTemplateAsync));
         assertThat(badMappingError.getDetailedMessage(),
                 containsString("Root mapping definition has unsupported parameters:  [my_doc_type"));
-    }
-
-    @SuppressWarnings("unchecked")
-    public void testPutTemplateWithNoTypesUsingTypedApi() throws Exception {
-        org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest putTemplateRequest =
-            new org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest()
-            .name("my-template")
-            .patterns(Arrays.asList("pattern-1", "name-*"))
-            .order(10)
-            .create(randomBoolean())
-            .settings(Settings.builder().put("number_of_shards", "3").put("number_of_replicas", "0"))
-            .mapping("my_doc_type",
-                    // Note that the declared type is missing from the mapping
-                    "{ "
-                    + "\"properties\":{"
-                    + "\"host_name\": {\"type\":\"keyword\"},"
-                    + "\"description\": {\"type\":\"text\"}"
-                    + "}"
-                    + "}", XContentType.JSON)
-            .alias(new Alias("alias-1").indexRouting("abc")).alias(new Alias("{index}-write").searchRouting("xyz"));
-
-        AcknowledgedResponse putTemplateResponse = execute(putTemplateRequest,
-            highLevelClient().indices()::putTemplate, highLevelClient().indices()::putTemplateAsync,
-            expectWarnings(RestPutIndexTemplateAction.TYPES_DEPRECATION_MESSAGE)
-            );
-        assertThat(putTemplateResponse.isAcknowledged(), equalTo(true));
-
-        Map<String, Object> templates = getAsMap("/_template/my-template");
-        assertThat(templates.keySet(), hasSize(1));
-        assertThat(extractValue("my-template.order", templates), equalTo(10));
-        assertThat(extractRawValues("my-template.index_patterns", templates), contains("pattern-1", "name-*"));
-        assertThat(extractValue("my-template.settings.index.number_of_shards", templates), equalTo("3"));
-        assertThat(extractValue("my-template.settings.index.number_of_replicas", templates), equalTo("0"));
-        assertThat(extractValue("my-template.mappings.properties.host_name.type", templates), equalTo("keyword"));
-        assertThat(extractValue("my-template.mappings.properties.description.type", templates), equalTo("text"));
-        assertThat((Map<String, String>) extractValue("my-template.aliases.alias-1", templates), hasEntry("index_routing", "abc"));
-        assertThat((Map<String, String>) extractValue("my-template.aliases.{index}-write", templates), hasEntry("search_routing", "xyz"));
     }
 
     public void testPutTemplateBadRequests() throws Exception {
@@ -1566,93 +1392,6 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
             highLevelClient().indices()::validateQueryAsync);
         assertFalse(response.isValid());
     }
-
-    // Tests the deprecated form of the API that returns templates with doc types (using the server-side's GetIndexTemplateResponse)
-    public void testCRUDIndexTemplateWithTypes() throws Exception {
-        RestHighLevelClient client = highLevelClient();
-
-        org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest putTemplate1 =
-            new org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest().name("template-1")
-            .patterns(Arrays.asList("pattern-1", "name-1")).alias(new Alias("alias-1"));
-        assertThat(execute(putTemplate1, client.indices()::putTemplate, client.indices()::putTemplateAsync
-                , expectWarnings(RestPutIndexTemplateAction.TYPES_DEPRECATION_MESSAGE))
-            .isAcknowledged(), equalTo(true));
-        org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest putTemplate2 =
-            new org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest().name("template-2")
-            .patterns(Arrays.asList("pattern-2", "name-2"))
-            .mapping("custom_doc_type", "name", "type=text")
-            .settings(Settings.builder().put("number_of_shards", "2").put("number_of_replicas", "0"));
-        assertThat(execute(putTemplate2, client.indices()::putTemplate, client.indices()::putTemplateAsync,
-                expectWarnings(RestPutIndexTemplateAction.TYPES_DEPRECATION_MESSAGE))
-                .isAcknowledged(), equalTo(true));
-
-        org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse getTemplate1 = execute(
-                new GetIndexTemplatesRequest("template-1"),
-                client.indices()::getTemplate, client.indices()::getTemplateAsync,
-                expectWarnings(RestGetIndexTemplateAction.TYPES_DEPRECATION_MESSAGE));
-        assertThat(getTemplate1.getIndexTemplates(), hasSize(1));
-        org.elasticsearch.cluster.metadata.IndexTemplateMetaData template1 = getTemplate1.getIndexTemplates().get(0);
-        assertThat(template1.name(), equalTo("template-1"));
-        assertThat(template1.patterns(), contains("pattern-1", "name-1"));
-        assertTrue(template1.aliases().containsKey("alias-1"));
-
-        //Check the typed version of the call
-        org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse getTemplate2 =
-            execute(new GetIndexTemplatesRequest("template-2"),
-                client.indices()::getTemplate, client.indices()::getTemplateAsync,
-                expectWarnings(RestGetIndexTemplateAction.TYPES_DEPRECATION_MESSAGE));
-        assertThat(getTemplate2.getIndexTemplates(), hasSize(1));
-        org.elasticsearch.cluster.metadata.IndexTemplateMetaData template2 = getTemplate2.getIndexTemplates().get(0);
-        assertThat(template2.name(), equalTo("template-2"));
-        assertThat(template2.patterns(), contains("pattern-2", "name-2"));
-        assertTrue(template2.aliases().isEmpty());
-        assertThat(template2.settings().get("index.number_of_shards"), equalTo("2"));
-        assertThat(template2.settings().get("index.number_of_replicas"), equalTo("0"));
-        // Ugly deprecated form of API requires use of doc type to get at mapping object which is CompressedXContent
-        assertTrue(template2.mappings().containsKey("custom_doc_type"));
-
-        List<String> names = randomBoolean()
-            ? Arrays.asList("*plate-1", "template-2")
-            : Arrays.asList("template-*");
-        GetIndexTemplatesRequest getBothRequest = new GetIndexTemplatesRequest(names);
-        org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse getBoth = execute(
-                getBothRequest, client.indices()::getTemplate, client.indices()::getTemplateAsync,
-                expectWarnings(RestGetIndexTemplateAction.TYPES_DEPRECATION_MESSAGE));
-        assertThat(getBoth.getIndexTemplates(), hasSize(2));
-        assertThat(getBoth.getIndexTemplates().stream().map(org.elasticsearch.cluster.metadata.IndexTemplateMetaData::getName).toArray(),
-            arrayContainingInAnyOrder("template-1", "template-2"));
-
-        GetIndexTemplatesRequest getAllRequest = new GetIndexTemplatesRequest();
-        org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse getAll = execute(
-                getAllRequest, client.indices()::getTemplate, client.indices()::getTemplateAsync,
-                expectWarnings(RestGetIndexTemplateAction.TYPES_DEPRECATION_MESSAGE));
-        assertThat(getAll.getIndexTemplates().size(), greaterThanOrEqualTo(2));
-        assertThat(getAll.getIndexTemplates().stream().map(org.elasticsearch.cluster.metadata.IndexTemplateMetaData::getName)
-                .collect(Collectors.toList()),
-            hasItems("template-1", "template-2"));
-
-        assertTrue(execute(new DeleteIndexTemplateRequest("template-1"),
-            client.indices()::deleteTemplate, client.indices()::deleteTemplateAsync).isAcknowledged());
-        assertThat(expectThrows(ElasticsearchException.class, () -> execute(new GetIndexTemplatesRequest("template-1"),
-            client.indices()::getTemplate, client.indices()::getTemplateAsync)).status(), equalTo(RestStatus.NOT_FOUND));
-        assertThat(expectThrows(ElasticsearchException.class, () -> execute(new DeleteIndexTemplateRequest("template-1"),
-            client.indices()::deleteTemplate, client.indices()::deleteTemplateAsync)).status(), equalTo(RestStatus.NOT_FOUND));
-
-        assertThat(execute(new GetIndexTemplatesRequest("template-*"),
-            client.indices()::getTemplate, client.indices()::getTemplateAsync,
-              expectWarnings(RestGetIndexTemplateAction.TYPES_DEPRECATION_MESSAGE)).getIndexTemplates(), hasSize(1));
-        assertThat(execute(new GetIndexTemplatesRequest("template-*"),
-            client.indices()::getTemplate, client.indices()::getTemplateAsync,
-              expectWarnings(RestGetIndexTemplateAction.TYPES_DEPRECATION_MESSAGE)).getIndexTemplates()
-                .get(0).name(), equalTo("template-2"));
-
-        assertTrue(execute(new DeleteIndexTemplateRequest("template-*"),
-            client.indices()::deleteTemplate, client.indices()::deleteTemplateAsync).isAcknowledged());
-        assertThat(expectThrows(ElasticsearchException.class, () -> execute(new GetIndexTemplatesRequest("template-*"),
-            client.indices()::getTemplate, client.indices()::getTemplateAsync,
-              expectWarnings(RestGetIndexTemplateAction.TYPES_DEPRECATION_MESSAGE))).status(), equalTo(RestStatus.NOT_FOUND));
-    }
-
 
     public void testCRUDIndexTemplate() throws Exception {
         RestHighLevelClient client = highLevelClient();

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
@@ -80,7 +80,6 @@ import static org.elasticsearch.client.indices.RandomCreateIndexGenerator.random
 import static org.elasticsearch.client.indices.RandomCreateIndexGenerator.randomMapping;
 import static org.elasticsearch.index.RandomCreateIndexGenerator.randomIndexSettings;
 import static org.elasticsearch.index.alias.RandomAliasActionsGenerator.randomAliasAction;
-import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -124,34 +123,6 @@ public class IndicesRequestConvertersTests extends ESTestCase {
             -> IndicesRequestConverters.indicesExist(new GetIndexRequest((String[]) null)));
     }
 
-    public void testIndicesExistEmptyIndicesWithTypes() {
-        LuceneTestCase.expectThrows(IllegalArgumentException.class,
-                () -> IndicesRequestConverters.indicesExist(new org.elasticsearch.action.admin.indices.get.GetIndexRequest()));
-        LuceneTestCase.expectThrows(IllegalArgumentException.class, () -> IndicesRequestConverters
-                .indicesExist(new org.elasticsearch.action.admin.indices.get.GetIndexRequest().indices((String[]) null)));
-    }
-
-    public void testIndicesExistWithTypes() {
-        String[] indices = RequestConvertersTests.randomIndicesNames(1, 10);
-
-        org.elasticsearch.action.admin.indices.get.GetIndexRequest getIndexRequest =
-                new org.elasticsearch.action.admin.indices.get.GetIndexRequest().indices(indices);
-
-        Map<String, String> expectedParams = new HashMap<>();
-        RequestConvertersTests.setRandomIndicesOptions(getIndexRequest::indicesOptions, getIndexRequest::indicesOptions, expectedParams);
-        RequestConvertersTests.setRandomLocal(getIndexRequest::local, expectedParams);
-        RequestConvertersTests.setRandomHumanReadable(getIndexRequest::humanReadable, expectedParams);
-        RequestConvertersTests.setRandomIncludeDefaults(getIndexRequest::includeDefaults, expectedParams);
-        expectedParams.put(INCLUDE_TYPE_NAME_PARAMETER, "true");
-
-        final Request request = IndicesRequestConverters.indicesExist(getIndexRequest);
-
-        Assert.assertEquals(HttpHead.METHOD_NAME, request.getMethod());
-        Assert.assertEquals("/" + String.join(",", indices), request.getEndpoint());
-        Assert.assertThat(expectedParams, equalTo(request.getParameters()));
-        Assert.assertNull(request.getEntity());
-    }
-
     public void testCreateIndex() throws IOException {
         CreateIndexRequest createIndexRequest = RandomCreateIndexGenerator.randomCreateIndexRequest();
 
@@ -159,23 +130,6 @@ public class IndicesRequestConvertersTests extends ESTestCase {
         RequestConvertersTests.setRandomTimeout(createIndexRequest, AcknowledgedRequest.DEFAULT_ACK_TIMEOUT, expectedParams);
         RequestConvertersTests.setRandomMasterTimeout(createIndexRequest, expectedParams);
         RequestConvertersTests.setRandomWaitForActiveShards(createIndexRequest::waitForActiveShards, expectedParams);
-
-        Request request = IndicesRequestConverters.createIndex(createIndexRequest);
-        Assert.assertEquals("/" + createIndexRequest.index(), request.getEndpoint());
-        Assert.assertEquals(expectedParams, request.getParameters());
-        Assert.assertEquals(HttpPut.METHOD_NAME, request.getMethod());
-        RequestConvertersTests.assertToXContentBody(createIndexRequest, request.getEntity());
-    }
-
-    public void testCreateIndexWithTypes() throws IOException {
-        org.elasticsearch.action.admin.indices.create.CreateIndexRequest createIndexRequest =
-            org.elasticsearch.index.RandomCreateIndexGenerator.randomCreateIndexRequest();
-
-        Map<String, String> expectedParams = new HashMap<>();
-        RequestConvertersTests.setRandomTimeout(createIndexRequest::timeout, AcknowledgedRequest.DEFAULT_ACK_TIMEOUT, expectedParams);
-        RequestConvertersTests.setRandomMasterTimeout(createIndexRequest, expectedParams);
-        RequestConvertersTests.setRandomWaitForActiveShards(createIndexRequest::waitForActiveShards, expectedParams);
-        expectedParams.put(INCLUDE_TYPE_NAME_PARAMETER, "true");
 
         Request request = IndicesRequestConverters.createIndex(createIndexRequest);
         Assert.assertEquals("/" + createIndexRequest.index(), request.getEndpoint());
@@ -222,37 +176,6 @@ public class IndicesRequestConvertersTests extends ESTestCase {
         endpoint.add("_mapping");
 
         Assert.assertEquals(endpoint.toString(), request.getEndpoint());
-        Assert.assertEquals(expectedParams, request.getParameters());
-        Assert.assertEquals(HttpPut.METHOD_NAME, request.getMethod());
-        RequestConvertersTests.assertToXContentBody(putMappingRequest, request.getEntity());
-    }
-
-    public void testPutMappingWithTypes() throws IOException {
-        org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest putMappingRequest =
-            new org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest();
-
-        String[] indices = RequestConvertersTests.randomIndicesNames(0, 5);
-        putMappingRequest.indices(indices);
-
-        String type = ESTestCase.randomAlphaOfLengthBetween(3, 10);
-        putMappingRequest.type(type);
-
-        Map<String, String> expectedParams = new HashMap<>();
-
-        RequestConvertersTests.setRandomTimeout(putMappingRequest::timeout, AcknowledgedRequest.DEFAULT_ACK_TIMEOUT, expectedParams);
-        RequestConvertersTests.setRandomMasterTimeout(putMappingRequest, expectedParams);
-        expectedParams.put(INCLUDE_TYPE_NAME_PARAMETER, "true");
-
-        Request request = IndicesRequestConverters.putMapping(putMappingRequest);
-        StringJoiner endpoint = new StringJoiner("/", "/", "");
-        String index = String.join(",", indices);
-        if (Strings.hasLength(index)) {
-            endpoint.add(index);
-        }
-        endpoint.add("_mapping");
-        endpoint.add(type);
-        Assert.assertEquals(endpoint.toString(), request.getEndpoint());
-
         Assert.assertEquals(expectedParams, request.getParameters());
         Assert.assertEquals(HttpPut.METHOD_NAME, request.getMethod());
         RequestConvertersTests.assertToXContentBody(putMappingRequest, request.getEntity());
@@ -327,64 +250,6 @@ public class IndicesRequestConvertersTests extends ESTestCase {
             endpoint.add(String.join(",", fields));
         }
         Assert.assertThat(endpoint.toString(), equalTo(request.getEndpoint()));
-        Assert.assertThat(expectedParams, equalTo(request.getParameters()));
-        Assert.assertThat(HttpGet.METHOD_NAME, equalTo(request.getMethod()));
-    }
-
-    public void testGetFieldMappingWithTypes() {
-        org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsRequest getFieldMappingsRequest =
-            new org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsRequest();
-
-        String[] indices = Strings.EMPTY_ARRAY;
-        if (randomBoolean()) {
-            indices = RequestConvertersTests.randomIndicesNames(0, 5);
-            getFieldMappingsRequest.indices(indices);
-        } else if (randomBoolean()) {
-            getFieldMappingsRequest.indices((String[]) null);
-        }
-
-        String type = null;
-        if (randomBoolean()) {
-            type = randomAlphaOfLengthBetween(3, 10);
-            getFieldMappingsRequest.types(type);
-        } else if (randomBoolean()) {
-            getFieldMappingsRequest.types((String[]) null);
-        }
-
-        String[] fields = null;
-        if (randomBoolean()) {
-            fields = new String[randomIntBetween(1, 5)];
-            for (int i = 0; i < fields.length; i++) {
-                fields[i] = randomAlphaOfLengthBetween(3, 10);
-            }
-            getFieldMappingsRequest.fields(fields);
-        } else if (randomBoolean()) {
-            getFieldMappingsRequest.fields((String[]) null);
-        }
-
-        Map<String, String> expectedParams = new HashMap<>();
-
-        RequestConvertersTests.setRandomIndicesOptions(getFieldMappingsRequest::indicesOptions, getFieldMappingsRequest::indicesOptions,
-            expectedParams);
-        RequestConvertersTests.setRandomLocal(getFieldMappingsRequest::local, expectedParams);
-        expectedParams.put(INCLUDE_TYPE_NAME_PARAMETER, "true");
-
-        Request request = IndicesRequestConverters.getFieldMapping(getFieldMappingsRequest);
-        StringJoiner endpoint = new StringJoiner("/", "/", "");
-        String index = String.join(",", indices);
-        if (Strings.hasLength(index)) {
-            endpoint.add(index);
-        }
-        endpoint.add("_mapping");
-        if (type != null) {
-            endpoint.add(type);
-        }
-        endpoint.add("field");
-        if (fields != null) {
-            endpoint.add(String.join(",", fields));
-        }
-        Assert.assertThat(endpoint.toString(), equalTo(request.getEndpoint()));
-
         Assert.assertThat(expectedParams, equalTo(request.getParameters()));
         Assert.assertThat(HttpGet.METHOD_NAME, equalTo(request.getMethod()));
     }
@@ -465,41 +330,6 @@ public class IndicesRequestConvertersTests extends ESTestCase {
         RequestConvertersTests.setRandomIndicesOptions(getIndexRequest::indicesOptions, getIndexRequest::indicesOptions, expectedParams);
         RequestConvertersTests.setRandomLocal(getIndexRequest::local, expectedParams);
         RequestConvertersTests.setRandomHumanReadable(getIndexRequest::humanReadable, expectedParams);
-
-        if (ESTestCase.randomBoolean()) {
-            // the request object will not have include_defaults present unless it is set to
-            // true
-            getIndexRequest.includeDefaults(ESTestCase.randomBoolean());
-            if (getIndexRequest.includeDefaults()) {
-                expectedParams.put("include_defaults", Boolean.toString(true));
-            }
-        }
-
-        StringJoiner endpoint = new StringJoiner("/", "/", "");
-        if (indicesUnderTest != null && indicesUnderTest.length > 0) {
-            endpoint.add(String.join(",", indicesUnderTest));
-        }
-
-        Request request = IndicesRequestConverters.getIndex(getIndexRequest);
-
-        Assert.assertThat(endpoint.toString(), equalTo(request.getEndpoint()));
-        Assert.assertThat(request.getParameters(), equalTo(expectedParams));
-        Assert.assertThat(request.getMethod(), equalTo(HttpGet.METHOD_NAME));
-        Assert.assertThat(request.getEntity(), nullValue());
-    }
-
-    public void testGetIndexWithTypes() throws IOException {
-        String[] indicesUnderTest = ESTestCase.randomBoolean() ? null : RequestConvertersTests.randomIndicesNames(0, 5);
-
-        org.elasticsearch.action.admin.indices.get.GetIndexRequest getIndexRequest =
-                new org.elasticsearch.action.admin.indices.get.GetIndexRequest().indices(indicesUnderTest);
-
-        Map<String, String> expectedParams = new HashMap<>();
-        RequestConvertersTests.setRandomMasterTimeout(getIndexRequest, expectedParams);
-        RequestConvertersTests.setRandomIndicesOptions(getIndexRequest::indicesOptions, getIndexRequest::indicesOptions, expectedParams);
-        RequestConvertersTests.setRandomLocal(getIndexRequest::local, expectedParams);
-        RequestConvertersTests.setRandomHumanReadable(getIndexRequest::humanReadable, expectedParams);
-        expectedParams.put(INCLUDE_TYPE_NAME_PARAMETER, "true");
 
         if (ESTestCase.randomBoolean()) {
             // the request object will not have include_defaults present unless it is set to
@@ -889,49 +719,6 @@ public class IndicesRequestConvertersTests extends ESTestCase {
         Assert.assertEquals(expectedParams, request.getParameters());
     }
 
-    public void testRolloverWithTypes() throws IOException {
-        org.elasticsearch.action.admin.indices.rollover.RolloverRequest rolloverRequest =
-            new  org.elasticsearch.action.admin.indices.rollover.RolloverRequest(ESTestCase.randomAlphaOfLengthBetween(3, 10),
-            ESTestCase.randomBoolean() ? null : ESTestCase.randomAlphaOfLengthBetween(3, 10));
-        Map<String, String> expectedParams = new HashMap<>();
-        RequestConvertersTests.setRandomTimeout(rolloverRequest::timeout, rolloverRequest.timeout(), expectedParams);
-        RequestConvertersTests.setRandomMasterTimeout(rolloverRequest, expectedParams);
-        if (ESTestCase.randomBoolean()) {
-            rolloverRequest.dryRun(ESTestCase.randomBoolean());
-            if (rolloverRequest.isDryRun()) {
-                expectedParams.put("dry_run", "true");
-            }
-        }
-        expectedParams.put(INCLUDE_TYPE_NAME_PARAMETER, "true");
-        if (ESTestCase.randomBoolean()) {
-            rolloverRequest.addMaxIndexAgeCondition(new TimeValue(ESTestCase.randomNonNegativeLong()));
-        }
-        if (ESTestCase.randomBoolean()) {
-            String type = ESTestCase.randomAlphaOfLengthBetween(3, 10);
-            rolloverRequest.getCreateIndexRequest().mapping(type,
-                org.elasticsearch.index.RandomCreateIndexGenerator.randomMapping(type));
-        }
-        if (ESTestCase.randomBoolean()) {
-            org.elasticsearch.index.RandomCreateIndexGenerator.randomAliases(rolloverRequest.getCreateIndexRequest());
-        }
-        if (ESTestCase.randomBoolean()) {
-            rolloverRequest.getCreateIndexRequest().settings(
-                org.elasticsearch.index.RandomCreateIndexGenerator.randomIndexSettings());
-        }
-        RequestConvertersTests.setRandomWaitForActiveShards(rolloverRequest.getCreateIndexRequest()::waitForActiveShards, expectedParams);
-
-        Request request = IndicesRequestConverters.rollover(rolloverRequest);
-        if (rolloverRequest.getNewIndexName() == null) {
-            Assert.assertEquals("/" + rolloverRequest.getAlias() + "/_rollover", request.getEndpoint());
-        } else {
-            Assert.assertEquals("/" + rolloverRequest.getAlias() + "/_rollover/" + rolloverRequest.getNewIndexName(),
-                request.getEndpoint());
-        }
-        Assert.assertEquals(HttpPost.METHOD_NAME, request.getMethod());
-        RequestConvertersTests.assertToXContentBody(rolloverRequest, request.getEntity());
-        Assert.assertEquals(expectedParams, request.getParameters());
-    }
-
     public void testGetAlias() {
         GetAliasesRequest getAliasesRequest = new GetAliasesRequest();
 
@@ -988,52 +775,6 @@ public class IndicesRequestConvertersTests extends ESTestCase {
         Assert.assertEquals(HttpPut.METHOD_NAME, request.getMethod());
         RequestConvertersTests.assertToXContentBody(updateSettingsRequest, request.getEntity());
         Assert.assertEquals(expectedParams, request.getParameters());
-    }
-
-    public void testPutTemplateRequestWithTypes() throws Exception {
-        Map<String, String> names = new HashMap<>();
-        names.put("log", "log");
-        names.put("template#1", "template%231");
-        names.put("-#template", "-%23template");
-        names.put("foo^bar", "foo%5Ebar");
-
-        org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest putTemplateRequest =
-                new org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest()
-                .name(ESTestCase.randomFrom(names.keySet()))
-                .patterns(Arrays.asList(ESTestCase.generateRandomStringArray(20, 100, false, false)));
-        if (ESTestCase.randomBoolean()) {
-            putTemplateRequest.order(ESTestCase.randomInt());
-        }
-        if (ESTestCase.randomBoolean()) {
-            putTemplateRequest.version(ESTestCase.randomInt());
-        }
-        if (ESTestCase.randomBoolean()) {
-            putTemplateRequest.settings(Settings.builder().put("setting-" + ESTestCase.randomInt(), ESTestCase.randomTimeValue()));
-        }
-        Map<String, String> expectedParams = new HashMap<>();
-        if (ESTestCase.randomBoolean()) {
-            putTemplateRequest.mapping("doc-" + ESTestCase.randomInt(),
-                "field-" + ESTestCase.randomInt(), "type=" + ESTestCase.randomFrom("text", "keyword"));
-        }
-        expectedParams.put(INCLUDE_TYPE_NAME_PARAMETER, "true");
-        if (ESTestCase.randomBoolean()) {
-            putTemplateRequest.alias(new Alias("alias-" + ESTestCase.randomInt()));
-        }
-        if (ESTestCase.randomBoolean()) {
-            expectedParams.put("create", Boolean.TRUE.toString());
-            putTemplateRequest.create(true);
-        }
-        if (ESTestCase.randomBoolean()) {
-            String cause = ESTestCase.randomUnicodeOfCodepointLengthBetween(1, 50);
-            putTemplateRequest.cause(cause);
-            expectedParams.put("cause", cause);
-        }
-        RequestConvertersTests.setRandomMasterTimeout(putTemplateRequest, expectedParams);
-
-        Request request = IndicesRequestConverters.putTemplate(putTemplateRequest);
-        Assert.assertThat(request.getEndpoint(), equalTo("/_template/" + names.get(putTemplateRequest.name())));
-        Assert.assertThat(request.getParameters(), equalTo(expectedParams));
-        RequestConvertersTests.assertToXContentBody(putTemplateRequest, request.getEntity());
     }
 
     public void testPutTemplateRequest() throws Exception {
@@ -1122,8 +863,7 @@ public class IndicesRequestConvertersTests extends ESTestCase {
         RequestConvertersTests.setRandomMasterTimeout(getTemplatesRequest::setMasterNodeTimeout, expectedParams);
         RequestConvertersTests.setRandomLocal(getTemplatesRequest::setLocal, expectedParams);
 
-        Request request = IndicesRequestConverters.getTemplatesWithDocumentTypes(getTemplatesRequest);
-        expectedParams.put(INCLUDE_TYPE_NAME_PARAMETER, "true");
+        Request request = IndicesRequestConverters.getTemplates(getTemplatesRequest);
         Assert.assertThat(request.getEndpoint(),
             equalTo("/_template/" + names.stream().map(encodes::get).collect(Collectors.joining(","))));
         Assert.assertThat(request.getParameters(), equalTo(expectedParams));


### PR DESCRIPTION
We have a number of deprecated methods on the high-level Rest client's 
`IndicesClient` that take server-side object classes and allow users to pass
the `include_type_name` parameter.  These all have equivalent methods that
use HLRC classes instead, the only difference being the lack of the types
parameter.

This commit removes these deprecated methods.