### PR TITLE
[DOCS] Replace `_uid` references in reindex slicing docs

### DIFF
--- a/docs/java-rest/high-level/document/reindex.asciidoc
+++ b/docs/java-rest/high-level/document/reindex.asciidoc
@@ -122,7 +122,7 @@ include-tagged::{doc-tests-file}[{api}-request-remote]
 <1> set remote elastic cluster
 
 +{request}+ also helps in automatically parallelizing using `sliced-scroll` to
-slice on `_uid`. Use `setSlices` to specify the number of slices to use.
+slice on `_id`. Use `setSlices` to specify the number of slices to use.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -245,7 +245,7 @@ which results in a sensible `total` like this one:
 ====== Automatic slicing
 
 You can also let `_reindex` automatically parallelize using <<sliced-scroll>> to
-slice on `_uid`. Use `slices` to specify the number of slices to use:
+slice on `_id`. Use `slices` to specify the number of slices to use:
 
 [source,console]
 ----------------------------------------------------------------


### PR DESCRIPTION
PR #25543 removed the `_uid` field in favor of the `_id` field, including for use in slicing.

This removes an outdated reference to `_uid` in our reindex docs.

Closes #48225