### PR TITLE
Fix Runtime Java Path for OSX in Gradle

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/Jdk.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/Jdk.java
@@ -115,7 +115,9 @@ public class Jdk implements Buildable, Iterable<File> {
         return new Object() {
             @Override
             public String toString() {
-                return getPath() + "/bin/java";
+                final String platform = getPlatform();
+                final boolean isOSX = "mac".equals(platform) || "darwin".equals(platform);
+                return getPath() + (isOSX ? "/Contents/Home" : "") + "/bin/java";
             }
         };
     }


### PR DESCRIPTION
On OSX the `bin` directory is nested under `Contents/Home`
relative to where it is for the other platforms.

Fixes the incorrect relative path used for `/bin/java` on OSX.