### PR TITLE
[docs] Fix typo

### DIFF
--- a/docs/reference/ilm/policy-definitions.asciidoc
+++ b/docs/reference/ilm/policy-definitions.asciidoc
@@ -89,7 +89,7 @@ executing.
 The below list shows the actions which are available in each phase.
 
 NOTE: The order that configured actions are performed in within each phase is
-determined by automatically by {ilm-init}, and cannot be changed by changing the
+determined automatically by {ilm-init}, and cannot be changed by changing the
 policy definition.
 
 * Hot


### PR DESCRIPTION
Removes an extra "by".
