### PR TITLE
[DOCS] Creates a cluster restart documentation page

### DIFF
--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -78,3 +78,5 @@ include::setup/starting.asciidoc[]
 include::setup/stopping.asciidoc[]
 
 include::setup/add-nodes.asciidoc[]
+
+include::setup/restart-cluster.asciidoc[]

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -34,7 +34,7 @@ include::{docdir}/upgrade/synced-flush.asciidoc[]
 . *Temporarily stop the tasks associated with active {ml} jobs and {dfeeds}.* (Optional)
 +
 --
-{ml-cap} features require platinum license. For more information about Elastic 
+{ml-cap} features require a platinum license or higher. For more information about Elastic 
 license levels, see https://www.elastic.co/subscriptions[the subscription page].
 
 You have two options to handle {ml} jobs and {dfeeds} when you shut down a 

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -15,7 +15,7 @@ time, so the service remains uninterrupted.
 
 // tag::disable_shard_alloc[]
 
-. *Disable shard allocation.*
+1. *Disable shard allocation.*
 +
 --
 include::{docdir}/upgrade/disable-shard-alloc.asciidoc[]
@@ -26,7 +26,7 @@ include::{docdir}/upgrade/disable-shard-alloc.asciidoc[]
 
 // tag::stop_indexing[]
 
-. *Stop indexing and perform a synced flush.*
+2. *Stop indexing and perform a synced flush.*
 +
 --
 Performing a <<indices-synced-flush-api, synced-flush>> speeds up shard
@@ -40,7 +40,7 @@ include::{docdir}/upgrade/synced-flush.asciidoc[]
 
 //tag::stop_ml[]
 
-. *Temporarily stop the tasks associated with active {ml} jobs and {dfeeds}.* (Optional)
+3. *Temporarily stop the tasks associated with active {ml} jobs and {dfeeds}.* (Optional)
 +
 --
 {ml-cap} features require platinum license. For more information about Elastic 
@@ -73,15 +73,15 @@ or jobs with large model states.
 // end::stop_ml[]
 
 
-. *Shut down all nodes.*
+4. *Shut down all nodes.*
 +
 --
 include::{docdir}/upgrade/shut-down-node.asciidoc[]
 --
 
-. *Perform any needed changes.*
+5. *Perform any needed changes.*
 
-. *Restart nodes.*
+6. *Restart nodes.*
 +
 --
 If you have dedicated master nodes, start them first and wait for them to
@@ -104,7 +104,7 @@ The `status` column returned by `_cat/health` shows the health of each node
 in the cluster: `red`, `yellow`, or `green`.
 --
 
-. *Wait for all nodes to join the cluster and report a status of yellow.*
+7. *Wait for all nodes to join the cluster and report a status of yellow.*
 +
 --
 When a node joins the cluster, it begins to recover any primary shards that
@@ -120,7 +120,7 @@ already have local shard copies.
 --
 
 
-. *Re-enable allocation.*
+8. *Re-enable allocation.*
 +
 --
 When all nodes have joined the cluster and recovered their primary shards,
@@ -156,7 +156,7 @@ GET _cat/recovery
 
 // tag::restart_ml[]
 
-. *Restart machine learning jobs.* (Optional)
+9. *Restart machine learning jobs.* (Optional)
 +
 --
 If you temporarily halted the tasks associated with your {ml} jobs, use the 
@@ -196,17 +196,17 @@ cluster.
 --
 
 
-. *Shut down a single node in case of rolling restart.*
+4. *Shut down a single node in case of rolling restart.*
 +
 --
 include::{docdir}/upgrade/shut-down-node.asciidoc[]
 --
 
 
-. *Perform any needed changes.*
+5. *Perform any needed changes.*
  
  
-. *Restart the node you changed.*
+6. *Restart the node you changed.*
 +
 --
 
@@ -221,7 +221,7 @@ GET _cat/nodes
 --
 
 
-. *Reenable shard allocation.*
+7. *Reenable shard allocation.*
 +
 --
 
@@ -241,7 +241,7 @@ PUT _cluster/settings
 
 --
 
-. *Repeat in case of rolling restart.*
+8. *Repeat in case of rolling restart.*
 +
 --
 When the node has recovered and the cluster is stable, repeat these steps

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -91,7 +91,7 @@ GET _cat/nodes
 The `status` column returned by `_cat/health` shows the health of each node
 in the cluster: `red`, `yellow`, or `green`.
 
-If you restarted a singe node, confirm that it joins the cluster by checking the 
+If you restarted a single node, confirm that it joins the cluster by checking the 
 log file or by submitting a `_cat/nodes` request (see above).
 --
 

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -20,7 +20,6 @@ time, so the service remains uninterrupted.
 include::{docdir}/upgrade/disable-shard-alloc.asciidoc[]
 --
 // end::disable_shard_alloc[]
-
 // tag::stop_indexing[]
 . *Stop indexing and perform a synced flush.*
 +
@@ -31,7 +30,6 @@ recovery.
 include::{docdir}/upgrade/synced-flush.asciidoc[]
 --
 // end::stop_indexing[]
