### PR TITLE
[DOCS] Clean up example pipelines and enrich policies in docs snippets

### DIFF
--- a/docs/reference/ingest/enrich.asciidoc
+++ b/docs/reference/ingest/enrich.asciidoc
@@ -592,3 +592,12 @@ The API returns the following response:
 }
 ----
 // TESTRESPONSE[s/"_seq_no": \d+/"_seq_no" : $body._seq_no/ s/"_primary_term":1/"_primary_term" : $body._primary_term/]
+
+////
+[source,console]
+--------------------------------------------------
+DELETE /_ingest/pipeline/user_lookup
+DELETE /_enrich/policy/users-policy
+--------------------------------------------------
+// TEST[continued]
+////


### PR DESCRIPTION
While backporting #49194, I discovered that some example ingest pipelines and enrich policies  used in snippets weren't deleted.

This didn't fail the CI tests for that PR because doc tests are performed randomly. However, this can cause issues for other doc tests (like those for the get enrich policies API) if performed in a different order.