### PR TITLE
Clean up static web server in sql-client tests (#49187)

### DIFF
--- a/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/JdbcHttpClientRequestTests.java
+++ b/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/JdbcHttpClientRequestTests.java
@@ -53,8 +53,11 @@ public class JdbcHttpClientRequestTests extends ESTestCase {
 
     @AfterClass
     public static void cleanup() {
-        webServer.close();
-        webServer = null;
+        try {
+            webServer.close();
+        } finally {
+            webServer = null;
+        }
     }
 
     public void testBinaryRequestEnabled() throws Exception {

--- a/x-pack/plugin/sql/sql-client/src/test/java/org/elasticsearch/xpack/sql/client/HttpClientRequestTests.java
+++ b/x-pack/plugin/sql/sql-client/src/test/java/org/elasticsearch/xpack/sql/client/HttpClientRequestTests.java
@@ -59,8 +59,11 @@ public class HttpClientRequestTests extends ESTestCase {
 
     @AfterClass
     public static void cleanup() {
-        webServer.close();
-        webServer = null;
+        try {
+            webServer.close();
+        } finally {
+            webServer = null;
+        }
     }
     
     public void testBinaryRequestForCLIEnabled() throws URISyntaxException {
@@ -146,7 +149,7 @@ public class HttpClientRequestTests extends ESTestCase {
         HttpClient httpClient = new HttpClient(conCfg);
         
         Mode mode = randomFrom(Mode.JDBC, Mode.ODBC);
-        SqlQueryRequest request = new SqlQueryRequest(query, 
+        SqlQueryRequest request = new SqlQueryRequest(query,
                 null,
                 ZoneId.of("Z"),
                 randomIntBetween(1, 100),


### PR DESCRIPTION
The JdbcHttpClientRequestTests and HttpClientRequestTests classes both
hold a static reference to a mock web server that internally uses the
JDKs built-in HttpServer, which resides in a sun package that the
RamUsageEstimator does not have access to. This causes builds that use
a runtime of Java 8 to fail since the StaticFieldsInvariantRule is run
when Java 8 is used.

Relates #41526
Relates #49105