### PR TITLE
Add disjointness check for parallel lines in EdgeTreeReader

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/geo/EdgeTreeReader.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/EdgeTreeReader.java
@@ -189,15 +189,24 @@ public class EdgeTreeReader implements ShapeTreeReader {
         // we just have to cross one edge to answer the question, so we descend the tree and return when we do.
         if (root.maxY >= extent.minY()) {
 
+            double a1x = root.x1;
+            double a1y = root.y1;
+            double b1x = root.x2;
+            double b1y = root.y2;
+            boolean outside = (a1y < extent.minY() && b1y < extent.minY()) ||
+                (a1y > extent.maxY() && b1y > extent.maxY()) ||
+                (a1x < extent.minX() && b1x < extent.minX()) ||
+                (a1x > extent.maxX() && b1x > extent.maxX());
+
             // does rectangle's edges intersect or reside inside polygon's edge
-            if (lineCrossesLineWithBoundary(root.x1, root.y1, root.x2, root.y2,
+            if (outside == false && (lineCrossesLineWithBoundary(root.x1, root.y1, root.x2, root.y2,
                 extent.minX(), extent.minY(), extent.maxX(), extent.minY()) ||
                 lineCrossesLineWithBoundary(root.x1, root.y1, root.x2, root.y2,
                     extent.maxX(), extent.minY(), extent.maxX(), extent.maxY()) ||
                 lineCrossesLineWithBoundary(root.x1, root.y1, root.x2, root.y2,
                     extent.maxX(), extent.maxY(), extent.minX(), extent.maxY()) ||
                 lineCrossesLineWithBoundary(root.x1, root.y1, root.x2, root.y2,
-                    extent.minX(), extent.maxY(), extent.minX(), extent.minY())) {
+                    extent.minX(), extent.maxY(), extent.minX(), extent.minY()))) {
                 return true;
             }
 

--- a/server/src/test/java/org/elasticsearch/common/geo/GeometryTreeTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeometryTreeTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.geometry.MultiPoint;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.Rectangle;
+import org.elasticsearch.geometry.ShapeType;
 import org.elasticsearch.index.mapper.GeoShapeIndexer;
 import org.elasticsearch.test.ESTestCase;
 
@@ -229,7 +230,6 @@ public class GeometryTreeTests extends ESTestCase {
 
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/37206")
     public void testRandomGeometryIntersection() throws IOException {
         int testPointCount = randomIntBetween(100, 200);
         Point[] testPoints = new Point[testPointCount];
@@ -241,15 +241,20 @@ public class GeometryTreeTests extends ESTestCase {
 
         Geometry geometry = randomGeometryTreeGeometry();
         GeoShapeIndexer indexer = new GeoShapeIndexer(true, "test");
-        geometry = indexer.prepareForIndexing(geometry);
+        Geometry preparedGeometry = indexer.prepareForIndexing(geometry);
 
-        for (int i = 0; i < testPointCount; i++) {
-            int cur = i;
-            intersects[cur] = fold(geometry, false, (g, s) -> s || intersects(g, testPoints[cur], extentSize));
+        // TODO: support multi-polygons
+        if (ShapeType.POLYGON == geometry.type() && ShapeType.MULTIPOLYGON == preparedGeometry.type()) {
+            return;
         }
 
         for (int i = 0; i < testPointCount; i++) {
-            assertEquals(intersects[i], intersects(geometry, testPoints[i], extentSize));
+            int cur = i;
+            intersects[cur] = fold(preparedGeometry, false, (g, s) -> s || intersects(g, testPoints[cur], extentSize));
+        }
+
+        for (int i = 0; i < testPointCount; i++) {
+            assertEquals(intersects[i], intersects(preparedGeometry, testPoints[i], extentSize));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/common/geo/GeometryTreeTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeometryTreeTests.java
@@ -244,9 +244,8 @@ public class GeometryTreeTests extends ESTestCase {
         Geometry preparedGeometry = indexer.prepareForIndexing(geometry);
 
         // TODO: support multi-polygons
-        if (ShapeType.POLYGON == geometry.type() && ShapeType.MULTIPOLYGON == preparedGeometry.type()) {
-            return;
-        }
+        assumeFalse("polygon crosses dateline",
+            ShapeType.POLYGON == geometry.type() && ShapeType.MULTIPOLYGON == preparedGeometry.type());
 
         for (int i = 0; i < testPointCount; i++) {
             int cur = i;


### PR DESCRIPTION
GeoUtils#lineCrossesLineWithBoundary returns true
for parallel lines that are disjoint. This commit
adds another disjointness check for each edge to
verify that they should not be accounted for even
if lineCrossesLine claims they cross.

relates #37206.