### PR TITLE
[ML][Inference] Fixing pre-processor value handling and size estimate

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/FrequencyEncoding.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/FrequencyEncoding.java
@@ -103,11 +103,11 @@ public class FrequencyEncoding implements LenientlyParsedPreProcessor, StrictlyP
 
     @Override
     public void process(Map<String, Object> fields) {
-        String value = fields.get(field).toString();
+        Object value = fields.get(field);
         if (value == null) {
             return;
         }
-        fields.put(featureName, frequencyMap.getOrDefault(value, 0.0));
+        fields.put(featureName, frequencyMap.getOrDefault(value.toString(), 0.0));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/FrequencyEncoding.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/FrequencyEncoding.java
@@ -103,7 +103,7 @@ public class FrequencyEncoding implements LenientlyParsedPreProcessor, StrictlyP
 
     @Override
     public void process(Map<String, Object> fields) {
-        String value = (String)fields.get(field);
+        String value = fields.get(field).toString();
         if (value == null) {
             return;
         }
@@ -152,7 +152,8 @@ public class FrequencyEncoding implements LenientlyParsedPreProcessor, StrictlyP
         long size = SHALLOW_SIZE;
         size += RamUsageEstimator.sizeOf(field);
         size += RamUsageEstimator.sizeOf(featureName);
-        size += RamUsageEstimator.sizeOfMap(frequencyMap);
+        // defSize:0 indicates that there is not a defined size. Finding the shallowSize of Double gives the best estimate
+        size += RamUsageEstimator.sizeOfMap(frequencyMap, 0);
         return size;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/OneHotEncoding.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/OneHotEncoding.java
@@ -86,7 +86,7 @@ public class OneHotEncoding implements LenientlyParsedPreProcessor, StrictlyPars
 
     @Override
     public void process(Map<String, Object> fields) {
-        String value = (String)fields.get(field);
+        String value = fields.get(field).toString();
         if (value == null) {
             return;
         }
@@ -134,7 +134,8 @@ public class OneHotEncoding implements LenientlyParsedPreProcessor, StrictlyPars
     public long ramBytesUsed() {
         long size = SHALLOW_SIZE;
         size += RamUsageEstimator.sizeOf(field);
-        size += RamUsageEstimator.sizeOfMap(hotMap);
+        // defSize:0 does not do much in this case as sizeOf(String) is a known quantity
+        size += RamUsageEstimator.sizeOfMap(hotMap, 0);
         return size;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/OneHotEncoding.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/OneHotEncoding.java
@@ -86,12 +86,12 @@ public class OneHotEncoding implements LenientlyParsedPreProcessor, StrictlyPars
 
     @Override
     public void process(Map<String, Object> fields) {
-        String value = fields.get(field).toString();
+        Object value = fields.get(field);
         if (value == null) {
             return;
         }
         hotMap.forEach((val, col) -> {
-            int encoding = value.equals(val) ? 1 : 0;
+            int encoding = value.toString().equals(val) ? 1 : 0;
             fields.put(col, encoding);
         });
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/TargetMeanEncoding.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/TargetMeanEncoding.java
@@ -114,7 +114,7 @@ public class TargetMeanEncoding implements LenientlyParsedPreProcessor, Strictly
 
     @Override
     public void process(Map<String, Object> fields) {
-        String value = (String)fields.get(field);
+        String value = fields.get(field).toString();
         if (value == null) {
             return;
         }
@@ -166,7 +166,8 @@ public class TargetMeanEncoding implements LenientlyParsedPreProcessor, Strictly
         long size = SHALLOW_SIZE;
         size += RamUsageEstimator.sizeOf(field);
         size += RamUsageEstimator.sizeOf(featureName);
-        size += RamUsageEstimator.sizeOfMap(meanMap);
+        // defSize:0 indicates that there is not a defined size. Finding the shallowSize of Double gives the best estimate
+        size += RamUsageEstimator.sizeOfMap(meanMap, 0);
         return size;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/TargetMeanEncoding.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/TargetMeanEncoding.java
@@ -114,11 +114,11 @@ public class TargetMeanEncoding implements LenientlyParsedPreProcessor, Strictly
 
     @Override
     public void process(Map<String, Object> fields) {
-        String value = fields.get(field).toString();
+        Object value = fields.get(field);
         if (value == null) {
             return;
         }
-        fields.put(featureName, meanMap.getOrDefault(value, defaultValue));
+        fields.put(featureName, meanMap.getOrDefault(value.toString(), defaultValue));
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/FrequencyEncodingTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/FrequencyEncodingTests.java
@@ -15,7 +15,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -48,13 +47,14 @@ public class FrequencyEncodingTests extends PreProcessingTests<FrequencyEncoding
 
     public void testProcessWithFieldPresent() {
         String field = "categorical";
-        List<String> values = Arrays.asList("foo", "bar", "foobar", "baz", "farequote");
-        Map<String, Double> valueMap = values.stream().collect(Collectors.toMap(Function.identity(),
+        List<Object> values = Arrays.asList("foo", "bar", "foobar", "baz", "farequote", 1.5);
+        Map<String, Double> valueMap = values.stream().collect(Collectors.toMap(Object::toString,
             v -> randomDoubleBetween(0.0, 1.0, false)));
         String encodedFeatureName = "encoded";
         FrequencyEncoding encoding = new FrequencyEncoding(field, encodedFeatureName, valueMap);
-        String fieldValue = randomFrom(values);
-        Map<String, Matcher<? super Object>> matchers = Collections.singletonMap(encodedFeatureName, equalTo(valueMap.get(fieldValue)));
+        Object fieldValue = randomFrom(values);
+        Map<String, Matcher<? super Object>> matchers = Collections.singletonMap(encodedFeatureName,
+            equalTo(valueMap.get(fieldValue.toString())));
         Map<String, Object> fieldValues = randomFieldValues(field, fieldValue);
         testProcess(encoding, fieldValues, matchers);
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/OneHotEncodingTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/OneHotEncodingTests.java
@@ -47,10 +47,10 @@ public class OneHotEncodingTests extends PreProcessingTests<OneHotEncoding> {
 
     public void testProcessWithFieldPresent() {
         String field = "categorical";
-        List<String> values = Arrays.asList("foo", "bar", "foobar", "baz", "farequote");
-        Map<String, String> valueMap = values.stream().collect(Collectors.toMap(Function.identity(), v -> "Column_" + v));
+        List<Object> values = Arrays.asList("foo", "bar", "foobar", "baz", "farequote", 1.0);
+        Map<String, String> valueMap = values.stream().collect(Collectors.toMap(Object::toString, v -> "Column_" + v.toString()));
         OneHotEncoding encoding = new OneHotEncoding(field, valueMap);
-        String fieldValue = randomFrom(values);
+        Object fieldValue = randomFrom(values);
         Map<String, Object> fieldValues = randomFieldValues(field, fieldValue);
 
         Map<String, Matcher<? super Object>> matchers = values.stream().map(v -> "Column_" + v)

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/PreProcessingTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/PreProcessingTests.java
@@ -58,9 +58,9 @@ public abstract class PreProcessingTests<T extends PreProcessor> extends Abstrac
         return fieldValues;
     }
 
-    Map<String, Object> randomFieldValues(String categoricalField, String catigoricalValue) {
+    Map<String, Object> randomFieldValues(String categoricalField, Object categoricalValue) {
         Map<String, Object> fieldValues = randomFieldValues();
-        fieldValues.put(categoricalField, catigoricalValue);
+        fieldValues.put(categoricalField, categoricalValue);
         return fieldValues;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/TargetMeanEncodingTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/TargetMeanEncodingTests.java
@@ -15,7 +15,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -51,14 +50,15 @@ public class TargetMeanEncodingTests extends PreProcessingTests<TargetMeanEncodi
 
     public void testProcessWithFieldPresent() {
         String field = "categorical";
-        List<String> values = Arrays.asList("foo", "bar", "foobar", "baz", "farequote");
-        Map<String, Double> valueMap = values.stream().collect(Collectors.toMap(Function.identity(),
+        List<Object> values = Arrays.asList("foo", "bar", "foobar", "baz", "farequote", 1.0);
+        Map<String, Double> valueMap = values.stream().collect(Collectors.toMap(Object::toString,
             v -> randomDoubleBetween(0.0, 1.0, false)));
         String encodedFeatureName = "encoded";
         Double defaultvalue = randomDouble();
         TargetMeanEncoding encoding = new TargetMeanEncoding(field, encodedFeatureName, valueMap, defaultvalue);
-        String fieldValue = randomFrom(values);
-        Map<String, Matcher<? super Object>> matchers = Collections.singletonMap(encodedFeatureName, equalTo(valueMap.get(fieldValue)));
+        Object fieldValue = randomFrom(values);
+        Map<String, Matcher<? super Object>> matchers = Collections.singletonMap(encodedFeatureName,
+            equalTo(valueMap.get(fieldValue.toString())));
         Map<String, Object> fieldValues = randomFieldValues(field, fieldValue);
         testProcess(encoding, fieldValues, matchers);
 


### PR DESCRIPTION
There is a bug right now when handling numerics that are treated as categorical values. This is a valid use as encoding semi-ordinal numbers `10, 50, 5000` categorically can improve model performance instead of simply treating them as numerics. 

Additionally, when estimating the size of the pre-processor HashMaps, `Double` entries were estimated with the default value of `256` when it should have been a simple `shallowSizeOf`. Setting `defSize` in the `sizeOfMap` to `0` corrects this.