### PR TITLE
Work around incorrect lintian version on debian 10

### DIFF
--- a/.ci/os.sh
+++ b/.ci/os.sh
@@ -36,7 +36,7 @@ if [ -f "/etc/os-release" ] ; then
         # Work around incorrect lintian version 
         #  https://github.com/elastic/elasticsearch/issues/48573 
         if [ $VERSION_ID == 10 ] ; then 
-            sudo apt-get install -y lintian=2.15.0
+            sudo apt-get install -y --allow-downgrades lintian=2.15.0
         fi
     fi
 else

--- a/.ci/os.sh
+++ b/.ci/os.sh
@@ -33,6 +33,11 @@ if [ -f "/etc/os-release" ] ; then
     if [[ "$ID" == "debian" || "$ID_LIKE" == "debian" ]] ; then 
         # FIXME: The base image should not have rpm installed
         sudo rm -Rf /usr/bin/rpm
+        # Work around incorrect lintian version 
+        #  https://github.com/elastic/elasticsearch/issues/48573 
+        if [ $VERSION_ID == 10 ] ; then 
+            sudo apt-get install -y lintian=2.15.0
+        fi
     fi
 else
     cat /etc/issue || true


### PR DESCRIPTION
Relates to #48573 and intended as a work around to stop the CI failures
until we fix the image.
