### PR TITLE
Fix Broken Snapshots in Mixed Clusters

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -315,9 +315,6 @@ public final class RepositoryData {
      * Writes the snapshots metadata and the related indices metadata to x-content.
      */
     public XContentBuilder snapshotsToXContent(final XContentBuilder builder, final boolean shouldWriteShardGens) throws IOException {
-        assert shouldWriteShardGens || shardGenerations.indices().isEmpty() :
-            "Should not build shard generations in BwC mode but saw generations [" + shardGenerations + "]";
-
         builder.startObject();
         // write the snapshots list
         builder.startArray(SNAPSHOTS);

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -581,9 +581,6 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
     }
 
     private static ShardGenerations buildGenerations(SnapshotsInProgress.Entry snapshot) {
-        if (snapshot.useShardGenerations() == false) {
-            return ShardGenerations.EMPTY;
-        }
         ShardGenerations.Builder builder = ShardGenerations.builder();
         final Map<String, IndexId> indexLookup = new HashMap<>();
         snapshot.indices().forEach(idx -> indexLookup.put(idx.getName(), idx));


### PR DESCRIPTION
Reverts #48947 and fixes the issue orginally addressed by removing the assertion.
It turns out we can't simply pass empty shard generations to the snapshot finalization in the
BwC case as that results in no indices being added to the meta for the given snapshot since
we take the indices from the shard generations (even in the BwC case the `null` generations work
fine for this).

Closes #48983

--------------------------------

Marking this as non-issue since this bug hasn't made it into any release.
I'd follwo this one up by adding consistency assertions to `SnapshotInfo` to prevent this from happening again. I'd do this PR separately though to fix the test asap because we have a large number of tests around serialization etc. that would need to be adjusted to allow for such an assertion to be added.