### PR TITLE
[DOCS] Reformat decimal digit token filter

### DIFF
--- a/docs/reference/analysis/tokenfilters/decimal-digit-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/decimal-digit-tokenfilter.asciidoc
@@ -22,7 +22,7 @@ GET /_analyze
 {
   "tokenizer" : "whitespace",
   "filter" : ["decimal_digit"],
-  "text" : "० १ २ ३ ४ ५ ६ ७ ८ ९"
+  "text" : "१-one two-२ ३"
 }
 --------------------------------------------------
 
@@ -30,7 +30,7 @@ The filter produces the following tokens:
 
 [source,text]
 --------------------------------------------------
-[ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ]
+[ 1-one, two-2, 3]
 --------------------------------------------------
 
 /////////////////////
@@ -39,74 +39,25 @@ The filter produces the following tokens:
 {
   "tokens" : [
     {
-      "token" : "0",
+      "token" : "1-one",
       "start_offset" : 0,
-      "end_offset" : 1,
+      "end_offset" : 5,
       "type" : "word",
       "position" : 0
     },
     {
-      "token" : "1",
-      "start_offset" : 2,
-      "end_offset" : 3,
+      "token" : "two-2",
+      "start_offset" : 6,
+      "end_offset" : 11,
       "type" : "word",
       "position" : 1
     },
     {
-      "token" : "2",
-      "start_offset" : 4,
-      "end_offset" : 5,
-      "type" : "word",
-      "position" : 2
-    },
-    {
       "token" : "3",
-      "start_offset" : 6,
-      "end_offset" : 7,
-      "type" : "word",
-      "position" : 3
-    },
-    {
-      "token" : "4",
-      "start_offset" : 8,
-      "end_offset" : 9,
-      "type" : "word",
-      "position" : 4
-    },
-    {
-      "token" : "5",
-      "start_offset" : 10,
-      "end_offset" : 11,
-      "type" : "word",
-      "position" : 5
-    },
-    {
-      "token" : "6",
       "start_offset" : 12,
       "end_offset" : 13,
       "type" : "word",
-      "position" : 6
-    },
-    {
-      "token" : "7",
-      "start_offset" : 14,
-      "end_offset" : 15,
-      "type" : "word",
-      "position" : 7
-    },
-    {
-      "token" : "8",
-      "start_offset" : 16,
-      "end_offset" : 17,
-      "type" : "word",
-      "position" : 8
-    },
-    {
-      "token" : "9",
-      "start_offset" : 18,
-      "end_offset" : 19,
-      "type" : "word",
-      "position" : 9
+      "position" : 2
     }
   ]
 }

--- a/docs/reference/analysis/tokenfilters/decimal-digit-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/decimal-digit-tokenfilter.asciidoc
@@ -1,4 +1,138 @@
 [[analysis-decimal-digit-tokenfilter]]
-=== Decimal Digit Token Filter
+=== Decimal digit token filter
+++++
+<titleabbrev>Decimal digit</titleabbrev>
+++++
 
-The `decimal_digit` token filter folds unicode digits to `0-9`
+Converts all digits in the Unicode `Decimal_Number` General Category to `0-9`.
+For example, the filter changes the Bengali numeral `৩` to `3`.
+
+This filter uses Lucene's
+https://lucene.apache.org/core/{lucene_version_path}/analyzers-common/org/apache/lucene/analysiscore/DecimalDigitFilter.html[DecimalDigitFilter].
+
+[[analysis-decimal-digit-tokenfilter-analyze-ex]]
+==== Example
+
+The following <<indices-analyze,analyze API>> request uses the `decimal_digit`
+filter to convert Devanagari numerals to `0-9`:
+
+[source,console]
+--------------------------------------------------
+GET /_analyze
+{
+  "tokenizer" : "whitespace",
+  "filter" : ["decimal_digit"],
+  "text" : "० १ २ ३ ४ ५ ६ ७ ८ ९"
+}
+--------------------------------------------------
+
+The filter produces the following tokens:
+
+[source,text]
+--------------------------------------------------
+[ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ]
+--------------------------------------------------
+
+/////////////////////
+[source,console-result]
+--------------------------------------------------
+{
+  "tokens" : [
+    {
+      "token" : "0",
+      "start_offset" : 0,
+      "end_offset" : 1,
+      "type" : "word",
+      "position" : 0
+    },
+    {
+      "token" : "1",
+      "start_offset" : 2,
+      "end_offset" : 3,
+      "type" : "word",
+      "position" : 1
+    },
+    {
+      "token" : "2",
+      "start_offset" : 4,
+      "end_offset" : 5,
+      "type" : "word",
+      "position" : 2
+    },
+    {
+      "token" : "3",
+      "start_offset" : 6,
+      "end_offset" : 7,
+      "type" : "word",
+      "position" : 3
+    },
+    {
+      "token" : "4",
+      "start_offset" : 8,
+      "end_offset" : 9,
+      "type" : "word",
+      "position" : 4
+    },
+    {
+      "token" : "5",
+      "start_offset" : 10,
+      "end_offset" : 11,
+      "type" : "word",
+      "position" : 5
+    },
+    {
+      "token" : "6",
+      "start_offset" : 12,
+      "end_offset" : 13,
+      "type" : "word",
+      "position" : 6
+    },
+    {
+      "token" : "7",
+      "start_offset" : 14,
+      "end_offset" : 15,
+      "type" : "word",
+      "position" : 7
+    },
+    {
+      "token" : "8",
+      "start_offset" : 16,
+      "end_offset" : 17,
+      "type" : "word",
+      "position" : 8
+    },
+    {
+      "token" : "9",
+      "start_offset" : 18,
+      "end_offset" : 19,
+      "type" : "word",
+      "position" : 9
+    }
+  ]
+}
+--------------------------------------------------
+/////////////////////
+
+[[analysis-decimal-digit-tokenfilter-analyzer-ex]]
+==== Add to an analyzer
+
+The following <<indices-create-index,create index API>> request uses the
+`decimal_digit` filter to configure a new 
+<<analysis-custom-analyzer,custom analyzer>>.
+
+[source,console]
+--------------------------------------------------
+PUT /decimal_digit_example
+{
+    "settings" : {
+        "analysis" : {
+            "analyzer" : {
+                "whitespace_decimal_digit" : {
+                    "tokenizer" : "whitespace",
+                    "filter" : ["decimal_digit"]
+                }
+            }
+        }
+    }
+}
+--------------------------------------------------


### PR DESCRIPTION
Reformats the decimal digit token filter docs as part of #44726.

### Changes

* Adds a title abbreviation
* Updates the description and adds a Lucene link
* Adds analyze and custom analyzer snippets