### PR TITLE
Increase timeouts for packaging tests

### DIFF
--- a/qa/os/bats/default/bootstrap_password.bash
+++ b/qa/os/bats/default/bootstrap_password.bash
@@ -81,6 +81,8 @@ NODE_SETTINGS
     password=$(cat /tmp/bootstrap.password)
     clusterHealth=$(sudo curl -u "elastic:$password" -H "Content-Type: application/json" \
 	                          -XGET "http://127.0.0.1:9200/_cluster/health?wait_for_status=green&timeout=180s")
+    echo "$clusterHealth" | grep '"status":"green"' || {
+        echo "Expected cluster health to be green but got:"
         echo "$clusterHealth"
         false
     }

--- a/qa/os/bats/default/bootstrap_password.bash
+++ b/qa/os/bats/default/bootstrap_password.bash
@@ -80,9 +80,7 @@ NODE_SETTINGS
 
     password=$(cat /tmp/bootstrap.password)
     clusterHealth=$(sudo curl -u "elastic:$password" -H "Content-Type: application/json" \
-	                          -XGET "http://127.0.0.1:9200/_cluster/health?wait_for_status=green&timeout=30s")
-    echo "$clusterHealth" | grep '"status":"green"' || {
-        echo "Expected cluster health to be green but got:"
+	                          -XGET "http://127.0.0.1:9200/_cluster/health?wait_for_status=green&timeout=180s")
         echo "$clusterHealth"
         false
     }

--- a/qa/os/bats/utils/utils.bash
+++ b/qa/os/bats/utils/utils.bash
@@ -349,7 +349,7 @@ run_elasticsearch_service() {
         if [ "$expectedStatus" = 0 ]; then
             background="-d"
         else
-            timeoutCommand="timeout 60s "
+            timeoutCommand="timeout 180s "
         fi
         # su and the Elasticsearch init script work together to break bats.
         # sudo isolates bats enough from the init script so everything continues
@@ -476,10 +476,10 @@ wait_for_elasticsearch_status() {
 
     if [ -z "index" ]; then
       echo "Tring to connect to elasticsearch and wait for expected status $desiredStatus..."
-      curl -sS "http://localhost:9200/_cluster/health?wait_for_status=$desiredStatus&timeout=60s&pretty"
+      curl -sS "http://localhost:9200/_cluster/health?wait_for_status=$desiredStatus&timeout=180s&pretty"
     else
       echo "Trying to connect to elasticsearch and wait for expected status $desiredStatus for index $index"
-      curl -sS "http://localhost:9200/_cluster/health/$index?wait_for_status=$desiredStatus&timeout=60s&pretty"
+      curl -sS "http://localhost:9200/_cluster/health/$index?wait_for_status=$desiredStatus&timeout=180s&pretty"
     fi
     if [ $? -eq 0 ]; then
         echo "Connected"

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/ServerUtils.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/ServerUtils.java
@@ -37,8 +37,9 @@ public class ServerUtils {
 
     protected static final Logger logger =  LogManager.getLogger(ServerUtils.class);
 
-    private static final long waitTime = TimeUnit.SECONDS.toMillis(60);
-    private static final long timeoutLength = TimeUnit.SECONDS.toMillis(10);
+    // generous timeout  as nested virtualization can be quite slow ...
+    private static final long waitTime = TimeUnit.MINUTES.toMillis(3);
+    private static final long timeoutLength = TimeUnit.SECONDS.toMillis(30);
 
     public static void waitForElasticsearch(Installation installation) throws IOException {
         waitForElasticsearch("green", null, installation);

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/ServerUtils.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/ServerUtils.java
@@ -38,8 +38,12 @@ public class ServerUtils {
     protected static final Logger logger =  LogManager.getLogger(ServerUtils.class);
 
     // generous timeout  as nested virtualization can be quite slow ...
-    private static final long waitTime = TimeUnit.MINUTES.toMillis(3);
-    private static final long timeoutLength = TimeUnit.SECONDS.toMillis(30);
+    private static final long waitTime = TimeUnit.MINUTES.toMillis(
+        System.getProperty("tests.inVM") == null ? 3 : 1
+    );
+    private static final long timeoutLength = TimeUnit.SECONDS.toMillis(
+        System.getProperty("tests.inVM") == null ? 30 : 10
+    );
 
     public static void waitForElasticsearch(Installation installation) throws IOException {
         waitForElasticsearch("green", null, installation);


### PR DESCRIPTION
This is in preparation to move to nested virtualization which is much slower
than the bare metal setup we use right now, but parallelizes better
resulting in a net win.t

