### PR TITLE
Update permissions for apm_user role

### DIFF
--- a/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
@@ -16,7 +16,8 @@ Grants access necessary for the APM system user to send system-level data
 
 [[built-in-roles-apm-user]] `apm_user` ::
 Grants the privileges required for APM users (such as `read` and 
-`view_index_metadata` privileges on the `apm-*` and `.ml-anomalies*` indices).
+`view_index_metadata` privileges on the `apm-*`, `.apm-agent-configuration` and
+`.ml-anomalies*` indices).
 
 [[built-in-roles-beats-admin]] `beats_admin` ::
 Grants access to the `.management-beats` index, which contains configuration

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -153,6 +153,8 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                     null, new RoleDescriptor.IndicesPrivileges[] {
                         RoleDescriptor.IndicesPrivileges.builder().indices("apm-*")
                             .privileges("read", "view_index_metadata").build(),
+                        RoleDescriptor.IndicesPrivileges.builder().indices(".apm-agent-configuration")
+                            .privileges("read", "write", "view_index_metadata").build(),
                         RoleDescriptor.IndicesPrivileges.builder().indices(".ml-anomalies*")
                             .privileges("view_index_metadata", "read").build(),
                     }, null, MetadataUtils.DEFAULT_RESERVED_METADATA))


### PR DESCRIPTION
Grants read/write privileges to the `apm_user` role for the index where remote agent configurations are stored by default (`.apm-agent-configuration`). See https://www.elastic.co/guide/en/kibana/master/agent-configuration.html