### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ We support development in the Eclipse and IntelliJ IDEs.
 For Eclipse, the minimum version that we support is [4.13][eclipse]. 
 For IntelliJ, the minimum version that we support is [IntelliJ 2017.2][intellij].
 
-[Docker](https://docs.docker.com/install/) is a necessary dependency for building Elasticsearch. You can run Elasticsearch without building all the artifacts with:
+[Docker](https://docs.docker.com/install/) is required for building some Elasticsearch artifacts and executing certain test suites. You can run Elasticsearch without building all the artifacts with:
 
     ./gradlew :run
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,9 @@ We support development in the Eclipse and IntelliJ IDEs.
 For Eclipse, the minimum version that we support is [4.13][eclipse]. 
 For IntelliJ, the minimum version that we support is [IntelliJ 2017.2][intellij].
 
-[Docker](https://docs.docker.com/install/) is a necessary dependency for building elasticsearch. Make sure docker is installed prior to running an instance of elasticsearch from source code.
+[Docker](https://docs.docker.com/install/) is a necessary dependency for building Elasticsearch. You can run Elasticsearch without building all the artifacts with:
+
+    ./gradlew :run
 
 ### Configuring IDEs And Running Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,8 @@ We support development in the Eclipse and IntelliJ IDEs.
 For Eclipse, the minimum version that we support is [4.13][eclipse]. 
 For IntelliJ, the minimum version that we support is [IntelliJ 2017.2][intellij].
 
+[Docker](https://docs.docker.com/install/) is a necessary dependency for building elasticsearch. Make sure docker is installed prior to running an instance of elasticsearch from source code.
+
 ### Configuring IDEs And Running Tests
 
 Eclipse users can automatically configure their IDE: `./gradlew eclipse`


### PR DESCRIPTION
./gradlew run will fail with error: "a problem occurred running Docker from [/usr/bin/docker] yet it is required to run the following tasks" if docker is not installed. Updated the contributing guide to reflect that docker is a necessary dependency. Change is made under "Contributing to the Elasticsearch codebase" section.
