### PR TITLE
Fix description typo and correct capitalization

### DIFF
--- a/modules/ingest-geoip/build.gradle
+++ b/modules/ingest-geoip/build.gradle
@@ -20,7 +20,7 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 
 esplugin {
-  description 'Ingest processor that uses looksup geo data based on ip adresses using the Maxmind geo database'
+  description 'Ingest processor that uses lookup geo data based on IP adresses using the MaxMind geo database'
   classname 'org.elasticsearch.ingest.geoip.IngestGeoIpPlugin'
 }
 


### PR DESCRIPTION
`ingest-geoip` module had a typo in the description ("looksup").
I've also changed some capitalization as per:
- https://en.wikipedia.org/wiki/IP_address
- https://www.maxmind.com/en/home