### PR TITLE
Fix Validity of RepositoryDataTests Randomness

### DIFF
--- a/server/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
@@ -276,7 +276,8 @@ public class RepositoryDataTests extends ESTestCase {
             for (IndexId someIndex : someIndices) {
                 final int shardCount = randomIntBetween(1, 10);
                 for (int j = 0; j < shardCount; ++j) {
-                    builder.put(someIndex, 0, UUIDs.randomBase64UUID(random()));
+                    final String uuid = randomBoolean() ? null : UUIDs.randomBase64UUID(random());
+                    builder.put(someIndex, j, uuid);
                 }
             }
             repositoryData = repositoryData.addSnapshot(snapshotId, randomFrom(SnapshotState.values()), builder.build());


### PR DESCRIPTION
Trivial point, but we were only testing shard generations
for a single shard here, accidentally, and not testing the
`null` generation case at all.