-
 //tag::stop_ml[]
 . *Temporarily stop the tasks associated with active {ml} jobs and {dfeeds}.* (Optional)
 +
@@ -143,7 +141,6 @@ GET _cat/health
 GET _cat/recovery
 --------------------------------------------------
 --
-
 // tag::restart_ml[]
 . *Restart machine learning jobs.* (Optional)
 +

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -13,16 +13,19 @@ time, so the service remains uninterrupted.
 [[restart-cluster-full]]
 === Full-cluster restart
 
-tag::disable_shard_alloc[]
+// tag::disable_shard_alloc[]
+
 . *Disable shard allocation.*
 +
 --
 include::{docdir}/upgrade/disable-shard-alloc.asciidoc[]
 --
-end::disable_shard_alloc[]
+
+// end::disable_shard_alloc[]
 
 
-tag::stop_indexing[]
+// tag::stop_indexing[]
+
 . *Stop indexing and perform a synced flush.*
 +
 --
@@ -31,10 +34,12 @@ recovery.
 
 include::{docdir}/upgrade/synced-flush.asciidoc[]
 --
-end::stop_indexing[]
+
+// end::stop_indexing[]
 
 
-tag::stop_ml[]
+//tag::stop_ml[]
+
 . *Temporarily stop the tasks associated with active {ml} jobs and {dfeeds}.* (Optional)
 +
 --
@@ -64,7 +69,8 @@ cluster restart, they use the exact same model. However, saving the latest model
 state takes longer than using upgrade mode, especially if you have a lot of jobs 
 or jobs with large model states.
 --
-end::stop_ml[]
+
+// end::stop_ml[]
 
 
 . *Shut down all nodes.*
@@ -148,7 +154,8 @@ GET _cat/recovery
 --------------------------------------------------
 --
 
-tag::restart_ml[]
+// tag::restart_ml[]
+
 . *Restart machine learning jobs.* (Optional)
 +
 --
@@ -164,7 +171,8 @@ If you closed all {ml} jobs before stopping the nodes, open the jobs and start
 the datafeeds from {kib} or with the <<ml-open-job,open jobs>> and
 <<ml-start-datafeed,start datafeed>> APIs.
 --
-end::restart_ml[]
+
+// end::restart_ml[]
 
 [float]
 [[restart-cluster-rolling]]

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -148,7 +148,7 @@ GET _cat/recovery
 . *Repeat in case of rolling restart.*
 +
 --
-When  the node has recovered and the cluster is stable, repeat these steps
+When the node has recovered and the cluster is stable, repeat these steps
 for each node that needs to be updated.
 --
 

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -2,19 +2,26 @@
 == Full-cluster restart and rolling restart
  
 There may be {ref}/configuring-tls.html#tls-transport[situations where you want 
-to perform a full-cluster restart] or a rolling restart. In the first case, you 
-shut down and restart all the nodes in the cluster while in the second, you shut 
-down only one node at a time, so the service remains uninterrupted. The 
-following description guides you through the process step by step and marks the 
-differences in the two possible methods.
+to perform a full-cluster restart] or a rolling restart. In the case of 
+<<restart-cluster-full,full-cluster restart>>, you shut down and restart all the 
+nodes in the cluster while in the case of 
+<<restart-cluster-rolling,rolling restart>>, you shut down only one node at a 
+time, so the service remains uninterrupted.
 
+
+[[restart-cluster-full]]
+=== Full-cluster restart
+
+tag::disable_shard_alloc[]
 . *Disable shard allocation.*
 +
 --
 include::{docdir}/upgrade/disable-shard-alloc.asciidoc[]
 --
+end::disable_shard_alloc[]
 
 
+tag::stop_indexing[]
 . *Stop indexing and perform a synced flush.*
 +
 --
@@ -23,7 +30,10 @@ recovery.
 
 include::{docdir}/upgrade/synced-flush.asciidoc[]
 --
+end::stop_indexing[]
 
+
+tag::stop_ml[]
 . *Temporarily stop the tasks associated with active {ml} jobs and {dfeeds}.* (Optional)
 +
 --
@@ -52,15 +62,11 @@ saves the model state at the time of closure. When you reopen the jobs after the
 cluster restart, they use the exact same model. However, saving the latest model 
 state takes longer than using upgrade mode, especially if you have a lot of jobs 
 or jobs with large model states.
-
-* If you perform a rolling restart, you can also leave your machine learning 
-jobs running. When you shut down a machine learning node, its jobs automatically 
-move to another node and restore the model states. This option enables your jobs 
-to continue running during the shutdown but it puts increased load on the 
-cluster.
 --
+end::stop_ml[]
 
-. *Shut down all nodes in case of full-cluster restart. Shut down a single node in case of rolling restart.*
+
+. *Shut down all nodes.*
 +
 --
 include::{docdir}/upgrade/shut-down-node.asciidoc[]
@@ -68,7 +74,7 @@ include::{docdir}/upgrade/shut-down-node.asciidoc[]
 
 . *Perform any needed changes.*
 
-. *Restart nodes if you perform full-cluster restart. Restart the node you changed if you perform rolling restart.*
+. *Restart nodes.*
 +
 --
 If you have dedicated master nodes, start them first and wait for them to
