### PR TITLE
[DOCS] Document `minimum_should_match` defaults for `bool` query

### DIFF
--- a/docs/reference/query-dsl/bool-query.asciidoc
+++ b/docs/reference/query-dsl/bool-query.asciidoc
@@ -66,8 +66,9 @@ POST _search
 You can use the `minimum_should_match` parameter to specify the number or
 percentage of `should` clauses returned documents _must_ match.
 
-If the `bool` query includes only `should` clauses, the default value is `1`.
-If the `bool` query includes any other type of clause, the default value is `0`.
+If the `bool` query includes at least one `should` clause and no `must` or
+`filter` clauses, the default value is `1`.
+Otherwise, the default value is `0`.
 
 For other valid values, see the
 <<query-dsl-minimum-should-match, `minimum_should_match` parameter>>.

--- a/docs/reference/query-dsl/bool-query.asciidoc
+++ b/docs/reference/query-dsl/bool-query.asciidoc
@@ -60,6 +60,18 @@ POST _search
 }
 --------------------------------------------------
 
+[[bool-min-should-match]]
+==== Using `minimum_should_match`
+
+You can use the `minimum_should_match` parameter to specify the number or
+percentage of `should` clauses returned documents _must_ match.
+
+If the `bool` query includes only `should` clauses, the default value is `1`.
+If the `bool` query includes any other type of clause, the default value is `0`.
+
+For other valid values, see the
+<<query-dsl-minimum-should-match, `minimum_should_match` parameter>>.
+
 [[score-bool-filter]]
 ==== Scoring with `bool.filter`
 


### PR DESCRIPTION
Adds documentation for the `minimum_should_match` parameter to the
`bool` query docs. Includes docs for the default values:

- `1` if the `bool` query only includes `should` clauses
- `0` if the `bool` query includes any other type of clauses

