### PR TITLE
Fix typo in Suggesters search API doc

### DIFF
--- a/docs/reference/search/suggesters/phrase-suggest.asciidoc
+++ b/docs/reference/search/suggesters/phrase-suggest.asciidoc
@@ -106,7 +106,7 @@ POST test/_search
 --------------------------------------------------
 // CONSOLE
 
-The response contains suggestions scored by the most likely spell correction first. In this case we received the expected correction "nobel prize".
+The response contains suggestions scored by the most likely spelling correction first. In this case we received the expected correction "nobel prize".
 
 [source,js]
 --------------------------------------------------


### PR DESCRIPTION
Corrects typo:

"spell" -> "spelling"
