### PR TITLE
Do not throw exceptions resulting from persisting datafeed timing stats.

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJob.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJob.java
@@ -117,7 +117,13 @@ class DatafeedJob {
     }
 
     public void finishReportingTimingStats() {
-        timingStatsReporter.finishReporting();
+        try {
+            timingStatsReporter.finishReporting();
+        } catch (Exception e) {
+            // We don't want the exception to propagate out of this method as it can leave the datafeed in the "stopping" state forever.
+            // Since persisting datafeed timing stats is not critical, we just log a warning here.
+            LOGGER.warn("[{}] Datafeed timing stats could not be reported due to: {}", jobId, e);
+        }
     }
 
     Long runLookBack(long startTime, Long endTime) throws Exception {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManager.java
@@ -361,7 +361,7 @@ public class DatafeedManager {
                     acquired = datafeedJobLock.tryLock(timeout.millis(), TimeUnit.MILLISECONDS);
                 } catch (InterruptedException e1) {
                     Thread.currentThread().interrupt();
-                } finally {
+                } finally {  // It is crucial that none of the calls this "finally" block makes throws an exception for minor problems.
                     logger.info("[{}] stopping datafeed [{}] for job [{}], acquired [{}]...", source, datafeedId,
                             datafeedJob.getJobId(), acquired);
                     runningDatafeedsOnThisNode.remove(allocationId);


### PR DESCRIPTION
Do not throw exceptions resulting from persisting datafeed timing stats on datafeed "stop".
Log them as warnings instead.

Relates https://github.com/elastic/elasticsearch/issues/49032