### PR TITLE
Fix specification for cluster.remote.connect

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -121,7 +121,7 @@ cluster.remote.connect: false <7>
 <4> Disable the `node.ingest` role (enabled by default).
 <5> Disable the `node.ml` role (enabled by default).
 <6> The `xpack.ml.enabled` setting is enabled by default.
-<7> Disable {ccs} (enabled by default).
+<7> Disable remote cluster connections (enabled by default).
 
 To create a dedicated master-eligible node in the {oss-dist}, set:
 
@@ -135,7 +135,7 @@ cluster.remote.connect: false <4>
 <1> The `node.master` role is enabled by default.
 <2> Disable the `node.data` role (enabled by default).
 <3> Disable the `node.ingest` role (enabled by default).
-<4> Disable {ccs} (enabled by default).
+<4> Disable remote cluster connections (enabled by default).
 
 [float]
 [[voting-only-node]]
@@ -200,7 +200,7 @@ cluster.remote.connect: false <7>
 <4> Disable the `node.ingest` role (enabled by default).
 <5> Disable the `node.ml` role (enabled by default).
 <6> The `xpack.ml.enabled` setting is enabled by default.
-<7> Disable {ccs} (enabled by default).
+<7> Disable remote cluster connections (enabled by default).
 
 [float]
 [[data-node]]
@@ -229,7 +229,7 @@ cluster.remote.connect: false <6>
 <3> The `node.data` role is enabled by default.
 <4> Disable the `node.ingest` role (enabled by default).
 <5> Disable the `node.ml` role (enabled by default).
-<6> Disable {ccs} (enabled by default).
+<6> Disable remote cluster connections (enabled by default).
 
 To create a dedicated data node in the {oss-dist}, set:
 [source,yaml]
@@ -242,7 +242,7 @@ cluster.remote.connect: false <4>
 <1> Disable the `node.master` role (enabled by default).
 <2> The `node.data` role is enabled by default.
 <3> Disable the `node.ingest` role (enabled by default).
-<4> Disable {ccs} (enabled by default).
+<4> Disable remote cluster connections (enabled by default).
 
 [float]
 [[node-ingest-node]]
@@ -269,7 +269,7 @@ cluster.remote.connect: false <6>
 <3> Disable the `node.data` role (enabled by default).
 <4> The `node.ingest` role is enabled by default.
 <5> Disable the `node.ml` role (enabled by default).
-<6> Disable {ccs} (enabled by default).
+<6> Disable remote cluster connections (enabled by default).
 
 To create a dedicated ingest node in the {oss-dist}, set:
 
@@ -283,7 +283,7 @@ cluster.remote.connect: false <4>
 <1> Disable the `node.master` role (enabled by default).
 <2> Disable the `node.data` role (enabled by default).
 <3> The `node.ingest` role is enabled by default.
-<4> Disable {ccs} (enabled by default).
+<4> Disable remote cluster connections (enabled by default).
 
 [float]
 [[coordinating-only-node]]
@@ -322,7 +322,7 @@ cluster.remote.connect: false <6>
 <3> Disable the `node.data` role (enabled by default).
 <4> Disable the `node.ingest` role (enabled by default).
 <5> Disable the `node.ml` role (enabled by default).
-<6> Disable {ccs} (enabled by default).
+<6> Disable remote cluster connections (enabled by default).
 
 To create a dedicated coordinating node in the {oss-dist}, set:
 
@@ -336,7 +336,7 @@ cluster.remote.connect: false <4>
 <1> Disable the `node.master` role (enabled by default).
 <2> Disable the `node.data` role (enabled by default).
 <3> Disable the `node.ingest` role (enabled by default).
-<4> Disable {ccs} (enabled by default).
+<4> Disable remote cluster connections (enabled by default).
 
 [float]
 [[ml-node]]
@@ -370,7 +370,7 @@ cluster.remote.connect: false <7>
 <4> Disable the `node.ingest` role (enabled by default).
 <5> The `node.ml` role is enabled by default.
 <6> The `xpack.ml.enabled` setting is enabled by default.
-<7> Disable {ccs} (enabled by default).
+<7> Disable remote cluster connections (enabled by default).
 
 [float]
 [[change-node-role]]


### PR DESCRIPTION
The docs specify that cluster.remote.connect disables cross-cluster search. This is correct, but not fully accurate as it disables any functionality that relies on remote cluster connections: cross-cluster search, remote data feeds, and cross-cluster replication. This commit updates the docs to reflect this.

