### PR TITLE
Fix TimeSeriesLifecycleActionsIT.testRolloverAlreadyExists

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
@@ -312,11 +312,14 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         // index another doc to trigger the policy
         index(client(), originalIndex, "_id", "foo", "bar");
         assertBusy(() -> {
-            logger.info(originalIndex + ": " + getStepKeyForIndex(originalIndex));
+            Map<String, Object> explainIndexResponse = explainIndex(originalIndex);
+            logger.info(originalIndex + ": " + getStepKey(explainIndexResponse));
             logger.info(secondIndex + ": " + getStepKeyForIndex(secondIndex));
-            assertThat(getStepKeyForIndex(originalIndex), equalTo(new StepKey("hot", RolloverAction.NAME, ErrorStep.NAME)));
-            assertThat(getFailedStepForIndex(originalIndex), equalTo(WaitForRolloverReadyStep.NAME));
-            assertThat(getReasonForIndex(originalIndex), containsString("already exists"));
+            assertThat(getStepKey(explainIndexResponse), equalTo(new StepKey("hot", RolloverAction.NAME, ErrorStep.NAME)));
+            assertThat(explainIndexResponse.get("failed_step"), equalTo(WaitForRolloverReadyStep.NAME));
+            @SuppressWarnings("unchecked")
+            String reason = ((Map<String, String>) explainIndexResponse.get("step_info")).get("reason");
+            assertThat(reason, containsString("already exists"));
         });
     }
 
@@ -1071,15 +1074,20 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         return (Map<String, Object>) response.get("settings");
     }
 
+
     public static StepKey getStepKeyForIndex(String indexName) throws IOException {
         Map<String, Object> indexResponse = explainIndex(indexName);
         if (indexResponse == null) {
             return new StepKey(null, null, null);
         }
 
-        String phase = (String) indexResponse.get("phase");
-        String action = (String) indexResponse.get("action");
-        String step = (String) indexResponse.get("step");
+        return getStepKey(indexResponse);
+    }
+
+    private static StepKey getStepKey(Map<String, Object> explainIndexResponse) {
+        String phase = (String) explainIndexResponse.get("phase");
+        String action = (String) explainIndexResponse.get("action");
+        String step = (String) explainIndexResponse.get("step");
         return new StepKey(phase, action, step);
     }
 
@@ -1088,14 +1096,6 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         if (indexResponse == null) return null;
 
         return (String) indexResponse.get("failed_step");
-    }
-
-    @SuppressWarnings("unchecked")
-    private String getReasonForIndex(String indexName) throws IOException {
-        Map<String, Object> indexResponse = explainIndex(indexName);
-        if (indexResponse == null) return null;
-
-        return ((Map<String, String>) indexResponse.get("step_info")).get("reason");
     }
 
     private static Map<String, Object> explainIndex(String indexName) throws IOException {

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
@@ -214,7 +214,6 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         RolloverAction action = RolloverActionTests.randomInstance();
         actions.put(RolloverAction.NAME, action);
         Phase phase = new Phase(phaseName, after, actions);
-        Map<String, Phase> phases = Map.of(phaseName, phase);
         PhaseExecutionInfo phaseExecutionInfo = new PhaseExecutionInfo(policyName, phase, 1, randomNonNegativeLong());
         String phaseJson = Strings.toString(phaseExecutionInfo);
         NoOpClient client = new NoOpClient(threadPool);


### PR DESCRIPTION
With the introduction of retryable steps subsequent ilm/_explain calls
can see the state of an ilm cycle move out of the error step. This test
made several assertions assuming that the cycle remains in the error
step so this commit changes the test to make one _explain call and have
all the asserts work on the same ilm state (so subsequent assumptions to
the cycle being in the error step are valid).

Build scan available at https://gradle-enterprise.elastic.co/s/e7bquvavqi4bw 