### PR TITLE
Bump bundled JDK to JDK 13.0.1+9

### DIFF
--- a/buildSrc/src/minimumRuntime/java/org/elasticsearch/gradle/VersionProperties.java
+++ b/buildSrc/src/minimumRuntime/java/org/elasticsearch/gradle/VersionProperties.java
@@ -23,8 +23,17 @@ public class VersionProperties {
         return lucene;
     }
 
-    public static String getBundledJdk() {
-        return bundledJdk;
+    public static String getBundledJdk(final String platform) {
+        switch (platform) {
+            case "linux":
+                return bundledJdkLinux;
+            case "darwin":
+                return bundledJdkDarwin;
+            case "windows":
+                return bundledJdkWindows;
+            default:
+                throw new IllegalArgumentException("unknown platform [" + platform + "]");
+        }
     }
 
     public static String getBundledJdkVendor() {
@@ -37,7 +46,9 @@ public class VersionProperties {
 
     private static final String elasticsearch;
     private static final String lucene;
-    private static final String bundledJdk;
+    private static final String bundledJdkDarwin;
+    private static final String bundledJdkLinux;
+    private static final String bundledJdkWindows;
     private static final String bundledJdkVendor;
     private static final Map<String, String> versions = new HashMap<String, String>();
 
@@ -46,7 +57,10 @@ public class VersionProperties {
         elasticsearch = props.getProperty("elasticsearch");
         lucene = props.getProperty("lucene");
         bundledJdkVendor = props.getProperty("bundled_jdk_vendor");
-        bundledJdk = props.getProperty("bundled_jdk");
+        final String bundledJdk = props.getProperty("bundled_jdk");
+        bundledJdkDarwin = props.getProperty("bundled_jdk_darwin", bundledJdk);
+        bundledJdkLinux = props.getProperty("bundled_jdk_linux", bundledJdk);
+        bundledJdkWindows = props.getProperty("bundled_jdk_windows", bundledJdk);
 
         for (String property : props.stringPropertyNames()) {
             versions.put(property, props.getProperty(property));

--- a/buildSrc/src/minimumRuntime/java/org/elasticsearch/gradle/VersionProperties.java
+++ b/buildSrc/src/minimumRuntime/java/org/elasticsearch/gradle/VersionProperties.java
@@ -25,10 +25,10 @@ public class VersionProperties {
 
     public static String getBundledJdk(final String platform) {
         switch (platform) {
-            case "linux":
-                return bundledJdkLinux;
             case "darwin":
                 return bundledJdkDarwin;
+            case "linux":
+                return bundledJdkLinux;
             case "windows":
                 return bundledJdkWindows;
             default:

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -2,7 +2,8 @@ elasticsearch     = 8.0.0
 lucene            = 8.3.0-snapshot-25968e3b75e
 
 bundled_jdk_vendor = adoptopenjdk
-bundled_jdk = 13+33
+bundled_jdk = 13.0.1+9
+bundled_jdk_windows = 13+33
 
 # optional dependencies
 spatial4j         = 0.7

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -395,7 +395,7 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
       project.jdks {
         "bundled_${platform}" {
           it.platform = platform
-          it.version = VersionProperties.bundledJdk
+          it.version = VersionProperties.getBundledJdk(platform)
           it.vendor = VersionProperties.bundledJdkVendor
         }
       }


### PR DESCRIPTION
This commit bumps the bundled JDK to 13.0.1+9. Since AdoptOpenJDK did not release 13.0.1+9 for Windows, this commit also enables that the bundled JDK version can vary by platform.

Relates #46498
