### PR TITLE
[docs] Synonym Token Filter

### DIFF
--- a/docs/reference/analysis/tokenfilters/synonym-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/synonym-tokenfilter.asciidoc
@@ -35,7 +35,7 @@ The above configures a `synonym` filter, with a path of
 `analysis/synonym.txt` (relative to the `config` location). The
 `synonym` analyzer is then configured with the filter.
 
-This filter tokenize synonyms with whatever tokenizer and token filters
+This filter tokenizes synonyms with whatever tokenizer and token filters
 appear before it in the chain.
 
 Additional settings are:


### PR DESCRIPTION
this doc is a bit sparse and appears rushed and incomplete IMHO.

some improvements which could be made:
- write something about the `expand` setting other than it defaults to true.
- text blocks like the one which begins 'With the above request the word...' are extremely dense and technical, difficult to understand
- the `parsing_synonym_files` section is hidden at the bottom but contains important information like "Elasticsearch will use the token filters preceding the synonym filter in a tokenizer chain to parse the entries in a synonym file", concepts like "stacked positions" are not adequately explained and there are no links provided to explain more about the implications for token filters which worked prior to the big changes in es6.