### PR TITLE
Update handshake response version constants to 7.6

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
@@ -231,8 +231,7 @@ final class TransportHandshaker {
             // During the handshake process, nodes set their stream version to the minimum compatibility
             // version they support. When deserializing the response, we use the version the other node
             // told us that it actually is in the handshake response (`version`).
-            // TODO: On backport update to 6.7
-            if (requestVersion.onOrAfter(Version.V_8_0_0) && version.onOrAfter(Version.V_8_0_0)) {
+            if (requestVersion.onOrAfter(Version.V_7_6_0) && version.onOrAfter(Version.V_7_6_0)) {
                 clusterName = new ClusterName(in);
                 discoveryNode = new DiscoveryNode(in);
             } else {
@@ -249,8 +248,7 @@ final class TransportHandshaker {
             // version they support. When deciding what response to send, we use the version the other node
             // told us that it actually is in the handshake request (`requestVersion`). If it did not tell
             // us a `requestVersion`, it is at least a pre-7.6 node.
-            // TODO: On backport update to 6.7
-            if (requestVersion != null && requestVersion.onOrAfter(Version.V_8_0_0) && version.onOrAfter(Version.V_8_0_0)) {
+            if (requestVersion != null && requestVersion.onOrAfter(Version.V_7_6_0) && version.onOrAfter(Version.V_7_6_0)) {
                 clusterName.writeTo(out);
                 discoveryNode.writeTo(out);
             }

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -2357,7 +2357,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 TransportStats transportStats = serviceC.transport.getStats(); // we did a single round-trip to do the initial handshake
                 assertEquals(1, transportStats.getRxCount());
                 assertEquals(1, transportStats.getTxCount());
-                assertEquals(25, transportStats.getRxSize().getBytes());
+                assertEquals(138, transportStats.getRxSize().getBytes());
                 assertEquals(51, transportStats.getTxSize().getBytes());
             });
             serviceC.sendRequest(connection, "internal:action", new TestRequest("hello world"), TransportRequestOptions.EMPTY,
@@ -2367,7 +2367,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 TransportStats transportStats = serviceC.transport.getStats(); // request has ben send
                 assertEquals(1, transportStats.getRxCount());
                 assertEquals(2, transportStats.getTxCount());
-                assertEquals(25, transportStats.getRxSize().getBytes());
+                assertEquals(138, transportStats.getRxSize().getBytes());
                 assertEquals(107, transportStats.getTxSize().getBytes());
             });
             sendResponseLatch.countDown();
@@ -2375,7 +2375,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             stats = serviceC.transport.getStats(); // response has been received
             assertEquals(2, stats.getRxCount());
             assertEquals(2, stats.getTxCount());
-            assertEquals(46, stats.getRxSize().getBytes());
+            assertEquals(159, stats.getRxSize().getBytes());
             assertEquals(107, stats.getTxSize().getBytes());
         } finally {
             serviceC.close();
@@ -2472,7 +2472,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 TransportStats transportStats = serviceC.transport.getStats(); // request has been sent
                 assertEquals(1, transportStats.getRxCount());
                 assertEquals(1, transportStats.getTxCount());
-                assertEquals(25, transportStats.getRxSize().getBytes());
+                assertEquals(138, transportStats.getRxSize().getBytes());
                 assertEquals(51, transportStats.getTxSize().getBytes());
             });
             serviceC.sendRequest(connection, "internal:action", new TestRequest("hello world"), TransportRequestOptions.EMPTY,
@@ -2482,7 +2482,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 TransportStats transportStats = serviceC.transport.getStats(); // request has been sent
                 assertEquals(1, transportStats.getRxCount());
                 assertEquals(2, transportStats.getTxCount());
-                assertEquals(25, transportStats.getRxSize().getBytes());
+                assertEquals(138, transportStats.getRxSize().getBytes());
                 assertEquals(107, transportStats.getTxSize().getBytes());
             });
             sendResponseLatch.countDown();
@@ -2497,7 +2497,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             String failedMessage = "Unexpected read bytes size. The transport exception that was received=" + exception;
             // 49 bytes are the non-exception message bytes that have been received. It should include the initial
             // handshake message and the header, version, etc bytes in the exception message.
-            assertEquals(failedMessage, 49 + streamOutput.bytes().length(), stats.getRxSize().getBytes());
+            assertEquals(failedMessage, 162 + streamOutput.bytes().length(), stats.getRxSize().getBytes());
             assertEquals(107, stats.getTxSize().getBytes());
         } finally {
             serviceC.close();


### PR DESCRIPTION
After backporting #48906 to 7.x, the new handshake response will be sent
in 7.6. With this, this commit will update the version constants to
reflect that change.