### PR TITLE
[DOCS] Clarify ML job closure prerequisites

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
@@ -27,6 +27,8 @@ operations, but you can still explore and navigate results.
 * If the {es} {security-features} are enabled, you must have `manage_ml` or
 `manage` cluster privileges to use this API. See
 <<security-privileges>>.
+* Before you can close an {anomaly-job}, you must stop its {dfeed}. See
+<<ml-stop-datafeed>>.
 
 [[ml-close-job-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-job.asciidoc
@@ -18,6 +18,9 @@ Deletes an existing {anomaly-job}.
 
 * If {es} {security-features} are enabled, you must have `manage_ml` or `manage`
 cluster privileges to use this API. See <<security-privileges>>.
+* Before you can delete a job, you must delete the {dfeeds} that are associated
+with it. See <<ml-delete-datafeed>>.
+* Before you can delete a job, you must close it (unless you specify the `force` parameter). See <<ml-close-job>>.
 
 [[ml-delete-job-desc]]
 ==== {api-description-title}
@@ -28,10 +31,6 @@ IMPORTANT:  Deleting an {anomaly-job} must be done via this API only. Do not
 delete the job directly from the `.ml-*` indices using the {es} delete document
 API. When {es} {security-features} are enabled, make sure no `write` privileges
 are granted to anyone over the `.ml-*` indices.
-
-Before you can delete a job, you must delete the {dfeeds} that are associated
-with it. See <<ml-delete-datafeed,Delete {dfeeds-cap}>>. Unless the `force`
-parameter is used the job must be closed before it can be deleted.
 
 It is not currently possible to delete multiple jobs using wildcards or a comma
 separated list.


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/pull/688

This PR clarifies the dependency between closing a job and stopping its datafeed.

Preview:
http://elasticsearch_49265.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-delete-job.html
http://elasticsearch_49265.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-close-job.html