### PR TITLE
[DOCS] Adds ml-cpp PRs to release notes

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -5,6 +5,7 @@
 --
 This section summarizes the changes in each release.
 
+* <<release-notes-6.8.5>>
 * <<release-notes-6.8.4>>
 * <<release-notes-6.8.3>>
 * <<release-notes-6.8.2>>

--- a/docs/reference/release-notes/6.8.asciidoc
+++ b/docs/reference/release-notes/6.8.asciidoc
@@ -1,3 +1,26 @@
+[[release-notes-6.8.5]]
+== {es} version 6.8.5
+
+Also see <<breaking-changes-6.8,Breaking changes in 6.8>>.
+
+[[enhancement-6.8.5]]
+[float]
+=== Enhancements
+
+Machine Learning::
+* The {ml} native processes are now arranged in a `.app` directory structure on
+  macOS to allow for notarization on macOS Catalina {ml-pull}593[#593]
+  
+  
+[[bug-6.8.5]]
+[float]
+=== Bug fixes
+
+Machine Learning::
+* Restore from checkpoint could damage seasonality modeling. For example, it could
+  cause seasonal components to be overwritten in error {ml-pull}821[#821]
+
+
 [[release-notes-6.8.4]]
 == {es} version 6.8.4
 

--- a/docs/reference/release-notes/6.8.asciidoc
+++ b/docs/reference/release-notes/6.8.asciidoc
@@ -1,6 +1,8 @@
 [[release-notes-6.8.5]]
 == {es} version 6.8.5
 
+coming[6.8.5]
+
 Also see <<breaking-changes-6.8,Breaking changes in 6.8>>.
 
 [[enhancement-6.8.5]]


### PR DESCRIPTION
This PR adds the information from the ml-cpp change log (https://github.com/elastic/ml-cpp/blob/6.8/docs/CHANGELOG.asciidoc) to the Elasticsearch Release Notes.

Preview: http://elasticsearch_49190.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.5.html