### PR TITLE
Update geoip.asciidoc to be compliant with ECS

### DIFF
--- a/docs/reference/ingest/processors/geoip.asciidoc
+++ b/docs/reference/ingest/processors/geoip.asciidoc
@@ -36,7 +36,7 @@ and `location`. The fields actually added depend on what has been found and whic
 `country_iso_code`, `country_name` and `continent_name`. The fields actually added depend on what has been found and which properties
 were configured in `properties`.
 * If the GeoLite2 ASN database is used, then the following fields may be added under the `target_field`: `ip`,
-`asn`, and `organization_name`. The fields actually added depend on what has been found and which properties were configured
+`as.number`, and `organization_name`. The fields actually added depend on what has been found and which properties were configured
 in `properties`.
 
 Here is an example that uses the default city database and adds the geographical information to the `geoip` field based on the `ip` field:


### PR DESCRIPTION
Hi,

I hope it is only a documentation issue. But regarding the ECS <https://www.elastic.co/guide/en/ecs/master/ecs-as.html> `as.number` should contain the number of the autonomous system and not `asn`.
