### PR TITLE
Detail the IDEs options for configuring the debug step

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -47,7 +47,9 @@ This will instruct all JVMs (including any that run cli tools such as creating t
 to suspend and initiate a debug connection on port incrementing from `5005`.
 As such the IDE needs to be instructed to listen for connections on this port.
 Since we might run multiple JVMs as part of configuring and starting the cluster it's
-recommended to have the option to aut restart checked.
+recommended to configure the IDE initiate multiple listening attempts. In case of IntelliJ, this option
+is called "Auto restart" and needs to be checked. In case of Eclipse, "Connection limit" setting
+needs to be configured with a greater value (ie 10 or more).
 
 ==== Distribution
 

--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -47,7 +47,7 @@ This will instruct all JVMs (including any that run cli tools such as creating t
 to suspend and initiate a debug connection on port incrementing from `5005`.
 As such the IDE needs to be instructed to listen for connections on this port.
 Since we might run multiple JVMs as part of configuring and starting the cluster it's
-recommended to configure the IDE initiate multiple listening attempts. In case of IntelliJ, this option
+recommended to configure the IDE to initiate multiple listening attempts. In case of IntelliJ, this option
 is called "Auto restart" and needs to be checked. In case of Eclipse, "Connection limit" setting
 needs to be configured with a greater value (ie 10 or more).
 


### PR DESCRIPTION
Add more information on how to configure each IDE (Eclipse/IntelliJ) to listen for debug connection in case of `--debug-jvm` setting.