### PR TITLE
Wrap ResponseException in AssertionError in ILM/CCR tests

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ilm/CCRIndexLifecycleIT.java
+++ b/x-pack/plugin/ilm/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ilm/CCRIndexLifecycleIT.java
@@ -747,16 +747,24 @@ public class CCRIndexLifecycleIT extends ESCCRRestTestCase {
     }
 
     private void assertDocumentExists(RestClient client, String index, String id) throws IOException {
-        Request request = new Request("HEAD", "/" + index + "/_doc/" + id);
+        Request request = new Request("GET", "/" + index + "/_doc/" + id);
         Response response;
         try {
             response = client.performRequest(request);
             if (response.getStatusLine().getStatusCode() != 200) {
-                logger.error(EntityUtils.toString(response.getEntity()));
+                if (response.getEntity() != null) {
+                    logger.error(EntityUtils.toString(response.getEntity()));
+                } else {
+                    logger.error("response body was null");
+                }
                 fail("HTTP response code expected to be [200] but was [" + response.getStatusLine().getStatusCode() + "]");
             }
         } catch (ResponseException ex) {
-            logger.error(EntityUtils.toString(ex.getResponse().getEntity()), ex);
+            if (ex.getResponse().getEntity() != null) {
+                logger.error(EntityUtils.toString(ex.getResponse().getEntity()), ex);
+            } else {
+                logger.error("response body was null");
+            }
             fail("HTTP response code expected to be [200] but was [" + ex.getResponse().getStatusLine().getStatusCode() + "]");
         }
     }

--- a/x-pack/plugin/ilm/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ilm/CCRIndexLifecycleIT.java
+++ b/x-pack/plugin/ilm/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ilm/CCRIndexLifecycleIT.java
@@ -756,7 +756,7 @@ public class CCRIndexLifecycleIT extends ESCCRRestTestCase {
                 fail("HTTP response code expected to be [200] but was [" + response.getStatusLine().getStatusCode() + "]");
             }
         } catch (ResponseException ex) {
-            logger.error(EntityUtils.toString(ex.getResponse().getEntity()));
+            logger.error(EntityUtils.toString(ex.getResponse().getEntity()), ex);
             fail("HTTP response code expected to be [200] but was [" + ex.getResponse().getStatusLine().getStatusCode() + "]");
         }
     }


### PR DESCRIPTION
When checking for the existence of a document in the ILM/CCR integration
tests, `assertDocumentExists` makes an HTTP request and checks the
response code. However, if the repsonse code is not successful, the call
will throw a `ResponseException`. `assertDocumentExists` is often called
inside an `assertBusy`, and replacing the `ResponseException` with an
`AssertionError` will allow the `assertBusy` to retry.

In particular, this fixes an issue with `testCCRUnfollowDuringSnapshot`
where the index in question may still be closed when the document is
requested.

This should fix https://github.com/elastic/elasticsearch/issues/48461