@@ -87,12 +93,8 @@ GET _cat/health
 GET _cat/nodes
 --------------------------------------------------
 
-
 The `status` column returned by `_cat/health` shows the health of each node
 in the cluster: `red`, `yellow`, or `green`.
-
-If you restarted a single node, confirm that it joins the cluster by checking the 
-log file or by submitting a `_cat/nodes` request (see above).
 --
 
 . *Wait for all nodes to join the cluster and report a status of yellow.*
@@ -109,6 +111,7 @@ re-enabled allocation. Delaying the allocation of replicas until all nodes
 are `yellow` allows the master to allocate replicas to nodes that
 already have local shard copies.
 --
+
 
 . *Re-enable allocation.*
 +
@@ -127,7 +130,6 @@ PUT _cluster/settings
 }
 ------------------------------------------------------
 
-
 Once allocation is re-enabled, the cluster starts allocating replica shards to
 the data nodes. At this point it is safe to resume indexing and searching,
 but your cluster will recover more quickly if you can wait until all primary
@@ -145,13 +147,7 @@ GET _cat/recovery
 --------------------------------------------------
 --
 
-. *Repeat in case of rolling restart.*
-+
---
-When the node has recovered and the cluster is stable, repeat these steps
-for each node that needs to be updated.
---
-
+tag::restart_ml[]
 . *Restart machine learning jobs.* (Optional)
 +
 --
@@ -167,3 +163,80 @@ If you closed all {ml} jobs before stopping the nodes, open the jobs and start
 the datafeeds from {kib} or with the <<ml-open-job,open jobs>> and
 <<ml-start-datafeed,start datafeed>> APIs.
 --
+end::restart_ml[]
+
+
+[[restart-cluster-rolling]]
+=== Rolling restart
+
+
+include::{docdir}/setup/restart-cluster.asciidoc[tag=disable_shard_alloc]
+
+
+include::{docdir}/setup/restart-cluster.asciidoc[tag=stop_indexing]
+
+
+include::{docdir}/setup/restart-cluster.asciidoc[tag=stop_ml]
++
+--
+* If you perform a rolling restart, you can also leave your machine learning 
+jobs running. When you shut down a machine learning node, its jobs automatically 
+move to another node and restore the model states. This option enables your jobs 
+to continue running during the shutdown but it puts increased load on the 
+cluster.
+--
+
+
+. *Shut down a single node in case of rolling restart.*
++
+--
+include::{docdir}/upgrade/shut-down-node.asciidoc[]
+--
+
+
+. *Perform any needed changes.*
+ 
+ 
+. *Restart the node you changed.*
++
+--
+
+Start the node and confirm that it joins the cluster by checking the log file or 
+by submitting a `_cat/nodes` request:
+
+[source,console]
+--------------------------------------------------
+GET _cat/nodes
+--------------------------------------------------
+
+--
+
+
+. *Reenable shard allocation.*
++
+--
+
+Once the node has joined the cluster, remove the 
+`cluster.routing.allocation.enable` setting to enable shard allocation and start 
+using the node:
+
+[source,console]
+--------------------------------------------------
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster.routing.allocation.enable": null
+  }
+}
+--------------------------------------------------
+
+--
+
+. *Repeat in case of rolling restart.*
++
+--
+When the node has recovered and the cluster is stable, repeat these steps
+for each node that needs to be changed.
+--
+
+include::{docdir}/setup/restart-cluster.asciidoc[tag=restart_ml]

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -1,12 +1,9 @@
 [[restart-cluster]]
-== Full-cluster restart and rolling restart
+== Restart a cluster
  
-There may be {ref}/configuring-tls.html#tls-transport[situations where you want 
-to perform a full-cluster restart] or a rolling restart. In the first case, you 
-shut down and restart all the nodes in the cluster while in the second, you shut 
-down only one node at a time, so the service remains uninterrupted. The 
-following description guides you through the process step by step and marks the 
-differences in the two possible methods.
+There may be situations where you want to perform a full-cluster restart, which 
+means you shut down and restart all the nodes in the cluster. The following 
+description guides you through the process step by step.
 
 . *Disable shard allocation.*
 +
@@ -52,15 +49,9 @@ saves the model state at the time of closure. When you reopen the jobs after the
 cluster restart, they use the exact same model. However, saving the latest model 
 state takes longer than using upgrade mode, especially if you have a lot of jobs 
 or jobs with large model states.
-+
-* If you perform a rolling restart, you can also leave your machine learning 
-jobs running. When you shut down a machine learning node, its jobs automatically 
-move to another node and restore the model states. This option enables your jobs 
-to continue running during the shutdown but it puts increased load on the 
-cluster.
 --
 
-. *Shut down all nodes in case of full-cluster restart. Shut down a single node in case of rolling restart.*
+. *Shut down all nodes.*
 +
 --
 include::{docdir}/upgrade/shut-down-node.asciidoc[]
@@ -68,7 +59,7 @@ include::{docdir}/upgrade/shut-down-node.asciidoc[]
 
 . *Perform any needed changes.*
 
