### PR TITLE
[DOCS] Groups pages related to encrypting communications

### DIFF
--- a/x-pack/docs/en/security/configuring-es.asciidoc
+++ b/x-pack/docs/en/security/configuring-es.asciidoc
@@ -137,12 +137,6 @@ Events are logged to a dedicated `<clustername>_audit.json` file in
 
 To walk through the configuration of {security-features} in {es}, {kib}, {ls}, and {metricbeat}, see <<security-getting-started>>.
 
-include::securing-communications/securing-elasticsearch.asciidoc[]
-
-include::securing-communications/configuring-tls-docker.asciidoc[]
-
-include::securing-communications/enabling-cipher-suites.asciidoc[]
-
 include::authentication/configuring-active-directory-realm.asciidoc[]
 include::authentication/configuring-pki-realm.asciidoc[]
 

--- a/x-pack/docs/en/security/securing-communications/index.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/index.asciidoc
@@ -18,4 +18,7 @@ The authentication of new nodes helps prevent a rogue node from joining the
 cluster and receiving data through replication.
 
 include::setting-up-ssl.asciidoc[]
+include::securing-elasticsearch.asciidoc[]
+include::configuring-tls-docker.asciidoc[]
+include::enabling-cipher-suites.asciidoc[]
 


### PR DESCRIPTION
Related to #46718

This PR moves the following pages:
https://www.elastic.co/guide/en/elasticsearch/reference/master/configuring-tls.html
https://www.elastic.co/guide/en/elasticsearch/reference/master/configuring-tls-docker.html
https://www.elastic.co/guide/en/elasticsearch/reference/master/ciphers.html
... from the "Configuring security" section to the "Encrypting communications" section.