### PR TITLE
ILM open/close steps are noop if idx is open/close

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CloseFollowerIndexStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CloseFollowerIndexStep.java
@@ -32,13 +32,17 @@ final class CloseFollowerIndexStep extends AsyncRetryDuringSnapshotActionStep {
             return;
         }
 
-        CloseIndexRequest closeIndexRequest = new CloseIndexRequest(followerIndex);
-        getClient().admin().indices().close(closeIndexRequest, ActionListener.wrap(
-            r -> {
-                assert r.isAcknowledged() : "close index response is not acknowledged";
-                listener.onResponse(true);
-            },
-            listener::onFailure)
-        );
+        if (indexMetaData.getState() == IndexMetaData.State.OPEN) {
+            CloseIndexRequest closeIndexRequest = new CloseIndexRequest(followerIndex);
+            getClient().admin().indices().close(closeIndexRequest, ActionListener.wrap(
+                r -> {
+                    assert r.isAcknowledged() : "close index response is not acknowledged";
+                    listener.onResponse(true);
+                },
+                listener::onFailure)
+            );
+        } else {
+            listener.onResponse(true);
+        }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/OpenFollowerIndexStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/OpenFollowerIndexStep.java
@@ -23,13 +23,17 @@ final class OpenFollowerIndexStep extends AsyncActionStep {
     @Override
     public void performAction(IndexMetaData indexMetaData, ClusterState currentClusterState,
                               ClusterStateObserver observer, Listener listener) {
-        OpenIndexRequest request = new OpenIndexRequest(indexMetaData.getIndex().getName());
-        getClient().admin().indices().open(request, ActionListener.wrap(
-            r -> {
-                assert r.isAcknowledged() :  "open index response is not acknowledged";
-                listener.onResponse(true);
-            },
-            listener::onFailure
-        ));
+        if (indexMetaData.getState() == IndexMetaData.State.CLOSE) {
+            OpenIndexRequest request = new OpenIndexRequest(indexMetaData.getIndex().getName());
+            getClient().admin().indices().open(request, ActionListener.wrap(
+                r -> {
+                    assert r.isAcknowledged() : "open index response is not acknowledged";
+                    listener.onResponse(true);
+                },
+                listener::onFailure
+            ));
+        } else {
+            listener.onResponse(true);
+        }
     }
 }


### PR DESCRIPTION
The open and close follower steps didn't check if the index is open,
closed respectively, before executing the open/close request.
This changes the steps to check the index state and only perform the
open/close operation if the index is not already open/closed.

This avoids a rather expensive operation and improves the resiliency of
the steps as a possible point of failure is avoided.