### PR TITLE
[Docs] Consolidate single example into a single line

### DIFF
--- a/docs/reference/analysis/tokenfilters/word-delimiter-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/word-delimiter-tokenfilter.asciidoc
@@ -6,8 +6,7 @@ optional transformations on subword groups. Words are split into
 subwords with the following rules:
 
 * split on intra-word delimiters (by default, all non alpha-numeric
-characters).
-* "Wi-Fi" -> "Wi", "Fi"
+characters): "Wi-Fi" -> "Wi", "Fi"
 * split on case transitions: "PowerShot" -> "Power", "Shot"
 * split on letter-number transitions: "SD500" -> "SD", "500"
 * leading and trailing intra-word delimiters on each subword are


### PR DESCRIPTION
The first example of splitting rules for the `word_delimiter` token filter was spread across two bullet points. This makes it look like they are two separate splitting rules.
