### PR TITLE
[Transform] Transform fix force stop race condition

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
@@ -80,6 +80,7 @@ import org.elasticsearch.xpack.transform.action.compat.TransportStopTransformAct
 import org.elasticsearch.xpack.transform.action.compat.TransportUpdateTransformActionDeprecated;
 import org.elasticsearch.xpack.transform.checkpoint.TransformCheckpointService;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
+import org.elasticsearch.xpack.transform.persistence.IndexBasedTransformConfigManager;
 import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 import org.elasticsearch.xpack.transform.persistence.TransformInternalIndex;
 import org.elasticsearch.xpack.transform.rest.action.RestDeleteTransformAction;
@@ -129,15 +130,14 @@ public class Transform extends Plugin implements ActionPlugin, PersistentTaskPlu
     public static final int DEFAULT_FAILURE_RETRIES = 10;
 
     // How many times the transform task can retry on an non-critical failure
-    public static final Setting<Integer> NUM_FAILURE_RETRIES_SETTING = Setting
-        .intSetting(
-            "xpack.transform.num_transform_failure_retries",
-            DEFAULT_FAILURE_RETRIES,
-            0,
-            100,
-            Setting.Property.NodeScope,
-            Setting.Property.Dynamic
-        );
+    public static final Setting<Integer> NUM_FAILURE_RETRIES_SETTING = Setting.intSetting(
+        "xpack.transform.num_transform_failure_retries",
+        DEFAULT_FAILURE_RETRIES,
+        0,
+        100,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
 
     public Transform(Settings settings) {
         this.settings = settings;
@@ -163,27 +163,26 @@ public class Transform extends Plugin implements ActionPlugin, PersistentTaskPlu
             return emptyList();
         }
 
-        return Arrays
-            .asList(
-                new RestPutTransformAction(restController),
-                new RestStartTransformAction(restController),
-                new RestStopTransformAction(restController),
-                new RestDeleteTransformAction(restController),
-                new RestGetTransformAction(restController),
-                new RestGetTransformStatsAction(restController),
-                new RestPreviewTransformAction(restController),
-                new RestUpdateTransformAction(restController),
+        return Arrays.asList(
+            new RestPutTransformAction(restController),
+            new RestStartTransformAction(restController),
+            new RestStopTransformAction(restController),
+            new RestDeleteTransformAction(restController),
+            new RestGetTransformAction(restController),
+            new RestGetTransformStatsAction(restController),
+            new RestPreviewTransformAction(restController),
+            new RestUpdateTransformAction(restController),
 
-                // deprecated endpoints, to be removed for 8.0.0
-                new RestPutTransformActionDeprecated(restController),
-                new RestStartTransformActionDeprecated(restController),
-                new RestStopTransformActionDeprecated(restController),
-                new RestDeleteTransformActionDeprecated(restController),
-                new RestGetTransformActionDeprecated(restController),
-                new RestGetTransformStatsActionDeprecated(restController),
-                new RestPreviewTransformActionDeprecated(restController),
-                new RestUpdateTransformActionDeprecated(restController)
-            );
+            // deprecated endpoints, to be removed for 8.0.0
+            new RestPutTransformActionDeprecated(restController),
+            new RestStartTransformActionDeprecated(restController),
+            new RestStopTransformActionDeprecated(restController),
+            new RestDeleteTransformActionDeprecated(restController),
+            new RestGetTransformActionDeprecated(restController),
+            new RestGetTransformStatsActionDeprecated(restController),
+            new RestPreviewTransformActionDeprecated(restController),
+            new RestUpdateTransformActionDeprecated(restController)
+        );
     }
 
     @Override
@@ -194,30 +193,29 @@ public class Transform extends Plugin implements ActionPlugin, PersistentTaskPlu
             return Arrays.asList(usageAction, infoAction);
         }
 
-        return Arrays
-            .asList(
-                new ActionHandler<>(PutTransformAction.INSTANCE, TransportPutTransformAction.class),
-                new ActionHandler<>(StartTransformAction.INSTANCE, TransportStartTransformAction.class),
-                new ActionHandler<>(StopTransformAction.INSTANCE, TransportStopTransformAction.class),
-                new ActionHandler<>(DeleteTransformAction.INSTANCE, TransportDeleteTransformAction.class),
-                new ActionHandler<>(GetTransformAction.INSTANCE, TransportGetTransformAction.class),
-                new ActionHandler<>(GetTransformStatsAction.INSTANCE, TransportGetTransformStatsAction.class),
-                new ActionHandler<>(PreviewTransformAction.INSTANCE, TransportPreviewTransformAction.class),
-                new ActionHandler<>(UpdateTransformAction.INSTANCE, TransportUpdateTransformAction.class),
+        return Arrays.asList(
+            new ActionHandler<>(PutTransformAction.INSTANCE, TransportPutTransformAction.class),
+            new ActionHandler<>(StartTransformAction.INSTANCE, TransportStartTransformAction.class),
+            new ActionHandler<>(StopTransformAction.INSTANCE, TransportStopTransformAction.class),
+            new ActionHandler<>(DeleteTransformAction.INSTANCE, TransportDeleteTransformAction.class),
+            new ActionHandler<>(GetTransformAction.INSTANCE, TransportGetTransformAction.class),
+            new ActionHandler<>(GetTransformStatsAction.INSTANCE, TransportGetTransformStatsAction.class),
+            new ActionHandler<>(PreviewTransformAction.INSTANCE, TransportPreviewTransformAction.class),
+            new ActionHandler<>(UpdateTransformAction.INSTANCE, TransportUpdateTransformAction.class),
 
-                // deprecated actions, to be removed for 8.0.0
-                new ActionHandler<>(PutTransformActionDeprecated.INSTANCE, TransportPutTransformActionDeprecated.class),
-                new ActionHandler<>(StartTransformActionDeprecated.INSTANCE, TransportStartTransformActionDeprecated.class),
-                new ActionHandler<>(StopTransformActionDeprecated.INSTANCE, TransportStopTransformActionDeprecated.class),
-                new ActionHandler<>(DeleteTransformActionDeprecated.INSTANCE, TransportDeleteTransformActionDeprecated.class),
-                new ActionHandler<>(GetTransformActionDeprecated.INSTANCE, TransportGetTransformActionDeprecated.class),
-                new ActionHandler<>(GetTransformStatsActionDeprecated.INSTANCE, TransportGetTransformStatsActionDeprecated.class),
-                new ActionHandler<>(PreviewTransformActionDeprecated.INSTANCE, TransportPreviewTransformActionDeprecated.class),
-                new ActionHandler<>(UpdateTransformActionDeprecated.INSTANCE, TransportUpdateTransformActionDeprecated.class),
+            // deprecated actions, to be removed for 8.0.0
+            new ActionHandler<>(PutTransformActionDeprecated.INSTANCE, TransportPutTransformActionDeprecated.class),
+            new ActionHandler<>(StartTransformActionDeprecated.INSTANCE, TransportStartTransformActionDeprecated.class),
+            new ActionHandler<>(StopTransformActionDeprecated.INSTANCE, TransportStopTransformActionDeprecated.class),
+            new ActionHandler<>(DeleteTransformActionDeprecated.INSTANCE, TransportDeleteTransformActionDeprecated.class),
+            new ActionHandler<>(GetTransformActionDeprecated.INSTANCE, TransportGetTransformActionDeprecated.class),
+            new ActionHandler<>(GetTransformStatsActionDeprecated.INSTANCE, TransportGetTransformStatsActionDeprecated.class),
+            new ActionHandler<>(PreviewTransformActionDeprecated.INSTANCE, TransportPreviewTransformActionDeprecated.class),
+            new ActionHandler<>(UpdateTransformActionDeprecated.INSTANCE, TransportUpdateTransformActionDeprecated.class),
 
-                usageAction,
-                infoAction
-            );
+            usageAction,
+            infoAction
+        );
     }
 
     @Override
@@ -247,24 +245,25 @@ public class Transform extends Plugin implements ActionPlugin, PersistentTaskPlu
             return emptyList();
         }
         transformAuditor.set(new TransformAuditor(client, clusterService.getNodeName()));
-        transformConfigManager.set(new TransformConfigManager(client, xContentRegistry));
+        transformConfigManager.set(new IndexBasedTransformConfigManager(client, xContentRegistry));
         transformCheckpointService.set(new TransformCheckpointService(client, transformConfigManager.get(), transformAuditor.get()));
 
