### PR TITLE
Disable thirdPartyAudit tests when running in a FIPS JVM

### DIFF
--- a/distribution/tools/plugin-cli/build.gradle
+++ b/distribution/tools/plugin-cli/build.gradle
@@ -45,7 +45,7 @@ test {
 thirdPartyAudit.onlyIf {
   // FIPS JVM includes manny classes from bouncycastle which count as jar hell for the third party audit,
   // rather than provide a long list of exclusions, disable the check on FIPS.
-  BuildParams.inFipsJvm
+  BuildParams.inFipsJvm == false
 }
 
 /*


### PR DESCRIPTION
This fixes a regression introduced in #42042. The logic here was
mistakenly inverted such that we only run these tests in a FIPS JVM
which is the opposite of what we intend.