-. *Restart nodes if you perform full-cluster restart. Restart the node you changed if you perform rolling restart.*
+. *Restart nodes.*
 +
 --
 If you have dedicated master nodes, start them first and wait for them to
@@ -90,9 +81,6 @@ GET _cat/nodes
 
 The `status` column returned by `_cat/health` shows the health of each node
 in the cluster: `red`, `yellow`, or `green`.
-
-If you restarted a singe node, confirm that it joins the cluster by checking the 
-log file or by submitting a `_cat/nodes` request (see above).
 --
 
 . *Wait for all nodes to join the cluster and report a status of yellow.*
@@ -143,13 +131,6 @@ GET _cat/health
 
 GET _cat/recovery
 --------------------------------------------------
---
-
-. *Repeat in case of rolling restart.*
-+
---
-When  the node has recovered and the cluster is stable, repeat these steps
-for each node that needs to be updated.
 --
 
 . *Restart machine learning jobs.* (Optional)

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -9,6 +9,7 @@ nodes in the cluster while in the case of
 time, so the service remains uninterrupted.
 
 
+[float]
 [[restart-cluster-full]]
 === Full-cluster restart
 
@@ -165,7 +166,7 @@ the datafeeds from {kib} or with the <<ml-open-job,open jobs>> and
 --
 end::restart_ml[]
 
-
+[float]
 [[restart-cluster-rolling]]
 === Rolling restart
 

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -1,9 +1,12 @@
 [[restart-cluster]]
-== Restart a cluster
+== Full-cluster restart and rolling restart
  
-There may be situations where you want to perform a full-cluster restart, which 
-means you shut down and restart all the nodes in the cluster. The following 
-description guides you through the process step by step.
+There may be {ref}/configuring-tls.html#tls-transport[situations where you want 
+to perform a full-cluster restart] or a rolling restart. In the first case, you 
+shut down and restart all the nodes in the cluster while in the second, you shut 
+down only one node at a time, so the service remains uninterrupted. The 
+following description guides you through the process step by step and marks the 
+differences in the two possible methods.
 
 . *Disable shard allocation.*
 +
@@ -49,9 +52,15 @@ saves the model state at the time of closure. When you reopen the jobs after the
 cluster restart, they use the exact same model. However, saving the latest model 
 state takes longer than using upgrade mode, especially if you have a lot of jobs 
 or jobs with large model states.
+
+* If you perform a rolling restart, you can also leave your machine learning 
+jobs running. When you shut down a machine learning node, its jobs automatically 
+move to another node and restore the model states. This option enables your jobs 
+to continue running during the shutdown but it puts increased load on the 
+cluster.
 --
 
-. *Shut down all nodes.*
+. *Shut down all nodes in case of full-cluster restart. Shut down a single node in case of rolling restart.*
 +
 --
 include::{docdir}/upgrade/shut-down-node.asciidoc[]
@@ -59,7 +68,7 @@ include::{docdir}/upgrade/shut-down-node.asciidoc[]
 
 . *Perform any needed changes.*
 
-. *Restart nodes.*
+. *Restart nodes if you perform full-cluster restart. Restart the node you changed if you perform rolling restart.*
 +
 --
 If you have dedicated master nodes, start them first and wait for them to
@@ -81,6 +90,9 @@ GET _cat/nodes
 
 The `status` column returned by `_cat/health` shows the health of each node
 in the cluster: `red`, `yellow`, or `green`.
+
+If you restarted a singe node, confirm that it joins the cluster by checking the 
+log file or by submitting a `_cat/nodes` request (see above).
 --
 
 . *Wait for all nodes to join the cluster and report a status of yellow.*
@@ -131,6 +143,13 @@ GET _cat/health
 
 GET _cat/recovery
 --------------------------------------------------
+--
+
+. *Repeat in case of rolling restart.*
++
+--
+When  the node has recovered and the cluster is stable, repeat these steps
+for each node that needs to be updated.
 --
 
 . *Restart machine learning jobs.* (Optional)

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -14,19 +14,15 @@ time, so the service remains uninterrupted.
 === Full-cluster restart
 
 // tag::disable_shard_alloc[]
-
-1. *Disable shard allocation.*
+. *Disable shard allocation.*
 +
 --
 include::{docdir}/upgrade/disable-shard-alloc.asciidoc[]
 --
-
 // end::disable_shard_alloc[]
 
-
 // tag::stop_indexing[]
-
-2. *Stop indexing and perform a synced flush.*
+. *Stop indexing and perform a synced flush.*
 +
 --
 Performing a <<indices-synced-flush-api, synced-flush>> speeds up shard
@@ -34,13 +30,10 @@ recovery.
 
 include::{docdir}/upgrade/synced-flush.asciidoc[]
 --
-
 // end::stop_indexing[]
 
-
 //tag::stop_ml[]
-
-3. *Temporarily stop the tasks associated with active {ml} jobs and {dfeeds}.* (Optional)
+. *Temporarily stop the tasks associated with active {ml} jobs and {dfeeds}.* (Optional)
 +
 --
 {ml-cap} features require platinum license. For more information about Elastic 
@@ -69,19 +62,17 @@ cluster restart, they use the exact same model. However, saving the latest model
 state takes longer than using upgrade mode, especially if you have a lot of jobs 
 or jobs with large model states.
 --
