### PR TITLE
SQL: [Tests] Mute testReplaceChildren for Pivot

### DIFF
--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/tree/NodeSubclassTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/tree/NodeSubclassTests.java
@@ -36,9 +36,11 @@ import org.elasticsearch.xpack.sql.expression.predicate.operator.comparison.In;
 import org.elasticsearch.xpack.sql.expression.predicate.operator.comparison.InPipe;
 import org.elasticsearch.xpack.sql.expression.predicate.regex.Like;
 import org.elasticsearch.xpack.sql.expression.predicate.regex.LikePattern;
+import org.elasticsearch.xpack.sql.plan.logical.Pivot;
 import org.elasticsearch.xpack.sql.tree.NodeTests.ChildrenAreAProperty;
 import org.elasticsearch.xpack.sql.tree.NodeTests.Dummy;
 import org.elasticsearch.xpack.sql.tree.NodeTests.NoChildren;
+import org.junit.Assume;
 import org.mockito.exceptions.base.MockitoException;
 
 import java.io.IOException;
@@ -164,6 +166,9 @@ public class NodeSubclassTests<T extends B, B extends Node<B>> extends ESTestCas
      * Test {@link Node#replaceChildren} implementation on {@link #subclass}.
      */
     public void testReplaceChildren() throws Exception {
+        // TODO: Provide a proper fix for: https://github.com/elastic/elasticsearch/issues/48900
+        Assume.assumeFalse(subclass.equals(Pivot.class));
+
         Constructor<T> ctor = longestCtor(subclass);
         Object[] nodeCtorArgs = ctorArgs(ctor);
         T node = ctor.newInstance(nodeCtorArgs);


### PR DESCRIPTION
Temporarily "mute" the testReplaceChildren for Pivot since it leads to
failing tests for some seeds, since the new child doesn't respond to a
valid data type.

Relates to #48900
