### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ Contributing to the Elasticsearch codebase
 
 **Repository:** [https://github.com/elastic/elasticsearch](https://github.com/elastic/elasticsearch)
 
-JDK 12 is required to build Elasticsearch. You must have a JDK 12 installation
+[JDK 12](https://www.oracle.com/technetwork/java/javase/downloads/java-archive-javase12-5440181.html) is required to build Elasticsearch. You must have a JDK 12 installation
 with the environment variable `JAVA_HOME` referencing the path to Java home for
 your JDK 12 installation. By default, tests use the same runtime as `JAVA_HOME`.
 However, since Elasticsearch supports JDK 11, the build supports compiling with


### PR DESCRIPTION
Because JDK 12 is no longer a supported version of java (now that java 13 has been released) it can be hard to find a version of it to download/install. The change links the first reference to JDK 12 in 'Contributing to Elasticsearch codebase' section to an archived oracle release of JDK 12.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->