### PR TITLE
Auto-expand replicated closed indices

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AutoExpandReplicas.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AutoExpandReplicas.java
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
 
+import static org.elasticsearch.cluster.metadata.MetaDataIndexStateService.isIndexVerifiedBeforeClosed;
+
 /**
  * This class acts as a functional wrapper around the {@code index.auto_expand_replicas} setting.
  * This setting or rather it's value is expanded into a min and max value which requires special handling
@@ -133,7 +135,7 @@ public final class AutoExpandReplicas {
         Map<Integer, List<String>> nrReplicasChanged = new HashMap<>();
 
         for (final IndexMetaData indexMetaData : metaData) {
-            if (indexMetaData.getState() != IndexMetaData.State.CLOSE) {
+            if (indexMetaData.getState() == IndexMetaData.State.OPEN || isIndexVerifiedBeforeClosed(indexMetaData)) {
                 AutoExpandReplicas autoExpandReplicas = SETTING.get(indexMetaData.getSettings());
                 autoExpandReplicas.getDesiredNumberOfReplicas(dataNodeCount).ifPresent(numberOfReplicas -> {
                     if (numberOfReplicas != indexMetaData.getNumberOfReplicas()) {

--- a/server/src/test/java/org/elasticsearch/indices/settings/UpdateNumberOfReplicasIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/settings/UpdateNumberOfReplicasIT.java
@@ -161,7 +161,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 2));
 
         if (randomBoolean()) {
-            client().admin().indices().prepareClose("test").setWaitForActiveShards(ActiveShardCount.ALL).get();
+            assertAcked(client().admin().indices().prepareClose("test").setWaitForActiveShards(ActiveShardCount.ALL));
 
             clusterHealth = client().admin().cluster().prepareHealth()
                 .setWaitForEvents(Priority.LANGUID)
@@ -266,7 +266,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 2));
 
         if (randomBoolean()) {
-            client().admin().indices().prepareClose("test").setWaitForActiveShards(ActiveShardCount.ALL).get();
+            assertAcked(client().admin().indices().prepareClose("test").setWaitForActiveShards(ActiveShardCount.ALL));
 
             clusterHealth = client().admin().cluster().prepareHealth()
                 .setWaitForEvents(Priority.LANGUID)

--- a/server/src/test/java/org/elasticsearch/indices/settings/UpdateNumberOfReplicasIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/settings/UpdateNumberOfReplicasIT.java
@@ -21,6 +21,7 @@ package org.elasticsearch.indices.settings;
 
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -159,6 +160,22 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         assertThat(clusterHealth.getIndices().get("test").getNumberOfReplicas(), equalTo(1));
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 2));
 
+        if (randomBoolean()) {
+            client().admin().indices().prepareClose("test").setWaitForActiveShards(ActiveShardCount.ALL).get();
+
+            clusterHealth = client().admin().cluster().prepareHealth()
+                .setWaitForEvents(Priority.LANGUID)
+                .setWaitForGreenStatus()
+                .setWaitForActiveShards(numShards.numPrimaries * 2)
+                .execute().actionGet();
+            logger.info("--> done cluster health, status {}", clusterHealth.getStatus());
+            assertThat(clusterHealth.isTimedOut(), equalTo(false));
+            assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
+            assertThat(clusterHealth.getIndices().get("test").getActivePrimaryShards(), equalTo(numShards.numPrimaries));
+            assertThat(clusterHealth.getIndices().get("test").getNumberOfReplicas(), equalTo(1));
+            assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 2));
+        }
+
         final long settingsVersion =
                 client().admin().cluster().prepareState().get().getState().metaData().index("test").getSettingsVersion();
 
@@ -247,6 +264,22 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         assertThat(clusterHealth.getIndices().get("test").getActivePrimaryShards(), equalTo(numShards.numPrimaries));
         assertThat(clusterHealth.getIndices().get("test").getNumberOfReplicas(), equalTo(1));
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 2));
+
+        if (randomBoolean()) {
+            client().admin().indices().prepareClose("test").setWaitForActiveShards(ActiveShardCount.ALL).get();
+
+            clusterHealth = client().admin().cluster().prepareHealth()
+                .setWaitForEvents(Priority.LANGUID)
+                .setWaitForGreenStatus()
+                .setWaitForActiveShards(numShards.numPrimaries * 2)
+                .execute().actionGet();
+            logger.info("--> done cluster health, status {}", clusterHealth.getStatus());
+            assertThat(clusterHealth.isTimedOut(), equalTo(false));
+            assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
+            assertThat(clusterHealth.getIndices().get("test").getActivePrimaryShards(), equalTo(numShards.numPrimaries));
+            assertThat(clusterHealth.getIndices().get("test").getNumberOfReplicas(), equalTo(1));
+            assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 2));
+        }
 
         final long settingsVersion =
                 client().admin().cluster().prepareState().get().getState().metaData().index("test").getSettingsVersion();


### PR DESCRIPTION
Fixes a bug where replicated closed indices were not being auto-expanded.