### PR TITLE
[7.5][ML] Avoid NPE when node load is calculated on job assignment (#…

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/MlTasksTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/MlTasksTests.java
@@ -13,18 +13,23 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
+import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
+import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsTaskState;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.config.JobTaskState;
 
 import java.net.InetAddress;
+import java.util.Collections;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 
 public class MlTasksTests extends ESTestCase {
+
     public void testGetJobState() {
         PersistentTasksCustomMetaData.Builder tasksBuilder = PersistentTasksCustomMetaData.builder();
         // A missing task is a closed job
@@ -167,5 +172,134 @@ public class MlTasksTests extends ESTestCase {
         String taskId = MlTasks.dataFrameAnalyticsTaskId("foo");
         assertThat(taskId, equalTo("data_frame_analytics-foo"));
         assertThat(MlTasks.dataFrameAnalyticsIdFromTaskId(taskId), equalTo("foo"));
+    }
+
+    public void testGetDataFrameAnalyticsState_GivenNullTask() {
+        DataFrameAnalyticsState state = MlTasks.getDataFrameAnalyticsState(null);
+        assertThat(state, equalTo(DataFrameAnalyticsState.STOPPED));
+    }
+
+    public void testGetDataFrameAnalyticsState_GivenTaskWithNullState() {
+        String jobId = "foo";
+        PersistentTasksCustomMetaData.PersistentTask<?> task = createDataFrameAnalyticsTask(jobId, "test_node", null, false);
+
+        DataFrameAnalyticsState state = MlTasks.getDataFrameAnalyticsState(task);
+
+        assertThat(state, equalTo(DataFrameAnalyticsState.STARTING));
+    }
+
+    public void testGetDataFrameAnalyticsState_GivenTaskWithStartedState() {
+        String jobId = "foo";
+        PersistentTasksCustomMetaData.PersistentTask<?> task = createDataFrameAnalyticsTask(jobId, "test_node",
+            DataFrameAnalyticsState.STARTED, false);
+
+        DataFrameAnalyticsState state = MlTasks.getDataFrameAnalyticsState(task);
+
+        assertThat(state, equalTo(DataFrameAnalyticsState.STARTED));
+    }
+
+    public void testGetDataFrameAnalyticsState_GivenStaleTaskWithStartedState() {
+        String jobId = "foo";
+        PersistentTasksCustomMetaData.PersistentTask<?> task = createDataFrameAnalyticsTask(jobId, "test_node",
+            DataFrameAnalyticsState.STARTED, true);
+
+        DataFrameAnalyticsState state = MlTasks.getDataFrameAnalyticsState(task);
+
+        assertThat(state, equalTo(DataFrameAnalyticsState.STARTING));
+    }
+
+    public void testGetDataFrameAnalyticsState_GivenTaskWithReindexingState() {
+        String jobId = "foo";
+        PersistentTasksCustomMetaData.PersistentTask<?> task = createDataFrameAnalyticsTask(jobId, "test_node",
+            DataFrameAnalyticsState.REINDEXING, false);
+
+        DataFrameAnalyticsState state = MlTasks.getDataFrameAnalyticsState(task);
+
+        assertThat(state, equalTo(DataFrameAnalyticsState.REINDEXING));
+    }
+
+    public void testGetDataFrameAnalyticsState_GivenStaleTaskWithReindexingState() {
+        String jobId = "foo";
+        PersistentTasksCustomMetaData.PersistentTask<?> task = createDataFrameAnalyticsTask(jobId, "test_node",
+            DataFrameAnalyticsState.REINDEXING, true);
+
+        DataFrameAnalyticsState state = MlTasks.getDataFrameAnalyticsState(task);
+
+        assertThat(state, equalTo(DataFrameAnalyticsState.STARTING));
+    }
+
+    public void testGetDataFrameAnalyticsState_GivenTaskWithAnalyzingState() {
+        String jobId = "foo";
+        PersistentTasksCustomMetaData.PersistentTask<?> task = createDataFrameAnalyticsTask(jobId, "test_node",
+            DataFrameAnalyticsState.ANALYZING, false);
+
+        DataFrameAnalyticsState state = MlTasks.getDataFrameAnalyticsState(task);
+
+        assertThat(state, equalTo(DataFrameAnalyticsState.ANALYZING));
+    }
+
+    public void testGetDataFrameAnalyticsState_GivenStaleTaskWithAnalyzingState() {
+        String jobId = "foo";
+        PersistentTasksCustomMetaData.PersistentTask<?> task = createDataFrameAnalyticsTask(jobId, "test_node",
+            DataFrameAnalyticsState.ANALYZING, true);
+
+        DataFrameAnalyticsState state = MlTasks.getDataFrameAnalyticsState(task);
+
+        assertThat(state, equalTo(DataFrameAnalyticsState.STARTING));
+    }
+
+    public void testGetDataFrameAnalyticsState_GivenTaskWithStoppingState() {
+        String jobId = "foo";
+        PersistentTasksCustomMetaData.PersistentTask<?> task = createDataFrameAnalyticsTask(jobId, "test_node",
+            DataFrameAnalyticsState.STOPPING, false);
+
+        DataFrameAnalyticsState state = MlTasks.getDataFrameAnalyticsState(task);
+
+        assertThat(state, equalTo(DataFrameAnalyticsState.STOPPING));
+    }
+
+    public void testGetDataFrameAnalyticsState_GivenStaleTaskWithStoppingState() {
+        String jobId = "foo";
+        PersistentTasksCustomMetaData.PersistentTask<?> task = createDataFrameAnalyticsTask(jobId, "test_node",
+            DataFrameAnalyticsState.STOPPING, true);
+
+        DataFrameAnalyticsState state = MlTasks.getDataFrameAnalyticsState(task);
+
+        assertThat(state, equalTo(DataFrameAnalyticsState.STOPPED));
+    }
+
+    public void testGetDataFrameAnalyticsState_GivenTaskWithFailedState() {
+        String jobId = "foo";
+        PersistentTasksCustomMetaData.PersistentTask<?> task = createDataFrameAnalyticsTask(jobId, "test_node",
+            DataFrameAnalyticsState.FAILED, false);
+
+        DataFrameAnalyticsState state = MlTasks.getDataFrameAnalyticsState(task);
+
+        assertThat(state, equalTo(DataFrameAnalyticsState.FAILED));
+    }
+
+    public void testGetDataFrameAnalyticsState_GivenStaleTaskWithFailedState() {
+        String jobId = "foo";
+        PersistentTasksCustomMetaData.PersistentTask<?> task = createDataFrameAnalyticsTask(jobId, "test_node",
+            DataFrameAnalyticsState.FAILED, true);
+
+        DataFrameAnalyticsState state = MlTasks.getDataFrameAnalyticsState(task);
+
+        assertThat(state, equalTo(DataFrameAnalyticsState.FAILED));
+    }
+
+    private static PersistentTasksCustomMetaData.PersistentTask<?> createDataFrameAnalyticsTask(String jobId, String nodeId,
+                                                                                                DataFrameAnalyticsState state,
+                                                                                                boolean isStale) {
+        PersistentTasksCustomMetaData.Builder builder = PersistentTasksCustomMetaData.builder();
+        builder.addTask(MlTasks.dataFrameAnalyticsTaskId(jobId), MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME,
+            new StartDataFrameAnalyticsAction.TaskParams(jobId, Version.CURRENT, Collections.emptyList(), false),
+            new PersistentTasksCustomMetaData.Assignment(nodeId, "test assignment"));
+        if (state != null) {
+            builder.updateTaskState(MlTasks.dataFrameAnalyticsTaskId(jobId),
+                new DataFrameAnalyticsTaskState(state, builder.getLastAllocationId() - (isStale ? 1 : 0), null));
+        }
+        PersistentTasksCustomMetaData tasks = builder.build();
+        return tasks.getTask(MlTasks.dataFrameAnalyticsTaskId(jobId));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobNodeSelector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobNodeSelector.java
@@ -16,7 +16,6 @@ import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
 import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
-import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsTaskState;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
@@ -269,7 +268,7 @@ public class JobNodeSelector {
             Collection<PersistentTasksCustomMetaData.PersistentTask<?>> assignedAnalyticsTasks = persistentTasks.findTasks(
                 MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME, task -> node.getId().equals(task.getExecutorNode()));
             for (PersistentTasksCustomMetaData.PersistentTask<?> assignedTask : assignedAnalyticsTasks) {
-                DataFrameAnalyticsState dataFrameAnalyticsState = ((DataFrameAnalyticsTaskState) assignedTask.getState()).getState();
+                DataFrameAnalyticsState dataFrameAnalyticsState = MlTasks.getDataFrameAnalyticsState(assignedTask);
 
                 // Don't count stopped and failed df-analytics tasks as they don't consume native memory
                 if (dataFrameAnalyticsState.isAnyOf(DataFrameAnalyticsState.STOPPED, DataFrameAnalyticsState.FAILED) == false) {


### PR DESCRIPTION
…49186)

This commit fixes a NPE problem as reported in #49150.
But this problem uncovered that we never added proper handling
of state for data frame analytics tasks.

In this commit we improve the `MlTasks.getDataFrameAnalyticsState`
method to handle null tasks and state tasks properly.

Closes #49150

Backport of #49186
