### PR TITLE
Always increase timeout for packaging tests

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/ServerUtils.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/ServerUtils.java
@@ -38,12 +38,8 @@ public class ServerUtils {
     protected static final Logger logger =  LogManager.getLogger(ServerUtils.class);
 
     // generous timeout  as nested virtualization can be quite slow ...
-    private static final long waitTime = TimeUnit.MINUTES.toMillis(
-        System.getProperty("tests.inVM") == null ? 3 : 1
-    );
-    private static final long timeoutLength = TimeUnit.SECONDS.toMillis(
-        System.getProperty("tests.inVM") == null ? 30 : 10
-    );
+    private static final long waitTime = TimeUnit.MINUTES.toMillis(3);
+    private static final long timeoutLength = TimeUnit.SECONDS.toMillis(30);
     private static final long requestInterval = TimeUnit.SECONDS.toMillis(5);
 
     public static void waitForElasticsearch(Installation installation) throws IOException {


### PR DESCRIPTION
The previous approach did not work because the system property is passed
to Gradle but not to the tests JVM.
We shouldn't really pass this to the tests as we wouldn't want to have
differences.
This timeout being different might not be bad, but having a way to
differentiate could lead to others and it's best avoided.

