### PR TITLE
Move MinIO fixture in its own project

### DIFF
--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -50,6 +50,8 @@ dependencies {
   // HACK: javax.xml.bind was removed from default modules in java 9, so we pull the api in here,
   // and whitelist this hack in JarHell 
   compile 'javax.xml.bind:jaxb-api:2.2.2'
+
+  testCompile project(':test:fixtures:minio-fixture')
 }
 
 dependencyLicenses {
@@ -105,10 +107,10 @@ boolean s3DisableChunkedEncoding = (new Random(Long.parseUnsignedLong(project.ro
 // credentials hard-coded in.
 
 if (!s3PermanentAccessKey && !s3PermanentSecretKey && !s3PermanentBucket && !s3PermanentBasePath) {
-  s3PermanentAccessKey = 's3_integration_test_permanent_access_key'
-  s3PermanentSecretKey = 's3_integration_test_permanent_secret_key'
-  s3PermanentBucket = 'permanent-bucket-test'
-  s3PermanentBasePath = 'integration_test'
+  s3PermanentAccessKey = 'access_key'
+  s3PermanentSecretKey = 'secret_key'
+  s3PermanentBucket = 'bucket'
+  s3PermanentBasePath = ''
 
   useFixture = true
 
@@ -147,25 +149,10 @@ task thirdPartyTest(type: Test) {
 if (useFixture) {
   apply plugin: 'elasticsearch.test.fixtures'
 
-  testFixtures.useFixture()
-
-  task writeDockerFile {
-    File minioDockerfile = new File("${project.buildDir}/minio-docker/Dockerfile")
-    outputs.file(minioDockerfile)
-    doLast {
-      minioDockerfile.parentFile.mkdirs()
-      minioDockerfile.text = "FROM minio/minio:RELEASE.2019-01-23T23-18-58Z\n" +
-              "RUN mkdir -p /minio/data/${s3PermanentBucket}\n" +
-              "ENV MINIO_ACCESS_KEY ${s3PermanentAccessKey}\n" +
-              "ENV MINIO_SECRET_KEY ${s3PermanentSecretKey}"
-    }
-  }
-  preProcessFixture {
-    dependsOn(writeDockerFile)
-  }
+  testFixtures.useFixture(':test:fixtures:minio-fixture')
 
   def minioAddress = {
-    int minioPort = postProcessFixture.ext."test.fixtures.minio-fixture.tcp.9000"
+    int minioPort = project(':test:fixtures:minio-fixture').postProcessFixture.ext."test.fixtures.minio-fixture.tcp.9000"
     assert minioPort > 0
     'http://127.0.0.1:' + minioPort
   }
@@ -178,13 +165,13 @@ if (useFixture) {
   }
 
   thirdPartyTest {
-    dependsOn tasks.bundlePlugin, tasks.postProcessFixture
+    dependsOn tasks.bundlePlugin
     nonInputProperties.systemProperty 'test.s3.endpoint', "${ -> minioAddress.call() }"
   }
 
   task integTestMinio(type: RestIntegTestTask) {
     description = "Runs REST tests using the Minio repository."
-    dependsOn tasks.bundlePlugin, tasks.postProcessFixture
+    dependsOn tasks.bundlePlugin
     runner {
       // Minio only supports a single access key, see https://github.com/minio/minio/pull/5968
       systemProperty 'tests.rest.blacklist', [

--- a/settings.gradle
+++ b/settings.gradle
@@ -52,6 +52,7 @@ List projects = [
   'test:fixtures:gcs-fixture',
   'test:fixtures:hdfs-fixture',
   'test:fixtures:krb5kdc-fixture',
+  'test:fixtures:minio-fixture',
   'test:fixtures:old-elasticsearch',
   'test:logger-usage'
 ]

--- a/test/fixtures/minio-fixture/Dockerfile
+++ b/test/fixtures/minio-fixture/Dockerfile
@@ -1,0 +1,9 @@
+FROM minio/minio:RELEASE.2019-01-23T23-18-58Z
+
+ARG bucket
+ARG accessKey
+ARG secretKey
+
+RUN mkdir -p /minio/data/${bucket}
+ENV MINIO_ACCESS_KEY=${accessKey}
+ENV MINIO_SECRET_KEY=${secretKey}

--- a/test/fixtures/minio-fixture/build.gradle
+++ b/test/fixtures/minio-fixture/build.gradle
@@ -1,0 +1,24 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+apply plugin: 'elasticsearch.build'
+apply plugin: 'elasticsearch.test.fixtures'
+
+description = 'Fixture for MinIO Storage service'
+test.enabled = false
+

--- a/test/fixtures/minio-fixture/docker-compose.yml
+++ b/test/fixtures/minio-fixture/docker-compose.yml
@@ -2,7 +2,11 @@ version: '3'
 services:
   minio-fixture:
     build:
-      context: ./build/minio-docker
+      context: .
+      args:
+        bucket: "bucket"
+        accessKey: "access_key"
+        secretKey: "secret_key"
       dockerfile: Dockerfile
     ports:
       - "9000"


### PR DESCRIPTION
Backport of #48921 to `7.5`.

This commit moves the MinIO docker-compose fixture from the
:plugins:repository-s3 to its own :test:minio-fixture Gradle project.