-        return Arrays
-            .asList(
-                transformConfigManager.get(),
-                transformAuditor.get(),
-                transformCheckpointService.get(),
-                new TransformClusterStateListener(clusterService, client)
-            );
+        return Arrays.asList(
+            transformConfigManager.get(),
+            transformAuditor.get(),
+            transformCheckpointService.get(),
+            new TransformClusterStateListener(clusterService, client)
+        );
     }
 
     @Override
     public UnaryOperator<Map<String, IndexTemplateMetaData>> getIndexTemplateMetaDataUpgrader() {
         return templates -> {
             try {
-                templates
-                    .put(TransformInternalIndexConstants.LATEST_INDEX_VERSIONED_NAME, TransformInternalIndex.getIndexTemplateMetaData());
+                templates.put(
+                    TransformInternalIndexConstants.LATEST_INDEX_VERSIONED_NAME,
+                    TransformInternalIndex.getIndexTemplateMetaData()
+                );
             } catch (IOException e) {
                 logger.error("Error creating data frame index template", e);
             }
@@ -296,19 +295,18 @@ public class Transform extends Plugin implements ActionPlugin, PersistentTaskPlu
         assert transformAuditor.get() != null;
         assert transformCheckpointService.get() != null;
 
-        return Collections
-            .singletonList(
-                new TransformPersistentTasksExecutor(
-                    client,
-                    transformConfigManager.get(),
-                    transformCheckpointService.get(),
-                    schedulerEngine.get(),
-                    transformAuditor.get(),
-                    threadPool,
-                    clusterService,
-                    settingsModule.getSettings()
-                )
-            );
+        return Collections.singletonList(
+            new TransformPersistentTasksExecutor(
+                client,
+                transformConfigManager.get(),
+                transformCheckpointService.get(),
+                schedulerEngine.get(),
+                transformAuditor.get(),
+                threadPool,
+                clusterService,
+                settingsModule.getSettings()
+            )
+        );
     }
 
     @Override

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/TransformServices.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/TransformServices.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.transform;
+
+import org.elasticsearch.xpack.core.scheduler.SchedulerEngine;
+import org.elasticsearch.xpack.transform.checkpoint.TransformCheckpointService;
+import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
+import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
+
+import java.util.Objects;
+
+/**
+ * Holder for all transform services that need to get injected via guice.
+ *
+ * Needed because interfaces can not be injected.
+ * Note: Guice will be removed in the long run.
+ */
+public final class TransformServices {
+
+    private final TransformConfigManager configManager;
+    private final TransformCheckpointService checkpointService;
+    private final TransformAuditor auditor;
+    private final SchedulerEngine schedulerEngine;
+
+    public TransformServices(TransformConfigManager transformConfigManager, TransformCheckpointService checkpointProvider,
+            TransformAuditor transformAuditor, SchedulerEngine schedulerEngine) {
+        this.configManager = Objects.requireNonNull(transformConfigManager);
+        this.checkpointService = Objects.requireNonNull(checkpointProvider);
+        this.auditor = Objects.requireNonNull(transformAuditor);
+        this.schedulerEngine = Objects.requireNonNull(schedulerEngine);
+    }
+
+    public TransformConfigManager getConfigManager() {
+        return configManager;
+    }
+
+    public TransformCheckpointService getCheckpointService() {
+        return checkpointService;
+    }
+
+    public TransformAuditor getAuditor() {
+        return auditor;
+    }
+
+    public SchedulerEngine getSchedulerEngine() {
+        return schedulerEngine;
+    }
+}

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/TransformServices.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/TransformServices.java
@@ -26,8 +26,12 @@ public final class TransformServices {
     private final TransformAuditor auditor;
     private final SchedulerEngine schedulerEngine;
 
-    public TransformServices(TransformConfigManager transformConfigManager, TransformCheckpointService checkpointProvider,
-            TransformAuditor transformAuditor, SchedulerEngine schedulerEngine) {
+    public TransformServices(
+        TransformConfigManager transformConfigManager,
+        TransformCheckpointService checkpointProvider,
+        TransformAuditor transformAuditor,
+        SchedulerEngine schedulerEngine
+    ) {
         this.configManager = Objects.requireNonNull(transformConfigManager);
         this.checkpointService = Objects.requireNonNull(checkpointProvider);
         this.auditor = Objects.requireNonNull(transformAuditor);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportDeleteTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportDeleteTransformAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.transform.action.DeleteTransformAction;
 import org.elasticsearch.xpack.core.transform.action.DeleteTransformAction.Request;
 import org.elasticsearch.xpack.core.transform.action.StopTransformAction;
+import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
 import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 
@@ -47,8 +48,7 @@ public class TransportDeleteTransformAction extends TransportMasterNodeAction<Re
         ThreadPool threadPool,
         ClusterService clusterService,
         IndexNameExpressionResolver indexNameExpressionResolver,
-        TransformConfigManager transformsConfigManager,
-        TransformAuditor auditor,
+        TransformServices transformServices,
         Client client
     ) {
         this(
@@ -58,8 +58,7 @@ public class TransportDeleteTransformAction extends TransportMasterNodeAction<Re
             threadPool,
             clusterService,
             indexNameExpressionResolver,
-            transformsConfigManager,
-            auditor,
+            transformServices,
             client
         );
     }
@@ -71,13 +70,12 @@ public class TransportDeleteTransformAction extends TransportMasterNodeAction<Re
         ThreadPool threadPool,
         ClusterService clusterService,
         IndexNameExpressionResolver indexNameExpressionResolver,
-        TransformConfigManager transformConfigManager,
-        TransformAuditor auditor,
+        TransformServices transformServices,
         Client client
     ) {
         super(name, transportService, clusterService, threadPool, actionFilters, Request::new, indexNameExpressionResolver);
-        this.transformConfigManager = transformConfigManager;
-        this.auditor = auditor;
+        this.transformConfigManager = transformServices.getConfigManager();
+        this.auditor = transformServices.getAuditor();
         this.client = client;
     }
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportDeleteTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportDeleteTransformAction.java
@@ -41,18 +41,40 @@ public class TransportDeleteTransformAction extends TransportMasterNodeAction<Re
     private final Client client;
 
     @Inject
-    public TransportDeleteTransformAction(TransportService transportService, ActionFilters actionFilters, ThreadPool threadPool,
-                                          ClusterService clusterService, IndexNameExpressionResolver indexNameExpressionResolver,
-                                          TransformConfigManager transformsConfigManager, TransformAuditor auditor,
-                                          Client client) {
-        this(DeleteTransformAction.NAME, transportService, actionFilters, threadPool, clusterService, indexNameExpressionResolver,
-             transformsConfigManager, auditor, client);
+    public TransportDeleteTransformAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ThreadPool threadPool,
+        ClusterService clusterService,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        TransformConfigManager transformsConfigManager,
+        TransformAuditor auditor,
+        Client client
+    ) {
+        this(
+            DeleteTransformAction.NAME,
+            transportService,
+            actionFilters,
+            threadPool,
+            clusterService,
+            indexNameExpressionResolver,
+            transformsConfigManager,
+            auditor,
+            client
+        );
     }
 
-    protected TransportDeleteTransformAction(String name, TransportService transportService, ActionFilters actionFilters,
-                                             ThreadPool threadPool, ClusterService clusterService,
-                                             IndexNameExpressionResolver indexNameExpressionResolver,
-                                             TransformConfigManager transformConfigManager, TransformAuditor auditor, Client client) {
+    protected TransportDeleteTransformAction(
+        String name,
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ThreadPool threadPool,
+        ClusterService clusterService,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        TransformConfigManager transformConfigManager,
+        TransformAuditor auditor,
+        Client client
+    ) {
         super(name, transportService, clusterService, threadPool, actionFilters, Request::new, indexNameExpressionResolver);
         this.transformConfigManager = transformConfigManager;
         this.auditor = auditor;
@@ -70,32 +92,32 @@ public class TransportDeleteTransformAction extends TransportMasterNodeAction<Re
     }
 
     @Override
-    protected void masterOperation(Task task, Request request, ClusterState state,
-                                   ActionListener<AcknowledgedResponse> listener) {
+    protected void masterOperation(Task task, Request request, ClusterState state, ActionListener<AcknowledgedResponse> listener) {
         final PersistentTasksCustomMetaData pTasksMeta = state.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
         if (pTasksMeta != null && pTasksMeta.getTask(request.getId()) != null && request.isForce() == false) {
-            listener.onFailure(new ElasticsearchStatusException("Cannot delete transform [" + request.getId() +
-                    "] as the task is running. Stop the task first", RestStatus.CONFLICT));
+            listener.onFailure(
+                new ElasticsearchStatusException(
+                    "Cannot delete transform [" + request.getId() + "] as the task is running. Stop the task first",
+                    RestStatus.CONFLICT
+                )
+            );
         } else {
             ActionListener<Void> stopTransformActionListener = ActionListener.wrap(
-                stopResponse -> transformConfigManager.deleteTransform(request.getId(),
-                    ActionListener.wrap(
-                        r -> {
-                            auditor.info(request.getId(), "Deleted transform.");
-                            listener.onResponse(new AcknowledgedResponse(r));
-                        },
-                        listener::onFailure)),
+                stopResponse -> transformConfigManager.deleteTransform(request.getId(), ActionListener.wrap(r -> {
+                    auditor.info(request.getId(), "Deleted transform.");
+                    listener.onResponse(new AcknowledgedResponse(r));
+                }, listener::onFailure)),
                 listener::onFailure
             );
 
             if (pTasksMeta != null && pTasksMeta.getTask(request.getId()) != null) {
-                executeAsyncWithOrigin(client,
+                executeAsyncWithOrigin(
+                    client,
                     TRANSFORM_ORIGIN,
                     StopTransformAction.INSTANCE,
                     new StopTransformAction.Request(request.getId(), true, true, null, true, false),
-                    ActionListener.wrap(
-                        r -> stopTransformActionListener.onResponse(null),
-                        stopTransformActionListener::onFailure));
+                    ActionListener.wrap(r -> stopTransformActionListener.onResponse(null), stopTransformActionListener::onFailure)
+                );
             } else {
                 stopTransformActionListener.onResponse(null);
             }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
@@ -47,8 +47,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-public class TransportGetTransformStatsAction extends
-    TransportTasksAction<TransformTask, GetTransformStatsAction.Request, GetTransformStatsAction.Response, GetTransformStatsAction.Response> {
+public class TransportGetTransformStatsAction extends TransportTasksAction<TransformTask, Request, Response, Response> {
 
     private static final Logger logger = LogManager.getLogger(TransportGetTransformStatsAction.class);
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
@@ -47,10 +47,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 public class TransportGetTransformStatsAction extends
-        TransportTasksAction<TransformTask,
-        GetTransformStatsAction.Request,
-        GetTransformStatsAction.Response,
-        GetTransformStatsAction.Response> {
+    TransportTasksAction<TransformTask, GetTransformStatsAction.Request, GetTransformStatsAction.Response, GetTransformStatsAction.Response> {
 
     private static final Logger logger = LogManager.getLogger(TransportGetTransformStatsAction.class);
 
@@ -58,27 +55,43 @@ public class TransportGetTransformStatsAction extends
     private final TransformCheckpointService transformCheckpointService;
 
     @Inject
-    public TransportGetTransformStatsAction(TransportService transportService, ActionFilters actionFilters,
-                                            ClusterService clusterService,
-                                            TransformConfigManager transformConfigManager,
-                                            TransformCheckpointService transformsCheckpointService) {
-        this(GetTransformStatsAction.NAME, transportService, actionFilters, clusterService, transformConfigManager,
-             transformsCheckpointService);
+    public TransportGetTransformStatsAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ClusterService clusterService,
+        TransformConfigManager transformConfigManager,
+        TransformCheckpointService transformsCheckpointService
+    ) {
+        this(
+            GetTransformStatsAction.NAME,
+            transportService,
+            actionFilters,
+            clusterService,
+            transformConfigManager,
+            transformsCheckpointService
+        );
     }
 
-    protected TransportGetTransformStatsAction(String name, TransportService transportService, ActionFilters actionFilters,
-                                               ClusterService clusterService, TransformConfigManager transformsConfigManager,
-                                               TransformCheckpointService transformsCheckpointService) {
-        super(name, clusterService, transportService, actionFilters, Request::new, Response::new,
-            Response::new, ThreadPool.Names.SAME);
+    protected TransportGetTransformStatsAction(
+        String name,
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ClusterService clusterService,
+        TransformConfigManager transformsConfigManager,
+        TransformCheckpointService transformsCheckpointService
+    ) {
+        super(name, clusterService, transportService, actionFilters, Request::new, Response::new, Response::new, ThreadPool.Names.SAME);
         this.transformConfigManager = transformsConfigManager;
         this.transformCheckpointService = transformsCheckpointService;
     }
 
-
     @Override
-    protected Response newResponse(Request request, List<Response> tasks, List<TaskOperationFailure> taskOperationFailures,
-            List<FailedNodeException> failedNodeExceptions) {
+    protected Response newResponse(
+        Request request,
+        List<Response> tasks,
+        List<TaskOperationFailure> taskOperationFailures,
+        List<FailedNodeException> failedNodeExceptions
+    ) {
         List<TransformStats> responses = tasks.stream()
             .flatMap(r -> r.getTransformsStats().stream())
             .sorted(Comparator.comparing(TransformStats::getId))
@@ -94,19 +107,25 @@ public class TransportGetTransformStatsAction extends
         ClusterState state = clusterService.state();
         String nodeId = state.nodes().getLocalNode().getId();
         if (task.isCancelled() == false) {
-            task.getCheckpointingInfo(transformCheckpointService, ActionListener.wrap(
-                checkpointingInfo -> listener.onResponse(new Response(
-                    Collections.singletonList(deriveStats(task, checkpointingInfo)),
-                    1L)),
-                e -> {
-                    logger.warn("Failed to retrieve checkpointing info for transform [" + task.getTransformId() + "]", e);
-                    listener.onResponse(new Response(
-                    Collections.singletonList(deriveStats(task, null)),
-                    1L,
-                    Collections.emptyList(),
-                    Collections.singletonList(new FailedNodeException(nodeId, "Failed to retrieve checkpointing info", e))));
-                }
-                ));
+            task.getCheckpointingInfo(
+                transformCheckpointService,
+                ActionListener.wrap(
+                    checkpointingInfo -> listener.onResponse(
+                        new Response(Collections.singletonList(deriveStats(task, checkpointingInfo)), 1L)
+                    ),
+                    e -> {
+                        logger.warn("Failed to retrieve checkpointing info for transform [" + task.getTransformId() + "]", e);
+                        listener.onResponse(
+                            new Response(
+                                Collections.singletonList(deriveStats(task, null)),
+                                1L,
+                                Collections.emptyList(),
+                                Collections.singletonList(new FailedNodeException(nodeId, "Failed to retrieve checkpointing info", e))
+                            )
+                        );
+                    }
+                )
+            );
         } else {
             listener.onResponse(new Response(Collections.emptyList(), 0L));
         }
@@ -114,44 +133,54 @@ public class TransportGetTransformStatsAction extends
 
     @Override
     protected void doExecute(Task task, Request request, ActionListener<Response> finalListener) {
-        transformConfigManager.expandTransformIds(request.getId(),
+        transformConfigManager.expandTransformIds(
+            request.getId(),
             request.getPageParams(),
             request.isAllowNoMatch(),
             ActionListener.wrap(hitsAndIds -> {
                 request.setExpandedIds(hitsAndIds.v2());
                 final ClusterState state = clusterService.state();
                 request.setNodes(TransformNodes.transformTaskNodes(hitsAndIds.v2(), state));
-                super.doExecute(task, request, ActionListener.wrap(
-                    response -> {
-                        PersistentTasksCustomMetaData tasksInProgress = state.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
-                        if (tasksInProgress != null) {
-                            // Mutates underlying state object with the assigned node attributes
-                            response.getTransformsStats().forEach(dtsasi -> setNodeAttributes(dtsasi, tasksInProgress, state));
-                        }
-                        collectStatsForTransformsWithoutTasks(request, response, ActionListener.wrap(
-                            finalResponse -> finalListener.onResponse(new Response(finalResponse.getTransformsStats(),
-                                hitsAndIds.v1(),
-                                finalResponse.getTaskFailures(),
-                                finalResponse.getNodeFailures())),
+                super.doExecute(task, request, ActionListener.wrap(response -> {
+                    PersistentTasksCustomMetaData tasksInProgress = state.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
+                    if (tasksInProgress != null) {
+                        // Mutates underlying state object with the assigned node attributes
+                        response.getTransformsStats().forEach(dtsasi -> setNodeAttributes(dtsasi, tasksInProgress, state));
+                    }
+                    collectStatsForTransformsWithoutTasks(
+                        request,
+                        response,
+                        ActionListener.wrap(
+                            finalResponse -> finalListener.onResponse(
+                                new Response(
+                                    finalResponse.getTransformsStats(),
+                                    hitsAndIds.v1(),
+                                    finalResponse.getTaskFailures(),
+                                    finalResponse.getNodeFailures()
+                                )
+                            ),
                             finalListener::onFailure
-                        ));
-                    },
-                    finalListener::onFailure
-                ));
+                        )
+                    );
+                }, finalListener::onFailure));
             },
-            e -> {
-                // If the index to search, or the individual config is not there, just return empty
-                if (e instanceof ResourceNotFoundException) {
-                    finalListener.onResponse(new Response(Collections.emptyList(), 0L));
-                } else {
-                    finalListener.onFailure(e);
+                e -> {
+                    // If the index to search, or the individual config is not there, just return empty
+                    if (e instanceof ResourceNotFoundException) {
+                        finalListener.onResponse(new Response(Collections.emptyList(), 0L));
+                    } else {
+                        finalListener.onFailure(e);
+                    }
                 }
-            }
-        ));
+            )
+        );
     }
 
-    private static void setNodeAttributes(TransformStats transformStats,
-                                          PersistentTasksCustomMetaData persistentTasksCustomMetaData, ClusterState state) {
+    private static void setNodeAttributes(
+        TransformStats transformStats,
+        PersistentTasksCustomMetaData persistentTasksCustomMetaData,
+        ClusterState state
+    ) {
         var pTask = persistentTasksCustomMetaData.getTask(transformStats.getId());
         if (pTask != null) {
             transformStats.setNode(NodeAttributes.fromDiscoveryNode(state.nodes().get(pTask.getExecutorNode())));
@@ -160,12 +189,14 @@ public class TransportGetTransformStatsAction extends
 
     static TransformStats deriveStats(TransformTask task, @Nullable TransformCheckpointingInfo checkpointingInfo) {
         TransformState transformState = task.getState();
-        TransformStats.State derivedState = TransformStats.State.fromComponents(transformState.getTaskState(),
-            transformState.getIndexerState());
+        TransformStats.State derivedState = TransformStats.State.fromComponents(
+            transformState.getTaskState(),
+            transformState.getIndexerState()
+        );
         String reason = transformState.getReason();
-        if (transformState.shouldStopAtNextCheckpoint() &&
-            derivedState.equals(TransformStats.State.STOPPED) == false &&
-            derivedState.equals(TransformStats.State.FAILED) == false) {
+        if (transformState.shouldStopAtNextCheckpoint()
+            && derivedState.equals(TransformStats.State.STOPPED) == false
+            && derivedState.equals(TransformStats.State.FAILED) == false) {
             derivedState = TransformStats.State.STOPPING;
             reason = reason.isEmpty() ? "transform is set to stop at the next checkpoint" : reason;
         }
@@ -175,12 +206,11 @@ public class TransportGetTransformStatsAction extends
             reason,
             null,
             task.getStats(),
-            checkpointingInfo == null ? TransformCheckpointingInfo.EMPTY : checkpointingInfo);
+            checkpointingInfo == null ? TransformCheckpointingInfo.EMPTY : checkpointingInfo
+        );
     }
 
-    private void collectStatsForTransformsWithoutTasks(Request request,
-                                                       Response response,
-                                                       ActionListener<Response> listener) {
+    private void collectStatsForTransformsWithoutTasks(Request request, Response response, ActionListener<Response> listener) {
         // We gathered all there is, no need to continue
         if (request.getExpandedIds().size() == response.getTransformsStats().size()) {
             listener.onResponse(response);
@@ -188,8 +218,7 @@ public class TransportGetTransformStatsAction extends
         }
 
         Set<String> transformsWithoutTasks = new HashSet<>(request.getExpandedIds());
-        transformsWithoutTasks.removeAll(response.getTransformsStats().stream().map(TransformStats::getId)
-            .collect(Collectors.toList()));
+        transformsWithoutTasks.removeAll(response.getTransformsStats().stream().map(TransformStats::getId).collect(Collectors.toList()));
 
         // Small assurance that we are at least below the max. Terms search has a hard limit of 10k, we should at least be below that.
         assert transformsWithoutTasks.size() <= Request.MAX_SIZE_RETURN;
@@ -197,61 +226,53 @@ public class TransportGetTransformStatsAction extends
         // If the persistent task does NOT exist, it is STOPPED
         // There is a potential race condition where the saved document does not actually have a STOPPED state
         // as the task is cancelled before we persist state.
-        ActionListener<List<TransformStoredDoc>> searchStatsListener = ActionListener.wrap(
-            statsForTransformsWithoutTasks -> {
-                List<TransformStats> allStateAndStats = response.getTransformsStats();
-                addCheckpointingInfoForTransformsWithoutTasks(allStateAndStats, statsForTransformsWithoutTasks,
-                    ActionListener.wrap(
-                        aVoid -> {
-                            transformsWithoutTasks.removeAll(statsForTransformsWithoutTasks.stream()
-                                .map(TransformStoredDoc::getId).collect(Collectors.toSet()));
+        ActionListener<List<TransformStoredDoc>> searchStatsListener = ActionListener.wrap(statsForTransformsWithoutTasks -> {
+            List<TransformStats> allStateAndStats = response.getTransformsStats();
+            addCheckpointingInfoForTransformsWithoutTasks(allStateAndStats, statsForTransformsWithoutTasks, ActionListener.wrap(aVoid -> {
+                transformsWithoutTasks.removeAll(
+                    statsForTransformsWithoutTasks.stream().map(TransformStoredDoc::getId).collect(Collectors.toSet())
+                );
 
-                            // Transforms that have not been started and have no state or stats.
-                            transformsWithoutTasks.forEach(
-                                transformId -> allStateAndStats.add(TransformStats.initialStats(transformId)));
+                // Transforms that have not been started and have no state or stats.
+                transformsWithoutTasks.forEach(transformId -> allStateAndStats.add(TransformStats.initialStats(transformId)));
 
-                            // Any transform in collection could NOT have a task, so, even though the list is initially sorted
-                            // it can easily become arbitrarily ordered based on which transforms don't have a task or stats docs
-                            allStateAndStats.sort(Comparator.comparing(TransformStats::getId));
+                // Any transform in collection could NOT have a task, so, even though the list is initially sorted
+                // it can easily become arbitrarily ordered based on which transforms don't have a task or stats docs
+                allStateAndStats.sort(Comparator.comparing(TransformStats::getId));
 
-                            listener.onResponse(new Response(allStateAndStats,
-                                allStateAndStats.size(),
-                                response.getTaskFailures(),
-                                response.getNodeFailures()));
-                        },
-                        listener::onFailure));
-            },
-            e -> {
-                if (e instanceof IndexNotFoundException) {
-                    listener.onResponse(response);
-                } else {
-                    listener.onFailure(e);
-                }
+                listener.onResponse(
+                    new Response(allStateAndStats, allStateAndStats.size(), response.getTaskFailures(), response.getNodeFailures())
+                );
+            }, listener::onFailure));
+        }, e -> {
+            if (e instanceof IndexNotFoundException) {
+                listener.onResponse(response);
+            } else {
+                listener.onFailure(e);
             }
-        );
+        });
 
-        transformConfigManager.getTransformStoredDoc(transformsWithoutTasks, searchStatsListener);
+        transformConfigManager.getTransformStoredDocs(transformsWithoutTasks, searchStatsListener);
     }
 
-    private void populateSingleStoppedTransformStat(TransformStoredDoc transform,
-                                                    ActionListener<TransformCheckpointingInfo> listener) {
+    private void populateSingleStoppedTransformStat(TransformStoredDoc transform, ActionListener<TransformCheckpointingInfo> listener) {
         transformCheckpointService.getCheckpointingInfo(
             transform.getId(),
             transform.getTransformState().getCheckpoint(),
             transform.getTransformState().getPosition(),
             transform.getTransformState().getProgress(),
-            ActionListener.wrap(
-                listener::onResponse,
-                e -> {
-                    logger.warn("Failed to retrieve checkpointing info for transform [" + transform.getId() + "]", e);
-                    listener.onResponse(TransformCheckpointingInfo.EMPTY);
-                }
-            ));
+            ActionListener.wrap(listener::onResponse, e -> {
+                logger.warn("Failed to retrieve checkpointing info for transform [" + transform.getId() + "]", e);
+                listener.onResponse(TransformCheckpointingInfo.EMPTY);
+            })
+        );
     }
 
-    private void addCheckpointingInfoForTransformsWithoutTasks(List<TransformStats> allStateAndStats,
-                                                               List<TransformStoredDoc> statsForTransformsWithoutTasks,
-                                                               ActionListener<Void> listener) {
+    private void addCheckpointingInfoForTransformsWithoutTasks(
+        List<TransformStats> allStateAndStats,
+        List<TransformStoredDoc> statsForTransformsWithoutTasks,
+        ActionListener<Void> listener
+    ) {
 
         if (statsForTransformsWithoutTasks.isEmpty()) {
             // No work to do, but we must respond to the listener
@@ -262,27 +283,19 @@ public class TransportGetTransformStatsAction extends
         AtomicInteger numberRemaining = new AtomicInteger(statsForTransformsWithoutTasks.size());
         AtomicBoolean isExceptionReported = new AtomicBoolean(false);
 
-        statsForTransformsWithoutTasks.forEach(stat -> populateSingleStoppedTransformStat(stat,
-            ActionListener.wrap(
-                checkpointingInfo -> {
-                    synchronized (allStateAndStats) {
-                        allStateAndStats.add(new TransformStats(
-                            stat.getId(),
-                            TransformStats.State.STOPPED,
-                            null,
-                            null,
-                            stat.getTransformStats(),
-                            checkpointingInfo));
-                    }
-                    if (numberRemaining.decrementAndGet() == 0) {
-                        listener.onResponse(null);
-                    }
-                },
-                e -> {
-                    if (isExceptionReported.compareAndSet(false, true)) {
-                        listener.onFailure(e);
-                    }
-                }
-            )));
+        statsForTransformsWithoutTasks.forEach(stat -> populateSingleStoppedTransformStat(stat, ActionListener.wrap(checkpointingInfo -> {
+            synchronized (allStateAndStats) {
+                allStateAndStats.add(
+                    new TransformStats(stat.getId(), TransformStats.State.STOPPED, null, null, stat.getTransformStats(), checkpointingInfo)
+                );
+            }
+            if (numberRemaining.decrementAndGet() == 0) {
+                listener.onResponse(null);
+            }
+        }, e -> {
+            if (isExceptionReported.compareAndSet(false, true)) {
+                listener.onFailure(e);
+            }
+        })));
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
@@ -32,6 +32,7 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpointingI
 import org.elasticsearch.xpack.core.transform.transforms.TransformState;
 import org.elasticsearch.xpack.core.transform.transforms.TransformStats;
 import org.elasticsearch.xpack.core.transform.transforms.TransformStoredDoc;
+import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.checkpoint.TransformCheckpointService;
 import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 import org.elasticsearch.xpack.transform.transforms.TransformTask;
@@ -59,17 +60,9 @@ public class TransportGetTransformStatsAction extends
         TransportService transportService,
         ActionFilters actionFilters,
         ClusterService clusterService,
-        TransformConfigManager transformConfigManager,
-        TransformCheckpointService transformsCheckpointService
+        TransformServices transformServices
     ) {
-        this(
-            GetTransformStatsAction.NAME,
-            transportService,
-            actionFilters,
-            clusterService,
-            transformConfigManager,
-            transformsCheckpointService
-        );
+        this(GetTransformStatsAction.NAME, transportService, actionFilters, clusterService, transformServices);
     }
 
     protected TransportGetTransformStatsAction(
@@ -77,12 +70,11 @@ public class TransportGetTransformStatsAction extends
         TransportService transportService,
         ActionFilters actionFilters,
         ClusterService clusterService,
-        TransformConfigManager transformsConfigManager,
-        TransformCheckpointService transformsCheckpointService
+        TransformServices transformServices
     ) {
         super(name, clusterService, transportService, actionFilters, Request::new, Response::new, Response::new, ThreadPool.Names.SAME);
-        this.transformConfigManager = transformsConfigManager;
-        this.transformCheckpointService = transformsCheckpointService;
+        this.transformConfigManager = transformServices.getConfigManager();
+        this.transformCheckpointService = transformServices.getCheckpointService();
     }
 
     @Override

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
@@ -67,39 +67,76 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
     private final TransformAuditor auditor;
 
     @Inject
-    public TransportPutTransformAction(Settings settings, TransportService transportService, ThreadPool threadPool,
-                                       ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
-                                       ClusterService clusterService, XPackLicenseState licenseState,
-                                       TransformConfigManager transformConfigManager, Client client,
-                                       TransformAuditor auditor) {
-        this(PutTransformAction.NAME, settings, transportService, threadPool, actionFilters, indexNameExpressionResolver,
-             clusterService, licenseState, transformConfigManager, client, auditor);
+    public TransportPutTransformAction(
+        Settings settings,
+        TransportService transportService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        ClusterService clusterService,
+        XPackLicenseState licenseState,
+        TransformConfigManager transformConfigManager,
+        Client client,
+        TransformAuditor auditor
+    ) {
+        this(
+            PutTransformAction.NAME,
+            settings,
+            transportService,
+            threadPool,
+            actionFilters,
+            indexNameExpressionResolver,
+            clusterService,
+            licenseState,
+            transformConfigManager,
+            client,
+            auditor
+        );
     }
 
-    protected TransportPutTransformAction(String name, Settings settings, TransportService transportService, ThreadPool threadPool,
-                                          ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
-                                          ClusterService clusterService, XPackLicenseState licenseState,
-                                          TransformConfigManager transformConfigManager, Client client,
-                                          TransformAuditor auditor) {
-        super(name, transportService, clusterService, threadPool, actionFilters,
-              PutTransformAction.Request::new, indexNameExpressionResolver);
+    protected TransportPutTransformAction(
+        String name,
+        Settings settings,
+        TransportService transportService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        ClusterService clusterService,
+        XPackLicenseState licenseState,
+        TransformConfigManager transformConfigManager,
+        Client client,
+        TransformAuditor auditor
+    ) {
+        super(
+            name,
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            PutTransformAction.Request::new,
+            indexNameExpressionResolver
+        );
         this.licenseState = licenseState;
         this.client = client;
         this.transformConfigManager = transformConfigManager;
-        this.securityContext = XPackSettings.SECURITY_ENABLED.get(settings) ?
-            new SecurityContext(settings, threadPool.getThreadContext()) : null;
+        this.securityContext = XPackSettings.SECURITY_ENABLED.get(settings)
+            ? new SecurityContext(settings, threadPool.getThreadContext())
+            : null;
         this.auditor = auditor;
     }
 
-
-    static HasPrivilegesRequest buildPrivilegeCheck(TransformConfig config,
-                                                    IndexNameExpressionResolver indexNameExpressionResolver,
-                                                    ClusterState clusterState,
-                                                    String username) {
+    static HasPrivilegesRequest buildPrivilegeCheck(
+        TransformConfig config,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        ClusterState clusterState,
+        String username
+    ) {
         final String destIndex = config.getDestination().getIndex();
-        final String[] concreteDest = indexNameExpressionResolver.concreteIndexNames(clusterState,
+        final String[] concreteDest = indexNameExpressionResolver.concreteIndexNames(
+            clusterState,
             IndicesOptions.lenientExpandOpen(),
-            config.getDestination().getIndex());
+            config.getDestination().getIndex()
+        );
         List<String> srcPrivileges = new ArrayList<>(2);
         srcPrivileges.add("read");
 
@@ -152,20 +189,21 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
         XPackPlugin.checkReadyForXPackCustomMetadata(clusterState);
 
         // set headers to run transform as calling user
-        Map<String, String> filteredHeaders = threadPool.getThreadContext().getHeaders().entrySet().stream()
-                    .filter(e -> ClientHelper.SECURITY_HEADER_FILTERS.contains(e.getKey()))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        Map<String, String> filteredHeaders = threadPool.getThreadContext()
+            .getHeaders()
+            .entrySet()
+            .stream()
+            .filter(e -> ClientHelper.SECURITY_HEADER_FILTERS.contains(e.getKey()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-        TransformConfig config = request.getConfig()
-            .setHeaders(filteredHeaders)
-            .setCreateTime(Instant.now())
-            .setVersion(Version.CURRENT);
+        TransformConfig config = request.getConfig().setHeaders(filteredHeaders).setCreateTime(Instant.now()).setVersion(Version.CURRENT);
 
         String transformId = config.getId();
         // quick check whether a transform has already been created under that name
         if (PersistentTasksCustomMetaData.getTaskWithId(clusterState, transformId) != null) {
-            listener.onFailure(new ResourceAlreadyExistsException(
-                    TransformMessages.getMessage(TransformMessages.REST_PUT_TRANSFORM_EXISTS, transformId)));
+            listener.onFailure(
+                new ResourceAlreadyExistsException(TransformMessages.getMessage(TransformMessages.REST_PUT_TRANSFORM_EXISTS, transformId))
+            );
             return;
         }
         try {
@@ -181,7 +219,8 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
             HasPrivilegesRequest privRequest = buildPrivilegeCheck(config, indexNameExpressionResolver, clusterState, username);
             ActionListener<HasPrivilegesResponse> privResponseListener = ActionListener.wrap(
                 r -> handlePrivsResponse(username, request, r, listener),
-                listener::onFailure);
+                listener::onFailure
+            );
 
             client.execute(HasPrivilegesAction.INSTANCE, privRequest, privResponseListener);
         } else { // No security enabled, just create the transform
@@ -194,10 +233,12 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
         return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
     }
 
-    private void handlePrivsResponse(String username,
-                                     Request request,
-                                     HasPrivilegesResponse privilegesResponse,
-                                     ActionListener<AcknowledgedResponse> listener) {
+    private void handlePrivsResponse(
+        String username,
+        Request request,
+        HasPrivilegesResponse privilegesResponse,
+        ActionListener<AcknowledgedResponse> listener
+    ) {
         if (privilegesResponse.isCompleteMatch()) {
             putTransform(request, listener);
         } else {
@@ -206,11 +247,14 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
                 .map(ResourcePrivileges::getResource)
                 .collect(Collectors.toList());
 
-            listener.onFailure(Exceptions.authorizationError(
-                "Cannot create transform [{}] because user {} lacks all the required permissions for indices: {}",
-                request.getConfig().getId(),
-                username,
-                indices));
+            listener.onFailure(
+                Exceptions.authorizationError(
+                    "Cannot create transform [{}] because user {} lacks all the required permissions for indices: {}",
+                    request.getConfig().getId(),
+                    username,
+                    indices
+                )
+            );
         }
     }
 
@@ -220,28 +264,31 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
         final Pivot pivot = new Pivot(config.getPivotConfig());
 
         // <3> Return to the listener
-        ActionListener<Boolean> putTransformConfigurationListener = ActionListener.wrap(
-            putTransformConfigurationResult -> {
-                auditor.info(config.getId(), "Created transform.");
-                listener.onResponse(new AcknowledgedResponse(true));
-            },
-            listener::onFailure
-        );
+        ActionListener<Boolean> putTransformConfigurationListener = ActionListener.wrap(putTransformConfigurationResult -> {
+            auditor.info(config.getId(), "Created transform.");
+            listener.onResponse(new AcknowledgedResponse(true));
+        }, listener::onFailure);
 
         // <2> Put our transform
         ActionListener<Boolean> pivotValidationListener = ActionListener.wrap(
             validationResult -> transformConfigManager.putTransformConfiguration(config, putTransformConfigurationListener),
             validationException -> {
                 if (validationException instanceof ElasticsearchStatusException) {
-                    listener.onFailure(new ElasticsearchStatusException(
-                        TransformMessages.REST_PUT_TRANSFORM_FAILED_TO_VALIDATE_CONFIGURATION,
-                        ((ElasticsearchStatusException)validationException).status(),
-                        validationException));
+                    listener.onFailure(
+                        new ElasticsearchStatusException(
+                            TransformMessages.REST_PUT_TRANSFORM_FAILED_TO_VALIDATE_CONFIGURATION,
+                            ((ElasticsearchStatusException) validationException).status(),
+                            validationException
+                        )
+                    );
                 } else {
-                    listener.onFailure(new ElasticsearchStatusException(
-                        TransformMessages.REST_PUT_TRANSFORM_FAILED_TO_VALIDATE_CONFIGURATION,
-                        RestStatus.INTERNAL_SERVER_ERROR,
-                        validationException));
+                    listener.onFailure(
+                        new ElasticsearchStatusException(
+                            TransformMessages.REST_PUT_TRANSFORM_FAILED_TO_VALIDATE_CONFIGURATION,
+                            RestStatus.INTERNAL_SERVER_ERROR,
+                            validationException
+                        )
+                    );
                 }
             }
         );
@@ -249,14 +296,18 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
         try {
             pivot.validateConfig();
         } catch (ElasticsearchStatusException e) {
-            listener.onFailure(new ElasticsearchStatusException(
-                TransformMessages.REST_PUT_TRANSFORM_FAILED_TO_VALIDATE_CONFIGURATION,
-                e.status(),
-                e));
+            listener.onFailure(
+                new ElasticsearchStatusException(TransformMessages.REST_PUT_TRANSFORM_FAILED_TO_VALIDATE_CONFIGURATION, e.status(), e)
+            );
             return;
         } catch (Exception e) {
-            listener.onFailure(new ElasticsearchStatusException(
-                TransformMessages.REST_PUT_TRANSFORM_FAILED_TO_VALIDATE_CONFIGURATION, RestStatus.INTERNAL_SERVER_ERROR, e));
+            listener.onFailure(
+                new ElasticsearchStatusException(
+                    TransformMessages.REST_PUT_TRANSFORM_FAILED_TO_VALIDATE_CONFIGURATION,
+                    RestStatus.INTERNAL_SERVER_ERROR,
+                    e
+                )
+            );
             return;
         }
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
@@ -46,6 +46,7 @@ import org.elasticsearch.xpack.core.transform.TransformMessages;
 import org.elasticsearch.xpack.core.transform.action.PutTransformAction;
 import org.elasticsearch.xpack.core.transform.action.PutTransformAction.Request;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
+import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
 import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 import org.elasticsearch.xpack.transform.transforms.SourceDestValidator;
@@ -75,9 +76,8 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
         IndexNameExpressionResolver indexNameExpressionResolver,
         ClusterService clusterService,
         XPackLicenseState licenseState,
-        TransformConfigManager transformConfigManager,
-        Client client,
-        TransformAuditor auditor
+        TransformServices transformServices,
+        Client client
     ) {
         this(
             PutTransformAction.NAME,
@@ -88,9 +88,8 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
             indexNameExpressionResolver,
             clusterService,
             licenseState,
-            transformConfigManager,
-            client,
-            auditor
+            transformServices,
+            client
         );
     }
 
@@ -103,9 +102,8 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
         IndexNameExpressionResolver indexNameExpressionResolver,
         ClusterService clusterService,
         XPackLicenseState licenseState,
-        TransformConfigManager transformConfigManager,
-        Client client,
-        TransformAuditor auditor
+        TransformServices transformServices,
+        Client client
     ) {
         super(
             name,
@@ -118,11 +116,11 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
         );
         this.licenseState = licenseState;
         this.client = client;
-        this.transformConfigManager = transformConfigManager;
+        this.transformConfigManager = transformServices.getConfigManager();
         this.securityContext = XPackSettings.SECURITY_ENABLED.get(settings)
             ? new SecurityContext(settings, threadPool.getThreadContext())
             : null;
-        this.auditor = auditor;
+        this.auditor = transformServices.getAuditor();
     }
 
     static HasPrivilegesRequest buildPrivilegeCheck(

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
@@ -41,6 +41,7 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformState;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskParams;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskState;
+import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
 import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 import org.elasticsearch.xpack.transform.persistence.TransformIndex;
@@ -74,10 +75,9 @@ public class TransportStartTransformAction extends TransportMasterNodeAction<Sta
         XPackLicenseState licenseState,
         ThreadPool threadPool,
         IndexNameExpressionResolver indexNameExpressionResolver,
-        TransformConfigManager transformConfigManager,
+        TransformServices transformServices,
         PersistentTasksService persistentTasksService,
-        Client client,
-        TransformAuditor auditor
+        Client client
     ) {
         this(
             StartTransformAction.NAME,
@@ -87,10 +87,9 @@ public class TransportStartTransformAction extends TransportMasterNodeAction<Sta
             licenseState,
             threadPool,
             indexNameExpressionResolver,
-            transformConfigManager,
+            transformServices,
             persistentTasksService,
-            client,
-            auditor
+            client
         );
     }
 
@@ -102,10 +101,9 @@ public class TransportStartTransformAction extends TransportMasterNodeAction<Sta
         XPackLicenseState licenseState,
         ThreadPool threadPool,
         IndexNameExpressionResolver indexNameExpressionResolver,
-        TransformConfigManager transformConfigManager,
+        TransformServices transformServices,
         PersistentTasksService persistentTasksService,
-        Client client,
-        TransformAuditor auditor
+        Client client
     ) {
         super(
             name,
@@ -117,10 +115,10 @@ public class TransportStartTransformAction extends TransportMasterNodeAction<Sta
             indexNameExpressionResolver
         );
         this.licenseState = licenseState;
-        this.transformConfigManager = transformConfigManager;
+        this.transformConfigManager = transformServices.getConfigManager();
         this.persistentTasksService = persistentTasksService;
         this.client = client;
-        this.auditor = auditor;
+        this.auditor = transformServices.getAuditor();
     }
 
     @Override

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
@@ -37,6 +37,7 @@ import org.elasticsearch.xpack.core.transform.action.StopTransformAction.Respons
 import org.elasticsearch.xpack.core.transform.transforms.TransformState;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskState;
 import org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants;
+import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 import org.elasticsearch.xpack.transform.transforms.TransformTask;
 
@@ -67,7 +68,7 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
         ClusterService clusterService,
         ThreadPool threadPool,
         PersistentTasksService persistentTasksService,
-        TransformConfigManager transformConfigManager,
+        TransformServices transformServices,
         Client client
     ) {
         this(
@@ -77,7 +78,7 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
             clusterService,
             threadPool,
             persistentTasksService,
-            transformConfigManager,
+            transformServices,
             client
         );
     }
@@ -89,12 +90,12 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
         ClusterService clusterService,
         ThreadPool threadPool,
         PersistentTasksService persistentTasksService,
-        TransformConfigManager transformConfigManager,
+        TransformServices transformServices,
         Client client
     ) {
         super(name, clusterService, transportService, actionFilters, Request::new, Response::new, Response::new, ThreadPool.Names.SAME);
         this.threadPool = threadPool;
-        this.transformConfigManager = transformConfigManager;
+        this.transformConfigManager = transformServices.getConfigManager();
         this.persistentTasksService = persistentTasksService;
         this.client = client;
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
@@ -61,22 +61,38 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
     private final Client client;
 
     @Inject
-    public TransportStopTransformAction(TransportService transportService, ActionFilters actionFilters,
-                                        ClusterService clusterService, ThreadPool threadPool,
-                                        PersistentTasksService persistentTasksService,
-                                        TransformConfigManager transformConfigManager,
-                                        Client client) {
-        this(StopTransformAction.NAME, transportService, actionFilters, clusterService, threadPool, persistentTasksService,
-             transformConfigManager, client);
+    public TransportStopTransformAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        PersistentTasksService persistentTasksService,
+        TransformConfigManager transformConfigManager,
+        Client client
+    ) {
+        this(
+            StopTransformAction.NAME,
+            transportService,
+            actionFilters,
+            clusterService,
+            threadPool,
+            persistentTasksService,
+            transformConfigManager,
+            client
+        );
     }
 
-    protected TransportStopTransformAction(String name, TransportService transportService, ActionFilters actionFilters,
-                                           ClusterService clusterService, ThreadPool threadPool,
-                                           PersistentTasksService persistentTasksService,
-                                           TransformConfigManager transformConfigManager,
-                                           Client client) {
-        super(name, clusterService, transportService, actionFilters, Request::new,
-              Response::new, Response::new, ThreadPool.Names.SAME);
+    protected TransportStopTransformAction(
+        String name,
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        PersistentTasksService persistentTasksService,
+        TransformConfigManager transformConfigManager,
+        Client client
+    ) {
+        super(name, clusterService, transportService, actionFilters, Request::new, Response::new, Response::new, ThreadPool.Names.SAME);
         this.threadPool = threadPool;
         this.transformConfigManager = transformConfigManager;
         this.persistentTasksService = persistentTasksService;
@@ -98,12 +114,13 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
                 }
             }
             if (failedTasks.isEmpty() == false) {
-                String msg = failedTasks.size() == 1 ?
-                    TransformMessages.getMessage(CANNOT_STOP_FAILED_TRANSFORM,
-                        failedTasks.get(0),
-                        failedReasons.get(0)) :
-                    "Unable to stop transforms. The following transforms are in a failed state " +
-                        failedTasks + " with reasons " + failedReasons + ". Use force stop to stop the transforms.";
+                String msg = failedTasks.size() == 1
+                    ? TransformMessages.getMessage(CANNOT_STOP_FAILED_TRANSFORM, failedTasks.get(0), failedReasons.get(0))
+                    : "Unable to stop transforms. The following transforms are in a failed state "
+                        + failedTasks
+                        + " with reasons "
+                        + failedReasons
+                        + ". Use force stop to stop the transforms.";
                 throw new ElasticsearchStatusException(msg, RestStatus.CONFLICT);
             }
         }
@@ -118,8 +135,12 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
             if (nodes.getMasterNode() == null) {
                 listener.onFailure(new MasterNotDiscoveredException("no known master node"));
             } else {
-                transportService.sendRequest(nodes.getMasterNode(), actionName, request,
-                        new ActionListenerResponseHandler<>(listener, Response::new));
+                transportService.sendRequest(
+                    nodes.getMasterNode(),
+                    actionName,
+                    request,
+                    new ActionListenerResponseHandler<>(listener, Response::new)
+                );
             }
         } else {
             final ActionListener<Response> finalListener;
@@ -129,7 +150,8 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
                 finalListener = listener;
             }
 
-            transformConfigManager.expandTransformIds(request.getId(),
+            transformConfigManager.expandTransformIds(
+                request.getId(),
                 new PageParams(0, 10_000),
                 request.isAllowNoMatch(),
                 ActionListener.wrap(hitsAndIds -> {
@@ -137,9 +159,8 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
                     request.setExpandedIds(new HashSet<>(hitsAndIds.v2()));
                     request.setNodes(TransformNodes.transformTaskNodes(hitsAndIds.v2(), state));
                     super.doExecute(task, request, finalListener);
-                },
-                listener::onFailure
-            ));
+                }, listener::onFailure)
+            );
         }
     }
 
@@ -153,35 +174,40 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
         }
 
         if (ids.contains(transformTask.getTransformId())) {
-            transformTask.setShouldStopAtCheckpoint(request.isWaitForCheckpoint(), ActionListener.wrap(
-                r -> {
-                    try {
-                        transformTask.stop(request.isForce(), request.isWaitForCheckpoint());
-                        listener.onResponse(new Response(true));
-                    } catch (ElasticsearchException ex) {
-                        listener.onFailure(ex);
-                    }
-                },
+            transformTask.setShouldStopAtCheckpoint(request.isWaitForCheckpoint(), ActionListener.wrap(r -> {
+                try {
+                    transformTask.stop(request.isForce(), request.isWaitForCheckpoint());
+                    listener.onResponse(new Response(true));
+                } catch (ElasticsearchException ex) {
+                    listener.onFailure(ex);
+                }
+            },
                 e -> listener.onFailure(
                     new ElasticsearchStatusException(
                         "Failed to update transform task [{}] state value should_stop_at_checkpoint from [{}] to [{}]",
                         RestStatus.CONFLICT,
                         transformTask.getTransformId(),
                         transformTask.getState().shouldStopAtNextCheckpoint(),
-                        request.isWaitForCheckpoint()))
+                        request.isWaitForCheckpoint()
+                    )
+                )
+            ));
+        } else {
+            listener.onFailure(
+                new RuntimeException(
+                    "ID of transform task [" + transformTask.getTransformId() + "] does not match request's ID [" + request.getId() + "]"
                 )
             );
-        } else {
-            listener.onFailure(new RuntimeException("ID of transform task [" + transformTask.getTransformId()
-                    + "] does not match request's ID [" + request.getId() + "]"));
         }
     }
 
     @Override
-    protected StopTransformAction.Response newResponse(Request request,
-                                                                List<Response> tasks,
-                                                                List<TaskOperationFailure> taskOperationFailures,
-                                                                List<FailedNodeException> failedNodeExceptions) {
+    protected StopTransformAction.Response newResponse(
+        Request request,
+        List<Response> tasks,
+        List<TaskOperationFailure> taskOperationFailures,
+        List<FailedNodeException> failedNodeExceptions
+    ) {
 
         if (taskOperationFailures.isEmpty() == false || failedNodeExceptions.isEmpty() == false) {
             return new Response(taskOperationFailures, failedNodeExceptions, false);
@@ -194,46 +220,49 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
     private ActionListener<Response> waitForStopListener(Request request, ActionListener<Response> listener) {
 
         ActionListener<Response> onStopListener = ActionListener.wrap(
-            waitResponse ->
-                client.admin()
-                    .indices()
-                    .prepareRefresh(TransformInternalIndexConstants.LATEST_INDEX_NAME)
-                    .execute(ActionListener.wrap(
-                        r -> listener.onResponse(waitResponse),
-                        e -> {
-                            logger.info("Failed to refresh internal index after delete", e);
-                            listener.onResponse(waitResponse);
-                        })
-                    ),
+            waitResponse -> client.admin()
+                .indices()
+                .prepareRefresh(TransformInternalIndexConstants.LATEST_INDEX_NAME)
+                .execute(ActionListener.wrap(r -> listener.onResponse(waitResponse), e -> {
+                    logger.info("Failed to refresh internal index after delete", e);
+                    listener.onResponse(waitResponse);
+                })),
             listener::onFailure
         );
         return ActionListener.wrap(
-                response -> {
-                    // If there were failures attempting to stop the tasks, we don't know if they will actually stop.
-                    // It is better to respond to the user now than allow for the persistent task waiting to timeout
-                    if (response.getTaskFailures().isEmpty() == false || response.getNodeFailures().isEmpty() == false) {
-                        RestStatus status = firstNotOKStatus(response.getTaskFailures(), response.getNodeFailures());
-                        listener.onFailure(buildException(response.getTaskFailures(), response.getNodeFailures(), status));
-                        return;
-                    }
-                    // Wait until the persistent task is stopped
-                    // Switch over to Generic threadpool so we don't block the network thread
-                    threadPool.generic().execute(() ->
-                        waitForTransformStopped(request.getExpandedIds(), request.getTimeout(), request.isForce(), onStopListener));
-                },
-                listener::onFailure
+            response -> {
+                // If there were failures attempting to stop the tasks, we don't know if they will actually stop.
+                // It is better to respond to the user now than allow for the persistent task waiting to timeout
+                if (response.getTaskFailures().isEmpty() == false || response.getNodeFailures().isEmpty() == false) {
+                    RestStatus status = firstNotOKStatus(response.getTaskFailures(), response.getNodeFailures());
+                    listener.onFailure(buildException(response.getTaskFailures(), response.getNodeFailures(), status));
+                    return;
+                }
+                // Wait until the persistent task is stopped
+                // Switch over to Generic threadpool so we don't block the network thread
+                threadPool.generic()
+                    .execute(
+                        () -> waitForTransformStopped(request.getExpandedIds(), request.getTimeout(), request.isForce(), onStopListener)
+                    );
+            },
+            listener::onFailure
         );
     }
 
-    static ElasticsearchStatusException buildException(List<TaskOperationFailure> taskOperationFailures,
-                                                       List<ElasticsearchException> elasticsearchExceptions,
-                                                       RestStatus status) {
+    static ElasticsearchStatusException buildException(
+        List<TaskOperationFailure> taskOperationFailures,
+        List<ElasticsearchException> elasticsearchExceptions,
+        RestStatus status
+    ) {
         List<Exception> exceptions = Stream.concat(
             taskOperationFailures.stream().map(TaskOperationFailure::getCause),
-            elasticsearchExceptions.stream()).collect(Collectors.toList());
+            elasticsearchExceptions.stream()
+        ).collect(Collectors.toList());
 
-        ElasticsearchStatusException elasticsearchStatusException =
-            new ElasticsearchStatusException(exceptions.get(0).getMessage(), status);
+        ElasticsearchStatusException elasticsearchStatusException = new ElasticsearchStatusException(
+            exceptions.get(0).getMessage(),
+            status
+        );
 
         for (int i = 1; i < exceptions.size(); i++) {
             elasticsearchStatusException.addSuppressed(exceptions.get(i));
@@ -265,10 +294,12 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
         return status == RestStatus.OK ? RestStatus.INTERNAL_SERVER_ERROR : status;
     }
 
-    private void waitForTransformStopped(Set<String> persistentTaskIds,
-                                         TimeValue timeout,
-                                         boolean force,
-                                         ActionListener<Response> listener) {
+    private void waitForTransformStopped(
+        Set<String> persistentTaskIds,
+        TimeValue timeout,
+        boolean force,
+        ActionListener<Response> listener
+    ) {
         // This map is accessed in the predicate and the listener callbacks
         final Map<String, ElasticsearchException> exceptions = new ConcurrentHashMap<>();
         persistentTasksService.waitForPersistentTasksCondition(persistentTasksCustomMetaData -> {
@@ -283,13 +314,15 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
                 }
 
                 // If force is true, then it should eventually go away, don't add it to the collection of failures.
-                TransformState taskState = (TransformState)transformsTask.getState();
+                TransformState taskState = (TransformState) transformsTask.getState();
                 if (force == false && taskState != null && taskState.getTaskState() == TransformTaskState.FAILED) {
-                    exceptions.put(persistentTaskId, new ElasticsearchStatusException(
-                        TransformMessages.getMessage(CANNOT_STOP_FAILED_TRANSFORM,
-                            persistentTaskId,
-                            taskState.getReason()),
-                        RestStatus.CONFLICT));
+                    exceptions.put(
+                        persistentTaskId,
+                        new ElasticsearchStatusException(
+                            TransformMessages.getMessage(CANNOT_STOP_FAILED_TRANSFORM, persistentTaskId, taskState.getReason()),
+                            RestStatus.CONFLICT
+                        )
+                    );
 
                     // If all the tasks are now flagged as failed, do not wait for another ClusterState update.
                     // Return to the caller as soon as possible
@@ -298,80 +331,80 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
                 return false;
             }
             return true;
-        }, timeout, ActionListener.wrap(
-            r -> {
-                // No exceptions AND the tasks have gone away
-                if (exceptions.isEmpty()) {
+        }, timeout, ActionListener.wrap(r -> {
+            // No exceptions AND the tasks have gone away
+            if (exceptions.isEmpty()) {
+                listener.onResponse(new Response(Boolean.TRUE));
+                return;
+            }
+
+            // We are only stopping one task, so if there is a failure, it is the only one
+            if (persistentTaskIds.size() == 1) {
+                listener.onFailure(exceptions.get(persistentTaskIds.iterator().next()));
+                return;
+            }
+
+            Set<String> stoppedTasks = new HashSet<>(persistentTaskIds);
+            stoppedTasks.removeAll(exceptions.keySet());
+            String message = stoppedTasks.isEmpty()
+                ? "Could not stop any of the tasks as all were failed. Use force stop to stop the transforms."
+                : LoggerMessageFormat.format(
+                    "Successfully stopped [{}] transforms. "
+                        + "Could not stop the transforms {} as they were failed. Use force stop to stop the transforms.",
+                    stoppedTasks.size(),
+                    exceptions.keySet()
+                );
+
+            listener.onFailure(new ElasticsearchStatusException(message, RestStatus.CONFLICT));
+        }, e -> {
+            // waitForPersistentTasksCondition throws a IllegalStateException on timeout
+            if (e instanceof IllegalStateException && e.getMessage().startsWith("Timed out")) {
+                PersistentTasksCustomMetaData persistentTasksCustomMetaData = clusterService.state()
+                    .metaData()
+                    .custom(PersistentTasksCustomMetaData.TYPE);
+
+                if (persistentTasksCustomMetaData == null) {
                     listener.onResponse(new Response(Boolean.TRUE));
                     return;
                 }
 
-                // We are only stopping one task, so if there is a failure, it is the only one
-                if (persistentTaskIds.size() == 1) {
-                    listener.onFailure(exceptions.get(persistentTaskIds.iterator().next()));
+                // collect which tasks are still running
+                Set<String> stillRunningTasks = new HashSet<>();
+                for (String persistentTaskId : persistentTaskIds) {
+                    if (persistentTasksCustomMetaData.getTask(persistentTaskId) != null) {
+                        stillRunningTasks.add(persistentTaskId);
+                    }
+                }
+
+                if (stillRunningTasks.isEmpty()) {
+                    // should not happen
+                    listener.onResponse(new Response(Boolean.TRUE));
+                    return;
+                } else {
+                    StringBuilder message = new StringBuilder();
+                    if (persistentTaskIds.size() - stillRunningTasks.size() - exceptions.size() > 0) {
+                        message.append("Successfully stopped [");
+                        message.append(persistentTaskIds.size() - stillRunningTasks.size() - exceptions.size());
+                        message.append("] transforms. ");
+                    }
+
+                    if (exceptions.size() > 0) {
+                        message.append("Could not stop the transforms ");
+                        message.append(exceptions.keySet());
+                        message.append(" as they were failed. Use force stop to stop the transforms. ");
+                    }
+
+                    if (stillRunningTasks.size() > 0) {
+                        message.append("Could not stop the transforms ");
+                        message.append(stillRunningTasks);
+                        message.append(" as they timed out.");
+                    }
+
+                    listener.onFailure(new ElasticsearchStatusException(message.toString(), RestStatus.REQUEST_TIMEOUT));
                     return;
                 }
-
-                Set<String> stoppedTasks = new HashSet<>(persistentTaskIds);
-                stoppedTasks.removeAll(exceptions.keySet());
-                String message = stoppedTasks.isEmpty() ?
-                    "Could not stop any of the tasks as all were failed. Use force stop to stop the transforms." :
-                    LoggerMessageFormat.format("Successfully stopped [{}] transforms. " +
-                        "Could not stop the transforms {} as they were failed. Use force stop to stop the transforms.",
-                        stoppedTasks.size(),
-                        exceptions.keySet());
-
-                listener.onFailure(new ElasticsearchStatusException(message, RestStatus.CONFLICT));
-            },
-            e -> {
-                // waitForPersistentTasksCondition throws a IllegalStateException on timeout
-                if (e instanceof IllegalStateException && e.getMessage().startsWith("Timed out")) {
-                    PersistentTasksCustomMetaData persistentTasksCustomMetaData = clusterService.state().metaData()
-                        .custom(PersistentTasksCustomMetaData.TYPE);
-
-                    if (persistentTasksCustomMetaData == null) {
-                        listener.onResponse(new Response(Boolean.TRUE));
-                        return;
-                    }
-
-                    // collect which tasks are still running
-                    Set<String> stillRunningTasks = new HashSet<>();
-                    for (String persistentTaskId : persistentTaskIds) {
-                        if (persistentTasksCustomMetaData.getTask(persistentTaskId) != null) {
-                            stillRunningTasks.add(persistentTaskId);
-                        }
-                    }
-
-                    if (stillRunningTasks.isEmpty()) {
-                        // should not happen
-                        listener.onResponse(new Response(Boolean.TRUE));
-                        return;
-                    } else {
-                        StringBuilder message = new StringBuilder();
-                        if (persistentTaskIds.size() - stillRunningTasks.size() - exceptions.size() > 0) {
-                            message.append("Successfully stopped [");
-                            message.append(persistentTaskIds.size() - stillRunningTasks.size() - exceptions.size());
-                            message.append("] transforms. ");
-                        }
-
-                        if (exceptions.size() > 0) {
-                            message.append("Could not stop the transforms ");
-                            message.append(exceptions.keySet());
-                            message.append(" as they were failed. Use force stop to stop the transforms. ");
-                        }
-
-                        if (stillRunningTasks.size() > 0) {
-                            message.append("Could not stop the transforms ");
-                            message.append(stillRunningTasks);
-                            message.append(" as they timed out.");
-                        }
-
-                        listener.onFailure(new ElasticsearchStatusException(message.toString(), RestStatus.REQUEST_TIMEOUT));
-                        return;
-                    }
-                }
-                listener.onFailure(e);
             }
-        ));
+            listener.onFailure(e);
+        }));
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
@@ -46,6 +46,7 @@ import org.elasticsearch.xpack.core.transform.action.UpdateTransformAction.Reque
 import org.elasticsearch.xpack.core.transform.action.UpdateTransformAction.Response;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfigUpdate;
+import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
 import org.elasticsearch.xpack.transform.persistence.SeqNoPrimaryTermAndIndex;
 import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
@@ -79,9 +80,8 @@ public class TransportUpdateTransformAction extends TransportMasterNodeAction<Re
         IndexNameExpressionResolver indexNameExpressionResolver,
         ClusterService clusterService,
         XPackLicenseState licenseState,
-        TransformConfigManager transformConfigManager,
-        Client client,
-        TransformAuditor auditor
+        TransformServices transformServices,
+        Client client
     ) {
         this(
             UpdateTransformAction.NAME,
@@ -92,9 +92,8 @@ public class TransportUpdateTransformAction extends TransportMasterNodeAction<Re
             indexNameExpressionResolver,
             clusterService,
             licenseState,
-            transformConfigManager,
-            client,
-            auditor
+            transformServices,
+            client
         );
     }
 
@@ -107,18 +106,17 @@ public class TransportUpdateTransformAction extends TransportMasterNodeAction<Re
         IndexNameExpressionResolver indexNameExpressionResolver,
         ClusterService clusterService,
         XPackLicenseState licenseState,
-        TransformConfigManager transformConfigManager,
-        Client client,
-        TransformAuditor auditor
+        TransformServices transformServices,
+        Client client
     ) {
         super(name, transportService, clusterService, threadPool, actionFilters, Request::new, indexNameExpressionResolver);
         this.licenseState = licenseState;
         this.client = client;
-        this.transformConfigManager = transformConfigManager;
+        this.transformConfigManager = transformServices.getConfigManager();
         this.securityContext = XPackSettings.SECURITY_ENABLED.get(settings)
             ? new SecurityContext(settings, threadPool.getThreadContext())
             : null;
-        this.auditor = auditor;
+        this.auditor = transformServices.getAuditor();
     }
 
     @Override

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
@@ -71,27 +71,53 @@ public class TransportUpdateTransformAction extends TransportMasterNodeAction<Re
     private final TransformAuditor auditor;
 
     @Inject
-    public TransportUpdateTransformAction(Settings settings, TransportService transportService, ThreadPool threadPool,
-                                          ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
-                                          ClusterService clusterService, XPackLicenseState licenseState,
-                                          TransformConfigManager transformConfigManager, Client client,
-                                          TransformAuditor auditor) {
-        this(UpdateTransformAction.NAME, settings, transportService, threadPool, actionFilters, indexNameExpressionResolver, clusterService,
-             licenseState, transformConfigManager, client, auditor);
+    public TransportUpdateTransformAction(
+        Settings settings,
+        TransportService transportService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        ClusterService clusterService,
+        XPackLicenseState licenseState,
+        TransformConfigManager transformConfigManager,
+        Client client,
+        TransformAuditor auditor
+    ) {
+        this(
+            UpdateTransformAction.NAME,
+            settings,
+            transportService,
+            threadPool,
+            actionFilters,
+            indexNameExpressionResolver,
+            clusterService,
+            licenseState,
+            transformConfigManager,
+            client,
+            auditor
+        );
     }
 
-    protected TransportUpdateTransformAction(String name, Settings settings, TransportService transportService, ThreadPool threadPool,
-                                             ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
-                                             ClusterService clusterService, XPackLicenseState licenseState,
-                                             TransformConfigManager transformConfigManager, Client client,
-                                             TransformAuditor auditor) {
-        super(name, transportService, clusterService, threadPool, actionFilters,
-              Request::new, indexNameExpressionResolver);
+    protected TransportUpdateTransformAction(
+        String name,
+        Settings settings,
+        TransportService transportService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        ClusterService clusterService,
+        XPackLicenseState licenseState,
+        TransformConfigManager transformConfigManager,
+        Client client,
+        TransformAuditor auditor
+    ) {
+        super(name, transportService, clusterService, threadPool, actionFilters, Request::new, indexNameExpressionResolver);
         this.licenseState = licenseState;
         this.client = client;
         this.transformConfigManager = transformConfigManager;
-        this.securityContext = XPackSettings.SECURITY_ENABLED.get(settings) ?
-            new SecurityContext(settings, threadPool.getThreadContext()) : null;
+        this.securityContext = XPackSettings.SECURITY_ENABLED.get(settings)
+            ? new SecurityContext(settings, threadPool.getThreadContext())
+            : null;
         this.auditor = auditor;
     }
 
@@ -116,28 +142,28 @@ public class TransportUpdateTransformAction extends TransportMasterNodeAction<Re
         XPackPlugin.checkReadyForXPackCustomMetadata(clusterState);
 
         // set headers to run transform as calling user
-        Map<String, String> filteredHeaders = threadPool.getThreadContext().getHeaders().entrySet().stream()
-                    .filter(e -> ClientHelper.SECURITY_HEADER_FILTERS.contains(e.getKey()))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        Map<String, String> filteredHeaders = threadPool.getThreadContext()
+            .getHeaders()
+            .entrySet()
+            .stream()
+            .filter(e -> ClientHelper.SECURITY_HEADER_FILTERS.contains(e.getKey()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         TransformConfigUpdate update = request.getUpdate();
         update.setHeaders(filteredHeaders);
 
         // GET transform and attempt to update
         // We don't want the update to complete if the config changed between GET and INDEX
-        transformConfigManager.getTransformConfigurationForUpdate(request.getId(), ActionListener.wrap(
-            configAndVersion -> {
-                final TransformConfig config = configAndVersion.v1();
-                // If it is a noop don't bother even writing the doc, save the cycles, just return here.
-                if (update.isNoop(config)) {
-                    listener.onResponse(new Response(config));
-                    return;
-                }
-                TransformConfig updatedConfig = update.apply(config);
-                validateAndUpdateTransform(request, clusterState, updatedConfig, configAndVersion.v2(), listener);
-            },
-            listener::onFailure
-        ));
+        transformConfigManager.getTransformConfigurationForUpdate(request.getId(), ActionListener.wrap(configAndVersion -> {
+            final TransformConfig config = configAndVersion.v1();
+            // If it is a noop don't bother even writing the doc, save the cycles, just return here.
+            if (update.isNoop(config)) {
+                listener.onResponse(new Response(config));
+                return;
+            }
+            TransformConfig updatedConfig = update.apply(config);
+            validateAndUpdateTransform(request, clusterState, updatedConfig, configAndVersion.v2(), listener);
+        }, listener::onFailure));
     }
 
     @Override
@@ -145,13 +171,15 @@ public class TransportUpdateTransformAction extends TransportMasterNodeAction<Re
         return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
     }
 
-    private void handlePrivsResponse(String username,
-                                     Request request,
-                                     TransformConfig config,
-                                     SeqNoPrimaryTermAndIndex seqNoPrimaryTermAndIndex,
-                                     ClusterState clusterState,
-                                     HasPrivilegesResponse privilegesResponse,
-                                     ActionListener<Response> listener) {
+    private void handlePrivsResponse(
+        String username,
+        Request request,
+        TransformConfig config,
+        SeqNoPrimaryTermAndIndex seqNoPrimaryTermAndIndex,
+        ClusterState clusterState,
+        HasPrivilegesResponse privilegesResponse,
+        ActionListener<Response> listener
+    ) {
         if (privilegesResponse.isCompleteMatch()) {
             updateTransform(request, config, seqNoPrimaryTermAndIndex, clusterState, listener);
         } else {
@@ -160,19 +188,24 @@ public class TransportUpdateTransformAction extends TransportMasterNodeAction<Re
                 .map(ResourcePrivileges::getResource)
                 .collect(Collectors.toList());
 
-            listener.onFailure(Exceptions.authorizationError(
-                "Cannot update transform [{}] because user {} lacks all the required permissions for indices: {}",
-                request.getId(),
-                username,
-                indices));
+            listener.onFailure(
+                Exceptions.authorizationError(
+                    "Cannot update transform [{}] because user {} lacks all the required permissions for indices: {}",
+                    request.getId(),
+                    username,
+                    indices
+                )
+            );
         }
     }
 
-    private void validateAndUpdateTransform(Request request,
-                                            ClusterState clusterState,
-                                            TransformConfig config,
-                                            SeqNoPrimaryTermAndIndex seqNoPrimaryTermAndIndex,
-                                            ActionListener<Response> listener) {
+    private void validateAndUpdateTransform(
+        Request request,
+        ClusterState clusterState,
+        TransformConfig config,
+        SeqNoPrimaryTermAndIndex seqNoPrimaryTermAndIndex,
+        ActionListener<Response> listener
+    ) {
         try {
             SourceDestValidator.validate(config, clusterState, indexNameExpressionResolver, request.isDeferValidation());
         } catch (ElasticsearchStatusException ex) {
@@ -180,45 +213,42 @@ public class TransportUpdateTransformAction extends TransportMasterNodeAction<Re
             return;
         }
 
-
         // Early check to verify that the user can create the destination index and can read from the source
         if (licenseState.isAuthAllowed() && request.isDeferValidation() == false) {
             final String username = securityContext.getUser().principal();
             HasPrivilegesRequest privRequest = buildPrivilegeCheck(config, indexNameExpressionResolver, clusterState, username);
             ActionListener<HasPrivilegesResponse> privResponseListener = ActionListener.wrap(
                 r -> handlePrivsResponse(username, request, config, seqNoPrimaryTermAndIndex, clusterState, r, listener),
-                listener::onFailure);
+                listener::onFailure
+            );
 
             client.execute(HasPrivilegesAction.INSTANCE, privRequest, privResponseListener);
         } else { // No security enabled, just create the transform
             updateTransform(request, config, seqNoPrimaryTermAndIndex, clusterState, listener);
         }
     }
-    private void updateTransform(Request request,
-                                 TransformConfig config,
-                                 SeqNoPrimaryTermAndIndex seqNoPrimaryTermAndIndex,
-                                 ClusterState clusterState,
-                                 ActionListener<Response> listener) {
+
+    private void updateTransform(
+        Request request,
+        TransformConfig config,
+        SeqNoPrimaryTermAndIndex seqNoPrimaryTermAndIndex,
+        ClusterState clusterState,
+        ActionListener<Response> listener
+    ) {
 
         final Pivot pivot = new Pivot(config.getPivotConfig());
 
         // <3> Return to the listener
-        ActionListener<Boolean> putTransformConfigurationListener = ActionListener.wrap(
-            putTransformConfigurationResult -> {
-                auditor.info(config.getId(), "updated transform.");
-                transformConfigManager.deleteOldTransformConfigurations(request.getId(), ActionListener.wrap(
-                    r -> {
-                        logger.trace("[{}] successfully deleted old transform configurations", request.getId());
-                        listener.onResponse(new Response(config));
-                    },
-                    e -> {
-                        logger.warn(
-                            LoggerMessageFormat.format("[{}] failed deleting old transform configurations.", request.getId()),
-                            e);
-                        listener.onResponse(new Response(config));
-                    }
-                ));
-            },
+        ActionListener<Boolean> putTransformConfigurationListener = ActionListener.wrap(putTransformConfigurationResult -> {
+            auditor.info(config.getId(), "updated transform.");
+            transformConfigManager.deleteOldTransformConfigurations(request.getId(), ActionListener.wrap(r -> {
+                logger.trace("[{}] successfully deleted old transform configurations", request.getId());
+                listener.onResponse(new Response(config));
+            }, e -> {
+                logger.warn(LoggerMessageFormat.format("[{}] failed deleting old transform configurations.", request.getId()), e);
+                listener.onResponse(new Response(config));
+            }));
+        },
             // If we failed to INDEX AND we created the destination index, the destination index will still be around
             // This is a similar behavior to _start
             listener::onFailure
@@ -226,59 +256,71 @@ public class TransportUpdateTransformAction extends TransportMasterNodeAction<Re
 
         // <2> Update our transform
         ActionListener<Void> createDestinationListener = ActionListener.wrap(
-            createDestResponse -> transformConfigManager.updateTransformConfiguration(config,
+            createDestResponse -> transformConfigManager.updateTransformConfiguration(
+                config,
                 seqNoPrimaryTermAndIndex,
-                putTransformConfigurationListener),
+                putTransformConfigurationListener
+            ),
             listener::onFailure
         );
 
         // <1> Create destination index if necessary
-        ActionListener<Boolean> pivotValidationListener = ActionListener.wrap(
-            validationResult -> {
-                String[] dest = indexNameExpressionResolver.concreteIndexNames(clusterState,
-                    IndicesOptions.lenientExpandOpen(),
-                    config.getDestination().getIndex());
-                String[] src = indexNameExpressionResolver.concreteIndexNames(clusterState,
-                    IndicesOptions.lenientExpandOpen(),
-                    config.getSource().getIndex());
-                // If we are running, we should verify that the destination index exists and create it if it does not
-                if (PersistentTasksCustomMetaData.getTaskWithId(clusterState, request.getId()) != null
-                    && dest.length == 0
-                    // Verify we have source indices. The user could defer_validations and if the task is already running
-                    // we allow source indices to disappear. If the source and destination indices do not exist, don't do anything
-                    // the transform will just have to dynamically create the destination index without special mapping.
-                    && src.length > 0) {
-                    createDestination(pivot, config, createDestinationListener);
-                } else {
-                    createDestinationListener.onResponse(null);
-                }
-            },
-            validationException -> {
-                if (validationException instanceof ElasticsearchStatusException) {
-                    listener.onFailure(new ElasticsearchStatusException(
+        ActionListener<Boolean> pivotValidationListener = ActionListener.wrap(validationResult -> {
+            String[] dest = indexNameExpressionResolver.concreteIndexNames(
+                clusterState,
+                IndicesOptions.lenientExpandOpen(),
+                config.getDestination().getIndex()
+            );
+            String[] src = indexNameExpressionResolver.concreteIndexNames(
+                clusterState,
+                IndicesOptions.lenientExpandOpen(),
+                config.getSource().getIndex()
+            );
+            // If we are running, we should verify that the destination index exists and create it if it does not
+            if (PersistentTasksCustomMetaData.getTaskWithId(clusterState, request.getId()) != null && dest.length == 0
+            // Verify we have source indices. The user could defer_validations and if the task is already running
+            // we allow source indices to disappear. If the source and destination indices do not exist, don't do anything
+            // the transform will just have to dynamically create the destination index without special mapping.
+                && src.length > 0) {
+                createDestination(pivot, config, createDestinationListener);
+            } else {
+                createDestinationListener.onResponse(null);
+            }
+        }, validationException -> {
+            if (validationException instanceof ElasticsearchStatusException) {
+                listener.onFailure(
+                    new ElasticsearchStatusException(
                         TransformMessages.REST_PUT_TRANSFORM_FAILED_TO_VALIDATE_CONFIGURATION,
-                        ((ElasticsearchStatusException)validationException).status(),
-                        validationException));
-                } else {
-                    listener.onFailure(new ElasticsearchStatusException(
+                        ((ElasticsearchStatusException) validationException).status(),
+                        validationException
+                    )
+                );
+            } else {
+                listener.onFailure(
+                    new ElasticsearchStatusException(
                         TransformMessages.REST_PUT_TRANSFORM_FAILED_TO_VALIDATE_CONFIGURATION,
                         RestStatus.INTERNAL_SERVER_ERROR,
-                        validationException));
-                }
+                        validationException
+                    )
+                );
             }
-        );
+        });
 
         try {
             pivot.validateConfig();
         } catch (ElasticsearchStatusException e) {
-            listener.onFailure(new ElasticsearchStatusException(
-                TransformMessages.REST_PUT_TRANSFORM_FAILED_TO_VALIDATE_CONFIGURATION,
-                e.status(),
-                e));
+            listener.onFailure(
+                new ElasticsearchStatusException(TransformMessages.REST_PUT_TRANSFORM_FAILED_TO_VALIDATE_CONFIGURATION, e.status(), e)
+            );
             return;
         } catch (Exception e) {
-            listener.onFailure(new ElasticsearchStatusException(
-                TransformMessages.REST_PUT_TRANSFORM_FAILED_TO_VALIDATE_CONFIGURATION, RestStatus.INTERNAL_SERVER_ERROR, e));
+            listener.onFailure(
+                new ElasticsearchStatusException(
+                    TransformMessages.REST_PUT_TRANSFORM_FAILED_TO_VALIDATE_CONFIGURATION,
+                    RestStatus.INTERNAL_SERVER_ERROR,
+                    e
+                )
+            );
             return;
         }
 
@@ -297,10 +339,11 @@ public class TransportUpdateTransformAction extends TransportMasterNodeAction<Re
                 Clock.systemUTC(),
                 config,
                 mappings,
-                ActionListener.wrap(r -> listener.onResponse(null), listener::onFailure)),
+                ActionListener.wrap(r -> listener.onResponse(null), listener::onFailure)
+            ),
             deduceTargetMappingsException -> listener.onFailure(
-                new RuntimeException(TransformMessages.REST_PUT_TRANSFORM_FAILED_TO_DEDUCE_DEST_MAPPINGS,
-                    deduceTargetMappingsException))
+                new RuntimeException(TransformMessages.REST_PUT_TRANSFORM_FAILED_TO_DEDUCE_DEST_MAPPINGS, deduceTargetMappingsException)
+            )
         );
 
         pivot.deduceMappings(client, config.getSource(), deduceMappingsListener);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportDeleteTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportDeleteTransformActionDeprecated.java
@@ -14,9 +14,8 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.transform.action.compat.DeleteTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.action.TransportDeleteTransformAction;
-import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
-import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 
 public class TransportDeleteTransformActionDeprecated extends TransportDeleteTransformAction {
 
@@ -27,8 +26,7 @@ public class TransportDeleteTransformActionDeprecated extends TransportDeleteTra
         ThreadPool threadPool,
         ClusterService clusterService,
         IndexNameExpressionResolver indexNameExpressionResolver,
-        TransformConfigManager transformsConfigManager,
-        TransformAuditor auditor,
+        TransformServices transformServices,
         Client client
     ) {
         super(
@@ -38,8 +36,7 @@ public class TransportDeleteTransformActionDeprecated extends TransportDeleteTra
             threadPool,
             clusterService,
             indexNameExpressionResolver,
-            transformsConfigManager,
-            auditor,
+            transformServices,
             client
         );
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportDeleteTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportDeleteTransformActionDeprecated.java
@@ -18,14 +18,29 @@ import org.elasticsearch.xpack.transform.action.TransportDeleteTransformAction;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
 import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 
-public class TransportDeleteTransformActionDeprecated extends TransportDeleteTransformAction{
+public class TransportDeleteTransformActionDeprecated extends TransportDeleteTransformAction {
 
     @Inject
-    public TransportDeleteTransformActionDeprecated(TransportService transportService, ActionFilters actionFilters, ThreadPool threadPool,
-                                                    ClusterService clusterService, IndexNameExpressionResolver indexNameExpressionResolver,
-                                                    TransformConfigManager transformsConfigManager, TransformAuditor auditor,
-                                                    Client client) {
-        super(DeleteTransformActionDeprecated.NAME, transportService, actionFilters, threadPool, clusterService,
-                indexNameExpressionResolver, transformsConfigManager, auditor, client);
+    public TransportDeleteTransformActionDeprecated(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ThreadPool threadPool,
+        ClusterService clusterService,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        TransformConfigManager transformsConfigManager,
+        TransformAuditor auditor,
+        Client client
+    ) {
+        super(
+            DeleteTransformActionDeprecated.NAME,
+            transportService,
+            actionFilters,
+            threadPool,
+            clusterService,
+            indexNameExpressionResolver,
+            transformsConfigManager,
+            auditor,
+            client
+        );
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportGetTransformStatsActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportGetTransformStatsActionDeprecated.java
@@ -11,9 +11,8 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.transform.action.compat.GetTransformStatsActionDeprecated;
+import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.action.TransportGetTransformStatsAction;
-import org.elasticsearch.xpack.transform.checkpoint.TransformCheckpointService;
-import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 
 public class TransportGetTransformStatsActionDeprecated extends TransportGetTransformStatsAction {
 
@@ -22,16 +21,8 @@ public class TransportGetTransformStatsActionDeprecated extends TransportGetTran
         TransportService transportService,
         ActionFilters actionFilters,
         ClusterService clusterService,
-        TransformConfigManager transformsConfigManager,
-        TransformCheckpointService transformsCheckpointService
+        TransformServices transformServices
     ) {
-        super(
-            GetTransformStatsActionDeprecated.NAME,
-            transportService,
-            actionFilters,
-            clusterService,
-            transformsConfigManager,
-            transformsCheckpointService
-        );
+        super(GetTransformStatsActionDeprecated.NAME, transportService, actionFilters, clusterService, transformServices);
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportGetTransformStatsActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportGetTransformStatsActionDeprecated.java
@@ -18,11 +18,20 @@ import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 public class TransportGetTransformStatsActionDeprecated extends TransportGetTransformStatsAction {
 
     @Inject
-    public TransportGetTransformStatsActionDeprecated(TransportService transportService, ActionFilters actionFilters,
-                                                      ClusterService clusterService,
-                                                      TransformConfigManager transformsConfigManager,
-                                                      TransformCheckpointService transformsCheckpointService) {
-        super(GetTransformStatsActionDeprecated.NAME, transportService, actionFilters, clusterService, transformsConfigManager,
-              transformsCheckpointService);
+    public TransportGetTransformStatsActionDeprecated(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ClusterService clusterService,
+        TransformConfigManager transformsConfigManager,
+        TransformCheckpointService transformsCheckpointService
+    ) {
+        super(
+            GetTransformStatsActionDeprecated.NAME,
+            transportService,
+            actionFilters,
+            clusterService,
+            transformsConfigManager,
+            transformsCheckpointService
+        );
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportPutTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportPutTransformActionDeprecated.java
@@ -16,9 +16,8 @@ import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.transform.action.compat.PutTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.action.TransportPutTransformAction;
-import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
-import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 
 public class TransportPutTransformActionDeprecated extends TransportPutTransformAction {
 
@@ -31,9 +30,8 @@ public class TransportPutTransformActionDeprecated extends TransportPutTransform
         IndexNameExpressionResolver indexNameExpressionResolver,
         ClusterService clusterService,
         XPackLicenseState licenseState,
-        TransformConfigManager transformConfigManager,
-        Client client,
-        TransformAuditor auditor
+        TransformServices transformServices,
+        Client client
     ) {
         super(
             PutTransformActionDeprecated.NAME,
@@ -44,9 +42,8 @@ public class TransportPutTransformActionDeprecated extends TransportPutTransform
             indexNameExpressionResolver,
             clusterService,
             licenseState,
-            transformConfigManager,
-            client,
-            auditor
+            transformServices,
+            client
         );
     }
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportPutTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportPutTransformActionDeprecated.java
@@ -23,13 +23,31 @@ import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 public class TransportPutTransformActionDeprecated extends TransportPutTransformAction {
 
     @Inject
-    public TransportPutTransformActionDeprecated(Settings settings, TransportService transportService, ThreadPool threadPool,
-                                                 ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
-                                                 ClusterService clusterService, XPackLicenseState licenseState,
-                                                 TransformConfigManager transformConfigManager, Client client,
-                                                 TransformAuditor auditor) {
-        super(PutTransformActionDeprecated.NAME, settings, transportService, threadPool, actionFilters, indexNameExpressionResolver,
-             clusterService, licenseState, transformConfigManager, client, auditor);
+    public TransportPutTransformActionDeprecated(
+        Settings settings,
+        TransportService transportService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        ClusterService clusterService,
+        XPackLicenseState licenseState,
+        TransformConfigManager transformConfigManager,
+        Client client,
+        TransformAuditor auditor
+    ) {
+        super(
+            PutTransformActionDeprecated.NAME,
+            settings,
+            transportService,
+            threadPool,
+            actionFilters,
+            indexNameExpressionResolver,
+            clusterService,
+            licenseState,
+            transformConfigManager,
+            client,
+            auditor
+        );
     }
 
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportStartTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportStartTransformActionDeprecated.java
@@ -23,13 +23,30 @@ import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 public class TransportStartTransformActionDeprecated extends TransportStartTransformAction {
 
     @Inject
-    public TransportStartTransformActionDeprecated(TransportService transportService, ActionFilters actionFilters,
-                                                   ClusterService clusterService, XPackLicenseState licenseState,
-                                                   ThreadPool threadPool, IndexNameExpressionResolver indexNameExpressionResolver,
-                                                   TransformConfigManager transformConfigManager,
-                                                   PersistentTasksService persistentTasksService, Client client,
-                                                   TransformAuditor auditor) {
-        super(StartTransformActionDeprecated.NAME, transportService, actionFilters, clusterService, licenseState, threadPool,
-              indexNameExpressionResolver, transformConfigManager, persistentTasksService, client, auditor);
+    public TransportStartTransformActionDeprecated(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ClusterService clusterService,
+        XPackLicenseState licenseState,
+        ThreadPool threadPool,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        TransformConfigManager transformConfigManager,
+        PersistentTasksService persistentTasksService,
+        Client client,
+        TransformAuditor auditor
+    ) {
+        super(
+            StartTransformActionDeprecated.NAME,
+            transportService,
+            actionFilters,
+            clusterService,
+            licenseState,
+            threadPool,
+            indexNameExpressionResolver,
+            transformConfigManager,
+            persistentTasksService,
+            client,
+            auditor
+        );
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportStartTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportStartTransformActionDeprecated.java
@@ -16,9 +16,8 @@ import org.elasticsearch.persistent.PersistentTasksService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.transform.action.compat.StartTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.action.TransportStartTransformAction;
-import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
-import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 
 public class TransportStartTransformActionDeprecated extends TransportStartTransformAction {
 
@@ -30,10 +29,9 @@ public class TransportStartTransformActionDeprecated extends TransportStartTrans
         XPackLicenseState licenseState,
         ThreadPool threadPool,
         IndexNameExpressionResolver indexNameExpressionResolver,
-        TransformConfigManager transformConfigManager,
+        TransformServices transformServices,
         PersistentTasksService persistentTasksService,
-        Client client,
-        TransformAuditor auditor
+        Client client
     ) {
         super(
             StartTransformActionDeprecated.NAME,
@@ -43,10 +41,9 @@ public class TransportStartTransformActionDeprecated extends TransportStartTrans
             licenseState,
             threadPool,
             indexNameExpressionResolver,
-            transformConfigManager,
+            transformServices,
             persistentTasksService,
-            client,
-            auditor
+            client
         );
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportStopTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportStopTransformActionDeprecated.java
@@ -14,8 +14,8 @@ import org.elasticsearch.persistent.PersistentTasksService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.transform.action.compat.StopTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.action.TransportStopTransformAction;
-import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 
 public class TransportStopTransformActionDeprecated extends TransportStopTransformAction {
 
@@ -26,7 +26,7 @@ public class TransportStopTransformActionDeprecated extends TransportStopTransfo
         ClusterService clusterService,
         ThreadPool threadPool,
         PersistentTasksService persistentTasksService,
-        TransformConfigManager transformConfigManager,
+        TransformServices transformServices,
         Client client
     ) {
         super(
@@ -36,7 +36,7 @@ public class TransportStopTransformActionDeprecated extends TransportStopTransfo
             clusterService,
             threadPool,
             persistentTasksService,
-            transformConfigManager,
+            transformServices,
             client
         );
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportStopTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportStopTransformActionDeprecated.java
@@ -20,13 +20,25 @@ import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 public class TransportStopTransformActionDeprecated extends TransportStopTransformAction {
 
     @Inject
-    public TransportStopTransformActionDeprecated(TransportService transportService, ActionFilters actionFilters,
-                                                  ClusterService clusterService, ThreadPool threadPool,
-                                                  PersistentTasksService persistentTasksService,
-                                                  TransformConfigManager transformConfigManager,
-                                                  Client client) {
-        super(StopTransformActionDeprecated.NAME, transportService, actionFilters, clusterService, threadPool, persistentTasksService,
-              transformConfigManager, client);
+    public TransportStopTransformActionDeprecated(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        PersistentTasksService persistentTasksService,
+        TransformConfigManager transformConfigManager,
+        Client client
+    ) {
+        super(
+            StopTransformActionDeprecated.NAME,
+            transportService,
+            actionFilters,
+            clusterService,
+            threadPool,
+            persistentTasksService,
+            transformConfigManager,
+            client
+        );
     }
 
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportUpdateTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportUpdateTransformActionDeprecated.java
@@ -16,9 +16,8 @@ import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.transform.action.compat.UpdateTransformActionDeprecated;
+import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.action.TransportUpdateTransformAction;
-import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
-import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 
 public class TransportUpdateTransformActionDeprecated extends TransportUpdateTransformAction {
 
@@ -31,9 +30,8 @@ public class TransportUpdateTransformActionDeprecated extends TransportUpdateTra
         IndexNameExpressionResolver indexNameExpressionResolver,
         ClusterService clusterService,
         XPackLicenseState licenseState,
-        TransformConfigManager transformConfigManager,
-        Client client,
-        TransformAuditor auditor
+        TransformServices transformServices,
+        Client client
     ) {
         super(
             UpdateTransformActionDeprecated.NAME,
@@ -44,9 +42,8 @@ public class TransportUpdateTransformActionDeprecated extends TransportUpdateTra
             indexNameExpressionResolver,
             clusterService,
             licenseState,
-            transformConfigManager,
-            client,
-            auditor
+            transformServices,
+            client
         );
     }
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportUpdateTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportUpdateTransformActionDeprecated.java
@@ -23,13 +23,31 @@ import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 public class TransportUpdateTransformActionDeprecated extends TransportUpdateTransformAction {
 
     @Inject
-    public TransportUpdateTransformActionDeprecated(Settings settings, TransportService transportService, ThreadPool threadPool,
-                                                    ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
-                                                    ClusterService clusterService, XPackLicenseState licenseState,
-                                                    TransformConfigManager transformConfigManager, Client client,
-                                                    TransformAuditor auditor) {
-        super(UpdateTransformActionDeprecated.NAME, settings, transportService, threadPool, actionFilters, indexNameExpressionResolver,
-              clusterService, licenseState, transformConfigManager, client, auditor);
+    public TransportUpdateTransformActionDeprecated(
+        Settings settings,
+        TransportService transportService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        ClusterService clusterService,
+        XPackLicenseState licenseState,
+        TransformConfigManager transformConfigManager,
+        Client client,
+        TransformAuditor auditor
+    ) {
+        super(
+            UpdateTransformActionDeprecated.NAME,
+            settings,
+            transportService,
+            threadPool,
+            actionFilters,
+            indexNameExpressionResolver,
+            clusterService,
+            licenseState,
+            transformConfigManager,
+            client,
+            auditor
+        );
     }
 
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProvider.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProvider.java
@@ -45,20 +45,16 @@ public class TimeBasedCheckpointProvider extends DefaultCheckpointProvider {
 
         final long timestamp = getTime();
 
-        SearchRequest searchRequest = new SearchRequest(transformConfig.getSource().getIndex())
-            .allowPartialSearchResults(false)
+        SearchRequest searchRequest = new SearchRequest(transformConfig.getSource().getIndex()).allowPartialSearchResults(false)
             .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
-            .size(0)
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().size(0)
             // we only want to know if there is at least 1 new document
             .trackTotalHitsUpTo(1);
 
         QueryBuilder queryBuilder = transformConfig.getSource().getQueryConfig().getQuery();
-        BoolQueryBuilder filteredQuery = new BoolQueryBuilder()
-            .filter(queryBuilder)
+        BoolQueryBuilder filteredQuery = new BoolQueryBuilder().filter(queryBuilder)
             .filter(
-                new RangeQueryBuilder(timeSyncConfig.getField())
-                    .gte(lastCheckpoint.getTimeUpperBound())
+                new RangeQueryBuilder(timeSyncConfig.getField()).gte(lastCheckpoint.getTimeUpperBound())
                     .lt(timestamp - timeSyncConfig.getDelay().millis())
                     .format("epoch_millis")
             );
@@ -68,15 +64,14 @@ public class TimeBasedCheckpointProvider extends DefaultCheckpointProvider {
 
         logger.trace("query for changes based on time: {}", sourceBuilder);
 
-        ClientHelper
-            .executeWithHeadersAsync(
-                transformConfig.getHeaders(),
-                ClientHelper.TRANSFORM_ORIGIN,
-                client,
-                SearchAction.INSTANCE,
-                searchRequest,
-                ActionListener.wrap(r -> { listener.onResponse(r.getHits().getTotalHits().value > 0L); }, listener::onFailure)
-            );
+        ClientHelper.executeWithHeadersAsync(
+            transformConfig.getHeaders(),
+            ClientHelper.TRANSFORM_ORIGIN,
+            client,
+            SearchAction.INSTANCE,
+            searchRequest,
+            ActionListener.wrap(r -> { listener.onResponse(r.getHits().getTotalHits().value > 0L); }, listener::onFailure)
+        );
     }
 
     @Override
@@ -88,16 +83,14 @@ public class TimeBasedCheckpointProvider extends DefaultCheckpointProvider {
         long timeUpperBound = timestamp - timeSyncConfig.getDelay().millis();
 
         getIndexCheckpoints(
-            ActionListener
-                .wrap(
-                    checkpointsByIndex -> {
-                        listener
-                            .onResponse(
-                                new TransformCheckpoint(transformConfig.getId(), timestamp, checkpoint, checkpointsByIndex, timeUpperBound)
-                            );
-                    },
-                    listener::onFailure
-                )
+            ActionListener.wrap(
+                checkpointsByIndex -> {
+                    listener.onResponse(
+                        new TransformCheckpoint(transformConfig.getId(), timestamp, checkpoint, checkpointsByIndex, timeUpperBound)
+                    );
+                },
+                listener::onFailure
+            )
         );
     }
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/IndexBasedTransformConfigManager.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/IndexBasedTransformConfigManager.java
@@ -1,0 +1,674 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.transform.persistence;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.ResourceAlreadyExistsException;
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.index.IndexAction;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchAction;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.engine.VersionConflictEngineException;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.reindex.BulkByScrollResponse;
+import org.elasticsearch.index.reindex.DeleteByQueryAction;
+import org.elasticsearch.index.reindex.DeleteByQueryRequest;
+import org.elasticsearch.index.reindex.ScrollableHitSource;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.sort.SortOrder;
+import org.elasticsearch.xpack.core.action.util.ExpandedIdsMatcher;
+import org.elasticsearch.xpack.core.action.util.PageParams;
+import org.elasticsearch.xpack.core.transform.TransformField;
+import org.elasticsearch.xpack.core.transform.TransformMessages;
+import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
+import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
+import org.elasticsearch.xpack.core.transform.transforms.TransformStoredDoc;
+import org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.elasticsearch.xpack.core.ClientHelper.TRANSFORM_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+
+/**
+ * Place of all interactions with the internal transforms index. For configuration and mappings see @link{TransformInternalIndex}
+ *
+ * Versioned Index:
+ *
+ * We wrap several indexes under 1 pattern: ".transform-internal-001", ".transform-internal-002", ".transform-internal-n" while
+ * n is the _current_ version of the index. For BWC we also search in ".data-frame-internal-1", ".data-frame-internal-2"
+ *
+ * - all gets/reads and dbq as well are searches on all indexes, while last-one-wins, so the result with the highest version is uses
+ * - all puts and updates go into the _current_ version of the index, in case of updates this can leave dups behind
+ *
+ * Duplicate handling / old version cleanup
+ *
+ * As we always write to the new index, updates of older documents leave a dup in the previous versioned index behind. However,
+ * documents are tiny, so the impact is rather small.
+ *
+ * Nevertheless cleanup would be good, eventually we need to move old documents into new indexes after major upgrades.
+ *
+ * TODO: Provide a method that moves old docs into the current index and delete old indexes and templates
+ */
+public class IndexBasedTransformConfigManager implements TransformConfigManager {
+
+    private static final Logger logger = LogManager.getLogger(IndexBasedTransformConfigManager.class);
+
+    private final Client client;
+    private final NamedXContentRegistry xContentRegistry;
+
+    public IndexBasedTransformConfigManager(Client client, NamedXContentRegistry xContentRegistry) {
+        this.client = client;
+        this.xContentRegistry = xContentRegistry;
+    }
+
+    @Override
+    public void putTransformCheckpoint(TransformCheckpoint checkpoint, ActionListener<Boolean> listener) {
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            XContentBuilder source = checkpoint.toXContent(builder, new ToXContent.MapParams(TO_XCONTENT_PARAMS));
+
+            IndexRequest indexRequest = new IndexRequest(TransformInternalIndexConstants.LATEST_INDEX_NAME).opType(
+                DocWriteRequest.OpType.INDEX
+            )
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                .id(TransformCheckpoint.documentId(checkpoint.getTransformId(), checkpoint.getCheckpoint()))
+                .source(source);
+
+            executeAsyncWithOrigin(
+                client,
+                TRANSFORM_ORIGIN,
+                IndexAction.INSTANCE,
+                indexRequest,
+                ActionListener.wrap(r -> { listener.onResponse(true); }, listener::onFailure)
+            );
+        } catch (IOException e) {
+            // not expected to happen but for the sake of completeness
+            listener.onFailure(e);
+        }
+    }
+
+    @Override
+    public void putTransformConfiguration(TransformConfig transformConfig, ActionListener<Boolean> listener) {
+        putTransformConfiguration(transformConfig, DocWriteRequest.OpType.CREATE, null, listener);
+    }
+
+    @Override
+    public void updateTransformConfiguration(
+        TransformConfig transformConfig,
+        SeqNoPrimaryTermAndIndex seqNoPrimaryTermAndIndex,
+        ActionListener<Boolean> listener
+    ) {
+        if (seqNoPrimaryTermAndIndex.getIndex().equals(TransformInternalIndexConstants.LATEST_INDEX_NAME)) {
+            // update the config in the same, current index using optimistic concurrency control
+            putTransformConfiguration(transformConfig, DocWriteRequest.OpType.INDEX, seqNoPrimaryTermAndIndex, listener);
+        } else {
+            // create the config in the current version of the index assuming there is no existing one
+            // this leaves a dup behind in the old index, see dup handling on the top
+            putTransformConfiguration(transformConfig, DocWriteRequest.OpType.CREATE, null, listener);
+        }
+    }
+
+    @Override
+    public void deleteOldTransformConfigurations(String transformId, ActionListener<Boolean> listener) {
+        DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(
+            TransformInternalIndexConstants.INDEX_NAME_PATTERN,
+            TransformInternalIndexConstants.INDEX_NAME_PATTERN_DEPRECATED
+        ).setQuery(
+            QueryBuilders.constantScoreQuery(
+                QueryBuilders.boolQuery()
+                    .mustNot(QueryBuilders.termQuery("_index", TransformInternalIndexConstants.LATEST_INDEX_NAME))
+                    .filter(QueryBuilders.termQuery("_id", TransformConfig.documentId(transformId)))
+            )
+        ).setIndicesOptions(IndicesOptions.lenientExpandOpen());
+
+        executeAsyncWithOrigin(
+            client,
+            TRANSFORM_ORIGIN,
+            DeleteByQueryAction.INSTANCE,
+            deleteByQueryRequest,
+            ActionListener.wrap(response -> {
+                if ((response.getBulkFailures().isEmpty() && response.getSearchFailures().isEmpty()) == false) {
+                    Tuple<RestStatus, Throwable> statusAndReason = getStatusAndReason(response);
+                    listener.onFailure(
+                        new ElasticsearchStatusException(statusAndReason.v2().getMessage(), statusAndReason.v1(), statusAndReason.v2())
+                    );
+                    return;
+                }
+                listener.onResponse(true);
+            }, listener::onFailure)
+        );
+    }
+
+    @Override
+    public void deleteOldTransformStoredDocuments(String transformId, ActionListener<Boolean> listener) {
+        DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(
+            TransformInternalIndexConstants.INDEX_NAME_PATTERN,
+            TransformInternalIndexConstants.INDEX_NAME_PATTERN_DEPRECATED
+        ).setQuery(
+            QueryBuilders.constantScoreQuery(
+                QueryBuilders.boolQuery()
+                    .mustNot(QueryBuilders.termQuery("_index", TransformInternalIndexConstants.LATEST_INDEX_NAME))
+                    .filter(QueryBuilders.termQuery("_id", TransformStoredDoc.documentId(transformId)))
+            )
+        ).setIndicesOptions(IndicesOptions.lenientExpandOpen());
+
+        executeAsyncWithOrigin(
+            client,
+            TRANSFORM_ORIGIN,
+            DeleteByQueryAction.INSTANCE,
+            deleteByQueryRequest,
+            ActionListener.wrap(response -> {
+                if ((response.getBulkFailures().isEmpty() && response.getSearchFailures().isEmpty()) == false) {
+                    Tuple<RestStatus, Throwable> statusAndReason = getStatusAndReason(response);
+                    listener.onFailure(
+                        new ElasticsearchStatusException(statusAndReason.v2().getMessage(), statusAndReason.v1(), statusAndReason.v2())
+                    );
+                    return;
+                }
+                listener.onResponse(true);
+            }, listener::onFailure)
+        );
+    }
+
+    private void putTransformConfiguration(
+        TransformConfig transformConfig,
+        DocWriteRequest.OpType optType,
+        SeqNoPrimaryTermAndIndex seqNoPrimaryTermAndIndex,
+        ActionListener<Boolean> listener
+    ) {
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            XContentBuilder source = transformConfig.toXContent(builder, new ToXContent.MapParams(TO_XCONTENT_PARAMS));
+
+            IndexRequest indexRequest = new IndexRequest(TransformInternalIndexConstants.LATEST_INDEX_NAME).opType(optType)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                .id(TransformConfig.documentId(transformConfig.getId()))
+                .source(source);
+            if (seqNoPrimaryTermAndIndex != null) {
+                indexRequest.setIfSeqNo(seqNoPrimaryTermAndIndex.getSeqNo()).setIfPrimaryTerm(seqNoPrimaryTermAndIndex.getPrimaryTerm());
+            }
+            executeAsyncWithOrigin(
+                client,
+                TRANSFORM_ORIGIN,
+                IndexAction.INSTANCE,
+                indexRequest,
+                ActionListener.wrap(r -> { listener.onResponse(true); }, e -> {
+                    if (e instanceof VersionConflictEngineException) {
+                        // the transform already exists
+                        listener.onFailure(
+                            new ResourceAlreadyExistsException(
+                                TransformMessages.getMessage(TransformMessages.REST_PUT_TRANSFORM_EXISTS, transformConfig.getId())
+                            )
+                        );
+                    } else {
+                        listener.onFailure(new RuntimeException(TransformMessages.REST_PUT_FAILED_PERSIST_TRANSFORM_CONFIGURATION, e));
+                    }
+                })
+            );
+        } catch (IOException e) {
+            // not expected to happen but for the sake of completeness
+            listener.onFailure(
+                new ElasticsearchParseException(
+                    TransformMessages.getMessage(TransformMessages.REST_FAILED_TO_SERIALIZE_TRANSFORM, transformConfig.getId()),
+                    e
+                )
+            );
+        }
+    }
+
+    @Override
+    public void getTransformCheckpoint(String transformId, long checkpoint, ActionListener<TransformCheckpoint> resultListener) {
+        QueryBuilder queryBuilder = QueryBuilders.termQuery("_id", TransformCheckpoint.documentId(transformId, checkpoint));
+        SearchRequest searchRequest = client.prepareSearch(
+            TransformInternalIndexConstants.INDEX_NAME_PATTERN,
+            TransformInternalIndexConstants.INDEX_NAME_PATTERN_DEPRECATED
+        )
+            .setQuery(queryBuilder)
+            // use sort to get the last
+            .addSort("_index", SortOrder.DESC)
+            .setSize(1)
+            .request();
+
+        executeAsyncWithOrigin(
+            client,
+            TRANSFORM_ORIGIN,
+            SearchAction.INSTANCE,
+            searchRequest,
+            ActionListener.<SearchResponse>wrap(searchResponse -> {
+                if (searchResponse.getHits().getHits().length == 0) {
+                    // do not fail if checkpoint does not exist but return an empty checkpoint
+                    logger.trace("found no checkpoint for transform [" + transformId + "], returning empty checkpoint");
+                    resultListener.onResponse(TransformCheckpoint.EMPTY);
+                    return;
+                }
+                BytesReference source = searchResponse.getHits().getHits()[0].getSourceRef();
+                parseCheckpointsLenientlyFromSource(source, transformId, resultListener);
+            }, resultListener::onFailure)
+        );
+    }
+
+    @Override
+    public void getTransformConfiguration(String transformId, ActionListener<TransformConfig> resultListener) {
+        QueryBuilder queryBuilder = QueryBuilders.termQuery("_id", TransformConfig.documentId(transformId));
+        SearchRequest searchRequest = client.prepareSearch(
+            TransformInternalIndexConstants.INDEX_NAME_PATTERN,
+            TransformInternalIndexConstants.INDEX_NAME_PATTERN_DEPRECATED
+        )
+            .setQuery(queryBuilder)
+            // use sort to get the last
+            .addSort("_index", SortOrder.DESC)
+            .setSize(1)
+            .request();
+
+        executeAsyncWithOrigin(
+            client,
+            TRANSFORM_ORIGIN,
+            SearchAction.INSTANCE,
+            searchRequest,
+            ActionListener.<SearchResponse>wrap(searchResponse -> {
+                if (searchResponse.getHits().getHits().length == 0) {
+                    resultListener.onFailure(
+                        new ResourceNotFoundException(TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, transformId))
+                    );
+                    return;
+                }
+                BytesReference source = searchResponse.getHits().getHits()[0].getSourceRef();
+                parseTransformLenientlyFromSource(source, transformId, resultListener);
+            }, resultListener::onFailure)
+        );
+    }
+
+    @Override
+    public void getTransformConfigurationForUpdate(
+        String transformId,
+        ActionListener<Tuple<TransformConfig, SeqNoPrimaryTermAndIndex>> configAndVersionListener
+    ) {
+        QueryBuilder queryBuilder = QueryBuilders.termQuery("_id", TransformConfig.documentId(transformId));
+        SearchRequest searchRequest = client.prepareSearch(
+            TransformInternalIndexConstants.INDEX_NAME_PATTERN,
+            TransformInternalIndexConstants.INDEX_NAME_PATTERN_DEPRECATED
+        )
+            .setQuery(queryBuilder)
+            // use sort to get the last
+            .addSort("_index", SortOrder.DESC)
+            .setSize(1)
+            .seqNoAndPrimaryTerm(true)
+            .request();
+
+        executeAsyncWithOrigin(client, TRANSFORM_ORIGIN, SearchAction.INSTANCE, searchRequest, ActionListener.wrap(searchResponse -> {
+            if (searchResponse.getHits().getHits().length == 0) {
+                configAndVersionListener.onFailure(
+                    new ResourceNotFoundException(TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, transformId))
+                );
+                return;
+            }
+            SearchHit hit = searchResponse.getHits().getHits()[0];
+            BytesReference source = hit.getSourceRef();
+            parseTransformLenientlyFromSource(
+                source,
+                transformId,
+                ActionListener.wrap(
+                    config -> configAndVersionListener.onResponse(
+                        Tuple.tuple(config, new SeqNoPrimaryTermAndIndex(hit.getSeqNo(), hit.getPrimaryTerm(), hit.getIndex()))
+                    ),
+                    configAndVersionListener::onFailure
+                )
+            );
+        }, configAndVersionListener::onFailure));
+    }
+
+    @Override
+    public void expandTransformIds(
+        String transformIdsExpression,
+        PageParams pageParams,
+        boolean allowNoMatch,
+        ActionListener<Tuple<Long, List<String>>> foundIdsListener
+    ) {
+        String[] idTokens = ExpandedIdsMatcher.tokenizeExpression(transformIdsExpression);
+        QueryBuilder queryBuilder = buildQueryFromTokenizedIds(idTokens, TransformConfig.NAME);
+
+        SearchRequest request = client.prepareSearch(
+            TransformInternalIndexConstants.INDEX_NAME_PATTERN,
+            TransformInternalIndexConstants.INDEX_NAME_PATTERN_DEPRECATED
+        )
+            .addSort(TransformField.ID.getPreferredName(), SortOrder.ASC)
+            .setFrom(pageParams.getFrom())
+            .setTrackTotalHits(true)
+            .setSize(pageParams.getSize())
+            .setQuery(queryBuilder)
+            // We only care about the `id` field, small optimization
+            .setFetchSource(TransformField.ID.getPreferredName(), "")
+            .request();
+
+        final ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(idTokens, allowNoMatch);
+
+        executeAsyncWithOrigin(
+            client.threadPool().getThreadContext(),
+            TRANSFORM_ORIGIN,
+            request,
+            ActionListener.<SearchResponse>wrap(searchResponse -> {
+                long totalHits = searchResponse.getHits().getTotalHits().value;
+                // important: preserve order
+                Set<String> ids = new LinkedHashSet<>(searchResponse.getHits().getHits().length);
+                for (SearchHit hit : searchResponse.getHits().getHits()) {
+                    BytesReference source = hit.getSourceRef();
+                    try (
+                        InputStream stream = source.streamInput();
+                        XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+                            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, stream)
+                    ) {
+                        ids.add((String) parser.map().get(TransformField.ID.getPreferredName()));
+                    } catch (IOException e) {
+                        foundIdsListener.onFailure(new ElasticsearchParseException("failed to parse search hit for ids", e));
+                        return;
+                    }
+                }
+                requiredMatches.filterMatchedIds(ids);
+                if (requiredMatches.hasUnmatchedIds()) {
+                    // some required Ids were not found
+                    foundIdsListener.onFailure(
+                        new ResourceNotFoundException(
+                            TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, requiredMatches.unmatchedIdsString())
+                        )
+                    );
+                    return;
+                }
+                foundIdsListener.onResponse(new Tuple<>(totalHits, new ArrayList<>(ids)));
+            }, foundIdsListener::onFailure),
+            client::search
+        );
+    }
+
+    @Override
+    public void deleteTransform(String transformId, ActionListener<Boolean> listener) {
+        DeleteByQueryRequest request = new DeleteByQueryRequest().setAbortOnVersionConflict(false); // since these documents are not
+                                                                                                    // updated, a conflict just means it was
+                                                                                                    // deleted previously
+
+        request.indices(TransformInternalIndexConstants.INDEX_NAME_PATTERN, TransformInternalIndexConstants.INDEX_NAME_PATTERN_DEPRECATED);
+        QueryBuilder query = QueryBuilders.termQuery(TransformField.ID.getPreferredName(), transformId);
+        request.setQuery(query);
+        request.setRefresh(true);
+
+        executeAsyncWithOrigin(client, TRANSFORM_ORIGIN, DeleteByQueryAction.INSTANCE, request, ActionListener.wrap(deleteResponse -> {
+            if (deleteResponse.getDeleted() == 0) {
+                listener.onFailure(
+                    new ResourceNotFoundException(TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, transformId))
+                );
+                return;
+            }
+            listener.onResponse(true);
+        }, e -> {
+            if (e.getClass() == IndexNotFoundException.class) {
+                listener.onFailure(
+                    new ResourceNotFoundException(TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, transformId))
+                );
+            } else {
+                listener.onFailure(e);
+            }
+        }));
+    }
+
+    @Override
+    public void putOrUpdateTransformStoredDoc(
+        TransformStoredDoc storedDoc,
+        SeqNoPrimaryTermAndIndex seqNoPrimaryTermAndIndex,
+        ActionListener<SeqNoPrimaryTermAndIndex> listener
+    ) {
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            XContentBuilder source = storedDoc.toXContent(builder, new ToXContent.MapParams(TO_XCONTENT_PARAMS));
+
+            IndexRequest indexRequest = new IndexRequest(TransformInternalIndexConstants.LATEST_INDEX_NAME).setRefreshPolicy(
+                WriteRequest.RefreshPolicy.IMMEDIATE
+            ).id(TransformStoredDoc.documentId(storedDoc.getId())).source(source);
+            if (seqNoPrimaryTermAndIndex != null
+                && seqNoPrimaryTermAndIndex.getIndex().equals(TransformInternalIndexConstants.LATEST_INDEX_NAME)) {
+                indexRequest.opType(DocWriteRequest.OpType.INDEX)
+                    .setIfSeqNo(seqNoPrimaryTermAndIndex.getSeqNo())
+                    .setIfPrimaryTerm(seqNoPrimaryTermAndIndex.getPrimaryTerm());
+            } else {
+                // If the index is NOT the latest or we are null, that means we have not created this doc before
+                // so, it should be a create option without the seqNo and primaryTerm set
+                indexRequest.opType(DocWriteRequest.OpType.CREATE);
+            }
+            executeAsyncWithOrigin(
+                client,
+                TRANSFORM_ORIGIN,
+                IndexAction.INSTANCE,
+                indexRequest,
+                ActionListener.wrap(
+                    r -> listener.onResponse(SeqNoPrimaryTermAndIndex.fromIndexResponse(r)),
+                    e -> listener.onFailure(
+                        new RuntimeException(
+                            TransformMessages.getMessage(TransformMessages.TRANSFORM_FAILED_TO_PERSIST_STATS, storedDoc.getId()),
+                            e
+                        )
+                    )
+                )
+            );
+        } catch (IOException e) {
+            // not expected to happen but for the sake of completeness
+            listener.onFailure(
+                new ElasticsearchParseException(
+                    TransformMessages.getMessage(TransformMessages.TRANSFORM_FAILED_TO_PERSIST_STATS, storedDoc.getId()),
+                    e
+                )
+            );
+        }
+    }
+
+    @Override
+    public void getTransformStoredDoc(
+        String transformId,
+        ActionListener<Tuple<TransformStoredDoc, SeqNoPrimaryTermAndIndex>> resultListener
+    ) {
+        QueryBuilder queryBuilder = QueryBuilders.termQuery("_id", TransformStoredDoc.documentId(transformId));
+        SearchRequest searchRequest = client.prepareSearch(
+            TransformInternalIndexConstants.INDEX_NAME_PATTERN,
+            TransformInternalIndexConstants.INDEX_NAME_PATTERN_DEPRECATED
+        )
+            .setQuery(queryBuilder)
+            // use sort to get the last
+            .addSort("_index", SortOrder.DESC)
+            .setSize(1)
+            .seqNoAndPrimaryTerm(true)
+            .request();
+
+        executeAsyncWithOrigin(
+            client,
+            TRANSFORM_ORIGIN,
+            SearchAction.INSTANCE,
+            searchRequest,
+            ActionListener.<SearchResponse>wrap(searchResponse -> {
+                if (searchResponse.getHits().getHits().length == 0) {
+                    resultListener.onFailure(
+                        new ResourceNotFoundException(TransformMessages.getMessage(TransformMessages.UNKNOWN_TRANSFORM_STATS, transformId))
+                    );
+                    return;
+                }
+                SearchHit searchHit = searchResponse.getHits().getHits()[0];
+                BytesReference source = searchHit.getSourceRef();
+                try (
+                    InputStream stream = source.streamInput();
+                    XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+                        .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, stream)
+                ) {
+                    resultListener.onResponse(
+                        Tuple.tuple(TransformStoredDoc.fromXContent(parser), SeqNoPrimaryTermAndIndex.fromSearchHit(searchHit))
+                    );
+                } catch (Exception e) {
+                    logger.error(
+                        TransformMessages.getMessage(TransformMessages.FAILED_TO_PARSE_TRANSFORM_STATISTICS_CONFIGURATION, transformId),
+                        e
+                    );
+                    resultListener.onFailure(e);
+                }
+            }, resultListener::onFailure)
+        );
+    }
+
+    @Override
+    public void getTransformStoredDocs(Collection<String> transformIds, ActionListener<List<TransformStoredDoc>> listener) {
+        QueryBuilder builder = QueryBuilders.constantScoreQuery(
+            QueryBuilders.boolQuery()
+                .filter(QueryBuilders.termsQuery(TransformField.ID.getPreferredName(), transformIds))
+                .filter(QueryBuilders.termQuery(TransformField.INDEX_DOC_TYPE.getPreferredName(), TransformStoredDoc.NAME))
+        );
+
+        SearchRequest searchRequest = client.prepareSearch(
+            TransformInternalIndexConstants.INDEX_NAME_PATTERN,
+            TransformInternalIndexConstants.INDEX_NAME_PATTERN_DEPRECATED
+        )
+            .addSort(TransformField.ID.getPreferredName(), SortOrder.ASC)
+            .addSort("_index", SortOrder.DESC)
+            .setQuery(builder)
+            // the limit for getting stats and transforms is 1000, as long as we do not have 10 indices this works
+            .setSize(Math.min(transformIds.size(), 10_000))
+            .request();
+
+        executeAsyncWithOrigin(
+            client.threadPool().getThreadContext(),
+            TRANSFORM_ORIGIN,
+            searchRequest,
+            ActionListener.<SearchResponse>wrap(searchResponse -> {
+                List<TransformStoredDoc> stats = new ArrayList<>();
+                String previousId = null;
+                for (SearchHit hit : searchResponse.getHits().getHits()) {
+                    // skip old versions
+                    if (hit.getId().equals(previousId) == false) {
+                        previousId = hit.getId();
+                        BytesReference source = hit.getSourceRef();
+                        try (
+                            InputStream stream = source.streamInput();
+                            XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+                                .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, stream)
+                        ) {
+                            stats.add(TransformStoredDoc.fromXContent(parser));
+                        } catch (IOException e) {
+                            listener.onFailure(new ElasticsearchParseException("failed to parse transform stats from search hit", e));
+                            return;
+                        }
+                    }
+                }
+
+                listener.onResponse(stats);
+            }, listener::onFailure),
+            client::search
+        );
+    }
+
+    private void parseTransformLenientlyFromSource(
+        BytesReference source,
+        String transformId,
+        ActionListener<TransformConfig> transformListener
+    ) {
+        try (
+            InputStream stream = source.streamInput();
+            XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+                .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, stream)
+        ) {
+            transformListener.onResponse(TransformConfig.fromXContent(parser, transformId, true));
+        } catch (Exception e) {
+            logger.error(TransformMessages.getMessage(TransformMessages.FAILED_TO_PARSE_TRANSFORM_CONFIGURATION, transformId), e);
+            transformListener.onFailure(e);
+        }
+    }
+
+    private void parseCheckpointsLenientlyFromSource(
+        BytesReference source,
+        String transformId,
+        ActionListener<TransformCheckpoint> transformListener
+    ) {
+        try (
+            InputStream stream = source.streamInput();
+            XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+                .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, stream)
+        ) {
+            transformListener.onResponse(TransformCheckpoint.fromXContent(parser, true));
+        } catch (Exception e) {
+            logger.error(TransformMessages.getMessage(TransformMessages.FAILED_TO_PARSE_TRANSFORM_CHECKPOINTS, transformId), e);
+            transformListener.onFailure(e);
+        }
+    }
+
+    private QueryBuilder buildQueryFromTokenizedIds(String[] idTokens, String resourceName) {
+        BoolQueryBuilder queryBuilder = QueryBuilders.boolQuery()
+            .filter(QueryBuilders.termQuery(TransformField.INDEX_DOC_TYPE.getPreferredName(), resourceName));
+        if (Strings.isAllOrWildcard(idTokens) == false) {
+            List<String> terms = new ArrayList<>();
+            BoolQueryBuilder shouldQueries = new BoolQueryBuilder();
+            for (String token : idTokens) {
+                if (Regex.isSimpleMatchPattern(token)) {
+                    shouldQueries.should(QueryBuilders.wildcardQuery(TransformField.ID.getPreferredName(), token));
+                } else {
+                    terms.add(token);
+                }
+            }
+            if (terms.isEmpty() == false) {
+                shouldQueries.should(QueryBuilders.termsQuery(TransformField.ID.getPreferredName(), terms));
+            }
+
+            if (shouldQueries.should().isEmpty() == false) {
+                queryBuilder.filter(shouldQueries);
+            }
+        }
+        return QueryBuilders.constantScoreQuery(queryBuilder);
+    }
+
+    private static Tuple<RestStatus, Throwable> getStatusAndReason(final BulkByScrollResponse response) {
+        RestStatus status = RestStatus.OK;
+        Throwable reason = new Exception("Unknown error");
+        // Getting the max RestStatus is sort of arbitrary, would the user care about 5xx over 4xx?
+        // Unsure of a better way to return an appropriate and possibly actionable cause to the user.
+        for (BulkItemResponse.Failure failure : response.getBulkFailures()) {
+            if (failure.getStatus().getStatus() > status.getStatus()) {
+                status = failure.getStatus();
+                reason = failure.getCause();
+            }
+        }
+
+        for (ScrollableHitSource.SearchFailure failure : response.getSearchFailures()) {
+            RestStatus failureStatus = org.elasticsearch.ExceptionsHelper.status(failure.getReason());
+            if (failureStatus.getStatus() > status.getStatus()) {
+                status = failureStatus;
+                reason = failure.getReason();
+            }
+        }
+        return new Tuple<>(status, reason);
+    }
+}

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformConfigManager.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformConfigManager.java
@@ -6,101 +6,22 @@
 
 package org.elasticsearch.xpack.transform.persistence;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.ElasticsearchStatusException;
-import org.elasticsearch.ResourceAlreadyExistsException;
-import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.DocWriteRequest;
-import org.elasticsearch.action.bulk.BulkItemResponse;
-import org.elasticsearch.action.index.IndexAction;
-import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.search.SearchAction;
-import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.WriteRequest;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
-import org.elasticsearch.common.regex.Regex;
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.index.IndexNotFoundException;
-import org.elasticsearch.index.engine.VersionConflictEngineException;
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.index.reindex.BulkByScrollResponse;
-import org.elasticsearch.index.reindex.DeleteByQueryAction;
-import org.elasticsearch.index.reindex.DeleteByQueryRequest;
-import org.elasticsearch.index.reindex.ScrollableHitSource;
-import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.search.sort.SortOrder;
-import org.elasticsearch.xpack.core.action.util.ExpandedIdsMatcher;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.transform.TransformField;
-import org.elasticsearch.xpack.core.transform.TransformMessages;
 import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformStoredDoc;
-import org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
-import static org.elasticsearch.xpack.core.ClientHelper.TRANSFORM_ORIGIN;
-import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+public interface TransformConfigManager {
 
-/**
- * Place of all interactions with the internal transforms index. For configuration and mappings see @link{TransformInternalIndex}
- *
- * Versioned Index:
- *
- * We wrap several indexes under 1 pattern: ".transform-internal-001", ".transform-internal-002", ".transform-internal-n" while
- * n is the _current_ version of the index. For BWC we also search in ".data-frame-internal-1", ".data-frame-internal-2"
- *
- * - all gets/reads and dbq as well are searches on all indexes, while last-one-wins, so the result with the highest version is uses
- * - all puts and updates go into the _current_ version of the index, in case of updates this can leave dups behind
- *
- * Duplicate handling / old version cleanup
- *
- * As we always write to the new index, updates of older documents leave a dup in the previous versioned index behind. However,
- * documents are tiny, so the impact is rather small.
- *
- * Nevertheless cleanup would be good, eventually we need to move old documents into new indexes after major upgrades.
- *
- * TODO: Provide a method that moves old docs into the current index and delete old indexes and templates
- */
-public class TransformConfigManager {
-
-    private static final Logger logger = LogManager.getLogger(TransformConfigManager.class);
-
-    public static final Map<String, String> TO_XCONTENT_PARAMS = Collections.singletonMap(TransformField.FOR_INTERNAL_STORAGE, "true");
-
-    private final Client client;
-    private final NamedXContentRegistry xContentRegistry;
-
-    public TransformConfigManager(Client client, NamedXContentRegistry xContentRegistry) {
-        this.client = client;
-        this.xContentRegistry = xContentRegistry;
-    }
+    Map<String, String> TO_XCONTENT_PARAMS = Collections.singletonMap(TransformField.FOR_INTERNAL_STORAGE, "true");
 
     /**
      * Persist a checkpoint in the internal index
@@ -108,24 +29,7 @@ public class TransformConfigManager {
      * @param checkpoint the @link{TransformCheckpoint}
      * @param listener listener to call after request has been made
      */
-    public void putTransformCheckpoint(TransformCheckpoint checkpoint, ActionListener<Boolean> listener) {
-        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
-            XContentBuilder source = checkpoint.toXContent(builder, new ToXContent.MapParams(TO_XCONTENT_PARAMS));
-
-            IndexRequest indexRequest = new IndexRequest(TransformInternalIndexConstants.LATEST_INDEX_NAME)
-                    .opType(DocWriteRequest.OpType.INDEX)
-                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                    .id(TransformCheckpoint.documentId(checkpoint.getTransformId(), checkpoint.getCheckpoint()))
-                    .source(source);
-
-            executeAsyncWithOrigin(client, TRANSFORM_ORIGIN, IndexAction.INSTANCE, indexRequest, ActionListener.wrap(r -> {
-                listener.onResponse(true);
-            }, listener::onFailure));
-        } catch (IOException e) {
-            // not expected to happen but for the sake of completeness
-            listener.onFailure(e);
-        }
-    }
+    void putTransformCheckpoint(TransformCheckpoint checkpoint, ActionListener<Boolean> listener);
 
     /**
      * Store the transform configuration in the internal index
@@ -133,14 +37,12 @@ public class TransformConfigManager {
      * @param transformConfig the @link{TransformConfig}
      * @param listener listener to call after request
      */
-    public void putTransformConfiguration(TransformConfig transformConfig, ActionListener<Boolean> listener) {
-        putTransformConfiguration(transformConfig, DocWriteRequest.OpType.CREATE, null, listener);
-    }
+    void putTransformConfiguration(TransformConfig transformConfig, ActionListener<Boolean> listener);
 
     /**
      * Update the transform configuration in the internal index.
      *
-     * Essentially the same as {@link TransformConfigManager#putTransformConfiguration(TransformConfig, ActionListener)}
+     * Essentially the same as {@link IndexBasedTransformConfigManager#putTransformConfiguration(TransformConfig, ActionListener)}
      * but is an index operation that will fail with a version conflict
      * if the current document seqNo and primaryTerm is not the same as the provided version.
      * @param transformConfig the @link{TransformConfig}
@@ -148,18 +50,11 @@ public class TransformConfigManager {
      *                             Used for optimistic concurrency control
      * @param listener listener to call after request
      */
-    public void updateTransformConfiguration(TransformConfig transformConfig,
-                                             SeqNoPrimaryTermAndIndex seqNoPrimaryTermAndIndex,
-                                             ActionListener<Boolean> listener) {
-        if (seqNoPrimaryTermAndIndex.getIndex().equals(TransformInternalIndexConstants.LATEST_INDEX_NAME)) {
-            // update the config in the same, current index using optimistic concurrency control
-            putTransformConfiguration(transformConfig, DocWriteRequest.OpType.INDEX, seqNoPrimaryTermAndIndex, listener);
-        } else {
-            // create the config in the current version of the index assuming there is no existing one
-            // this leaves a dup behind in the old index, see dup handling on the top
-            putTransformConfiguration(transformConfig, DocWriteRequest.OpType.CREATE, null, listener);
-        }
-    }
+    void updateTransformConfiguration(
+        TransformConfig transformConfig,
+        SeqNoPrimaryTermAndIndex seqNoPrimaryTermAndIndex,
+        ActionListener<Boolean> listener
+    );
 
     /**
      * This deletes configuration documents that match the given transformId that are contained in old index versions.
@@ -167,28 +62,7 @@ public class TransformConfigManager {
      * @param transformId The configuration ID potentially referencing configurations stored in the old indices
      * @param listener listener to alert on completion
      */
-    public void deleteOldTransformConfigurations(String transformId, ActionListener<Boolean> listener) {
-        DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(
-                TransformInternalIndexConstants.INDEX_NAME_PATTERN,
-                TransformInternalIndexConstants.INDEX_NAME_PATTERN_DEPRECATED)
-            .setQuery(QueryBuilders.constantScoreQuery(QueryBuilders.boolQuery()
-                .mustNot(QueryBuilders.termQuery("_index", TransformInternalIndexConstants.LATEST_INDEX_NAME))
-                .filter(QueryBuilders.termQuery("_id", TransformConfig.documentId(transformId)))))
-            .setIndicesOptions(IndicesOptions.lenientExpandOpen());
-
-        executeAsyncWithOrigin(client, TRANSFORM_ORIGIN, DeleteByQueryAction.INSTANCE, deleteByQueryRequest, ActionListener.wrap(
-            response -> {
-                if ((response.getBulkFailures().isEmpty() && response.getSearchFailures().isEmpty()) == false) {
-                    Tuple<RestStatus, Throwable> statusAndReason = getStatusAndReason(response);
-                    listener.onFailure(
-                        new ElasticsearchStatusException(statusAndReason.v2().getMessage(), statusAndReason.v1(), statusAndReason.v2()));
-                    return;
-                }
-                listener.onResponse(true);
-            },
-            listener::onFailure
-        ));
-    }
+    void deleteOldTransformConfigurations(String transformId, ActionListener<Boolean> listener);
 
     /**
      * This deletes stored state/stats documents for the given transformId that are contained in old index versions.
@@ -196,64 +70,7 @@ public class TransformConfigManager {
      * @param transformId The transform ID referenced by the documents
      * @param listener listener to alert on completion
      */
-    public void deleteOldTransformStoredDocuments(String transformId, ActionListener<Boolean> listener) {
-        DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(
-                TransformInternalIndexConstants.INDEX_NAME_PATTERN, TransformInternalIndexConstants.INDEX_NAME_PATTERN_DEPRECATED)
-            .setQuery(QueryBuilders.constantScoreQuery(QueryBuilders.boolQuery()
-                .mustNot(QueryBuilders.termQuery("_index", TransformInternalIndexConstants.LATEST_INDEX_NAME))
-                .filter(QueryBuilders.termQuery("_id", TransformStoredDoc.documentId(transformId)))))
-            .setIndicesOptions(IndicesOptions.lenientExpandOpen());
-
-        executeAsyncWithOrigin(client, TRANSFORM_ORIGIN, DeleteByQueryAction.INSTANCE, deleteByQueryRequest, ActionListener.wrap(
-            response -> {
-                if ((response.getBulkFailures().isEmpty() && response.getSearchFailures().isEmpty()) == false) {
-                    Tuple<RestStatus, Throwable> statusAndReason = getStatusAndReason(response);
-                    listener.onFailure(
-                        new ElasticsearchStatusException(statusAndReason.v2().getMessage(), statusAndReason.v1(), statusAndReason.v2()));
-                    return;
-                }
-                listener.onResponse(true);
-            },
-            listener::onFailure
-        ));
-    }
-
-    private void putTransformConfiguration(TransformConfig transformConfig,
-                                           DocWriteRequest.OpType optType,
-                                           SeqNoPrimaryTermAndIndex seqNoPrimaryTermAndIndex,
-                                           ActionListener<Boolean> listener) {
-        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
-            XContentBuilder source = transformConfig.toXContent(builder, new ToXContent.MapParams(TO_XCONTENT_PARAMS));
-
-            IndexRequest indexRequest = new IndexRequest(TransformInternalIndexConstants.LATEST_INDEX_NAME)
-                .opType(optType)
-                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                .id(TransformConfig.documentId(transformConfig.getId()))
-                .source(source);
-            if (seqNoPrimaryTermAndIndex != null) {
-                indexRequest.setIfSeqNo(seqNoPrimaryTermAndIndex.getSeqNo())
-                    .setIfPrimaryTerm(seqNoPrimaryTermAndIndex.getPrimaryTerm());
-            }
-            executeAsyncWithOrigin(client, TRANSFORM_ORIGIN, IndexAction.INSTANCE, indexRequest, ActionListener.wrap(r -> {
-                listener.onResponse(true);
-            }, e -> {
-                if (e instanceof VersionConflictEngineException) {
-                    // the transform already exists
-                    listener.onFailure(new ResourceAlreadyExistsException(
-                        TransformMessages.getMessage(TransformMessages.REST_PUT_TRANSFORM_EXISTS,
-                            transformConfig.getId())));
-                } else {
-                    listener.onFailure(
-                        new RuntimeException(TransformMessages.REST_PUT_FAILED_PERSIST_TRANSFORM_CONFIGURATION, e));
-                }
-            }));
-        } catch (IOException e) {
-            // not expected to happen but for the sake of completeness
-            listener.onFailure(new ElasticsearchParseException(
-                TransformMessages.getMessage(TransformMessages.REST_FAILED_TO_SERIALIZE_TRANSFORM, transformConfig.getId()),
-                e));
-        }
-    }
+    void deleteOldTransformStoredDocuments(String transformId, ActionListener<Boolean> listener);
 
     /**
      * Get a stored checkpoint, requires the transform id as well as the checkpoint id
@@ -262,29 +79,7 @@ public class TransformConfigManager {
      * @param checkpoint the checkpoint
      * @param resultListener listener to call after request has been made
      */
-    public void getTransformCheckpoint(String transformId, long checkpoint, ActionListener<TransformCheckpoint> resultListener) {
-        QueryBuilder queryBuilder = QueryBuilders.termQuery("_id", TransformCheckpoint.documentId(transformId, checkpoint));
-        SearchRequest searchRequest = client
-            .prepareSearch(TransformInternalIndexConstants.INDEX_NAME_PATTERN,
-                TransformInternalIndexConstants.INDEX_NAME_PATTERN_DEPRECATED)
-            .setQuery(queryBuilder)
-            // use sort to get the last
-            .addSort("_index", SortOrder.DESC)
-            .setSize(1)
-            .request();
-
-        executeAsyncWithOrigin(client, TRANSFORM_ORIGIN, SearchAction.INSTANCE, searchRequest, ActionListener.<SearchResponse>wrap(
-            searchResponse -> {
-                if (searchResponse.getHits().getHits().length == 0) {
-                    // do not fail if checkpoint does not exist but return an empty checkpoint
-                    logger.trace("found no checkpoint for transform [" + transformId + "], returning empty checkpoint");
-                    resultListener.onResponse(TransformCheckpoint.EMPTY);
-                    return;
-                }
-                BytesReference source = searchResponse.getHits().getHits()[0].getSourceRef();
-                parseCheckpointsLenientlyFromSource(source, transformId, resultListener);
-            }, resultListener::onFailure));
-    }
+    void getTransformCheckpoint(String transformId, long checkpoint, ActionListener<TransformCheckpoint> resultListener);
 
     /**
      * Get the transform configuration for a given transform id. This function is only for internal use. For transforms returned via GET
@@ -293,29 +88,7 @@ public class TransformConfigManager {
      * @param transformId the transform id
      * @param resultListener listener to call after inner request has returned
      */
-    public void getTransformConfiguration(String transformId, ActionListener<TransformConfig> resultListener) {
-        QueryBuilder queryBuilder = QueryBuilders.termQuery("_id", TransformConfig.documentId(transformId));
-        SearchRequest searchRequest = client
-            .prepareSearch(TransformInternalIndexConstants.INDEX_NAME_PATTERN,
-                TransformInternalIndexConstants.INDEX_NAME_PATTERN_DEPRECATED)
-            .setQuery(queryBuilder)
-            // use sort to get the last
-            .addSort("_index", SortOrder.DESC)
-            .setSize(1)
-            .request();
-
-        executeAsyncWithOrigin(client, TRANSFORM_ORIGIN, SearchAction.INSTANCE, searchRequest,
-            ActionListener.<SearchResponse>wrap(
-                searchResponse -> {
-                    if (searchResponse.getHits().getHits().length == 0) {
-                        resultListener.onFailure(new ResourceNotFoundException(
-                            TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, transformId)));
-                        return;
-                    }
-                    BytesReference source = searchResponse.getHits().getHits()[0].getSourceRef();
-                    parseTransformLenientlyFromSource(source, transformId, resultListener);
-                }, resultListener::onFailure));
-    }
+    void getTransformConfiguration(String transformId, ActionListener<TransformConfig> resultListener);
 
     /**
      * Get the transform configuration for a given transform id. This function is only for internal use. For transforms returned via GET
@@ -324,35 +97,10 @@ public class TransformConfigManager {
      * @param transformId the transform id
      * @param configAndVersionListener listener to call after inner request has returned
      */
-    public void getTransformConfigurationForUpdate(String transformId,
-                                                   ActionListener<Tuple<TransformConfig,
-                                                       SeqNoPrimaryTermAndIndex>> configAndVersionListener) {
-        QueryBuilder queryBuilder = QueryBuilders.termQuery("_id", TransformConfig.documentId(transformId));
-        SearchRequest searchRequest = client
-            .prepareSearch(TransformInternalIndexConstants.INDEX_NAME_PATTERN,
-                TransformInternalIndexConstants.INDEX_NAME_PATTERN_DEPRECATED)
-            .setQuery(queryBuilder)
-            // use sort to get the last
-            .addSort("_index", SortOrder.DESC)
-            .setSize(1)
-            .seqNoAndPrimaryTerm(true)
-            .request();
-
-        executeAsyncWithOrigin(client, TRANSFORM_ORIGIN, SearchAction.INSTANCE, searchRequest, ActionListener.wrap(
-            searchResponse -> {
-                if (searchResponse.getHits().getHits().length == 0) {
-                    configAndVersionListener.onFailure(new ResourceNotFoundException(
-                        TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, transformId)));
-                    return;
-                }
-                SearchHit hit = searchResponse.getHits().getHits()[0];
-                BytesReference source = hit.getSourceRef();
-                parseTransformLenientlyFromSource(source, transformId, ActionListener.wrap(
-                    config -> configAndVersionListener.onResponse(Tuple.tuple(config,
-                        new SeqNoPrimaryTermAndIndex(hit.getSeqNo(), hit.getPrimaryTerm(), hit.getIndex()))),
-                    configAndVersionListener::onFailure));
-            }, configAndVersionListener::onFailure));
-    }
+    void getTransformConfigurationForUpdate(
+        String transformId,
+        ActionListener<Tuple<TransformConfig, SeqNoPrimaryTermAndIndex>> configAndVersionListener
+    );
 
     /**
      * Given some expression comma delimited string of id expressions,
@@ -364,55 +112,12 @@ public class TransformConfigManager {
      * @param pageParams             The paging params
      * @param foundIdsListener       The listener on signal on success or failure
      */
-    public void expandTransformIds(String transformIdsExpression,
-                                   PageParams pageParams,
-                                   boolean allowNoMatch,
-                                   ActionListener<Tuple<Long, List<String>>> foundIdsListener) {
-        String[] idTokens = ExpandedIdsMatcher.tokenizeExpression(transformIdsExpression);
-        QueryBuilder queryBuilder = buildQueryFromTokenizedIds(idTokens, TransformConfig.NAME);
-
-        SearchRequest request = client
-            .prepareSearch(TransformInternalIndexConstants.INDEX_NAME_PATTERN,
-                TransformInternalIndexConstants.INDEX_NAME_PATTERN_DEPRECATED)
-            .addSort(TransformField.ID.getPreferredName(), SortOrder.ASC)
-            .setFrom(pageParams.getFrom())
-            .setTrackTotalHits(true)
-            .setSize(pageParams.getSize())
-            .setQuery(queryBuilder)
-            // We only care about the `id` field, small optimization
-            .setFetchSource(TransformField.ID.getPreferredName(), "")
-            .request();
-
-        final ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(idTokens, allowNoMatch);
-
-        executeAsyncWithOrigin(client.threadPool().getThreadContext(), TRANSFORM_ORIGIN, request, ActionListener.<SearchResponse>wrap(
-            searchResponse -> {
-                long totalHits = searchResponse.getHits().getTotalHits().value;
-                // important: preserve order
-                Set<String> ids = new LinkedHashSet<>(searchResponse.getHits().getHits().length);
-                for (SearchHit hit : searchResponse.getHits().getHits()) {
-                    BytesReference source = hit.getSourceRef();
-                    try (InputStream stream = source.streamInput();
-                         XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(NamedXContentRegistry.EMPTY,
-                             LoggingDeprecationHandler.INSTANCE, stream)) {
-                        ids.add((String) parser.map().get(TransformField.ID.getPreferredName()));
-                    } catch (IOException e) {
-                        foundIdsListener.onFailure(new ElasticsearchParseException("failed to parse search hit for ids", e));
-                        return;
-                    }
-                }
-                requiredMatches.filterMatchedIds(ids);
-                if (requiredMatches.hasUnmatchedIds()) {
-                    // some required Ids were not found
-                    foundIdsListener.onFailure(
-                        new ResourceNotFoundException(
-                            TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM,
-                                requiredMatches.unmatchedIdsString())));
-                    return;
-                }
-                foundIdsListener.onResponse(new Tuple<>(totalHits, new ArrayList<>(ids)));
-            }, foundIdsListener::onFailure), client::search);
-    }
+    void expandTransformIds(
+        String transformIdsExpression,
+        PageParams pageParams,
+        boolean allowNoMatch,
+        ActionListener<Tuple<Long, List<String>>> foundIdsListener
+    );
 
     /**
      * This deletes the configuration and all other documents corresponding to the transform id (e.g. checkpoints).
@@ -420,211 +125,16 @@ public class TransformConfigManager {
      * @param transformId the transform id
      * @param listener listener to call after inner request returned
      */
-    public void deleteTransform(String transformId, ActionListener<Boolean> listener) {
-        DeleteByQueryRequest request = new DeleteByQueryRequest()
-            .setAbortOnVersionConflict(false); //since these documents are not updated, a conflict just means it was deleted previously
+    void deleteTransform(String transformId, ActionListener<Boolean> listener);
 
-        request.indices(TransformInternalIndexConstants.INDEX_NAME_PATTERN, TransformInternalIndexConstants.INDEX_NAME_PATTERN_DEPRECATED);
-        QueryBuilder query = QueryBuilders.termQuery(TransformField.ID.getPreferredName(), transformId);
-        request.setQuery(query);
-        request.setRefresh(true);
+    void putOrUpdateTransformStoredDoc(
+        TransformStoredDoc storedDoc,
+        SeqNoPrimaryTermAndIndex seqNoPrimaryTermAndIndex,
+        ActionListener<SeqNoPrimaryTermAndIndex> listener
+    );
 
-        executeAsyncWithOrigin(client, TRANSFORM_ORIGIN, DeleteByQueryAction.INSTANCE, request, ActionListener.wrap(deleteResponse -> {
-            if (deleteResponse.getDeleted() == 0) {
-                listener.onFailure(new ResourceNotFoundException(
-                        TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, transformId)));
-                return;
-            }
-            listener.onResponse(true);
-        }, e -> {
-            if (e.getClass() == IndexNotFoundException.class) {
-                listener.onFailure(new ResourceNotFoundException(
-                        TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, transformId)));
-            } else {
-                listener.onFailure(e);
-            }
-        }));
-    }
+    void getTransformStoredDoc(String transformId, ActionListener<Tuple<TransformStoredDoc, SeqNoPrimaryTermAndIndex>> resultListener);
 
-    public void putOrUpdateTransformStoredDoc(TransformStoredDoc stats,
-                                              SeqNoPrimaryTermAndIndex seqNoPrimaryTermAndIndex,
-                                              ActionListener<SeqNoPrimaryTermAndIndex> listener) {
-        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
-            XContentBuilder source = stats.toXContent(builder, new ToXContent.MapParams(TO_XCONTENT_PARAMS));
+    void getTransformStoredDocs(Collection<String> transformIds, ActionListener<List<TransformStoredDoc>> listener);
 
-            IndexRequest indexRequest = new IndexRequest(TransformInternalIndexConstants.LATEST_INDEX_NAME)
-                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                .id(TransformStoredDoc.documentId(stats.getId()))
-                .source(source);
-            if (seqNoPrimaryTermAndIndex != null &&
-                seqNoPrimaryTermAndIndex.getIndex().equals(TransformInternalIndexConstants.LATEST_INDEX_NAME)) {
-                indexRequest.opType(DocWriteRequest.OpType.INDEX)
-                    .setIfSeqNo(seqNoPrimaryTermAndIndex.getSeqNo())
-                    .setIfPrimaryTerm(seqNoPrimaryTermAndIndex.getPrimaryTerm());
-            } else {
-                // If the index is NOT the latest or we are null, that means we have not created this doc before
-                // so, it should be a create option without the seqNo and primaryTerm set
-                indexRequest.opType(DocWriteRequest.OpType.CREATE);
-            }
-            executeAsyncWithOrigin(client, TRANSFORM_ORIGIN, IndexAction.INSTANCE, indexRequest, ActionListener.wrap(
-                r -> listener.onResponse(SeqNoPrimaryTermAndIndex.fromIndexResponse(r)),
-                e -> listener.onFailure(new RuntimeException(
-                        TransformMessages.getMessage(TransformMessages.TRANSFORM_FAILED_TO_PERSIST_STATS, stats.getId()),
-                        e))
-            ));
-        } catch (IOException e) {
-            // not expected to happen but for the sake of completeness
-            listener.onFailure(new ElasticsearchParseException(
-                TransformMessages.getMessage(TransformMessages.TRANSFORM_FAILED_TO_PERSIST_STATS, stats.getId()),
-                e));
-        }
-    }
-
-    public void getTransformStoredDoc(String transformId,
-                                      ActionListener<Tuple<TransformStoredDoc, SeqNoPrimaryTermAndIndex>> resultListener) {
-        QueryBuilder queryBuilder = QueryBuilders.termQuery("_id", TransformStoredDoc.documentId(transformId));
-        SearchRequest searchRequest = client
-            .prepareSearch(TransformInternalIndexConstants.INDEX_NAME_PATTERN,
-                TransformInternalIndexConstants.INDEX_NAME_PATTERN_DEPRECATED)
-            .setQuery(queryBuilder)
-            // use sort to get the last
-            .addSort("_index", SortOrder.DESC)
-            .setSize(1)
-            .seqNoAndPrimaryTerm(true)
-            .request();
-
-        executeAsyncWithOrigin(client, TRANSFORM_ORIGIN, SearchAction.INSTANCE, searchRequest, ActionListener.<SearchResponse>wrap(
-            searchResponse -> {
-                if (searchResponse.getHits().getHits().length == 0) {
-                    resultListener.onFailure(new ResourceNotFoundException(
-                        TransformMessages.getMessage(TransformMessages.UNKNOWN_TRANSFORM_STATS, transformId)));
-                    return;
-                }
-                SearchHit searchHit = searchResponse.getHits().getHits()[0];
-                BytesReference source = searchHit.getSourceRef();
-                try (InputStream stream = source.streamInput();
-                    XContentParser parser = XContentFactory.xContent(XContentType.JSON)
-                        .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, stream)) {
-                    resultListener.onResponse(
-                        Tuple.tuple(TransformStoredDoc.fromXContent(parser),
-                        SeqNoPrimaryTermAndIndex.fromSearchHit(searchHit)));
-                } catch (Exception e) {
-                    logger.error(TransformMessages.getMessage(TransformMessages.FAILED_TO_PARSE_TRANSFORM_STATISTICS_CONFIGURATION,
-                            transformId), e);
-                    resultListener.onFailure(e);
-                }
-            }, resultListener::onFailure));
-    }
-
-    public void getTransformStoredDoc(Collection<String> transformIds, ActionListener<List<TransformStoredDoc>> listener) {
-        QueryBuilder builder = QueryBuilders.constantScoreQuery(QueryBuilders.boolQuery()
-            .filter(QueryBuilders.termsQuery(TransformField.ID.getPreferredName(), transformIds))
-            .filter(QueryBuilders.termQuery(TransformField.INDEX_DOC_TYPE.getPreferredName(), TransformStoredDoc.NAME)));
-
-        SearchRequest searchRequest = client
-            .prepareSearch(TransformInternalIndexConstants.INDEX_NAME_PATTERN,
-                TransformInternalIndexConstants.INDEX_NAME_PATTERN_DEPRECATED)
-            .addSort(TransformField.ID.getPreferredName(), SortOrder.ASC)
-            .addSort("_index", SortOrder.DESC)
-            .setQuery(builder)
-            // the limit for getting stats and transforms is 1000, as long as we do not have 10 indices this works
-            .setSize(Math.min(transformIds.size(), 10_000))
-            .request();
-
-        executeAsyncWithOrigin(client.threadPool().getThreadContext(), TRANSFORM_ORIGIN, searchRequest,
-            ActionListener.<SearchResponse>wrap(
-                    searchResponse -> {
-                        List<TransformStoredDoc> stats = new ArrayList<>();
-                        String previousId = null;
-                        for (SearchHit hit : searchResponse.getHits().getHits()) {
-                            // skip old versions
-                            if (hit.getId().equals(previousId) == false) {
-                                previousId = hit.getId();
-                                BytesReference source = hit.getSourceRef();
-                                try (InputStream stream = source.streamInput();
-                                     XContentParser parser = XContentFactory.xContent(XContentType.JSON)
-                                             .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, stream)) {
-                                    stats.add(TransformStoredDoc.fromXContent(parser));
-                                } catch (IOException e) {
-                                    listener.onFailure(
-                                            new ElasticsearchParseException("failed to parse transform stats from search hit", e));
-                                    return;
-                                }
-                            }
-                        }
-
-                        listener.onResponse(stats);
-                    }, listener::onFailure
-            ), client::search);
-    }
-
-    private void parseTransformLenientlyFromSource(BytesReference source, String transformId,
-            ActionListener<TransformConfig> transformListener) {
-        try (InputStream stream = source.streamInput();
-                XContentParser parser = XContentFactory.xContent(XContentType.JSON)
-                     .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, stream)) {
-            transformListener.onResponse(TransformConfig.fromXContent(parser, transformId, true));
-        } catch (Exception e) {
-            logger.error(TransformMessages.getMessage(TransformMessages.FAILED_TO_PARSE_TRANSFORM_CONFIGURATION, transformId), e);
-            transformListener.onFailure(e);
-        }
-    }
-
-    private void parseCheckpointsLenientlyFromSource(BytesReference source, String transformId,
-            ActionListener<TransformCheckpoint> transformListener) {
-        try (InputStream stream = source.streamInput();
-                XContentParser parser = XContentFactory.xContent(XContentType.JSON)
-                     .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, stream)) {
-            transformListener.onResponse(TransformCheckpoint.fromXContent(parser, true));
-        } catch (Exception e) {
-            logger.error(TransformMessages.getMessage(TransformMessages.FAILED_TO_PARSE_TRANSFORM_CHECKPOINTS, transformId), e);
-            transformListener.onFailure(e);
-        }
-    }
-
-    private QueryBuilder buildQueryFromTokenizedIds(String[] idTokens, String resourceName) {
-        BoolQueryBuilder queryBuilder = QueryBuilders.boolQuery()
-            .filter(QueryBuilders.termQuery(TransformField.INDEX_DOC_TYPE.getPreferredName(), resourceName));
-        if (Strings.isAllOrWildcard(idTokens) == false) {
-            List<String> terms = new ArrayList<>();
-            BoolQueryBuilder shouldQueries = new BoolQueryBuilder();
-            for (String token : idTokens) {
-                if (Regex.isSimpleMatchPattern(token)) {
-                    shouldQueries.should(QueryBuilders.wildcardQuery(TransformField.ID.getPreferredName(), token));
-                } else {
-                    terms.add(token);
-                }
-            }
-            if (terms.isEmpty() == false) {
-                shouldQueries.should(QueryBuilders.termsQuery(TransformField.ID.getPreferredName(), terms));
-            }
-
-            if (shouldQueries.should().isEmpty() == false) {
-                queryBuilder.filter(shouldQueries);
-            }
-        }
-        return QueryBuilders.constantScoreQuery(queryBuilder);
-    }
-
-    private static Tuple<RestStatus, Throwable> getStatusAndReason(final BulkByScrollResponse response) {
-        RestStatus status = RestStatus.OK;
-        Throwable reason = new Exception("Unknown error");
-        //Getting the max RestStatus is sort of arbitrary, would the user care about 5xx over 4xx?
-        //Unsure of a better way to return an appropriate and possibly actionable cause to the user.
-        for (BulkItemResponse.Failure failure : response.getBulkFailures()) {
-            if (failure.getStatus().getStatus() > status.getStatus()) {
-                status = failure.getStatus();
-                reason = failure.getCause();
-            }
-        }
-
-        for (ScrollableHitSource.SearchFailure failure : response.getSearchFailures()) {
-            RestStatus failureStatus = org.elasticsearch.ExceptionsHelper.status(failure.getReason());
-            if (failureStatus.getStatus() > status.getStatus()) {
-                status = failureStatus;
-                reason = failure.getReason();
-            }
-        }
-        return new Tuple<>(status, reason);
-    }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -162,8 +162,7 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
             transformsCheckpointService.getCheckpointingInfo(transform.getId(), context.getCheckpoint(), initialPosition, null, listener);
             return;
         }
-        indexer
-            .getCheckpointProvider()
+        indexer.getCheckpointProvider()
             .getCheckpointingInfo(
                 indexer.getLastCheckpoint(),
                 indexer.getNextCheckpoint(),
@@ -189,13 +188,12 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
     synchronized void start(Long startingCheckpoint, ActionListener<StartTransformAction.Response> listener) {
         logger.debug("[{}] start called with state [{}].", getTransformId(), getState());
         if (context.getTaskState() == TransformTaskState.FAILED) {
-            listener
-                .onFailure(
-                    new ElasticsearchStatusException(
-                        TransformMessages.getMessage(CANNOT_START_FAILED_TRANSFORM, getTransformId(), context.getStateReason()),
-                        RestStatus.CONFLICT
-                    )
-                );
+            listener.onFailure(
+                new ElasticsearchStatusException(
+                    TransformMessages.getMessage(CANNOT_START_FAILED_TRANSFORM, getTransformId(), context.getStateReason()),
+                    RestStatus.CONFLICT
+                )
+            );
             return;
         }
         if (getIndexer() == null) {
@@ -205,23 +203,21 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
             String msg = context.getTaskState() == TransformTaskState.FAILED
                 ? "It failed during the initialization process; force stop to allow reinitialization."
                 : "Try again later.";
-            listener
-                .onFailure(
-                    new ElasticsearchStatusException(
-                        "Task for transform [{}] not fully initialized. {}",
-                        RestStatus.CONFLICT,
-                        getTransformId(),
-                        msg
-                    )
-                );
+            listener.onFailure(
+                new ElasticsearchStatusException(
+                    "Task for transform [{}] not fully initialized. {}",
+                    RestStatus.CONFLICT,
+                    getTransformId(),
+                    msg
+                )
+            );
             return;
         }
         final IndexerState newState = getIndexer().start();
         if (Arrays.stream(RUNNING_STATES).noneMatch(newState::equals)) {
-            listener
-                .onFailure(
-                    new ElasticsearchException("Cannot start task for transform [{}], because state was [{}]", transform.getId(), newState)
-                );
+            listener.onFailure(
+                new ElasticsearchException("Cannot start task for transform [{}], because state was [{}]", transform.getId(), newState)
+            );
             return;
         }
         context.resetTaskState();
@@ -254,20 +250,18 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
             registerWithSchedulerJob();
             listener.onResponse(new StartTransformAction.Response(true));
         }, exc -> {
-            auditor
-                .warning(
-                    transform.getId(),
-                    "Failed to persist to cluster state while marking task as started. Failure: " + exc.getMessage()
-                );
+            auditor.warning(
+                transform.getId(),
+                "Failed to persist to cluster state while marking task as started. Failure: " + exc.getMessage()
+            );
             logger.error(new ParameterizedMessage("[{}] failed updating state to [{}].", getTransformId(), state), exc);
             getIndexer().stop();
-            listener
-                .onFailure(
-                    new ElasticsearchException(
-                        "Error while updating state for transform [" + transform.getId() + "] to [" + state.getIndexerState() + "].",
-                        exc
-                    )
-                );
+            listener.onFailure(
+                new ElasticsearchException(
+                    "Error while updating state for transform [" + transform.getId() + "] to [" + state.getIndexerState() + "].",
+                    exc
+                )
+            );
         }));
     }
 
@@ -288,13 +282,12 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
         boolean shouldStopAtCheckpoint,
         ActionListener<Void> shouldStopAtCheckpointListener
     ) {
-        logger
-            .debug(
-                "[{}] attempted to set task to stop at checkpoint [{}] with state [{}]",
-                getTransformId(),
-                shouldStopAtCheckpoint,
-                getState()
-            );
+        logger.debug(
+            "[{}] attempted to set task to stop at checkpoint [{}] with state [{}]",
+            getTransformId(),
+            shouldStopAtCheckpoint,
+            getState()
+        );
         if (context.getTaskState() != TransformTaskState.STARTED || getIndexer() == null) {
             shouldStopAtCheckpointListener.onResponse(null);
             return;
@@ -363,12 +356,11 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
         }
 
         if (context.getTaskState() == TransformTaskState.FAILED || context.getTaskState() == TransformTaskState.STOPPED) {
-            logger
-                .debug(
-                    "[{}] schedule was triggered for transform but task is [{}]. Ignoring trigger.",
-                    getTransformId(),
-                    context.getTaskState()
-                );
+            logger.debug(
+                "[{}] schedule was triggered for transform but task is [{}]. Ignoring trigger.",
+                getTransformId(),
+                context.getTaskState()
+            );
             return;
         }
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -16,8 +16,10 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.persistent.AllocatedPersistentTask;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
+import org.elasticsearch.persistent.PersistentTasksService;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.core.scheduler.SchedulerEngine;
@@ -296,24 +298,14 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
     }
 
     public synchronized void stop(boolean force, boolean shouldStopAtCheckpoint) {
-        logger
-            .debug(
-                "[{}] stop called with force [{}], shouldStopAtCheckpoint [{}], state [{}]",
-                getTransformId(),
-                force,
-                shouldStopAtCheckpoint,
-                getState()
-            );
-        if (getIndexer() == null) {
-            // If there is no indexer the task has not been triggered
-            // but it still needs to be stopped and removed
-            shutdown();
-            return;
-        }
-
-        if (getIndexer().getState() == IndexerState.STOPPED || getIndexer().getState() == IndexerState.STOPPING) {
-            return;
-        }
+        logger.debug(
+            "[{}] stop called with force [{}], shouldStopAtCheckpoint [{}], state [{}], indexerstate[{}]",
+            getTransformId(),
+            force,
+            shouldStopAtCheckpoint,
+            getState(),
+            getIndexer() != null ? getIndexer().getState() : null
+        );
 
         if (context.getTaskState() == TransformTaskState.FAILED && force == false) {
             throw new ElasticsearchStatusException(
@@ -322,18 +314,34 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
             );
         }
 
+        // cleanup potentially failed state.
+        boolean wasFailed = context.setTaskState(TransformTaskState.FAILED, TransformTaskState.STARTED);
         context.resetReasonAndFailureCounter();
 
-        // No reason to keep it in the potentially failed state.
-        boolean wasFailed = context.setTaskState(TransformTaskState.FAILED, TransformTaskState.STARTED);
+        // If state was in a failed state, we should stop immediately
+        if (wasFailed) {
+            getIndexer().onStop();
+            getIndexer().doSaveState(IndexerState.STOPPED, getIndexer().getPosition(), () -> {});
+            return;
+        }
+
+        if (getIndexer().getState() == IndexerState.STOPPED || getIndexer().getState() == IndexerState.STOPPING) {
+            return;
+        }
+
+        if (getIndexer() == null) {
+            // If there is no indexer the task has not been triggered
+            // but it still needs to be stopped and removed
+            shutdown();
+            return;
+        }
+
         // shouldStopAtCheckpoint only comes into play when onFinish is called (or doSaveState right after).
         // if it is false, stop immediately
         if (shouldStopAtCheckpoint == false ||
-        // If state was in a failed state, we should stop immediately as we will never reach the next checkpoint
-            wasFailed ||
-            // If the indexerState is STARTED and it is on an initialRun, that means that the indexer has previously finished a checkpoint,
-            // or has yet to even start one.
-            // Either way, this means that we won't get to have onFinish called down stream (or at least won't for some time).
+        // If the indexerState is STARTED and it is on an initialRun, that means that the indexer has previously finished a checkpoint,
+        // or has yet to even start one.
+        // Either way, this means that we won't get to have onFinish called down stream (or at least won't for some time).
             (getIndexer().getState() == IndexerState.STARTED && getIndexer().initialRun())) {
             IndexerState state = getIndexer().stop();
             if (state == IndexerState.STOPPED) {
@@ -341,6 +349,16 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
                 getIndexer().doSaveState(state, getIndexer().getPosition(), () -> {});
             }
         }
+    }
+
+    @Override
+    protected void init(
+        PersistentTasksService persistentTasksService,
+        TaskManager taskManager,
+        String persistentTaskId,
+        long allocationId
+    ) {
+        super.init(persistentTasksService, taskManager, persistentTaskId, allocationId);
     }
 
     @Override
@@ -390,6 +408,7 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
      */
     @Override
     public synchronized void shutdown() {
+        logger.trace("shutdown requested");
         deregisterSchedulerJob();
         markAsCompleted();
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -318,6 +318,13 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
         boolean wasFailed = context.setTaskState(TransformTaskState.FAILED, TransformTaskState.STARTED);
         context.resetReasonAndFailureCounter();
 
+        if (getIndexer() == null) {
+            // If there is no indexer the task has not been triggered
+            // but it still needs to be stopped and removed
+            shutdown();
+            return;
+        }
+
         // If state was in a failed state, we should stop immediately
         if (wasFailed) {
             getIndexer().onStop();
@@ -326,13 +333,6 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
         }
 
         if (getIndexer().getState() == IndexerState.STOPPED || getIndexer().getState() == IndexerState.STOPPING) {
-            return;
-        }
-
-        if (getIndexer() == null) {
-            // If there is no indexer the task has not been triggered
-            // but it still needs to be stopped and removed
-            shutdown();
             return;
         }
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -408,7 +408,7 @@ public class TransformTask extends AllocatedPersistentTask implements SchedulerE
      */
     @Override
     public synchronized void shutdown() {
-        logger.trace("shutdown requested");
+        logger.debug("[{}] shutdown of transform requested", transform.getId());
         deregisterSchedulerJob();
         markAsCompleted();
     }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProviderTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProviderTests.java
@@ -19,7 +19,7 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfigTests;
 import org.elasticsearch.xpack.transform.notifications.MockTransformAuditor;
 import org.elasticsearch.xpack.transform.notifications.MockTransformAuditor.AuditExpectation;
-import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
+import org.elasticsearch.xpack.transform.persistence.IndexBasedTransformConfigManager;
 import org.junit.Before;
 
 import java.util.Collections;
@@ -32,13 +32,13 @@ public class DefaultCheckpointProviderTests extends ESTestCase {
     private Client client;
 
     private MockTransformAuditor transformAuditor;
-    private TransformConfigManager transformConfigManager;
+    private IndexBasedTransformConfigManager transformConfigManager;
     private Logger checkpointProviderlogger = LogManager.getLogger(DefaultCheckpointProvider.class);
 
     @Before
     public void setUpMocks() throws IllegalAccessException {
         client = mock(Client.class);
-        transformConfigManager = mock(TransformConfigManager.class);
+        transformConfigManager = mock(IndexBasedTransformConfigManager.class);
         transformAuditor = new MockTransformAuditor();
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/TransformCheckpointServiceNodeTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/TransformCheckpointServiceNodeTests.java
@@ -49,7 +49,7 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformProgress;
 import org.elasticsearch.xpack.core.transform.transforms.TransformProgressTests;
 import org.elasticsearch.xpack.transform.TransformSingleNodeTestCase;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
-import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
+import org.elasticsearch.xpack.transform.persistence.IndexBasedTransformConfigManager;
 import org.junit.AfterClass;
 import org.junit.Before;
 
@@ -72,7 +72,7 @@ public class TransformCheckpointServiceNodeTests extends TransformSingleNodeTest
     // see https://github.com/elastic/elasticsearch/issues/45238 and https://github.com/elastic/elasticsearch/issues/42577
     private static MockClientForCheckpointing mockClientForCheckpointing = null;
 
-    private TransformConfigManager transformsConfigManager;
+    private IndexBasedTransformConfigManager transformsConfigManager;
     private TransformCheckpointService transformsCheckpointService;
 
     private class MockClientForCheckpointing extends NoOpClient {
@@ -88,7 +88,7 @@ public class TransformCheckpointServiceNodeTests extends TransformSingleNodeTest
             this.shardStats = shardStats;
 
             Set<String> indices = new HashSet<>();
-            for (ShardStats s:shardStats) {
+            for (ShardStats s : shardStats) {
                 indices.add(s.getShardRouting().getIndexName());
             }
 
@@ -97,12 +97,15 @@ public class TransformCheckpointServiceNodeTests extends TransformSingleNodeTest
 
         @SuppressWarnings("unchecked")
         @Override
-        protected <Request extends ActionRequest, Response extends ActionResponse>
-        void doExecute(ActionType<Response> action, Request request, ActionListener<Response> listener) {
+        protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+            ActionType<Response> action,
+            Request request,
+            ActionListener<Response> listener
+        ) {
 
             if (request instanceof GetIndexRequest) {
                 // for this test we only need the indices
-                assert(indices != null);
+                assert (indices != null);
                 final GetIndexResponse indexResponse = new GetIndexResponse(indices, null, null, null, null);
 
                 listener.onResponse((Response) indexResponse);
@@ -113,7 +116,6 @@ public class TransformCheckpointServiceNodeTests extends TransformSingleNodeTest
                 final IndicesStatsResponse indicesStatsResponse = mock(IndicesStatsResponse.class);
                 when(indicesStatsResponse.getShards()).thenReturn(shardStats);
                 when(indicesStatsResponse.getFailedShards()).thenReturn(0);
-
 
                 listener.onResponse((Response) indicesStatsResponse);
                 return;
@@ -130,13 +132,11 @@ public class TransformCheckpointServiceNodeTests extends TransformSingleNodeTest
             mockClientForCheckpointing = new MockClientForCheckpointing("TransformCheckpointServiceNodeTests");
         }
 
-        transformsConfigManager = new TransformConfigManager(client(), xContentRegistry());
+        transformsConfigManager = new IndexBasedTransformConfigManager(client(), xContentRegistry());
 
         // use a mock for the checkpoint service
         TransformAuditor mockAuditor = mock(TransformAuditor.class);
-        transformsCheckpointService = new TransformCheckpointService(mockClientForCheckpointing,
-                                                                               transformsConfigManager,
-                                                                               mockAuditor);
+        transformsCheckpointService = new TransformCheckpointService(mockClientForCheckpointing, transformsConfigManager, mockAuditor);
     }
 
     @AfterClass
@@ -149,26 +149,45 @@ public class TransformCheckpointServiceNodeTests extends TransformSingleNodeTest
         String transformId = randomAlphaOfLengthBetween(3, 10);
         long timestamp = 1000;
 
-        TransformCheckpoint checkpoint = new TransformCheckpoint(transformId, timestamp, 1L,
-                createCheckPointMap(transformId, 10, 10, 10), null);
+        TransformCheckpoint checkpoint = new TransformCheckpoint(
+            transformId,
+            timestamp,
+            1L,
+            createCheckPointMap(transformId, 10, 10, 10),
+            null
+        );
 
         // create transform
         assertAsync(
-                listener -> transformsConfigManager
-                        .putTransformConfiguration(TransformConfigTests.randomTransformConfig(transformId), listener),
-                true, null, null);
+            listener -> transformsConfigManager.putTransformConfiguration(
+                TransformConfigTests.randomTransformConfig(transformId),
+                listener
+            ),
+            true,
+            null,
+            null
+        );
 
         // by design no exception is thrown but an empty checkpoint is returned
-        assertAsync(listener -> transformsConfigManager.getTransformCheckpoint(transformId, 1L, listener),
-                TransformCheckpoint.EMPTY, null, null);
+        assertAsync(
+            listener -> transformsConfigManager.getTransformCheckpoint(transformId, 1L, listener),
+            TransformCheckpoint.EMPTY,
+            null,
+            null
+        );
 
         assertAsync(listener -> transformsConfigManager.putTransformCheckpoint(checkpoint, listener), true, null, null);
 
         assertAsync(listener -> transformsConfigManager.getTransformCheckpoint(transformId, 1L, listener), checkpoint, null, null);
 
         // add a 2nd checkpoint
-        TransformCheckpoint checkpoint2 = new TransformCheckpoint(transformId, timestamp + 100L, 2L,
-                createCheckPointMap(transformId, 20, 20, 20), null);
+        TransformCheckpoint checkpoint2 = new TransformCheckpoint(
+            transformId,
+            timestamp + 100L,
+            2L,
+            createCheckPointMap(transformId, 20, 20, 20),
+            null
+        );
 
         assertAsync(listener -> transformsConfigManager.putTransformCheckpoint(checkpoint2, listener), true, null, null);
 
@@ -180,11 +199,19 @@ public class TransformCheckpointServiceNodeTests extends TransformSingleNodeTest
         assertAsync(listener -> transformsConfigManager.deleteTransform(transformId, listener), true, null, null);
 
         // checkpoints should be empty again
-        assertAsync(listener -> transformsConfigManager.getTransformCheckpoint(transformId, 1L, listener),
-                TransformCheckpoint.EMPTY, null, null);
+        assertAsync(
+            listener -> transformsConfigManager.getTransformCheckpoint(transformId, 1L, listener),
+            TransformCheckpoint.EMPTY,
+            null,
+            null
+        );
 
-        assertAsync(listener -> transformsConfigManager.getTransformCheckpoint(transformId, 2L, listener),
-                TransformCheckpoint.EMPTY, null, null);
+        assertAsync(
+            listener -> transformsConfigManager.getTransformCheckpoint(transformId, 2L, listener),
+            TransformCheckpoint.EMPTY,
+            null,
+            null
+        );
     }
 
     public void testGetCheckpointStats() throws InterruptedException {
@@ -195,52 +222,83 @@ public class TransformCheckpointServiceNodeTests extends TransformSingleNodeTest
 
         // create transform
         assertAsync(
-                listener -> transformsConfigManager
-                        .putTransformConfiguration(TransformConfigTests.randomTransformConfig(transformId), listener),
-                true, null, null);
+            listener -> transformsConfigManager.putTransformConfiguration(
+                TransformConfigTests.randomTransformConfig(transformId),
+                listener
+            ),
+            true,
+            null,
+            null
+        );
 
-        TransformCheckpoint checkpoint = new TransformCheckpoint(transformId, timestamp, 1L,
-                createCheckPointMap(transformId, 10, 10, 10), null);
+        TransformCheckpoint checkpoint = new TransformCheckpoint(
+            transformId,
+            timestamp,
+            1L,
+            createCheckPointMap(transformId, 10, 10, 10),
+            null
+        );
 
         assertAsync(listener -> transformsConfigManager.putTransformCheckpoint(checkpoint, listener), true, null, null);
 
-        TransformCheckpoint checkpoint2 = new TransformCheckpoint(transformId, timestamp + 100L, 2L,
-                createCheckPointMap(transformId, 20, 20, 20), null);
+        TransformCheckpoint checkpoint2 = new TransformCheckpoint(
+            transformId,
+            timestamp + 100L,
+            2L,
+            createCheckPointMap(transformId, 20, 20, 20),
+            null
+        );
 
         assertAsync(listener -> transformsConfigManager.putTransformCheckpoint(checkpoint2, listener), true, null, null);
 
         mockClientForCheckpointing.setShardStats(createShardStats(createCheckPointMap(transformId, 20, 20, 20)));
         TransformCheckpointingInfo checkpointInfo = new TransformCheckpointingInfo(
-                new TransformCheckpointStats(1, null, null, timestamp, 0L),
-                new TransformCheckpointStats(2, position, progress, timestamp + 100L, 0L),
-                30L);
+            new TransformCheckpointStats(1, null, null, timestamp, 0L),
+            new TransformCheckpointStats(2, position, progress, timestamp + 100L, 0L),
+            30L
+        );
 
-        assertAsync(listener ->
-                transformsCheckpointService.getCheckpointingInfo(transformId, 1, position, progress, listener),
-            checkpointInfo, null, null);
+        assertAsync(
+            listener -> transformsCheckpointService.getCheckpointingInfo(transformId, 1, position, progress, listener),
+            checkpointInfo,
+            null,
+            null
+        );
 
         mockClientForCheckpointing.setShardStats(createShardStats(createCheckPointMap(transformId, 10, 50, 33)));
         checkpointInfo = new TransformCheckpointingInfo(
-                new TransformCheckpointStats(1, null, null, timestamp, 0L),
-                new TransformCheckpointStats(2, position, progress, timestamp + 100L, 0L),
-                63L);
-        assertAsync(listener ->
-                transformsCheckpointService.getCheckpointingInfo(transformId, 1, position, progress, listener),
-            checkpointInfo, null, null);
+            new TransformCheckpointStats(1, null, null, timestamp, 0L),
+            new TransformCheckpointStats(2, position, progress, timestamp + 100L, 0L),
+            63L
+        );
+        assertAsync(
+            listener -> transformsCheckpointService.getCheckpointingInfo(transformId, 1, position, progress, listener),
+            checkpointInfo,
+            null,
+            null
+        );
 
         // same as current
         mockClientForCheckpointing.setShardStats(createShardStats(createCheckPointMap(transformId, 10, 10, 10)));
         checkpointInfo = new TransformCheckpointingInfo(
-                new TransformCheckpointStats(1, null, null, timestamp, 0L),
-                new TransformCheckpointStats(2, position, progress, timestamp + 100L, 0L),
-                0L);
-        assertAsync(listener ->
-                transformsCheckpointService.getCheckpointingInfo(transformId, 1, position, progress, listener),
-            checkpointInfo, null, null);
+            new TransformCheckpointStats(1, null, null, timestamp, 0L),
+            new TransformCheckpointStats(2, position, progress, timestamp + 100L, 0L),
+            0L
+        );
+        assertAsync(
+            listener -> transformsCheckpointService.getCheckpointingInfo(transformId, 1, position, progress, listener),
+            checkpointInfo,
+            null,
+            null
+        );
     }
 
-    private static Map<String, long[]> createCheckPointMap(String index, long checkpointShard1, long checkpointShard2,
-            long checkpointShard3) {
+    private static Map<String, long[]> createCheckPointMap(
+        String index,
+        long checkpointShard1,
+        long checkpointShard2,
+        long checkpointShard3
+    ) {
         return Collections.singletonMap(index, new long[] { checkpointShard1, checkpointShard2, checkpointShard3 });
     }
 
@@ -270,8 +328,12 @@ public class TransformCheckpointServiceNodeTests extends TransformSingleNodeTest
                 SeqNoStats seqNoStats = new SeqNoStats(checkpoint, checkpoint, checkpoint);
                 Index index = new Index(entry.getKey(), UUIDs.randomBase64UUID(random()));
                 ShardId shardId = new ShardId(index, i);
-                ShardRouting shardRouting = ShardRouting.newUnassigned(shardId, true, RecoverySource.EmptyStoreRecoverySource.INSTANCE,
-                        new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, null));
+                ShardRouting shardRouting = ShardRouting.newUnassigned(
+                    shardId,
+                    true,
+                    RecoverySource.EmptyStoreRecoverySource.INSTANCE,
+                    new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, null)
+                );
                 Path path = createTempDir().resolve("indices").resolve(index.getUUID()).resolve(String.valueOf(i));
 
                 shardStats.add(new ShardStats(shardRouting, new ShardPath(false, path, path, shardId), stats, null, seqNoStats, null));

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/InMemoryTransformConfigManager.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/InMemoryTransformConfigManager.java
@@ -122,7 +122,7 @@ public class InMemoryTransformConfigManager implements TransformConfigManager {
             return;
         }
 
-        configAndVersionListener.onResponse(Tuple.tuple(config, new SeqNoPrimaryTermAndIndex(1l, 1l, "index-1")));
+        configAndVersionListener.onResponse(Tuple.tuple(config, new SeqNoPrimaryTermAndIndex(1L, 1L, "index-1")));
     }
 
     @Override
@@ -172,7 +172,7 @@ public class InMemoryTransformConfigManager implements TransformConfigManager {
 
         // for now we ignore seqNoPrimaryTermAndIndex
         transformStoredDocs.put(storedDoc.getId(), storedDoc);
-        listener.onResponse(new SeqNoPrimaryTermAndIndex(1l, 1l, "index-1"));
+        listener.onResponse(new SeqNoPrimaryTermAndIndex(1L, 1L, "index-1"));
     }
 
     @Override
@@ -189,7 +189,7 @@ public class InMemoryTransformConfigManager implements TransformConfigManager {
             return;
         }
 
-        resultListener.onResponse(Tuple.tuple(storedDoc, new SeqNoPrimaryTermAndIndex(1l, 1l, "index-1")));
+        resultListener.onResponse(Tuple.tuple(storedDoc, new SeqNoPrimaryTermAndIndex(1L, 1L, "index-1")));
     }
 
     @Override

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/InMemoryTransformConfigManager.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/InMemoryTransformConfigManager.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.transform.persistence;
+
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.xpack.core.action.util.PageParams;
+import org.elasticsearch.xpack.core.transform.TransformMessages;
+import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
+import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
+import org.elasticsearch.xpack.core.transform.transforms.TransformStoredDoc;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Simple in-memory based TransformConfigManager
+ *
+ *  NOTE: This is an incomplete implementation, only to be used for testing!
+ */
+public class InMemoryTransformConfigManager implements TransformConfigManager {
+
+    private final Map<String, List<TransformCheckpoint>> checkpoints = new HashMap<>();
+    private final Map<String, TransformConfig> configs = new HashMap<>();
+    private final Map<String, TransformStoredDoc> transformStoredDocs = new HashMap<>();
+
+    public InMemoryTransformConfigManager() {}
+
+    @Override
+    public void putTransformCheckpoint(TransformCheckpoint checkpoint, ActionListener<Boolean> listener) {
+        checkpoints.compute(checkpoint.getTransformId(), (id, listOfCheckpoints) -> {
+            if (listOfCheckpoints == null) {
+                listOfCheckpoints = new ArrayList<TransformCheckpoint>();
+            }
+            listOfCheckpoints.add(checkpoint);
+            return listOfCheckpoints;
+        });
+
+        listener.onResponse(true);
+    }
+
+    @Override
+    public void putTransformConfiguration(TransformConfig transformConfig, ActionListener<Boolean> listener) {
+        configs.put(transformConfig.getId(), transformConfig);
+        listener.onResponse(true);
+    }
+
+    @Override
+    public void updateTransformConfiguration(
+        TransformConfig transformConfig,
+        SeqNoPrimaryTermAndIndex seqNoPrimaryTermAndIndex,
+        ActionListener<Boolean> listener
+    ) {
+
+        // for now we ignore seqNoPrimaryTermAndIndex
+        configs.put(transformConfig.getId(), transformConfig);
+        listener.onResponse(true);
+    }
+
+    @Override
+    public void deleteOldTransformConfigurations(String transformId, ActionListener<Boolean> listener) {
+        configs.remove(transformId);
+        listener.onResponse(true);
+    }
+
+    @Override
+    public void deleteOldTransformStoredDocuments(String transformId, ActionListener<Boolean> listener) {
+        transformStoredDocs.remove(transformId);
+        listener.onResponse(true);
+    }
+
+    @Override
+    public void getTransformCheckpoint(String transformId, long checkpoint, ActionListener<TransformCheckpoint> resultListener) {
+        List<TransformCheckpoint> checkpointsById = checkpoints.get(transformId);
+
+        if (checkpointsById != null) {
+            for (TransformCheckpoint t : checkpointsById) {
+                if (t.getCheckpoint() == checkpoint) {
+                    resultListener.onResponse(t);
+                    return;
+                }
+            }
+        }
+
+        resultListener.onResponse(TransformCheckpoint.EMPTY);
+    }
+
+    @Override
+    public void getTransformConfiguration(String transformId, ActionListener<TransformConfig> resultListener) {
+        TransformConfig config = configs.get(transformId);
+        if (config == null) {
+            resultListener.onFailure(
+                new ResourceNotFoundException(TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, transformId))
+            );
+            return;
+        }
+        resultListener.onResponse(config);
+    }
+
+    @Override
+    public void getTransformConfigurationForUpdate(
+        String transformId,
+        ActionListener<Tuple<TransformConfig, SeqNoPrimaryTermAndIndex>> configAndVersionListener
+    ) {
+        TransformConfig config = configs.get(transformId);
+        if (config == null) {
+            configAndVersionListener.onFailure(
+                new ResourceNotFoundException(TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, transformId))
+            );
+            return;
+        }
+
+        configAndVersionListener.onResponse(Tuple.tuple(config, new SeqNoPrimaryTermAndIndex(1l, 1l, "index-1")));
+    }
+
+    @Override
+    public void expandTransformIds(
+        String transformIdsExpression,
+        PageParams pageParams,
+        boolean allowNoMatch,
+        ActionListener<Tuple<Long, List<String>>> foundIdsListener
+    ) {
+
+        if (Regex.isMatchAllPattern(transformIdsExpression)) {
+            List<String> ids = new ArrayList<>(configs.keySet());
+            foundIdsListener.onResponse(new Tuple<>((long) ids.size(), ids));
+            return;
+        }
+
+        if (!Regex.isSimpleMatchPattern(transformIdsExpression)) {
+            if (configs.containsKey(transformIdsExpression)) {
+                foundIdsListener.onResponse(new Tuple<>(1L, Collections.singletonList(transformIdsExpression)));
+            } else {
+                foundIdsListener.onResponse(new Tuple<>(0L, Collections.emptyList()));
+            }
+            return;
+        }
+        Set<String> ids = new LinkedHashSet<>();
+        configs.keySet().forEach(id -> {
+            if (Regex.simpleMatch(transformIdsExpression, id)) {
+                ids.add(id);
+            }
+        });
+        foundIdsListener.onResponse(new Tuple<>((long) ids.size(), new ArrayList<>(ids)));
+    }
+
+    @Override
+    public void deleteTransform(String transformId, ActionListener<Boolean> listener) {
+        configs.remove(transformId);
+        transformStoredDocs.remove(transformId);
+        checkpoints.remove(transformId);
+    }
+
+    @Override
+    public void putOrUpdateTransformStoredDoc(
+        TransformStoredDoc storedDoc,
+        SeqNoPrimaryTermAndIndex seqNoPrimaryTermAndIndex,
+        ActionListener<SeqNoPrimaryTermAndIndex> listener
+    ) {
+
+        // for now we ignore seqNoPrimaryTermAndIndex
+        transformStoredDocs.put(storedDoc.getId(), storedDoc);
+        listener.onResponse(new SeqNoPrimaryTermAndIndex(1l, 1l, "index-1"));
+    }
+
+    @Override
+    public void getTransformStoredDoc(
+        String transformId,
+        ActionListener<Tuple<TransformStoredDoc, SeqNoPrimaryTermAndIndex>> resultListener
+    ) {
+
+        TransformStoredDoc storedDoc = transformStoredDocs.get(transformId);
+        if (storedDoc == null) {
+            resultListener.onFailure(
+                new ResourceNotFoundException(TransformMessages.getMessage(TransformMessages.UNKNOWN_TRANSFORM_STATS, transformId))
+            );
+            return;
+        }
+
+        resultListener.onResponse(Tuple.tuple(storedDoc, new SeqNoPrimaryTermAndIndex(1l, 1l, "index-1")));
+    }
+
+    @Override
+    public void getTransformStoredDocs(Collection<String> transformIds, ActionListener<List<TransformStoredDoc>> listener) {
+        List<TransformStoredDoc> docs = new ArrayList<>();
+        for (String transformId : transformIds) {
+            TransformStoredDoc storedDoc = transformStoredDocs.get(transformId);
+            if (storedDoc != null) {
+                docs.add(storedDoc);
+            }
+        }
+        listener.onResponse(docs);
+    }
+
+}

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformConfigManagerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformConfigManagerTests.java
@@ -45,35 +45,43 @@ import static org.hamcrest.Matchers.instanceOf;
 
 public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
 
-    private TransformConfigManager transformConfigManager;
+    private IndexBasedTransformConfigManager transformConfigManager;
 
     @Before
     public void createComponents() {
-        transformConfigManager = new TransformConfigManager(client(), xContentRegistry());
+        transformConfigManager = new IndexBasedTransformConfigManager(client(), xContentRegistry());
     }
 
     public void testGetMissingTransform() throws InterruptedException {
         // the index does not exist yet
-        assertAsync(listener -> transformConfigManager.getTransformConfiguration("not_there", listener), (TransformConfig) null,
-                null, e -> {
-                    assertEquals(ResourceNotFoundException.class, e.getClass());
-                    assertEquals(TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, "not_there"),
-                            e.getMessage());
-                });
+        assertAsync(
+            listener -> transformConfigManager.getTransformConfiguration("not_there", listener),
+            (TransformConfig) null,
+            null,
+            e -> {
+                assertEquals(ResourceNotFoundException.class, e.getClass());
+                assertEquals(TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, "not_there"), e.getMessage());
+            }
+        );
 
         // create one transform and test with an existing index
         assertAsync(
-                listener -> transformConfigManager
-                        .putTransformConfiguration(TransformConfigTests.randomTransformConfig(), listener),
-                true, null, null);
+            listener -> transformConfigManager.putTransformConfiguration(TransformConfigTests.randomTransformConfig(), listener),
+            true,
+            null,
+            null
+        );
 
         // same test, but different code path
-        assertAsync(listener -> transformConfigManager.getTransformConfiguration("not_there", listener), (TransformConfig) null,
-                null, e -> {
-                    assertEquals(ResourceNotFoundException.class, e.getClass());
-                    assertEquals(TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, "not_there"),
-                            e.getMessage());
-                });
+        assertAsync(
+            listener -> transformConfigManager.getTransformConfiguration("not_there", listener),
+            (TransformConfig) null,
+            null,
+            e -> {
+                assertEquals(ResourceNotFoundException.class, e.getClass());
+                assertEquals(TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, "not_there"), e.getMessage());
+            }
+        );
     }
 
     public void testDeleteMissingTransform() throws InterruptedException {
@@ -85,9 +93,11 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
 
         // create one transform and test with an existing index
         assertAsync(
-                listener -> transformConfigManager
-                        .putTransformConfiguration(TransformConfigTests.randomTransformConfig(), listener),
-                true, null, null);
+            listener -> transformConfigManager.putTransformConfiguration(TransformConfigTests.randomTransformConfig(), listener),
+            true,
+            null,
+            null
+        );
 
         // same test, but different code path
         assertAsync(listener -> transformConfigManager.deleteTransform("not_there", listener), (Boolean) null, null, e -> {
@@ -103,14 +113,20 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
         assertAsync(listener -> transformConfigManager.putTransformConfiguration(transformConfig, listener), true, null, null);
 
         // read transform
-        assertAsync(listener -> transformConfigManager.getTransformConfiguration(transformConfig.getId(), listener), transformConfig, null,
-                null);
+        assertAsync(
+            listener -> transformConfigManager.getTransformConfiguration(transformConfig.getId(), listener),
+            transformConfig,
+            null,
+            null
+        );
 
         // try to create again
         assertAsync(listener -> transformConfigManager.putTransformConfiguration(transformConfig, listener), (Boolean) null, null, e -> {
             assertEquals(ResourceAlreadyExistsException.class, e.getClass());
-            assertEquals(TransformMessages.getMessage(TransformMessages.REST_PUT_TRANSFORM_EXISTS, transformConfig.getId()),
-                    e.getMessage());
+            assertEquals(
+                TransformMessages.getMessage(TransformMessages.REST_PUT_TRANSFORM_EXISTS, transformConfig.getId()),
+                e.getMessage()
+            );
         });
 
         // delete transform
@@ -119,17 +135,22 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
         // delete again
         assertAsync(listener -> transformConfigManager.deleteTransform(transformConfig.getId(), listener), (Boolean) null, null, e -> {
             assertEquals(ResourceNotFoundException.class, e.getClass());
-            assertEquals(TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, transformConfig.getId()),
-                    e.getMessage());
+            assertEquals(TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, transformConfig.getId()), e.getMessage());
         });
 
         // try to get deleted transform
-        assertAsync(listener -> transformConfigManager.getTransformConfiguration(transformConfig.getId(), listener),
-                (TransformConfig) null, null, e -> {
-                    assertEquals(ResourceNotFoundException.class, e.getClass());
-                    assertEquals(TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, transformConfig.getId()),
-                            e.getMessage());
-                });
+        assertAsync(
+            listener -> transformConfigManager.getTransformConfiguration(transformConfig.getId(), listener),
+            (TransformConfig) null,
+            null,
+            e -> {
+                assertEquals(ResourceNotFoundException.class, e.getClass());
+                assertEquals(
+                    TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, transformConfig.getId()),
+                    e.getMessage()
+                );
+            }
+        );
     }
 
     public void testCreateReadDeleteCheckPoint() throws InterruptedException {
@@ -139,8 +160,12 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
         assertAsync(listener -> transformConfigManager.putTransformCheckpoint(checkpoint, listener), true, null, null);
 
         // read
-        assertAsync(listener -> transformConfigManager.getTransformCheckpoint(checkpoint.getTransformId(), checkpoint.getCheckpoint(),
-                listener), checkpoint, null, null);
+        assertAsync(
+            listener -> transformConfigManager.getTransformCheckpoint(checkpoint.getTransformId(), checkpoint.getCheckpoint(), listener),
+            checkpoint,
+            null,
+            null
+        );
 
         // delete
         assertAsync(listener -> transformConfigManager.deleteTransform(checkpoint.getTransformId(), listener), true, null, null);
@@ -148,13 +173,19 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
         // delete again
         assertAsync(listener -> transformConfigManager.deleteTransform(checkpoint.getTransformId(), listener), (Boolean) null, null, e -> {
             assertEquals(ResourceNotFoundException.class, e.getClass());
-            assertEquals(TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, checkpoint.getTransformId()),
-                    e.getMessage());
+            assertEquals(
+                TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, checkpoint.getTransformId()),
+                e.getMessage()
+            );
         });
 
         // getting a non-existing checkpoint returns null
