### PR TITLE
 Reduce allocations when draining HTTP requests bodies in repository tests

### DIFF
--- a/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryTests.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryTests.java
@@ -199,7 +199,7 @@ public class AzureBlobStoreRepositoryTests extends ESMockAPIBasedRepositoryInteg
                     exchange.getResponseBody().write(blob.toBytesRef().bytes, start, length);
 
                 } else if (Regex.simpleMatch("DELETE /container/*", request)) {
-                    Streams.readFully(exchange.getRequestBody());
+                    drainInputStream(exchange.getRequestBody());
                     blobs.entrySet().removeIf(blob -> blob.getKey().startsWith(exchange.getRequestURI().getPath()));
                     exchange.sendResponseHeaders(RestStatus.ACCEPTED.getStatus(), -1);
 
@@ -251,7 +251,7 @@ public class AzureBlobStoreRepositoryTests extends ESMockAPIBasedRepositoryInteg
 
         @Override
         protected void handleAsError(final HttpExchange exchange) throws IOException {
-            Streams.readFully(exchange.getRequestBody());
+            drainInputStream(exchange.getRequestBody());
             TestUtils.sendError(exchange, randomFrom(RestStatus.INTERNAL_SERVER_ERROR, RestStatus.SERVICE_UNAVAILABLE));
             exchange.close();
         }

--- a/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -176,7 +176,7 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
                     StorageOptions options = super.createStorageOptions(clientSettings, httpTransportOptions);
                     return options.toBuilder()
                         .setRetrySettings(RetrySettings.newBuilder()
-                            .setTotalTimeout(Duration.ofSeconds(120L))
+                            .setTotalTimeout(options.getRetrySettings().getTotalTimeout())
                             .setInitialRetryDelay(Duration.ofMillis(10L))
                             .setRetryDelayMultiplier(options.getRetrySettings().getRetryDelayMultiplier())
                             .setMaxRetryDelay(Duration.ofSeconds(1L))

--- a/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -176,7 +176,7 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
                     StorageOptions options = super.createStorageOptions(clientSettings, httpTransportOptions);
                     return options.toBuilder()
                         .setRetrySettings(RetrySettings.newBuilder()
-                            .setTotalTimeout(options.getRetrySettings().getTotalTimeout())
+                            .setTotalTimeout(Duration.ofSeconds(120L))
                             .setInitialRetryDelay(Duration.ofMillis(10L))
                             .setRetryDelayMultiplier(options.getRetrySettings().getRetryDelayMultiplier())
                             .setMaxRetryDelay(Duration.ofSeconds(1L))

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
@@ -194,7 +194,7 @@ public class S3BlobStoreRepositoryTests extends ESMockAPIBasedRepositoryIntegTes
                     }
 
                 } else if (Regex.simpleMatch("POST /bucket/*?uploadId=*", request)) {
-                    Streams.readFully(exchange.getRequestBody());
+                    drainInputStream(exchange.getRequestBody());
                     final Map<String, String> params = new HashMap<>();
                     RestUtils.decodeQueryString(exchange.getRequestURI().getQuery(), 0, params);
                     final String uploadId = params.get("uploadId");


### PR DESCRIPTION
This PR adjusts the total time that a Google Cloud Storage request can take in the GCS repository tests from 50 sec to 120 seconds (see https://gradle-enterprise.elastic.co/s/zz5bstxyoqunk/tests/avmwsupzrdux6-dp22mjd7itzv6 for a test failure).

@original-brownbear I still think that instead of increasing the timeout we should configure an executor service in the HTTP handler, as GCS requests take more time than S3/Azure to be processed (most of them are multipart encoded).