### PR TITLE
[7.4 backport] Add warnings for potential ergonomics failures for JDK8/Windows 

### DIFF
--- a/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/JvmErgonomics.java
+++ b/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/JvmErgonomics.java
@@ -72,12 +72,20 @@ final class JvmErgonomics {
             }
         }
         final long maxDirectMemorySize = extractMaxDirectMemorySize(finalJvmOptions);
-        if (maxDirectMemorySize == 0) {
+
+        if (System.getProperty("os.name").startsWith("Windows") && JavaVersion.majorVersion(JavaVersion.CURRENT) == 8) {
+            Launchers.errPrintln("Warning: with JDK 8 on Windows, Elasticsearch may be unable to derive correct");
+            Launchers.errPrintln("  ergonomic settings due to a JDK issue (JDK-8074459). Please use a newer");
+            Launchers.errPrintln("  version of Java.");
+        }
+
+        if (maxDirectMemorySize == 0 && userDefinedJvmOptions.stream().noneMatch(s -> s.startsWith("-XX:MaxDirectMemorySize"))) {
+
             if (System.getProperty("os.name").startsWith("Windows") && JavaVersion.majorVersion(JavaVersion.CURRENT) == 8) {
-                Launchers.errPrintln("Warning: with JDK 8 on Windows, Elasticsearch may miscalculate MaxDirectMemorySize");
-                Launchers.errPrintln("  due to a JDK issue (JDK-8074459).");
-                Launchers.errPrintln("  Please use a newer version of Java or set MaxDirectMemorySize explicitly");
+                Launchers.errPrintln("Warning: MaxDirectMemorySize may have been miscalculated due to JDK-8074459.");
+                Launchers.errPrintln("  Please use a newer version of Java or set MaxDirectMemorySize explicitly.");
             }
+
             ergonomicChoices.add("-XX:MaxDirectMemorySize=" + heapSize / 2);
         }
         return ergonomicChoices;

--- a/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/JvmErgonomics.java
+++ b/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/JvmErgonomics.java
@@ -59,10 +59,16 @@ final class JvmErgonomics {
         final Map<String, Optional<String>> finalJvmOptions = finalJvmOptions(userDefinedJvmOptions);
         final long heapSize = extractHeapSize(finalJvmOptions);
         final Map<String, String> systemProperties = extractSystemProperties(userDefinedJvmOptions);
+
+        if (System.getProperty("os.name").startsWith("Windows") && JavaVersion.majorVersion(JavaVersion.CURRENT) == 8) {
+            Launchers.errPrintln("Warning: with JDK 8 on Windows, Elasticsearch may be unable to derive correct");
+            Launchers.errPrintln("  ergonomic settings due to a JDK issue (JDK-8074459). Please use a newer");
+            Launchers.errPrintln("  version of Java.");
+        }
+
         if (systemProperties.containsKey("io.netty.allocator.type") == false) {
             if (System.getProperty("os.name").startsWith("Windows") && JavaVersion.majorVersion(JavaVersion.CURRENT) == 8) {
-                Launchers.errPrintln("Warning: with JDK 8 on Windows, Elasticsearch may miscalculate io.netty.allocator.type");
-                Launchers.errPrintln("  due to a JDK issue (JDK-8074459).");
+                Launchers.errPrintln("Warning: io.netty.allocator.type may have been miscalculated due to JDK-8074459.");
                 Launchers.errPrintln("  Please use a newer version of Java or set io.netty.allocator.type explicitly");
             }
             if (heapSize <= 1 << 30) {
@@ -72,13 +78,6 @@ final class JvmErgonomics {
             }
         }
         final long maxDirectMemorySize = extractMaxDirectMemorySize(finalJvmOptions);
-
-        if (System.getProperty("os.name").startsWith("Windows") && JavaVersion.majorVersion(JavaVersion.CURRENT) == 8) {
-            Launchers.errPrintln("Warning: with JDK 8 on Windows, Elasticsearch may be unable to derive correct");
-            Launchers.errPrintln("  ergonomic settings due to a JDK issue (JDK-8074459). Please use a newer");
-            Launchers.errPrintln("  version of Java.");
-        }
-
         if (maxDirectMemorySize == 0 && userDefinedJvmOptions.stream().noneMatch(s -> s.startsWith("-XX:MaxDirectMemorySize"))) {
 
             if (System.getProperty("os.name").startsWith("Windows") && JavaVersion.majorVersion(JavaVersion.CURRENT) == 8) {

--- a/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/JvmErgonomicsTests.java
+++ b/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/JvmErgonomicsTests.java
@@ -56,8 +56,8 @@ public class JvmErgonomicsTests extends LaunchersTestCase {
     }
 
     public void testExtractValidHeapSizeNoOptionPresent() throws InterruptedException, IOException {
-        // Muting on Windows, awaitsfix: https://github.com/elastic/elasticsearch/issues/47384
-        assumeFalse(System.getProperty("os.name").startsWith("Windows"));
+        // Muted for jdk8/Windows, see: https://github.com/elastic/elasticsearch/issues/47384
+        assumeFalse(System.getProperty("os.name").startsWith("Windows") && JavaVersion.majorVersion(JavaVersion.CURRENT) == 8);
         assertThat(
                 JvmErgonomics.extractHeapSize(JvmErgonomics.finalJvmOptions(Collections.emptyList())),
                 greaterThan(0L));
@@ -132,6 +132,7 @@ public class JvmErgonomicsTests extends LaunchersTestCase {
     }
 
     public void testPooledMemoryChoiceOnNotSmallHeap() throws InterruptedException, IOException {
+        // Muted for jdk8/Windows, see: https://github.com/elastic/elasticsearch/issues/47384
         assumeFalse(System.getProperty("os.name").startsWith("Windows") && JavaVersion.majorVersion(JavaVersion.CURRENT) == 8);
         final String largeHeap = randomFrom(Arrays.asList("1025M", "2048M", "2G", "8G"));
         assertThat(
@@ -140,6 +141,7 @@ public class JvmErgonomicsTests extends LaunchersTestCase {
     }
 
     public void testMaxDirectMemorySizeChoice() throws InterruptedException, IOException {
+        // Muted for jdk8/Windows, see: https://github.com/elastic/elasticsearch/issues/47384
         assumeFalse(System.getProperty("os.name").startsWith("Windows") && JavaVersion.majorVersion(JavaVersion.CURRENT) == 8);
         final Map<String, String> heapMaxDirectMemorySize = new HashMap<>();
         heapMaxDirectMemorySize.put("64M", Long.toString((64L << 20) / 2));

--- a/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/JvmErgonomicsTests.java
+++ b/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/JvmErgonomicsTests.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.anyOf;
@@ -158,8 +159,10 @@ public class JvmErgonomicsTests extends LaunchersTestCase {
     }
 
     public void testMaxDirectMemorySizeChoiceWhenSet() throws InterruptedException, IOException {
+        List<String> derivedSettingList = JvmErgonomics.choose(Arrays.asList("-Xms5g", "-Xmx5g", "-XX:MaxDirectMemorySize=4g"));
         assertThat(
-                JvmErgonomics.choose(Arrays.asList("-Xms1g", "-Xmx1g", "-XX:MaxDirectMemorySize=1g")),
+                derivedSettingList,
+                // if MaxDirectMemorySize is set, we shouldn't derive our own value for it
                 everyItem(not(startsWith("-XX:MaxDirectMemorySize="))));
     }
 


### PR DESCRIPTION
The 7.4 branch doesn't have the fix that removes the ergonomic configuration of the netty allocator, so the only difference between this branch and the 7.5 backport ( #48968 ) is a warning when the ergonomics bugs might affect the netty allocator settings.