### PR TITLE
SQL: Fix issue with mins & hours for DATEDIFF

### DIFF
--- a/docs/reference/sql/functions/date-time.asciidoc
+++ b/docs/reference/sql/functions/date-time.asciidoc
@@ -395,6 +395,20 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[dateDiffDateTimeSeconds]
 include-tagged::{sql-specs}/docs/docs.csv-spec[dateDiffDateQuarters]
 --------------------------------------------------
 
+[NOTE]
+For `hour` and `minute`, `DATEDIFF` doesn't do any rounding, but instead first truncates
+the more detailed time fields on the 2 dates to zero and then calculates the subtraction.
+
+[source, sql]
+--------------------------------------------------
+include-tagged::{sql-specs}/docs/docs.csv-spec[dateDiffDateTimeHours]
+--------------------------------------------------
+
+[source, sql]
+--------------------------------------------------
+include-tagged::{sql-specs}/docs/docs.csv-spec[dateDiffDateTimeMinutes]
+--------------------------------------------------
+
 [source, sql]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[dateDiffDateMinutes]

--- a/x-pack/plugin/sql/qa/src/main/resources/datetime.csv-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/datetime.csv-spec
@@ -717,9 +717,9 @@ M       | 1996-11-05 00:00:00.000Z
 castedDateTimeWithGroupBy1
 SELECT CONVERT(birth_date, DOUBLE) AS date FROM test_emp GROUP BY date ORDER BY date LIMIT 10;
 
-    date:d
+    date:d      
 ---------------
-null
+null           
 -5.631552E11
 -5.586624E11
 -5.56416E11
@@ -751,19 +751,19 @@ SELECT CAST(hire_date AS LONG) AS date FROM test_emp GROUP BY date ORDER BY date
 dateTimeAggByIsoDayOfWeekWithFilter
 SELECT IDOW(birth_date) day, DAY_NAME(birth_date) name, COUNT(*) c FROM test_emp WHERE IDOW(birth_date) < 6 GROUP BY day, name ORDER BY day desc;
 
-    day:i      |   name:s      |     c:l
+    day:i      |   name:s      |     c:l       
 ---------------+---------------+---------------
-5              |Friday         |12
-4              |Thursday       |15
-3              |Wednesday      |14
-2              |Tuesday        |18
-1              |Monday         |8
+5              |Friday         |12             
+4              |Thursday       |15             
+3              |Wednesday      |14             
+2              |Tuesday        |18             
+1              |Monday         |8              
 ;
 
 dateTimeAggByIsoDayOfWeek
 SELECT IDOW(birth_date) day, DAY_NAME(birth_date) name, COUNT(*) c FROM test_emp GROUP BY day, name ORDER BY day desc;
 
-    day:i      |   name:s      |     c:l
+    day:i      |   name:s      |     c:l       
 ---------------+---------------+---------------
 7              |Sunday         |10
 6              |Saturday       |13
@@ -778,151 +778,151 @@ null           |null           |10
 dateTimeAggByIsoWeekOfYear
 SELECT IW(birth_date) iso_week, WEEK(birth_date) week FROM test_emp WHERE IW(birth_date) < 20 GROUP BY iso_week, week ORDER BY iso_week;
 
- iso_week:i    |    week:i
+ iso_week:i    |    week:i      
 ---------------+---------------
-1              |2
-3              |4
-4              |4
-4              |5
-6              |7
-7              |7
-8              |8
-8              |9
-9              |9
-10             |11
-12             |12
-14             |14
-14             |15
-15             |16
-16             |16
-16             |17
-18             |18
+1              |2              
+3              |4              
+4              |4              
+4              |5              
+6              |7              
+7              |7              
+8              |8              
+8              |9              
+9              |9              
+10             |11             
+12             |12             
+14             |14             
+14             |15             
+15             |16             
+16             |16             
+16             |17             
+18             |18             
 ;
 
 dateTimeAggByYear
 SELECT YEAR(birth_date) AS d, CAST(SUM(emp_no) AS INT) s FROM "test_emp" GROUP BY YEAR(birth_date) ORDER BY YEAR(birth_date) LIMIT 13;
 
 d:i                  | s:i
-null                 |100445
-1952                 |80425
-1953                 |110398
-1954                 |80447
-1955                 |40240
-1956                 |50230
-1957                 |40235
-1958                 |70225
-1959                 |90436
-1960                 |80412
-1961                 |80513
-1962                 |60361
-1963                 |70324
-;
+null                 |100445         
+1952                 |80425          
+1953                 |110398         
+1954                 |80447          
+1955                 |40240          
+1956                 |50230          
+1957                 |40235          
+1958                 |70225          
+1959                 |90436          
+1960                 |80412          
+1961                 |80513          
+1962                 |60361          
+1963                 |70324    
+;                   
 
 dateTimeAggByMonth
 SELECT MONTH(birth_date) AS d, COUNT(*) AS c, CAST(SUM(emp_no) AS INT) s FROM "test_emp" GROUP BY MONTH(birth_date) ORDER BY MONTH(birth_date) DESC;
 
 d:i                  | c:l                  | s:i
 12                   |7                     |70325
-11                   |8                     |80439
-10                   |9                     |90517
-9                    |10                    |100561
-8                    |6                     |60290
-7                    |9                     |90392
-6                    |7                     |70267
-5                    |10                    |100573
-4                    |8                     |80401
-3                    |2                     |20164
-2                    |8                     |80388
-1                    |6                     |60288
-null                 |10                    |100445
+11                   |8                     |80439          
+10                   |9                     |90517          
+9                    |10                    |100561         
+8                    |6                     |60290          
+7                    |9                     |90392          
+6                    |7                     |70267          
+5                    |10                    |100573         
+4                    |8                     |80401          
+3                    |2                     |20164          
+2                    |8                     |80388          
+1                    |6                     |60288          
+null                 |10                    |100445  
 ;
 
 dateTimeAggByDayOfMonth
 SELECT DAY_OF_MONTH(birth_date) AS d, COUNT(*) AS c, CAST(SUM(emp_no) AS INT) s FROM "test_emp" GROUP BY DAY_OF_MONTH(birth_date) ORDER BY DAY_OF_MONTH(birth_date) DESC;
 
 d:i                  | c:l                  | s:i
-31                   |1                     |10025
-30                   |2                     |20147
-29                   |2                     |20057
-28                   |2                     |20125
-27                   |2                     |20128
-26                   |3                     |30148
-25                   |5                     |50443
-24                   |1                     |10020
-23                   |6                     |60367
-22                   |1                     |10037
-21                   |5                     |50315
-20                   |4                     |40135
-19                   |7                     |70256
-18                   |2                     |20169
-17                   |1                     |10081
-16                   |1                     |10096
-15                   |2                     |20132
-14                   |3                     |30128
-13                   |4                     |40224
-12                   |1                     |10014
-11                   |1                     |10093
-10                   |2                     |20063
-9                    |3                     |30189
-8                    |2                     |20057
-7                    |5                     |50240
-6                    |4                     |40204
-5                    |2                     |20103
-4                    |3                     |30157
-3                    |4                     |40204
-2                    |4                     |40081
-1                    |5                     |50167
-null                 |10                    |100445
+31                   |1                     |10025          
+30                   |2                     |20147          
+29                   |2                     |20057          
+28                   |2                     |20125          
+27                   |2                     |20128          
+26                   |3                     |30148          
+25                   |5                     |50443          
+24                   |1                     |10020          
+23                   |6                     |60367          
+22                   |1                     |10037          
+21                   |5                     |50315          
+20                   |4                     |40135          
+19                   |7                     |70256          
+18                   |2                     |20169          
+17                   |1                     |10081          
+16                   |1                     |10096          
+15                   |2                     |20132          
+14                   |3                     |30128          
+13                   |4                     |40224          
+12                   |1                     |10014          
+11                   |1                     |10093          
+10                   |2                     |20063          
+9                    |3                     |30189          
+8                    |2                     |20057          
+7                    |5                     |50240          
+6                    |4                     |40204          
+5                    |2                     |20103          
+4                    |3                     |30157          
+3                    |4                     |40204          
+2                    |4                     |40081          
+1                    |5                     |50167          
+null                 |10                    |100445 
 ;
 
 weekOfYearGroupBy
 SELECT WEEK(birth_date) week, COUNT(*) c FROM test_emp WHERE MOD(WEEK(birth_date), 4) = 0 GROUP BY week ORDER BY WEEK(birth_date);
 
-    week:i     |     c:l
+    week:i     |     c:l       
 ---------------+---------------
-4              |3
-8              |2
-12             |1
-16             |3
-20             |1
-24             |2
-28             |3
-32             |1
-36             |3
-40             |4
-44             |2
-48             |2
-52             |3
+4              |3              
+8              |2              
+12             |1              
+16             |3              
+20             |1              
+24             |2              
+28             |3              
+32             |1              
+36             |3              
+40             |4              
+44             |2              
+48             |2              
+52             |3              
 ;
 
 currentTimestampKeywordWithDivision
 SELECT YEAR(CURRENT_TIMESTAMP) / 1000 AS result;
 
-    result
+    result     
 ---------------
-2
+2    
 ;
 
 currentTimestampFunctionNoArgsWithDivision
 SELECT YEAR(CURRENT_TIMESTAMP()) / 1000 AS result;
 
-    result
+    result     
 ---------------
-2
+2    
 ;
 
 currentTimestampFunctionPrecisionWithDivision
 SELECT YEAR(CURRENT_TIMESTAMP(2)) / 1000 AS result;
 
-    result
+    result     
 ---------------
-2
+2    
 ;
 
 nowWithDivision
 SELECT YEAR(NOW()) / 1000 AS result;
 
-    result
+    result     
 ---------------
 2
 ;
@@ -930,7 +930,7 @@ SELECT YEAR(NOW()) / 1000 AS result;
 nowIntervalSubstraction
 SELECT YEAR(NOW() - INTERVAL 2 YEARS) / 1000 AS result;
 
-    result
+    result     
 ---------------
 2
 ;
@@ -938,52 +938,52 @@ SELECT YEAR(NOW() - INTERVAL 2 YEARS) / 1000 AS result;
 dateAndIntervalPaginated
 SELECT YEAR(birth_date - INTERVAL 2 YEARS) / 1000 AS result FROM test_emp ORDER BY birth_date LIMIT 10;
 
-    result
+    result     
 ---------------
-1
-1
-1
-1
-1
-1
-1
-1
-1
+1              
+1              
+1              
+1              
+1              
+1              
+1              
+1              
+1              
 1
 ;
 
 currentTimestampFilter
-SELECT first_name FROM test_emp WHERE hire_date > NOW() - INTERVAL 100 YEARS ORDER BY first_name ASC LIMIT 10;
+SELECT first_name FROM test_emp WHERE hire_date > NOW() - INTERVAL 100 YEARS ORDER BY first_name ASC LIMIT 10; 
 
-  first_name
+  first_name   
 ---------------
-Alejandro
-Amabile
-Anneke
-Anoosh
-Arumugam
-Basil
-Berhard
-Berni
-Bezalel
-Bojan
+Alejandro      
+Amabile        
+Anneke         
+Anoosh         
+Arumugam       
+Basil          
+Berhard        
+Berni          
+Bezalel        
+Bojan      
 ;
 
 currentTimestampFilterScript
 SELECT first_name FROM test_emp WHERE YEAR(hire_date) - YEAR(NOW()) / 1000 > 10 ORDER BY first_name ASC LIMIT 10;
 
-  first_name
+  first_name   
 ---------------
-Alejandro
-Amabile
-Anneke
-Anoosh
-Arumugam
-Basil
-Berhard
-Berni
-Bezalel
-Bojan
+Alejandro      
+Amabile        
+Anneke         
+Anoosh         
+Arumugam       
+Basil          
+Berhard        
+Berni          
+Bezalel        
+Bojan  
 
 ;
 

