### PR TITLE
[DOCS] Fix note format in index suggestion docs

### DIFF
--- a/docs/reference/search/suggesters/completion-suggest.asciidoc
+++ b/docs/reference/search/suggesters/completion-suggest.asciidoc
@@ -99,11 +99,14 @@ The following parameters are supported:
     The input to store, this can be an array of strings or just
     a string. This field is mandatory.
 +
-NOTE: This value cannot contain the following UTF-16 control characters:
+[NOTE]
+====
+This value cannot contain the following UTF-16 control characters:
 
 * `\u0000` (null)
 * `\u001f` (information separator one)
 * `\u001e` (information separator two)
+====
 
 
 `weight`::


### PR DESCRIPTION
#48445 added a note to the `input` parameter definition for index suggestions.

This fixes the formatting for the note so the bulleted list falls within the note.