### PR TITLE
[DOCS] List `indices.lifecycle.poll_interval` as cluster-level setting

### DIFF
--- a/docs/reference/settings/ilm-settings.asciidoc
+++ b/docs/reference/settings/ilm-settings.asciidoc
@@ -10,6 +10,10 @@ These are the settings available for configuring Index Lifecycle Management
 Whether ILM is enabled or disabled, setting this to `false` disables any
 ILM REST API endpoints and functionality. Defaults to `true`.
 
+`indices.lifecycle.poll_interval`::
+(<<time-units, time units>>) How often {ilm} checks for indices that meet policy
+criteria. Defaults to `10m`.
+
 ==== Index level settings
 These index-level {ilm-init} settings are typically configured through index
 templates. For more information, see <<ilm-gs-create-policy>>.
@@ -22,10 +26,6 @@ The index alias to update when the index rolls over. Specify when using a
 policy that contains a rollover action. When the index rolls over, the alias is
 updated to reflect that the index is no longer the write index. For more
 information about rollover, see <<using-policies-rollover>>.
-
-`indices.lifecycle.poll_interval`::
-(<<time-units, time units>>) How often {ilm} checks for indices that meet policy
-criteria. Defaults to `10m`.
 
 `index.lifecycle.parse_origination_date`::
 When configured to `true` the origination date will be parsed from the index


### PR DESCRIPTION
Lists `indices.lifecycle.poll_interval` with other cluster-level ILM settings.

Previously, it was included under index-level settings.

Closes #48811.