### PR TITLE
Fix NPE in artificial document _termvectors request

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsFilter.java
+++ b/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsFilter.java
@@ -207,8 +207,6 @@ public class TermVectorsFilter {
             while (termsEnum.next() != null) {
                 BytesRef termBytesRef = termsEnum.term();
                 boolean foundTerm = topLevelTermsEnum.seekExact(termBytesRef);
-                assert foundTerm : "Term: " + termBytesRef.utf8ToString() + " not found!";
-
                 Term term = new Term(fieldName, termBytesRef);
 
                 // remove noise words
@@ -218,8 +216,8 @@ public class TermVectorsFilter {
                 }
 
                 // now call on docFreq
-                long docFreq = getTermStatistics(topLevelTermsEnum, term).docFreq();
-                if (!isAccepted(docFreq)) {
+                long docFreq = foundTerm ? getTermStatistics(topLevelTermsEnum, term).docFreq() : 1;
+                if (isAccepted(docFreq) == false) {
                     continue;
                 }
 

--- a/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsResponse.java
@@ -240,8 +240,8 @@ public class TermVectorsResponse extends ActionResponse implements ToXContentObj
         // boolean that says if these values actually were requested.
         // However, we can assume that they were not if the statistic values are
         // <= 0.
-        assert (((termIter.docFreq() > 0) && (termIter.totalTermFreq() > 0)) ||
-            ((termIter.docFreq() == -1) && (termIter.totalTermFreq() == -1)));
+        assert (((termIter.docFreq() >= 0) && (termIter.totalTermFreq() >= 0)) ||
+            ((termIter.docFreq() == 0) && (termIter.totalTermFreq() == 0)));
         int docFreq = termIter.docFreq();
         if (docFreq > 0) {
             builder.field(FieldStrings.DOC_FREQ, docFreq);


### PR DESCRIPTION
This commit fixes an NPE when an artificial document contains terms
that don't appear in the index.

Closes #47723
Closes #48744