--- a/x-pack/plugin/sql/qa/src/main/resources/datetime.csv-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/datetime.csv-spec
@@ -307,7 +307,7 @@ DATE_DIFF('mcs', '2019-09-04T11:25:21.123456Z'::datetime, '2019-09-04T11:22:33.9
 
  diff_year | diff_quarter | diff_month | diff_week | diff_day | diff_hours | diff_min | diff_sec  | diff_millis | diff_mcsec | diff_nsec
 -----------+--------------+------------+-----------+----------+------------+----------+-----------+-------------+------------+----------
-57         | -114         | 406        | -947      | 2825     | -123228    | 3762357  | -10265677 | 205849864   | -167135802 | 135802468
+57         | -114         | 406        | -947      | 2825     | -123228    | 3762356  | -10265677 | 205849864   | -167135802 | 135802468
 ;
 
 selectDiffWithDate
@@ -717,9 +717,9 @@ M       | 1996-11-05 00:00:00.000Z
 castedDateTimeWithGroupBy1
 SELECT CONVERT(birth_date, DOUBLE) AS date FROM test_emp GROUP BY date ORDER BY date LIMIT 10;
 
-    date:d      
+    date:d
 ---------------
-null           
+null
 -5.631552E11
 -5.586624E11
 -5.56416E11
@@ -751,19 +751,19 @@ SELECT CAST(hire_date AS LONG) AS date FROM test_emp GROUP BY date ORDER BY date
 dateTimeAggByIsoDayOfWeekWithFilter
 SELECT IDOW(birth_date) day, DAY_NAME(birth_date) name, COUNT(*) c FROM test_emp WHERE IDOW(birth_date) < 6 GROUP BY day, name ORDER BY day desc;
 
-    day:i      |   name:s      |     c:l       
+    day:i      |   name:s      |     c:l
 ---------------+---------------+---------------
-5              |Friday         |12             
-4              |Thursday       |15             
-3              |Wednesday      |14             
-2              |Tuesday        |18             
-1              |Monday         |8              
+5              |Friday         |12
+4              |Thursday       |15
+3              |Wednesday      |14
+2              |Tuesday        |18
+1              |Monday         |8
 ;
 
 dateTimeAggByIsoDayOfWeek
 SELECT IDOW(birth_date) day, DAY_NAME(birth_date) name, COUNT(*) c FROM test_emp GROUP BY day, name ORDER BY day desc;
 
-    day:i      |   name:s      |     c:l       
+    day:i      |   name:s      |     c:l
 ---------------+---------------+---------------
 7              |Sunday         |10
 6              |Saturday       |13
@@ -778,151 +778,151 @@ null           |null           |10
 dateTimeAggByIsoWeekOfYear
 SELECT IW(birth_date) iso_week, WEEK(birth_date) week FROM test_emp WHERE IW(birth_date) < 20 GROUP BY iso_week, week ORDER BY iso_week;
 
- iso_week:i    |    week:i      
+ iso_week:i    |    week:i
 ---------------+---------------
-1              |2              
-3              |4              
-4              |4              
-4              |5              
-6              |7              
-7              |7              
-8              |8              
-8              |9              
-9              |9              
-10             |11             
-12             |12             
-14             |14             
-14             |15             
-15             |16             
-16             |16             
-16             |17             
-18             |18             
+1              |2
+3              |4
+4              |4
+4              |5
+6              |7
+7              |7
+8              |8
+8              |9
+9              |9
+10             |11
+12             |12
+14             |14
+14             |15
+15             |16
+16             |16
+16             |17
+18             |18
 ;
 
 dateTimeAggByYear
 SELECT YEAR(birth_date) AS d, CAST(SUM(emp_no) AS INT) s FROM "test_emp" GROUP BY YEAR(birth_date) ORDER BY YEAR(birth_date) LIMIT 13;
 
 d:i                  | s:i
-null                 |100445         
-1952                 |80425          
-1953                 |110398         
-1954                 |80447          
-1955                 |40240          
-1956                 |50230          
-1957                 |40235          
-1958                 |70225          
-1959                 |90436          
-1960                 |80412          
-1961                 |80513          
-1962                 |60361          
-1963                 |70324    
-;                   
+null                 |100445
+1952                 |80425
+1953                 |110398
+1954                 |80447
+1955                 |40240
+1956                 |50230
+1957                 |40235
+1958                 |70225
+1959                 |90436
+1960                 |80412
+1961                 |80513
+1962                 |60361
+1963                 |70324
+;
 
 dateTimeAggByMonth
 SELECT MONTH(birth_date) AS d, COUNT(*) AS c, CAST(SUM(emp_no) AS INT) s FROM "test_emp" GROUP BY MONTH(birth_date) ORDER BY MONTH(birth_date) DESC;
 
 d:i                  | c:l                  | s:i
 12                   |7                     |70325
-11                   |8                     |80439          
-10                   |9                     |90517          
-9                    |10                    |100561         
-8                    |6                     |60290          
-7                    |9                     |90392          
-6                    |7                     |70267          
-5                    |10                    |100573         
-4                    |8                     |80401          
-3                    |2                     |20164          
-2                    |8                     |80388          
-1                    |6                     |60288          
-null                 |10                    |100445  
+11                   |8                     |80439
+10                   |9                     |90517
+9                    |10                    |100561
+8                    |6                     |60290
+7                    |9                     |90392
+6                    |7                     |70267
+5                    |10                    |100573
+4                    |8                     |80401
+3                    |2                     |20164
+2                    |8                     |80388
+1                    |6                     |60288
+null                 |10                    |100445
 ;
 
 dateTimeAggByDayOfMonth
 SELECT DAY_OF_MONTH(birth_date) AS d, COUNT(*) AS c, CAST(SUM(emp_no) AS INT) s FROM "test_emp" GROUP BY DAY_OF_MONTH(birth_date) ORDER BY DAY_OF_MONTH(birth_date) DESC;
 
 d:i                  | c:l                  | s:i
-31                   |1                     |10025          
-30                   |2                     |20147          
-29                   |2                     |20057          
-28                   |2                     |20125          
-27                   |2                     |20128          
-26                   |3                     |30148          
-25                   |5                     |50443          
-24                   |1                     |10020          
-23                   |6                     |60367          
-22                   |1                     |10037          
-21                   |5                     |50315          
-20                   |4                     |40135          
-19                   |7                     |70256          
-18                   |2                     |20169          
-17                   |1                     |10081          
-16                   |1                     |10096          
-15                   |2                     |20132          
-14                   |3                     |30128          
-13                   |4                     |40224          
-12                   |1                     |10014          
-11                   |1                     |10093          
-10                   |2                     |20063          
-9                    |3                     |30189          
-8                    |2                     |20057          
-7                    |5                     |50240          
-6                    |4                     |40204          
-5                    |2                     |20103          
-4                    |3                     |30157          
-3                    |4                     |40204          
-2                    |4                     |40081          
-1                    |5                     |50167          
-null                 |10                    |100445 
+31                   |1                     |10025
+30                   |2                     |20147
+29                   |2                     |20057
+28                   |2                     |20125
+27                   |2                     |20128
+26                   |3                     |30148
+25                   |5                     |50443
+24                   |1                     |10020
+23                   |6                     |60367
+22                   |1                     |10037
+21                   |5                     |50315
+20                   |4                     |40135
+19                   |7                     |70256
+18                   |2                     |20169
+17                   |1                     |10081
+16                   |1                     |10096
+15                   |2                     |20132
+14                   |3                     |30128
+13                   |4                     |40224
+12                   |1                     |10014
+11                   |1                     |10093
+10                   |2                     |20063
+9                    |3                     |30189
+8                    |2                     |20057
+7                    |5                     |50240
+6                    |4                     |40204
+5                    |2                     |20103
+4                    |3                     |30157
+3                    |4                     |40204
+2                    |4                     |40081
+1                    |5                     |50167
+null                 |10                    |100445
 ;
 
 weekOfYearGroupBy
 SELECT WEEK(birth_date) week, COUNT(*) c FROM test_emp WHERE MOD(WEEK(birth_date), 4) = 0 GROUP BY week ORDER BY WEEK(birth_date);
 
-    week:i     |     c:l       
+    week:i     |     c:l
 ---------------+---------------
-4              |3              
-8              |2              
-12             |1              
-16             |3              
-20             |1              
-24             |2              
-28             |3              
-32             |1              
-36             |3              
-40             |4              
-44             |2              
-48             |2              
-52             |3              
+4              |3
+8              |2
+12             |1
+16             |3
+20             |1
+24             |2
+28             |3
+32             |1
+36             |3
+40             |4
+44             |2
+48             |2
+52             |3
 ;
 
 currentTimestampKeywordWithDivision
 SELECT YEAR(CURRENT_TIMESTAMP) / 1000 AS result;
 
-    result     
+    result
 ---------------
-2    
+2
 ;
 
 currentTimestampFunctionNoArgsWithDivision
 SELECT YEAR(CURRENT_TIMESTAMP()) / 1000 AS result;
 
-    result     
+    result
 ---------------
-2    
+2
 ;
 
 currentTimestampFunctionPrecisionWithDivision
 SELECT YEAR(CURRENT_TIMESTAMP(2)) / 1000 AS result;
 
-    result     
+    result
 ---------------
-2    
+2
 ;
 
 nowWithDivision
 SELECT YEAR(NOW()) / 1000 AS result;
 
-    result     
+    result
 ---------------
 2
 ;
@@ -930,7 +930,7 @@ SELECT YEAR(NOW()) / 1000 AS result;
 nowIntervalSubstraction
 SELECT YEAR(NOW() - INTERVAL 2 YEARS) / 1000 AS result;
 
-    result     
+    result
 ---------------
 2
 ;
@@ -938,52 +938,52 @@ SELECT YEAR(NOW() - INTERVAL 2 YEARS) / 1000 AS result;
 dateAndIntervalPaginated
 SELECT YEAR(birth_date - INTERVAL 2 YEARS) / 1000 AS result FROM test_emp ORDER BY birth_date LIMIT 10;
 
-    result     
+    result
 ---------------
-1              
-1              
-1              
-1              
-1              
-1              
-1              
-1              
-1              
+1
+1
+1
+1
+1
+1
+1
+1
+1
 1
 ;
 
 currentTimestampFilter
-SELECT first_name FROM test_emp WHERE hire_date > NOW() - INTERVAL 100 YEARS ORDER BY first_name ASC LIMIT 10; 
+SELECT first_name FROM test_emp WHERE hire_date > NOW() - INTERVAL 100 YEARS ORDER BY first_name ASC LIMIT 10;
 
-  first_name   
+  first_name
 ---------------
-Alejandro      
-Amabile        
-Anneke         
-Anoosh         
-Arumugam       
-Basil          
-Berhard        
-Berni          
-Bezalel        
-Bojan      
+Alejandro
+Amabile
+Anneke
+Anoosh
+Arumugam
+Basil
+Berhard
+Berni
+Bezalel
+Bojan
 ;
 
 currentTimestampFilterScript
 SELECT first_name FROM test_emp WHERE YEAR(hire_date) - YEAR(NOW()) / 1000 > 10 ORDER BY first_name ASC LIMIT 10;
 
-  first_name   
+  first_name
 ---------------
-Alejandro      
-Amabile        
-Anneke         
-Anoosh         
-Arumugam       
-Basil          
-Berhard        
-Berni          
-Bezalel        
-Bojan  
+Alejandro
+Amabile
+Anneke
+Anoosh
+Arumugam
+Basil
+Berhard
+Berni
+Bezalel
+Bojan
 
 ;
 

--- a/x-pack/plugin/sql/qa/src/main/resources/docs/docs.csv-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/docs/docs.csv-spec
@@ -14,7 +14,7 @@ describeTable
 // tag::describeTable
 DESCRIBE emp;
 
-       column       |     type      |    mapping
+       column       |     type      |    mapping    
 --------------------+---------------+---------------
 birth_date          |TIMESTAMP      |datetime
 dep                 |STRUCT         |nested
@@ -40,7 +40,7 @@ salary              |INTEGER        |integer
 // tag::describeTableAlias
 //DESCRIBE employee;
 
-//    column     |     type
+//    column     |     type      
 //---------------+---------------
 
 // end::describeTableAlias
@@ -48,12 +48,12 @@ salary              |INTEGER        |integer
 
 //
 // Show columns
-//
+// 
 showColumns
 // tag::showColumns
 SHOW COLUMNS IN emp;
 
-       column       |     type      |    mapping
+       column       |     type      |    mapping    
 --------------------+---------------+---------------
 birth_date          |TIMESTAMP      |datetime
 dep                 |STRUCT         |nested
@@ -79,9 +79,9 @@ salary              |INTEGER        |integer
 // tag::showColumnsInAlias
 //SHOW COLUMNS FROM employee;
 
-//    column     |     type
+//    column     |     type      
 //---------------+---------------
-
+               
 // end::showColumnsInAlias
 //;
 
@@ -95,11 +95,11 @@ showTables
 // tag::showTables
 SHOW TABLES;
 
-     name      |     type      |     kind
+     name      |     type      |     kind      
 ---------------+---------------+---------------
-emp            |BASE TABLE     |INDEX
-employees      |VIEW           |ALIAS
-library        |BASE TABLE     |INDEX
+emp            |BASE TABLE     |INDEX          
+employees      |VIEW           |ALIAS          
+library        |BASE TABLE     |INDEX    
 
 // end::showTables
 ;
@@ -108,9 +108,9 @@ showTablesLikeExact
 // tag::showTablesLikeExact
 SHOW TABLES LIKE 'emp';
 
-     name      |     type      |     kind
+     name      |     type      |     kind      
 ---------------+---------------+---------------
-emp            |BASE TABLE     |INDEX
+emp            |BASE TABLE     |INDEX    
 
 // end::showTablesLikeExact
 ;
@@ -119,10 +119,10 @@ showTablesLikeWildcard
 // tag::showTablesLikeWildcard
 SHOW TABLES LIKE 'emp%';
 
-     name      |     type      |     kind
+     name      |     type      |     kind      
 ---------------+---------------+---------------
-emp            |BASE TABLE     |INDEX
-employees      |VIEW           |ALIAS
+emp            |BASE TABLE     |INDEX          
+employees      |VIEW           |ALIAS             
 
 // end::showTablesLikeWildcard
 ;
@@ -132,9 +132,9 @@ showTablesLikeOneChar
 // tag::showTablesLikeOneChar
 SHOW TABLES LIKE 'em_';
 
-     name      |     type      |     kind
+     name      |     type      |     kind      
 ---------------+---------------+---------------
-emp            |BASE TABLE     |INDEX
+emp            |BASE TABLE     |INDEX     
 
 // end::showTablesLikeOneChar
 ;
@@ -143,9 +143,9 @@ showTablesLikeMixed
 // tag::showTablesLikeMixed
 SHOW TABLES LIKE '%em_';
 
-     name      |     type      |     kind
+     name      |     type      |     kind      
 ---------------+---------------+---------------
-emp            |BASE TABLE     |INDEX
+emp            |BASE TABLE     |INDEX        
 
 // end::showTablesLikeMixed
 ;
@@ -155,7 +155,7 @@ schema::name:s|type:s|kind:s
 // tag::showTablesLikeEscape
 SHOW TABLES LIKE 'emp!%' ESCAPE '!';
 
-     name      |     type      |     kind
+     name      |     type      |     kind      
 ---------------+---------------+---------------
 
 // end::showTablesLikeEscape
@@ -166,10 +166,10 @@ showTablesEsMultiIndex
 // tag::showTablesEsMultiIndex
 SHOW TABLES "*,-l*";
 
-     name      |     type      |     kind
+     name      |     type      |     kind      
 ---------------+---------------+---------------
-emp            |BASE TABLE     |INDEX
-employees      |VIEW           |ALIAS
+emp            |BASE TABLE     |INDEX          
+employees      |VIEW           |ALIAS  
 
 // end::showTablesEsMultiIndex
 ;
@@ -182,12 +182,12 @@ showTablesIncludeFrozen
 // tag::showTablesIncludeFrozen
 SHOW TABLES INCLUDE FROZEN;
 
-     name      |     type      |     kind
+     name      |     type      |     kind      
 ---------------+---------------+---------------
 archive        |BASE TABLE     |FROZEN INDEX
-emp            |BASE TABLE     |INDEX
-employees      |VIEW           |ALIAS
-library        |BASE TABLE     |INDEX
+emp            |BASE TABLE     |INDEX          
+employees      |VIEW           |ALIAS          
+library        |BASE TABLE     |INDEX    
 
 // end::showTablesIncludeFrozen
 ;
@@ -205,23 +205,23 @@ SHOW FUNCTIONS;
 
       name       |     type
 -----------------+---------------
-AVG              |AGGREGATE
+AVG              |AGGREGATE      
 COUNT            |AGGREGATE
 FIRST            |AGGREGATE
 FIRST_VALUE      |AGGREGATE
 LAST             |AGGREGATE
 LAST_VALUE       |AGGREGATE
-MAX              |AGGREGATE
-MIN              |AGGREGATE
-SUM              |AGGREGATE
+MAX              |AGGREGATE      
+MIN              |AGGREGATE      
+SUM              |AGGREGATE      
 KURTOSIS         |AGGREGATE
-MAD              |AGGREGATE
-PERCENTILE       |AGGREGATE
-PERCENTILE_RANK  |AGGREGATE
-SKEWNESS         |AGGREGATE
-STDDEV_POP       |AGGREGATE
-SUM_OF_SQUARES   |AGGREGATE
-VAR_POP          |AGGREGATE
+MAD              |AGGREGATE      
+PERCENTILE       |AGGREGATE      
+PERCENTILE_RANK  |AGGREGATE      
+SKEWNESS         |AGGREGATE      
+STDDEV_POP       |AGGREGATE      
+SUM_OF_SQUARES   |AGGREGATE      
+VAR_POP          |AGGREGATE      
 HISTOGRAM        |GROUPING
 CASE             |CONDITIONAL
 COALESCE         |CONDITIONAL
@@ -255,10 +255,10 @@ DAY_OF_MONTH     |SCALAR
 DAY_OF_WEEK      |SCALAR
 DAY_OF_YEAR      |SCALAR
 DOM              |SCALAR
-DOW              |SCALAR
-DOY              |SCALAR
-HOUR             |SCALAR
-HOUR_OF_DAY      |SCALAR
+DOW              |SCALAR         
+DOY              |SCALAR         
+HOUR             |SCALAR         
+HOUR_OF_DAY      |SCALAR         
 IDOW             |SCALAR
 ISODAYOFWEEK     |SCALAR
 ISODOW           |SCALAR
@@ -268,16 +268,16 @@ ISO_DAY_OF_WEEK  |SCALAR
 ISO_WEEK_OF_YEAR |SCALAR
 IW               |SCALAR
 IWOY             |SCALAR
-MINUTE           |SCALAR
-MINUTE_OF_DAY    |SCALAR
-MINUTE_OF_HOUR   |SCALAR
-MONTH            |SCALAR
-MONTHNAME        |SCALAR
-MONTH_NAME       |SCALAR
+MINUTE           |SCALAR         
+MINUTE_OF_DAY    |SCALAR         
+MINUTE_OF_HOUR   |SCALAR         
+MONTH            |SCALAR         
+MONTHNAME        |SCALAR         
+MONTH_NAME       |SCALAR         
 MONTH_OF_YEAR    |SCALAR
 NOW              |SCALAR
-QUARTER          |SCALAR
-SECOND           |SCALAR
+QUARTER          |SCALAR         
+SECOND           |SCALAR         
 SECOND_OF_MINUTE |SCALAR
 TIMESTAMPADD     |SCALAR
 TIMESTAMPDIFF    |SCALAR
@@ -285,60 +285,60 @@ TIMESTAMP_ADD    |SCALAR
 TIMESTAMP_DIFF   |SCALAR
 TODAY            |SCALAR
 WEEK             |SCALAR
-WEEK_OF_YEAR     |SCALAR
-YEAR             |SCALAR
-ABS              |SCALAR
-ACOS             |SCALAR
-ASIN             |SCALAR
-ATAN             |SCALAR
-ATAN2            |SCALAR
-CBRT             |SCALAR
-CEIL             |SCALAR
-CEILING          |SCALAR
-COS              |SCALAR
-COSH             |SCALAR
-COT              |SCALAR
-DEGREES          |SCALAR
-E                |SCALAR
-EXP              |SCALAR
-EXPM1            |SCALAR
-FLOOR            |SCALAR
-LOG              |SCALAR
-LOG10            |SCALAR
-MOD              |SCALAR
-PI               |SCALAR
-POWER            |SCALAR
-RADIANS          |SCALAR
-RAND             |SCALAR
-RANDOM           |SCALAR
-ROUND            |SCALAR
-SIGN             |SCALAR
-SIGNUM           |SCALAR
-SIN              |SCALAR
-SINH             |SCALAR
-SQRT             |SCALAR
-TAN              |SCALAR
-TRUNCATE         |SCALAR
-ASCII            |SCALAR
-BIT_LENGTH       |SCALAR
-CHAR             |SCALAR
-CHARACTER_LENGTH |SCALAR
-CHAR_LENGTH      |SCALAR
-CONCAT           |SCALAR
-INSERT           |SCALAR
-LCASE            |SCALAR
-LEFT             |SCALAR
-LENGTH           |SCALAR
-LOCATE           |SCALAR
-LTRIM            |SCALAR
-OCTET_LENGTH     |SCALAR
-POSITION         |SCALAR
-REPEAT           |SCALAR
-REPLACE          |SCALAR
-RIGHT            |SCALAR
-RTRIM            |SCALAR
-SPACE            |SCALAR
-SUBSTRING        |SCALAR
+WEEK_OF_YEAR     |SCALAR         
+YEAR             |SCALAR         
+ABS              |SCALAR         
+ACOS             |SCALAR         
+ASIN             |SCALAR         
+ATAN             |SCALAR         
+ATAN2            |SCALAR         
+CBRT             |SCALAR         
+CEIL             |SCALAR         
+CEILING          |SCALAR         
+COS              |SCALAR         
+COSH             |SCALAR         
+COT              |SCALAR         
+DEGREES          |SCALAR         
+E                |SCALAR         
+EXP              |SCALAR         
+EXPM1            |SCALAR         
+FLOOR            |SCALAR         
+LOG              |SCALAR         
+LOG10            |SCALAR         
+MOD              |SCALAR         
+PI               |SCALAR         
+POWER            |SCALAR         
+RADIANS          |SCALAR         
+RAND             |SCALAR         
+RANDOM           |SCALAR         
+ROUND            |SCALAR         
+SIGN             |SCALAR         
+SIGNUM           |SCALAR         
+SIN              |SCALAR         
+SINH             |SCALAR         
+SQRT             |SCALAR         
+TAN              |SCALAR         
+TRUNCATE         |SCALAR         
+ASCII            |SCALAR         
+BIT_LENGTH       |SCALAR         
+CHAR             |SCALAR         
+CHARACTER_LENGTH |SCALAR         
+CHAR_LENGTH      |SCALAR         
+CONCAT           |SCALAR         
+INSERT           |SCALAR         
+LCASE            |SCALAR         
+LEFT             |SCALAR         
+LENGTH           |SCALAR         
+LOCATE           |SCALAR         
+LTRIM            |SCALAR         
+OCTET_LENGTH     |SCALAR         
+POSITION         |SCALAR         
+REPEAT           |SCALAR         
+REPLACE          |SCALAR         
+RIGHT            |SCALAR         
+RTRIM            |SCALAR         
+SPACE            |SCALAR         
+SUBSTRING        |SCALAR         
 UCASE            |SCALAR
 CAST             |SCALAR
 CONVERT          |SCALAR
@@ -361,9 +361,9 @@ showFunctionsLikeExact
 // tag::showFunctionsLikeExact
 SHOW FUNCTIONS LIKE 'ABS';
 
-     name      |     type
+     name      |     type      
 ---------------+---------------
-ABS            |SCALAR
+ABS            |SCALAR    
 
 // end::showFunctionsLikeExact
 ;
@@ -372,15 +372,15 @@ showFunctionsLikeWildcard
 // tag::showFunctionsLikeWildcard
 SHOW FUNCTIONS LIKE 'A%';
 
-     name      |     type
+     name      |     type      
 ---------------+---------------
-AVG            |AGGREGATE
-ABS            |SCALAR
-ACOS           |SCALAR
-ASIN           |SCALAR
-ATAN           |SCALAR
+AVG            |AGGREGATE      
+ABS            |SCALAR         
+ACOS           |SCALAR         
+ASIN           |SCALAR         
+ATAN           |SCALAR         
 ATAN2          |SCALAR
-ASCII          |SCALAR
+ASCII          |SCALAR     
 // end::showFunctionsLikeWildcard
 ;
 
@@ -388,10 +388,10 @@ showFunctionsLikeChar
 // tag::showFunctionsLikeChar
 SHOW FUNCTIONS LIKE 'A__';
 
-     name      |     type
+     name      |     type      
 ---------------+---------------
-AVG            |AGGREGATE
-ABS            |SCALAR
+AVG            |AGGREGATE      
+ABS            |SCALAR         
 // end::showFunctionsLikeChar
 ;
 
@@ -399,7 +399,7 @@ showFunctionsWithPattern
 // tag::showFunctionsWithPattern
 SHOW FUNCTIONS LIKE '%DAY%';
 
-     name      |     type
+     name      |     type      
 ---------------+---------------
 DAY            |SCALAR
 DAYNAME        |SCALAR
@@ -410,10 +410,10 @@ DAY_NAME       |SCALAR
 DAY_OF_MONTH   |SCALAR
 DAY_OF_WEEK    |SCALAR
 DAY_OF_YEAR    |SCALAR
-HOUR_OF_DAY    |SCALAR
+HOUR_OF_DAY    |SCALAR         
 ISODAYOFWEEK   |SCALAR
 ISO_DAY_OF_WEEK|SCALAR
-MINUTE_OF_DAY  |SCALAR
+MINUTE_OF_DAY  |SCALAR         
 TODAY          |SCALAR
 
 // end::showFunctionsWithPattern
@@ -429,9 +429,9 @@ selectColumnAlias
 // tag::selectColumnAlias
 SELECT 1 + 1 AS result;
 
-    result
+    result     
 ---------------
-2
+2    
 
 // end::selectColumnAlias
 ;
@@ -440,9 +440,9 @@ selectInline
 // tag::selectInline
 SELECT 1 + 1;
 
-    1 + 1
+    1 + 1    
 --------------
-2
+2      
 
 // end::selectInline
 ;
@@ -451,9 +451,9 @@ selectColumn
 // tag::selectColumn
 SELECT emp_no FROM emp LIMIT 1;
 
-    emp_no
+    emp_no     
 ---------------
-10001
+10001   
 
 // end::selectColumn
 ;
@@ -462,9 +462,9 @@ selectQualifiedColumn
 // tag::selectQualifiedColumn
 SELECT emp.emp_no FROM emp LIMIT 1;
 
-    emp_no
+    emp_no     
 ---------------
-10001
+10001   
 
 // end::selectQualifiedColumn
 ;
@@ -474,9 +474,9 @@ wildcardWithOrder
 // tag::wildcardWithOrder
 SELECT * FROM emp LIMIT 1;
 
-     birth_date     |    emp_no     |  first_name   |    gender     |     hire_date      |   languages   |   last_name   |    salary
+     birth_date     |    emp_no     |  first_name   |    gender     |     hire_date      |   languages   |   last_name   |    salary     
 --------------------+---------------+---------------+---------------+--------------------+---------------+---------------+---------------
-1953-09-02T00:00:00Z|10001          |Georgi         |M              |1986-06-26T00:00:00Z|2              |Facello        |57305
+1953-09-02T00:00:00Z|10001          |Georgi         |M              |1986-06-26T00:00:00Z|2              |Facello        |57305 
 
 // end::wildcardWithOrder
 ;
@@ -485,10 +485,10 @@ fromTable
 // tag::fromTable
 SELECT * FROM emp LIMIT 1;
 
-     birth_date     |    emp_no     |  first_name   |    gender     |     hire_date      |   languages   |   last_name   |    salary
+     birth_date     |    emp_no     |  first_name   |    gender     |     hire_date      |   languages   |   last_name   |    salary     
 --------------------+---------------+---------------+---------------+--------------------+---------------+---------------+---------------
-1953-09-02T00:00:00Z|10001          |Georgi         |M              |1986-06-26T00:00:00Z|2              |Facello        |57305
-
+1953-09-02T00:00:00Z|10001          |Georgi         |M              |1986-06-26T00:00:00Z|2              |Facello        |57305        
+  
 
 // end::fromTable
 ;
@@ -497,9 +497,9 @@ fromTableQuoted
 // tag::fromTableQuoted
 SELECT * FROM "emp" LIMIT 1;
 
-     birth_date     |    emp_no     |  first_name   |    gender     |     hire_date      |   languages   |   last_name   |    salary
+     birth_date     |    emp_no     |  first_name   |    gender     |     hire_date      |   languages   |   last_name   |    salary     
 --------------------+---------------+---------------+---------------+--------------------+---------------+---------------+---------------
-1953-09-02T00:00:00Z|10001          |Georgi         |M              |1986-06-26T00:00:00Z|2              |Facello        |57305
+1953-09-02T00:00:00Z|10001          |Georgi         |M              |1986-06-26T00:00:00Z|2              |Facello        |57305   
 
 // end::fromTableQuoted
 ;
@@ -508,7 +508,7 @@ fromTableIncludeFrozen
 // tag::fromTableIncludeFrozen
 SELECT * FROM FROZEN archive LIMIT 1;
 
-     author      |        name        |  page_count   |    release_date
+     author      |        name        |  page_count   |    release_date    
 -----------------+--------------------+---------------+--------------------
 James S.A. Corey |Leviathan Wakes     |561            |2011-06-02T00:00:00Z
 
@@ -519,9 +519,9 @@ fromTableQuoted
 // tag::fromTablePatternQuoted
 SELECT emp_no FROM "e*p" LIMIT 1;
 
-    emp_no
+    emp_no     
 ---------------
-10001
+10001   
 
 // end::fromTablePatternQuoted
 ;
@@ -530,9 +530,9 @@ fromTableAlias
 // tag::fromTableAlias
 SELECT e.emp_no FROM emp AS e LIMIT 1;
 
-    emp_no
+    emp_no     
 -------------
-10001
+10001   
 
 // end::fromTableAlias
 ;
@@ -541,9 +541,9 @@ basicWhere
 // tag::basicWhere
 SELECT last_name FROM emp WHERE emp_no = 10001;
 
-   last_name
+   last_name   
 ---------------
-Facello
+Facello   
 
 // end::basicWhere
 ;
@@ -559,7 +559,7 @@ schema::g:s
 // tag::groupByColumn
 SELECT gender AS g FROM emp GROUP BY gender;
 
-       g
+       g       
 ---------------
 null
 F
@@ -573,11 +573,11 @@ schema::gender:s
 // tag::groupByOrdinal
 SELECT gender FROM emp GROUP BY 1;
 
-    gender
+    gender     
 ---------------
 null
-F
-M
+F              
+M   
 
 // end::groupByOrdinal
 ;
@@ -587,11 +587,11 @@ schema::g:s
 // tag::groupByAlias
 SELECT gender AS g FROM emp GROUP BY g;
 
-       g
+       g       
 ---------------
 null
-F
-M
+F              
+M  
 
 // end::groupByAlias
 ;
@@ -600,15 +600,15 @@ groupByExpression
 // tag::groupByExpression
 SELECT languages + 1 AS l FROM emp GROUP BY l;
 
-       l
+       l       
 ---------------
 null
-2
-3
-4
-5
-6
-
+2              
+3              
+4              
+5              
+6              
+ 
 
 // end::groupByExpression
 ;
@@ -618,24 +618,24 @@ schema::g:s|l:i|c:l
 // tag::groupByMulti
 SELECT gender g, languages l, COUNT(*) c FROM "emp" GROUP BY g, l ORDER BY languages ASC, gender DESC;
 
-       g       |       l       |       c
+       g       |       l       |       c       
 ---------------+---------------+---------------
-M              |null           |7
-F              |null           |3
-M              |1              |9
-F              |1              |4
-null           |1              |2
-M              |2              |11
-F              |2              |5
-null           |2              |3
-M              |3              |11
-F              |3              |6
-M              |4              |11
-F              |4              |6
-null           |4              |1
-M              |5              |8
-F              |5              |9
-null           |5              |4
+M              |null           |7              
+F              |null           |3              
+M              |1              |9              
+F              |1              |4              
+null           |1              |2              
+M              |2              |11             
+F              |2              |5              
+null           |2              |3              
+M              |3              |11             
+F              |3              |6              
+M              |4              |11             
+F              |4              |6              
+null           |4              |1              
+M              |5              |8              
+F              |5              |9              
+null           |5              |4  
 
 
 // end::groupByMulti
@@ -647,11 +647,11 @@ schema::g:s|c:i
 // tag::groupByAndAgg
 SELECT gender AS g, COUNT(*) AS c FROM emp GROUP BY gender;
 
-       g       |       c
+       g       |       c       
 ---------------+---------------
-null           |10
-F              |33
-M              |57
+null           |10             
+F              |33             
+M              |57       
 
 // end::groupByAndAgg
 ;
@@ -661,11 +661,11 @@ schema::g:s|salary:i
 // tag::groupByAndAggExpression
 SELECT gender AS g, ROUND((MIN(salary) / 100)) AS salary FROM emp GROUP BY gender;
 
-       g       |    salary
+       g       |    salary     
 ---------------+---------------
-null           |253
-F              |260
-M              |259
+null           |253            
+F              |260            
+M              |259        
 // end::groupByAndAggExpression
 ;
 
@@ -674,11 +674,11 @@ schema::g:s|k:d|s:d
 // tag::groupByAndMultipleAggs
 SELECT gender AS g, KURTOSIS(salary) AS k, SKEWNESS(salary) AS s FROM emp GROUP BY gender;
 
-       g       |        k         |         s
+       g       |        k         |         s         
 ---------------+------------------+-------------------
 null           |2.2215791166941923|-0.03373126000214023
-F              |1.7873117044424276|0.05504995122217512
-M              |2.280646181070106 |0.44302407229580243
+F              |1.7873117044424276|0.05504995122217512 
+M              |2.280646181070106 |0.44302407229580243 
 
 
 // end::groupByAndMultipleAggs
@@ -688,9 +688,9 @@ groupByImplicitCount
 // tag::groupByImplicitCount
 SELECT COUNT(*) AS count FROM emp;
 
-     count
+     count     
 ---------------
-100
+100 
 
 // end::groupByImplicitCount
 ;
@@ -705,12 +705,12 @@ groupByHaving
 // tag::groupByHaving
 SELECT languages AS l, COUNT(*) AS c FROM emp GROUP BY l HAVING c BETWEEN 15 AND 20;
 
-       l       |       c
+       l       |       c       
 ---------------+---------------
-1              |15
-2              |19
-3              |17
-4              |18
+1              |15             
+2              |19             
+3              |17             
+4              |18     
 
 // end::groupByHaving
 ;
@@ -719,14 +719,14 @@ groupByHavingMultiple
 // tag::groupByHavingMultiple
 SELECT MIN(salary) AS min, MAX(salary) AS max, MAX(salary) - MIN(salary) AS diff FROM emp GROUP BY languages HAVING diff - max % min > 0 AND AVG(salary) > 30000;
 
-      min      |      max      |     diff
+      min      |      max      |     diff      
 ---------------+---------------+---------------
-28336          |74999          |46663
-25976          |73717          |47741
-29175          |73578          |44403
-26436          |74970          |48534
-27215          |74572          |47357
-25324          |66817          |41493
+28336          |74999          |46663          
+25976          |73717          |47741          
+29175          |73578          |44403          
+26436          |74970          |48534          
+27215          |74572          |47357          
+25324          |66817          |41493          
 
 
 // end::groupByHavingMultiple
@@ -736,9 +736,9 @@ groupByImplicitMultipleAggs
 // tag::groupByImplicitMultipleAggs
 SELECT MIN(salary) AS min, MAX(salary) AS max, AVG(salary) AS avg, COUNT(*) AS count FROM emp;
 
-      min:i    |      max:i    |      avg:d    |     count:l
+      min:i    |      max:i    |      avg:d    |     count:l     
 ---------------+---------------+---------------+---------------
-25324          |74999          |48248.55       |100
+25324          |74999          |48248.55       |100  
 
 // end::groupByImplicitMultipleAggs
 ;
@@ -747,9 +747,9 @@ groupByHavingImplicitMatch
 // tag::groupByHavingImplicitMatch
 SELECT MIN(salary) AS min, MAX(salary) AS max FROM emp HAVING min > 25000;
 
-      min      |      max
+      min      |      max      
 ---------------+---------------
-25324          |74999
+25324          |74999        
 
 // end::groupByHavingImplicitMatch
 ;
@@ -758,7 +758,7 @@ SELECT MIN(salary) AS min, MAX(salary) AS max FROM emp HAVING min > 25000;
 // tag::groupByHavingImplicitNoMatch
 //SELECT MIN(salary) AS min, MAX(salary) AS max FROM emp HAVING max > 75000;
 
-//      min      |      max
+//      min      |      max      
 //---------------+---------------
 
 // end::groupByHavingImplicitNoMatch
@@ -776,20 +776,20 @@ histogramNumeric
 // tag::histogramNumeric
 SELECT HISTOGRAM(salary, 5000) AS h FROM emp GROUP BY h;
 
-       h
+       h       
 ---------------
-25000
-30000
-35000
-40000
-45000
-50000
-55000
-60000
-65000
+25000          
+30000          
+35000          
+40000          
+45000          
+50000          
+55000          
+60000          
+65000          
 70000
 
-// end::histogramNumeric
+// end::histogramNumeric  
 ;
 
 histogramNumericExpression
@@ -797,20 +797,20 @@ schema::h:i|c:l
 // tag::histogramNumericExpression
 SELECT HISTOGRAM(salary % 100, 10) AS h, COUNT(*) AS c FROM emp GROUP BY h;
 
-       h       |       c
+       h       |       c       
 ---------------+---------------
-0              |10
-10             |15
-20             |10
-30             |14
-40             |9
-50             |9
-60             |8
-70             |13
-80             |3
-90             |9
+0              |10             
+10             |15             
+20             |10             
+30             |14             
+40             |9              
+50             |9              
+60             |8              
+70             |13             
+80             |3              
+90             |9    
 
-// end::histogramNumericExpression
+// end::histogramNumericExpression  
 ;
 
 histogramDateTime
@@ -819,23 +819,23 @@ schema::h:ts|c:l
 SELECT HISTOGRAM(birth_date, INTERVAL 1 YEAR) AS h, COUNT(*) AS c FROM emp GROUP BY h;
 
 
-           h            |       c
+           h            |       c       
 ------------------------+---------------
-null                    |10
-1952-01-01T00:00:00.000Z|8
-1953-01-01T00:00:00.000Z|11
-1954-01-01T00:00:00.000Z|8
-1955-01-01T00:00:00.000Z|4
-1956-01-01T00:00:00.000Z|5
-1957-01-01T00:00:00.000Z|4
-1958-01-01T00:00:00.000Z|7
-1959-01-01T00:00:00.000Z|9
-1960-01-01T00:00:00.000Z|8
-1961-01-01T00:00:00.000Z|8
-1962-01-01T00:00:00.000Z|6
-1963-01-01T00:00:00.000Z|7
-1964-01-01T00:00:00.000Z|4
-1965-01-01T00:00:00.000Z|1
+null                    |10             
+1952-01-01T00:00:00.000Z|8              
+1953-01-01T00:00:00.000Z|11             
+1954-01-01T00:00:00.000Z|8              
+1955-01-01T00:00:00.000Z|4              
+1956-01-01T00:00:00.000Z|5              
+1957-01-01T00:00:00.000Z|4              
+1958-01-01T00:00:00.000Z|7              
+1959-01-01T00:00:00.000Z|9              
+1960-01-01T00:00:00.000Z|8              
+1961-01-01T00:00:00.000Z|8              
+1962-01-01T00:00:00.000Z|6              
+1963-01-01T00:00:00.000Z|7              
+1964-01-01T00:00:00.000Z|4              
+1965-01-01T00:00:00.000Z|1              
 
 // end::histogramDateTime
 ;
@@ -850,16 +850,16 @@ schema::h:i|c:l
 // tag::histogramDateTimeExpression
 SELECT HISTOGRAM(MONTH(birth_date), 2) AS h, COUNT(*) as c FROM emp GROUP BY h ORDER BY h DESC;
 
-       h       |       c
+       h       |       c       
 ---------------+---------------
-12             |7
-10             |17
-8              |16
-6              |16
-4              |18
-2              |10
-0              |6
-null           |10
+12             |7              
+10             |17             
+8              |16             
+6              |16             
+4              |18             
+2              |10             
+0              |6              
+null           |10 
 
 // end::histogramDateTimeExpression
 ;
@@ -875,9 +875,9 @@ dtIntervalPlusInterval
 // tag::dtIntervalPlusInterval
 SELECT INTERVAL 1 DAY + INTERVAL 53 MINUTES AS result;
 
-    result
+    result     
 ---------------
-+1 00:53:00.0
++1 00:53:00.0                       
 
 // end::dtIntervalPlusInterval
 ;
@@ -887,7 +887,7 @@ dtDateTimePlusInterval
 // tag::dtDateTimePlusInterval
 SELECT CAST('1969-05-13T12:34:56' AS DATETIME) + INTERVAL 49 YEARS AS result;
 
-       result
+       result       
 --------------------
 2018-05-13T12:34:56Z
 // end::dtDateTimePlusInterval
@@ -897,9 +897,9 @@ dtMinusInterval
 // tag::dtMinusInterval
 SELECT - INTERVAL '49-1' YEAR TO MONTH result;
 
-    result
+    result     
 ---------------
--49-1
+-49-1         
 
 // end::dtMinusInterval
 ;
@@ -908,9 +908,9 @@ dtIntervalMinusInterval
 // tag::dtIntervalMinusInterval
 SELECT INTERVAL '1' DAY - INTERVAL '2' HOURS AS result;
 
-    result
+    result     
 ---------------
-+0 22:00:00.0
++0 22:00:00.0  
 // end::dtIntervalMinusInterval
 ;
 
@@ -919,7 +919,7 @@ dtDateTimeMinusInterval
 // tag::dtDateTimeMinusInterval
 SELECT CAST('2018-05-13T12:34:56' AS DATETIME) - INTERVAL '2-8' YEAR TO MONTH AS result;
 
-       result
+       result       
 --------------------
 2015-09-13T12:34:56Z
 // end::dtDateTimeMinusInterval
@@ -929,9 +929,9 @@ dtIntervalMul
 // tag::dtIntervalMul
 SELECT -2 * INTERVAL '3' YEARS AS result;
 
-    result
+    result     
 ---------------
--6-0
+-6-0    
 // end::dtIntervalMul
 ;
 
@@ -946,7 +946,7 @@ orderByBasic
 // tag::orderByBasic
 SELECT * FROM library ORDER BY page_count DESC LIMIT 5;
 
-     author      |        name        |  page_count   |    release_date
+     author      |        name        |  page_count   |    release_date    
 -----------------+--------------------+---------------+--------------------
 Peter F. Hamilton|Pandora's Star      |768            |2004-03-02T00:00:00Z
 Vernor Vinge     |A Fire Upon the Deep|613            |1992-06-01T00:00:00Z
@@ -962,12 +962,12 @@ schema::g:s|c:i
 // tag::orderByGroup
 SELECT gender AS g, COUNT(*) AS c FROM emp GROUP BY gender ORDER BY g DESC;
 
-       g       |       c
+       g       |       c       
 ---------------+---------------
 M              |57
-F              |33
-null           |10
-
+F              |33             
+null           |10             
+      
 // end::orderByGroup
 ;
 
@@ -976,12 +976,12 @@ schema::g:s|salary:i
 // tag::orderByAgg
 SELECT gender AS g, MIN(salary) AS salary FROM emp GROUP BY gender ORDER BY salary DESC;
 
-       g       |    salary
+       g       |    salary     
 ---------------+---------------
-F              |25976
-M              |25945
-null           |25324
-
+F              |25976          
+M              |25945          
+null           |25324             
+    
 // end::orderByAgg
 ;
 
@@ -1068,7 +1068,7 @@ orderByScore
 // tag::orderByScore
 SELECT SCORE(), * FROM library WHERE MATCH(name, 'dune') ORDER BY SCORE() DESC;
 
-    SCORE()    |    author     |       name        |  page_count   |    release_date
+    SCORE()    |    author     |       name        |  page_count   |    release_date    
 ---------------+---------------+-------------------+---------------+--------------------
 2.2886353      |Frank Herbert  |Dune               |604            |1965-06-01T00:00:00Z
 1.8893257      |Frank Herbert  |Dune Messiah       |331            |1969-10-15T00:00:00Z
@@ -1082,7 +1082,7 @@ orderByScoreWithMatch
 // tag::orderByScoreWithMatch
 SELECT SCORE(), * FROM library WHERE MATCH(name, 'dune') ORDER BY page_count DESC;
 
-    SCORE()    |    author     |       name        |  page_count   |    release_date
+    SCORE()    |    author     |       name        |  page_count   |    release_date    
 ---------------+---------------+-------------------+---------------+--------------------
 2.2886353      |Frank Herbert  |Dune               |604            |1965-06-01T00:00:00Z
 1.4005898      |Frank Herbert  |God Emperor of Dune|454            |1981-05-28T00:00:00Z
@@ -1096,7 +1096,7 @@ scoreWithMatch
 // tag::scoreWithMatch
 SELECT SCORE() AS score, name, release_date FROM library WHERE QUERY('dune') ORDER BY YEAR(release_date) DESC;
 
-     score     |       name        |    release_date
+     score     |       name        |    release_date    
 ---------------+-------------------+--------------------
 1.4005898      |God Emperor of Dune|1981-05-28T00:00:00Z
 1.6086556      |Children of Dune   |1976-04-21T00:00:00Z
@@ -1116,9 +1116,9 @@ limitBasic
 // tag::limitBasic
 SELECT first_name, last_name, emp_no FROM emp LIMIT 1;
 
-  first_name   |   last_name   |    emp_no
+  first_name   |   last_name   |    emp_no     
 ---------------+---------------+---------------
-Georgi         |Facello        |10001
+Georgi         |Facello        |10001     
 
 // end::limitBasic
 ;
@@ -1133,9 +1133,9 @@ aggAvg
 // tag::aggAvg
 SELECT AVG(salary) AS avg FROM emp;
 
-      avg:d
+      avg:d      
 ---------------
-48248.55
+48248.55          
 // end::aggAvg
 ;
 
@@ -1143,9 +1143,9 @@ aggCountStar
 // tag::aggCountStar
 SELECT COUNT(*) AS count FROM emp;
 
-     count
+     count     
 ---------------
-100
+100               
 // end::aggCountStar
 ;
 
@@ -1153,9 +1153,9 @@ aggCountAll
 // tag::aggCountAll
 SELECT COUNT(ALL last_name) AS count_all, COUNT(DISTINCT last_name) count_distinct FROM emp;
 
-   count_all   |  count_distinct
+   count_all   |  count_distinct  
 ---------------+------------------
-100            |96
+100            |96   
 // end::aggCountAll
 ;
 
@@ -1309,9 +1309,9 @@ aggMax
 // tag::aggMax
 SELECT MAX(salary) AS max FROM emp;
 
-      max
+      max     
 ---------------
-74999
+74999               
 // end::aggMax
 ;
 
@@ -1319,9 +1319,9 @@ aggMin
 // tag::aggMin
 SELECT MIN(salary) AS min FROM emp;
 
-      min
+      min     
 ---------------
-25324
+25324               
 // end::aggMin
 ;
 
@@ -1339,7 +1339,7 @@ aggKurtosis
 // tag::aggKurtosis
 SELECT MIN(salary) AS min, MAX(salary) AS max, KURTOSIS(salary) AS k FROM emp;
 
-      min      |      max      |        k
+      min      |      max      |        k         
 ---------------+---------------+------------------
 25324          |74999          |2.0444718929142986
 // end::aggKurtosis
@@ -1349,25 +1349,25 @@ aggMad
 // tag::aggMad
 SELECT MIN(salary) AS min, MAX(salary) AS max, AVG(salary) AS avg, MAD(salary) AS mad FROM emp;
 
-      min      |      max      |      avg      |      mad
+      min      |      max      |      avg      |      mad      
 ---------------+---------------+---------------+---------------
-25324          |74999          |48248.55       |10096.5
+25324          |74999          |48248.55       |10096.5   
 // end::aggMad
 ;
 
 aggPercentile
 // tag::aggPercentile
-SELECT languages, PERCENTILE(salary, 95) AS "95th" FROM emp
+SELECT languages, PERCENTILE(salary, 95) AS "95th" FROM emp 
        GROUP BY languages;
 
-   languages   |      95th
+   languages   |      95th       
 ---------------+-----------------
-null           |74999.0
-1              |72790.5
+null           |74999.0          
+1              |72790.5          
 2              |71924.70000000001
-3              |73638.25
+3              |73638.25         
 4              |72115.59999999999
-5              |61071.7
+5              |61071.7       
 // end::aggPercentile
 ;
 
@@ -1375,14 +1375,14 @@ aggPercentileRank
 // tag::aggPercentileRank
 SELECT languages, PERCENTILE_RANK(salary, 65000) AS rank FROM emp GROUP BY languages;
 
-   languages   |      rank
+   languages   |      rank       
 ---------------+-----------------
 null           |73.65766569962062
-1              |73.7291625157734
+1              |73.7291625157734 
 2              |88.88005607010643
 3              |79.43662623295829
 4              |85.70446389643493
-5              |100.0
+5              |100.0      
 // end::aggPercentileRank
 ;
 
@@ -1390,7 +1390,7 @@ aggSkewness
 // tag::aggSkewness
 SELECT MIN(salary) AS min, MAX(salary) AS max, SKEWNESS(salary) AS s FROM emp;
 
-      min      |      max      |        s
+      min      |      max      |        s         
 ---------------+---------------+------------------
 25324          |74999          |0.2707722118423227
 // end::aggSkewness
@@ -1398,10 +1398,10 @@ SELECT MIN(salary) AS min, MAX(salary) AS max, SKEWNESS(salary) AS s FROM emp;
 
 aggStddevPop
 // tag::aggStddevPop
-SELECT MIN(salary) AS min, MAX(salary) AS max, STDDEV_POP(salary) AS stddev
+SELECT MIN(salary) AS min, MAX(salary) AS max, STDDEV_POP(salary) AS stddev 
        FROM emp;
 
-      min      |      max      |      stddev
+      min      |      max      |      stddev      
 ---------------+---------------+------------------
 25324          |74999          |13765.125502787832
 // end::aggStddevPop
@@ -1410,10 +1410,10 @@ SELECT MIN(salary) AS min, MAX(salary) AS max, STDDEV_POP(salary) AS stddev
 
 aggSumOfSquares
 // tag::aggSumOfSquares
-SELECT MIN(salary) AS min, MAX(salary) AS max, SUM_OF_SQUARES(salary) AS sumsq
+SELECT MIN(salary) AS min, MAX(salary) AS max, SUM_OF_SQUARES(salary) AS sumsq 
        FROM emp;
 
-      min      |      max      |     sumsq
+      min      |      max      |     sumsq      
 ---------------+---------------+----------------
 25324          |74999          |2.51740125721E11
 // end::aggSumOfSquares
@@ -1424,7 +1424,7 @@ aggVarPop
 // tag::aggVarPop
 SELECT MIN(salary) AS min, MAX(salary) AS max, VAR_POP(salary) AS varpop FROM emp;
 
-      min      |      max      |     varpop
+      min      |      max      |     varpop     
 ---------------+---------------+----------------
 25324          |74999          |1.894786801075E8
 // end::aggVarPop
@@ -1441,9 +1441,9 @@ stringAscii
 // tag::stringAscii
 SELECT ASCII('Elastic');
 
-ASCII('Elastic')
+ASCII('Elastic') 
 ----------------
-69
+69   
 // end::stringAscii
 ;
 
@@ -1453,7 +1453,7 @@ SELECT BIT_LENGTH('Elastic');
 
 BIT_LENGTH('Elastic')
 ---------------------
-56
+56  
 // end::stringBitLength
 ;
 
@@ -1461,9 +1461,9 @@ stringChar
 // tag::stringChar
 SELECT CHAR(69);
 
-   CHAR(69)
+   CHAR(69)    
 ---------------
-E
+E        
 // end::stringChar
 ;
 
@@ -1473,7 +1473,7 @@ SELECT CHAR_LENGTH('Elastic');
 
 CHAR_LENGTH('Elastic')
 ----------------------
-7
+7     
 // end::stringCharLength
 ;
 
@@ -1483,7 +1483,7 @@ SELECT CONCAT('Elasticsearch', ' SQL');
 
 CONCAT('Elasticsearch', ' SQL')
 -------------------------------
-Elasticsearch SQL
+Elasticsearch SQL  
 // end::stringConcat
 ;
 
@@ -1503,7 +1503,7 @@ SELECT LCASE('Elastic');
 
 LCASE('Elastic')
 ----------------
-elastic
+elastic    
 // end::stringLCase
 ;
 
@@ -1513,7 +1513,7 @@ SELECT LEFT('Elastic',3);
 
 LEFT('Elastic',3)
 -----------------
-Ela
+Ela    
 // end::stringLeft
 ;
 
@@ -1523,7 +1523,7 @@ SELECT LENGTH('Elastic   ');
 
 LENGTH('Elastic   ')
 --------------------
-7
+7     
 // end::stringLength
 ;
 
@@ -1533,7 +1533,7 @@ SELECT LOCATE('a', 'Elasticsearch');
 
 LOCATE('a', 'Elasticsearch')
 ----------------------------
-3
+3        
 // end::stringLocateWoStart
 ;
 
@@ -1553,7 +1553,7 @@ SELECT LTRIM('   Elastic');
 
 LTRIM('   Elastic')
 -------------------
-Elastic
+Elastic   
 // end::stringLTrim
 ;
 
@@ -1563,7 +1563,7 @@ SELECT OCTET_LENGTH('Elastic');
 
 OCTET_LENGTH('Elastic')
 -----------------------
-7
+7  
 // end::stringOctetLength
 ;
 
@@ -1573,7 +1573,7 @@ SELECT POSITION('Elastic', 'Elasticsearch');
 
 POSITION('Elastic', 'Elasticsearch')
 ------------------------------------
-1
+1  
 // end::stringPosition
 ;
 
@@ -1581,9 +1581,9 @@ stringRepeat
 // tag::stringRepeat
 SELECT REPEAT('La', 3);
 
- REPEAT('La', 3)
+ REPEAT('La', 3)  
 ----------------
-LaLaLa
+LaLaLa      
 // end::stringRepeat
 ;
 
@@ -1603,7 +1603,7 @@ SELECT RIGHT('Elastic',3);
 
 RIGHT('Elastic',3)
 ------------------
-tic
+tic    
 // end::stringRight
 ;
 
@@ -1613,7 +1613,7 @@ SELECT RTRIM('Elastic   ');
 
 RTRIM('Elastic   ')
 -------------------
-Elastic
+Elastic       
 // end::stringRTrim
 ;
 
@@ -1622,10 +1622,10 @@ schema::SPACE(3):s
 // tag::stringSpace
 SELECT SPACE(3);
 
-   SPACE(3)
+   SPACE(3)    
 ---------------
-
-
+               
+ 
 // end::stringSpace
 ;
 
@@ -1635,7 +1635,7 @@ SELECT SUBSTRING('Elasticsearch', 0, 7);
 
 SUBSTRING('Elasticsearch', 0, 7)
 --------------------------------
-Elastic
+Elastic    
 // end::stringSubString
 ;
 
@@ -1643,9 +1643,9 @@ stringUCase
 // tag::stringUCase
 SELECT UCASE('Elastic');
 
-UCASE('Elastic')
+UCASE('Elastic') 
 ----------------
-ELASTIC
+ELASTIC    
 // end::stringUCase
 ;
 
@@ -1660,9 +1660,9 @@ conversionStringToIntCast
 // tag::conversionStringToIntCast
 SELECT CAST('123' AS INT) AS int;
 
-      int
+      int      
 ---------------
-123
+123    
 // end::conversionStringToIntCast
 ;
 
@@ -1670,9 +1670,9 @@ conversionIntToStringCast-Ignore
 // tag::conversionIntToStringCast
 SELECT CAST(123 AS VARCHAR) AS string;
 
-    string
+    string     
 ---------------
-123
+123   
 
 // end::conversionIntToStringCast
 ;
@@ -2527,7 +2527,6 @@ SELECT DATE_DIFF('seconds', '2019-09-04T11:22:33.123Z'::datetime, '2019-07-12T22
 // end::dateDiffDateTimeSeconds
 ;
 
-
 dateDiffDateQuarters
 // tag::dateDiffDateQuarters
 SELECT DATE_DIFF('qq', '2019-09-04'::date, '2025-04-25'::date) AS "diffInQuarters";
@@ -2873,7 +2872,7 @@ currentTimestamp-Ignore
 // tag::curTs
 SELECT CURRENT_TIMESTAMP AS result;
 
-         result
+         result         
 ------------------------
 2018-12-12T14:48:52.448Z
 // end::curTs
@@ -2883,7 +2882,7 @@ currentTimestampFunction-Ignore
 // tag::curTsFunction
 SELECT CURRENT_TIMESTAMP() AS result;
 
-         result
+         result         
 ------------------------
 2018-12-12T14:48:52.448Z
 // end::curTsFunction
@@ -2893,7 +2892,7 @@ currentTimestampFunctionPrecision-Ignore
 // tag::curTsFunctionPrecision
 SELECT CURRENT_TIMESTAMP(1) AS result;
 
-         result
+         result         
 ------------------------
 2018-12-12T14:48:52.4Z
 // end::curTsFunctionPrecision
@@ -2904,7 +2903,7 @@ nowFunction-Ignore
 // tag::nowFunction
 SELECT NOW() AS result;
 
-         result
+         result         
 ------------------------
 2018-12-12T14:48:52.448Z
 // end::nowFunction

--- a/x-pack/plugin/sql/qa/src/main/resources/docs/docs.csv-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/docs/docs.csv-spec
@@ -14,7 +14,7 @@ describeTable
 // tag::describeTable
 DESCRIBE emp;
 
-       column       |     type      |    mapping    
+       column       |     type      |    mapping
 --------------------+---------------+---------------
 birth_date          |TIMESTAMP      |datetime
 dep                 |STRUCT         |nested
@@ -40,7 +40,7 @@ salary              |INTEGER        |integer
 // tag::describeTableAlias
 //DESCRIBE employee;
 
-//    column     |     type      
+//    column     |     type
 //---------------+---------------
 
 // end::describeTableAlias
@@ -48,12 +48,12 @@ salary              |INTEGER        |integer
 
 //
 // Show columns
-// 
+//
 showColumns
 // tag::showColumns
 SHOW COLUMNS IN emp;
 
-       column       |     type      |    mapping    
+       column       |     type      |    mapping
 --------------------+---------------+---------------
 birth_date          |TIMESTAMP      |datetime
 dep                 |STRUCT         |nested
@@ -79,9 +79,9 @@ salary              |INTEGER        |integer
 // tag::showColumnsInAlias
 //SHOW COLUMNS FROM employee;
 
-//    column     |     type      
+//    column     |     type
 //---------------+---------------
-               
+
 // end::showColumnsInAlias
 //;
 
@@ -95,11 +95,11 @@ showTables
 // tag::showTables
 SHOW TABLES;
 
-     name      |     type      |     kind      
+     name      |     type      |     kind
 ---------------+---------------+---------------
-emp            |BASE TABLE     |INDEX          
-employees      |VIEW           |ALIAS          
-library        |BASE TABLE     |INDEX    
+emp            |BASE TABLE     |INDEX
+employees      |VIEW           |ALIAS
+library        |BASE TABLE     |INDEX
 
 // end::showTables
 ;
@@ -108,9 +108,9 @@ showTablesLikeExact
 // tag::showTablesLikeExact
 SHOW TABLES LIKE 'emp';
 
-     name      |     type      |     kind      
+     name      |     type      |     kind
 ---------------+---------------+---------------
-emp            |BASE TABLE     |INDEX    
+emp            |BASE TABLE     |INDEX
 
 // end::showTablesLikeExact
 ;
@@ -119,10 +119,10 @@ showTablesLikeWildcard
 // tag::showTablesLikeWildcard
 SHOW TABLES LIKE 'emp%';
 
-     name      |     type      |     kind      
+     name      |     type      |     kind
 ---------------+---------------+---------------
-emp            |BASE TABLE     |INDEX          
-employees      |VIEW           |ALIAS             
+emp            |BASE TABLE     |INDEX
+employees      |VIEW           |ALIAS
 
 // end::showTablesLikeWildcard
 ;
@@ -132,9 +132,9 @@ showTablesLikeOneChar
 // tag::showTablesLikeOneChar
 SHOW TABLES LIKE 'em_';
 
-     name      |     type      |     kind      
+     name      |     type      |     kind
 ---------------+---------------+---------------
-emp            |BASE TABLE     |INDEX     
+emp            |BASE TABLE     |INDEX
 
 // end::showTablesLikeOneChar
 ;
@@ -143,9 +143,9 @@ showTablesLikeMixed
 // tag::showTablesLikeMixed
 SHOW TABLES LIKE '%em_';
 
-     name      |     type      |     kind      
+     name      |     type      |     kind
 ---------------+---------------+---------------
-emp            |BASE TABLE     |INDEX        
+emp            |BASE TABLE     |INDEX
 
 // end::showTablesLikeMixed
 ;
@@ -155,7 +155,7 @@ schema::name:s|type:s|kind:s
 // tag::showTablesLikeEscape
 SHOW TABLES LIKE 'emp!%' ESCAPE '!';
 
-     name      |     type      |     kind      
+     name      |     type      |     kind
 ---------------+---------------+---------------
 
 // end::showTablesLikeEscape
@@ -166,10 +166,10 @@ showTablesEsMultiIndex
 // tag::showTablesEsMultiIndex
 SHOW TABLES "*,-l*";
 
-     name      |     type      |     kind      
+     name      |     type      |     kind
 ---------------+---------------+---------------
-emp            |BASE TABLE     |INDEX          
-employees      |VIEW           |ALIAS  
+emp            |BASE TABLE     |INDEX
+employees      |VIEW           |ALIAS
 
 // end::showTablesEsMultiIndex
 ;
@@ -182,12 +182,12 @@ showTablesIncludeFrozen
 // tag::showTablesIncludeFrozen
 SHOW TABLES INCLUDE FROZEN;
 
-     name      |     type      |     kind      
+     name      |     type      |     kind
 ---------------+---------------+---------------
 archive        |BASE TABLE     |FROZEN INDEX
-emp            |BASE TABLE     |INDEX          
-employees      |VIEW           |ALIAS          
-library        |BASE TABLE     |INDEX    
+emp            |BASE TABLE     |INDEX
+employees      |VIEW           |ALIAS
+library        |BASE TABLE     |INDEX
 
 // end::showTablesIncludeFrozen
 ;
@@ -205,23 +205,23 @@ SHOW FUNCTIONS;
 
       name       |     type
 -----------------+---------------
-AVG              |AGGREGATE      
+AVG              |AGGREGATE
 COUNT            |AGGREGATE
 FIRST            |AGGREGATE
 FIRST_VALUE      |AGGREGATE
 LAST             |AGGREGATE
 LAST_VALUE       |AGGREGATE
-MAX              |AGGREGATE      
-MIN              |AGGREGATE      
-SUM              |AGGREGATE      
+MAX              |AGGREGATE
+MIN              |AGGREGATE
+SUM              |AGGREGATE
 KURTOSIS         |AGGREGATE
-MAD              |AGGREGATE      
-PERCENTILE       |AGGREGATE      
-PERCENTILE_RANK  |AGGREGATE      
-SKEWNESS         |AGGREGATE      
-STDDEV_POP       |AGGREGATE      
-SUM_OF_SQUARES   |AGGREGATE      
-VAR_POP          |AGGREGATE      
+MAD              |AGGREGATE
+PERCENTILE       |AGGREGATE
+PERCENTILE_RANK  |AGGREGATE
+SKEWNESS         |AGGREGATE
+STDDEV_POP       |AGGREGATE
+SUM_OF_SQUARES   |AGGREGATE
+VAR_POP          |AGGREGATE
 HISTOGRAM        |GROUPING
 CASE             |CONDITIONAL
 COALESCE         |CONDITIONAL
@@ -255,10 +255,10 @@ DAY_OF_MONTH     |SCALAR
 DAY_OF_WEEK      |SCALAR
 DAY_OF_YEAR      |SCALAR
 DOM              |SCALAR
-DOW              |SCALAR         
-DOY              |SCALAR         
-HOUR             |SCALAR         
-HOUR_OF_DAY      |SCALAR         
+DOW              |SCALAR
+DOY              |SCALAR
+HOUR             |SCALAR
+HOUR_OF_DAY      |SCALAR
 IDOW             |SCALAR
 ISODAYOFWEEK     |SCALAR
 ISODOW           |SCALAR
@@ -268,16 +268,16 @@ ISO_DAY_OF_WEEK  |SCALAR
 ISO_WEEK_OF_YEAR |SCALAR
 IW               |SCALAR
 IWOY             |SCALAR
-MINUTE           |SCALAR         
-MINUTE_OF_DAY    |SCALAR         
-MINUTE_OF_HOUR   |SCALAR         
-MONTH            |SCALAR         
-MONTHNAME        |SCALAR         
-MONTH_NAME       |SCALAR         
+MINUTE           |SCALAR
+MINUTE_OF_DAY    |SCALAR
+MINUTE_OF_HOUR   |SCALAR
+MONTH            |SCALAR
+MONTHNAME        |SCALAR
+MONTH_NAME       |SCALAR
 MONTH_OF_YEAR    |SCALAR
 NOW              |SCALAR
-QUARTER          |SCALAR         
-SECOND           |SCALAR         
+QUARTER          |SCALAR
+SECOND           |SCALAR
 SECOND_OF_MINUTE |SCALAR
 TIMESTAMPADD     |SCALAR
 TIMESTAMPDIFF    |SCALAR
@@ -285,60 +285,60 @@ TIMESTAMP_ADD    |SCALAR
 TIMESTAMP_DIFF   |SCALAR
 TODAY            |SCALAR
 WEEK             |SCALAR
-WEEK_OF_YEAR     |SCALAR         
-YEAR             |SCALAR         
-ABS              |SCALAR         
-ACOS             |SCALAR         
-ASIN             |SCALAR         
-ATAN             |SCALAR         
-ATAN2            |SCALAR         
-CBRT             |SCALAR         
-CEIL             |SCALAR         
-CEILING          |SCALAR         
-COS              |SCALAR         
-COSH             |SCALAR         
-COT              |SCALAR         
-DEGREES          |SCALAR         
-E                |SCALAR         
-EXP              |SCALAR         
-EXPM1            |SCALAR         
-FLOOR            |SCALAR         
-LOG              |SCALAR         
-LOG10            |SCALAR         
-MOD              |SCALAR         
-PI               |SCALAR         
-POWER            |SCALAR         
-RADIANS          |SCALAR         
-RAND             |SCALAR         
-RANDOM           |SCALAR         
-ROUND            |SCALAR         
-SIGN             |SCALAR         
-SIGNUM           |SCALAR         
-SIN              |SCALAR         
-SINH             |SCALAR         
-SQRT             |SCALAR         
-TAN              |SCALAR         
-TRUNCATE         |SCALAR         
-ASCII            |SCALAR         
-BIT_LENGTH       |SCALAR         
-CHAR             |SCALAR         
-CHARACTER_LENGTH |SCALAR         
-CHAR_LENGTH      |SCALAR         
-CONCAT           |SCALAR         
-INSERT           |SCALAR         
-LCASE            |SCALAR         
-LEFT             |SCALAR         
-LENGTH           |SCALAR         
-LOCATE           |SCALAR         
-LTRIM            |SCALAR         
-OCTET_LENGTH     |SCALAR         
-POSITION         |SCALAR         
-REPEAT           |SCALAR         
-REPLACE          |SCALAR         
-RIGHT            |SCALAR         
-RTRIM            |SCALAR         
-SPACE            |SCALAR         
-SUBSTRING        |SCALAR         
+WEEK_OF_YEAR     |SCALAR
+YEAR             |SCALAR
+ABS              |SCALAR
+ACOS             |SCALAR
+ASIN             |SCALAR
+ATAN             |SCALAR
+ATAN2            |SCALAR
+CBRT             |SCALAR
+CEIL             |SCALAR
+CEILING          |SCALAR
+COS              |SCALAR
+COSH             |SCALAR
+COT              |SCALAR
+DEGREES          |SCALAR
+E                |SCALAR
+EXP              |SCALAR
+EXPM1            |SCALAR
+FLOOR            |SCALAR
+LOG              |SCALAR
+LOG10            |SCALAR
+MOD              |SCALAR
+PI               |SCALAR
+POWER            |SCALAR
+RADIANS          |SCALAR
+RAND             |SCALAR
+RANDOM           |SCALAR
+ROUND            |SCALAR
+SIGN             |SCALAR
+SIGNUM           |SCALAR
+SIN              |SCALAR
+SINH             |SCALAR
+SQRT             |SCALAR
+TAN              |SCALAR
+TRUNCATE         |SCALAR
+ASCII            |SCALAR
+BIT_LENGTH       |SCALAR
+CHAR             |SCALAR
+CHARACTER_LENGTH |SCALAR
+CHAR_LENGTH      |SCALAR
+CONCAT           |SCALAR
+INSERT           |SCALAR
+LCASE            |SCALAR
+LEFT             |SCALAR
+LENGTH           |SCALAR
+LOCATE           |SCALAR
+LTRIM            |SCALAR
+OCTET_LENGTH     |SCALAR
+POSITION         |SCALAR
+REPEAT           |SCALAR
+REPLACE          |SCALAR
+RIGHT            |SCALAR
+RTRIM            |SCALAR
+SPACE            |SCALAR
+SUBSTRING        |SCALAR
 UCASE            |SCALAR
 CAST             |SCALAR
 CONVERT          |SCALAR
@@ -361,9 +361,9 @@ showFunctionsLikeExact
 // tag::showFunctionsLikeExact
 SHOW FUNCTIONS LIKE 'ABS';
 
-     name      |     type      
+     name      |     type
 ---------------+---------------
-ABS            |SCALAR    
+ABS            |SCALAR
 
 // end::showFunctionsLikeExact
 ;
@@ -372,15 +372,15 @@ showFunctionsLikeWildcard
 // tag::showFunctionsLikeWildcard
 SHOW FUNCTIONS LIKE 'A%';
 
-     name      |     type      
+     name      |     type
 ---------------+---------------
-AVG            |AGGREGATE      
-ABS            |SCALAR         
-ACOS           |SCALAR         
-ASIN           |SCALAR         
-ATAN           |SCALAR         
+AVG            |AGGREGATE
+ABS            |SCALAR
+ACOS           |SCALAR
+ASIN           |SCALAR
+ATAN           |SCALAR
 ATAN2          |SCALAR
-ASCII          |SCALAR     
+ASCII          |SCALAR
 // end::showFunctionsLikeWildcard
 ;
 
@@ -388,10 +388,10 @@ showFunctionsLikeChar
 // tag::showFunctionsLikeChar
 SHOW FUNCTIONS LIKE 'A__';
 
-     name      |     type      
+     name      |     type
 ---------------+---------------
-AVG            |AGGREGATE      
-ABS            |SCALAR         
+AVG            |AGGREGATE
+ABS            |SCALAR
 // end::showFunctionsLikeChar
 ;
 
@@ -399,7 +399,7 @@ showFunctionsWithPattern
 // tag::showFunctionsWithPattern
 SHOW FUNCTIONS LIKE '%DAY%';
 
-     name      |     type      
+     name      |     type
 ---------------+---------------
 DAY            |SCALAR
 DAYNAME        |SCALAR
@@ -410,10 +410,10 @@ DAY_NAME       |SCALAR
 DAY_OF_MONTH   |SCALAR
 DAY_OF_WEEK    |SCALAR
 DAY_OF_YEAR    |SCALAR
-HOUR_OF_DAY    |SCALAR         
+HOUR_OF_DAY    |SCALAR
 ISODAYOFWEEK   |SCALAR
 ISO_DAY_OF_WEEK|SCALAR
-MINUTE_OF_DAY  |SCALAR         
+MINUTE_OF_DAY  |SCALAR
 TODAY          |SCALAR
 
 // end::showFunctionsWithPattern
@@ -429,9 +429,9 @@ selectColumnAlias
 // tag::selectColumnAlias
 SELECT 1 + 1 AS result;
 
-    result     
+    result
 ---------------
-2    
+2
 
 // end::selectColumnAlias
 ;
@@ -440,9 +440,9 @@ selectInline
 // tag::selectInline
 SELECT 1 + 1;
 
-    1 + 1    
+    1 + 1
 --------------
-2      
+2
 
 // end::selectInline
 ;
@@ -451,9 +451,9 @@ selectColumn
 // tag::selectColumn
 SELECT emp_no FROM emp LIMIT 1;
 
-    emp_no     
+    emp_no
 ---------------
-10001   
+10001
 
 // end::selectColumn
 ;
@@ -462,9 +462,9 @@ selectQualifiedColumn
 // tag::selectQualifiedColumn
 SELECT emp.emp_no FROM emp LIMIT 1;
 
-    emp_no     
+    emp_no
 ---------------
-10001   
+10001
 
 // end::selectQualifiedColumn
 ;
@@ -474,9 +474,9 @@ wildcardWithOrder
 // tag::wildcardWithOrder
 SELECT * FROM emp LIMIT 1;
 
-     birth_date     |    emp_no     |  first_name   |    gender     |     hire_date      |   languages   |   last_name   |    salary     
+     birth_date     |    emp_no     |  first_name   |    gender     |     hire_date      |   languages   |   last_name   |    salary
 --------------------+---------------+---------------+---------------+--------------------+---------------+---------------+---------------
-1953-09-02T00:00:00Z|10001          |Georgi         |M              |1986-06-26T00:00:00Z|2              |Facello        |57305 
+1953-09-02T00:00:00Z|10001          |Georgi         |M              |1986-06-26T00:00:00Z|2              |Facello        |57305
 
 // end::wildcardWithOrder
 ;
@@ -485,10 +485,10 @@ fromTable
 // tag::fromTable
 SELECT * FROM emp LIMIT 1;
 
-     birth_date     |    emp_no     |  first_name   |    gender     |     hire_date      |   languages   |   last_name   |    salary     
+     birth_date     |    emp_no     |  first_name   |    gender     |     hire_date      |   languages   |   last_name   |    salary
 --------------------+---------------+---------------+---------------+--------------------+---------------+---------------+---------------
-1953-09-02T00:00:00Z|10001          |Georgi         |M              |1986-06-26T00:00:00Z|2              |Facello        |57305        
-  
+1953-09-02T00:00:00Z|10001          |Georgi         |M              |1986-06-26T00:00:00Z|2              |Facello        |57305
+
 
 // end::fromTable
 ;
@@ -497,9 +497,9 @@ fromTableQuoted
 // tag::fromTableQuoted
 SELECT * FROM "emp" LIMIT 1;
 
-     birth_date     |    emp_no     |  first_name   |    gender     |     hire_date      |   languages   |   last_name   |    salary     
+     birth_date     |    emp_no     |  first_name   |    gender     |     hire_date      |   languages   |   last_name   |    salary
 --------------------+---------------+---------------+---------------+--------------------+---------------+---------------+---------------
-1953-09-02T00:00:00Z|10001          |Georgi         |M              |1986-06-26T00:00:00Z|2              |Facello        |57305   
+1953-09-02T00:00:00Z|10001          |Georgi         |M              |1986-06-26T00:00:00Z|2              |Facello        |57305
 
 // end::fromTableQuoted
 ;
@@ -508,7 +508,7 @@ fromTableIncludeFrozen
 // tag::fromTableIncludeFrozen
 SELECT * FROM FROZEN archive LIMIT 1;
 
-     author      |        name        |  page_count   |    release_date    
+     author      |        name        |  page_count   |    release_date
 -----------------+--------------------+---------------+--------------------
 James S.A. Corey |Leviathan Wakes     |561            |2011-06-02T00:00:00Z
 
@@ -519,9 +519,9 @@ fromTableQuoted
 // tag::fromTablePatternQuoted
 SELECT emp_no FROM "e*p" LIMIT 1;
 
-    emp_no     
+    emp_no
 ---------------
-10001   
+10001
 
 // end::fromTablePatternQuoted
 ;
@@ -530,9 +530,9 @@ fromTableAlias
 // tag::fromTableAlias
 SELECT e.emp_no FROM emp AS e LIMIT 1;
 
-    emp_no     
+    emp_no
 -------------
-10001   
+10001
 
 // end::fromTableAlias
 ;
@@ -541,9 +541,9 @@ basicWhere
 // tag::basicWhere
 SELECT last_name FROM emp WHERE emp_no = 10001;
 
-   last_name   
+   last_name
 ---------------
-Facello   
+Facello
 
 // end::basicWhere
 ;
@@ -559,7 +559,7 @@ schema::g:s
 // tag::groupByColumn
 SELECT gender AS g FROM emp GROUP BY gender;
 
-       g       
+       g
 ---------------
 null
 F
@@ -573,11 +573,11 @@ schema::gender:s
 // tag::groupByOrdinal
 SELECT gender FROM emp GROUP BY 1;
 
-    gender     
+    gender
 ---------------
 null
-F              
-M   
+F
+M
 
 // end::groupByOrdinal
 ;
@@ -587,11 +587,11 @@ schema::g:s
 // tag::groupByAlias
 SELECT gender AS g FROM emp GROUP BY g;
 
-       g       
+       g
 ---------------
 null
-F              
-M  
+F
+M
 
 // end::groupByAlias
 ;
@@ -600,15 +600,15 @@ groupByExpression
 // tag::groupByExpression
 SELECT languages + 1 AS l FROM emp GROUP BY l;
 
-       l       
+       l
 ---------------
 null
-2              
-3              
-4              
-5              
-6              
- 
+2
+3
+4
+5
+6
+
 
 // end::groupByExpression
 ;
@@ -618,24 +618,24 @@ schema::g:s|l:i|c:l
 // tag::groupByMulti
 SELECT gender g, languages l, COUNT(*) c FROM "emp" GROUP BY g, l ORDER BY languages ASC, gender DESC;
 
-       g       |       l       |       c       
+       g       |       l       |       c
 ---------------+---------------+---------------
-M              |null           |7              
-F              |null           |3              
-M              |1              |9              
-F              |1              |4              
-null           |1              |2              
-M              |2              |11             
-F              |2              |5              
-null           |2              |3              
-M              |3              |11             
-F              |3              |6              
-M              |4              |11             
-F              |4              |6              
-null           |4              |1              
-M              |5              |8              
-F              |5              |9              
-null           |5              |4  
+M              |null           |7
+F              |null           |3
+M              |1              |9
+F              |1              |4
+null           |1              |2
+M              |2              |11
+F              |2              |5
+null           |2              |3
+M              |3              |11
+F              |3              |6
+M              |4              |11
+F              |4              |6
+null           |4              |1
+M              |5              |8
+F              |5              |9
+null           |5              |4
 
 
 // end::groupByMulti
@@ -647,11 +647,11 @@ schema::g:s|c:i
 // tag::groupByAndAgg
 SELECT gender AS g, COUNT(*) AS c FROM emp GROUP BY gender;
 
-       g       |       c       
+       g       |       c
 ---------------+---------------
-null           |10             
-F              |33             
-M              |57       
+null           |10
+F              |33
+M              |57
 
 // end::groupByAndAgg
 ;
@@ -661,11 +661,11 @@ schema::g:s|salary:i
 // tag::groupByAndAggExpression
 SELECT gender AS g, ROUND((MIN(salary) / 100)) AS salary FROM emp GROUP BY gender;
 
-       g       |    salary     
+       g       |    salary
 ---------------+---------------
-null           |253            
-F              |260            
-M              |259        
+null           |253
+F              |260
+M              |259
 // end::groupByAndAggExpression
 ;
 
@@ -674,11 +674,11 @@ schema::g:s|k:d|s:d
 // tag::groupByAndMultipleAggs
 SELECT gender AS g, KURTOSIS(salary) AS k, SKEWNESS(salary) AS s FROM emp GROUP BY gender;
 
-       g       |        k         |         s         
+       g       |        k         |         s
 ---------------+------------------+-------------------
 null           |2.2215791166941923|-0.03373126000214023
-F              |1.7873117044424276|0.05504995122217512 
-M              |2.280646181070106 |0.44302407229580243 
+F              |1.7873117044424276|0.05504995122217512
+M              |2.280646181070106 |0.44302407229580243
 
 
 // end::groupByAndMultipleAggs
@@ -688,9 +688,9 @@ groupByImplicitCount
 // tag::groupByImplicitCount
 SELECT COUNT(*) AS count FROM emp;
 
-     count     
+     count
 ---------------
-100 
+100
 
 // end::groupByImplicitCount
 ;
@@ -705,12 +705,12 @@ groupByHaving
 // tag::groupByHaving
 SELECT languages AS l, COUNT(*) AS c FROM emp GROUP BY l HAVING c BETWEEN 15 AND 20;
 
-       l       |       c       
+       l       |       c
 ---------------+---------------
-1              |15             
-2              |19             
-3              |17             
-4              |18     
+1              |15
+2              |19
+3              |17
+4              |18
 
 // end::groupByHaving
 ;
@@ -719,14 +719,14 @@ groupByHavingMultiple
 // tag::groupByHavingMultiple
 SELECT MIN(salary) AS min, MAX(salary) AS max, MAX(salary) - MIN(salary) AS diff FROM emp GROUP BY languages HAVING diff - max % min > 0 AND AVG(salary) > 30000;
 
-      min      |      max      |     diff      
+      min      |      max      |     diff
 ---------------+---------------+---------------
-28336          |74999          |46663          
-25976          |73717          |47741          
-29175          |73578          |44403          
-26436          |74970          |48534          
-27215          |74572          |47357          
-25324          |66817          |41493          
+28336          |74999          |46663
+25976          |73717          |47741
+29175          |73578          |44403
+26436          |74970          |48534
+27215          |74572          |47357
+25324          |66817          |41493
 
 
 // end::groupByHavingMultiple
@@ -736,9 +736,9 @@ groupByImplicitMultipleAggs
 // tag::groupByImplicitMultipleAggs
 SELECT MIN(salary) AS min, MAX(salary) AS max, AVG(salary) AS avg, COUNT(*) AS count FROM emp;
 
-      min:i    |      max:i    |      avg:d    |     count:l     
+      min:i    |      max:i    |      avg:d    |     count:l
 ---------------+---------------+---------------+---------------
-25324          |74999          |48248.55       |100  
+25324          |74999          |48248.55       |100
 
 // end::groupByImplicitMultipleAggs
 ;
@@ -747,9 +747,9 @@ groupByHavingImplicitMatch
 // tag::groupByHavingImplicitMatch
 SELECT MIN(salary) AS min, MAX(salary) AS max FROM emp HAVING min > 25000;
 
-      min      |      max      
+      min      |      max
 ---------------+---------------
-25324          |74999        
+25324          |74999
 
 // end::groupByHavingImplicitMatch
 ;
@@ -758,7 +758,7 @@ SELECT MIN(salary) AS min, MAX(salary) AS max FROM emp HAVING min > 25000;
 // tag::groupByHavingImplicitNoMatch
 //SELECT MIN(salary) AS min, MAX(salary) AS max FROM emp HAVING max > 75000;
 
-//      min      |      max      
+//      min      |      max
 //---------------+---------------
 
 // end::groupByHavingImplicitNoMatch
@@ -776,20 +776,20 @@ histogramNumeric
 // tag::histogramNumeric
 SELECT HISTOGRAM(salary, 5000) AS h FROM emp GROUP BY h;
 
-       h       
+       h
 ---------------
-25000          
-30000          
-35000          
-40000          
-45000          
-50000          
-55000          
-60000          
-65000          
+25000
+30000
+35000
+40000
+45000
+50000
+55000
+60000
+65000
 70000
 
-// end::histogramNumeric  
+// end::histogramNumeric
 ;
 
 histogramNumericExpression
@@ -797,20 +797,20 @@ schema::h:i|c:l
 // tag::histogramNumericExpression
 SELECT HISTOGRAM(salary % 100, 10) AS h, COUNT(*) AS c FROM emp GROUP BY h;
 
-       h       |       c       
+       h       |       c
 ---------------+---------------
-0              |10             
-10             |15             
-20             |10             
-30             |14             
-40             |9              
-50             |9              
-60             |8              
-70             |13             
-80             |3              
-90             |9    
+0              |10
+10             |15
+20             |10
+30             |14
+40             |9
+50             |9
+60             |8
+70             |13
+80             |3
+90             |9
 
-// end::histogramNumericExpression  
+// end::histogramNumericExpression
 ;
 
 histogramDateTime
@@ -819,23 +819,23 @@ schema::h:ts|c:l
 SELECT HISTOGRAM(birth_date, INTERVAL 1 YEAR) AS h, COUNT(*) AS c FROM emp GROUP BY h;
 
 
-           h            |       c       
+           h            |       c
 ------------------------+---------------
-null                    |10             
-1952-01-01T00:00:00.000Z|8              
-1953-01-01T00:00:00.000Z|11             
-1954-01-01T00:00:00.000Z|8              
-1955-01-01T00:00:00.000Z|4              
-1956-01-01T00:00:00.000Z|5              
-1957-01-01T00:00:00.000Z|4              
-1958-01-01T00:00:00.000Z|7              
-1959-01-01T00:00:00.000Z|9              
-1960-01-01T00:00:00.000Z|8              
-1961-01-01T00:00:00.000Z|8              
-1962-01-01T00:00:00.000Z|6              
-1963-01-01T00:00:00.000Z|7              
-1964-01-01T00:00:00.000Z|4              
-1965-01-01T00:00:00.000Z|1              
+null                    |10
+1952-01-01T00:00:00.000Z|8
+1953-01-01T00:00:00.000Z|11
+1954-01-01T00:00:00.000Z|8
+1955-01-01T00:00:00.000Z|4
+1956-01-01T00:00:00.000Z|5
+1957-01-01T00:00:00.000Z|4
+1958-01-01T00:00:00.000Z|7
+1959-01-01T00:00:00.000Z|9
+1960-01-01T00:00:00.000Z|8
+1961-01-01T00:00:00.000Z|8
+1962-01-01T00:00:00.000Z|6
+1963-01-01T00:00:00.000Z|7
+1964-01-01T00:00:00.000Z|4
+1965-01-01T00:00:00.000Z|1
 
 // end::histogramDateTime
 ;
@@ -850,16 +850,16 @@ schema::h:i|c:l
 // tag::histogramDateTimeExpression
 SELECT HISTOGRAM(MONTH(birth_date), 2) AS h, COUNT(*) as c FROM emp GROUP BY h ORDER BY h DESC;
 
-       h       |       c       
+       h       |       c
 ---------------+---------------
-12             |7              
-10             |17             
-8              |16             
-6              |16             
-4              |18             
-2              |10             
-0              |6              
-null           |10 
+12             |7
+10             |17
+8              |16
+6              |16
+4              |18
+2              |10
+0              |6
+null           |10
 
 // end::histogramDateTimeExpression
 ;
@@ -875,9 +875,9 @@ dtIntervalPlusInterval
 // tag::dtIntervalPlusInterval
 SELECT INTERVAL 1 DAY + INTERVAL 53 MINUTES AS result;
 
-    result     
+    result
 ---------------
-+1 00:53:00.0                       
++1 00:53:00.0
 
 // end::dtIntervalPlusInterval
 ;
@@ -887,7 +887,7 @@ dtDateTimePlusInterval
 // tag::dtDateTimePlusInterval
 SELECT CAST('1969-05-13T12:34:56' AS DATETIME) + INTERVAL 49 YEARS AS result;
 
-       result       
+       result
 --------------------
 2018-05-13T12:34:56Z
 // end::dtDateTimePlusInterval
@@ -897,9 +897,9 @@ dtMinusInterval
 // tag::dtMinusInterval
 SELECT - INTERVAL '49-1' YEAR TO MONTH result;
 
-    result     
+    result
 ---------------
--49-1         
+-49-1
 
 // end::dtMinusInterval
 ;
@@ -908,9 +908,9 @@ dtIntervalMinusInterval
 // tag::dtIntervalMinusInterval
 SELECT INTERVAL '1' DAY - INTERVAL '2' HOURS AS result;
 
-    result     
+    result
 ---------------
-+0 22:00:00.0  
++0 22:00:00.0
 // end::dtIntervalMinusInterval
 ;
 
@@ -919,7 +919,7 @@ dtDateTimeMinusInterval
 // tag::dtDateTimeMinusInterval
 SELECT CAST('2018-05-13T12:34:56' AS DATETIME) - INTERVAL '2-8' YEAR TO MONTH AS result;
 
-       result       
+       result
 --------------------
 2015-09-13T12:34:56Z
 // end::dtDateTimeMinusInterval
@@ -929,9 +929,9 @@ dtIntervalMul
 // tag::dtIntervalMul
 SELECT -2 * INTERVAL '3' YEARS AS result;
 
-    result     
+    result
 ---------------
--6-0    
+-6-0
 // end::dtIntervalMul
 ;
 
@@ -946,7 +946,7 @@ orderByBasic
 // tag::orderByBasic
 SELECT * FROM library ORDER BY page_count DESC LIMIT 5;
 
-     author      |        name        |  page_count   |    release_date    
+     author      |        name        |  page_count   |    release_date
 -----------------+--------------------+---------------+--------------------
 Peter F. Hamilton|Pandora's Star      |768            |2004-03-02T00:00:00Z
 Vernor Vinge     |A Fire Upon the Deep|613            |1992-06-01T00:00:00Z
@@ -962,12 +962,12 @@ schema::g:s|c:i
 // tag::orderByGroup
 SELECT gender AS g, COUNT(*) AS c FROM emp GROUP BY gender ORDER BY g DESC;
 
-       g       |       c       
+       g       |       c
 ---------------+---------------
 M              |57
-F              |33             
-null           |10             
-      
+F              |33
+null           |10
+
 // end::orderByGroup
 ;
 
@@ -976,12 +976,12 @@ schema::g:s|salary:i
 // tag::orderByAgg
 SELECT gender AS g, MIN(salary) AS salary FROM emp GROUP BY gender ORDER BY salary DESC;
 
-       g       |    salary     
+       g       |    salary
 ---------------+---------------
-F              |25976          
-M              |25945          
-null           |25324             
-    
+F              |25976
+M              |25945
+null           |25324
+
 // end::orderByAgg
 ;
 
@@ -1068,7 +1068,7 @@ orderByScore
 // tag::orderByScore
 SELECT SCORE(), * FROM library WHERE MATCH(name, 'dune') ORDER BY SCORE() DESC;
 
-    SCORE()    |    author     |       name        |  page_count   |    release_date    
+    SCORE()    |    author     |       name        |  page_count   |    release_date
 ---------------+---------------+-------------------+---------------+--------------------
 2.2886353      |Frank Herbert  |Dune               |604            |1965-06-01T00:00:00Z
 1.8893257      |Frank Herbert  |Dune Messiah       |331            |1969-10-15T00:00:00Z
@@ -1082,7 +1082,7 @@ orderByScoreWithMatch
 // tag::orderByScoreWithMatch
 SELECT SCORE(), * FROM library WHERE MATCH(name, 'dune') ORDER BY page_count DESC;
 
-    SCORE()    |    author     |       name        |  page_count   |    release_date    
+    SCORE()    |    author     |       name        |  page_count   |    release_date
 ---------------+---------------+-------------------+---------------+--------------------
 2.2886353      |Frank Herbert  |Dune               |604            |1965-06-01T00:00:00Z
 1.4005898      |Frank Herbert  |God Emperor of Dune|454            |1981-05-28T00:00:00Z
@@ -1096,7 +1096,7 @@ scoreWithMatch
 // tag::scoreWithMatch
 SELECT SCORE() AS score, name, release_date FROM library WHERE QUERY('dune') ORDER BY YEAR(release_date) DESC;
 
-     score     |       name        |    release_date    
+     score     |       name        |    release_date
 ---------------+-------------------+--------------------
 1.4005898      |God Emperor of Dune|1981-05-28T00:00:00Z
 1.6086556      |Children of Dune   |1976-04-21T00:00:00Z
@@ -1116,9 +1116,9 @@ limitBasic
 // tag::limitBasic
 SELECT first_name, last_name, emp_no FROM emp LIMIT 1;
 
-  first_name   |   last_name   |    emp_no     
+  first_name   |   last_name   |    emp_no
 ---------------+---------------+---------------
-Georgi         |Facello        |10001     
+Georgi         |Facello        |10001
 
 // end::limitBasic
 ;
@@ -1133,9 +1133,9 @@ aggAvg
 // tag::aggAvg
 SELECT AVG(salary) AS avg FROM emp;
 
-      avg:d      
+      avg:d
 ---------------
-48248.55          
+48248.55
 // end::aggAvg
 ;
 
@@ -1143,9 +1143,9 @@ aggCountStar
 // tag::aggCountStar
 SELECT COUNT(*) AS count FROM emp;
 
-     count     
+     count
 ---------------
-100               
+100
 // end::aggCountStar
 ;
 
@@ -1153,9 +1153,9 @@ aggCountAll
 // tag::aggCountAll
 SELECT COUNT(ALL last_name) AS count_all, COUNT(DISTINCT last_name) count_distinct FROM emp;
 
-   count_all   |  count_distinct  
+   count_all   |  count_distinct
 ---------------+------------------
-100            |96   
+100            |96
 // end::aggCountAll
 ;
 
@@ -1309,9 +1309,9 @@ aggMax
 // tag::aggMax
 SELECT MAX(salary) AS max FROM emp;
 
-      max     
+      max
 ---------------
-74999               
+74999
 // end::aggMax
 ;
 
@@ -1319,9 +1319,9 @@ aggMin
 // tag::aggMin
 SELECT MIN(salary) AS min FROM emp;
 
-      min     
+      min
 ---------------
-25324               
+25324
 // end::aggMin
 ;
 
@@ -1339,7 +1339,7 @@ aggKurtosis
 // tag::aggKurtosis
 SELECT MIN(salary) AS min, MAX(salary) AS max, KURTOSIS(salary) AS k FROM emp;
 
-      min      |      max      |        k         
+      min      |      max      |        k
 ---------------+---------------+------------------
 25324          |74999          |2.0444718929142986
 // end::aggKurtosis
@@ -1349,25 +1349,25 @@ aggMad
 // tag::aggMad
 SELECT MIN(salary) AS min, MAX(salary) AS max, AVG(salary) AS avg, MAD(salary) AS mad FROM emp;
 
-      min      |      max      |      avg      |      mad      
+      min      |      max      |      avg      |      mad
 ---------------+---------------+---------------+---------------
-25324          |74999          |48248.55       |10096.5   
+25324          |74999          |48248.55       |10096.5
 // end::aggMad
 ;
 
 aggPercentile
 // tag::aggPercentile
-SELECT languages, PERCENTILE(salary, 95) AS "95th" FROM emp 
+SELECT languages, PERCENTILE(salary, 95) AS "95th" FROM emp
        GROUP BY languages;
 
-   languages   |      95th       
+   languages   |      95th
 ---------------+-----------------
-null           |74999.0          
-1              |72790.5          
+null           |74999.0
+1              |72790.5
 2              |71924.70000000001
-3              |73638.25         
+3              |73638.25
 4              |72115.59999999999
-5              |61071.7       
+5              |61071.7
 // end::aggPercentile
 ;
 
@@ -1375,14 +1375,14 @@ aggPercentileRank
 // tag::aggPercentileRank
 SELECT languages, PERCENTILE_RANK(salary, 65000) AS rank FROM emp GROUP BY languages;
 
-   languages   |      rank       
+   languages   |      rank
 ---------------+-----------------
 null           |73.65766569962062
-1              |73.7291625157734 
+1              |73.7291625157734
 2              |88.88005607010643
 3              |79.43662623295829
 4              |85.70446389643493
-5              |100.0      
+5              |100.0
 // end::aggPercentileRank
 ;
 
@@ -1390,7 +1390,7 @@ aggSkewness
 // tag::aggSkewness
 SELECT MIN(salary) AS min, MAX(salary) AS max, SKEWNESS(salary) AS s FROM emp;
 
-      min      |      max      |        s         
+      min      |      max      |        s
 ---------------+---------------+------------------
 25324          |74999          |0.2707722118423227
 // end::aggSkewness
@@ -1398,10 +1398,10 @@ SELECT MIN(salary) AS min, MAX(salary) AS max, SKEWNESS(salary) AS s FROM emp;
 
 aggStddevPop
 // tag::aggStddevPop
-SELECT MIN(salary) AS min, MAX(salary) AS max, STDDEV_POP(salary) AS stddev 
+SELECT MIN(salary) AS min, MAX(salary) AS max, STDDEV_POP(salary) AS stddev
        FROM emp;
 
-      min      |      max      |      stddev      
+      min      |      max      |      stddev
 ---------------+---------------+------------------
 25324          |74999          |13765.125502787832
 // end::aggStddevPop
@@ -1410,10 +1410,10 @@ SELECT MIN(salary) AS min, MAX(salary) AS max, STDDEV_POP(salary) AS stddev
 
 aggSumOfSquares
 // tag::aggSumOfSquares
-SELECT MIN(salary) AS min, MAX(salary) AS max, SUM_OF_SQUARES(salary) AS sumsq 
+SELECT MIN(salary) AS min, MAX(salary) AS max, SUM_OF_SQUARES(salary) AS sumsq
        FROM emp;
 
-      min      |      max      |     sumsq      
+      min      |      max      |     sumsq
 ---------------+---------------+----------------
 25324          |74999          |2.51740125721E11
 // end::aggSumOfSquares
@@ -1424,7 +1424,7 @@ aggVarPop
 // tag::aggVarPop
 SELECT MIN(salary) AS min, MAX(salary) AS max, VAR_POP(salary) AS varpop FROM emp;
 
-      min      |      max      |     varpop     
+      min      |      max      |     varpop
 ---------------+---------------+----------------
 25324          |74999          |1.894786801075E8
 // end::aggVarPop
@@ -1441,9 +1441,9 @@ stringAscii
 // tag::stringAscii
 SELECT ASCII('Elastic');
 
-ASCII('Elastic') 
+ASCII('Elastic')
 ----------------
-69   
+69
 // end::stringAscii
 ;
 
@@ -1453,7 +1453,7 @@ SELECT BIT_LENGTH('Elastic');
 
 BIT_LENGTH('Elastic')
 ---------------------
-56  
+56
 // end::stringBitLength
 ;
 
@@ -1461,9 +1461,9 @@ stringChar
 // tag::stringChar
 SELECT CHAR(69);
 
-   CHAR(69)    
+   CHAR(69)
 ---------------
-E        
+E
 // end::stringChar
 ;
 
@@ -1473,7 +1473,7 @@ SELECT CHAR_LENGTH('Elastic');
 
 CHAR_LENGTH('Elastic')
 ----------------------
-7     
+7
 // end::stringCharLength
 ;
 
@@ -1483,7 +1483,7 @@ SELECT CONCAT('Elasticsearch', ' SQL');
 
 CONCAT('Elasticsearch', ' SQL')
 -------------------------------
-Elasticsearch SQL  
+Elasticsearch SQL
 // end::stringConcat
 ;
 
@@ -1503,7 +1503,7 @@ SELECT LCASE('Elastic');
 
 LCASE('Elastic')
 ----------------
-elastic    
+elastic
 // end::stringLCase
 ;
 
@@ -1513,7 +1513,7 @@ SELECT LEFT('Elastic',3);
 
 LEFT('Elastic',3)
 -----------------
-Ela    
+Ela
 // end::stringLeft
 ;
 
@@ -1523,7 +1523,7 @@ SELECT LENGTH('Elastic   ');
 
 LENGTH('Elastic   ')
 --------------------
-7     
+7
 // end::stringLength
 ;
 
@@ -1533,7 +1533,7 @@ SELECT LOCATE('a', 'Elasticsearch');
 
 LOCATE('a', 'Elasticsearch')
 ----------------------------
-3        
+3
 // end::stringLocateWoStart
 ;
 
@@ -1553,7 +1553,7 @@ SELECT LTRIM('   Elastic');
 
 LTRIM('   Elastic')
 -------------------
-Elastic   
+Elastic
 // end::stringLTrim
 ;
 
@@ -1563,7 +1563,7 @@ SELECT OCTET_LENGTH('Elastic');
 
 OCTET_LENGTH('Elastic')
 -----------------------
-7  
+7
 // end::stringOctetLength
 ;
 
@@ -1573,7 +1573,7 @@ SELECT POSITION('Elastic', 'Elasticsearch');
 
 POSITION('Elastic', 'Elasticsearch')
 ------------------------------------
-1  
+1
 // end::stringPosition
 ;
 
@@ -1581,9 +1581,9 @@ stringRepeat
 // tag::stringRepeat
 SELECT REPEAT('La', 3);
 
- REPEAT('La', 3)  
+ REPEAT('La', 3)
 ----------------
-LaLaLa      
+LaLaLa
 // end::stringRepeat
 ;
 
@@ -1603,7 +1603,7 @@ SELECT RIGHT('Elastic',3);
 
 RIGHT('Elastic',3)
 ------------------
-tic    
+tic
 // end::stringRight
 ;
 
@@ -1613,7 +1613,7 @@ SELECT RTRIM('Elastic   ');
 
 RTRIM('Elastic   ')
 -------------------
-Elastic       
+Elastic
 // end::stringRTrim
 ;
 
@@ -1622,10 +1622,10 @@ schema::SPACE(3):s
 // tag::stringSpace
 SELECT SPACE(3);
 
-   SPACE(3)    
+   SPACE(3)
 ---------------
-               
- 
+
+
 // end::stringSpace
 ;
 
@@ -1635,7 +1635,7 @@ SELECT SUBSTRING('Elasticsearch', 0, 7);
 
 SUBSTRING('Elasticsearch', 0, 7)
 --------------------------------
-Elastic    
+Elastic
 // end::stringSubString
 ;
 
@@ -1643,9 +1643,9 @@ stringUCase
 // tag::stringUCase
 SELECT UCASE('Elastic');
 
-UCASE('Elastic') 
+UCASE('Elastic')
 ----------------
-ELASTIC    
+ELASTIC
 // end::stringUCase
 ;
 
@@ -1660,9 +1660,9 @@ conversionStringToIntCast
 // tag::conversionStringToIntCast
 SELECT CAST('123' AS INT) AS int;
 
-      int      
+      int
 ---------------
-123    
+123
 // end::conversionStringToIntCast
 ;
 
@@ -1670,9 +1670,9 @@ conversionIntToStringCast-Ignore
 // tag::conversionIntToStringCast
 SELECT CAST(123 AS VARCHAR) AS string;
 
-    string     
+    string
 ---------------
-123   
+123
 
 // end::conversionIntToStringCast
 ;
@@ -2496,6 +2496,27 @@ SELECT DATE_DIFF('week', '2019-09-04T11:22:33.000Z'::datetime, '2016-12-08T22:33
 // end::dateDiffDateTimeWeeks
 ;
 
+dateDiffDateTimeHours
+// tag::dateDiffDateTimeHours
+SELECT DATEDIFF('hours', '2019-11-10T12:10:00.000Z'::datetime, '2019-11-10T23:59:59.999Z'::datetime) AS "diffInHours";
+
+      diffInHours
+------------------------
+11
+// end::dateDiffDateTimeHours
+;
+
+
+dateDiffDateTimeMinutes
+// tag::dateDiffDateTimeMinutes
+SELECT DATEDIFF('minute', '2019-11-10T12:10:00.000Z'::datetime, '2019-11-10T12:15:59.999Z'::datetime) AS "diffInMinutes";
+
+      diffInMinutes
+------------------------
+5
+// end::dateDiffDateTimeMinutes
+;
+
 dateDiffDateTimeSeconds
 // tag::dateDiffDateTimeSeconds
 SELECT DATE_DIFF('seconds', '2019-09-04T11:22:33.123Z'::datetime, '2019-07-12T22:33:11.321Z'::datetime) AS "diffInSeconds";
@@ -2505,6 +2526,7 @@ SELECT DATE_DIFF('seconds', '2019-09-04T11:22:33.123Z'::datetime, '2019-07-12T22
 -4625362
 // end::dateDiffDateTimeSeconds
 ;
+
 
 dateDiffDateQuarters
 // tag::dateDiffDateQuarters
@@ -2851,7 +2873,7 @@ currentTimestamp-Ignore
 // tag::curTs
 SELECT CURRENT_TIMESTAMP AS result;
 
-         result         
+         result
 ------------------------
 2018-12-12T14:48:52.448Z
 // end::curTs
@@ -2861,7 +2883,7 @@ currentTimestampFunction-Ignore
 // tag::curTsFunction
 SELECT CURRENT_TIMESTAMP() AS result;
 
-         result         
+         result
 ------------------------
 2018-12-12T14:48:52.448Z
 // end::curTsFunction
@@ -2871,7 +2893,7 @@ currentTimestampFunctionPrecision-Ignore
 // tag::curTsFunctionPrecision
 SELECT CURRENT_TIMESTAMP(1) AS result;
 
-         result         
+         result
 ------------------------
 2018-12-12T14:48:52.4Z
 // end::curTsFunctionPrecision
@@ -2882,7 +2904,7 @@ nowFunction-Ignore
 // tag::nowFunction
 SELECT NOW() AS result;
 
-         result         
+         result
 ------------------------
 2018-12-12T14:48:52.448Z
 // end::nowFunction

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateDiff.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateDiff.java
@@ -114,12 +114,8 @@ public class DateDiff extends ThreeArgsDateTimeFunction {
         }
 
         private static long diffInMinutes(ZonedDateTime start, ZonedDateTime end) {
-            long secondsDiff = diffInSeconds(start, end);
-            if (secondsDiff > 0) {
-                return (long) Math.ceil(secondsDiff / 60.0d);
-            } else {
-                return (long) Math.floor(secondsDiff / 60.0d);
-            }
+            // Truncate first to minutes (ignore any seconds and sub-seconds fields)
+            return (end.toEpochSecond() / 60) - (start.toEpochSecond() / 60);
         }
 
         private static long diffInHours(ZonedDateTime start, ZonedDateTime end) {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateDiffProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateDiffProcessorTests.java
@@ -284,6 +284,61 @@ public class DateDiffProcessorTests extends AbstractSqlWireSerializingTestCase<D
             .makePipe().asProcessor().process(null));
         assertEquals(-436, new DateDiff(Source.EMPTY, l("ww"), dt2, dt1, zoneId)
             .makePipe().asProcessor().process(null));
+
+        dt1 = l(dateTime(1997, 9, 19, 0, 0, 0, 0));
+        dt2 = l(dateTime(2004, 8, 2, 7, 59, 23, 0));
+        assertEquals(60223, new DateDiff(Source.EMPTY, l("hour"), dt1, dt2, UTC)
+            .makePipe().asProcessor().process(null));
+        assertEquals(-60223, new DateDiff(Source.EMPTY, l("hours"), dt2, dt1, UTC)
+            .makePipe().asProcessor().process(null));
+        assertEquals(60223, new DateDiff(Source.EMPTY, l("hh"), dt1, dt2, zoneId)
+            .makePipe().asProcessor().process(null));
+        assertEquals(-60223, new DateDiff(Source.EMPTY, l("hh"), dt2, dt1, zoneId)
+            .makePipe().asProcessor().process(null));
+
+        dt1 = l(dateTime(1997, 9, 19, 0, 0, 0, 0));
+        dt2 = l(dateTime(2004, 8, 2, 7, 59, 59, 999999999));
+        assertEquals(60223, new DateDiff(Source.EMPTY, l("hour"), dt1, dt2, UTC)
+            .makePipe().asProcessor().process(null));
+        assertEquals(-60223, new DateDiff(Source.EMPTY, l("hours"), dt2, dt1, UTC)
+            .makePipe().asProcessor().process(null));
+        assertEquals(60223, new DateDiff(Source.EMPTY, l("hh"), dt1, dt2, zoneId)
+            .makePipe().asProcessor().process(null));
+        assertEquals(-60223, new DateDiff(Source.EMPTY, l("hh"), dt2, dt1, zoneId)
+            .makePipe().asProcessor().process(null));
+
+        dt1 = l(dateTime(2002, 4, 27, 0, 0, 0, 0));
+        dt2 = l(dateTime(2004, 7, 28, 12, 34, 28, 0));
+        assertEquals(1185874, new DateDiff(Source.EMPTY, l("minute"), dt1, dt2, UTC)
+            .makePipe().asProcessor().process(null));
+        assertEquals(-1185874, new DateDiff(Source.EMPTY, l("minutes"), dt2, dt1, UTC)
+            .makePipe().asProcessor().process(null));
+        assertEquals(1185874, new DateDiff(Source.EMPTY, l("mi"), dt1, dt2, zoneId)
+            .makePipe().asProcessor().process(null));
+        assertEquals(-1185874, new DateDiff(Source.EMPTY, l("n"), dt2, dt1, zoneId)
+            .makePipe().asProcessor().process(null));
+
+        dt1 = l(dateTime(1995, 9, 3, 0, 0, 0, 0));
+        dt2 = l(dateTime(2004, 7, 26, 12, 30, 34, 0));
+        assertEquals(4679310, new DateDiff(Source.EMPTY, l("minute"), dt1, dt2, UTC)
+            .makePipe().asProcessor().process(null));
+        assertEquals(-4679310, new DateDiff(Source.EMPTY, l("minutes"), dt2, dt1, UTC)
+            .makePipe().asProcessor().process(null));
+        assertEquals(4679310, new DateDiff(Source.EMPTY, l("mi"), dt1, dt2, zoneId)
+            .makePipe().asProcessor().process(null));
+        assertEquals(-4679310, new DateDiff(Source.EMPTY, l("n"), dt2, dt1, zoneId)
+            .makePipe().asProcessor().process(null));
+
+        dt1 = l(dateTime(1997, 5, 30, 0, 0, 0, 0));
+        dt2 = l(dateTime(2004, 7, 28, 23, 30, 59, 999999999));
+        assertEquals(3768450, new DateDiff(Source.EMPTY, l("minute"), dt1, dt2, UTC)
+            .makePipe().asProcessor().process(null));
+        assertEquals(-3768450, new DateDiff(Source.EMPTY, l("minutes"), dt2, dt1, UTC)
+            .makePipe().asProcessor().process(null));
+        assertEquals(3768450, new DateDiff(Source.EMPTY, l("mi"), dt1, dt2, zoneId)
+            .makePipe().asProcessor().process(null));
+        assertEquals(-3768450, new DateDiff(Source.EMPTY, l("n"), dt2, dt1, zoneId)
+            .makePipe().asProcessor().process(null));
     }
 
     public void testOverflow() {


### PR DESCRIPTION
Previously, `DATEDIFF` for `minutes` and `hours` was doing a 
rounding calculation using all the time fields (secs, msecs/micros/nanos).
Instead it should first truncate the 2 dates to the respective field (mins or hours) 
zeroing out all the more detailed time fields and then make the subtraction.