-        assertAsync(listener -> transformConfigManager.getTransformCheckpoint(checkpoint.getTransformId(), checkpoint.getCheckpoint(),
-                listener), TransformCheckpoint.EMPTY, null, null);
+        assertAsync(
+            listener -> transformConfigManager.getTransformCheckpoint(checkpoint.getTransformId(), checkpoint.getCheckpoint(), listener),
+            TransformCheckpoint.EMPTY,
+            null,
+            null
+        );
     }
 
     public void testExpandIds() throws Exception {
@@ -167,94 +198,88 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
         assertAsync(listener -> transformConfigManager.putTransformConfiguration(transformConfig2, listener), true, null, null);
         assertAsync(listener -> transformConfigManager.putTransformConfiguration(transformConfig3, listener), true, null, null);
 
-
         // expand 1 id
-        assertAsync(listener ->
-                transformConfigManager.expandTransformIds(transformConfig1.getId(),
-                    PageParams.defaultParams(),
-                    true,
-                    listener),
+        assertAsync(
+            listener -> transformConfigManager.expandTransformIds(transformConfig1.getId(), PageParams.defaultParams(), true, listener),
             new Tuple<>(1L, Collections.singletonList("transform1_expand")),
             null,
-            null);
+            null
+        );
 
         // expand 2 ids explicitly
-        assertAsync(listener ->
-                transformConfigManager.expandTransformIds("transform1_expand,transform2_expand",
-                    PageParams.defaultParams(),
-                    true,
-                    listener),
+        assertAsync(
+            listener -> transformConfigManager.expandTransformIds(
+                "transform1_expand,transform2_expand",
+                PageParams.defaultParams(),
+                true,
+                listener
+            ),
             new Tuple<>(2L, Arrays.asList("transform1_expand", "transform2_expand")),
             null,
-            null);
+            null
+        );
 
         // expand 3 ids wildcard and explicit
-        assertAsync(listener ->
-                transformConfigManager.expandTransformIds("transform1*,transform2_expand,transform3_expand",
-                    PageParams.defaultParams(),
-                    true,
-                    listener),
+        assertAsync(
+            listener -> transformConfigManager.expandTransformIds(
+                "transform1*,transform2_expand,transform3_expand",
+                PageParams.defaultParams(),
+                true,
+                listener
+            ),
             new Tuple<>(3L, Arrays.asList("transform1_expand", "transform2_expand", "transform3_expand")),
             null,
-            null);
+            null
+        );
 
         // expand 3 ids _all
-        assertAsync(listener ->
-                transformConfigManager.expandTransformIds("_all",
-                    PageParams.defaultParams(),
-                    true,
-                    listener),
+        assertAsync(
+            listener -> transformConfigManager.expandTransformIds("_all", PageParams.defaultParams(), true, listener),
             new Tuple<>(3L, Arrays.asList("transform1_expand", "transform2_expand", "transform3_expand")),
             null,
-            null);
+            null
+        );
 
         // expand 1 id _all with pagination
-        assertAsync(listener ->
-                transformConfigManager.expandTransformIds("_all",
-                    new PageParams(0, 1),
-                    true,
-                    listener),
+        assertAsync(
+            listener -> transformConfigManager.expandTransformIds("_all", new PageParams(0, 1), true, listener),
             new Tuple<>(3L, Collections.singletonList("transform1_expand")),
             null,
-            null);
+            null
+        );
 
         // expand 2 later ids _all with pagination
-        assertAsync(listener ->
-                transformConfigManager.expandTransformIds("_all",
-                    new PageParams(1, 2),
-                    true,
-                    listener),
+        assertAsync(
+            listener -> transformConfigManager.expandTransformIds("_all", new PageParams(1, 2), true, listener),
             new Tuple<>(3L, Arrays.asList("transform2_expand", "transform3_expand")),
             null,
-            null);
+            null
+        );
 
         // expand 1 id explicitly that does not exist
-        assertAsync(listener ->
-                transformConfigManager.expandTransformIds("unknown,unknown2",
-                    new PageParams(1, 2),
-                    true,
-                    listener),
-            (Tuple<Long, List<String>>)null,
+        assertAsync(
+            listener -> transformConfigManager.expandTransformIds("unknown,unknown2", new PageParams(1, 2), true, listener),
+            (Tuple<Long, List<String>>) null,
             null,
             e -> {
                 assertThat(e, instanceOf(ResourceNotFoundException.class));
-                assertThat(e.getMessage(),
-                    equalTo(TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, "unknown,unknown2")));
-            });
+                assertThat(
+                    e.getMessage(),
+                    equalTo(TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, "unknown,unknown2"))
+                );
+            }
+        );
 
         // expand 1 id implicitly that does not exist
