### PR TITLE
update IngestStats version guards to 7.6 and re-enable bwc tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -206,8 +206,8 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
-final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/48661<Paste>" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = true
+final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
@@ -36,7 +36,6 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.discovery.DiscoveryModule;
-import org.elasticsearch.ingest.IngestStats;
 import org.elasticsearch.monitor.fs.FsInfo;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.plugins.PluginInfo;

--- a/server/src/main/java/org/elasticsearch/ingest/IngestStats.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestStats.java
@@ -68,7 +68,7 @@ public class IngestStats implements Writeable, ToXContentFragment {
             List<ProcessorStat> processorStatsPerPipeline = new ArrayList<>(processorsSize);
             for (int j = 0; j < processorsSize; j++) {
                 String processorName = in.readString();
-                String processorType = null;
+                String processorType = "_NOT_AVAILABLE";
                 if (in.getVersion().onOrAfter(Version.V_7_6_0)) {
                     processorType = in.readString();
                 }

--- a/server/src/main/java/org/elasticsearch/ingest/IngestStats.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestStats.java
@@ -69,7 +69,7 @@ public class IngestStats implements Writeable, ToXContentFragment {
             for (int j = 0; j < processorsSize; j++) {
                 String processorName = in.readString();
                 String processorType = null;
-                if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+                if (in.getVersion().onOrAfter(Version.V_7_6_0)) {
                     processorType = in.readString();
                 }
                 Stats processorStat = new Stats(in);
@@ -93,7 +93,7 @@ public class IngestStats implements Writeable, ToXContentFragment {
                 out.writeVInt(processorStatsForPipeline.size());
                 for (ProcessorStat processorStat : processorStatsForPipeline) {
                     out.writeString(processorStat.getName());
-                    if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+                    if (out.getVersion().onOrAfter(Version.V_7_6_0)) {
                         out.writeString(processorStat.getType());
                     }
                     processorStat.getStats().writeTo(out);


### PR DESCRIPTION
after backporting #48485 in #48661, version guards in master can
be updated from 8.0 to 7.6 for IngestStats serialization guards