### PR TITLE
Fix AutoFollowIT

### DIFF
--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
@@ -491,10 +491,9 @@ public class AutoFollowIT extends CcrIntegTestCase {
 
         // start creating new indices on the remote cluster
         final Thread createNewLeaderIndicesThread = new Thread(() -> {
-            int leaderIndicesCount;
-            while (running.get() && (leaderIndicesCount = leaderIndices.incrementAndGet()) < 20) {
+            while (running.get() && leaderIndices.get() < 20) {
                 final String prefix = randomFrom(prefixes);
-                final String leaderIndex = prefix + leaderIndicesCount;
+                final String leaderIndex = prefix + leaderIndices.incrementAndGet();
                 try {
                     createLeaderIndex(leaderIndex, leaderIndexSettings);
                     ensureLeaderGreen(leaderIndex);

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
@@ -527,7 +527,8 @@ public class AutoFollowIT extends CcrIntegTestCase {
 
         // wait for more leader indices to be created on the remote cluster
         assertBusy(() -> assertThat(leaderIndices.get(), greaterThanOrEqualTo(9)));
-        assertBusy(() -> assertThat(getAutoFollowStats().getNumberOfSuccessfulFollowIndices(), greaterThanOrEqualTo(9L)));
+        assertBusy(() -> assertThat(getAutoFollowStats().getNumberOfSuccessfulFollowIndices(), greaterThanOrEqualTo(9L)),
+            30L, TimeUnit.SECONDS);
 
         running.set(false);
         createNewLeaderIndicesThread.join();

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
@@ -520,7 +520,6 @@ public class AutoFollowIT extends CcrIntegTestCase {
 
         // wait for more leader indices to be created on the remote cluster
         assertBusy(() -> assertThat(leaderIndices.get(), greaterThanOrEqualTo(6)));
-        assertBusy(() -> assertThat(getAutoFollowStats().getNumberOfSuccessfulFollowIndices(), greaterThanOrEqualTo(6L)));
 
         // resume auto follow patterns
         pausedAutoFollowerPatterns.forEach(this::resumeAutoFollowPattern);

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
@@ -498,8 +498,7 @@ public class AutoFollowIT extends CcrIntegTestCase {
                     createLeaderIndex(leaderIndex, leaderIndexSettings);
                     ensureLeaderGreen(leaderIndex);
                     if (pausedAutoFollowerPatterns.stream().noneMatch(pattern -> pattern.startsWith(prefix))) {
-                        final String followingIndex = "copy-" + leaderIndex;
-                        assertBusy(() -> assertTrue(ESIntegTestCase.indexExists(followingIndex, followerClient())));
+                        ensureFollowerGreen("copy-" + leaderIndex);
                     } else {
                         Thread.sleep(200L);
                     }


### PR DESCRIPTION
This pull request fixes a stupid bug in the AutoFollowIT test that causes failures because the `leaderIndices` counter is incremented during the evaluation of the `leaderIndices.incrementAndGet() < 20` condition but the 20th index is not created, making the final assertion not verified:

```
assertThat(followerClient().admin().indices().prepareStats("copy-*").get().getIndices().size(), equalTo(leaderIndices.get()));
```

Closes #48982