### PR TITLE
Adjust date parsing in ILM integration tests

### DIFF
--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
@@ -63,6 +63,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
+import static java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME;
 import static org.elasticsearch.client.Requests.clusterHealthRequest;
 import static org.elasticsearch.client.Requests.createIndexRequest;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
@@ -162,7 +163,7 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
         GetLifecycleAction.LifecyclePolicyResponseItem responseItem = getLifecycleResponse.getPolicies().get(0);
         assertThat(responseItem.getLifecyclePolicy(), equalTo(lifecyclePolicy));
         assertThat(responseItem.getVersion(), equalTo(1L));
-        long actualModifiedDate = Instant.parse(responseItem.getModifiedDate()).toEpochMilli();
+        long actualModifiedDate = Instant.from(ISO_ZONED_DATE_TIME.parse(responseItem.getModifiedDate())).toEpochMilli();
         assertThat(actualModifiedDate,
             is(both(greaterThanOrEqualTo(lowerBoundModifiedDate)).and(lessThanOrEqualTo(upperBoundModifiedDate))));
 
@@ -201,7 +202,7 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
         GetLifecycleAction.LifecyclePolicyResponseItem responseItem = getLifecycleResponse.getPolicies().get(0);
         assertThat(responseItem.getLifecyclePolicy(), equalTo(lifecyclePolicy));
         assertThat(responseItem.getVersion(), equalTo(1L));
-        long actualModifiedDate = Instant.parse(responseItem.getModifiedDate()).toEpochMilli();
+        long actualModifiedDate = Instant.from(ISO_ZONED_DATE_TIME.parse(responseItem.getModifiedDate())).toEpochMilli();
 
         logger.info("Creating index [test]");
         CreateIndexResponse createIndexResponse = client().admin().indices().create(createIndexRequest("test").settings(settings))
@@ -276,7 +277,6 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
         GetLifecycleAction.LifecyclePolicyResponseItem responseItem = getLifecycleResponse.getPolicies().get(0);
         assertThat(responseItem.getLifecyclePolicy(), equalTo(lifecyclePolicy));
         assertThat(responseItem.getVersion(), equalTo(1L));
-        long actualModifiedDate = Instant.parse(responseItem.getModifiedDate()).toEpochMilli();
 
         String indexName = "test-2019.09.14";
         logger.info("Creating index [{}]", indexName);
@@ -475,7 +475,7 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
         GetLifecycleAction.LifecyclePolicyResponseItem responseItem = getLifecycleResponse.getPolicies().get(0);
         assertThat(responseItem.getLifecyclePolicy(), equalTo(lifecyclePolicy));
         assertThat(responseItem.getVersion(), equalTo(1L));
-        long actualModifiedDate = Instant.parse(responseItem.getModifiedDate()).toEpochMilli();
+        long actualModifiedDate = Instant.from(ISO_ZONED_DATE_TIME.parse(responseItem.getModifiedDate())).toEpochMilli();
         assertThat(actualModifiedDate,
             is(both(greaterThanOrEqualTo(lowerBoundModifiedDate)).and(lessThanOrEqualTo(upperBoundModifiedDate))));
         // assert ILM is still stopped


### PR DESCRIPTION
The format returned by the API is not always parsable with
`Instant.parse()`, so this commit adjusts to parsing those dates as
`ISO_ZONED_DATE_TIME` instead, which appears to always parse the
returned value correctly.

Fixes https://github.com/elastic/elasticsearch/issues/44943