### PR TITLE
Added missing methods to enrich and slm endpoints

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.execute_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.execute_policy.json
@@ -6,7 +6,7 @@
       "paths": [
         {
           "path": "/_enrich/policy/{name}/_execute",
-          "methods": [ "PUT" ],
+          "methods": [ "PUT", "POST" ],
           "parts": {
             "name": {
               "type" : "string",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.execute_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.execute_lifecycle.json
@@ -9,7 +9,8 @@
         {
           "path":"/_slm/policy/{policy_id}/_execute",
           "methods":[
-            "PUT"
+            "PUT",
+            "POST"
           ],
           "parts":{
             "policy_id":{


### PR DESCRIPTION
Hello!

In the spec both `/_slm/policy/{name}/_execute` and `/_enrich/policy/{name}/_execute` declare `PUT` as the only method supported, but in the code `POST` is  supported as well.

https://github.com/elastic/elasticsearch/blob/b42923f339a52905b2fb011d9dcc3d3eede3af8a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/RestExecuteSnapshotLifecycleAction.java#L18-L21

https://github.com/elastic/elasticsearch/blob/f914172cb37dc11d50b5d37c210f671a870d1eb8/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/rest/RestExecuteEnrichPolicyAction.java#L19-L22

cc @elastic/es-clients 