### PR TITLE
[7.x] Validate index name time format setting at parse time

### DIFF
--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/Exporter.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/Exporter.java
@@ -15,7 +15,6 @@ import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.xpack.monitoring.exporter.http.HttpExporter;
 
-import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
@@ -103,9 +102,14 @@ public abstract class Exporter implements AutoCloseable {
     /**
      * Every {@code Exporter} allows users to use a different index time format.
      */
-    private static final Setting.AffixSetting<String> INDEX_NAME_TIME_FORMAT_SETTING =
-            Setting.affixKeySetting("xpack.monitoring.exporters.","index.name.time_format",
-                    key -> Setting.simpleString(key, Property.Dynamic, Property.NodeScope));
+    static final Setting.AffixSetting<DateFormatter> INDEX_NAME_TIME_FORMAT_SETTING =
+                Setting.affixKeySetting("xpack.monitoring.exporters.","index.name.time_format",
+                        key -> new Setting<DateFormatter>(
+                                key,
+                                Exporter.INDEX_FORMAT,
+                                DateFormatter::forPattern,
+                                Property.Dynamic,
+                                Property.NodeScope));
 
     private static final String INDEX_FORMAT = "yyyy.MM.dd";
 
@@ -151,14 +155,8 @@ public abstract class Exporter implements AutoCloseable {
     protected abstract void doClose();
 
     protected static DateFormatter dateTimeFormatter(final Config config) {
-        Setting<String> setting = INDEX_NAME_TIME_FORMAT_SETTING.getConcreteSettingForNamespace(config.name);
-        String format = setting.exists(config.settings()) ? setting.get(config.settings()) : INDEX_FORMAT;
-        try {
-            return DateFormatter.forPattern(format).withZone(ZoneOffset.UTC);
-        } catch (IllegalArgumentException e) {
-            throw new SettingsException("[" + INDEX_NAME_TIME_FORMAT_SETTING.getKey() + "] invalid index name time format: ["
-                    + format + "]", e);
-        }
+        Setting<DateFormatter> setting = INDEX_NAME_TIME_FORMAT_SETTING.getConcreteSettingForNamespace(config.name);
+        return setting.get(config.settings());
     }
 
     public static List<Setting.AffixSetting<?>> getSettings() {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/ExportersTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/ExportersTests.java
@@ -111,6 +111,19 @@ public class ExportersTests extends ESTestCase {
         assertThat(e.getCause(), hasToString(containsString("host list for [" + prefix + ".host] is empty")));
     }
 
+    public void testIndexNameTimeFormatMustBeValid() {
+        final String prefix = "xpack.monitoring.exporters.example";
+        final String setting = ".index.name.time_format";
+        final String value = "yyyy.MM.dd.j";
+        final Settings settings = Settings.builder().put(prefix + setting, value).build();
+        final IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> Exporter.INDEX_NAME_TIME_FORMAT_SETTING.getConcreteSetting(prefix + setting).get(settings));
+        assertThat(e, hasToString(containsString("Invalid format: [" + value + "]: Unknown pattern letter: j")));
+        assertThat(e.getCause(), instanceOf(IllegalArgumentException.class));
+        assertThat(e.getCause(), hasToString(containsString("Unknown pattern letter: j")));
+    }
+
     public void testExporterIndexPattern() {
         Exporter.Config config = mock(Exporter.Config.class);
         when(config.name()).thenReturn("anything");


### PR DESCRIPTION
Provides parse-time validation for `INDEX_NAME_TIME_FORMAT_SETTING` as described in #47711.

Backport of https://github.com/elastic/elasticsearch/pull/47911.
