### PR TITLE
[7.x] Relax assertions related to datafeed timing stats in .yml test (#49285)

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_datafeed_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_datafeed_stats.yml
@@ -183,10 +183,10 @@ setup:
   - match:  { datafeeds.0.datafeed_id: "datafeed-1"}
   - match:  { datafeeds.0.state: "started"}
   - match:  { datafeeds.0.timing_stats.job_id: "get-datafeed-stats-1"}
-  - match:  { datafeeds.0.timing_stats.search_count: 0}
-  - match:  { datafeeds.0.timing_stats.bucket_count: 0}
-  - match:  { datafeeds.0.timing_stats.total_search_time_ms: 0.0}
-  - is_false: datafeeds.0.timing_stats.average_search_time_per_bucket_ms
+  # We don't really know at this point if datafeed managed to perform at least one search, hence the very relaxed assertion
+  - gte:  { datafeeds.0.timing_stats.search_count: 0}
+  - gte:  { datafeeds.0.timing_stats.bucket_count: 0}
+  - gte:  { datafeeds.0.timing_stats.total_search_time_ms: 0.0}
 
   - do:
       ml.stop_datafeed:


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Relax assertions related to datafeed timing stats in .yml test  (#49285)