### PR TITLE
Map missing error code to its Azure equivalent in Azure repository tests

### DIFF
--- a/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/TestUtils.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/TestUtils.java
@@ -67,8 +67,10 @@ final class TestUtils {
                 return StorageErrorCodeStrings.BLOB_NOT_FOUND;
             case INTERNAL_SERVER_ERROR:
                 return StorageErrorCodeStrings.INTERNAL_ERROR;
+            case SERVICE_UNAVAILABLE:
+                return StorageErrorCodeStrings.SERVER_BUSY;
             default:
-                return null;
+                throw new IllegalArgumentException("Error code [" + status.getStatus() + "] is not mapped to an existing Azure code");
         }
     }
 }


### PR DESCRIPTION
In #47176 we changed the internal HTTP server that emulates the Azure Storage service so that it includes a response body for injected errors. This fixed most of the issues reported in #47120 but sadly I missed to map one error to its Azure equivalent, and it triggered some CI failures today.

This is fixed by this PR.

Closes #47120