-        assertAsync(listener ->
-                transformConfigManager.expandTransformIds("unknown*",
-                    new PageParams(1, 2),
-                    false,
-                    listener),
-            (Tuple<Long, List<String>>)null,
+        assertAsync(
+            listener -> transformConfigManager.expandTransformIds("unknown*", new PageParams(1, 2), false, listener),
+            (Tuple<Long, List<String>>) null,
             null,
             e -> {
                 assertThat(e, instanceOf(ResourceNotFoundException.class));
-                assertThat(e.getMessage(),
-                    equalTo(TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, "unknown*")));
-            });
+                assertThat(e.getMessage(), equalTo(TransformMessages.getMessage(TransformMessages.REST_UNKNOWN_TRANSFORM, "unknown*")));
+            }
+        );
 
     }
 
@@ -264,48 +289,48 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
         TransformStoredDoc storedDocs = TransformStoredDocTests.randomTransformStoredDoc(transformId);
         SeqNoPrimaryTermAndIndex firstIndex = new SeqNoPrimaryTermAndIndex(0, 1, TransformInternalIndexConstants.LATEST_INDEX_NAME);
 
-        assertAsync(listener -> transformConfigManager.putOrUpdateTransformStoredDoc(storedDocs, null, listener),
-            firstIndex,
-            null,
-            null);
-        assertAsync(listener -> transformConfigManager.getTransformStoredDoc(transformId, listener),
+        assertAsync(listener -> transformConfigManager.putOrUpdateTransformStoredDoc(storedDocs, null, listener), firstIndex, null, null);
+        assertAsync(
+            listener -> transformConfigManager.getTransformStoredDoc(transformId, listener),
             Tuple.tuple(storedDocs, firstIndex),
             null,
-            null);
+            null
+        );
 
         SeqNoPrimaryTermAndIndex secondIndex = new SeqNoPrimaryTermAndIndex(1, 1, TransformInternalIndexConstants.LATEST_INDEX_NAME);
         TransformStoredDoc updated = TransformStoredDocTests.randomTransformStoredDoc(transformId);
