### PR TITLE
Log exceptions thrown by HttpHandlers in repository integration tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
@@ -192,10 +192,8 @@ public abstract class ESMockAPIBasedRepositoryIntegTestCase extends ESBlobStoreR
             try {
                 handler.handle(exchange);
             } catch (final Exception e) {
-                String request = exchange.getRemoteAddress().toString()
-                    + " " + exchange.getRequestMethod()
-                    + " " + exchange.getRequestURI();
-                logger.error("Exception when handling request {}", request, e);
+                logger.error("Exception when handling request {} {} {}",
+                    exchange.getRemoteAddress(), exchange.getRequestMethod(), exchange.getRequestURI(), e);
                 throw e;
             }
         };

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
@@ -23,6 +23,7 @@ import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeResponse;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.Strings;
@@ -192,8 +193,8 @@ public abstract class ESMockAPIBasedRepositoryIntegTestCase extends ESBlobStoreR
             try {
                 handler.handle(exchange);
             } catch (final Exception e) {
-                logger.error("Exception when handling request {} {} {}",
-                    exchange.getRemoteAddress(), exchange.getRequestMethod(), exchange.getRequestURI(), e);
+                logger.error(() -> new ParameterizedMessage("Exception when handling request {} {} {}",
+                    exchange.getRemoteAddress(), exchange.getRequestMethod(), exchange.getRequestURI()), e);
                 throw e;
             }
         };


### PR DESCRIPTION
This pull request changes the `ESMockAPIBasedRepositoryIntegTestCase` so that `HttpHandler` are now wrapped in order to log any exceptions that could be thrown when executing the server side logic in repository integration tests.

This should (hopefully) help debugging recent test failures like:
https://gradle-enterprise.elastic.co/s/jkkkmi6mvuixk/tests/lgycqkw2bfw46-kysdm6ag7igo6
https://gradle-enterprise.elastic.co/s/3fv4hpmy3mulm/tests/lgycqkw2bfw46-clvf2uhrzpiw4
https://gradle-enterprise.elastic.co/s/rqyhtjrdui3oy/tests/lgycqkw2bfw46-clvf2uhrzpiw4
