### PR TITLE
[DOCS] Remove unneeded filter from common grams analyze ex

### DIFF
--- a/docs/reference/analysis/tokenfilters/common-grams-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/common-grams-tokenfilter.asciidoc
@@ -30,7 +30,7 @@ GET /_analyze
 {
   "tokenizer" : "whitespace",
   "filter" : [
-    "common_grams", {
+    {
       "type": "common_grams",
       "common_words": ["is", "the"]
     }


### PR DESCRIPTION
Removes a duplicated "common_grams" filter from the analyze snippet for the common grams token filter docs.

As this filter has no common words defined, it's doing no work.