### PR TITLE
Greedily advance safe commit on new global checkpoint

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/CombinedDeletionPolicy.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/CombinedDeletionPolicy.java
@@ -51,6 +51,7 @@ public class CombinedDeletionPolicy extends IndexDeletionPolicy {
     private final LongSupplier globalCheckpointSupplier;
     private final ObjectIntHashMap<IndexCommit> snapshottedCommits; // Number of snapshots held against each commit point.
     private volatile IndexCommit safeCommit; // the most recent safe commit point - its max_seqno at most the persisted global checkpoint.
+    private volatile IndexCommit nextSafeCommit;
     private volatile IndexCommit lastCommit; // the most recent commit point
     private volatile SafeCommitInfo safeCommitInfo = SafeCommitInfo.EMPTY;
 
@@ -83,6 +84,7 @@ public class CombinedDeletionPolicy extends IndexDeletionPolicy {
             this.safeCommitInfo = SafeCommitInfo.EMPTY;
             this.lastCommit = commits.get(commits.size() - 1);
             this.safeCommit = commits.get(keptPosition);
+            this.nextSafeCommit = keptPosition == commits.size() - 1 ? null : commits.get(keptPosition + 1);
             for (int i = 0; i < keptPosition; i++) {
                 if (snapshottedCommits.containsKey(commits.get(i)) == false) {
                     deleteCommit(commits.get(i));
@@ -217,16 +219,12 @@ public class CombinedDeletionPolicy extends IndexDeletionPolicy {
     }
 
     /**
-     * Checks if the deletion policy can release some index commits with the latest global checkpoint.
+     * Checks if the deletion policy can delete some index commits with the latest global checkpoint.
      */
     boolean hasUnreferencedCommits() throws IOException {
-        final IndexCommit lastCommit = this.lastCommit;
-        if (safeCommit != lastCommit) { // Race condition can happen but harmless
-            final long maxSeqNoFromLastCommit = Long.parseLong(lastCommit.getUserData().get(SequenceNumbers.MAX_SEQ_NO));
-            // We can clean up the current safe commit if the last commit is safe
-            return globalCheckpointSupplier.getAsLong() >= maxSeqNoFromLastCommit;
-        }
-        return false;
+        final IndexCommit nextSafeCommit = this.nextSafeCommit;
+        return nextSafeCommit != null
+            && Long.parseLong(nextSafeCommit.getUserData().get(SequenceNumbers.MAX_SEQ_NO)) <= globalCheckpointSupplier.getAsLong();
     }
 
     /**


### PR DESCRIPTION
Today we won't advance the safe commit on a new global checkpoint unless the last commit can become safe. This is not great if we have more than two commits as we can have a new safe commit sooner.

Closes #48532