### PR TITLE
Reindex search response fix

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexFailureTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexFailureTests.java
@@ -90,7 +90,6 @@ public class ReindexFailureTests extends ReindexTestCase {
      * the whole process. We do lose some information about how far along the
      * process got, but its important that they see these failures.
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/49295")
     public void testResponseOnSearchFailure() throws Exception {
         /*
          * Attempt to trigger a reindex failure by deleting the source index out
@@ -122,7 +121,8 @@ public class ReindexFailureTests extends ReindexTestCase {
                         either(containsString("all shards failed"))
                         .or(containsString("No search context found"))
                         .or(containsString("no such index [source]"))
-                        );
+                        .or(containsString("Failed to execute phase [query], Partial shards failure"))
+                );
                 return;
             }
         }


### PR DESCRIPTION
Fixed test case to also accept another error message, now that reindex
does not allow searching against red shards.

Closes #49295
