### PR TITLE
[docs] Remove the reference to `type` from README

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -124,7 +124,7 @@ curl -XGET 'http://localhost:9200/twitter/_search?pretty=true' -H 'Content-Type:
 
 There are many more options to perform search, after all, it's a search product no? All the familiar Lucene queries are available through the JSON query language, or through the query parser.
 
-h3. Multi Tenant - Indices and Types
+h3. Multi Tenant and Indices
 
 Man, that twitter index might get big (in this case, index size == valuation). Let's see if we can structure our twitter system a bit differently in order to support such large amounts of data.
 


### PR DESCRIPTION
as types are no longer supported by ES.