### PR TITLE
[DOCS] Fix shard type in ccr overview doc

### DIFF
--- a/docs/reference/ccr/overview.asciidoc
+++ b/docs/reference/ccr/overview.asciidoc
@@ -83,7 +83,7 @@ configured the follower index. If there are no new operations available on the
 leader shard, the leader shard waits up to a configured timeout for new
 operations. If new operations occur within that timeout, the leader shard
 immediately responds with those new operations. Otherwise, if the timeout
-elapses, the follower shard replies that there are no new operations. The
+elapses, the leader shard replies that there are no new operations. The
 follower shard task updates some statistics and immediately sends another read
 request to the leader shard. This ensures that the network connections between
 the remote cluster and the local cluster are continually being used so as to


### PR DESCRIPTION
The shard type is not correct in ccr overview doc. 'the follower shard' should be 'the leader shard'.