### PR TITLE
Ignore dangling indices created in newer versions

### DIFF
--- a/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
+++ b/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
@@ -117,6 +117,13 @@ public class LocalAllocateDangledIndices {
                                 minIndexCompatibilityVersion);
                             continue;
                         }
+                        if (currentState.getNodes().getMasterNode().getVersion().before(indexMetaData.getCreationVersion())) {
+                            logger.warn("ignoring dangled index [{}] on node [{}]" +
+                                " since its created version [{}] is later than the current master version [{}]",
+                                indexMetaData.getIndex(), request.fromNode, indexMetaData.getCreationVersion(),
+                                currentState.getNodes().getMasterNode().getVersion());
+                            continue;
+                        }
                         if (currentState.metaData().hasIndex(indexMetaData.getIndex().getName())) {
                             continue;
                         }

--- a/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
+++ b/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
@@ -117,9 +117,9 @@ public class LocalAllocateDangledIndices {
                                 minIndexCompatibilityVersion);
                             continue;
                         }
-                        if (currentState.getNodes().getMasterNode().getVersion().before(indexMetaData.getCreationVersion())) {
+                        if (currentState.nodes().getMinNodeVersion().before(indexMetaData.getCreationVersion())) {
                             logger.warn("ignoring dangled index [{}] on node [{}]" +
-                                " since its created version [{}] is later than the current master version [{}]",
+                                " since its created version [{}] is later than the oldest versioned node in the cluster [{}]",
                                 indexMetaData.getIndex(), request.fromNode, indexMetaData.getCreationVersion(),
                                 currentState.getNodes().getMasterNode().getVersion());
                             continue;

--- a/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
@@ -424,22 +424,6 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
         dangling.allocateDangled(Arrays.asList(indexMetaDataLater), ActionListener.wrap(latch::countDown));
         latch.await();
         assertThat(clusterService.state(), equalTo(originalState));
-
-        //import an index with the same version as cluster master version, it should work
-        final String indexNameCurrent = "test-idxcurrent";
-        final Settings idxSettingCurrent = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
-                                                             .put(IndexMetaData.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
-                                                             .build();
-        final IndexMetaData indexMetaDataCurrent = new IndexMetaData.Builder(indexNameCurrent)
-                                                                .settings(idxSettingCurrent)
-                                                                .numberOfShards(1)
-                                                                .numberOfReplicas(0)
-                                                                .build();
-        latch = new CountDownLatch(1);
-        dangling.allocateDangled(Arrays.asList(indexMetaDataCurrent), ActionListener.wrap(latch::countDown));
-        latch.await();
-        assertThat(clusterService.state(), not(originalState));
-        assertNotNull(clusterService.state().getMetaData().index(indexNameCurrent));
     }
 
     /**


### PR DESCRIPTION
Today it is possible that we import a dangling index that was created in a
newer version than one or more of the nodes in the cluster. Such an index would
prevent the older node(s) from rejoining the cluster if they were to briefly
leave it for some reason. This commit prevents the import of such dangling
indices.

Fixes #34264