-
 // end::stop_ml[]
 
-
-4. *Shut down all nodes.*
+. *Shut down all nodes.*
 +
 --
 include::{docdir}/upgrade/shut-down-node.asciidoc[]
 --
 
-5. *Perform any needed changes.*
+. *Perform any needed changes.*
 
-6. *Restart nodes.*
+. *Restart nodes.*
 +
 --
 If you have dedicated master nodes, start them first and wait for them to
@@ -104,7 +95,7 @@ The `status` column returned by `_cat/health` shows the health of each node
 in the cluster: `red`, `yellow`, or `green`.
 --
 
-7. *Wait for all nodes to join the cluster and report a status of yellow.*
+. *Wait for all nodes to join the cluster and report a status of yellow.*
 +
 --
 When a node joins the cluster, it begins to recover any primary shards that
@@ -119,8 +110,7 @@ are `yellow` allows the master to allocate replicas to nodes that
 already have local shard copies.
 --
 
-
-8. *Re-enable allocation.*
+. *Re-enable allocation.*
 +
 --
 When all nodes have joined the cluster and recovered their primary shards,
@@ -155,8 +145,7 @@ GET _cat/recovery
 --
 
 // tag::restart_ml[]
-
-9. *Restart machine learning jobs.* (Optional)
+. *Restart machine learning jobs.* (Optional)
 +
 --
 If you temporarily halted the tasks associated with your {ml} jobs, use the 
@@ -171,8 +160,8 @@ If you closed all {ml} jobs before stopping the nodes, open the jobs and start
 the datafeeds from {kib} or with the <<ml-open-job,open jobs>> and
 <<ml-start-datafeed,start datafeed>> APIs.
 --
-
 // end::restart_ml[]
+
 
 [float]
 [[restart-cluster-rolling]]
@@ -181,9 +170,7 @@ the datafeeds from {kib} or with the <<ml-open-job,open jobs>> and
 
 include::{docdir}/setup/restart-cluster.asciidoc[tag=disable_shard_alloc]
 
-
 include::{docdir}/setup/restart-cluster.asciidoc[tag=stop_indexing]
-
 
 include::{docdir}/setup/restart-cluster.asciidoc[tag=stop_ml]
 +
@@ -195,21 +182,17 @@ to continue running during the shutdown but it puts increased load on the
 cluster.
 --
 
-
-4. *Shut down a single node in case of rolling restart.*
+. *Shut down a single node in case of rolling restart.*
 +
 --
 include::{docdir}/upgrade/shut-down-node.asciidoc[]
 --
 
-
-5. *Perform any needed changes.*
+. *Perform any needed changes.*
  
- 
-6. *Restart the node you changed.*
+. *Restart the node you changed.*
 +
 --
-
 Start the node and confirm that it joins the cluster by checking the log file or 
 by submitting a `_cat/nodes` request:
 
@@ -217,14 +200,11 @@ by submitting a `_cat/nodes` request:
 --------------------------------------------------
 GET _cat/nodes
 --------------------------------------------------
-
 --
 
-
-7. *Reenable shard allocation.*
+. *Reenable shard allocation.*
 +
 --
-
 Once the node has joined the cluster, remove the 
 `cluster.routing.allocation.enable` setting to enable shard allocation and start 
 using the node:
@@ -238,10 +218,9 @@ PUT _cluster/settings
   }
 }
 --------------------------------------------------
-
 --
 
-8. *Repeat in case of rolling restart.*
+. *Repeat in case of rolling restart.*
 +
 --
 When the node has recovered and the cluster is stable, repeat these steps

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -1,9 +1,12 @@
 [[restart-cluster]]
-== Restart a cluster
+== Full-cluster restart and rolling restart
  
-There may be situations where you want to perform a full-cluster restart, which 
-means you shut down and restart all the nodes in the cluster. The following 
-description guides you through the process step by step.
+There may be {ref}/configuring-tls.html#tls-transport[situations where you want 
+to perform a full-cluster restart] or a rolling restart. In the first case, you 
+shut down and restart all the nodes in the cluster while in the second, you shut 
+down only one node at a time, so the service remains uninterrupted. The 
+following description guides you through the process step by step and marks the 
+differences in the two possible methods.
 
 . *Disable shard allocation.*
 +
@@ -49,9 +52,15 @@ saves the model state at the time of closure. When you reopen the jobs after the
 cluster restart, they use the exact same model. However, saving the latest model 
 state takes longer than using upgrade mode, especially if you have a lot of jobs 
 or jobs with large model states.
++
+* If you perform a rolling restart, you can also leave your machine learning 
+jobs running. When you shut down a machine learning node, its jobs automatically 
+move to another node and restore the model states. This option enables your jobs 
+to continue running during the shutdown but it puts increased load on the 
+cluster.
 --
 
-. *Shut down all nodes.*
+. *Shut down all nodes in case of full-cluster restart. Shut down a single node in case of rolling restart.*
 +
 --
 include::{docdir}/upgrade/shut-down-node.asciidoc[]
