### PR TITLE
Fix typo in Indices module docs

### DIFF
--- a/docs/reference/modules/indices.asciidoc
+++ b/docs/reference/modules/indices.asciidoc
@@ -16,7 +16,7 @@ Available settings include:
 
 <<query-cache,Node query cache>>::
 
-    Configure the amount heap used to cache queries results.
+    Configure the amount of heap used to cache queries results.
 
 <<indexing-buffer,Indexing buffer>>::
 


### PR DESCRIPTION
Added missing word "of".
