### PR TITLE
Warn when MaxDirectMemorySize or Netty Allocator Type may be incorrect (Windows/JDK8 only issue)

### DIFF
--- a/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/JvmErgonomics.java
+++ b/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/JvmErgonomics.java
@@ -60,6 +60,11 @@ final class JvmErgonomics {
         final long heapSize = extractHeapSize(finalJvmOptions);
         final Map<String, String> systemProperties = extractSystemProperties(userDefinedJvmOptions);
         if (systemProperties.containsKey("io.netty.allocator.type") == false) {
+            if (System.getProperty("os.name").startsWith("Windows") && JavaVersion.majorVersion(JavaVersion.CURRENT) == 8) {
+                Launchers.errPrintln("Warning: with JDK 8 on Windows, Elasticsearch may set io.netty.allocator.type");
+                Launchers.errPrintln("  incorrectly due to a JDK issue (JDK-8074459).");
+                Launchers.errPrintln("  Please use a newer version of Java or set io.netty.allocator.type explicitly");
+            }
             if (heapSize <= 1 << 30) {
                 ergonomicChoices.add("-Dio.netty.allocator.type=unpooled");
             } else {

--- a/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/JvmErgonomics.java
+++ b/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/JvmErgonomics.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.tools.launchers;
 
+import org.elasticsearch.tools.java_version_checker.JavaVersion;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -66,6 +68,11 @@ final class JvmErgonomics {
         }
         final long maxDirectMemorySize = extractMaxDirectMemorySize(finalJvmOptions);
         if (maxDirectMemorySize == 0) {
+            if (System.getProperty("os.name").startsWith("Windows") && JavaVersion.majorVersion(JavaVersion.CURRENT) == 8) {
+                Launchers.errPrintln("Warning: with JDK 8 on Windows, Elasticsearch may miscalculate MaxDirectMemorySize");
+                Launchers.errPrintln("  due to a JDK issue (JDK-8074459).");
+                Launchers.errPrintln("  Please use a newer version of Java or set MaxDirectMemorySize explicitly");
+            }
             ergonomicChoices.add("-XX:MaxDirectMemorySize=" + heapSize / 2);
         }
         return ergonomicChoices;

--- a/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/JvmErgonomicsTests.java
+++ b/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/JvmErgonomicsTests.java
@@ -56,8 +56,8 @@ public class JvmErgonomicsTests extends LaunchersTestCase {
     }
 
     public void testExtractValidHeapSizeNoOptionPresent() throws InterruptedException, IOException {
-        // Muting on Windows, awaitsfix: https://github.com/elastic/elasticsearch/issues/47384
-        assumeFalse(System.getProperty("os.name").startsWith("Windows"));
+        // Muted for jdk8/Windows, see: https://github.com/elastic/elasticsearch/issues/47384
+        assumeFalse(System.getProperty("os.name").startsWith("Windows") && JavaVersion.majorVersion(JavaVersion.CURRENT) == 8);
         assertThat(
                 JvmErgonomics.extractHeapSize(JvmErgonomics.finalJvmOptions(Collections.emptyList())),
                 greaterThan(0L));
@@ -140,6 +140,7 @@ public class JvmErgonomicsTests extends LaunchersTestCase {
     }
 
     public void testMaxDirectMemorySizeChoice() throws InterruptedException, IOException {
+        // Muted for jdk8/Windows, see: https://github.com/elastic/elasticsearch/issues/47384
         assumeFalse(System.getProperty("os.name").startsWith("Windows") && JavaVersion.majorVersion(JavaVersion.CURRENT) == 8);
         final Map<String, String> heapMaxDirectMemorySize = new HashMap<>();
         heapMaxDirectMemorySize.put("64M", Long.toString((64L << 20) / 2));

--- a/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/JvmErgonomicsTests.java
+++ b/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/JvmErgonomicsTests.java
@@ -132,6 +132,7 @@ public class JvmErgonomicsTests extends LaunchersTestCase {
     }
 
     public void testPooledMemoryChoiceOnNotSmallHeap() throws InterruptedException, IOException {
+        // Muted for jdk8/Windows, see: https://github.com/elastic/elasticsearch/issues/47384
         assumeFalse(System.getProperty("os.name").startsWith("Windows") && JavaVersion.majorVersion(JavaVersion.CURRENT) == 8);
         final String largeHeap = randomFrom(Arrays.asList("1025M", "2048M", "2G", "8G"));
         assertThat(


### PR DESCRIPTION
This PR is intended to backport #48365. However, there's one additional change. Since #48310 is not being backported to 7.5, we need to warn about a potentially incorrect `io.netty.allocator.type` as well.