@@ -59,7 +68,7 @@ include::{docdir}/upgrade/shut-down-node.asciidoc[]
 
 . *Perform any needed changes.*
 
-. *Restart nodes.*
+. *Restart nodes if you perform full-cluster restart. Restart the node you changed if you perform rolling restart.*
 +
 --
 If you have dedicated master nodes, start them first and wait for them to
@@ -81,6 +90,9 @@ GET _cat/nodes
 
 The `status` column returned by `_cat/health` shows the health of each node
 in the cluster: `red`, `yellow`, or `green`.
+
+If you restarted a singe node, confirm that it joins the cluster by checking the 
+log file or by submitting a `_cat/nodes` request (see above).
 --
 
 . *Wait for all nodes to join the cluster and report a status of yellow.*
@@ -131,6 +143,13 @@ GET _cat/health
 
 GET _cat/recovery
 --------------------------------------------------
+--
+
+. *Repeat in case of rolling restart.*
++
+--
+When  the node has recovered and the cluster is stable, repeat these steps
+for each node that needs to be updated.
 --
 
 . *Restart machine learning jobs.* (Optional)

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -113,7 +113,7 @@ PUT _cluster/settings
 ------------------------------------------------------
 
 
-Once allocation is reenabled, the cluster starts allocating replica shards to
+Once allocation is re-enabled, the cluster starts allocating replica shards to
 the data nodes. At this point it is safe to resume indexing and searching,
 but your cluster will recover more quickly if you can wait until all primary
 and replica shards have been successfully allocated and the status of all nodes

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -65,7 +65,7 @@ You can check progress by looking at the logs.
 
 As soon as enough master-eligible nodes have discovered each other, they form a
 cluster and elect a master. At that point, you can use
-<<cat-health,`_cat/health`>> and <<cat-nodes,`_cat/nodes`>> to monitor nodes
+the <<cat-health, cat health>> and <<cat-nodes,cat nodes>> APIs to monitor nodes
 joining the cluster:
 
 [source,console]

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -24,6 +24,9 @@ include::{docdir}/upgrade/synced-flush.asciidoc[]
 . *Temporarily stop the tasks associated with active {ml} jobs and {dfeeds}.* (Optional)
 +
 --
+{ml-cap} features require platinum license. For more information about Elastic 
+license levels, see https://www.elastic.co/subscriptions[the subscription page].
+
 You have two options to handle {ml} jobs and {dfeeds} when you shut down a 
 cluster:
 
@@ -54,7 +57,7 @@ or jobs with large model states.
 include::{docdir}/upgrade/shut-down-node.asciidoc[]
 --
 
-. *Perform the changes that require to shut down the cluster.*
+. *Perform any needed changes.*
 
 . *Restart nodes.*
 +

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -1,0 +1,148 @@
+[[restart-cluster]]
+== Restarting a cluster
+ 
+There might be situations when you need to perform a full-cluster restart which 
+means you need to shut down and restart all the nodes in the cluster. The 
+following description guides you through the process step by step.
+
+. *Disable shard allocation.*
++
+--
+include::{docdir}/upgrade/disable-shard-alloc.asciidoc[]
+--
+
+
+. *Stop indexing and perform a synced flush.*
++
+--
+Performing a <<indices-synced-flush-api, synced-flush>> speeds up shard
+recovery.
+
+include::{docdir}/upgrade/synced-flush.asciidoc[]
+--
+
+. *Temporarily stop the tasks associated with active {ml} jobs and {dfeeds}.* (Optional)
++
+--
+You have two options to handle {ml} jobs and {dfeeds} when you shut down a 
+cluster:
+
+* Temporarily halt the tasks associated with your {ml} jobs and {dfeeds} and
+prevent new jobs from opening by using the 
+<<ml-set-upgrade-mode,set upgrade mode API>>:
++
+[source,console]
+--------------------------------------------------
+POST _ml/set_upgrade_mode?enabled=true
+--------------------------------------------------
++
+When you disable upgrade mode, the jobs resume using the last model state that 
+was automatically saved. This option avoids the overhead of managing active jobs 
+during the shutdown and is faster than explicitly stopping {dfeeds} and closing 
+jobs.
+
+* {stack-ov}/stopping-ml.html[Stop all {dfeeds} and close all jobs]. This option
+saves the model state at the time of closure. When you reopen the jobs after the
+cluster restart, they use the exact same model. However, saving the latest model 
+state takes longer than using upgrade mode, especially if you have a lot of jobs 
+or jobs with large model states.
+--
+
+. *Shut down all nodes.*
++
+--
+include::{docdir}/upgrade/shut-down-node.asciidoc[]
+--
+
+. *Perform the changes that require to shut down the cluster.*
+
+. *Restart nodes.*
++
+--
+If you have dedicated master nodes, start them first and wait for them to
+form a cluster and elect a master before proceeding with your data nodes.
+You can check progress by looking at the logs.
+
+As soon as enough master-eligible nodes have discovered each other, they form a
+cluster and elect a master. At that point, you can use
+<<cat-health,`_cat/health`>> and <<cat-nodes,`_cat/nodes`>> to monitor nodes
+joining the cluster:
+
+[source,sh]
+--------------------------------------------------
+GET _cat/health
+
+GET _cat/nodes
+--------------------------------------------------
+// CONSOLE
+
+The `status` column returned by `_cat/health` shows the health of each node
+in the cluster: `red`, `yellow`, or `green`.
+--
+
+. *Wait for all nodes to join the cluster and report a status of yellow.*
++
+--
+When a node joins the cluster, it begins to recover any primary shards that
+are stored locally. The <<cat-health,`_cat/health`>> API initially reports
+a `status` of `red`, indicating that not all primary shards have been allocated.
+
+Once a node recovers its local shards, the cluster `status` switches to 
+`yellow`,indicating that all primary shards have been recovered, but not all 
+replica shards are allocated. This is to be expected because you have not yet
+reenabled allocation. Delaying the allocation of replicas until all nodes
+are `yellow` allows the master to allocate replicas to nodes that
+already have local shard copies.
+--
+
+. *Reenable allocation.*
++
+--
+When all nodes have joined the cluster and recovered their primary shards,
+reenable allocation by restoring `cluster.routing.allocation.enable` to its
+default:
+
+[source,js]
+------------------------------------------------------
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster.routing.allocation.enable": null
+  }
+}
+------------------------------------------------------
+// CONSOLE
+
+Once allocation is reenabled, the cluster starts allocating replica shards to
+the data nodes. At this point it is safe to resume indexing and searching,
+but your cluster will recover more quickly if you can wait until all primary
+and replica shards have been successfully allocated and the status of all nodes
+is `green`.
+
+You can monitor progress with the <<cat-health,`_cat/health`>> and
+<<cat-recovery,`_cat/recovery`>> APIs:
+
+[source,sh]
+--------------------------------------------------
+GET _cat/health
+
+GET _cat/recovery
+--------------------------------------------------
+// CONSOLE
+--
+
+. *Restart machine learning jobs.*
++
+--
+If you temporarily halted the tasks associated with your {ml} jobs, use the 
+<<ml-set-upgrade-mode,set upgrade mode API>> to return them to active states:
+
+[source,console]
+--------------------------------------------------
+POST _ml/set_upgrade_mode?enabled=false
+--------------------------------------------------
+
+If you closed all {ml} jobs before stopping the nodes, open the jobs and start 
+the datafeeds from {kib} or with the <<ml-open-job,open jobs>> and
+<<ml-start-datafeed,start datafeed>> APIs.
+--

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -95,7 +95,7 @@ are `yellow` allows the master to allocate replicas to nodes that
 already have local shard copies.
 --
 
