### PR TITLE
Stop ignoring types warnings in REST tests.

### DIFF
--- a/docs/reference/mapping/fields/type-field.asciidoc
+++ b/docs/reference/mapping/fields/type-field.asciidoc
@@ -18,7 +18,11 @@ PUT my_index/_doc/1?refresh=true
 {
   "text": "Document with type 'doc'"
 }
+--------------------------
+// TESTSETUP
 
+[source,console]
+--------------------------
 GET my_index/_search
 {
   "query": {
@@ -52,6 +56,8 @@ GET my_index/_search
 }
 
 --------------------------
+// TEST[warning:[types removal] Using the _type field in queries and aggregations is deprecated, prefer to use a field instead.]
+// TEST[warning:[types removal] Looking up doc types [_type] in scripts is deprecated.]
 
 <1> Querying on the `_type` field
 <2> Aggregating on the `_type` field

--- a/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/120_grok.yml
+++ b/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/120_grok.yml
@@ -134,7 +134,6 @@ teardown:
             "docs": [
               {
                 "_index": "index",
-                "_type": "type",
                 "_id": "id",
                 "_source": {
                   "field": "abc2xyz"

--- a/qa/smoke-test-ingest-with-all-dependencies/src/test/resources/rest-api-spec/test/ingest/10_pipeline_with_mustache_templates.yml
+++ b/qa/smoke-test-ingest-with-all-dependencies/src/test/resources/rest-api-spec/test/ingest/10_pipeline_with_mustache_templates.yml
@@ -295,7 +295,6 @@
             "docs": [
               {
                 "_index": "index",
-                "_type": "type",
                 "_id": "id",
                 "_source": {
                   "foo": "bar"

--- a/server/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.Fields;
 import org.apache.lucene.search.BooleanClause;
@@ -43,7 +42,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.lucene.search.MoreLikeThisQuery;
 import org.elasticsearch.common.lucene.search.XMoreLikeThis;
 import org.elasticsearch.common.lucene.uid.Versions;
@@ -79,11 +77,6 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
  */
 public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQueryBuilder> {
     public static final String NAME = "more_like_this";
-    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
-        LogManager.getLogger(MoreLikeThisQueryBuilder.class));
-    static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Types are deprecated in [more_like_this] " +
-        "queries. The type should no longer be specified in the [like] and [unlike] sections.";
-
 
     public static final int DEFAULT_MAX_QUERY_TERMS = XMoreLikeThis.DEFAULT_MAX_QUERY_TERMS;
     public static final int DEFAULT_MIN_TERM_FREQ = XMoreLikeThis.DEFAULT_MIN_TERM_FREQ;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -292,11 +292,8 @@ public class DoSection implements ExecutableSection {
             final boolean matches = matcher.matches();
             if (matches) {
                 final String message = matcher.group(1);
-                if (message.startsWith("[types removal]") || message.startsWith("[_data_frame/transforms/] is deprecated")) {
-                    /*
-                     * We skip warnings related to types deprecation and transform rename so that we can continue to run the many
-                     * mixed-version tests that used typed APIs.
-                     */
+                if (message.startsWith("[_data_frame/transforms/] is deprecated")) {
+                    // We skip warnings related to the transform rename so that we can continue to run the many mixed-version tests.
                 } else if (expected.remove(message) == false) {
                     unexpected.add(header);
                 }

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
@@ -128,16 +128,6 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         }
     }
 
-    public void testIgnoreTypesWarnings() {
-        String legitimateWarning = DeprecationLogger.formatWarning("warning");
-        String typesWarning = DeprecationLogger.formatWarning("[types removal] " +
-            "The endpoint /{index}/{type}/_count is deprecated, use /{index}/_count instead.");
-
-        DoSection section = new DoSection(new XContentLocation(1, 1));
-        section.setExpectedWarningHeaders(singletonList("warning"));
-        section.checkWarningHeaders(Arrays.asList(legitimateWarning, typesWarning), Version.CURRENT);
-    }
-
     public void testParseDoSectionNoBody() throws Exception {
         parser = createParser(YamlXContent.yamlXContent,
                 "get:\n" +

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilder.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilder.java
@@ -35,9 +35,6 @@ import java.util.function.Supplier;
 public class ShapeQueryBuilder extends AbstractGeometryQueryBuilder<ShapeQueryBuilder> {
     public static final String NAME = "shape";
 
-    static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Types are deprecated in [geo_shape] queries. " +
-        "The type should no longer be specified in the [indexed_shape] section.";
-
     /**
      * Creates a new GeoShapeQueryBuilder whose Query will be against the given
      * field name using the given Shape


### PR DESCRIPTION
In 7.x we added logic to the REST test harness to ignore warnings related to
types removal. This allowed us to continue to run mixed-cluster tests that
included 6.x nodes.

Now that master is on 8.x, we've no longer need to include 6.x nodes in testing
and have removed almost all typed calls. The logic to ignore warnings can
therefore be removed.

Relates to #35395.