### PR TITLE
Fix ignoring missing values in min/max aggregations

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregator.java
@@ -181,7 +181,7 @@ class MinAggregator extends NumericMetricsAggregator.SingleValue {
         if (parent != null) {
             return null;
         }
-        if (config.fieldContext() != null && config.script() == null) {
+        if (config.fieldContext() != null && config.script() == null && config.missing() == null) {
             MappedFieldType fieldType = config.fieldContext().fieldType();
             if (fieldType == null || fieldType.indexOptions() == IndexOptions.NONE) {
                 return null;


### PR DESCRIPTION
Fixes the issue when the missing values can be ignored in min/max
due to BKD optimization.

Fixes #48905
