### PR TITLE
Remove the 'experimental' marking from vector fields.

### DIFF
--- a/docs/reference/mapping/types/dense-vector.asciidoc
+++ b/docs/reference/mapping/types/dense-vector.asciidoc
@@ -6,8 +6,6 @@
 <titleabbrev>Dense vector</titleabbrev>
 ++++
 
-experimental[]
-
 A `dense_vector` field stores dense vectors of float values.
 The maximum number of dimensions that can be in a vector should
 not exceed 1024. A `dense_vector` field is a single-valued field.

--- a/docs/reference/vectors/vector-functions.asciidoc
+++ b/docs/reference/vectors/vector-functions.asciidoc
@@ -3,14 +3,10 @@
 [[vector-functions]]
 ===== Functions for vector fields
 
-experimental[]
-
 NOTE: During vector functions' calculation, all matched documents are
 linearly scanned. Thus, expect the query time grow linearly
 with the number of matched documents. For this reason, we recommend
 to limit the number of matched documents with a `query` parameter.
-
-====== `dense_vector` functions
 
 Let's create an index with a `dense_vector` mapping and index a couple
 of documents into it.


### PR DESCRIPTION
We wrapped up the API changes we wanted to make, and vector fields can now be
considered GA.