-. *Reenable allocation.*
+. *Re-enable allocation.*
 +
 --
 When all nodes have joined the cluster and recovered their primary shards,

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -1,7 +1,7 @@
 [[restart-cluster]]
 == Restart a cluster
  
-There might be situations when you want to perform a full-cluster restart which 
+There may be situations where you want to perform a full-cluster restart, which 
 means you shut down and restart all the nodes in the cluster. The following 
 description guides you through the process step by step.
 

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -1,5 +1,5 @@
 [[restart-cluster]]
-== Restarting a cluster
+== Restart a cluster
  
 There might be situations when you want to perform a full-cluster restart which 
 means you shut down and restart all the nodes in the cluster. The following 

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -1,9 +1,9 @@
 [[restart-cluster]]
 == Restarting a cluster
  
-There might be situations when you need to perform a full-cluster restart which 
-means you need to shut down and restart all the nodes in the cluster. The 
-following description guides you through the process step by step.
+There might be situations when you want to perform a full-cluster restart which 
+means you shut down and restart all the nodes in the cluster. The following 
+description guides you through the process step by step.
 
 . *Disable shard allocation.*
 +

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -99,7 +99,7 @@ already have local shard copies.
 +
 --
 When all nodes have joined the cluster and recovered their primary shards,
-reenable allocation by restoring `cluster.routing.allocation.enable` to its
+re-enable allocation by restoring `cluster.routing.allocation.enable` to its
 default:
 
 [source,console]

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -130,7 +130,7 @@ GET _cat/recovery
 --------------------------------------------------
 --
 
-. *Restart machine learning jobs.*
+. *Restart machine learning jobs.* (Optional)
 +
 --
 If you temporarily halted the tasks associated with your {ml} jobs, use the 

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -68,13 +68,13 @@ cluster and elect a master. At that point, you can use
 <<cat-health,`_cat/health`>> and <<cat-nodes,`_cat/nodes`>> to monitor nodes
 joining the cluster:
 
-[source,sh]
+[source,console]
 --------------------------------------------------
 GET _cat/health
 
 GET _cat/nodes
 --------------------------------------------------
-// CONSOLE
+
 
 The `status` column returned by `_cat/health` shows the health of each node
 in the cluster: `red`, `yellow`, or `green`.
@@ -102,7 +102,7 @@ When all nodes have joined the cluster and recovered their primary shards,
 reenable allocation by restoring `cluster.routing.allocation.enable` to its
 default:
 
-[source,js]
+[source,console]
 ------------------------------------------------------
 PUT _cluster/settings
 {
@@ -111,7 +111,7 @@ PUT _cluster/settings
   }
 }
 ------------------------------------------------------
