### PR TITLE
Remove unneeded // CONSOLE statements from docs

### DIFF
--- a/docs/README.asciidoc
+++ b/docs/README.asciidoc
@@ -26,19 +26,12 @@ Snippets marked with `[source,console]` are automatically annotated with
 tested by the command `./gradlew -pdocs check`. To test just the docs from a
 single page, use e.g. `./gradlew -ddocs integTestRunner --tests "*rollover*"`.
 
-NOTE: Previously we use `// CONSOLE` instead of `[source,console]`. This worked
-well for a long time so you'll see it all over early branches but we're phasing
-it out because it requires some unpleasant hackery on the docs build side.
-
-NOTE: If you have an elasticsearch-extra folder alongside your elasticsearch
-folder, you must temporarily rename it when you are testing 6.3 or later branches.
-
-By default each `// CONSOLE` snippet runs as its own isolated test. You can
-manipulate the test execution in the following ways:
+By default each `[source,console]` snippet runs as its own isolated test. You
+can manipulate the test execution in the following ways:
 
 * `// TEST`: Explicitly marks a snippet as a test. Snippets marked this way
-are tests even if they don't have `// CONSOLE` but usually `// TEST` is used
-for its modifiers:
+are tests even if they don't have `[source,console]` but usually `// TEST` is
+used for its modifiers:
   * `// TEST[s/foo/bar/]`: Replace `foo` with `bar` in the generated test. This
   should be used sparingly because it makes the snippet "lie". Sometimes,
   though, you can use it to make the snippet more clear. Keep in mind that

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -305,7 +305,6 @@ POST twitter/_update_by_query?conflicts=proceed
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 <1> The query must be passed as a value to the `query` key, in the same
@@ -318,7 +317,6 @@ Update documents in multiple indices:
 --------------------------------------------------
 POST twitter,blog/_update_by_query
 --------------------------------------------------
-// CONSOLE
 // TEST[s/^/PUT twitter\nPUT blog\n/]
 
 Limit the update by query operation to shards that a particular routing value:
@@ -327,7 +325,6 @@ Limit the update by query operation to shards that a particular routing value:
 --------------------------------------------------
 POST twitter/_update_by_query?routing=1
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 By default update by query uses scroll batches of 1000. 
@@ -337,7 +334,6 @@ You can change the batch size with the `scroll_size` parameter:
 --------------------------------------------------
 POST twitter/_update_by_query?scroll_size=100
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 [[docs-update-by-query-api-source]]
@@ -361,7 +357,6 @@ POST twitter/_update_by_query
   }
 }
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 Note that `conflicts=proceed` is not specified in this example. In this case, a
@@ -402,7 +397,6 @@ PUT _ingest/pipeline/set-foo
 }
 POST twitter/_update_by_query?pipeline=set-foo
 --------------------------------------------------
-// CONSOLE
 // TEST[setup:twitter]
 
 


### PR DESCRIPTION
I also removed a paragraph mentioning those old statements, as everything seems to be converted. The same applies to the mention of the `elasticsearch-extra` folder, which has been removed more than a year ago.