### PR TITLE
Increase timeout in ILM doc test slightly

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/ILMDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/ILMDocumentationIT.java
@@ -633,7 +633,7 @@ public class ILMDocumentationIT extends ESRestHighLevelClientTestCase {
             client.indices().create(createIndexRequest, RequestOptions.DEFAULT);
             assertBusy(() -> assertNotNull(client.indexLifecycle()
                 .explainLifecycle(new ExplainLifecycleRequest("my_index"), RequestOptions.DEFAULT)
-                .getIndexResponses().get("my_index").getFailedStep()));
+                .getIndexResponses().get("my_index").getFailedStep()), 15, TimeUnit.SECONDS);
         }
 
         // tag::ilm-retry-lifecycle-policy-request


### PR DESCRIPTION
This assertBusy can occasionally time out on systems under heavy load,
such as CI, so this commit increases the timeout.

Fixes https://github.com/elastic/elasticsearch/issues/48527