### PR TITLE
[6.8] Remove limitation for SAML encryption in FIPS mode (#48948)

### DIFF
--- a/x-pack/docs/en/security/fips-140-compliance.asciidoc
+++ b/x-pack/docs/en/security/fips-140-compliance.asciidoc
@@ -124,5 +124,3 @@ features are not available while running in fips mode. The list is as follows:
   available.
 * The SQL CLI client cannot run in a FIPS 140-2 enabled JVM while using
   TLS for transport security or PKI for client authentication.
-* The SAML Realm cannot decrypt and consume encrypted Assertions or encrypted
-  attributes in Attribute Statements from the SAML IdP.


### PR DESCRIPTION
Backports the following commits to 6.8:
 - Remove limitation for SAML encryption in FIPS mode (#48948)