### PR TITLE
[DOCS] Fix _count HTTP method

### DIFF
--- a/docs/reference/search/count.asciidoc
+++ b/docs/reference/search/count.asciidoc
@@ -16,7 +16,7 @@ the <<search-search,search api>> works.
 [[search-count-api-request]]
 ==== {api-request-title}
 
-`PUT /<index>/_count`
+`GET /<index>/_count`
 
 
 [[search-count-api-desc]]


### PR DESCRIPTION
The [Count API documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-count.html) currently states `PUT` as the HTTP method:

<img width="762" alt="Screenshot 2019-11-12 at 10 51 43" src="https://user-images.githubusercontent.com/809707/68661003-807ae080-053a-11ea-9e09-7f84f11da38e.png">
 