### PR TITLE
[Transform] improve error handling of script errors

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
@@ -77,6 +77,8 @@ public class TransformMessages {
     public static final String LOG_TRANSFORM_PIVOT_LOW_PAGE_SIZE_FAILURE =
             "Insufficient memory for search after repeated page size reductions to [{0}], unable to continue pivot, "
             + "please simplify job or increase heap size on data nodes.";
+    public static final String LOG_TRANSFORM_PIVOT_SCRIPT_ERROR =
+            "Failed to execute script with error: [{0}], stack trace: {1}";
 
     public static final String FAILED_TO_PARSE_TRANSFORM_CHECKPOINTS =
             "Failed to parse transform checkpoints for [{0}]";

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -521,12 +521,6 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         }));
     }
 
-    private boolean isIrrecoverableFailure(Exception e) {
-        return e instanceof IndexNotFoundException
-            || e instanceof AggregationResultUtils.AggregationExtractionException
-            || e instanceof TransformConfigReloadingException;
-    }
-
     private IterationResult<TransformIndexerPosition> processBuckets(final CompositeAggregation agg) {
         // we reached the end
         if (agg.getBuckets().isEmpty()) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -480,12 +480,11 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
             || unwrappedException instanceof TransformConfigReloadingException) {
             failIndexer("task encountered irrecoverable failure: " + e.getMessage());
         } else if (context.getAndIncrementFailureCount() > context.getNumFailureRetries()) {
-            failIndexer(
-                "task encountered more than " + context.getNumFailureRetries() + " failures; latest failure: " + unwrappedException == null
-                    ? e.getMessage()
-                    : unwrappedException.getDetailedMessage()
-            );
+            String failure = unwrappedException != null ? unwrappedException.getDetailedMessage() : e.getMessage();
+            failIndexer("task encountered more than " + context.getNumFailureRetries() + " failures; latest failure: " + failure);
         } else {
+            // Since our schedule fires again very quickly after failures it is possible to run into the same failure numerous
+            // times in a row, very quickly. We do not want to spam the audit log with repeated failures, so only record the first one
             if (e.getMessage().equals(lastAuditedExceptionMessage) == false) {
                 String message = unwrappedException == null ? e.getMessage() : unwrappedException.getDetailedMessage();
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/utils/ExceptionRootCauseFinder.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/utils/ExceptionRootCauseFinder.java
@@ -39,6 +39,12 @@ public final class ExceptionRootCauseFinder {
         return t;
     }
 
+    /**
+     * Return the best error message possible given a already unwrapped exception.
+     *
+     * @param t the throwable
+     * @return the message string of the given throwable
+     */
     public static String getDetailedMessage(Throwable t) {
         if (t instanceof ElasticsearchException) {
             return ((ElasticsearchException) t).getDetailedMessage();

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/utils/SearchExceptionRootCauseFinder.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/utils/SearchExceptionRootCauseFinder.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.transform.utils;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+import org.elasticsearch.action.search.ShardSearchFailure;
+
+/**
+ * Set of static utils to find the cause of a search exception.
+ */
+public final class SearchExceptionRootCauseFinder {
+
+    /**
+     * Unwrap the Exceptionstack and return the most likely cause.
+     *
+     * @param e raw Exception
+     * @return unwrapped elasticsearch exception
+     */
+    public static ElasticsearchException getRootCauseElasticsearchException(Exception e) {
+        // circuit breaking exceptions are at the bottom
+        Throwable unwrappedThrowable = org.elasticsearch.ExceptionsHelper.unwrapCause(e);
+
+        if (unwrappedThrowable instanceof SearchPhaseExecutionException) {
+            SearchPhaseExecutionException searchPhaseException = (SearchPhaseExecutionException) e;
+            for (ShardSearchFailure shardFailure : searchPhaseException.shardFailures()) {
+                Throwable unwrappedShardFailure = org.elasticsearch.ExceptionsHelper.unwrapCause(shardFailure.getCause());
+
+                if (unwrappedShardFailure instanceof ElasticsearchException) {
+                    return (ElasticsearchException) unwrappedShardFailure;
+                }
+            }
+        } else if (unwrappedThrowable instanceof ElasticsearchException) {
+            return (ElasticsearchException) unwrappedThrowable;
+        }
+
+        return null;
+    }
+
+    private SearchExceptionRootCauseFinder() {}
+
+}

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.breaker.CircuitBreaker.Durability;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.script.ScriptException;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.internal.InternalSearchResponse;
@@ -36,6 +37,7 @@ import org.elasticsearch.xpack.core.transform.transforms.pivot.AggregationConfig
 import org.elasticsearch.xpack.core.transform.transforms.pivot.GroupConfigTests;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.PivotConfig;
 import org.elasticsearch.xpack.transform.checkpoint.CheckpointProvider;
+import org.elasticsearch.xpack.transform.notifications.MockTransformAuditor;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
 import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 import org.elasticsearch.xpack.transform.transforms.pivot.Pivot;
@@ -51,10 +53,12 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static java.util.Collections.singletonList;
 import static org.elasticsearch.xpack.core.transform.transforms.DestConfigTests.randomDestConfig;
 import static org.elasticsearch.xpack.core.transform.transforms.SourceConfigTests.randomSourceConfig;
 import static org.hamcrest.CoreMatchers.is;
@@ -62,6 +66,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.matchesRegex;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -75,7 +80,7 @@ public class TransformIndexerTests extends ESTestCase {
 
         private final Function<SearchRequest, SearchResponse> searchFunction;
         private final Function<BulkRequest, BulkResponse> bulkFunction;
-        private final Consumer<Exception> failureConsumer;
+        private final Consumer<String> failureConsumer;
 
         // used for synchronizing with the test
         private CountDownLatch latch;
@@ -94,7 +99,7 @@ public class TransformIndexerTests extends ESTestCase {
             TransformContext context,
             Function<SearchRequest, SearchResponse> searchFunction,
             Function<BulkRequest, BulkResponse> bulkFunction,
-            Consumer<Exception> failureConsumer
+            Consumer<String> failureConsumer
         ) {
             super(
                 executor,
@@ -174,14 +179,12 @@ public class TransformIndexerTests extends ESTestCase {
         @Override
         protected void onFailure(Exception exc) {
             try {
-                // mimic same behavior as {@link TransformTask}
-                if (handleCircuitBreakingException(exc)) {
-                    return;
-                }
-
-                failureConsumer.accept(exc);
+                super.onFailure(exc);
             } catch (Exception e) {
-                fail("Internal error: " + e.getMessage());
+                final StringWriter sw = new StringWriter();
+                final PrintWriter pw = new PrintWriter(sw, true);
+                e.printStackTrace(pw);
+                fail("Unexpected failure: " + e.getMessage() + " Trace: " + sw.getBuffer().toString());
             }
         }
 
@@ -198,7 +201,12 @@ public class TransformIndexerTests extends ESTestCase {
 
         @Override
         protected void failIndexer(String message) {
-            fail("failIndexer should not be called, received error: " + message);
+            if (failureConsumer != null) {
+                failureConsumer.accept(message);
+                super.failIndexer(message);
+            } else {
+                fail("failIndexer should not be called, received error: " + message);
+            }
         }
 
     }
@@ -238,33 +246,20 @@ public class TransformIndexerTests extends ESTestCase {
 
         Function<BulkRequest, BulkResponse> bulkFunction = bulkRequest -> new BulkResponse(new BulkItemResponse[0], 100);
 
-        Consumer<Exception> failureConsumer = e -> {
-            final StringWriter sw = new StringWriter();
-            final PrintWriter pw = new PrintWriter(sw, true);
-            e.printStackTrace(pw);
-            fail("expected circuit breaker exception to be handled, got:" + e + " Trace: " + sw.getBuffer().toString());
-        };
-
         final ExecutorService executor = Executors.newFixedThreadPool(1);
         try {
             TransformAuditor auditor = new TransformAuditor(client, "node_1");
             TransformContext context = new TransformContext(TransformTaskState.STARTED, "", 0, mock(TransformContext.Listener.class));
 
-            MockedTransformIndexer indexer = new MockedTransformIndexer(
-                executor,
-                mock(TransformConfigManager.class),
-                mock(CheckpointProvider.class),
-                new TransformProgressGatherer(client),
+            MockedTransformIndexer indexer = createMockIndexer(
                 config,
-                Collections.emptyMap(),
-                auditor,
                 state,
-                null,
-                new TransformIndexerStats(),
-                context,
                 searchFunction,
                 bulkFunction,
-                failureConsumer
+                null,
+                executor,
+                auditor,
+                context
             );
             final CountDownLatch latch = indexer.newLatch(1);
             indexer.start();
@@ -333,33 +328,20 @@ public class TransformIndexerTests extends ESTestCase {
         Function<SearchRequest, SearchResponse> searchFunction = searchRequest -> searchResponse;
         Function<BulkRequest, BulkResponse> bulkFunction = bulkRequest -> new BulkResponse(new BulkItemResponse[0], 100);
 
-        Consumer<Exception> failureConsumer = e -> {
-            final StringWriter sw = new StringWriter();
-            final PrintWriter pw = new PrintWriter(sw, true);
-            e.printStackTrace(pw);
-            fail(e.getMessage());
-        };
-
         final ExecutorService executor = Executors.newFixedThreadPool(1);
         try {
             TransformAuditor auditor = mock(TransformAuditor.class);
             TransformContext context = new TransformContext(TransformTaskState.STARTED, "", 0, mock(TransformContext.Listener.class));
 
-            MockedTransformIndexer indexer = new MockedTransformIndexer(
-                executor,
-                mock(TransformConfigManager.class),
-                mock(CheckpointProvider.class),
-                new TransformProgressGatherer(client),
+            MockedTransformIndexer indexer = createMockIndexer(
                 config,
-                Collections.emptyMap(),
-                auditor,
                 state,
-                null,
-                new TransformIndexerStats(),
-                context,
                 searchFunction,
                 bulkFunction,
-                failureConsumer
+                null,
+                executor,
+                auditor,
+                context
             );
 
             IterationResult<TransformIndexerPosition> newPosition = indexer.doProcess(searchResponse);
@@ -370,6 +352,119 @@ public class TransformIndexerTests extends ESTestCase {
         } finally {
             executor.shutdownNow();
         }
+    }
+
+    public void testScriptError() throws Exception {
+        Integer pageSize = randomBoolean() ? null : randomIntBetween(500, 10_000);
+        String transformId = randomAlphaOfLength(10);
+        TransformConfig config = new TransformConfig(
+            transformId,
+            randomSourceConfig(),
+            randomDestConfig(),
+            null,
+            null,
+            null,
+            new PivotConfig(GroupConfigTests.randomGroupConfig(), AggregationConfigTests.randomAggregationConfig(), pageSize),
+            randomBoolean() ? null : randomAlphaOfLengthBetween(1, 1000)
+        );
+        AtomicReference<IndexerState> state = new AtomicReference<>(IndexerState.STOPPED);
+        Function<SearchRequest, SearchResponse> searchFunction = searchRequest -> {
+            throw new SearchPhaseExecutionException(
+                "query",
+                "Partial shards failure",
+                new ShardSearchFailure[] {
+                    new ShardSearchFailure(
+                        new ScriptException(
+                            "runtime error",
+                            new ArithmeticException("/ by zero"),
+                            singletonList("stack"),
+                            "test",
+                            "painless"
+                        )
+                    ) }
+
+            );
+        };
+
+        Function<BulkRequest, BulkResponse> bulkFunction = bulkRequest -> new BulkResponse(new BulkItemResponse[0], 100);
+
+        final AtomicBoolean failIndexerCalled = new AtomicBoolean(false);
+        final AtomicReference<String> failureMessage = new AtomicReference<>();
+        Consumer<String> failureConsumer = message -> {
+            failIndexerCalled.compareAndSet(false, true);
+            failureMessage.compareAndSet(null, message);
+        };
+
+        final ExecutorService executor = Executors.newFixedThreadPool(1);
+        try {
+            MockTransformAuditor auditor = new MockTransformAuditor();
+            TransformContext context = new TransformContext(TransformTaskState.STARTED, "", 0, mock(TransformContext.Listener.class));
+
+            MockedTransformIndexer indexer = createMockIndexer(
+                config,
+                state,
+                searchFunction,
+                bulkFunction,
+                failureConsumer,
+                executor,
+                auditor,
+                context
+            );
+
+            final CountDownLatch latch = indexer.newLatch(1);
+            auditor
+                .addExpectation(
+                    new MockTransformAuditor.SeenAuditExpectation(
+                        "fail indexer due to script error",
+                        org.elasticsearch.xpack.core.common.notifications.Level.ERROR,
+                        transformId,
+                        "Failed to execute script with error: [*ArithmeticException: / by zero], stack trace: [stack]"
+                    )
+                );
+            indexer.start();
+            assertThat(indexer.getState(), equalTo(IndexerState.STARTED));
+            assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
+            assertThat(indexer.getState(), equalTo(IndexerState.INDEXING));
+
+            latch.countDown();
+            assertBusy(() -> assertThat(indexer.getState(), equalTo(IndexerState.STARTED)), 10, TimeUnit.SECONDS);
+            assertTrue(failIndexerCalled.get());
+            assertThat(
+                failureMessage.get(),
+                matchesRegex("Failed to execute script with error: \\[.*ArithmeticException: / by zero\\], stack trace: \\[stack\\]")
+            );
+            auditor.assertAllExpectationsMatched();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private MockedTransformIndexer createMockIndexer(
+        TransformConfig config,
+        AtomicReference<IndexerState> state,
+        Function<SearchRequest, SearchResponse> searchFunction,
+        Function<BulkRequest, BulkResponse> bulkFunction,
+        Consumer<String> failureConsumer,
+        final ExecutorService executor,
+        TransformAuditor auditor,
+        TransformContext context
+    ) {
+        return new MockedTransformIndexer(
+            executor,
+            mock(TransformConfigManager.class),
+            mock(CheckpointProvider.class),
+            new TransformProgressGatherer(client),
+            config,
+            Collections.emptyMap(),
+            auditor,
+            state,
+            null,
+            new TransformIndexerStats(),
+            context,
+            searchFunction,
+            bulkFunction,
+            failureConsumer
+        );
     }
 
 }


### PR DESCRIPTION
improve error handling for script errors, treating it as irrecoverable errors which puts the task
immediately into failed state, also improves the error extraction to properly report the script error.

fixes #48467