### PR TITLE
Remove include_type_name from the REST API spec and docs.

### DIFF
--- a/docs/reference/indices/create-index.asciidoc
+++ b/docs/reference/indices/create-index.asciidoc
@@ -51,8 +51,6 @@ Index names must meet the following criteria:
 [[indices-create-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=include-type-name]
-
 include::{docdir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
@@ -134,10 +132,6 @@ PUT /test
     }
 }
 --------------------------------------------------
-
-NOTE: Before 7.0.0, the 'mappings' definition used to include a type name. Although specifying
-types in requests is now deprecated, a type can still be provided if the request parameter
-include_type_name is set. For more details, please see <<removal-of-types>>.
 
 [[create-index-aliases]]
 ===== Aliases

--- a/docs/reference/indices/get-field-mapping.asciidoc
+++ b/docs/reference/indices/get-field-mapping.asciidoc
@@ -40,8 +40,6 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=include-type-name]
-
 include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
 `include_defaults`::

--- a/docs/reference/indices/get-index-template.asciidoc
+++ b/docs/reference/indices/get-index-template.asciidoc
@@ -46,8 +46,6 @@ or use a value of `_all` or `*`.
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=include-type-name]
-
 include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]

--- a/docs/reference/indices/get-index.asciidoc
+++ b/docs/reference/indices/get-index.asciidoc
@@ -12,11 +12,6 @@ GET /twitter
 --------------------------------------------------
 // TEST[setup:twitter]
 
-NOTE: Before 7.0.0, the 'mappings' definition used to include a type name. Although mappings
-in responses no longer contain a type name by default, you can still request the old format
-through the parameter include_type_name. For more details, please see <<removal-of-types>>.
-
-
 [[get-index-api-request]]
 ==== {api-request-title}
 
@@ -48,8 +43,6 @@ Defaults to `open`.
 include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=include-defaults]
-
-include::{docdir}/rest-api/common-parms.asciidoc[tag=include-type-name]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 

--- a/docs/reference/indices/get-mapping.asciidoc
+++ b/docs/reference/indices/get-mapping.asciidoc
@@ -12,11 +12,6 @@ GET /twitter/_mapping
 --------------------------------------------------
 // TEST[setup:twitter]
 
-NOTE: Before 7.0.0, the 'mappings' definition used to include a type name. Although mappings
-in responses no longer contain a type name by default, you can still request the old format
-through the parameter `include_type_name`. For more details, please see <<removal-of-types>>.
-
-
 [[get-mapping-api-request]]
 ==== {api-request-title}
 
@@ -39,8 +34,6 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
-
-include::{docdir}/rest-api/common-parms.asciidoc[tag=include-type-name]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 

--- a/docs/reference/indices/put-mapping.asciidoc
+++ b/docs/reference/indices/put-mapping.asciidoc
@@ -20,12 +20,6 @@ PUT /twitter/_mapping
 ----
 // TEST[setup:twitter]
 
-NOTE: Before 7.0.0, the 'mappings' definition used to include a type name.
-Although specifying types in requests is now deprecated, a type can still be
-provided if the request parameter `include_type_name` is set. For more details,
-please see <<removal-of-types>>.
-
-
 [[put-mapping-api-request]]
 ==== {api-request-title}
 
@@ -51,8 +45,6 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
-
-include::{docdir}/rest-api/common-parms.asciidoc[tag=include-type-name]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 

--- a/docs/reference/indices/rollover-index.asciidoc
+++ b/docs/reference/indices/rollover-index.asciidoc
@@ -113,8 +113,6 @@ the request checks whether the index matches provided conditions
 but does not perform a rollover.
 Defaults to `false`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=include-type-name]
-
 include::{docdir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]

--- a/docs/reference/indices/templates.asciidoc
+++ b/docs/reference/indices/templates.asciidoc
@@ -86,8 +86,6 @@ Defaults to `false`.
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=include-type-name]
-
 `order`::
 (Optional,integer)
 Order in which {es} applies this template

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -281,13 +281,6 @@ each one  of the Lucene index files (only applies if segment stats are
 requested). Defaults to `false`.
 end::include-segment-file-sizes[]
 
-tag::include-type-name[]
-`include_type_name`::
-deprecated:[7.0.0, Mapping types have been deprecated. See <<removal-of-types>>.]
-(Optional, boolean) If `true`, a mapping type is expected in the body of
-mappings. Defaults to `false`.
-end::include-type-name[]
-
 tag::include-unloaded-segments[]
 `include_unloaded_segments`::
 (Optional, boolean) If `true`, the response includes information from segments

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json
@@ -22,10 +22,6 @@
       ]
     },
     "params":{
-      "include_type_name":{
-        "type":"boolean",
-        "description":"Whether a type should be expected in the body of the mappings."
-      },
       "wait_for_active_shards":{
         "type":"string",
         "description":"Set the number of active shards to wait for before the operation returns."

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
@@ -22,10 +22,6 @@
       ]
     },
     "params":{
-      "include_type_name":{
-        "type":"boolean",
-        "description":"Whether to add the type name to the response (default: false)"
-      },
       "local":{
         "type":"boolean",
         "description":"Return local information, do not retrieve the state from master node (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
@@ -38,10 +38,6 @@
       ]
     },
     "params":{
-      "include_type_name":{
-        "type":"boolean",
-        "description":"Whether a type should be returned in the body of the mappings."
-      },
       "include_defaults":{
         "type":"boolean",
         "description":"Whether the default mapping values should be returned as well"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
@@ -28,10 +28,6 @@
       ]
     },
     "params":{
-      "include_type_name":{
-        "type":"boolean",
-        "description":"Whether a type should be returned in the body of the mappings."
-      },
       "flat_settings":{
         "type":"boolean",
         "description":"Return settings in flat format (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
@@ -23,10 +23,6 @@
       ]
     },
     "params":{
-      "include_type_name":{
-        "type":"boolean",
-        "description":"Whether a type should be returned in the body of the mappings."
-      },
       "order":{
         "type":"number",
         "description":"The order for this template when merging multiple matching ones (higher numbers are merged later, overriding the lower numbers)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
@@ -38,10 +38,6 @@
       ]
     },
     "params":{
-      "include_type_name":{
-        "type":"boolean",
-        "description":"Whether a type should be included in the body of the mappings."
-      },
       "timeout":{
         "type":"time",
         "description":"Explicit operation timeout"


### PR DESCRIPTION
In #48632 we removed support for `include_type_name` in the REST API. This PR
removes it from the API spec and documentation.