### PR TITLE
Fix issue with bulk loading

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -318,7 +318,7 @@ To get some data into {es} that you can start searching and analyzing:
 +
 [source,sh]
 --------------------------------------------------
-curl -H "Content-Type: application/json" -XPOST "localhost:9200/bank/_bulk?pretty&refresh" --data-binary "@accounts.json"
+curl -H "Content-Type: application/json" -XPOST "localhost:9200/bank/_doc/_bulk?pretty&refresh" --data-binary "@accounts.json"
 curl "localhost:9200/_cat/indices?v"
 --------------------------------------------------
 // NOTCONSOLE


### PR DESCRIPTION
The documentation and example data is missing a type, and the URL does not include a type. Using the example as is generated a "type is missing" error, which is fixed by adding /_doc/ to the URL.
