### PR TITLE
Check Security Roles in Deprecation Info API

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecationInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecationInfoAction.java
@@ -206,8 +206,7 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
             return new DeprecationInfoAction.Response(mergedClusterIssues, mergedNodeIssues, indexSettingsIssues, mlSettingsIssues);
         }
 
-        private static List<DeprecationIssue> mergeNodeIssues(Map<DiscoveryNode,
-                                                              List<DeprecationIssue>> nodeIssues,
+        private static List<DeprecationIssue> mergeNodeIssues(Map<DiscoveryNode, List<DeprecationIssue>> nodeIssues,
                                                               Map<DiscoveryNode, List<DeprecationIssue>> rolesIssuesByNode) {
             Map<DeprecationIssue, List<String>> issuesToNodeMap = new HashMap<>();
             Stream.concat(nodeIssues.entrySet().stream(), rolesIssuesByNode.entrySet().stream())

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/GetFileRolesAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/GetFileRolesAction.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.security.action.role;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.nodes.BaseNodeRequest;
+import org.elasticsearch.action.support.nodes.BaseNodeResponse;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+public class GetFileRolesAction extends ActionType<GetFileRolesResponse> {
+    public static final GetFileRolesAction INSTANCE = new GetFileRolesAction();
+    public static final String NAME = "cluster:admin/xpack/security/role/file/get";
+
+
+    private GetFileRolesAction() {
+        super(NAME, GetFileRolesResponse::new);
+    }
+
+    public static class NodeRequest extends BaseNodeRequest {
+        GetFileRolesRequest request;
+
+        public NodeRequest(StreamInput in) throws IOException {
+            super(in);
+            request = new GetFileRolesRequest(in);
+        }
+
+        public NodeRequest(GetFileRolesRequest request) {
+            this.request = request;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            request.writeTo(out);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            NodeRequest that = (NodeRequest) o;
+            return Objects.equals(request, that.request);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(request);
+        }
+    }
+
+    public static class NodeResponse extends BaseNodeResponse {
+        private final List<RoleDescriptor> roles;
+
+        public NodeResponse(StreamInput in) throws IOException {
+            super(in);
+            roles = in.readList(RoleDescriptor::new);
+        }
+
+        public NodeResponse(DiscoveryNode node, List<RoleDescriptor> roles) {
+            super(node);
+            this.roles = roles;
+        }
+
+        public List<RoleDescriptor> getRoles() {
+            return roles;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeList(roles);
+        }
+
+        @Override
+        public String toString() {
+            return "GetFileRolesNodeResponse[roles=" + roles.toString() + "]";
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            NodeResponse that = (NodeResponse) o;
+            return Objects.equals(this.getNode(), that.getNode())
+                && Objects.equals(roles, that.roles);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getNode(), roles);
+        }
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/GetFileRolesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/GetFileRolesRequest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.security.action.role;
+
+import org.elasticsearch.action.support.nodes.BaseNodesRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
+
+public class GetFileRolesRequest extends BaseNodesRequest<GetFileRolesRequest> {
+    public GetFileRolesRequest(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    public GetFileRolesRequest(String... nodesIds) {
+        super(nodesIds);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash((Object[]) this.nodesIds());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        GetFileRolesRequest that = (GetFileRolesRequest) obj;
+        return Arrays.equals(this.nodesIds(), that.nodesIds());
+    }
+
+    @Override
+    public String toString() {
+        return "GetFileRolesRequest[nodes: " + Arrays.toString(this.nodesIds()) + "]";
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/GetFileRolesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/GetFileRolesResponse.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.security.action.role;
+
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.nodes.BaseNodesResponse;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+public class GetFileRolesResponse extends BaseNodesResponse<GetFileRolesAction.NodeResponse> {
+
+    public GetFileRolesResponse(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    public GetFileRolesResponse(ClusterName clusterName, List<GetFileRolesAction.NodeResponse> nodes,
+                                   List<FailedNodeException> failures) {
+        super(clusterName, nodes, failures);
+    }
+
+    @Override
+    protected List<GetFileRolesAction.NodeResponse> readNodesFrom(StreamInput in) throws IOException {
+        return in.readList(GetFileRolesAction.NodeResponse::new);
+    }
+
+    @Override
+    protected void writeNodesTo(StreamOutput out, List<GetFileRolesAction.NodeResponse> nodes) throws IOException {
+        out.writeList(nodes);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GetFileRolesResponse that = (GetFileRolesResponse) o;
+        return Objects.equals(getClusterName(), that.getClusterName())
+            && Objects.equals(getNodes(), that.getNodes())
+            && Objects.equals(failures(), that.failures());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getClusterName(), getNodes(), failures());
+    }
+
+    @Override
+    public String toString() {
+        return "GetFileRolesResponse[nodeResponses= " + this.getNodes().toString() + "]";
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/deprecation/DeprecationInfoActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/deprecation/DeprecationInfoActionResponseTests.java
@@ -23,8 +23,13 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfigTests;
+import org.elasticsearch.xpack.core.security.action.role.GetFileRolesAction;
+import org.elasticsearch.xpack.core.security.action.role.GetFileRolesResponse;
+import org.elasticsearch.xpack.core.security.action.role.GetRolesResponse;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -35,7 +40,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
-import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 public class DeprecationInfoActionResponseTests extends AbstractWireSerializingTestCase<DeprecationInfoAction.Response> {
@@ -85,11 +90,15 @@ public class DeprecationInfoActionResponseTests extends AbstractWireSerializingT
         boolean nodeIssueFound = randomBoolean();
         boolean indexIssueFound = randomBoolean();
         boolean mlIssueFound = randomBoolean();
+        boolean rolesIssueFound = randomBoolean();
         DeprecationIssue foundIssue = DeprecationIssueTests.createTestInstance();
+        // We need to be able to differentiate the roles issue, because it gets merged in with the cluster and/or node issues
+        DeprecationIssue rolesIssue = randomValueOtherThan(foundIssue , DeprecationIssueTests::createTestInstance);
         List<Function<ClusterState, DeprecationIssue>> clusterSettingsChecks = List.of((s) -> clusterIssueFound ? foundIssue : null);
         List<Function<IndexMetaData, DeprecationIssue>> indexSettingsChecks = List.of((idx) -> indexIssueFound ? foundIssue : null);
         List<BiFunction<DatafeedConfig, NamedXContentRegistry, DeprecationIssue>> mlSettingsChecks =
                 List.of((idx, unused) -> mlIssueFound ? foundIssue : null);
+        List<Function<List<RoleDescriptor>, DeprecationIssue>> rolesChecks = List.of(roles -> rolesIssueFound ? rolesIssue : null);
 
         NodesDeprecationCheckResponse nodeDeprecationIssues = new NodesDeprecationCheckResponse(
             new ClusterName(randomAlphaOfLength(5)),
@@ -99,24 +108,41 @@ public class DeprecationInfoActionResponseTests extends AbstractWireSerializingT
                 : emptyList(),
             emptyList());
 
+        GetRolesResponse rolesResponse = new GetRolesResponse(new RoleDescriptor(randomAlphaOfLength(10), null, null, null));
+        GetFileRolesResponse nodeRolesResponse = new GetFileRolesResponse(new ClusterName(randomAlphaOfLength(5)),
+            rolesIssueFound
+                ? Collections.singletonList(
+                    new GetFileRolesAction.NodeResponse(discoveryNode,
+                        Collections.singletonList(new RoleDescriptor(randomAlphaOfLength(10), null, null, null))))
+                : emptyList(),
+            emptyList());
+
+        // Fix this this test vvv
         DeprecationInfoAction.Response response = DeprecationInfoAction.Response.from(state, NamedXContentRegistry.EMPTY,
-            resolver, Strings.EMPTY_ARRAY, indicesOptions, datafeeds,
-            nodeDeprecationIssues, indexSettingsChecks, clusterSettingsChecks, mlSettingsChecks);
+            resolver, Strings.EMPTY_ARRAY, indicesOptions, datafeeds, rolesResponse, nodeRolesResponse, indexSettingsChecks,
+            clusterSettingsChecks, mlSettingsChecks, rolesChecks, nodeDeprecationIssues);
 
+        List<DeprecationIssue> expectedClusterIssues = new ArrayList<>();
         if (clusterIssueFound) {
-            assertThat(response.getClusterSettingsIssues(), equalTo(Collections.singletonList(foundIssue)));
-        } else {
-            assertThat(response.getClusterSettingsIssues(), empty());
+            expectedClusterIssues.add(foundIssue);
         }
+        if (rolesIssueFound) {
+            expectedClusterIssues.add(rolesIssue);
+        }
+        assertThat(response.getClusterSettingsIssues(), containsInAnyOrder(expectedClusterIssues.toArray()));
 
+        List<DeprecationIssue> expectedNodeIssues = new ArrayList<>();
         if (nodeIssueFound) {
             String details = foundIssue.getDetails() != null ? foundIssue.getDetails() + " " : "";
-            DeprecationIssue mergedFoundIssue = new DeprecationIssue(foundIssue.getLevel(), foundIssue.getMessage(), foundIssue.getUrl(),
-                details + "(nodes impacted: [" + discoveryNode.getName() + "])");
-            assertThat(response.getNodeSettingsIssues(), equalTo(Collections.singletonList(mergedFoundIssue)));
-        } else {
-            assertTrue(response.getNodeSettingsIssues().isEmpty());
+            expectedNodeIssues.add(new DeprecationIssue(foundIssue.getLevel(), foundIssue.getMessage(), foundIssue.getUrl(),
+                details + "(nodes impacted: [" + discoveryNode.getName() + "])"));
         }
+        if (rolesIssueFound) {
+            String rolesIssueDetails = rolesIssue.getDetails() != null ? rolesIssue.getDetails() + " " : "";
+            expectedNodeIssues.add(new DeprecationIssue(rolesIssue.getLevel(), rolesIssue.getMessage(), rolesIssue.getUrl(),
+                rolesIssueDetails + "(nodes impacted: [" + discoveryNode.getName() + "])"));
+        }
+        assertThat(response.getNodeSettingsIssues(), containsInAnyOrder(expectedNodeIssues.toArray()));
 
         if (indexIssueFound) {
             assertThat(response.getIndexSettingsIssues(), equalTo(Collections.singletonMap("test",

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/role/GetFileRolesRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/role/GetFileRolesRequestTests.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.security.action.role;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+
+public class GetFileRolesRequestTests extends AbstractWireSerializingTestCase<GetFileRolesRequest> {
+
+    @Override
+    protected GetFileRolesRequest createTestInstance() {
+        return new GetFileRolesRequest(generateRandomStringArray(randomIntBetween(1,10), randomIntBetween(5, 10), false, true));
+    }
+
+    @Override
+    protected Writeable.Reader<GetFileRolesRequest> instanceReader() {
+        return GetFileRolesRequest::new;
+    }
+
+    @Override
+    protected GetFileRolesRequest mutateInstance(GetFileRolesRequest instance) {
+        boolean givenInstanceEmpty = instance.nodesIds().length == 0;
+        return new GetFileRolesRequest(randomValueOtherThan(instance.nodesIds(),
+            () -> generateRandomStringArray(randomIntBetween(1,10), randomIntBetween(5, 10), false, givenInstanceEmpty == false)));
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/role/GetFileRolesResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/role/GetFileRolesResponseTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.security.action.role;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+
+import java.net.InetAddress;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class GetFileRolesResponseTests extends AbstractWireSerializingTestCase<GetFileRolesResponse> {
+
+    @Override
+    protected GetFileRolesResponse createTestInstance() {
+        List<GetFileRolesAction.NodeResponse> responses = Arrays.asList(
+            randomArray(1, 10, GetFileRolesAction.NodeResponse[]::new, GetFileRolesResponseTests::randomNodeResponse));
+        return new GetFileRolesResponse(new ClusterName(randomAlphaOfLength(10)), responses, Collections.emptyList());
+    }
+
+    @Override
+    protected Writeable.Reader<GetFileRolesResponse> instanceReader() {
+        return GetFileRolesResponse::new;
+    }
+
+    @Override
+    protected GetFileRolesResponse mutateInstance(GetFileRolesResponse instance) {
+        int mutate = randomIntBetween(1,2);
+        switch (mutate) {
+            case 1:
+                String newClusterName = randomValueOtherThan(instance.getClusterName().value(), () -> randomAlphaOfLength(10));
+                return new GetFileRolesResponse(new ClusterName(newClusterName), instance.getNodes(), instance.failures());
+            case 2:
+                List<GetFileRolesAction.NodeResponse> newResponses = randomValueOtherThan(instance.getNodes(), () -> Arrays.asList(
+                    randomArray(1, 10, GetFileRolesAction.NodeResponse[]::new, GetFileRolesResponseTests::randomNodeResponse)));
+                return new GetFileRolesResponse(instance.getClusterName(), newResponses, instance.failures());
+            default:
+                fail("invalid randomization");
+        }
+        throw new IllegalArgumentException("invalid randomization, did not return from switch");
+    }
+
+    private static DiscoveryNode randomDiscoveryNode() throws Exception {
+        InetAddress inetAddress = InetAddress.getByAddress(randomAlphaOfLength(5),
+            new byte[] { (byte) 192, (byte) 168, (byte) 0, (byte) 1});
+        TransportAddress transportAddress = new TransportAddress(inetAddress, randomIntBetween(0, 65535));
+
+        return new DiscoveryNode(randomAlphaOfLength(5), randomAlphaOfLength(5), transportAddress,
+            Collections.emptyMap(), Collections.emptySet(), Version.CURRENT);
+    }
+
+    private static RoleDescriptor randomRoleDescriptor() {
+        String[] clusterPrivs = randomArray(1, 10, String[]::new, () -> randomAlphaOfLengthBetween(5, 15));
+        return new RoleDescriptor(randomAlphaOfLengthBetween(5, 15), clusterPrivs, null, null);
+    }
+
+    private static GetFileRolesAction.NodeResponse randomNodeResponse() {
+        DiscoveryNode node;
+        try {
+            node = randomDiscoveryNode();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        List<RoleDescriptor> roles = Arrays.asList(
+            randomArray(0, 10, RoleDescriptor[]::new, GetFileRolesResponseTests::randomRoleDescriptor));
+        return new GetFileRolesAction.NodeResponse(node, roles);
+    }
+}

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.deprecation.DeprecationInfoAction;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 
 import java.util.Collections;
 import java.util.List;
@@ -40,6 +41,9 @@ public class DeprecationChecks {
 
     static List<BiFunction<DatafeedConfig, NamedXContentRegistry, DeprecationIssue>> ML_SETTINGS_CHECKS =
             List.of(MlDeprecationChecks::checkDataFeedAggregations, MlDeprecationChecks::checkDataFeedQuery);
+
+    static List<Function<List<RoleDescriptor>, DeprecationIssue>> ROLE_CHECKS =
+        List.of(RoleDeprecationChecks::createPrivilegeCheck);
 
     /**
      * helper utility function to reduce repeat of running a specific {@link List} of checks.

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/RoleDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/RoleDeprecationChecks.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.deprecation;
+
+import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+
+public class RoleDeprecationChecks {
+
+    static DeprecationIssue createPrivilegeCheck(List<RoleDescriptor> roles) {
+        final List<String> rolesWithDeprecatedPriv = roles.stream()
+            .filter(hasPrivilegeForAnyIndexPredicate("create"))
+            .map(RoleDescriptor::getName)
+            .sorted() // maintains a consistent ordering so the message is consistent
+            .collect(Collectors.toList());
+        return new DeprecationIssue(DeprecationIssue.Level.WARNING,
+            "Some roles use deprecated privilege \"create\"",
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html", // TODO: Fix this link
+            "Roles which use the deprevated privilege \"create\": "
+                + rolesWithDeprecatedPriv.toString()
+                + ". Please use the privilege \"index_doc\" instead.");
+
+    }
+
+    private static Predicate<RoleDescriptor> hasPrivilegeForAnyIndexPredicate(String privilege) {
+        return role -> Stream.of(role.getIndicesPrivileges())
+            .map(RoleDescriptor.IndicesPrivileges::getPrivileges)
+            .flatMap(Stream::of)
+            .anyMatch(privilege::equals);
+    }
+}

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/RoleDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/RoleDeprecationChecksTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.deprecation;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.elasticsearch.xpack.deprecation.DeprecationChecks.ROLE_CHECKS;
+
+public class RoleDeprecationChecksTests extends ESTestCase {
+
+    public void testCreatePrivilegeCheck() {
+        RoleDescriptor.IndicesPrivileges badPriv = RoleDescriptor.IndicesPrivileges.builder()
+            .indices(randomAlphaOfLength(10))
+            .privileges("create")
+            .build();
+        RoleDescriptor.IndicesPrivileges fixedPriv = RoleDescriptor.IndicesPrivileges.builder()
+            .indices(randomAlphaOfLength(10))
+            .privileges("index_doc")
+            .build();
+        final String badRoleName = randomAlphaOfLength(10);
+        RoleDescriptor badRole = new RoleDescriptor(badRoleName, null,
+            new RoleDescriptor.IndicesPrivileges[]{badPriv}, null);
+        final String fixedRoleName = randomValueOtherThan(badRoleName, () -> randomAlphaOfLength(10));
+        RoleDescriptor fixedRole = new RoleDescriptor(fixedRoleName, null,
+            new RoleDescriptor.IndicesPrivileges[]{fixedPriv}, null);
+        List<RoleDescriptor> roles = Arrays.asList(badRole, fixedRole);
+
+        DeprecationIssue expected =  new DeprecationIssue(DeprecationIssue.Level.WARNING,
+            "Some roles use deprecated privilege \"create\"",
+            "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html", // TODO: Fix this
+            "Roles which use the deprevated privilege \"create\": ["
+                + badRoleName
+                + "]. Please use the privilege \"index_doc\" instead.");
+        List<DeprecationIssue> issues = DeprecationChecks.filterChecks(ROLE_CHECKS, c -> c.apply(roles));
+        assertEquals(Collections.singletonList(expected), issues);
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -91,6 +91,7 @@ import org.elasticsearch.xpack.core.security.action.privilege.PutPrivilegesActio
 import org.elasticsearch.xpack.core.security.action.realm.ClearRealmCacheAction;
 import org.elasticsearch.xpack.core.security.action.role.ClearRolesCacheAction;
 import org.elasticsearch.xpack.core.security.action.role.DeleteRoleAction;
+import org.elasticsearch.xpack.core.security.action.role.GetFileRolesAction;
 import org.elasticsearch.xpack.core.security.action.role.GetRolesAction;
 import org.elasticsearch.xpack.core.security.action.role.PutRoleAction;
 import org.elasticsearch.xpack.core.security.action.rolemapping.DeleteRoleMappingAction;
@@ -152,6 +153,7 @@ import org.elasticsearch.xpack.security.action.privilege.TransportPutPrivilegesA
 import org.elasticsearch.xpack.security.action.realm.TransportClearRealmCacheAction;
 import org.elasticsearch.xpack.security.action.role.TransportClearRolesCacheAction;
 import org.elasticsearch.xpack.security.action.role.TransportDeleteRoleAction;
+import org.elasticsearch.xpack.security.action.role.TransportGetFileRolesAction;
 import org.elasticsearch.xpack.security.action.role.TransportGetRolesAction;
 import org.elasticsearch.xpack.security.action.role.TransportPutRoleAction;
 import org.elasticsearch.xpack.security.action.rolemapping.TransportDeleteRoleMappingAction;
@@ -410,6 +412,8 @@ public class Security extends Plugin implements ActionPlugin, IngestPlugin, Netw
         final FieldPermissionsCache fieldPermissionsCache = new FieldPermissionsCache(settings);
         final FileRolesStore fileRolesStore = new FileRolesStore(settings, env, resourceWatcherService, getLicenseState(),
             xContentRegistry);
+        components.add(fileRolesStore);
+
         final NativeRolesStore nativeRolesStore = new NativeRolesStore(settings, client, getLicenseState(), securityIndex.get());
         final ReservedRolesStore reservedRolesStore = new ReservedRolesStore();
         List<BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>>> rolesProviders = new ArrayList<>();
@@ -703,6 +707,7 @@ public class Security extends Plugin implements ActionPlugin, IngestPlugin, Netw
                 new ActionHandler<>(PutUserAction.INSTANCE, TransportPutUserAction.class),
                 new ActionHandler<>(DeleteUserAction.INSTANCE, TransportDeleteUserAction.class),
                 new ActionHandler<>(GetRolesAction.INSTANCE, TransportGetRolesAction.class),
+                new ActionHandler<>(GetFileRolesAction.INSTANCE, TransportGetFileRolesAction.class),
                 new ActionHandler<>(PutRoleAction.INSTANCE, TransportPutRoleAction.class),
                 new ActionHandler<>(DeleteRoleAction.INSTANCE, TransportDeleteRoleAction.class),
                 new ActionHandler<>(ChangePasswordAction.INSTANCE, TransportChangePasswordAction.class),

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportGetFileRolesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportGetFileRolesAction.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.security.action.role;
+
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.nodes.TransportNodesAction;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.security.action.role.GetFileRolesAction;
+import org.elasticsearch.xpack.core.security.action.role.GetFileRolesRequest;
+import org.elasticsearch.xpack.core.security.action.role.GetFileRolesResponse;
+import org.elasticsearch.xpack.security.authz.store.FileRolesStore;
+
+import java.io.IOException;
+import java.util.List;
+
+public class TransportGetFileRolesAction extends TransportNodesAction<GetFileRolesRequest, GetFileRolesResponse,
+    GetFileRolesAction.NodeRequest, GetFileRolesAction.NodeResponse> {
+
+    private final FileRolesStore fileRolesStore;
+
+    @Inject
+    public TransportGetFileRolesAction(ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
+                                          ActionFilters actionFilters, FileRolesStore fileRolesStore) {
+        super(GetFileRolesAction.NAME, threadPool, clusterService, transportService, actionFilters,
+            GetFileRolesRequest::new,
+            GetFileRolesAction.NodeRequest::new,
+            ThreadPool.Names.GENERIC, //TODO: Is this the right threadpool?
+            GetFileRolesAction.NodeResponse.class);
+        this.fileRolesStore = fileRolesStore;
+    }
+
+    @Override
+    protected GetFileRolesResponse newResponse(GetFileRolesRequest request, List<GetFileRolesAction.NodeResponse> nodeResponses,
+                                               List<FailedNodeException> failures) {
+        return new GetFileRolesResponse(clusterService.getClusterName(), nodeResponses, failures);
+    }
+
+    @Override
+    protected GetFileRolesAction.NodeRequest newNodeRequest(GetFileRolesRequest request) {
+        return new GetFileRolesAction.NodeRequest(request);
+    }
+
+    @Override
+    protected GetFileRolesAction.NodeResponse newNodeResponse(StreamInput in) throws IOException {
+        return new GetFileRolesAction.NodeResponse(in);
+    }
+
+    @Override
+    protected GetFileRolesAction.NodeResponse nodeOperation(GetFileRolesAction.NodeRequest request, Task task) {
+        return new GetFileRolesAction.NodeResponse(transportService.getLocalNode(), fileRolesStore.getAllRoleDescriptors());
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/FileRolesStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/FileRolesStore.java
@@ -107,6 +107,10 @@ public class FileRolesStore implements BiConsumer<Set<String>, ActionListener<Ro
         return descriptors;
     }
 
+    public List<RoleDescriptor> getAllRoleDescriptors() {
+        return new ArrayList<>(permissions.values());
+    }
+
     public Map<String, Object> usageStats() {
         final Map<String, RoleDescriptor> localPermissions = permissions;
         Map<String, Object> usageStats = new HashMap<>(3);


### PR DESCRIPTION
This PR adds infrastructure to allow Roles to be checked in the
Deprecation Info API. Roles are retrieved via the existing Get Roles API
for roles defined via API, or by new infrastructure which retrieves the
file-based roles from each node.

Each role deprecation check is run under two different circumstances:
Once against the list of roles defined via the API, which are shared
across the cluster, and again against the list of roles retrieved from
each node. The deprecation issues produced by running against the
cluster-wide roles are merged into the list of Cluster-level issues,
whereas the deprecation issues produced by running against the
node-specific roles are deduplicated using a similar process to the
existing node-level deprecation checks and merged into the list of
node-level issues.

Note that this means there is *no change* in the format of the response
from the Deprecation Info API.

This PR also includes one deprecation check as an example. This 
check may have to be removed prior to merging if the replacement role
is not yet ready.

Closes https://github.com/elastic/elasticsearch/issues/47714
Relates https://github.com/elastic/elasticsearch/issues/47333