### PR TITLE
Fix client jar project generation of POM artifacts

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -151,8 +151,8 @@ class PluginBuildPlugin implements Plugin<Project> {
             // always configure publishing for client jars
             project.plugins.apply(MavenScmPlugin.class)
             project.publishing.publications.nebula(MavenPublication).artifactId(extension.name + "-client")
-            project.tasks.withType(GenerateMavenPom.class) { GenerateMavenPom generatePOMTask ->
-                generatePOMTask.ext.pomFileName = "${project.archivesBaseName}-client-${project.versions.elasticsearch}.pom"
+            project.tasks.withType(GenerateMavenPom.class).configureEach { GenerateMavenPom generatePOMTask ->
+                generatePOMTask.destination = "${project.buildDir}/distributions/${project.archivesBaseName}-client-${project.versions.elasticsearch}.pom"
             }
         } else {
             if (project.plugins.hasPlugin(MavenPublishPlugin)) {


### PR DESCRIPTION
This PR fixes a side-effect of https://github.com/elastic/elasticsearch/pull/48478 which caused us to lose the `-client` suffix on published artifacts from projects with `hasClientJar = true`. Specifically, we lost this on the generated POM files.