-// CONSOLE
+
 
 Once allocation is reenabled, the cluster starts allocating replica shards to
 the data nodes. At this point it is safe to resume indexing and searching,
@@ -122,13 +122,12 @@ is `green`.
 You can monitor progress with the <<cat-health,`_cat/health`>> and
 <<cat-recovery,`_cat/recovery`>> APIs:
 
-[source,sh]
+[source,console]
 --------------------------------------------------
 GET _cat/health
 
 GET _cat/recovery
 --------------------------------------------------
-// CONSOLE
 --
 
 . *Restart machine learning jobs.*

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -90,7 +90,7 @@ a `status` of `red`, indicating that not all primary shards have been allocated.
 Once a node recovers its local shards, the cluster `status` switches to 
 `yellow`,indicating that all primary shards have been recovered, but not all 
 replica shards are allocated. This is to be expected because you have not yet
-reenabled allocation. Delaying the allocation of replicas until all nodes
+re-enabled allocation. Delaying the allocation of replicas until all nodes
 are `yellow` allows the master to allocate replicas to nodes that
 already have local shard copies.
 --

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -91,7 +91,7 @@ are stored locally. The <<cat-health,`_cat/health`>> API initially reports
 a `status` of `red`, indicating that not all primary shards have been allocated.
 
 Once a node recovers its local shards, the cluster `status` switches to 
-`yellow`,indicating that all primary shards have been recovered, but not all 
+`yellow`, indicating that all primary shards have been recovered, but not all 
 replica shards are allocated. This is to be expected because you have not yet
 re-enabled allocation. Delaying the allocation of replicas until all nodes
 are `yellow` allows the master to allocate replicas to nodes that

--- a/x-pack/docs/en/security/securing-communications/tls-transport.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/tls-transport.asciidoc
@@ -89,10 +89,10 @@ bin/elasticsearch-keystore add xpack.security.transport.ssl.secure_key_passphras
 . Restart {es}.
 +
 --
-You must perform a <<restart-cluster,full cluster restart>>. Nodes which are 
-configured to use TLS cannot communicate with nodes that are using unencrypted 
-networking (and vice-versa). After enabling TLS you must restart all nodes in 
-order to maintain communication across the cluster.
+You must perform a full cluster restart. Nodes which are configured to use TLS 
+cannot communicate with nodes that are using unencrypted networking 
+(and vice-versa). After enabling TLS you must restart all nodes in order to 
+maintain communication across the cluster.
 --
 
 [NOTE]

--- a/x-pack/docs/en/security/securing-communications/tls-transport.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/tls-transport.asciidoc
@@ -89,10 +89,10 @@ bin/elasticsearch-keystore add xpack.security.transport.ssl.secure_key_passphras
 . Restart {es}.
 +
 --
-You must perform a full cluster restart. Nodes which are configured to use TLS 
-cannot communicate with nodes that are using unencrypted networking 
-(and vice-versa). After enabling TLS you must restart all nodes in order to 
-maintain communication across the cluster.
+You must perform a <<restart-cluster,full cluster restart>>. Nodes which are 
+configured to use TLS cannot communicate with nodes that are using unencrypted 
+networking (and vice-versa). After enabling TLS you must restart all nodes in 
+order to maintain communication across the cluster.
 --
 
 [NOTE]

--- a/x-pack/docs/en/security/securing-communications/tls-transport.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/tls-transport.asciidoc
@@ -89,10 +89,10 @@ bin/elasticsearch-keystore add xpack.security.transport.ssl.secure_key_passphras
 . Restart {es}.
 +
 --
-You must perform a full cluster restart. Nodes which are configured to use TLS
-cannot communicate with nodes that are using unencrypted networking (and
-vice-versa). After enabling TLS you must restart all nodes in order to maintain
-communication across the cluster.
+You must perform a <<restart-cluster,full cluster restart>>. Nodes which are 
+configured to use TLS cannot communicate with nodes that are using unencrypted 
+networking (and vice-versa). After enabling TLS you must restart all nodes in 
+order to maintain communication across the cluster.
 --
 
 [NOTE]

--- a/x-pack/docs/en/security/securing-communications/tls-transport.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/tls-transport.asciidoc
@@ -89,10 +89,10 @@ bin/elasticsearch-keystore add xpack.security.transport.ssl.secure_key_passphras
 . Restart {es}.
 +
 --
-You must perform a <<restart-cluster,full cluster restart>>. Nodes which are 
-configured to use TLS cannot communicate with nodes that are using unencrypted 
-networking (and vice-versa). After enabling TLS you must restart all nodes in 
-order to maintain communication across the cluster.
+You must perform a full cluster restart. Nodes which are configured to use TLS
+cannot communicate with nodes that are using unencrypted networking (and
+vice-versa). After enabling TLS you must restart all nodes in order to maintain
+communication across the cluster.
 --
 
 [NOTE]


### PR DESCRIPTION
This PR documents the full-cluster restart procedure and adds it to the "Set up Elasticsearch" chapter as an individual menu item.

Related issue: https://github.com/elastic/elasticsearch/issues/48051
