### PR TITLE
[DOCS] Updates ML PRs in 6.8.4 release notes

### DIFF
--- a/docs/reference/release-notes/6.8.asciidoc
+++ b/docs/reference/release-notes/6.8.asciidoc
@@ -50,9 +50,7 @@ Machine Learning::
 * Reinstate ML daily maintenance actions {pull}47103[#47103] (issue: {issue}47003[#47003])
 * Fix two datafeed flush lockup bugs {pull}46982[#46982]
 * Throw an error when a datafeed needs CCS but it is not enabled for the node {pull}46044[#46044]
-* A reference to a temporary variable was causing forecast model restoration to 
-fail. The bug exhibited itself on MacOS builds with versions of clangd > 10.0.0
-{ml-pull}688[#688]
+* Fix possibility of crash when calculating forecasts that overflow to disk {ml-pull}688[#688]
 
 SQL::
 * SQL: Allow whitespaces in escape patterns {pull}47577[#47577] (issue: {issue}47401[#47401])

--- a/docs/reference/release-notes/6.8.asciidoc
+++ b/docs/reference/release-notes/6.8.asciidoc
@@ -14,7 +14,7 @@ Infra/Settings::
 * Add more meaningful keystore version mismatch errors {pull}46291[#46291] (issue: {issue}44624[#44624])
 
 Machine Learning::
-* [ML] Throttle the delete-by-query of expired results {pull}47177[#47177] (issues: {issue}47003[#47003], {issue}47103[#47103])
+* Throttle the delete-by-query of expired results {pull}47177[#47177] (issues: {issue}47003[#47003], {issue}47103[#47103])
 
 
 
@@ -47,9 +47,11 @@ Features/Watcher::
 * Fix class used to initialize logger in Watcher {pull}46467[#46467]
 
 Machine Learning::
-* [ML] Reinstate ML daily maintenance actions {pull}47103[#47103] (issue: {issue}47003[#47003])
-* [ML] fix two datafeed flush lockup bugs {pull}46982[#46982]
-* [ML] Throw an error when a datafeed needs CCS but it is not enabled for the node {pull}46044[#46044] (issue: {issue}46025[#46025])
+* Reinstate ML daily maintenance actions {pull}47103[#47103] (issue: {issue}47003[#47003])
+* Fix two datafeed flush lockup bugs {pull}46982[#46982]
+* Throw an error when a datafeed needs CCS but it is not enabled for the node {pull}46044[#46044] (issue: {issue}46025[#46025])
+* A reference to a temporary variable was causing forecast model restoration to fail.
+The bug exhibited itself on MacOS builds with versions of clangd > 10.0.0 {ml-pull}688[#688]
 
 SQL::
 * SQL: Allow whitespaces in escape patterns {pull}47577[#47577] (issue: {issue}47401[#47401])

--- a/docs/reference/release-notes/6.8.asciidoc
+++ b/docs/reference/release-notes/6.8.asciidoc
@@ -14,7 +14,7 @@ Infra/Settings::
 * Add more meaningful keystore version mismatch errors {pull}46291[#46291] (issue: {issue}44624[#44624])
 
 Machine Learning::
-* Throttle the delete-by-query of expired results {pull}47177[#47177] (issues: {issue}47003[#47003], {issue}47103[#47103])
+* Throttle the delete-by-query of expired results {pull}47177[#47177] (issues: {issue}47003[#47003])
 
 
 
@@ -49,9 +49,10 @@ Features/Watcher::
 Machine Learning::
 * Reinstate ML daily maintenance actions {pull}47103[#47103] (issue: {issue}47003[#47003])
 * Fix two datafeed flush lockup bugs {pull}46982[#46982]
-* Throw an error when a datafeed needs CCS but it is not enabled for the node {pull}46044[#46044] (issue: {issue}46025[#46025])
-* A reference to a temporary variable was causing forecast model restoration to fail.
-The bug exhibited itself on MacOS builds with versions of clangd > 10.0.0 {ml-pull}688[#688]
+* Throw an error when a datafeed needs CCS but it is not enabled for the node {pull}46044[#46044]
+* A reference to a temporary variable was causing forecast model restoration to 
+fail. The bug exhibited itself on MacOS builds with versions of clangd > 10.0.0
+{ml-pull}688[#688]
 
 SQL::
 * SQL: Allow whitespaces in escape patterns {pull}47577[#47577] (issue: {issue}47401[#47401])


### PR DESCRIPTION
This PR adds content from https://github.com/elastic/ml-cpp/blob/6.8/docs/CHANGELOG.asciidoc to the 6.8.4 release notes. It also edits the list of PRs and removes a PR that was incorrectly listed as an issue.