### PR TITLE
mmap dim files in HybridDirectory

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/store/FsDirectoryFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/store/FsDirectoryFactory.java
@@ -159,6 +159,7 @@ public class FsDirectoryFactory implements IndexStorePlugin.DirectoryFactory {
                 case "tim":
                 case "tip":
                 case "cfs":
+                case "dim":
                     return true;
                 default:
                     return false;

--- a/server/src/test/java/org/elasticsearch/index/store/FsDirectoryFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/FsDirectoryFactoryTests.java
@@ -63,6 +63,7 @@ public class FsDirectoryFactoryTests extends ESTestCase {
             assertTrue(hybridDirectory.useDelegate("foo.tim"));
             assertTrue(hybridDirectory.useDelegate("foo.tip"));
             assertTrue(hybridDirectory.useDelegate("foo.cfs"));
+            assertTrue(hybridDirectory.useDelegate("foo.dim"));
             assertFalse(hybridDirectory.useDelegate("foo.bar"));
             MMapDirectory delegate = hybridDirectory.getDelegate();
             assertThat(delegate, Matchers.instanceOf(FsDirectoryFactory.PreLoadMMapDirectory.class));


### PR DESCRIPTION
This change mmaps dim files in HybridDirectory to take advantage of off-heap BKD trees.  This is based off of (https://github.com/elastic/elasticsearch/issues/48509) via (https://issues.apache.org/jira/browse/LUCENE-8932).

Should this be backported prior to 8.0?