### PR TITLE
Add release highlights for 7.5.0

### DIFF
--- a/docs/reference/release-notes/highlights-7.5.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.5.0.asciidoc
@@ -31,18 +31,20 @@ now work for the {ref}/shape.html[`shape`] field type introduced in 7.3.
 [float]
 ==== Snapshot lifecycle management retention
 
-A new {ref}/slm-retention.html[snapshot lifecycle management retention] which
-allows to delete older snapshots automatically through custom policy’s schedule.
+There is a new {ref}/slm-retention.html[snapshot lifecycle management retention],
+which allows you to delete older snapshots automatically through a custom
+policy’s schedule.
 
 // end::notable-highlights[]
 
 
 // tag::notable-highlights[]
 [float]
-==== Pause Cross-Cluster Replication
+==== Pause {ccr}
 
-New {ref}/ccr-post-pause-follow.html[pause] and {ref}/ccr-post-pause-follow.html[resume]
-API endpoints for {ref}/ccr.htm[cross-cluster replication] which allow to temporarily pause
+New {ref}/ccr-post-pause-follow.html[pause] and
+{ref}/ccr-post-pause-follow.html[resume] API endpoints for
+{ref}/ccr.htm[{ccr}] have been added, which enable you to temporarily pause
 auto-follow patterns.
 
 // end::notable-highlights[]
@@ -51,8 +53,8 @@ auto-follow patterns.
 [float]
 ==== Classification API
 
-The {ref}/ml-df-analytics-apis.html[data frame analytics jobs] now supports binary classification
-which allows to predict the class or category of a document.
+{ref}/ml-df-analytics-apis.html[{dfanalytics-jobs-cap}] now support binary
+classification, which enables you to predict the class or category of a document.
 
 // end::notable-highlights[]
 

--- a/docs/reference/release-notes/highlights-7.5.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.5.0.asciidoc
@@ -1,0 +1,58 @@
+[[release-highlights-7.5.0]]
+== 7.5.0 release highlights
+++++
+<titleabbrev>7.5.0</titleabbrev>
+++++
+
+//NOTE: The notable-highlights tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+// tag::notable-highlights[]
+[float]
+==== Enrich processor
+
+A new {ref}/enrich-processor.html[enrich ingest processor] has been added,
+which can enrich documents with data from another index.
+
+// end::notable-highlights[]
+
+// tag::notable-highlights[]
+[float]
+==== Shape support in SQL
+
+{ref}/xpack-sql.html[SQL] functionality that worked for geo_shape will
+now work for the {ref}/shape.html[`shape`] field type introduced in 7.3.
+
+
+// end::notable-highlights[]
+
+
+// tag::notable-highlights[]
+[float]
+==== Snapshot lifecycle management retention
+
+A new {ref}/slm-retention.html[snapshot lifecycle management retention] which
+allows to delete older snapshots automatically through custom policy’s schedule.
+
+// end::notable-highlights[]
+
+
+// tag::notable-highlights[]
+[float]
+==== Pause Cross-Cluster Replication
+
+New {ref}/ccr-post-pause-follow.html[pause] and {ref}/ccr-post-pause-follow.html[resume]
+API endpoints for {ref}/ccr.htm[cross-cluster replication] which allow to temporarily pause
+auto-follow patterns.
+
+// end::notable-highlights[]
+
+// tag::notable-highlights[]
+[float]
+==== Classification API
+
+The {ref}/ml-df-analytics-apis.html[data frame analytics jobs] now supports binary classification
+which allows to predict the class or category of a document.
+
+// end::notable-highlights[]
+

--- a/docs/reference/release-notes/highlights-7.5.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.5.0.asciidoc
@@ -51,10 +51,14 @@ auto-follow patterns.
 
 // tag::notable-highlights[]
 [float]
-==== Classification API
+==== {ml-cap} {classanalysis}
 
-{ref}/ml-df-analytics-apis.html[{dfanalytics-jobs-cap}] now support binary
-classification, which enables you to predict the class or category of a document.
+{ref}/dfa-classification.html[{classanalysis-cap}] is a supervised {ml} process
+for predicting a class or category of a given data point in a dataset. For
+example, it can determine whether an email is spam or not. {classification-cap}
+is for predicting discrete, categorical values, unlike {reganalysis}, which
+predicts continuous, numerical values. 7.5.0 introduces binary classification,
+which can label data points into two possible categories.
 
 // end::notable-highlights[]
 

--- a/docs/reference/release-notes/highlights-7.5.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.5.0.asciidoc
@@ -44,8 +44,8 @@ policy’s schedule.
 
 New {ref}/ccr-post-pause-follow.html[pause] and
 {ref}/ccr-post-pause-follow.html[resume] API endpoints for
-{ref}/ccr.htm[{ccr}] have been added, which enable you to temporarily pause
-auto-follow patterns.
+{ref}/xpack-ccr.html[{ccr}] have been added, which enable you to temporarily
+pause auto-follow patterns.
 
 // end::notable-highlights[]
 
@@ -53,12 +53,12 @@ auto-follow patterns.
 [float]
 ==== {ml-cap} {classanalysis}
 
-{ref}/dfa-classification.html[{classanalysis-cap}] is a supervised {ml} process
-for predicting a class or category of a given data point in a dataset. For
-example, it can determine whether an email is spam or not. {classification-cap}
-is for predicting discrete, categorical values, unlike {reganalysis}, which
-predicts continuous, numerical values. 7.5.0 introduces binary classification,
-which can label data points into two possible categories.
+{stack-ov}/dfa-classification.html[{classanalysis-cap}] is a supervised {ml}
+process for predicting a class or category of a given data point in a dataset.
+For example, it can determine whether an email is spam or not.
+{classification-cap} is for predicting discrete, categorical values, unlike
+{reganalysis}, which predicts continuous, numerical values. 7.5.0 introduces
+binary classification, which can label data points into two possible categories.
 
 // end::notable-highlights[]
 

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -6,6 +6,7 @@
 This section summarizes the most important changes in each release. For the
 full list, see <<es-release-notes>> and <<breaking-changes>>.
 
+* <<release-highlights-7.5.0>>
 * <<release-highlights-7.4.0>>
 * <<release-highlights-7.3.0>>
 * <<release-highlights-7.2.0>>
@@ -14,6 +15,7 @@ full list, see <<es-release-notes>> and <<breaking-changes>>.
 
 --
 
+include::highlights-7.5.0.asciidoc[]
 include::highlights-7.4.0.asciidoc[]
 include::highlights-7.3.0.asciidoc[]
 include::highlights-7.2.0.asciidoc[]


### PR DESCRIPTION
Release highlights for 7.5.0.

Preview: http://elasticsearch_49320.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.5/release-highlights-7.5.0.html