### PR TITLE
Update HdrHistogram to 2.1.11

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -111,7 +111,7 @@ dependencies {
   // percentiles aggregation
   compile 'com.tdunning:t-digest:3.2'
   // precentil ranks aggregation
-  compile 'org.hdrhistogram:HdrHistogram:2.1.9'
+  compile 'org.hdrhistogram:HdrHistogram:2.1.11'
 
   // lucene spatial
   compile "org.locationtech.spatial4j:spatial4j:${versions.spatial4j}", optional


### PR DESCRIPTION
The current 2.1.9 version is from 2016, there are a lot of changes since then, so we should probably upgrade. Compare between versions: [here](https://github.com/HdrHistogram/HdrHistogram/compare/HdrHistogram-2.1.9...HdrHistogram-2.1.11)