### PR TITLE
[DOCS] Fine-tunes classification section in PUT DFA documentation

### DIFF
--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -80,12 +80,6 @@ the `dest` index that don’t contain a results field are not included in the
 single number. For example, in case of age ranges, you can model the values as 
 "0-14" = 0, "15-24" = 1, "25-34" = 2, and so on.
 
-Fields that are highly correlated to the `dependent_variable` should be excluded 
-from the analysis. For example, if you have a multi-value field as 
-`dependent_variable`, {es} will be mapping it both as text and keyword which 
-results in two fields (`field` and `field.keyword`). It is required to exclude 
-the field with the text mapping to get exact results from the analysis.
-
 
 [[ml-put-dfanalytics-path-params]]
 ==== {api-path-parms-title}


### PR DESCRIPTION
This PR removes a best practice about fields that are highly correlated to the dependent variable.