### PR TITLE
Fix ilm/20_move_to_step basic moving to step

### DIFF
--- a/x-pack/plugin/ilm/qa/rest/src/test/resources/rest-api-spec/test/ilm/20_move_to_step.yml
+++ b/x-pack/plugin/ilm/qa/rest/src/test/resources/rest-api-spec/test/ilm/20_move_to_step.yml
@@ -73,17 +73,17 @@ teardown:
             action: "complete"
             name: "complete"
           next_step:
-            phase: "warm"
-            action: "forcemerge"
-            name: "forcemerge"
+            phase: "completed"
+            action: "completed"
+            name: "completed"
 
   - do:
         ilm.explain_lifecycle:
           index: "my_index"
   - match: { indices.my_index.policy: "my_moveable_timeseries_lifecycle" }
-  - match: { indices.my_index.step: "forcemerge" }
-  - match: { indices.my_index.action: "forcemerge" }
-  - match: { indices.my_index.phase: "warm" }
+  - match: { indices.my_index.step: "completed" }
+  - match: { indices.my_index.action: "completed" }
+  - match: { indices.my_index.phase: "completed" }
 
 ---
 "Test Invalid Move To Step With Incorrect Current Step":


### PR DESCRIPTION
Previously this step moved to the forcemerge step, however, if the
machine running the test was fast enough, it would execute the
forcemerge and move to the next step (`segment-count`) so the comparison
would fail. This commit changes the step to be a step that will never go
anywhere else, the terminal step.

Resolves #48761
