### PR TITLE
Fix ShardGenerations in RepositoryData in BwC Case (#48920)

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -594,6 +594,9 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
     }
 
     private static ShardGenerations buildGenerations(SnapshotsInProgress.Entry snapshot) {
+        if (snapshot.useShardGenerations() == false) {
+            return ShardGenerations.EMPTY;
+        }
         ShardGenerations.Builder builder = ShardGenerations.builder();
         final Map<String, IndexId> indexLookup = new HashMap<>();
         snapshot.indices().forEach(idx -> indexLookup.put(idx.getName(), idx));


### PR DESCRIPTION
We were tripping the assertion that the makes sure we only have empty `ShardGenerations` in `RepositoryData` in the BwC case because shard generations were passed to the `Repository` in the BwC case. Fixed by only generating empty shard gen for BwC snapshots in `SnapshotsService`.

backport of #48920 