### PR TITLE
Reindex in mixed cluster

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/ReindexPlugin.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/ReindexPlugin.java
@@ -64,6 +64,7 @@ public class ReindexPlugin extends Plugin implements ActionPlugin, PersistentTas
 
     private final SetOnce<ScriptService> scriptService = new SetOnce<>();
     private final SetOnce<ReindexSslConfig> reindexSslConfig = new SetOnce<>();
+    private final SetOnce<ClusterService> clusterService = new SetOnce<>();
 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
@@ -98,7 +99,7 @@ public class ReindexPlugin extends Plugin implements ActionPlugin, PersistentTas
             IndexScopedSettings indexScopedSettings, SettingsFilter settingsFilter, IndexNameExpressionResolver indexNameExpressionResolver,
             Supplier<DiscoveryNodes> nodesInCluster) {
         return Arrays.asList(
-                new RestReindexAction(restController),
+                new RestReindexAction(restController, clusterService.get()),
                 new RestUpdateByQueryAction(restController),
                 new RestDeleteByQueryAction(restController),
                 new RestRethrottleAction(restController, nodesInCluster));
@@ -112,6 +113,7 @@ public class ReindexPlugin extends Plugin implements ActionPlugin, PersistentTas
         this.scriptService.set(scriptService);
         this.reindexSslConfig.set(new ReindexSslConfig(environment.settings(), environment, resourceWatcherService));
         namedXContentRegistry.set(xContentRegistry);
+        this.clusterService.set(clusterService);
         return Collections.singletonList(reindexSslConfig.get());
     }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RestReindexActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RestReindexActionTests.java
@@ -38,7 +38,7 @@ public class RestReindexActionTests extends RestActionTestCase {
 
     @Before
     public void setUpAction() {
-        action = new RestReindexAction(controller());
+        action = new RestReindexAction(controller(), null);
     }
 
     public void testPipelineQueryParameterIsError() throws IOException {

--- a/qa/mixed-cluster/src/test/resources/rest-api-spec/test/mixed_cluster/reindex/10_basic.yml
+++ b/qa/mixed-cluster/src/test/resources/rest-api-spec/test/mixed_cluster/reindex/10_basic.yml
@@ -1,0 +1,36 @@
+---
+"Verify that reindex completes successfully in a mixed cluster":
+  - do:
+      indices.create:
+        index: reindex_mixed_cluster_source
+        body:
+          settings:
+            index:
+              number_of_replicas: 0
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "reindex_mixed_cluster_source"}}'
+          - '{"f1": "1"}'
+          - '{"index": {"_index": "reindex_mixed_cluster_source"}}'
+          - '{"f1": "2"}'
+          - '{"index": {"_index": "reindex_mixed_cluster_source"}}'
+          - '{"f1": "3"}'
+          - '{"index": {"_index": "reindex_mixed_cluster_source"}}'
+          - '{"f1": "4"}'
+          - '{"index": {"_index": "reindex_mixed_cluster_source"}}'
+          - '{"f1": "5"}'
+
+  - do:
+      reindex:
+        body:
+          source:
+            index: reindex_mixed_cluster_source
+            size: 1
+          dest:
+            index: reindex_mixed_custer_copy
+  - match: {created: 5}
+  - match: {version_conflicts: 0}
+  - match: {batches: 5}
+  - match: {failures: []}


### PR DESCRIPTION
Ensure that reindex works in a mixed cluster state during rolling
upgrade by not doing resilient reindex until all nodes are on the new
version.

Relates #42612
