### PR TITLE
[Backport] Add IndexOrDocValuesQuery to GeoPolygonQueryBuilder (#48449)

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoPolygonQueryBuilderTests.java
@@ -19,11 +19,15 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.document.LatLonDocValuesField;
+import org.apache.lucene.document.LatLonPoint;
+import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.test.AbstractQueryTestCase;
 import org.elasticsearch.test.geo.RandomShapeGenerator;
 import org.elasticsearch.test.geo.RandomShapeGenerator.ShapeType;
@@ -53,12 +57,30 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
         if (randomBoolean()) {
             builder.ignoreUnmapped(randomBoolean());
         }
+
         return builder;
     }
 
     @Override
     protected void doAssertLuceneQuery(GeoPolygonQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
-        // todo LatLonPointInPolygon is package private
+        MappedFieldType fieldType = context.fieldMapper(queryBuilder.fieldName());
+        if (fieldType == null) {
+            assertTrue("Found no indexed geo query.", query instanceof MatchNoDocsQuery);
+        } else { // TODO: Test case when there are no docValues
+            Query indexQuery = ((IndexOrDocValuesQuery) query).getIndexQuery();
+            String expectedFieldName = expectedFieldName(queryBuilder.fieldName());
+            List<GeoPoint> points = queryBuilder.points();
+            double[] lats = new double[points.size()];
+            double[] lons = new double[points.size()];
+            for (int i =0; i < points.size(); i++) {
+                lats[i] = points.get(i).getLat();
+                lons[i] = points.get(i).getLon();
+            }
+            org.apache.lucene.geo.Polygon polygon = new org.apache.lucene.geo.Polygon(lats, lons);
+            assertEquals(LatLonPoint.newPolygonQuery(expectedFieldName, polygon), indexQuery);
+            Query dvQuery = ((IndexOrDocValuesQuery) query).getRandomAccessQuery();
+            assertEquals(LatLonDocValuesField.newSlowPolygonQuery(expectedFieldName, polygon), dvQuery);
+        }
     }
 
     private static List<GeoPoint> randomPolygon() {
@@ -196,9 +218,8 @@ public class GeoPolygonQueryBuilderTests extends AbstractQueryTestCase<GeoPolygo
 
     private void assertGeoPolygonQuery(String query) throws IOException {
         QueryShardContext context = createShardContext();
-        parseQuery(query).toQuery(context);
-        // TODO LatLonPointInPolygon is package private, need a closeTo check on the query
-        // since some points can be computed from the geohash
+        GeoPolygonQueryBuilder queryBuilder = (GeoPolygonQueryBuilder) parseQuery(query);
+        doAssertLuceneQuery(queryBuilder, queryBuilder.toQuery(context), context);
     }
 
     public void testFromJson() throws IOException {


### PR DESCRIPTION
In Lucene 8.3, it was added a new polygon query over geo points using docValues (https://issues.apache.org/jira/browse/LUCENE-8960). We can use it as part of an IndexOrDocValuesQuery to speed up queries when there is a more selective filter.

Backport of #48449