### PR TITLE
[ML][Inference] changing setting to be memorySizeSettting

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
@@ -20,7 +20,6 @@ import org.elasticsearch.common.cache.RemovalNotification;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.set.Sets;
@@ -57,8 +56,8 @@ public class ModelLoadingService implements ClusterStateListener {
      * Once the limit is reached, LRU models are evicted in favor of new models
      */
     public static final Setting<ByteSizeValue> INFERENCE_MODEL_CACHE_SIZE =
-        Setting.byteSizeSetting("xpack.ml.inference_model.cache_size",
-            new ByteSizeValue(1, ByteSizeUnit.GB),
+        Setting.memorySizeSetting("xpack.ml.inference_model.cache_size",
+            "40%",
             Setting.Property.NodeScope);
 
     /**


### PR DESCRIPTION
While going through the settings and experimenting, I found that having `xpack.ml.inference_model.cache_size` strictly be a byteSized value to be problematic. 

What if the user provides a byte sized value that is more than the heap?
What if the heap of the node is less than the default value?

Having it as a `memorySizeSetting` allows users and us to set the value as a percentage of heap or a static bytesized value. 