-        assertAsync(listener -> transformConfigManager.putOrUpdateTransformStoredDoc(updated, firstIndex, listener),
+        assertAsync(
+            listener -> transformConfigManager.putOrUpdateTransformStoredDoc(updated, firstIndex, listener),
             secondIndex,
             null,
-            null);
-        assertAsync(listener -> transformConfigManager.getTransformStoredDoc(transformId, listener),
+            null
+        );
+        assertAsync(
+            listener -> transformConfigManager.getTransformStoredDoc(transformId, listener),
             Tuple.tuple(updated, secondIndex),
             null,
-            null);
+            null
+        );
 
-        assertAsync(listener -> transformConfigManager.putOrUpdateTransformStoredDoc(updated, firstIndex, listener),
-            (SeqNoPrimaryTermAndIndex)null,
+        assertAsync(
+            listener -> transformConfigManager.putOrUpdateTransformStoredDoc(updated, firstIndex, listener),
+            (SeqNoPrimaryTermAndIndex) null,
             r -> fail("did not fail with version conflict."),
             e -> assertThat(
                 e.getMessage(),
-                equalTo("Failed to persist transform statistics for transform [transform_test_stored_doc_create_read_update]"))
-            );
+                equalTo("Failed to persist transform statistics for transform [transform_test_stored_doc_create_read_update]")
+            )
+        );
     }
 
     public void testGetStoredDocMultiple() throws InterruptedException {
         int numStats = randomIntBetween(10, 15);
         List<TransformStoredDoc> expectedDocs = new ArrayList<>();
-        for (int i=0; i<numStats; i++) {
-            SeqNoPrimaryTermAndIndex initialSeqNo =
-                new SeqNoPrimaryTermAndIndex(i, 1, TransformInternalIndexConstants.LATEST_INDEX_NAME);
-            TransformStoredDoc stat =
-                    TransformStoredDocTests.randomTransformStoredDoc(randomAlphaOfLength(6) + i);
+        for (int i = 0; i < numStats; i++) {
+            SeqNoPrimaryTermAndIndex initialSeqNo = new SeqNoPrimaryTermAndIndex(i, 1, TransformInternalIndexConstants.LATEST_INDEX_NAME);
+            TransformStoredDoc stat = TransformStoredDocTests.randomTransformStoredDoc(randomAlphaOfLength(6) + i);
             expectedDocs.add(stat);
-            assertAsync(listener -> transformConfigManager.putOrUpdateTransformStoredDoc(stat, null, listener),
-                initialSeqNo,
-                null,
-                null);
+            assertAsync(listener -> transformConfigManager.putOrUpdateTransformStoredDoc(stat, null, listener), initialSeqNo, null, null);
         }
 
         // remove one of the put docs so we don't retrieve all
@@ -316,22 +341,22 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
 
         // returned docs will be ordered by id
         expectedDocs.sort(Comparator.comparing(TransformStoredDoc::getId));
-        assertAsync(listener -> transformConfigManager.getTransformStoredDoc(ids, listener), expectedDocs, null, null);
+        assertAsync(listener -> transformConfigManager.getTransformStoredDocs(ids, listener), expectedDocs, null, null);
     }
 
     public void testDeleteOldTransformConfigurations() throws Exception {
         String oldIndex = TransformInternalIndexConstants.INDEX_PATTERN + "1";
         String transformId = "transform_test_delete_old_configurations";
         String docId = TransformConfig.documentId(transformId);
-        TransformConfig transformConfig = TransformConfigTests
-            .randomTransformConfig("transform_test_delete_old_configurations");
-        client().admin().indices().create(new CreateIndexRequest(oldIndex)
-            .mapping(MapperService.SINGLE_MAPPING_NAME, mappings())).actionGet();
+        TransformConfig transformConfig = TransformConfigTests.randomTransformConfig("transform_test_delete_old_configurations");
+        client().admin()
+            .indices()
+            .create(new CreateIndexRequest(oldIndex).mapping(MapperService.SINGLE_MAPPING_NAME, mappings()))
+            .actionGet();
 
-        try(XContentBuilder builder = XContentFactory.jsonBuilder()) {
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
             XContentBuilder source = transformConfig.toXContent(builder, new ToXContent.MapParams(TO_XCONTENT_PARAMS));
-            IndexRequest request = new IndexRequest(oldIndex)
-                .source(source)
+            IndexRequest request = new IndexRequest(oldIndex).source(source)
                 .id(docId)
                 .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
             client().index(request).actionGet();
@@ -340,56 +365,64 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
         assertAsync(listener -> transformConfigManager.putTransformConfiguration(transformConfig, listener), true, null, null);
 
         assertThat(client().get(new GetRequest(oldIndex).id(docId)).actionGet().isExists(), is(true));
-        assertThat(client().get(new GetRequest(TransformInternalIndexConstants.LATEST_INDEX_NAME).id(docId)).actionGet().isExists(),
-                is(true));
+        assertThat(
+            client().get(new GetRequest(TransformInternalIndexConstants.LATEST_INDEX_NAME).id(docId)).actionGet().isExists(),
+            is(true)
+        );
 
         assertAsync(listener -> transformConfigManager.deleteOldTransformConfigurations(transformId, listener), true, null, null);
 
         client().admin().indices().refresh(new RefreshRequest(TransformInternalIndexConstants.INDEX_NAME_PATTERN)).actionGet();
         assertThat(client().get(new GetRequest(oldIndex).id(docId)).actionGet().isExists(), is(false));
-        assertThat(client().get(new GetRequest(TransformInternalIndexConstants.LATEST_INDEX_NAME).id(docId)).actionGet().isExists(),
-                is(true));
+        assertThat(
+            client().get(new GetRequest(TransformInternalIndexConstants.LATEST_INDEX_NAME).id(docId)).actionGet().isExists(),
+            is(true)
+        );
     }
 
     public void testDeleteOldTransformStoredDocuments() throws Exception {
         String oldIndex = TransformInternalIndexConstants.INDEX_PATTERN + "1";
         String transformId = "transform_test_delete_old_stored_documents";
         String docId = TransformStoredDoc.documentId(transformId);
-        TransformStoredDoc transformStoredDoc = TransformStoredDocTests
-            .randomTransformStoredDoc(transformId);
-        client().admin().indices().create(new CreateIndexRequest(oldIndex)
-            .mapping(MapperService.SINGLE_MAPPING_NAME, mappings())).actionGet();
+        TransformStoredDoc transformStoredDoc = TransformStoredDocTests.randomTransformStoredDoc(transformId);
+        client().admin()
+            .indices()
+            .create(new CreateIndexRequest(oldIndex).mapping(MapperService.SINGLE_MAPPING_NAME, mappings()))
+            .actionGet();
 
-        try(XContentBuilder builder = XContentFactory.jsonBuilder()) {
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
             XContentBuilder source = transformStoredDoc.toXContent(builder, new ToXContent.MapParams(TO_XCONTENT_PARAMS));
-            IndexRequest request = new IndexRequest(oldIndex)
-                .source(source)
-                .id(docId);
+            IndexRequest request = new IndexRequest(oldIndex).source(source).id(docId);
             client().index(request).actionGet();
         }
 
         // Put when referencing the old index should create the doc in the new index, even if we have seqNo|primaryTerm info
-        assertAsync(listener -> transformConfigManager.putOrUpdateTransformStoredDoc(transformStoredDoc,
-            new SeqNoPrimaryTermAndIndex(3, 1, oldIndex),
-            listener),
+        assertAsync(
+            listener -> transformConfigManager.putOrUpdateTransformStoredDoc(
+                transformStoredDoc,
+                new SeqNoPrimaryTermAndIndex(3, 1, oldIndex),
+                listener
+            ),
             new SeqNoPrimaryTermAndIndex(0, 1, TransformInternalIndexConstants.LATEST_INDEX_NAME),
             null,
-            null);
+            null
+        );
 
         client().admin().indices().refresh(new RefreshRequest(TransformInternalIndexConstants.INDEX_NAME_PATTERN)).actionGet();
 
         assertThat(client().get(new GetRequest(oldIndex).id(docId)).actionGet().isExists(), is(true));
-        assertThat(client().get(new GetRequest(TransformInternalIndexConstants.LATEST_INDEX_NAME).id(docId)).actionGet().isExists(),
-                is(true));
+        assertThat(
+            client().get(new GetRequest(TransformInternalIndexConstants.LATEST_INDEX_NAME).id(docId)).actionGet().isExists(),
+            is(true)
+        );
 
-        assertAsync(listener -> transformConfigManager.deleteOldTransformStoredDocuments(transformId, listener),
-            true,
-            null,
-            null);
+        assertAsync(listener -> transformConfigManager.deleteOldTransformStoredDocuments(transformId, listener), true, null, null);
 
         client().admin().indices().refresh(new RefreshRequest(TransformInternalIndexConstants.INDEX_NAME_PATTERN)).actionGet();
         assertThat(client().get(new GetRequest(oldIndex).id(docId)).actionGet().isExists(), is(false));
-        assertThat(client().get(new GetRequest(TransformInternalIndexConstants.LATEST_INDEX_NAME).id(docId)).actionGet().isExists(),
-                is(true));
+        assertThat(
+            client().get(new GetRequest(TransformInternalIndexConstants.LATEST_INDEX_NAME).id(docId)).actionGet().isExists(),
+            is(true)
+        );
     }
 }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
@@ -17,7 +17,7 @@ import org.elasticsearch.xpack.core.transform.transforms.persistence.TransformIn
 import org.elasticsearch.xpack.transform.checkpoint.CheckpointProvider;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
 import org.elasticsearch.xpack.transform.persistence.SeqNoPrimaryTermAndIndex;
-import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
+import org.elasticsearch.xpack.transform.persistence.IndexBasedTransformConfigManager;
 
 import java.time.Instant;
 import java.util.Collections;
@@ -39,7 +39,7 @@ public class ClientTransformIndexerTests extends ESTestCase {
 
         ClientTransformIndexer indexer = new ClientTransformIndexer(
             mock(Executor.class),
-            mock(TransformConfigManager.class),
+            mock(IndexBasedTransformConfigManager.class),
             mock(CheckpointProvider.class),
             new TransformProgressGatherer(mock(Client.class)),
             new AtomicReference<>(IndexerState.STOPPED),

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
@@ -39,7 +39,7 @@ import org.elasticsearch.xpack.core.transform.transforms.pivot.PivotConfig;
 import org.elasticsearch.xpack.transform.checkpoint.CheckpointProvider;
 import org.elasticsearch.xpack.transform.notifications.MockTransformAuditor;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
-import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
+import org.elasticsearch.xpack.transform.persistence.IndexBasedTransformConfigManager;
 import org.elasticsearch.xpack.transform.transforms.pivot.Pivot;
 import org.junit.After;
 import org.junit.Before;
@@ -87,7 +87,7 @@ public class TransformIndexerTests extends ESTestCase {
 
         MockedTransformIndexer(
             Executor executor,
-            TransformConfigManager transformsConfigManager,
+            IndexBasedTransformConfigManager transformsConfigManager,
             CheckpointProvider checkpointProvider,
             TransformProgressGatherer progressGatherer,
             TransformConfig transformConfig,
@@ -412,15 +412,14 @@ public class TransformIndexerTests extends ESTestCase {
             );
 
             final CountDownLatch latch = indexer.newLatch(1);
-            auditor
-                .addExpectation(
-                    new MockTransformAuditor.SeenAuditExpectation(
-                        "fail indexer due to script error",
-                        org.elasticsearch.xpack.core.common.notifications.Level.ERROR,
-                        transformId,
-                        "Failed to execute script with error: [*ArithmeticException: / by zero], stack trace: [stack]"
-                    )
-                );
+            auditor.addExpectation(
+                new MockTransformAuditor.SeenAuditExpectation(
+                    "fail indexer due to script error",
+                    org.elasticsearch.xpack.core.common.notifications.Level.ERROR,
+                    transformId,
+                    "Failed to execute script with error: [*ArithmeticException: / by zero], stack trace: [stack]"
+                )
+            );
             indexer.start();
             assertThat(indexer.getState(), equalTo(IndexerState.STARTED));
             assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
@@ -451,7 +450,7 @@ public class TransformIndexerTests extends ESTestCase {
     ) {
         return new MockedTransformIndexer(
             executor,
-            mock(TransformConfigManager.class),
+            mock(IndexBasedTransformConfigManager.class),
             mock(CheckpointProvider.class),
             new TransformProgressGatherer(client),
             config,

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
@@ -35,7 +35,7 @@ import org.elasticsearch.xpack.core.transform.transforms.persistence.TransformIn
 import org.elasticsearch.xpack.transform.Transform;
 import org.elasticsearch.xpack.transform.checkpoint.TransformCheckpointService;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
-import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
+import org.elasticsearch.xpack.transform.persistence.IndexBasedTransformConfigManager;
 import org.elasticsearch.xpack.transform.persistence.TransformInternalIndexTests;
 
 import java.util.ArrayList;
@@ -53,8 +53,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
         MetaData.Builder metaData = MetaData.builder();
         RoutingTable.Builder routingTable = RoutingTable.builder();
         addIndices(metaData, routingTable);
-        PersistentTasksCustomMetaData.Builder pTasksBuilder = PersistentTasksCustomMetaData
-            .builder()
+        PersistentTasksCustomMetaData.Builder pTasksBuilder = PersistentTasksCustomMetaData.builder()
             .addTask(
                 "transform-task-1",
                 TransformTaskParams.NAME,
@@ -78,8 +77,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
 
         metaData.putCustom(PersistentTasksCustomMetaData.TYPE, pTasks);
 
-        DiscoveryNodes.Builder nodes = DiscoveryNodes
-            .builder()
+        DiscoveryNodes.Builder nodes = DiscoveryNodes.builder()
             .add(
                 new DiscoveryNode(
                     "past-data-node-1",
@@ -124,7 +122,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
         ClusterState cs = csBuilder.build();
         Client client = mock(Client.class);
         TransformAuditor mockAuditor = mock(TransformAuditor.class);
-        TransformConfigManager transformsConfigManager = new TransformConfigManager(client, xContentRegistry());
+        IndexBasedTransformConfigManager transformsConfigManager = new IndexBasedTransformConfigManager(client, xContentRegistry());
         TransformCheckpointService transformCheckpointService = new TransformCheckpointService(
             client,
             transformsConfigManager,
@@ -175,20 +173,16 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
         } else {
             Index index = new Index(indexToRemove, "_uuid");
             ShardId shardId = new ShardId(index, 0);
-            ShardRouting shardRouting = ShardRouting
-                .newUnassigned(
-                    shardId,
-                    true,
-                    RecoverySource.EmptyStoreRecoverySource.INSTANCE,
-                    new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "")
-                );
+            ShardRouting shardRouting = ShardRouting.newUnassigned(
+                shardId,
+                true,
+                RecoverySource.EmptyStoreRecoverySource.INSTANCE,
+                new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "")
+            );
             shardRouting = shardRouting.initialize("node_id", null, 0L);
-            routingTable
-                .add(
-                    IndexRoutingTable
-                        .builder(index)
-                        .addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting).build())
-                );
+            routingTable.add(
+                IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting).build())
+            );
         }
 
         csBuilder.routingTable(routingTable.build());
@@ -204,32 +198,26 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
         indices.add(TransformInternalIndexConstants.LATEST_INDEX_NAME);
         for (String indexName : indices) {
             IndexMetaData.Builder indexMetaData = IndexMetaData.builder(indexName);
-            indexMetaData
-                .settings(
-                    Settings
-                        .builder()
-                        .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
-                        .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
-                        .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
-                );
+            indexMetaData.settings(
+                Settings.builder()
+                    .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+                    .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+            );
             metaData.put(indexMetaData);
             Index index = new Index(indexName, "_uuid");
             ShardId shardId = new ShardId(index, 0);
-            ShardRouting shardRouting = ShardRouting
-                .newUnassigned(
-                    shardId,
-                    true,
-                    RecoverySource.EmptyStoreRecoverySource.INSTANCE,
-                    new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "")
-                );
+            ShardRouting shardRouting = ShardRouting.newUnassigned(
+                shardId,
+                true,
+                RecoverySource.EmptyStoreRecoverySource.INSTANCE,
+                new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "")
+            );
             shardRouting = shardRouting.initialize("node_id", null, 0L);
             shardRouting = shardRouting.moveToStarted();
-            routingTable
-                .add(
-                    IndexRoutingTable
-                        .builder(index)
-                        .addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting).build())
-                );
+            routingTable.add(
+                IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting).build())
+            );
         }
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
@@ -33,6 +33,7 @@ import org.elasticsearch.xpack.core.scheduler.SchedulerEngine;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskParams;
 import org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants;
 import org.elasticsearch.xpack.transform.Transform;
