### PR TITLE
[ML][Inference] adjusting bwc after backport

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MachineLearningFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MachineLearningFeatureSetUsage.java
@@ -61,7 +61,7 @@ public class MachineLearningFeatureSetUsage extends XPackFeatureSet.Usage {
         } else {
             this.analyticsUsage = Collections.emptyMap();
         }
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_6_0)) {
             this.inferenceUsage = in.readMap();
         } else {
             this.inferenceUsage = Collections.emptyMap();
@@ -77,7 +77,7 @@ public class MachineLearningFeatureSetUsage extends XPackFeatureSet.Usage {
         if (out.getVersion().onOrAfter(Version.V_7_4_0)) {
             out.writeMap(analyticsUsage);
         }
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_6_0)) {
             out.writeMap(inferenceUsage);
         }
         out.writeInt(nodeCount);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfig.java
@@ -22,7 +22,7 @@ public class ClassificationConfig implements InferenceConfig {
     public static final String NAME = "classification";
 
     public static final ParseField  NUM_TOP_CLASSES = new ParseField("num_top_classes");
-    private static final Version MIN_SUPPORTED_VERSION = Version.V_8_0_0;
+    private static final Version MIN_SUPPORTED_VERSION = Version.V_7_6_0;
 
     public static ClassificationConfig EMPTY_PARAMS = new ClassificationConfig(0);
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RegressionConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RegressionConfig.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 public class RegressionConfig implements InferenceConfig {
 
     public static final String NAME = "regression";
-    private static final Version MIN_SUPPORTED_VERSION = Version.V_8_0_0;
+    private static final Version MIN_SUPPORTED_VERSION = Version.V_7_6_0;
 
     public static RegressionConfig fromMap(Map<String, Object> map) {
         if (map.isEmpty() == false) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
@@ -176,7 +176,7 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
             fail("Should not have successfully created");
         } catch (ElasticsearchException ex) {
             assertThat(ex.getMessage(),
-                equalTo("Configuration [regression] requires minimum node version [8.0.0] (current minimum node version [7.5.0]"));
+                equalTo("Configuration [regression] requires minimum node version [7.6.0] (current minimum node version [7.5.0]"));
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
@@ -194,7 +194,7 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
             fail("Should not have successfully created");
         } catch (ElasticsearchException ex) {
             assertThat(ex.getMessage(),
-                equalTo("Configuration [classification] requires minimum node version [8.0.0] (current minimum node version [7.5.0]"));
+                equalTo("Configuration [classification] requires minimum node version [7.6.0] (current minimum node version [7.5.0]"));
         } catch (Exception ex) {
             fail(ex.getMessage());
         }


### PR DESCRIPTION
After the merge of backport: https://github.com/elastic/elasticsearch/pull/49257 7.6.0 is now the required node version for inference things.