### PR TITLE
Make `_search` and `_msearch` consistent for support of common query params #4227 

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/search/CommonSearchRestRequestParamsParser.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/CommonSearchRestRequestParamsParser.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.search;
+
+import org.elasticsearch.common.Booleans;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.fetch.StoredFieldsContext;
+import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.sort.SortOrder;
+
+import java.util.Arrays;
+import java.util.function.IntConsumer;
+
+//TODO Should this be dependency injected instead of class with static method?
+public class CommonSearchRestRequestParamsParser {
+    public static void parse(SearchSourceBuilder searchSourceBuilder, RestRequest request, IntConsumer setSize) {
+        int from = request.paramAsInt("from", -1);
+        if (from != -1) {
+            searchSourceBuilder.from(from);
+        }
+        int size = request.paramAsInt("size", -1);
+        if (size != -1) {
+            setSize.accept(size);
+        }
+        if (request.hasParam("explain")) {
+            searchSourceBuilder.explain(request.paramAsBoolean("explain", null));
+        }
+        if (request.hasParam("version")) {
+            searchSourceBuilder.version(request.paramAsBoolean("version", null));
+        }
+        if (request.hasParam("seq_no_primary_term")) {
+            searchSourceBuilder.seqNoAndPrimaryTerm(request.paramAsBoolean("seq_no_primary_term", null));
+        }
+        if (request.hasParam("timeout")) {
+            searchSourceBuilder.timeout(request.paramAsTime("timeout", null));
+        }
+        if (request.hasParam("terminate_after")) {
+            int terminateAfter = request.paramAsInt("terminate_after",
+                SearchContext.DEFAULT_TERMINATE_AFTER);
+            if (terminateAfter < 0) {
+                throw new IllegalArgumentException("terminateAfter must be > 0");
+            } else if (terminateAfter > 0) {
+                searchSourceBuilder.terminateAfter(terminateAfter);
+            }
+        }
+
+        // TODO As this is field dependent, and ultimately index depednent, should this be supported as query params
+        //  for _msearch as well, which may deal with different indices?
+        StoredFieldsContext storedFieldsContext =
+            StoredFieldsContext.fromRestRequest(SearchSourceBuilder.STORED_FIELDS_FIELD.getPreferredName(), request);
+        if (storedFieldsContext != null) {
+            searchSourceBuilder.storedFields(storedFieldsContext);
+        }
+
+        // TODO As this is field dependent, and ultimately index depednent, should this be supported as query params
+        //  for _msearch as well, which may deal with different indices?
+        String sDocValueFields = request.param("docvalue_fields");
+        if (sDocValueFields != null) {
+            if (Strings.hasText(sDocValueFields)) {
+                String[] sFields = Strings.splitStringByCommaToArray(sDocValueFields);
+                for (String field : sFields) {
+                    searchSourceBuilder.docValueField(field, null);
+                }
+            }
+        }
+        FetchSourceContext fetchSourceContext = FetchSourceContext.parseFromRestRequest(request);
+        if (fetchSourceContext != null) {
+            searchSourceBuilder.fetchSource(fetchSourceContext);
+        }
+
+        if (request.hasParam("track_scores")) {
+            searchSourceBuilder.trackScores(request.paramAsBoolean("track_scores", false));
+        }
+
+        if (request.hasParam("track_total_hits")) {
+            if (Booleans.isBoolean(request.param("track_total_hits"))) {
+                searchSourceBuilder.trackTotalHits(
+                    request.paramAsBoolean("track_total_hits", true)
+                );
+            } else {
+                searchSourceBuilder.trackTotalHitsUpTo(
+                    request.paramAsInt("track_total_hits", SearchContext.DEFAULT_TRACK_TOTAL_HITS_UP_TO)
+                );
+            }
+        }
+
+        // TODO As this is field dependent, and ultimately index depednent, should this be supported as query params
+        //  for _msearch as well, which may deal with different indices?
+        String sSorts = request.param("sort");
+        if (sSorts != null) {
+            String[] sorts = Strings.splitStringByCommaToArray(sSorts);
+            for (String sort : sorts) {
+                int delimiter = sort.lastIndexOf(":");
+                if (delimiter != -1) {
+                    String sortField = sort.substring(0, delimiter);
+                    String reverse = sort.substring(delimiter + 1);
+                    if ("asc".equals(reverse)) {
+                        searchSourceBuilder.sort(sortField, SortOrder.ASC);
+                    } else if ("desc".equals(reverse)) {
+                        searchSourceBuilder.sort(sortField, SortOrder.DESC);
+                    }
+                } else {
+                    searchSourceBuilder.sort(sort);
+                }
+            }
+        }
+
+        String sStats = request.param("stats");
+        if (sStats != null) {
+            searchSourceBuilder.stats(Arrays.asList(Strings.splitStringByCommaToArray(sStats)));
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -104,6 +104,11 @@ public class RestMultiSearchAction extends BaseRestHandler {
 
         parseMultiLineRequest(restRequest, multiRequest.indicesOptions(), allowExplicitIndex, (searchRequest, parser) -> {
             searchRequest.source(SearchSourceBuilder.fromXContent(parser, false));
+
+            // Since in RestSearchAction, rest request params may override values specified in query body,
+            // having the following parsing after SearchSourceBuilder.fromXContent will stay consistent with that behavior
+            CommonSearchRestRequestParamsParser.parse(searchRequest.source(), restRequest, size -> searchRequest.source().size(size));
+
             RestSearchAction.checkRestTotalHits(restRequest, searchRequest);
             multiRequest.add(searchRequest);
         });

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -24,7 +24,6 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
-import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -35,10 +34,7 @@ import org.elasticsearch.rest.action.RestActions;
 import org.elasticsearch.rest.action.RestStatusToXContentListener;
 import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.elasticsearch.search.fetch.StoredFieldsContext;
-import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.search.suggest.SuggestBuilder;
 import org.elasticsearch.search.suggest.term.TermSuggestionBuilder.SuggestMode;
 
@@ -177,96 +173,7 @@ public class RestSearchAction extends BaseRestHandler {
             searchSourceBuilder.query(queryBuilder);
         }
 
-        int from = request.paramAsInt("from", -1);
-        if (from != -1) {
-            searchSourceBuilder.from(from);
-        }
-        int size = request.paramAsInt("size", -1);
-        if (size != -1) {
-            setSize.accept(size);
-        }
-
-        if (request.hasParam("explain")) {
-            searchSourceBuilder.explain(request.paramAsBoolean("explain", null));
-        }
-        if (request.hasParam("version")) {
-            searchSourceBuilder.version(request.paramAsBoolean("version", null));
-        }
-        if (request.hasParam("seq_no_primary_term")) {
-            searchSourceBuilder.seqNoAndPrimaryTerm(request.paramAsBoolean("seq_no_primary_term", null));
-        }
-        if (request.hasParam("timeout")) {
-            searchSourceBuilder.timeout(request.paramAsTime("timeout", null));
-        }
-        if (request.hasParam("terminate_after")) {
-            int terminateAfter = request.paramAsInt("terminate_after",
-                    SearchContext.DEFAULT_TERMINATE_AFTER);
-            if (terminateAfter < 0) {
-                throw new IllegalArgumentException("terminateAfter must be > 0");
-            } else if (terminateAfter > 0) {
-                searchSourceBuilder.terminateAfter(terminateAfter);
-            }
-        }
-
-        StoredFieldsContext storedFieldsContext =
-            StoredFieldsContext.fromRestRequest(SearchSourceBuilder.STORED_FIELDS_FIELD.getPreferredName(), request);
-        if (storedFieldsContext != null) {
-            searchSourceBuilder.storedFields(storedFieldsContext);
-        }
-        String sDocValueFields = request.param("docvalue_fields");
-        if (sDocValueFields != null) {
-            if (Strings.hasText(sDocValueFields)) {
-                String[] sFields = Strings.splitStringByCommaToArray(sDocValueFields);
-                for (String field : sFields) {
-                    searchSourceBuilder.docValueField(field, null);
-                }
-            }
-        }
-        FetchSourceContext fetchSourceContext = FetchSourceContext.parseFromRestRequest(request);
-        if (fetchSourceContext != null) {
-            searchSourceBuilder.fetchSource(fetchSourceContext);
-        }
-
-        if (request.hasParam("track_scores")) {
-            searchSourceBuilder.trackScores(request.paramAsBoolean("track_scores", false));
-        }
-
-
-        if (request.hasParam("track_total_hits")) {
-            if (Booleans.isBoolean(request.param("track_total_hits"))) {
-                searchSourceBuilder.trackTotalHits(
-                    request.paramAsBoolean("track_total_hits", true)
-                );
-            } else {
-                searchSourceBuilder.trackTotalHitsUpTo(
-                    request.paramAsInt("track_total_hits", SearchContext.DEFAULT_TRACK_TOTAL_HITS_UP_TO)
-                );
-            }
-        }
-
-        String sSorts = request.param("sort");
-        if (sSorts != null) {
-            String[] sorts = Strings.splitStringByCommaToArray(sSorts);
-            for (String sort : sorts) {
-                int delimiter = sort.lastIndexOf(":");
-                if (delimiter != -1) {
-                    String sortField = sort.substring(0, delimiter);
-                    String reverse = sort.substring(delimiter + 1);
-                    if ("asc".equals(reverse)) {
-                        searchSourceBuilder.sort(sortField, SortOrder.ASC);
-                    } else if ("desc".equals(reverse)) {
-                        searchSourceBuilder.sort(sortField, SortOrder.DESC);
-                    }
-                } else {
-                    searchSourceBuilder.sort(sort);
-                }
-            }
-        }
-
-        String sStats = request.param("stats");
-        if (sStats != null) {
-            searchSourceBuilder.stats(Arrays.asList(Strings.splitStringByCommaToArray(sStats)));
-        }
+        CommonSearchRestRequestParamsParser.parse(searchSourceBuilder, request, setSize);
 
         String suggestField = request.param("suggest_field");
         if (suggestField != null) {

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourceContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourceContext.java
@@ -105,11 +105,13 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
             }
         }
 
+        // TODO this query param currently not supported in msearch query body. Should it be supported?
         String sIncludes = request.param("_source_includes");
         if (sIncludes != null) {
             sourceIncludes = Strings.splitStringByCommaToArray(sIncludes);
         }
 
+        // TODO this query param currently not supported in msearch query body. Should it be supported?
         String sExcludes = request.param("_source_excludes");
         if (sExcludes != null) {
             sourceExcludes = Strings.splitStringByCommaToArray(sExcludes);

--- a/server/src/test/java/org/elasticsearch/rest/action/search/RestSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/search/RestSearchActionTests.java
@@ -1,0 +1,84 @@
+package org.elasticsearch.rest.action.search;
+
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.sort.SortBuilders;
+import org.elasticsearch.search.sort.SortOrder;
+import org.elasticsearch.test.rest.FakeRestRequest;
+import org.elasticsearch.test.rest.RestActionTestCase;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.IntConsumer;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.singletonList;
+
+public class RestSearchActionTests extends RestActionTestCase {
+    public void testRestRequestQueryParamsParsing() throws IOException {
+        String body = "{\"query\": {\"match_all\" : {}}}\n";
+
+        SearchRequest searchRequest = new SearchRequest();
+        RestRequest restRequest = new FakeRestRequest.Builder(xContentRegistry())
+            .withMethod(RestRequest.Method.GET)
+            .withPath("/_search")
+            .withParams(new HashMap<>() {{
+                put("explain", "true");
+                put("stored_fields", "author,title");
+                put("docvalue_fields", "author,title");
+                put("from", "0");
+                put("size", "5");
+                put("sort", "author:asc,title:desc");
+                put("_source", "true");
+                put("terminate_after", "1");
+                put("stats", "merge,refresh");
+                put("timeout", "10s");
+                put("track_scores", "true");
+                put("track_total_hits", "true");
+                put("version", "true");
+                put("seq_no_primary_term", "true");
+            }})
+            .withContent(new BytesArray(body), XContentType.JSON)
+            .build();
+        IntConsumer setSize = size -> searchRequest.source().size(size);
+
+        try (XContentParser parser = createParser(XContentType.JSON.xContent(), body)) {
+            RestSearchAction.parseSearchRequest(searchRequest, restRequest, parser, setSize);
+        }
+
+        assertTrue(searchRequest.source().explain());
+        assertEquals(List.of("author", "title"), searchRequest.source().storedFields().fieldNames());
+        assertEquals(List.of("author", "title"), searchRequest.source().docValueFields()
+                                                                        .stream().map(f -> f.field).collect(Collectors.toList()));
+        assertEquals(0, searchRequest.source().from());
+        assertEquals(5, searchRequest.source().size());
+        assertEquals(List.of(SortBuilders.fieldSort("author").order(SortOrder.ASC),
+                                SortBuilders.fieldSort("title").order(SortOrder.DESC)),
+                        searchRequest.source().sorts());
+        assertTrue(searchRequest.source().fetchSource().fetchSource());
+        assertEquals(1, searchRequest.source().terminateAfter());
+        assertEquals(List.of("merge", "refresh"), searchRequest.source().stats());
+        assertEquals(new TimeValue(10, TimeUnit.SECONDS), searchRequest.source().timeout());
+        assertTrue(searchRequest.source().trackScores());
+        assertEquals(SearchContext.TRACK_TOTAL_HITS_ACCURATE, searchRequest.source().trackTotalHitsUpTo().intValue());
+        assertTrue(searchRequest.source().version());
+        assertTrue(searchRequest.source().seqNoAndPrimaryTerm());
+    }
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        return new NamedXContentRegistry(singletonList(new NamedXContentRegistry.Entry(QueryBuilder.class,
+            new ParseField(MatchAllQueryBuilder.NAME), (p, c) -> MatchAllQueryBuilder.fromXContent(p))));
+    }
+}


### PR DESCRIPTION
This PR extracts query params parsing logic from `_search` API action and reuses it for `_msearch` API action, so that existing common query params such as `version`, `timeout`, `explain` etc are supported in both in a consistent way, and future additions won't be missed easily. For detailed discussion and testing done, please refer to https://github.com/elastic/elasticsearch/issues/4227 