### PR TITLE
fix syntax error

### DIFF
--- a/docs/reference/mapping/fields/id-field.asciidoc
+++ b/docs/reference/mapping/fields/id-field.asciidoc
@@ -16,7 +16,7 @@ PUT my_index/_doc/1
   "text": "Document with ID 1"
 }
 
-PUT my_index/_doc/2&refresh=true
+PUT my_index/_doc/2?refresh=true
 {
   "text": "Document with ID 2"
 }


### PR DESCRIPTION
In order to index a document with id 2, the "&" should be replaced by "?"
