### PR TITLE
Move env vars to script, add build scan wrapper

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+JAVA_HOME=${JAVA_HOME:-$HOME/.java/openjdk12}
+RUNTIME_JAVA_HOME=${RUNTIME_JAVA_HOME:-$HOME/.java/openjdk11}
+
+JAVA7_HOME=$HOME/.java/java7
+JAVA8_HOME=$HOME/.java/java8
+JAVA9_HOME=$HOME/.java/java9
+JAVA10_HOME=$HOME/.java/java10
+JAVA11_HOME=$HOME/.java/java11
+JAVA12_HOME=$HOME/.java/openjdk12
+JAVA13_HOME=$HOME/.java/openjdk13
+
 # drop page cache and kernel slab objects on linux
 [[ -x /usr/local/sbin/drop-caches ]] && sudo /usr/local/sbin/drop-caches
 
@@ -11,8 +22,8 @@ if [ -f /proc/cpuinfo ] ; then
 else
    if [[ "$OSTYPE" == "darwin"* ]]; then
       MAX_WORKERS=`sysctl -n hw.physicalcpu | sed 's/\s\+//g'`
-      # Looks like it's too much for our workers so reduce it further
-      MAX_WORKERS=$(($MAX_WORKERS/2))
+      # Looks like it's too much for our workers so we reduce it for now
+      MAX_WORKERS=2
    else
       echo "Unsupported OS Type: $OSTYPE"
       exit 1

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -21,8 +21,9 @@ if [ -f /proc/cpuinfo ] ; then
    MAX_WORKERS=`grep '^cpu\scores' /proc/cpuinfo  | uniq | sed 's/\s\+//g' |  cut -d':' -f 2`
 else
    if [[ "$OSTYPE" == "darwin"* ]]; then
-      MAX_WORKERS=`sysctl -n hw.physicalcpu | sed 's/\s\+//g'`
-      # Looks like it's too much for our workers so we reduce it for now
+      # Parallel is disabled at  this time (eventually set to 1) due to errors on the Mac workers
+      # We'll have to do more testing to see if this can be re-enabled or what the proper value is.
+      # MAX_WORKERS=`sysctl -n hw.physicalcpu | sed 's/\s\+//g'`
       MAX_WORKERS=2
    else
       echo "Unsupported OS Type: $OSTYPE"

--- a/.ci/jobs.t/defaults.yml
+++ b/.ci/jobs.t/defaults.yml
@@ -35,8 +35,7 @@
           fail: true
       - ansicolor
       - timestamps
-      # TODO: No support un JJBB ?
-      # - gradle-build-scan
+      - gradle-build-scan
     properties:
         - github:
             url: https://github.com/elastic/elasticsearch/
@@ -44,21 +43,9 @@
             properties-content: |
               HOME=$JENKINS_HOME
     builders:
-       - inject:
-          properties-file: '.ci/java-versions.properties'
-          properties-content: |
-            JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
-            JAVA7_HOME=$HOME/.java/java7
-            JAVA8_HOME=$HOME/.java/java8
-            JAVA9_HOME=$HOME/.java/java9
-            JAVA10_HOME=$HOME/.java/java10
-            JAVA11_HOME=$HOME/.java/java11
-            JAVA12_HOME=$HOME/.java/openjdk12
-            JAVA13_HOME=$HOME/.java/openjdk13
        - shell: |
           #!/usr/local/bin/runbld --redirect-stderr --last-good-commit elastic+elasticsearch+%BRANCH%+git+push
-          .ci/build.sh check
+          .ci/build.sh -Dbwc.checkout.align=true check
     publishers:
       - email:
           recipients: infra-root+build@elastic.co

--- a/.ci/jobs.t/elastic+elasticsearch+{branch}+periodic-next.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+{branch}+periodic-next.yml
@@ -5,7 +5,3 @@
     description: "Periodic testing of the Elasticsearch %BRANCH% branch.\n"
     triggers:
       - timed: "H H/1 * * *"
-    builders:
-      - shell: |
-          #!/usr/local/bin/runbld --redirect-stderr --last-good-commit elastic+elasticsearch+%BRANCH%+git+push
-          .ci/build.sh -Dbwc.checkout.align=true check


### PR DESCRIPTION
Having the env vars being set up in the build script makes it easier to
reason about.
This PR also adds the gradle scan wrapper back as support for it was
added t o jjbb.

