### PR TITLE
Fix SnapshotLifecycleService logger

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleService.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
  */
 public class SnapshotLifecycleService implements LocalNodeMasterListener, Closeable, ClusterStateListener {
 
-    private static final Logger logger = LogManager.getLogger(SnapshotLifecycleMetadata.class);
+    private static final Logger logger = LogManager.getLogger(SnapshotLifecycleService.class);
     private static final String JOB_PATTERN_SUFFIX = "-\\d+$";
 
     private final SchedulerEngine scheduler;


### PR DESCRIPTION
The logger was erroneously using the `SnapshotLifecycleMetadata` class
for its initialization, making it hard to target packages for logging
levels since `SnapshotLifecycleMetadata` is in a different package.
