### PR TITLE
Fix failures in ShuffleForcedMergePolicyTests#testDiagnostics

### DIFF
--- a/server/src/main/java/org/apache/lucene/index/ShuffleForcedMergePolicy.java
+++ b/server/src/main/java/org/apache/lucene/index/ShuffleForcedMergePolicy.java
@@ -77,7 +77,7 @@ public class ShuffleForcedMergePolicy extends FilterMergePolicy {
 
                 @Override
                 public void setMergeInfo(SegmentCommitInfo info) {
-                    // Record that this merged segment is current as of this schemaGen:
+                    // record that this segment was merged with interleaved segments
                     Map<String, String> copy = new HashMap<>(info.info.getDiagnostics());
                     copy.put(SHUFFLE_MERGE_KEY, "");
                     info.info.setDiagnostics(copy);

--- a/server/src/test/java/org/apache/lucene/index/ShuffleForcedMergePolicyTests.java
+++ b/server/src/test/java/org/apache/lucene/index/ShuffleForcedMergePolicyTests.java
@@ -32,6 +32,7 @@ import java.util.function.Consumer;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 public class ShuffleForcedMergePolicyTests extends BaseMergePolicyTestCase {
     public void testDiagnostics() throws IOException {
@@ -56,17 +57,13 @@ public class ShuffleForcedMergePolicyTests extends BaseMergePolicyTestCase {
                     writer.addDocument(doc);
                 }
                 try (DirectoryReader reader = DirectoryReader.open(writer)) {
-                    assertThat(reader.leaves().size(), greaterThan(2));
-                    assertSegmentReaders(reader, leaf -> {
-                        assertFalse(ShuffleForcedMergePolicy.isInterleavedSegment(leaf));
-                    });
+                    assertThat(reader.leaves().size(), greaterThan(1));
+                    assertSegmentReaders(reader, leaf -> assertFalse(ShuffleForcedMergePolicy.isInterleavedSegment(leaf)));
                 }
                 writer.forceMerge(1);
                 try (DirectoryReader reader = DirectoryReader.open(writer)) {
                     assertThat(reader.leaves().size(), equalTo(1));
-                    assertSegmentReaders(reader, leaf -> {
-                        assertTrue(ShuffleForcedMergePolicy.isInterleavedSegment(leaf));
-                    });
+                    assertSegmentReaders(reader, leaf -> assertTrue(ShuffleForcedMergePolicy.isInterleavedSegment(leaf)));
                 }
             }
         }

--- a/server/src/test/java/org/apache/lucene/index/ShuffleForcedMergePolicyTests.java
+++ b/server/src/test/java/org/apache/lucene/index/ShuffleForcedMergePolicyTests.java
@@ -32,7 +32,6 @@ import java.util.function.Consumer;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 public class ShuffleForcedMergePolicyTests extends BaseMergePolicyTestCase {
     public void testDiagnostics() throws IOException {

--- a/server/src/test/java/org/apache/lucene/index/ShuffleForcedMergePolicyTests.java
+++ b/server/src/test/java/org/apache/lucene/index/ShuffleForcedMergePolicyTests.java
@@ -38,7 +38,7 @@ public class ShuffleForcedMergePolicyTests extends BaseMergePolicyTestCase {
     public void testDiagnostics() throws IOException {
         try (Directory dir = newDirectory()) {
             IndexWriterConfig iwc = newIndexWriterConfig();
-            MergePolicy mp = new ShuffleForcedMergePolicy(newLogMergePolicy());
+            MergePolicy mp = new ShuffleForcedMergePolicy(newTieredMergePolicy());
             iwc.setMergePolicy(mp);
             boolean sorted = random().nextBoolean();
             if (sorted) {
@@ -57,7 +57,7 @@ public class ShuffleForcedMergePolicyTests extends BaseMergePolicyTestCase {
                     writer.addDocument(doc);
                 }
                 try (DirectoryReader reader = DirectoryReader.open(writer)) {
-                    assertThat(reader.leaves().size(), greaterThan(1));
+                    assertThat(reader.leaves().size(), greaterThan(2));
                     assertSegmentReaders(reader, leaf -> assertFalse(ShuffleForcedMergePolicy.isInterleavedSegment(leaf)));
                 }
                 writer.forceMerge(1);
@@ -81,8 +81,10 @@ public class ShuffleForcedMergePolicyTests extends BaseMergePolicyTestCase {
     }
 
     @Override
-    protected void assertSegmentInfos(MergePolicy policy, SegmentInfos infos) throws IOException {}
+    protected void assertSegmentInfos(MergePolicy policy, SegmentInfos infos) throws IOException {
+    }
 
     @Override
-    protected void assertMerge(MergePolicy policy, MergePolicy.MergeSpecification merge) throws IOException {}
+    protected void assertMerge(MergePolicy policy, MergePolicy.MergeSpecification merge) throws IOException {
+    }
 }


### PR DESCRIPTION
This commit fixes intermittent failures in ShuffleForcedMergePolicyTests#testDiagnostics
by setting a more restricted merge policy that ensures that extra merging will not happen
before the forced merge.