### PR TITLE
Remove index.force_memory_term_dictionary setting

### DIFF
--- a/docs/reference/migration/migrate_8_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_8_0/indices.asciidoc
@@ -1,6 +1,9 @@
 [float]
 [[breaking_80_indices_changes]]
-=== Force Merge API changes
+=== Indices changes
+
+[float]
+==== Force Merge API changes
 
 Previously, the Force Merge API allowed the parameters `only_expunge_deletes`
 and `max_num_segments` to be set to a non default value at the same time. But
@@ -9,3 +12,11 @@ to `true`, leaving the false impression that it has been applied.
 
 The Force Merge API now rejects requests that have a `max_num_segments` greater
 than or equal to 0 when the `only_expunge_deletes` is set to true.
+
+[float]
+==== On-disk term dictionary cannot be disabled
+
+The `index.force_memory_term_dictionary` setting was introduced in 7.0 as a
+temporary measure to allow users to opt-out of the optimization that leaves the
+term dictionary on disk when appropriate. This optimization is now mandatory
+and the setting is removed.

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -158,7 +158,6 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
             IndexModule.INDEX_STORE_PRE_LOAD_SETTING,
             IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING,
             FsDirectoryFactory.INDEX_LOCK_FACTOR_SETTING,
-            Store.FORCE_RAM_TERM_DICT,
             EngineConfig.INDEX_CODEC_SETTING,
             IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS,
             IndexSettings.DEFAULT_PIPELINE,

--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -128,14 +128,6 @@ import static java.util.Collections.unmodifiableMap;
  * </pre>
  */
 public class Store extends AbstractIndexShardComponent implements Closeable, RefCounted {
-    /**
-     * This is an escape hatch for lucenes internal optimization that checks if the IndexInput is an instance of ByteBufferIndexInput
-     * and if that's the case doesn't load the term dictionary into ram but loads it off disk iff the fields is not an ID like field.
-     * Since this optimization has been added very late in the release processes we add this setting to allow users to opt-out of
-     * this by exploiting lucene internals and wrapping the IndexInput in a simple delegate.
-     */
-    public static final Setting<Boolean> FORCE_RAM_TERM_DICT = Setting.boolSetting("index.force_memory_term_dictionary", false,
-        Property.IndexScope, Property.Deprecated);
     static final String CODEC = "store";
     static final int CORRUPTED_MARKER_CODEC_VERSION = 2;
     // public is for test purposes

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -105,7 +105,6 @@ import org.elasticsearch.index.MockEngineFactoryPlugin;
 import org.elasticsearch.index.codec.CodecService;
 import org.elasticsearch.index.engine.Segment;
 import org.elasticsearch.index.mapper.MockFieldFilterPlugin;
-import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.indices.IndicesQueryCache;
 import org.elasticsearch.indices.IndicesRequestCache;
@@ -437,10 +436,6 @@ public abstract class ESIntegTestCase extends ESTestCase {
             // keep this low so we don't stall tests
             builder.put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(),
                     RandomNumbers.randomIntBetween(random, 1, 15) + "ms");
-        }
-
-        if (randomBoolean()) {
-            builder.put(Store.FORCE_RAM_TERM_DICT.getKey(), true);
         }
 
         return builder;


### PR DESCRIPTION
This temporary setting was introduced in #39741 but has had no effect since it
was deprecated in #42838. This commit removes this setting.