### PR TITLE
ThreadPool and ThreadContext are not closeable (#43249)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -262,7 +262,6 @@ public class DeprecationLogger {
 
     public String getXOpaqueId(Set<ThreadContext> threadContexts) {
         return threadContexts.stream()
-                             .filter(t -> t.isClosed() == false)
                              .filter(t -> t.getHeader(Task.X_OPAQUE_ID) != null)
                              .findFirst()
                              .map(t -> t.getHeader(Task.X_OPAQUE_ID))

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsThreadPoolExecutor.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsThreadPoolExecutor.java
@@ -106,17 +106,8 @@ public class EsThreadPoolExecutor extends ThreadPoolExecutor {
     }
 
     private boolean assertDefaultContext(Runnable r) {
-        try {
-            assert contextHolder.isDefaultContext() : "the thread context is not the default context and the thread [" +
-                Thread.currentThread().getName() + "] is being returned to the pool after executing [" + r + "]";
-        } catch (IllegalStateException ex) {
-            // sometimes we execute on a closed context and isDefaultContext doen't bypass the ensureOpen checks
-            // this must not trigger an exception here since we only assert if the default is restored and
-            // we don't really care if we are closed
-            if (contextHolder.isClosed() == false) {
-                throw ex;
-            }
-        }
+        assert contextHolder.isDefaultContext() : "the thread context is not the default context and the thread [" +
+            Thread.currentThread().getName() + "] is being returned to the pool after executing [" + r + "]";
         return true;
     }
 

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/ThreadContext.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/ThreadContext.java
@@ -20,10 +20,10 @@ package org.elasticsearch.common.util.concurrent;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.util.CloseableThreadLocal;
 import org.elasticsearch.action.support.ContextPreservingActionListener;
 import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.common.collect.MapBuilder;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -33,7 +33,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.http.HttpTransportSettings;
 import org.elasticsearch.tasks.Task;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -44,7 +43,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
@@ -84,7 +82,7 @@ import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_MAX_WARN
  * </pre>
  *
  */
-public final class ThreadContext implements Closeable, Writeable {
+public final class ThreadContext implements Writeable {
 
     public static final String PREFIX = "request.headers";
     public static final Setting<Settings> DEFAULT_HEADERS_SETTING = Setting.groupSetting(PREFIX + ".", Property.NodeScope);
@@ -97,7 +95,7 @@ public final class ThreadContext implements Closeable, Writeable {
     private static final Logger logger = LogManager.getLogger(ThreadContext.class);
     private static final ThreadContextStruct DEFAULT_CONTEXT = new ThreadContextStruct();
     private final Map<String, String> defaultHeader;
-    private final ContextThreadLocal threadLocal;
+    private final ThreadLocal<ThreadContextStruct> threadLocal;
     private final int maxWarningHeaderCount;
     private final long maxWarningHeaderSize;
 
@@ -106,24 +104,10 @@ public final class ThreadContext implements Closeable, Writeable {
      * @param settings the settings to read the default request headers from
      */
     public ThreadContext(Settings settings) {
-        Settings headers = DEFAULT_HEADERS_SETTING.get(settings);
-        if (headers == null) {
-            this.defaultHeader = Collections.emptyMap();
-        } else {
-            Map<String, String> defaultHeader = new HashMap<>();
-            for (String key : headers.names()) {
-                defaultHeader.put(key, headers.get(key));
-            }
-            this.defaultHeader = Collections.unmodifiableMap(defaultHeader);
-        }
-        threadLocal = new ContextThreadLocal();
+        this.defaultHeader = buildDefaultHeaders(settings);
+        this.threadLocal = ThreadLocal.withInitial(() -> DEFAULT_CONTEXT);
         this.maxWarningHeaderCount = SETTING_HTTP_MAX_WARNING_HEADER_COUNT.get(settings);
         this.maxWarningHeaderSize = SETTING_HTTP_MAX_WARNING_HEADER_SIZE.get(settings).getBytes();
-    }
-
-    @Override
-    public void close() {
-        threadLocal.close();
     }
 
     /**
@@ -144,19 +128,13 @@ public final class ThreadContext implements Closeable, Writeable {
                     .immutableMap());
             threadLocal.set(threadContextStruct);
         } else {
-            threadLocal.set(null);
+            threadLocal.set(DEFAULT_CONTEXT);
         }
         return () -> {
             // If the node and thus the threadLocal get closed while this task
             // is still executing, we don't want this runnable to fail with an
             // uncaught exception
-            try {
-                threadLocal.set(context);
-            } catch (IllegalStateException e) {
-                if (isClosed() == false) {
-                    throw e;
-                }
-            }
+            threadLocal.set(context);
         };
     }
 
@@ -259,7 +237,20 @@ public final class ThreadContext implements Closeable, Writeable {
      * Reads the headers from the stream into the current context
      */
     public void readHeaders(StreamInput in) throws IOException {
-        final Map<String, String>  requestHeaders = in.readMap(StreamInput::readString, StreamInput::readString);
+        final Tuple<Map<String, String>, Map<String, Set<String>>> streamTuple = readHeadersFromStream(in);
+        final Map<String, String>  requestHeaders = streamTuple.v1();
+        final Map<String, Set<String>> responseHeaders = streamTuple.v2();
+        final ThreadContextStruct struct;
+        if (requestHeaders.isEmpty() && responseHeaders.isEmpty()) {
+            struct = ThreadContextStruct.EMPTY;
+        } else {
+            struct = new ThreadContextStruct(requestHeaders, responseHeaders, Collections.emptyMap(), false);
+        }
+        threadLocal.set(struct);
+    }
+
+    public static Tuple<Map<String, String>, Map<String, Set<String>>> readHeadersFromStream(StreamInput in) throws IOException {
+        final Map<String, String> requestHeaders = in.readMap(StreamInput::readString, StreamInput::readString);
         final Map<String, Set<String>> responseHeaders = in.readMap(StreamInput::readString, input -> {
             final int size = input.readVInt();
             if (size == 0) {
@@ -277,13 +268,7 @@ public final class ThreadContext implements Closeable, Writeable {
                 return values;
             }
         });
-        final ThreadContextStruct struct;
-        if (requestHeaders.isEmpty() && responseHeaders.isEmpty()) {
-            struct = ThreadContextStruct.EMPTY;
-        } else {
-            struct = new ThreadContextStruct(requestHeaders, responseHeaders, Collections.emptyMap(), false);
-        }
-        threadLocal.set(struct);
+        return new Tuple<>(requestHeaders, responseHeaders);
     }
 
     /**
@@ -377,17 +362,7 @@ public final class ThreadContext implements Closeable, Writeable {
      * @param uniqueValue the function that produces de-duplication values
      */
     public void addResponseHeader(final String key, final String value, final Function<String, String> uniqueValue) {
-        /*
-         * Updating the thread local is expensive due to a shared reference that we synchronize on, so we should only do it if the thread
-         * context struct changed. It will not change if we de-duplicate this value to an existing one, or if we don't add a new one because
-         * we have reached capacity.
-         */
-        final ThreadContextStruct current = threadLocal.get();
-        final ThreadContextStruct maybeNext =
-                current.putResponse(key, value, uniqueValue, maxWarningHeaderCount, maxWarningHeaderSize);
-        if (current != maybeNext) {
-            threadLocal.set(maybeNext);
-        }
+        threadLocal.set(threadLocal.get().putResponse(key, value, uniqueValue, maxWarningHeaderCount, maxWarningHeaderSize));
     }
 
     /**
@@ -439,13 +414,6 @@ public final class ThreadContext implements Closeable, Writeable {
         return threadLocal.get().isSystemContext;
     }
 
-    /**
-     * Returns <code>true</code> if the context is closed, otherwise <code>true</code>
-     */
-    public boolean isClosed() {
-        return threadLocal.closed.get();
-    }
-
     @FunctionalInterface
     public interface StoredContext extends AutoCloseable {
         @Override
@@ -453,6 +421,19 @@ public final class ThreadContext implements Closeable, Writeable {
 
         default void restore() {
             close();
+        }
+    }
+
+    public static Map<String, String> buildDefaultHeaders(Settings settings) {
+        Settings headers = DEFAULT_HEADERS_SETTING.get(settings);
+        if (headers == null) {
+            return Collections.emptyMap();
+        } else {
+            Map<String, String> defaultHeader = new HashMap<>();
+            for (String key : headers.names()) {
+                defaultHeader.put(key, headers.get(key));
+            }
+            return Collections.unmodifiableMap(defaultHeader);
         }
     }
 
@@ -633,55 +614,6 @@ public final class ThreadContext implements Closeable, Writeable {
         }
     }
 
-    private static class ContextThreadLocal extends CloseableThreadLocal<ThreadContextStruct> {
-        private final AtomicBoolean closed = new AtomicBoolean(false);
-
-        @Override
-        public void set(ThreadContextStruct object) {
-            try {
-                if (object == DEFAULT_CONTEXT) {
-                    super.set(null);
-                } else {
-                    super.set(object);
-                }
-            } catch (NullPointerException ex) {
-                /* This is odd but CloseableThreadLocal throws a NPE if it was closed but still accessed.
-                   to get a real exception we call ensureOpen() to tell the user we are already closed.*/
-                ensureOpen();
-                throw ex;
-            }
-        }
-
-        @Override
-        public ThreadContextStruct get() {
-            try {
-                ThreadContextStruct threadContextStruct = super.get();
-                if (threadContextStruct != null) {
-                    return threadContextStruct;
-                }
-                return DEFAULT_CONTEXT;
-            } catch (NullPointerException ex) {
-                /* This is odd but CloseableThreadLocal throws a NPE if it was closed but still accessed.
-                   to get a real exception we call ensureOpen() to tell the user we are already closed.*/
-                ensureOpen();
-                throw ex;
-            }
-        }
-
-        private void ensureOpen() {
-            if (closed.get()) {
-                throw new IllegalStateException("threadcontext is already closed");
-            }
-        }
-
-        @Override
-        public void close() {
-            if (closed.compareAndSet(false, true)) {
-                super.close();
-            }
-        }
-    }
-
     /**
      * Wraps a Runnable to preserve the thread context.
      */
@@ -696,19 +628,9 @@ public final class ThreadContext implements Closeable, Writeable {
 
         @Override
         public void run() {
-            boolean whileRunning = false;
             try (ThreadContext.StoredContext ignore = stashContext()){
                 ctx.restore();
-                whileRunning = true;
                 in.run();
-                whileRunning = false;
-            } catch (IllegalStateException ex) {
-                if (whileRunning || threadLocal.closed.get() == false) {
-                    throw ex;
-                }
-                // if we hit an ISE here we have been shutting down
-                // this comes from the threadcontext and barfs if
-                // our threadpool has been shutting down
             }
         }
 
@@ -765,21 +687,9 @@ public final class ThreadContext implements Closeable, Writeable {
 
         @Override
         protected void doRun() throws Exception {
-            boolean whileRunning = false;
             threadsOriginalContext = stashContext();
-            try {
-                creatorsContext.restore();
-                whileRunning = true;
-                in.doRun();
-                whileRunning = false;
-            } catch (IllegalStateException ex) {
-                if (whileRunning || threadLocal.closed.get() == false) {
-                    throw ex;
-                }
-                // if we hit an ISE here we have been shutting down
-                // this comes from the threadcontext and barfs if
-                // our threadpool has been shutting down
-            }
+            creatorsContext.restore();
+            in.doRun();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -40,7 +40,6 @@ import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.node.Node;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -60,7 +59,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.unmodifiableMap;
 
-public class ThreadPool implements Scheduler, Closeable {
+public class ThreadPool implements Scheduler {
 
     private static final Logger logger = LogManager.getLogger(ThreadPool.class);
 
@@ -754,15 +753,13 @@ public class ThreadPool implements Scheduler, Closeable {
     public static boolean terminate(ThreadPool pool, long timeout, TimeUnit timeUnit) {
         if (pool != null) {
             // Leverage try-with-resources to close the threadpool
-            try (ThreadPool c = pool) {
-                pool.shutdown();
-                if (awaitTermination(pool, timeout, timeUnit)) {
-                    return true;
-                }
-                // last resort
-                pool.shutdownNow();
-                return awaitTermination(pool, timeout, timeUnit);
+            pool.shutdown();
+            if (awaitTermination(pool, timeout, timeUnit)) {
+                return true;
             }
+            // last resort
+            pool.shutdownNow();
+            return awaitTermination(pool, timeout, timeUnit);
         }
         return false;
     }
@@ -779,11 +776,6 @@ public class ThreadPool implements Scheduler, Closeable {
             Thread.currentThread().interrupt();
         }
         return false;
-    }
-
-    @Override
-    public void close() {
-        threadContext.close();
     }
 
     public ThreadContext getThreadContext() {

--- a/server/src/main/java/org/elasticsearch/transport/TransportLogger.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportLogger.java
@@ -25,7 +25,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.Compressor;
 import org.elasticsearch.common.compress.NotCompressedException;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.internal.io.IOUtils;
 
@@ -93,10 +92,9 @@ public final class TransportLogger {
                         }
                         streamInput = compressor.streamInput(streamInput);
                     }
-
-                    try (ThreadContext context = new ThreadContext(Settings.EMPTY)) {
-                        context.readHeaders(streamInput);
-                    }
+    
+                    // read and discard headers
+                    ThreadContext.readHeadersFromStream(streamInput);
                     // now we decode the features
                     if (streamInput.getVersion().onOrAfter(Version.V_6_3_0)) {
                         streamInput.readStringArray();

--- a/server/src/test/java/org/elasticsearch/action/support/ContextPreservingActionListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/ContextPreservingActionListenerTests.java
@@ -28,129 +28,126 @@ import java.io.IOException;
 public class ContextPreservingActionListenerTests extends ESTestCase {
 
     public void testOriginalContextIsPreservedAfterOnResponse() throws IOException {
-        try (ThreadContext threadContext = new ThreadContext(Settings.EMPTY)) {
-            final boolean nonEmptyContext = randomBoolean();
-            if (nonEmptyContext) {
-                threadContext.putHeader("not empty", "value");
-            }
-            final ContextPreservingActionListener<Void> actionListener;
-            try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
-                threadContext.putHeader("foo", "bar");
-                final ActionListener<Void> delegate = new ActionListener<Void>() {
-                    @Override
-                    public void onResponse(Void aVoid) {
-                        assertEquals("bar", threadContext.getHeader("foo"));
-                        assertNull(threadContext.getHeader("not empty"));
-                    }
-
-                    @Override
-                    public void onFailure(Exception e) {
-                        throw new RuntimeException("onFailure shouldn't be called", e);
-                    }
-                };
-                if (randomBoolean()) {
-                    actionListener = new ContextPreservingActionListener<>(threadContext.newRestorableContext(true), delegate);
-                } else {
-                    actionListener = ContextPreservingActionListener.wrapPreservingContext(delegate, threadContext);
-                }
-            }
-
-            assertNull(threadContext.getHeader("foo"));
-            assertEquals(nonEmptyContext ? "value" : null, threadContext.getHeader("not empty"));
-
-            actionListener.onResponse(null);
-
-            assertNull(threadContext.getHeader("foo"));
-            assertEquals(nonEmptyContext ? "value" : null, threadContext.getHeader("not empty"));
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        final boolean nonEmptyContext = randomBoolean();
+        if (nonEmptyContext) {
+            threadContext.putHeader("not empty", "value");
         }
+        final ContextPreservingActionListener<Void> actionListener;
+        try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
+            threadContext.putHeader("foo", "bar");
+            final ActionListener<Void> delegate = new ActionListener<Void>() {
+                @Override
+                public void onResponse(Void aVoid) {
+                    assertEquals("bar", threadContext.getHeader("foo"));
+                    assertNull(threadContext.getHeader("not empty"));
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    throw new RuntimeException("onFailure shouldn't be called", e);
+                }
+            };
+            if (randomBoolean()) {
+                actionListener = new ContextPreservingActionListener<>(threadContext.newRestorableContext(true), delegate);
+            } else {
+                actionListener = ContextPreservingActionListener.wrapPreservingContext(delegate, threadContext);
+            }
+        }
+
+        assertNull(threadContext.getHeader("foo"));
+        assertEquals(nonEmptyContext ? "value" : null, threadContext.getHeader("not empty"));
+
+        actionListener.onResponse(null);
+
+        assertNull(threadContext.getHeader("foo"));
+        assertEquals(nonEmptyContext ? "value" : null, threadContext.getHeader("not empty"));
     }
 
     public void testOriginalContextIsPreservedAfterOnFailure() throws Exception {
-        try (ThreadContext threadContext = new ThreadContext(Settings.EMPTY)) {
-            final boolean nonEmptyContext = randomBoolean();
-            if (nonEmptyContext) {
-                threadContext.putHeader("not empty", "value");
-            }
-            final ContextPreservingActionListener<Void> actionListener;
-            try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
-                threadContext.putHeader("foo", "bar");
-                final ActionListener<Void> delegate = new ActionListener<Void>() {
-                    @Override
-                    public void onResponse(Void aVoid) {
-                        throw new RuntimeException("onResponse shouldn't be called");
-                    }
-
-                    @Override
-                    public void onFailure(Exception e) {
-                        assertEquals("bar", threadContext.getHeader("foo"));
-                        assertNull(threadContext.getHeader("not empty"));
-                    }
-                };
-
-                if (randomBoolean()) {
-                    actionListener = new ContextPreservingActionListener<>(threadContext.newRestorableContext(true), delegate);
-                } else {
-                    actionListener = ContextPreservingActionListener.wrapPreservingContext(delegate, threadContext);
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        final boolean nonEmptyContext = randomBoolean();
+        if (nonEmptyContext) {
+            threadContext.putHeader("not empty", "value");
+        }
+        final ContextPreservingActionListener<Void> actionListener;
+        try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
+            threadContext.putHeader("foo", "bar");
+            final ActionListener<Void> delegate = new ActionListener<Void>() {
+                @Override
+                public void onResponse(Void aVoid) {
+                    throw new RuntimeException("onResponse shouldn't be called");
                 }
 
+                @Override
+                public void onFailure(Exception e) {
+                    assertEquals("bar", threadContext.getHeader("foo"));
+                    assertNull(threadContext.getHeader("not empty"));
+                }
+            };
+
+            if (randomBoolean()) {
+                actionListener = new ContextPreservingActionListener<>(threadContext.newRestorableContext(true), delegate);
+            } else {
+                actionListener = ContextPreservingActionListener.wrapPreservingContext(delegate, threadContext);
             }
 
-            assertNull(threadContext.getHeader("foo"));
-            assertEquals(nonEmptyContext ? "value" : null, threadContext.getHeader("not empty"));
-
-            actionListener.onFailure(null);
-
-            assertNull(threadContext.getHeader("foo"));
-            assertEquals(nonEmptyContext ? "value" : null, threadContext.getHeader("not empty"));
         }
-    }
+
+        assertNull(threadContext.getHeader("foo"));
+        assertEquals(nonEmptyContext ? "value" : null, threadContext.getHeader("not empty"));
+
+        actionListener.onFailure(null);
+
+        assertNull(threadContext.getHeader("foo"));
+        assertEquals(nonEmptyContext ? "value" : null, threadContext.getHeader("not empty"));
+}
 
     public void testOriginalContextIsWhenListenerThrows() throws Exception {
-        try (ThreadContext threadContext = new ThreadContext(Settings.EMPTY)) {
-            final boolean nonEmptyContext = randomBoolean();
-            if (nonEmptyContext) {
-                threadContext.putHeader("not empty", "value");
-            }
-            final ContextPreservingActionListener<Void> actionListener;
-            try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
-                threadContext.putHeader("foo", "bar");
-                final ActionListener<Void> delegate = new ActionListener<Void>() {
-                    @Override
-                    public void onResponse(Void aVoid) {
-                        assertEquals("bar", threadContext.getHeader("foo"));
-                        assertNull(threadContext.getHeader("not empty"));
-                        throw new RuntimeException("onResponse called");
-                    }
-
-                    @Override
-                    public void onFailure(Exception e) {
-                        assertEquals("bar", threadContext.getHeader("foo"));
-                        assertNull(threadContext.getHeader("not empty"));
-                        throw new RuntimeException("onFailure called");
-                    }
-                };
-
-                if (randomBoolean()) {
-                    actionListener = new ContextPreservingActionListener<>(threadContext.newRestorableContext(true), delegate);
-                } else {
-                    actionListener = ContextPreservingActionListener.wrapPreservingContext(delegate, threadContext);
-                }
-            }
-
-            assertNull(threadContext.getHeader("foo"));
-            assertEquals(nonEmptyContext ? "value" : null, threadContext.getHeader("not empty"));
-
-            RuntimeException e = expectThrows(RuntimeException.class, () -> actionListener.onResponse(null));
-            assertEquals("onResponse called", e.getMessage());
-
-            assertNull(threadContext.getHeader("foo"));
-            assertEquals(nonEmptyContext ? "value" : null, threadContext.getHeader("not empty"));
-
-            e = expectThrows(RuntimeException.class, () -> actionListener.onFailure(null));
-            assertEquals("onFailure called", e.getMessage());
-
-            assertNull(threadContext.getHeader("foo"));
-            assertEquals(nonEmptyContext ? "value" : null, threadContext.getHeader("not empty"));
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        final boolean nonEmptyContext = randomBoolean();
+        if (nonEmptyContext) {
+            threadContext.putHeader("not empty", "value");
         }
+        final ContextPreservingActionListener<Void> actionListener;
+        try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
+            threadContext.putHeader("foo", "bar");
+            final ActionListener<Void> delegate = new ActionListener<Void>() {
+                @Override
+                public void onResponse(Void aVoid) {
+                    assertEquals("bar", threadContext.getHeader("foo"));
+                    assertNull(threadContext.getHeader("not empty"));
+                    throw new RuntimeException("onResponse called");
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    assertEquals("bar", threadContext.getHeader("foo"));
+                    assertNull(threadContext.getHeader("not empty"));
+                    throw new RuntimeException("onFailure called");
+                }
+            };
+
+            if (randomBoolean()) {
+                actionListener = new ContextPreservingActionListener<>(threadContext.newRestorableContext(true), delegate);
+            } else {
+                actionListener = ContextPreservingActionListener.wrapPreservingContext(delegate, threadContext);
+            }
+        }
+
+        assertNull(threadContext.getHeader("foo"));
+        assertEquals(nonEmptyContext ? "value" : null, threadContext.getHeader("not empty"));
+
+        RuntimeException e = expectThrows(RuntimeException.class, () -> actionListener.onResponse(null));
+        assertEquals("onResponse called", e.getMessage());
+
+        assertNull(threadContext.getHeader("foo"));
+        assertEquals(nonEmptyContext ? "value" : null, threadContext.getHeader("not empty"));
+
+        e = expectThrows(RuntimeException.class, () -> actionListener.onFailure(null));
+        assertEquals("onFailure called", e.getMessage());
+
+        assertNull(threadContext.getHeader("foo"));
+        assertEquals(nonEmptyContext ? "value" : null, threadContext.getHeader("not empty"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/AsyncIOProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/AsyncIOProcessorTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.common.util.concurrent;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
-import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -45,11 +44,6 @@ public class AsyncIOProcessorTests extends ESTestCase {
     @Before
     public void setUpThreadContext() {
         threadContext = new ThreadContext(Settings.EMPTY);
-    }
-
-    @After
-    public void tearDownThreadContext() {
-        threadContext.close();
     }
 
     public void testPut() throws InterruptedException {

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/QueueResizingEsThreadPoolExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/QueueResizingEsThreadPoolExecutorTests.java
@@ -64,7 +64,6 @@ public class QueueResizingEsThreadPoolExecutorTests extends ESTestCase {
         });
         executor.shutdown();
         executor.awaitTermination(10, TimeUnit.SECONDS);
-        context.close();
     }
 
     public void testAutoQueueSizingUp() throws Exception {
@@ -93,7 +92,6 @@ public class QueueResizingEsThreadPoolExecutorTests extends ESTestCase {
         });
         executor.shutdown();
         executor.awaitTermination(10, TimeUnit.SECONDS);
-        context.close();
     }
 
     public void testAutoQueueSizingDown() throws Exception {
@@ -121,7 +119,6 @@ public class QueueResizingEsThreadPoolExecutorTests extends ESTestCase {
         });
         executor.shutdown();
         executor.awaitTermination(10, TimeUnit.SECONDS);
-        context.close();
     }
 
     public void testAutoQueueSizingWithMin() throws Exception {
@@ -151,7 +148,6 @@ public class QueueResizingEsThreadPoolExecutorTests extends ESTestCase {
         });
         executor.shutdown();
         executor.awaitTermination(10, TimeUnit.SECONDS);
-        context.close();
     }
 
     public void testAutoQueueSizingWithMax() throws Exception {
@@ -181,7 +177,6 @@ public class QueueResizingEsThreadPoolExecutorTests extends ESTestCase {
         });
         executor.shutdown();
         executor.awaitTermination(10, TimeUnit.SECONDS);
-        context.close();
     }
 
     public void testExecutionEWMACalculation() throws Exception {
@@ -222,7 +217,6 @@ public class QueueResizingEsThreadPoolExecutorTests extends ESTestCase {
 
         executor.shutdown();
         executor.awaitTermination(10, TimeUnit.SECONDS);
-        context.close();
     }
 
     /** Use a runnable wrapper that simulates a task with unknown failures. */
@@ -244,7 +238,6 @@ public class QueueResizingEsThreadPoolExecutorTests extends ESTestCase {
         executeTask(executor, 1);
         executor.shutdown();
         executor.awaitTermination(10, TimeUnit.SECONDS);
-        context.close();
     }
 
     private Function<Runnable, WrappedRunnable> fastWrapper() {

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/ThreadContextTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/ThreadContextTests.java
@@ -244,35 +244,6 @@ public class ThreadContextTests extends ESTestCase {
         assertEquals("bar", threadContext.getHeader("foo"));
     }
 
-    public void testAccessClosed() throws IOException {
-        Settings build = Settings.builder().put("request.headers.default", "1").build();
-        ThreadContext threadContext = new ThreadContext(build);
-        threadContext.putHeader("foo", "bar");
-        threadContext.putTransient("ctx.foo", 1);
-
-        threadContext.close();
-        try {
-            threadContext.getHeader("foo");
-            fail();
-        } catch (IllegalStateException ise) {
-            assertEquals("threadcontext is already closed", ise.getMessage());
-        }
-
-        try {
-            threadContext.putTransient("foo", new Object());
-            fail();
-        } catch (IllegalStateException ise) {
-            assertEquals("threadcontext is already closed", ise.getMessage());
-        }
-
-        try {
-            threadContext.putHeader("boom", "boom");
-            fail();
-        } catch (IllegalStateException ise) {
-            assertEquals("threadcontext is already closed", ise.getMessage());
-        }
-    }
-
     public void testSerialize() throws IOException {
         Settings build = Settings.builder().put("request.headers.default", "1").build();
         ThreadContext threadContext = new ThreadContext(build);
@@ -397,244 +368,238 @@ public class ThreadContextTests extends ESTestCase {
     }
 
     public void testPreserveContext() throws IOException {
-        try (ThreadContext threadContext = new ThreadContext(Settings.EMPTY)) {
-            Runnable withContext;
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        Runnable withContext;
 
-            // Create a runnable that should run with some header
-            try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
-                threadContext.putHeader("foo", "bar");
-                withContext = threadContext.preserveContext(sometimesAbstractRunnable(() -> {
-                    assertEquals("bar", threadContext.getHeader("foo"));
-                }));
-            }
-
-            // We don't see the header outside of the runnable
-            assertNull(threadContext.getHeader("foo"));
-
-            // But we do inside of it
-            withContext.run();
-
-            // but not after
-            assertNull(threadContext.getHeader("foo"));
+        // Create a runnable that should run with some header
+        try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
+            threadContext.putHeader("foo", "bar");
+            withContext = threadContext.preserveContext(sometimesAbstractRunnable(() -> {
+                assertEquals("bar", threadContext.getHeader("foo"));
+            }));
         }
+
+        // We don't see the header outside of the runnable
+        assertNull(threadContext.getHeader("foo"));
+
+        // But we do inside of it
+        withContext.run();
+
+        // but not after
+        assertNull(threadContext.getHeader("foo"));
     }
 
     public void testPreserveContextKeepsOriginalContextWhenCalledTwice() throws IOException {
-        try (ThreadContext threadContext = new ThreadContext(Settings.EMPTY)) {
-            Runnable originalWithContext;
-            Runnable withContext;
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        Runnable originalWithContext;
+        Runnable withContext;
 
-            // Create a runnable that should run with some header
-            try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
-                threadContext.putHeader("foo", "bar");
-                withContext = threadContext.preserveContext(sometimesAbstractRunnable(() -> {
-                    assertEquals("bar", threadContext.getHeader("foo"));
-                }));
-            }
-
-            // Now attempt to rewrap it
-            originalWithContext = withContext;
-            try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
-                threadContext.putHeader("foo", "zot");
-                withContext = threadContext.preserveContext(withContext);
-            }
-
-            // We get the original context inside the runnable
-            withContext.run();
-
-            // In fact the second wrapping didn't even change it
-            assertThat(withContext, sameInstance(originalWithContext));
+        // Create a runnable that should run with some header
+        try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
+            threadContext.putHeader("foo", "bar");
+            withContext = threadContext.preserveContext(sometimesAbstractRunnable(() -> {
+                assertEquals("bar", threadContext.getHeader("foo"));
+            }));
         }
+
+        // Now attempt to rewrap it
+        originalWithContext = withContext;
+        try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
+            threadContext.putHeader("foo", "zot");
+            withContext = threadContext.preserveContext(withContext);
+        }
+
+        // We get the original context inside the runnable
+        withContext.run();
+
+        // In fact the second wrapping didn't even change it
+        assertThat(withContext, sameInstance(originalWithContext));
     }
 
     public void testPreservesThreadsOriginalContextOnRunException() throws IOException {
-        try (ThreadContext threadContext = new ThreadContext(Settings.EMPTY)) {
-            Runnable withContext;
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        Runnable withContext;
 
-            // create a abstract runnable, add headers and transient objects and verify in the methods
-            try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
-                threadContext.putHeader("foo", "bar");
-                boolean systemContext = randomBoolean();
-                if (systemContext) {
-                    threadContext.markAsSystemContext();
-                }
-                threadContext.putTransient("foo", "bar_transient");
-                withContext = threadContext.preserveContext(new AbstractRunnable() {
-
-                    @Override
-                    public void onAfter() {
-                        assertEquals(systemContext, threadContext.isSystemContext());
-                        assertEquals("bar", threadContext.getHeader("foo"));
-                        assertEquals("bar_transient", threadContext.getTransient("foo"));
-                        assertNotNull(threadContext.getTransient("failure"));
-                        assertEquals("exception from doRun", ((RuntimeException) threadContext.getTransient("failure")).getMessage());
-                        assertFalse(threadContext.isDefaultContext());
-                        threadContext.putTransient("after", "after");
-                    }
-
-                    @Override
-                    public void onFailure(Exception e) {
-                        assertEquals(systemContext, threadContext.isSystemContext());
-                        assertEquals("exception from doRun", e.getMessage());
-                        assertEquals("bar", threadContext.getHeader("foo"));
-                        assertEquals("bar_transient", threadContext.getTransient("foo"));
-                        assertFalse(threadContext.isDefaultContext());
-                        threadContext.putTransient("failure", e);
-                    }
-
-                    @Override
-                    protected void doRun() throws Exception {
-                        assertEquals(systemContext, threadContext.isSystemContext());
-                        assertEquals("bar", threadContext.getHeader("foo"));
-                        assertEquals("bar_transient", threadContext.getTransient("foo"));
-                        assertFalse(threadContext.isDefaultContext());
-                        throw new RuntimeException("exception from doRun");
-                    }
-                });
+        // create a abstract runnable, add headers and transient objects and verify in the methods
+        try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
+            threadContext.putHeader("foo", "bar");
+            boolean systemContext = randomBoolean();
+            if (systemContext) {
+                threadContext.markAsSystemContext();
             }
+            threadContext.putTransient("foo", "bar_transient");
+            withContext = threadContext.preserveContext(new AbstractRunnable() {
 
-            // We don't see the header outside of the runnable
-            assertNull(threadContext.getHeader("foo"));
-            assertNull(threadContext.getTransient("foo"));
-            assertNull(threadContext.getTransient("failure"));
-            assertNull(threadContext.getTransient("after"));
-            assertTrue(threadContext.isDefaultContext());
+                @Override
+                public void onAfter() {
+                    assertEquals(systemContext, threadContext.isSystemContext());
+                    assertEquals("bar", threadContext.getHeader("foo"));
+                    assertEquals("bar_transient", threadContext.getTransient("foo"));
+                    assertNotNull(threadContext.getTransient("failure"));
+                    assertEquals("exception from doRun", ((RuntimeException) threadContext.getTransient("failure")).getMessage());
+                    assertFalse(threadContext.isDefaultContext());
+                    threadContext.putTransient("after", "after");
+                }
 
-            // But we do inside of it
-            withContext.run();
-
-            // verify not seen after
-            assertNull(threadContext.getHeader("foo"));
-            assertNull(threadContext.getTransient("foo"));
-            assertNull(threadContext.getTransient("failure"));
-            assertNull(threadContext.getTransient("after"));
-            assertTrue(threadContext.isDefaultContext());
-
-            // repeat with regular runnable
-            try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
-                threadContext.putHeader("foo", "bar");
-                threadContext.putTransient("foo", "bar_transient");
-                withContext = threadContext.preserveContext(() -> {
+                @Override
+                public void onFailure(Exception e) {
+                    assertEquals(systemContext, threadContext.isSystemContext());
+                    assertEquals("exception from doRun", e.getMessage());
                     assertEquals("bar", threadContext.getHeader("foo"));
                     assertEquals("bar_transient", threadContext.getTransient("foo"));
                     assertFalse(threadContext.isDefaultContext());
-                    threadContext.putTransient("run", true);
-                    throw new RuntimeException("exception from run");
-                });
-            }
+                    threadContext.putTransient("failure", e);
+                }
 
-            assertNull(threadContext.getHeader("foo"));
-            assertNull(threadContext.getTransient("foo"));
-            assertNull(threadContext.getTransient("run"));
-            assertTrue(threadContext.isDefaultContext());
-
-            final Runnable runnable = withContext;
-            RuntimeException e = expectThrows(RuntimeException.class, runnable::run);
-            assertEquals("exception from run", e.getMessage());
-            assertNull(threadContext.getHeader("foo"));
-            assertNull(threadContext.getTransient("foo"));
-            assertNull(threadContext.getTransient("run"));
-            assertTrue(threadContext.isDefaultContext());
+                @Override
+                protected void doRun() throws Exception {
+                    assertEquals(systemContext, threadContext.isSystemContext());
+                    assertEquals("bar", threadContext.getHeader("foo"));
+                    assertEquals("bar_transient", threadContext.getTransient("foo"));
+                    assertFalse(threadContext.isDefaultContext());
+                    throw new RuntimeException("exception from doRun");
+                }
+            });
         }
+
+        // We don't see the header outside of the runnable
+        assertNull(threadContext.getHeader("foo"));
+        assertNull(threadContext.getTransient("foo"));
+        assertNull(threadContext.getTransient("failure"));
+        assertNull(threadContext.getTransient("after"));
+        assertTrue(threadContext.isDefaultContext());
+
+        // But we do inside of it
+        withContext.run();
+
+        // verify not seen after
+        assertNull(threadContext.getHeader("foo"));
+        assertNull(threadContext.getTransient("foo"));
+        assertNull(threadContext.getTransient("failure"));
+        assertNull(threadContext.getTransient("after"));
+        assertTrue(threadContext.isDefaultContext());
+
+        // repeat with regular runnable
+        try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
+            threadContext.putHeader("foo", "bar");
+            threadContext.putTransient("foo", "bar_transient");
+            withContext = threadContext.preserveContext(() -> {
+                assertEquals("bar", threadContext.getHeader("foo"));
+                assertEquals("bar_transient", threadContext.getTransient("foo"));
+                assertFalse(threadContext.isDefaultContext());
+                threadContext.putTransient("run", true);
+                throw new RuntimeException("exception from run");
+            });
+        }
+
+        assertNull(threadContext.getHeader("foo"));
+        assertNull(threadContext.getTransient("foo"));
+        assertNull(threadContext.getTransient("run"));
+        assertTrue(threadContext.isDefaultContext());
+
+        final Runnable runnable = withContext;
+        RuntimeException e = expectThrows(RuntimeException.class, runnable::run);
+        assertEquals("exception from run", e.getMessage());
+        assertNull(threadContext.getHeader("foo"));
+        assertNull(threadContext.getTransient("foo"));
+        assertNull(threadContext.getTransient("run"));
+        assertTrue(threadContext.isDefaultContext());
     }
 
     public void testPreservesThreadsOriginalContextOnFailureException() throws IOException {
-        try (ThreadContext threadContext = new ThreadContext(Settings.EMPTY)) {
-            Runnable withContext;
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        Runnable withContext;
 
-            // a runnable that throws from onFailure
-            try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
-                threadContext.putHeader("foo", "bar");
-                threadContext.putTransient("foo", "bar_transient");
-                withContext = threadContext.preserveContext(new AbstractRunnable() {
-                    @Override
-                    public void onFailure(Exception e) {
-                        throw new RuntimeException("from onFailure", e);
-                    }
+        // a runnable that throws from onFailure
+        try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
+            threadContext.putHeader("foo", "bar");
+            threadContext.putTransient("foo", "bar_transient");
+            withContext = threadContext.preserveContext(new AbstractRunnable() {
+                @Override
+                public void onFailure(Exception e) {
+                    throw new RuntimeException("from onFailure", e);
+                }
 
-                    @Override
-                    protected void doRun() throws Exception {
-                        assertEquals("bar", threadContext.getHeader("foo"));
-                        assertEquals("bar_transient", threadContext.getTransient("foo"));
-                        assertFalse(threadContext.isDefaultContext());
-                        throw new RuntimeException("from doRun");
-                    }
-                });
-            }
-
-            // We don't see the header outside of the runnable
-            assertNull(threadContext.getHeader("foo"));
-            assertNull(threadContext.getTransient("foo"));
-            assertTrue(threadContext.isDefaultContext());
-
-            // But we do inside of it
-            RuntimeException e = expectThrows(RuntimeException.class, withContext::run);
-            assertEquals("from onFailure", e.getMessage());
-            assertEquals("from doRun", e.getCause().getMessage());
-
-            // but not after
-            assertNull(threadContext.getHeader("foo"));
-            assertNull(threadContext.getTransient("foo"));
-            assertTrue(threadContext.isDefaultContext());
+                @Override
+                protected void doRun() throws Exception {
+                    assertEquals("bar", threadContext.getHeader("foo"));
+                    assertEquals("bar_transient", threadContext.getTransient("foo"));
+                    assertFalse(threadContext.isDefaultContext());
+                    throw new RuntimeException("from doRun");
+                }
+            });
         }
+
+        // We don't see the header outside of the runnable
+        assertNull(threadContext.getHeader("foo"));
+        assertNull(threadContext.getTransient("foo"));
+        assertTrue(threadContext.isDefaultContext());
+
+        // But we do inside of it
+        RuntimeException e = expectThrows(RuntimeException.class, withContext::run);
+        assertEquals("from onFailure", e.getMessage());
+        assertEquals("from doRun", e.getCause().getMessage());
+
+        // but not after
+        assertNull(threadContext.getHeader("foo"));
+        assertNull(threadContext.getTransient("foo"));
+        assertTrue(threadContext.isDefaultContext());
     }
 
     public void testPreservesThreadsOriginalContextOnAfterException() throws IOException {
-        try (ThreadContext threadContext = new ThreadContext(Settings.EMPTY)) {
-            Runnable withContext;
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        Runnable withContext;
 
-            // a runnable that throws from onAfter
-            try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
-                threadContext.putHeader("foo", "bar");
-                threadContext.putTransient("foo", "bar_transient");
-                withContext = threadContext.preserveContext(new AbstractRunnable() {
+        // a runnable that throws from onAfter
+        try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
+            threadContext.putHeader("foo", "bar");
+            threadContext.putTransient("foo", "bar_transient");
+            withContext = threadContext.preserveContext(new AbstractRunnable() {
 
-                    @Override
-                    public void onAfter() {
-                        throw new RuntimeException("from onAfter");
-                    }
+                @Override
+                public void onAfter() {
+                    throw new RuntimeException("from onAfter");
+                }
 
-                    @Override
-                    public void onFailure(Exception e) {
-                        throw new RuntimeException("from onFailure", e);
-                    }
+                @Override
+                public void onFailure(Exception e) {
+                    throw new RuntimeException("from onFailure", e);
+                }
 
-                    @Override
-                    protected void doRun() throws Exception {
-                        assertEquals("bar", threadContext.getHeader("foo"));
-                        assertEquals("bar_transient", threadContext.getTransient("foo"));
-                        assertFalse(threadContext.isDefaultContext());
-                    }
-                });
-            }
-
-            // We don't see the header outside of the runnable
-            assertNull(threadContext.getHeader("foo"));
-            assertNull(threadContext.getTransient("foo"));
-            assertTrue(threadContext.isDefaultContext());
-
-            // But we do inside of it
-            RuntimeException e = expectThrows(RuntimeException.class, withContext::run);
-            assertEquals("from onAfter", e.getMessage());
-            assertNull(e.getCause());
-
-            // but not after
-            assertNull(threadContext.getHeader("foo"));
-            assertNull(threadContext.getTransient("foo"));
-            assertTrue(threadContext.isDefaultContext());
+                @Override
+                protected void doRun() throws Exception {
+                    assertEquals("bar", threadContext.getHeader("foo"));
+                    assertEquals("bar_transient", threadContext.getTransient("foo"));
+                    assertFalse(threadContext.isDefaultContext());
+                }
+            });
         }
+
+        // We don't see the header outside of the runnable
+        assertNull(threadContext.getHeader("foo"));
+        assertNull(threadContext.getTransient("foo"));
+        assertTrue(threadContext.isDefaultContext());
+
+        // But we do inside of it
+        RuntimeException e = expectThrows(RuntimeException.class, withContext::run);
+        assertEquals("from onAfter", e.getMessage());
+        assertNull(e.getCause());
+
+        // but not after
+        assertNull(threadContext.getHeader("foo"));
+        assertNull(threadContext.getTransient("foo"));
+        assertTrue(threadContext.isDefaultContext());
     }
 
     public void testMarkAsSystemContext() throws IOException {
-        try (ThreadContext threadContext = new ThreadContext(Settings.EMPTY)) {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        assertFalse(threadContext.isSystemContext());
+        try (ThreadContext.StoredContext context = threadContext.stashContext()) {
             assertFalse(threadContext.isSystemContext());
-            try (ThreadContext.StoredContext context = threadContext.stashContext()) {
-                assertFalse(threadContext.isSystemContext());
-                threadContext.markAsSystemContext();
-                assertTrue(threadContext.isSystemContext());
-            }
-            assertFalse(threadContext.isSystemContext());
+            threadContext.markAsSystemContext();
+            assertTrue(threadContext.isSystemContext());
         }
+        assertFalse(threadContext.isSystemContext());
     }
 
     public void testPutHeaders() {

--- a/server/src/test/java/org/elasticsearch/node/NodeTests.java
+++ b/server/src/test/java/org/elasticsearch/node/NodeTests.java
@@ -36,7 +36,6 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.MockHttpTransport;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.hamcrest.Matchers;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/server/src/test/java/org/elasticsearch/node/NodeTests.java
+++ b/server/src/test/java/org/elasticsearch/node/NodeTests.java
@@ -166,7 +166,6 @@ public class NodeTests extends ESTestCase {
         assertTrue(node.awaitClose(1, TimeUnit.DAYS));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/42577")
     public void testCloseRaceWithTaskExecution() throws Exception {
         Node node = new MockNode(baseSettings().build(), basePlugins());
         node.start();

--- a/server/src/test/java/org/elasticsearch/node/NodeTests.java
+++ b/server/src/test/java/org/elasticsearch/node/NodeTests.java
@@ -44,12 +44,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.containsString;
 
 @LuceneTestCase.SuppressFileSystems(value = "ExtrasFS")
 public class NodeTests extends ESTestCase {
@@ -179,9 +181,13 @@ public class NodeTests extends ESTestCase {
             } catch (InterruptedException e) {
                 throw new AssertionError("interrupted while waiting", e);
             }
-            threadpool.executor(ThreadPool.Names.SEARCH).execute(() -> {
-                while (shouldRun.get());
-            });
+            try {
+                threadpool.executor(ThreadPool.Names.SEARCH).execute(() -> {
+                    while (shouldRun.get());
+                });
+            } catch (RejectedExecutionException e) {
+                assertThat(e.getMessage(), containsString("[Terminated,"));
+            }
         });
         Thread closeThread = new Thread(() -> {
             running.countDown();
@@ -267,7 +273,7 @@ public class NodeTests extends ESTestCase {
 
         IllegalStateException e = expectThrows(IllegalStateException.class, () -> node.awaitClose(1, TimeUnit.DAYS));
         searcher.close();
-        assertThat(e.getMessage(), Matchers.containsString("Something is leaking index readers or store references"));
+        assertThat(e.getMessage(), containsString("Something is leaking index readers or store references"));
     }
 
     public void testCloseOnLeakedStoreReference() throws Exception {
@@ -283,6 +289,6 @@ public class NodeTests extends ESTestCase {
 
         IllegalStateException e = expectThrows(IllegalStateException.class, () -> node.awaitClose(1, TimeUnit.DAYS));
         shard.store().decRef();
-        assertThat(e.getMessage(), Matchers.containsString("Something is leaking index readers or store references"));
+        assertThat(e.getMessage(), containsString("Something is leaking index readers or store references"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolTests.java
@@ -62,8 +62,7 @@ public class ThreadPoolTests extends ESTestCase {
             // the delta can be large, we just care it is the same order of magnitude
             assertTrue("thread pool cached absolute time " + gotTime + " is too far from real current time " + currentTime, delta < 10000);
         } finally {
-            threadPool.shutdown();
-            threadPool.close();
+            terminate(threadPool);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/transport/TransportLoggerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportLoggerTests.java
@@ -90,9 +90,8 @@ public class TransportLoggerTests extends ESTestCase {
     private BytesReference buildRequest() throws IOException {
         try (BytesStreamOutput messageOutput = new BytesStreamOutput()) {
             messageOutput.setVersion(Version.CURRENT);
-            try (ThreadContext context = new ThreadContext(Settings.EMPTY)) {
-                context.writeTo(messageOutput);
-            }
+            ThreadContext context = new ThreadContext(Settings.EMPTY);
+            context.writeTo(messageOutput);
             messageOutput.writeStringArray(new String[0]);
             messageOutput.writeString(ClusterStatsAction.NAME);
             new ClusterStatsRequest().writeTo(messageOutput);

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -374,7 +374,8 @@ public abstract class ESTestCase extends LuceneTestCase {
         // initialized
         if (threadContext != null) {
             ensureNoWarnings();
-            assert threadContext == null;
+            DeprecationLogger.removeThreadContext(threadContext);
+            threadContext = null;
         }
         ensureAllSearchContextsReleased();
         ensureCheckIndexPassed();
@@ -403,7 +404,7 @@ public abstract class ESTestCase extends LuceneTestCase {
                 assertNull("unexpected warning headers", warnings);
             }
         } finally {
-            resetDeprecationLogger(false);
+            resetDeprecationLogger();
         }
     }
 
@@ -441,7 +442,7 @@ public abstract class ESTestCase extends LuceneTestCase {
                 assertWarnings(actualWarnings, expectedWarnings);
             }
         } finally {
-            resetDeprecationLogger(true);
+            resetDeprecationLogger();
         }
     }
 
@@ -464,21 +465,11 @@ public abstract class ESTestCase extends LuceneTestCase {
     }
 
     /**
-     * Reset the deprecation logger by removing the current thread context, and setting a new thread context if {@code setNewThreadContext}
-     * is set to {@code true} and otherwise clearing the current thread context.
-     *
-     * @param setNewThreadContext whether or not to attach a new thread context to the deprecation logger
+     * Reset the deprecation logger by clearing the current thread context.
      */
-    private void resetDeprecationLogger(final boolean setNewThreadContext) {
-        // "clear" current warning headers by setting a new ThreadContext
-        DeprecationLogger.removeThreadContext(this.threadContext);
-        this.threadContext.close();
-        if (setNewThreadContext) {
-            this.threadContext = new ThreadContext(Settings.EMPTY);
-            DeprecationLogger.setThreadContext(this.threadContext);
-        } else {
-            this.threadContext = null;
-        }
+    private void resetDeprecationLogger() {
+        // "clear" context by stashing current values and dropping the returned StoredContext
+        threadContext.stashContext();
     }
 
     private static final List<StatusData> statusData = new ArrayList<>();

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -863,14 +863,13 @@ public abstract class ESRestTestCase extends ESTestCase {
                 throw new RuntimeException("Error setting up ssl", e);
             }
         }
-        try (ThreadContext threadContext = new ThreadContext(settings)) {
-            Header[] defaultHeaders = new Header[threadContext.getHeaders().size()];
-            int i = 0;
-            for (Map.Entry<String, String> entry : threadContext.getHeaders().entrySet()) {
-                defaultHeaders[i++] = new BasicHeader(entry.getKey(), entry.getValue());
-            }
-            builder.setDefaultHeaders(defaultHeaders);
+        Map<String, String> headers = ThreadContext.buildDefaultHeaders(settings);
+        Header[] defaultHeaders = new Header[headers.size()];
+        int i = 0;
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            defaultHeaders[i++] = new BasicHeader(entry.getKey(), entry.getValue());
         }
+        builder.setDefaultHeaders(defaultHeaders);
         final String socketTimeoutString = settings.get(CLIENT_SOCKET_TIMEOUT);
         final TimeValue socketTimeout =
             TimeValue.parseTimeValue(socketTimeoutString == null ? "60s" : socketTimeoutString, CLIENT_SOCKET_TIMEOUT);

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotRetentionServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotRetentionServiceTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.xpack.core.watcher.watch.ClockMock;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
@@ -43,13 +44,13 @@ public class SnapshotRetentionServiceTests extends ESTestCase {
         clusterSettings = new ClusterSettings(Settings.EMPTY, internalSettings);
     }
 
-    public void testJobsAreScheduled() {
+    public void testJobsAreScheduled() throws InterruptedException {
         final DiscoveryNode discoveryNode = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(),
             Collections.emptyMap(), DiscoveryNodeRole.BUILT_IN_ROLES, Version.CURRENT);
         ClockMock clock = new ClockMock();
 
-        try (ThreadPool threadPool = new TestThreadPool("test");
-             ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool, discoveryNode, clusterSettings);
+        ThreadPool threadPool = new TestThreadPool("test");
+        try (ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool, discoveryNode, clusterSettings);
              SnapshotRetentionService service = new SnapshotRetentionService(Settings.EMPTY,
                  FakeRetentionTask::new, clusterService, clock)) {
             assertThat(service.getScheduler().jobCount(), equalTo(0));
@@ -76,33 +77,34 @@ public class SnapshotRetentionServiceTests extends ESTestCase {
         }
     }
 
-    public void testManualTriggering() {
+    public void testManualTriggering() throws InterruptedException {
         final DiscoveryNode discoveryNode = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(),
             Collections.emptyMap(), DiscoveryNodeRole.BUILT_IN_ROLES, Version.CURRENT);
         ClockMock clock = new ClockMock();
         AtomicInteger invoked = new AtomicInteger(0);
-
-        try (ThreadPool threadPool = new TestThreadPool("test");
-             ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool, discoveryNode, clusterSettings);
+    
+        ThreadPool threadPool = new TestThreadPool("test");
+        try (ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool, discoveryNode, clusterSettings);
              SnapshotRetentionService service = new SnapshotRetentionService(Settings.EMPTY,
                  () -> new FakeRetentionTask(event -> {
                      assertThat(event.getJobName(), equalTo(SnapshotRetentionService.SLM_RETENTION_MANUAL_JOB_ID));
                      invoked.incrementAndGet();
                  }), clusterService, clock)) {
-
+    
             service.onMaster();
             service.triggerRetention();
             assertThat(invoked.get(), equalTo(1));
-
+    
             service.offMaster();
             service.triggerRetention();
             assertThat(invoked.get(), equalTo(1));
-
+    
             service.onMaster();
             service.triggerRetention();
             assertThat(invoked.get(), equalTo(2));
-
+        } finally {
             threadPool.shutdownNow();
+            threadPool.awaitTermination(10, TimeUnit.SECONDS);
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -49,9 +49,8 @@ import org.elasticsearch.xpack.security.audit.AuditTrailService;
 import org.elasticsearch.xpack.security.audit.logfile.LoggingAuditTrail;
 import org.elasticsearch.xpack.security.authc.Realms;
 import org.hamcrest.Matchers;
-import org.junit.Before;
+import org.junit.After;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -143,13 +142,9 @@ public class SecurityTests extends ESTestCase {
         return null;
     }
 
-    @Before
-    public void cleanup() throws IOException {
-        if (threadContext != null) {
-            threadContext.stashContext();
-            threadContext.close();
-            threadContext = null;
-        }
+    @After
+    public void cleanup() {
+        threadContext = null;
     }
 
     public void testCustomRealmExtension() throws Exception {


### PR DESCRIPTION
This commit changes the ThreadContext to just use a regular ThreadLocal
over the lucene CloseableThreadLocal. The CloseableThreadLocal solves
issues with ThreadLocals that are no longer needed during runtime but
in the case of the ThreadContext, we need it for the runtime of the
node and it is typically not closed until the node closes, so we miss
out on the benefits that this class provides.

Additionally by removing the close logic, we simplify code in other
places that deal with exceptions and tracking to see if it happens when
the node is closing.

Closes #42577