+import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.checkpoint.TransformCheckpointService;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
 import org.elasticsearch.xpack.transform.persistence.IndexBasedTransformConfigManager;
@@ -128,16 +129,20 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
             transformsConfigManager,
             mockAuditor
         );
+        TransformServices transformServices = new TransformServices(
+            transformsConfigManager,
+            transformCheckpointService,
+            mockAuditor,
+            mock(SchedulerEngine.class)
+        );
+
         ClusterSettings cSettings = new ClusterSettings(Settings.EMPTY, Collections.singleton(Transform.NUM_FAILURE_RETRIES_SETTING));
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(cSettings);
         when(clusterService.state()).thenReturn(TransformInternalIndexTests.STATE_WITH_LATEST_VERSIONED_INDEX_TEMPLATE);
         TransformPersistentTasksExecutor executor = new TransformPersistentTasksExecutor(
             client,
-            transformsConfigManager,
-            transformCheckpointService,
-            mock(SchedulerEngine.class),
-            new TransformAuditor(client, ""),
+            transformServices,
             mock(ThreadPool.class),
             clusterService,
             Settings.EMPTY

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.transform.transforms;
+
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.Version;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.persistent.PersistentTasksService;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.tasks.TaskManager;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.indexing.IndexerState;
+import org.elasticsearch.xpack.core.scheduler.SchedulerEngine;
+import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
+import org.elasticsearch.xpack.core.transform.transforms.TransformConfigTests;
+import org.elasticsearch.xpack.core.transform.transforms.TransformState;
+import org.elasticsearch.xpack.core.transform.transforms.TransformTaskParams;
+import org.elasticsearch.xpack.core.transform.transforms.TransformTaskState;
+import org.elasticsearch.xpack.transform.checkpoint.TransformCheckpointService;
+import org.elasticsearch.xpack.transform.notifications.MockTransformAuditor;
+import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
+import org.elasticsearch.xpack.transform.persistence.InMemoryTransformConfigManager;
+import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TransformTaskTests extends ESTestCase {
+
+    private Client client;
+
+    @Before
+    public void setupClient() {
+        if (client != null) {
+            client.close();
+        }
+        client = new NoOpClient(getTestName());
+    }
+
+    @After
+    public void tearDownClient() {
+        client.close();
+    }
+
+    // see https://github.com/elastic/elasticsearch/issues/48957
+    public void testStopOnFailedTaskWithStoppedIndexer() {
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.executor("generic")).thenReturn(mock(ExecutorService.class));
+
+        TransformConfig transformConfig = TransformConfigTests.randomDataFrameTransformConfigWithoutHeaders();
+        TransformAuditor auditor = new MockTransformAuditor();
+        TransformConfigManager transformsConfigManager = new InMemoryTransformConfigManager();
+
+        TransformCheckpointService transformsCheckpointService = new TransformCheckpointService(client, transformsConfigManager, auditor);
+
+        TransformState transformState = new TransformState(
+            TransformTaskState.FAILED,
+            IndexerState.STOPPED,
+            null,
+            0L,
+            "because",
+            null,
+            null,
+            false
+        );
+
+        TransformTask transformTask = new TransformTask(
+            42,
+            "some_type",
+            "some_action",
+            TaskId.EMPTY_TASK_ID,
+            new TransformTaskParams(transformConfig.getId(), Version.CURRENT, TimeValue.timeValueSeconds(10)),
+            transformState,
+            mock(SchedulerEngine.class),
+            auditor,
+            threadPool,
+            Collections.emptyMap()
+        );
+
+        TaskManager taskManager = mock(TaskManager.class);
+
+        transformTask.init(mock(PersistentTasksService.class), taskManager, "task-id", 42);
+
+        ClientTransformIndexerBuilder indexerBuilder = new ClientTransformIndexerBuilder();
+        indexerBuilder.setClient(client)
+            .setTransformConfig(transformConfig)
+            .setAuditor(auditor)
+            .setTransformsConfigManager(transformsConfigManager)
+            .setTransformsCheckpointService(transformsCheckpointService)
+            .setFieldMappings(Collections.emptyMap());
+
+        transformTask.initializeIndexer(indexerBuilder);
+        TransformState state = transformTask.getState();
+        assertEquals(TransformTaskState.FAILED, state.getTaskState());
+        assertEquals(IndexerState.STOPPED, state.getIndexerState());
+        assertThat(state.getReason(), equalTo("because"));
+
+        ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class, () -> transformTask.stop(false, false));
+
+        assertThat(e.status(), equalTo(RestStatus.CONFLICT));
+        assertThat(
+            e.getMessage(),
+            equalTo(
+                "Unable to stop transform ["
+                    + transformConfig.getId()
+                    + "] as it is in a failed state with reason [because]. Use force stop to stop the transform."
+            )
+        );
+
+        // verify that shutdown has not been called
+        verify(taskManager, times(0)).unregister(any());
+
+        state = transformTask.getState();
+        assertEquals(TransformTaskState.FAILED, state.getTaskState());
+        assertEquals(IndexerState.STOPPED, state.getIndexerState());
+        assertThat(state.getReason(), equalTo("because"));
+
+        transformTask.stop(true, false);
+
+        // verify shutdown has been called
+        verify(taskManager).unregister(any());
+
+        state = transformTask.getState();
+        assertEquals(TransformTaskState.STARTED, state.getTaskState());
+        assertEquals(IndexerState.STOPPED, state.getIndexerState());
+        assertEquals(state.getReason(), null);
+    }
+
+}


### PR DESCRIPTION
fix force stopping transform if indexer state hasn't been written and/or is set to STOPPED. In certain situations the transform could not be stopped, which means the task could not be removed. Introduces improved abstraction in order to better test state handling in future.

fixes #48957 

Notes:

- this turned into a large refactoring and due to upstream changes in code formating produced a lot of formating changes. I therefore put the formating and simple changes into the 1st commit, the [2nd commit](https://github.com/elastic/elasticsearch/commit/45d6715981878f35d95a5723e0943996852f67cc) contains the important parts.
- I had to create a holder class for transform config manager due to problems with service injection. For future enhancements I moved all transform services into the TransformServices holder

**Reviewers: please start with the 2nd commit, the 1st has only cosmetic changes**