### PR TITLE
Ensure parameters are updated when merging flattened mappings.

### DIFF
--- a/docs/reference/mapping/types/flattened.asciidoc
+++ b/docs/reference/mapping/types/flattened.asciidoc
@@ -140,7 +140,8 @@ The following mapping parameters are accepted:
 
     The maximum allowed depth of the flattened object field, in terms of nested
     inner objects. If a flattened object field exceeds this limit, then an
-    error will be thrown. Defaults to `20`.
+    error will be thrown. Defaults to `20`. Note that `depth_limit` can be
+    updated dynamically through the <<indices-put-mapping, put mapping>> API.
 
 <<doc-values,`doc_values`>>::
 

--- a/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapper.java
+++ b/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapper.java
@@ -525,7 +525,7 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
         }
     }
 
-    private final FlatObjectFieldParser fieldParser;
+    private FlatObjectFieldParser fieldParser;
     private int depthLimit;
     private int ignoreAbove;
 
@@ -552,7 +552,12 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
     @Override
     protected void doMerge(Mapper mergeWith) {
         super.doMerge(mergeWith);
-        this.ignoreAbove = ((FlatObjectFieldMapper) mergeWith).ignoreAbove;
+
+        FlatObjectFieldMapper other = ((FlatObjectFieldMapper) mergeWith);
+        this.depthLimit = other.depthLimit;
+        this.ignoreAbove = other.ignoreAbove;
+        this.fieldParser = new FlatObjectFieldParser(fieldType.name(), keyedFieldName(),
+            fieldType, depthLimit, ignoreAbove);
     }
 
     @Override


### PR DESCRIPTION
This PR makes the following two fixes around updating flattened fields:
* Make sure that the new value for `ignore_above` is immediately taken into
  affect. Previously we recorded the new value but did not use it when parsing
  documents.
* Allow `depth_limit` to be updated dynamically. It seems plausible that a user
  might want to tweak this setting as they encounter more data.

Addresses #48907.