### PR TITLE
Elasticsearch 7.5 is on Lucene 8.3.

### DIFF
--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -123,7 +123,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_7_4_1 = new Version(7040199, org.apache.lucene.util.Version.LUCENE_8_2_0);
     public static final Version V_7_4_2 = new Version(7040299, org.apache.lucene.util.Version.LUCENE_8_2_0);
     public static final Version V_7_4_3 = new Version(7040399, org.apache.lucene.util.Version.LUCENE_8_2_0);
-    public static final Version V_7_5_0 = new Version(7050099, org.apache.lucene.util.Version.LUCENE_8_2_0);
+    public static final Version V_7_5_0 = new Version(7050099, org.apache.lucene.util.Version.LUCENE_8_3_0);
     public static final Version V_7_6_0 = new Version(7060099, org.apache.lucene.util.Version.LUCENE_8_3_0);
     public static final Version CURRENT = V_7_6_0;
 


### PR DESCRIPTION
Backport of #48830.