### PR TITLE
Fix cases where we would unintentionally tar the entire build workspace

### DIFF
--- a/gradle/build-complete.gradle
+++ b/gradle/build-complete.gradle
@@ -13,18 +13,26 @@ if (buildNumber) {
     try {
       ant.tar(destfile: uploadFile, compression: "bzip2", longfile: "gnu") {
         fileset(dir: projectDir) {
-          fileTree(projectDir)
-            .include("**/*.hprof")
-            .include("**/reaper.log")
-            .include("**/build/testclusters/**")
-            .exclude("**/build/testclusters/**/data/**")
-            .exclude("**/build/testclusters/**/distro/**")
-            .exclude("**/build/testclusters/**/repo/**")
-            .exclude("**/build/testclusters/**/extract/**")
-            .filter { Files.isRegularFile(it.toPath()) }
-            .each {
+          Set<File> fileSet = fileTree(projectDir) {
+            include("**/*.hprof")
+            include("**/reaper.log")
+            include("**/build/testclusters/**")
+            exclude("**/build/testclusters/**/data/**")
+            exclude("**/build/testclusters/**/distro/**")
+            exclude("**/build/testclusters/**/repo/**")
+            exclude("**/build/testclusters/**/extract/**")
+          }
+            .files
+            .findAll { Files.isRegularFile(it.toPath()) }
+
+          if (fileSet.empty) {
+            // In cases where we don't match any workspace files, exclude everything
+            exclude(name: "**/*")
+          } else {
+            fileSet.each {
               include(name: projectDir.toPath().relativize(it.toPath()))
             }
+          }
         }
 
         fileset(dir: "${gradle.gradleUserHomeDir}/daemon/${gradle.gradleVersion}", followsymlinks: false) {

--- a/gradle/build-complete.gradle
+++ b/gradle/build-complete.gradle
@@ -27,10 +27,10 @@ if (buildNumber) {
 
           if (fileSet.empty) {
             // In cases where we don't match any workspace files, exclude everything
-            exclude(name: "**/*")
+            ant.exclude(name: "**/*")
           } else {
             fileSet.each {
-              include(name: projectDir.toPath().relativize(it.toPath()))
+              ant.include(name: projectDir.toPath().relativize(it.toPath()))
             }
           }
         }


### PR DESCRIPTION
We recently started noticing that [end of build](https://gradle-enterprise.elastic.co/s/kxtvljut2och4/performance/build#build-time-end-of-build) had increased substantially. This is attributed to the `buildFinished` hook that packs up certain log files and test output and uploads to GCP for later retrieval if needed. There seemed to be some issue with the logic here that would cause the entire build workspace to be included in the bundle. One scenario in which this could happen is if our included filters didn't match any files, in which case we wouldn't add any filters to our Ant fileset, so by default this would include the entire workspace. Essentially, this happens for any build that doesn't spin up elasticsearch clusters via testclusters. For such a build, none of the workspace files would match our criteria and the default behavior would kick in.

We began to observe this behavior after https://github.com/elastic/elasticsearch/pull/48732 was merged. The reason was that for any given build we would at least include the `journalctl.log` file created in the build workspace. When that was removed, certain builds (those that didn't leverage testclusters) would now not match any files and Ant would default to the "include all" strategy.