### PR TITLE
Restrict support for CMS to pre-JDK 14

### DIFF
--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -33,16 +33,18 @@
 ################################################################
 
 ## GC configuration
--XX:+UseConcMarkSweepGC
--XX:CMSInitiatingOccupancyFraction=75
--XX:+UseCMSInitiatingOccupancyOnly
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
 
-## G1GC Configuration; to use G1GC uncomment the lines below
-# -XX:-UseConcMarkSweepGC
-# -XX:-UseCMSInitiatingOccupancyOnly
-# -XX:+UseG1GC
-# -XX:G1ReservePercent=25
-# -XX:InitiatingHeapOccupancyPercent=30
+## G1GC Configuration
+# to use G1GC, uncomment the next line and update the version on the following
+# lines to your version of the JDK
+# 8-13:-XX:-UseConcMarkSweepGC
+14-:-XX:-UseCMSInitiatingOccupancyOnly
+14-:-XX:+UseG1GC
+14-:-XX:G1ReservePercent=25
+14-:-XX:InitiatingHeapOccupancyPercent=30
 
 ## JVM temporary directory
 -Djava.io.tmpdir=${ES_TMPDIR}

--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -38,10 +38,10 @@
 8-13:-XX:+UseCMSInitiatingOccupancyOnly
 
 ## G1GC Configuration
-# to use G1GC, uncomment the next line and update the version on the following
-# lines to your version of the JDK
+# to use G1GC, uncomment the next two lines and update the version on the
+# following three lines to your version of the JDK
 # 8-13:-XX:-UseConcMarkSweepGC
-14-:-XX:-UseCMSInitiatingOccupancyOnly
+# 8-13:-XX:-UseCMSInitiatingOccupancyOnly
 14-:-XX:+UseG1GC
 14-:-XX:G1ReservePercent=25
 14-:-XX:InitiatingHeapOccupancyPercent=30


### PR DESCRIPTION
JDK 14 has removed CMS. This commit restricts the support for CMS to JDK 8 through JDK 13, and defaults to G1 GC on JDK 14. We will revisit all defaults in the future, but this ensures that we run with a properly-configured garbage collector on JDK 14+.

Relates #46973 