### PR TITLE
[Docs]: minor typo

### DIFF
--- a/docs/reference/query-dsl/match-query.asciidoc
+++ b/docs/reference/query-dsl/match-query.asciidoc
@@ -261,7 +261,7 @@ GET /_search
 [[query-dsl-match-query-cutoff]]
 ===== Cutoff frequency
 
-deprecated[7.3.0,"This option can be omitted as the <<query-dsl-match-query>> can skip block of documents efficiently, without any configuration, provided that the total number of hits is not tracked."]
+deprecated[7.3.0,"This option can be omitted as the <<query-dsl-match-query>> can skip blocks of documents efficiently, without any configuration, provided that the total number of hits is not tracked."]
 
 The match query supports a `cutoff_frequency` that allows
 specifying an absolute or relative document frequency where high


### PR DESCRIPTION
Heya,

I think this section is missing pluralization somewhere, I think this is more correct?

I also noticed that the way the `<<query-dsl-match-query>>` placeholder is rendered means it doesn't read well in a common sentence structure, it would probably be easier to read as "Match Query".

<img width="739" alt="Screenshot 2019-11-14 at 13 42 15" src="https://user-images.githubusercontent.com/738069/68858173-bfe53080-06e4-11ea-8c2c-6f51e1a8db0e.png">
