### PR TITLE
[Backport] Add Sysprop to Adjust IO Buffer Size (#48267)

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/CopyBytesSocketChannel.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/CopyBytesSocketChannel.java
@@ -39,6 +39,7 @@ import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import org.elasticsearch.common.SuppressForbidden;
+import org.elasticsearch.common.unit.ByteSizeValue;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -60,7 +61,8 @@ import static io.netty.channel.internal.ChannelUtils.MAX_BYTES_PER_GATHERING_WRI
 @SuppressForbidden(reason = "Channel#write")
 public class CopyBytesSocketChannel extends NioSocketChannel {
 
-    private static final int MAX_BYTES_PER_WRITE = 1 << 20;
+    private static final int MAX_BYTES_PER_WRITE = StrictMath.toIntExact(ByteSizeValue.parseBytesSizeValue(
+        System.getProperty("es.transport.buffer.size", "1m"), "es.transport.buffer.size").getBytes());
 
     private static final ThreadLocal<ByteBuffer> ioBuffer = ThreadLocal.withInitial(() -> ByteBuffer.allocateDirect(MAX_BYTES_PER_WRITE));
     private final WriteConfig writeConfig = new WriteConfig();

--- a/x-pack/plugin/security/build.gradle
+++ b/x-pack/plugin/security/build.gradle
@@ -309,6 +309,12 @@ test {
      * other if we allow them to set the number of available processors as it's set-once in Netty.
      */
     systemProperty 'es.set.netty.runtime.available.processors', 'false'
+
+    /*
+     * Some tests in this module set up a lot of transport threads so we reduce the buffer size per transport thread from the 1M default
+     * to keep direct memory usage under control.
+     */
+    systemProperty 'es.transport.buffer.size', '256k'
 }
 
 // xpack modules are installed in real clusters as the meta plugin, so


### PR DESCRIPTION
The 1MB IO-buffer size per transport thread is causing trouble in
some tests, albeit at a low rate. Reducing the number of transport
threads was not enough to fully fix this situation.
Allowing to configure the size of the buffer and reducing it by
more than an order of magnitude should fix these tests.

Closes #46803
