### PR TITLE
ILM guard explain api serialisation against 7.6.0

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleExplainResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleExplainResponse.java
@@ -174,7 +174,7 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
             stepTime = in.readOptionalLong();
             stepInfo = in.readOptionalBytesReference();
             phaseExecutionInfo = in.readOptionalWriteable(PhaseExecutionInfo::new);
-            if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            if (in.getVersion().onOrAfter(Version.V_7_6_0)) {
                 isAutoRetryableError = in.readOptionalBoolean();
                 failedStepRetryCount = in.readOptionalVInt();
             } else {
@@ -214,7 +214,7 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
             out.writeOptionalLong(stepTime);
             out.writeOptionalBytesReference(stepInfo);
             out.writeOptionalWriteable(phaseExecutionInfo);
-            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            if (out.getVersion().onOrAfter(Version.V_7_6_0)) {
                 out.writeOptionalBoolean(isAutoRetryableError);
                 out.writeOptionalVInt(failedStepRetryCount);
             }


### PR DESCRIPTION
The explain api change was backported to 7.x so we should now guard the
serialisation changes against 7.6.0

Fixes https://github.com/elastic/elasticsearch/issues/48749