### PR TITLE
[DOCS] Update doc_values documentation

### DIFF
--- a/docs/reference/mapping/params/doc-values.asciidoc
+++ b/docs/reference/mapping/params/doc-values.asciidoc
@@ -15,7 +15,7 @@ Doc values are the on-disk data structure, built at document index time, which
 makes this data access pattern possible. They store the same values as the
 `_source` but in a column-oriented fashion that is way more efficient for
 sorting and aggregations. Doc values are supported on almost all field types,
-with the __notable exception of `analyzed` string fields__.
+with the __notable exception of `text` and `annotated_text` fields__.
 
 All fields which support doc values have them enabled by default. If you are
 sure that you don't need to sort or aggregate on a field, or access the field


### PR DESCRIPTION
According to https://kb.objectrocket.com/elasticsearch/when-to-use-the-keyword-type-vs-text-datatype-in-elasticsearch, the `string` type (with option `analyzed`) has been replaced by `text` after `6.0` (This version is 7.4)

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
