### PR TITLE
Add negative boolean expression note to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,6 +197,10 @@ Please follow these formatting guidelines:
   decrease in consistency.
 * Note that JavaDoc and block comments i.e. `/* ... */` are not formatted,
   but line comments i.e `// ...` are.
+* There is an implicit rule that negative boolean expressions should use
+  the form `foo == false` instead of `!foo` for better readability of the
+  code. While this isn't strictly enforced, if might get called out in PR
+  reviews as something to change.
 
 #### Editor / IDE Support
 


### PR DESCRIPTION
The team sometimes get questions around the use of `!foo` vs. `foo == false` in
PRs and reviews (e.g.  #48615). This change adds a bullet point to CONTRIBUTING.md
to make expectations here clearer and gives us something to point to in case of
discussion.