### PR TITLE
Remove default indent from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,10 +7,27 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
-indent_size = 4
-
-[*.bat]
-indent_size = 2
 
 [*.gradle]
 indent_size = 2
+
+[*.groovy]
+indent_size = 4
+
+[*.java]
+indent_size = 4
+
+[*.json]
+indent_size = 2
+
+[*.py]
+indent_size = 2
+
+[*.sh]
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.{xsd,xml}]
+indent_size = 4


### PR DESCRIPTION
Backport of #49136.

Prior to 3a3e5f6, there was no default indent configured in
`.editorconfig`. This changed to 4 spaces when we configured an explicit
indent of 2 for Gradle files. However, this change meant that YAML files
then had 4-space indents, which is valid, but the repo's YAML files
typically use 2-space indents.

Remove the default indent again, and instead explicitly set an indent size
for a variety of file types.