### PR TITLE
Add owner flag parameter to the rest spec

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_api_key.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_api_key.json
@@ -30,6 +30,11 @@
       "realm_name":{
         "type":"string",
         "description":"realm name of the user who created this API key to be retrieved"
+      },
+      "owner": {
+        "type":"boolean",
+        "default": false,
+        "description":"flag to query API keys owned by the currently authenticated user"
       }
     }
   }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/api_key/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/api_key/10_basic.yml
@@ -176,6 +176,16 @@ teardown:
   - match: { "api_keys.0.invalidated": false }
   - is_true: "api_keys.0.creation"
 
+  - do:
+      headers:
+        Authorization: "Basic YXBpX2tleV91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" # api_key_user
+      security.get_api_key:
+        owner: true
+  - length: { "api_keys" : 1 }
+  - match: { "api_keys.0.username": "api_key_user" }
+  - match: { "api_keys.0.invalidated": false }
+  - is_true: "api_keys.0.creation"
+
 ---
 "Test invalidate api key":
   - skip:


### PR DESCRIPTION
This commit adds missing info about newly added
`owner` flag to the rest spec, also adds a rest test
for the same.

Closes #48499 
