### PR TITLE
Add index name to search requests

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/20_dense_vector_special_cases.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/20_dense_vector_special_cases.yml
@@ -55,6 +55,7 @@ setup:
         Content-Type: application/json
       search:
         rest_total_hits_as_int: true
+        index: test-index
         body:
           query:
             script_score:
@@ -74,6 +75,7 @@ setup:
         Content-Type: application/json
       search:
         rest_total_hits_as_int: true
+        index: test-index
         body:
           query:
             script_score:
@@ -104,6 +106,7 @@ setup:
       catch: bad_request
       search:
         rest_total_hits_as_int: true
+        index: test-index
         body:
           query:
             script_score:
@@ -118,6 +121,7 @@ setup:
       catch: bad_request
       search:
         rest_total_hits_as_int: true
+        index: test-index
         body:
           query:
             script_score:
@@ -154,6 +158,7 @@ setup:
       Content-Type: application/json
     search:
       rest_total_hits_as_int: true
+      index: test-index
       body:
         query:
           script_score:
@@ -170,6 +175,7 @@ setup:
       Content-Type: application/json
     search:
       rest_total_hits_as_int: true
+      index: test-index
       body:
         query:
           script_score:


### PR DESCRIPTION
We can't guarantee expected request failures if search request is across
many indexes, as if expected shards fail, some indexes may return 200.

closes #47743
