### PR TITLE
Fix and re-enable ClusterStatsNodesTests#testIngestStats

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodesTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.cluster.stats;
 
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
+import org.elasticsearch.action.admin.cluster.node.stats.NodeStatsTests;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
@@ -37,7 +38,6 @@ import java.util.TreeMap;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.elasticsearch.action.admin.cluster.node.stats.NodeStatsTests.createNodeStats;
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -67,10 +67,8 @@ public class ClusterStatsNodesTests extends ESTestCase {
         + "}", toXContent(stats, XContentType.JSON, randomBoolean()).utf8ToString());
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/48684")
     public void testIngestStats() throws Exception {
-        NodeStats nodeStats = createNodeStats();
-
+        NodeStats nodeStats = randomValueOtherThanMany(n -> n.getIngestStats() == null, NodeStatsTests::createNodeStats);
         SortedMap<String, long[]> processorStats = new TreeMap<>();
         nodeStats.getIngestStats().getProcessorStats().values().forEach(l -> l.forEach(s -> processorStats.put(s.getType(),
             new long[] { s.getStats().getIngestCount(), s.getStats().getIngestFailedCount(),


### PR DESCRIPTION
This commit creates random NodesStats until IngestStats is not null, so
that it can be properly tested. This is done as to not change the existing
behavior of createNodesStats since it depends on IngestStats being null
at times for serialization testing purposes. I think it is OK to do this since
it is unlikely that it will be null.

relates #48485

closes #48684