### PR TITLE
[Docs] - fix indent level for Role Mapping 'except' field

### DIFF
--- a/x-pack/docs/en/rest-api/security/role-mapping-resources.asciidoc
+++ b/x-pack/docs/en/rest-api/security/role-mapping-resources.asciidoc
@@ -26,7 +26,7 @@ A rule is a logical condition that is expressed by using a JSON DSL. The DSL sup
 (array of rules) If *all* of its children are true, it evaluates to `true`.
 `field`::: 
 (object) See <<mapping-roles-rule-field>>. 
-`except`:::
+`except`::: 
 (object) A single rule as an object. Only valid as a child of an `all` rule. If 
 its child is `false`, the `except` is `true`.
 


### PR DESCRIPTION
Fixes the indentation level for the `except` field.

## Previous:
![image](https://user-images.githubusercontent.com/3493255/68031648-76332980-fc92-11e9-9de8-69b67bd222a8.png)


## Fixed:
![image](https://user-images.githubusercontent.com/3493255/68031673-7fbc9180-fc92-11e9-99bc-7a1f833c6972.png)

