### PR TITLE
[DOCS] Reformat ILM API docs

### DIFF
--- a/docs/reference/ilm/apis/delete-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/delete-lifecycle.asciidoc
@@ -8,36 +8,37 @@
 
 Deletes a lifecycle policy.
 
-[[sample-api-request]]
+[[ilm-delete-lifecycle-request]]
 ==== {api-request-title}
 
 `DELETE _ilm/policy/<policy_id>`
 
-[[sample-api-desc]]
+[[ilm-delete-lifecycle-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage_ilm`
+cluster privilege to use this API. For more information, see
+<<security-privileges>>.
+
+[[ilm-delete-lifecycle-desc]]
 ==== {api-description-title}
 
 Deletes the specified lifecycle policy definition. You cannot delete policies
 that are currently in use. If the policy is being used to manage any indices,
 the request fails and returns an error.
 
-[[sample-api-path-params]]
+[[ilm-delete-lifecycle-path-params]]
 ==== {api-path-parms-title}
 
-`policy` (required)::
-  (string) Identifier for the policy.
+`<policy_id>`::
+  (Required, string) Identifier for the policy.
 
-[[sample-api-query-params]]
+[[ilm-delete-lifecycle-query-params]]
 ==== {api-query-parms-title}
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-[[sample-api-prereqs]]
-==== {api-prereq-title}
-
-You must have the `manage_ilm` cluster privilege to use this API.
-For more information, see <<security-privileges>>.
-
-[[sample-api-example]]
+[[ilm-delete-lifecycle-example]]
 ==== {api-examples-title}
 
 The following example deletes `my_policy`:

--- a/docs/reference/ilm/apis/delete-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/delete-lifecycle.asciidoc
@@ -8,31 +8,37 @@
 
 Deletes a lifecycle policy.
 
-==== Request
+[[sample-api-request]]
+==== {api-request-title}
 
 `DELETE _ilm/policy/<policy_id>`
 
-==== Description
+[[sample-api-desc]]
+==== {api-description-title}
 
 Deletes the specified lifecycle policy definition. You cannot delete policies
 that are currently in use. If the policy is being used to manage any indices,
 the request fails and returns an error.
 
-==== Path Parameters
+[[sample-api-path-params]]
+==== {api-path-parms-title}
 
 `policy` (required)::
   (string) Identifier for the policy.
 
-==== Request Parameters
+[[sample-api-query-params]]
+==== {api-query-parms-title}
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-==== Authorization
+[[sample-api-prereqs]]
+==== {api-prereq-title}
 
 You must have the `manage_ilm` cluster privilege to use this API.
 For more information, see <<security-privileges>>.
 
-==== Examples
+[[sample-api-example]]
+==== {api-examples-title}
 
 The following example deletes `my_policy`:
 

--- a/docs/reference/ilm/apis/explain.asciidoc
+++ b/docs/reference/ilm/apis/explain.asciidoc
@@ -8,12 +8,19 @@
 
 Shows an index's current lifecycle status.
 
-[[sample-api-request]]
+[[ilm-explain-lifecycle-request]]
 ==== {api-request-title}
 
 `GET <index>/_ilm/explain`
 
-[[sample-api-desc]]
+[[ilm-explain-lifecycle-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the
+`view_index_metadata` or `manage_ilm` or both privileges on the indices being
+managed to use this API. For more information, see <<security-privileges>>.
+
+[[ilm-explain-lifecycle-desc]]
 ==== {api-description-title}
 
 Retrieves information about the index's current lifecycle state, such as
@@ -21,34 +28,27 @@ the currently executing phase, action, and step. Shows when the index entered
 each one, the definition of the running phase, and information
 about any failures.
 
-[[sample-api-path-params]]
+[[ilm-explain-lifecycle-path-params]]
 ==== {api-path-parms-title}
 
-`index` (required)::
-  (string) Identifier for the index.
+`<index>`::
+  (Required, string) Identifier for the index.
 
-[[sample-api-query-params]]
+[[ilm-explain-lifecycle-query-params]]
 ==== {api-query-parms-title}
 
 `only_managed`::
-  (boolean) Filters the returned indices to only indices that are managed by
+  (Optional, boolean) Filters the returned indices to only indices that are managed by
   ILM.
 
 `only_errors`::
-  (boolean) Filters the returned indices to only indices that are managed by
+  (Optional, boolean) Filters the returned indices to only indices that are managed by
   ILM and are in an error state, either due to an encountering an error while
   executing the policy, or attempting to use a policy that does not exist.
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-[[sample-api-prereqs]]
-==== {api-prereq-title}
-
-You must have the `view_index_metadata` or `manage_ilm` or both privileges on the indices
-being managed to use this API.
-For more information, see <<security-privileges>>.
-
-[[sample-api-example]]
+[[ilm-explain-lifecycle-example]]
 ==== {api-examples-title}
 
 The following example retrieves the lifecycle state of `my_index`:

--- a/docs/reference/ilm/apis/explain.asciidoc
+++ b/docs/reference/ilm/apis/explain.asciidoc
@@ -8,23 +8,27 @@
 
 Shows an index's current lifecycle status.
 
-==== Request
+[[sample-api-request]]
+==== {api-request-title}
 
 `GET <index>/_ilm/explain`
 
-==== Description
+[[sample-api-desc]]
+==== {api-description-title}
 
 Retrieves information about the index's current lifecycle state, such as
 the currently executing phase, action, and step. Shows when the index entered
 each one, the definition of the running phase, and information
 about any failures.
 
-==== Path Parameters
+[[sample-api-path-params]]
+==== {api-path-parms-title}
 
 `index` (required)::
   (string) Identifier for the index.
 
-==== Request Parameters
+[[sample-api-query-params]]
+==== {api-query-parms-title}
 
 `only_managed`::
   (boolean) Filters the returned indices to only indices that are managed by
@@ -37,13 +41,15 @@ about any failures.
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-==== Authorization
+[[sample-api-prereqs]]
+==== {api-prereq-title}
 
 You must have the `view_index_metadata` or `manage_ilm` or both privileges on the indices
 being managed to use this API.
 For more information, see <<security-privileges>>.
 
-==== Examples
+[[sample-api-example]]
+==== {api-examples-title}
 
 The following example retrieves the lifecycle state of `my_index`:
 

--- a/docs/reference/ilm/apis/get-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/get-lifecycle.asciidoc
@@ -8,31 +8,37 @@
 
 Retrieves a lifecycle policy.
 
-==== Request
+[[sample-api-request]]
+==== {api-request-title}
 
 `GET _ilm/policy`
 `GET _ilm/policy/<policy_id>`
 
-==== Description
+[[sample-api-desc]]
+==== {api-description-title}
 
 Returns the specified policy definition. Includes the policy version and last
 modified date. If no policy is specified, returns all defined policies.
 
-==== Path Parameters
+[[sample-api-path-params]]
+==== {api-path-parms-title}
 
 `policy` (optional)::
   (string) Identifier for the policy.
 
-==== Request Parameters
+[[sample-api-query-params]]
+==== {api-query-parms-title}
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-==== Authorization
+[[sample-api-prereqs]]
+==== {api-prereq-title}
 
 You must have the `manage_ilm` or `read_ilm` or both cluster privileges to use this API.
 For more information, see <<security-privileges>>.
 
-==== Examples
+[[sample-api-example]]
+==== {api-examples-title}
 
 The following example retrieves `my_policy`:
 

--- a/docs/reference/ilm/apis/get-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/get-lifecycle.asciidoc
@@ -8,36 +8,37 @@
 
 Retrieves a lifecycle policy.
 
-[[sample-api-request]]
+[[ilm-get-lifecycle-request]]
 ==== {api-request-title}
 
 `GET _ilm/policy`
 `GET _ilm/policy/<policy_id>`
 
-[[sample-api-desc]]
+[[ilm-get-lifecycle-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage_ilm` or
+`read_ilm` or both cluster privileges to use this API. For more information, see
+<<security-privileges>>.
+
+[[ilm-get-lifecycle-desc]]
 ==== {api-description-title}
 
 Returns the specified policy definition. Includes the policy version and last
 modified date. If no policy is specified, returns all defined policies.
 
-[[sample-api-path-params]]
+[[ilm-get-lifecycle-path-params]]
 ==== {api-path-parms-title}
 
-`policy` (optional)::
-  (string) Identifier for the policy.
+`<policy_id>`::
+  (Optional, string) Identifier for the policy.
 
-[[sample-api-query-params]]
+[[ilm-get-lifecycle-query-params]]
 ==== {api-query-parms-title}
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-[[sample-api-prereqs]]
-==== {api-prereq-title}
-
-You must have the `manage_ilm` or `read_ilm` or both cluster privileges to use this API.
-For more information, see <<security-privileges>>.
-
-[[sample-api-example]]
+[[ilm-get-lifecycle-example]]
 ==== {api-examples-title}
 
 The following example retrieves `my_policy`:

--- a/docs/reference/ilm/apis/get-status.asciidoc
+++ b/docs/reference/ilm/apis/get-status.asciidoc
@@ -10,31 +10,32 @@
 
 Retrieves the current {ilm} ({ilm-init}) status.
 
-[[sample-api-request]]
+[[ilm-get-status-request]]
 ==== {api-request-title}
 
 `GET /_ilm/status`
 
-[[sample-api-desc]]
+[[ilm-get-status-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage_ilm` or
+`read_ilm` or both cluster privileges to use this API. For more information, see
+<<security-privileges>>.
+
+[[ilm-get-status-desc]]
 ==== {api-description-title}
 
 Returns the status of the {ilm-init} plugin. The `operation_mode` field in the
 response shows one of three states: `STARTED`, `STOPPING`,
 or `STOPPED`. You can change the status of the {ilm-init} plugin with the
-<<ilm-start, Start ILM>> and <<ilm-stop, Stop ILM>> APIs.
+<<ilm-start,start ILM>> and <<ilm-stop,stop ILM>> APIs.
 
-[[sample-api-query-params]]
+[[ilm-get-status-query-params]]
 ==== {api-query-parms-title}
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-[[sample-api-prereqs]]
-==== {api-prereq-title}
-
-You must have the `manage_ilm` or `read_ilm` or both cluster privileges to use this API.
-For more information, see <<security-privileges>>.
-
-[[sample-api-example]]
+[[ilm-get-status-example]]
 ==== {api-examples-title}
 
 The following example gets the {ilm-init} plugin status.

--- a/docs/reference/ilm/apis/get-status.asciidoc
+++ b/docs/reference/ilm/apis/get-status.asciidoc
@@ -10,27 +10,32 @@
 
 Retrieves the current {ilm} ({ilm-init}) status.
 
-==== Request
+[[sample-api-request]]
+==== {api-request-title}
 
 `GET /_ilm/status`
 
-==== Description
+[[sample-api-desc]]
+==== {api-description-title}
 
 Returns the status of the {ilm-init} plugin. The `operation_mode` field in the
 response shows one of three states: `STARTED`, `STOPPING`,
 or `STOPPED`. You can change the status of the {ilm-init} plugin with the
 <<ilm-start, Start ILM>> and <<ilm-stop, Stop ILM>> APIs.
 
-==== Request Parameters
+[[sample-api-query-params]]
+==== {api-query-parms-title}
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-==== Authorization
+[[sample-api-prereqs]]
+==== {api-prereq-title}
 
 You must have the `manage_ilm` or `read_ilm` or both cluster privileges to use this API.
 For more information, see <<security-privileges>>.
 
-==== Examples
+[[sample-api-example]]
+==== {api-examples-title}
 
 The following example gets the {ilm-init} plugin status.
 

--- a/docs/reference/ilm/apis/ilm-api.asciidoc
+++ b/docs/reference/ilm/apis/ilm-api.asciidoc
@@ -1,9 +1,8 @@
 [[index-lifecycle-management-api]]
 == {ilm-cap} API
 
-You can use the following APIs to manage policies on indices. See
-<<index-lifecycle-management,Managing the index lifecycle>> for more information
-about Index Lifecycle Management.
+You can use the following APIs to manage policies on indices. For more
+information, see <<index-lifecycle-management>>.
 
 [float]
 [[ilm-api-policy-endpoint]]

--- a/docs/reference/ilm/apis/move-to-step.asciidoc
+++ b/docs/reference/ilm/apis/move-to-step.asciidoc
@@ -8,11 +8,13 @@
 
 Triggers execution of a specific step in the lifecycle policy.
 
-==== Request
+[[sample-api-request]]
+==== {api-request-title}
 
 `POST _ilm/move/<index>`
 
-==== Description
+[[sample-api-desc]]
+==== {api-description-title}
 
 WARNING: This operation can result in the loss of data. Manually moving an index
 into a specific step executes that step even if it has already been performed.
@@ -27,21 +29,25 @@ The request will fail if the current step does not match the step currently
 being executed for the index. This is to prevent the index from being moved from
 an unexpected step into the next step.
 
-==== Path Parameters
+[[sample-api-path-params]]
+==== {api-path-parms-title}
 
 `index` (required)::
   (string) Identifier for the index.
 
-==== Request Parameters
+[[sample-api-query-params]]
+==== {api-query-parms-title}
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-==== Authorization
+[[sample-api-prereqs]]
+==== {api-prereq-title}
 
 You must have the `manage_ilm` privileges on the indices being managed to use this API.
 For more information, see <<security-privileges>>.
 
-==== Examples
+[[sample-api-example]]
+==== {api-examples-title}
 
 The following example moves `my_index` from the initial step to the
 `forcemerge` step:

--- a/docs/reference/ilm/apis/move-to-step.asciidoc
+++ b/docs/reference/ilm/apis/move-to-step.asciidoc
@@ -8,12 +8,19 @@
 
 Triggers execution of a specific step in the lifecycle policy.
 
-[[sample-api-request]]
+[[ilm-move-to-step-request]]
 ==== {api-request-title}
 
 `POST _ilm/move/<index>`
 
-[[sample-api-desc]]
+[[ilm-move-to-step-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage_ilm`
+privileges on the indices being managed to use this API. For more information,
+see <<security-privileges>>.
+
+[[ilm-move-to-step-desc]]
 ==== {api-description-title}
 
 WARNING: This operation can result in the loss of data. Manually moving an index
@@ -29,24 +36,18 @@ The request will fail if the current step does not match the step currently
 being executed for the index. This is to prevent the index from being moved from
 an unexpected step into the next step.
 
-[[sample-api-path-params]]
+[[ilm-move-to-step-path-params]]
 ==== {api-path-parms-title}
 
-`index` (required)::
-  (string) Identifier for the index.
+`<index>`::
+  (Required, string) Identifier for the index.
 
-[[sample-api-query-params]]
+[[ilm-move-to-step-query-params]]
 ==== {api-query-parms-title}
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-[[sample-api-prereqs]]
-==== {api-prereq-title}
-
-You must have the `manage_ilm` privileges on the indices being managed to use this API.
-For more information, see <<security-privileges>>.
-
-[[sample-api-example]]
+[[ilm-move-to-step-example]]
 ==== {api-examples-title}
 
 The following example moves `my_index` from the initial step to the

--- a/docs/reference/ilm/apis/put-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/put-lifecycle.asciidoc
@@ -9,11 +9,13 @@
 Creates or updates lifecycle policy. See <<ilm-policy-definition,Policy phases and actions>>
 for definitions of policy components.
 
-==== Request
+[[sample-api-request]]
+==== {api-request-title}
 
 `PUT _ilm/policy/<policy_id>`
 
-==== Description
+[[sample-api-desc]]
+==== {api-description-title}
 
 Creates a lifecycle policy. If the specified policy exists, the policy is
 replaced and the policy version is incremented.
@@ -21,16 +23,19 @@ replaced and the policy version is incremented.
 NOTE: Only the latest version of the policy is stored, you cannot revert to
 previous versions.
 
-==== Path Parameters
+[[sample-api-path-params]]
+==== {api-path-parms-title}
 
 `policy` (required)::
   (string) Identifier for the policy.
 
-==== Request Parameters
+[[sample-api-query-params]]
+==== {api-query-parms-title}
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-==== Authorization
+[[sample-api-prereqs]]
+==== {api-prereq-title}
 
 You must have the `manage_ilm` cluster privilege to use this API. You must
 also have the `manage` index privilege on all indices being managed by `policy`.
@@ -38,7 +43,8 @@ All operations executed by {ilm} for a policy are executed as the user that
 put the latest version of a policy.
 For more information, see <<security-privileges>>.
 
-==== Examples
+[[sample-api-example]]
+==== {api-examples-title}
 
 The following example creates a new policy named `my_policy`:
 

--- a/docs/reference/ilm/apis/put-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/put-lifecycle.asciidoc
@@ -6,15 +6,24 @@
 <titleabbrev>Create policy</titleabbrev>
 ++++
 
-Creates or updates lifecycle policy. See <<ilm-policy-definition,Policy phases and actions>>
-for definitions of policy components.
+Creates or updates lifecycle policy. See <<ilm-policy-definition>> for
+definitions of policy components.
 
-[[sample-api-request]]
+[[ilm-put-lifecycle-request]]
 ==== {api-request-title}
 
 `PUT _ilm/policy/<policy_id>`
 
-[[sample-api-desc]]
+[[ilm-put-lifecycle-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage_ilm`
+cluster privilege to use this API. You must also have the `manage` index
+privilege on all indices being managed by `policy`. All operations executed by
+{ilm} for a policy are executed as the user that put the latest version of a
+policy. For more information, see <<security-privileges>>.
+
+[[ilm-put-lifecycle-desc]]
 ==== {api-description-title}
 
 Creates a lifecycle policy. If the specified policy exists, the policy is
@@ -23,27 +32,18 @@ replaced and the policy version is incremented.
 NOTE: Only the latest version of the policy is stored, you cannot revert to
 previous versions.
 
-[[sample-api-path-params]]
+[[ilm-put-lifecycle-path-params]]
 ==== {api-path-parms-title}
 
-`policy` (required)::
-  (string) Identifier for the policy.
+`<policy_id>`::
+  (Required, string) Identifier for the policy.
 
-[[sample-api-query-params]]
+[[ilm-put-lifecycle-query-params]]
 ==== {api-query-parms-title}
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-[[sample-api-prereqs]]
-==== {api-prereq-title}
-
-You must have the `manage_ilm` cluster privilege to use this API. You must
-also have the `manage` index privilege on all indices being managed by `policy`.
-All operations executed by {ilm} for a policy are executed as the user that
-put the latest version of a policy.
-For more information, see <<security-privileges>>.
-
-[[sample-api-example]]
+[[ilm-put-lifecycle-example]]
 ==== {api-examples-title}
 
 The following example creates a new policy named `my_policy`:

--- a/docs/reference/ilm/apis/remove-policy-from-index.asciidoc
+++ b/docs/reference/ilm/apis/remove-policy-from-index.asciidoc
@@ -8,31 +8,37 @@
 
 Removes the assigned lifecycle policy from an index.
 
-==== Request
+[[sample-api-request]]
+==== {api-request-title}
 
 `POST <index>/_ilm/remove`
 
-==== Description
+[[sample-api-desc]]
+==== {api-description-title}
 
 Removes the assigned lifecycle policy and stops managing the specified index.
 If an index pattern is specified, removes the assigned policies from all matching
 indices.
 
-==== Path Parameters
+[[sample-api-path-params]]
+==== {api-path-parms-title}
 
 `index` (required)::
   (string) Identifier for the index.
 
-==== Request Parameters
+[[sample-api-query-params]]
+==== {api-query-parms-title}
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-==== Authorization
+[[sample-api-prereqs]]
+==== {api-prereq-title}
 
 You must have the `manage_ilm` privileges on the indices being managed to use this API.
 For more information, see <<security-privileges>>.
 
-==== Examples
+[[sample-api-example]]
+==== {api-examples-title}
 
 The following example removes the assigned policy from `my_index`.
 

--- a/docs/reference/ilm/apis/remove-policy-from-index.asciidoc
+++ b/docs/reference/ilm/apis/remove-policy-from-index.asciidoc
@@ -8,36 +8,37 @@
 
 Removes the assigned lifecycle policy from an index.
 
-[[sample-api-request]]
+[[ilm-remove-policy-request]]
 ==== {api-request-title}
 
 `POST <index>/_ilm/remove`
 
-[[sample-api-desc]]
+[[ilm-remove-policy-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage_ilm`
+privileges on the indices being managed to use this API. For more information,
+see <<security-privileges>>.
+
+[[ilm-remove-policy-desc]]
 ==== {api-description-title}
 
 Removes the assigned lifecycle policy and stops managing the specified index.
 If an index pattern is specified, removes the assigned policies from all matching
 indices.
 
-[[sample-api-path-params]]
+[[ilm-remove-policy-path-params]]
 ==== {api-path-parms-title}
 
-`index` (required)::
-  (string) Identifier for the index.
+`<index>`::
+  (Required, string) Identifier for the index.
 
-[[sample-api-query-params]]
+[[ilm-remove-policy-query-params]]
 ==== {api-query-parms-title}
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-[[sample-api-prereqs]]
-==== {api-prereq-title}
-
-You must have the `manage_ilm` privileges on the indices being managed to use this API.
-For more information, see <<security-privileges>>.
-
-[[sample-api-example]]
+[[ilm-remove-policy-example]]
 ==== {api-examples-title}
 
 The following example removes the assigned policy from `my_index`.

--- a/docs/reference/ilm/apis/retry-policy.asciidoc
+++ b/docs/reference/ilm/apis/retry-policy.asciidoc
@@ -8,31 +8,37 @@
 
 Retry executing the policy for an index that is in the ERROR step.
 
-==== Request
+[[sample-api-request]]
+==== {api-request-title}
 
 `POST <index>/_ilm/retry`
 
-==== Description
+[[sample-api-desc]]
+==== {api-description-title}
 
 Sets the policy back to the step where the error occurred and executes the step.
 Use the <<ilm-explain-lifecycle, ILM Explain API>> to determine if an index is in the ERROR
 step.
 
-==== Path Parameters
+[[sample-api-path-params]]
+==== {api-path-parms-title}
 
 `index` (required)::
   (string) Identifier for the indices to retry in comma-separated format.
 
-==== Request Parameters
+[[sample-api-query-params]]
+==== {api-query-parms-title}
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-==== Authorization
+[[sample-api-prereqs]]
+==== {api-prereq-title}
 
 You must have the `manage_ilm` privileges on the indices being managed to use this API.
 For more information, see <<security-privileges>>.
 
-==== Examples
+[[sample-api-example]]
+==== {api-examples-title}
 
 The following example retries the policy for `my_index`.
 

--- a/docs/reference/ilm/apis/retry-policy.asciidoc
+++ b/docs/reference/ilm/apis/retry-policy.asciidoc
@@ -8,36 +8,37 @@
 
 Retry executing the policy for an index that is in the ERROR step.
 
-[[sample-api-request]]
+[[ilm-retry-policy-request]]
 ==== {api-request-title}
 
 `POST <index>/_ilm/retry`
 
-[[sample-api-desc]]
+[[ilm-retry-policy-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage_ilm`
+privileges on the indices being managed to use this API. For more information,
+see <<security-privileges>>.
+
+[[ilm-retry-policy-desc]]
 ==== {api-description-title}
 
 Sets the policy back to the step where the error occurred and executes the step.
 Use the <<ilm-explain-lifecycle, ILM Explain API>> to determine if an index is in the ERROR
 step.
 
-[[sample-api-path-params]]
+[[ilm-retry-policy-path-params]]
 ==== {api-path-parms-title}
 
-`index` (required)::
-  (string) Identifier for the indices to retry in comma-separated format.
+`<index>`::
+  (Required, string) Identifier for the indices to retry in comma-separated format.
 
-[[sample-api-query-params]]
+[[ilm-retry-policy-query-params]]
 ==== {api-query-parms-title}
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-[[sample-api-prereqs]]
-==== {api-prereq-title}
-
-You must have the `manage_ilm` privileges on the indices being managed to use this API.
-For more information, see <<security-privileges>>.
-
-[[sample-api-example]]
+[[ilm-retry-policy-example]]
 ==== {api-examples-title}
 
 The following example retries the policy for `my_index`.

--- a/docs/reference/ilm/apis/start.asciidoc
+++ b/docs/reference/ilm/apis/start.asciidoc
@@ -10,30 +10,31 @@
 
 Start the {ilm} ({ilm-init}) plugin.
 
-[[sample-api-request]]
+[[ilm-start-request]]
 ==== {api-request-title}
 
 `POST /_ilm/start`
 
-[[sample-api-desc]]
+[[ilm-start-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage_ilm`
+cluster privilege to use this API. For more information, see
+<<security-privileges>>.
+
+[[ilm-start-desc]]
 ==== {api-description-title}
 
 Starts the {ilm-init} plugin if it is currently stopped. {ilm-init} is started
 automatically when the cluster is formed. Restarting {ilm-init} is only
 necessary if it has been stopped using the <<ilm-stop, Stop {ilm-init} API>>.
 
-[[sample-api-query-params]]
+[[ilm-start-query-params]]
 ==== {api-query-parms-title}
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-[[sample-api-prereqs]]
-==== {api-prereq-title}
-
-You must have the `manage_ilm` cluster privilege to use this API.
-For more information, see <<security-privileges>>.
-
-[[sample-api-example]]
+[[ilm-start-example]]
 ==== {api-examples-title}
 
 The following example starts the ILM plugin.

--- a/docs/reference/ilm/apis/start.asciidoc
+++ b/docs/reference/ilm/apis/start.asciidoc
@@ -10,26 +10,31 @@
 
 Start the {ilm} ({ilm-init}) plugin.
 
-==== Request
+[[sample-api-request]]
+==== {api-request-title}
 
 `POST /_ilm/start`
 
-==== Description
+[[sample-api-desc]]
+==== {api-description-title}
 
 Starts the {ilm-init} plugin if it is currently stopped. {ilm-init} is started
 automatically when the cluster is formed. Restarting {ilm-init} is only
 necessary if it has been stopped using the <<ilm-stop, Stop {ilm-init} API>>.
 
-==== Request Parameters
+[[sample-api-query-params]]
+==== {api-query-parms-title}
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-==== Authorization
+[[sample-api-prereqs]]
+==== {api-prereq-title}
 
 You must have the `manage_ilm` cluster privilege to use this API.
 For more information, see <<security-privileges>>.
 
-==== Examples
+[[sample-api-example]]
+==== {api-examples-title}
 
 The following example starts the ILM plugin.
 

--- a/docs/reference/ilm/apis/stop.asciidoc
+++ b/docs/reference/ilm/apis/stop.asciidoc
@@ -10,11 +10,13 @@
 
 Stop the {ilm} ({ilm-init}) plugin.
 
-==== Request
+[[sample-api-request]]
+==== {api-request-title}
 
 `POST /_ilm/stop`
 
-==== Description
+[[sample-api-desc]]
+==== {api-description-title}
 
 Halts all lifecycle management operations and stops the {ilm-init} plugin. This
 is useful when you are performing maintenance on the cluster and need to prevent
@@ -25,16 +27,19 @@ plugin might continue to run until in-progress operations complete and the plugi
 can be safely stopped. Use the  <<ilm-get-status, Get ILM Status>> API to see
 if {ilm-init} is running.
 
-==== Request Parameters
+[[sample-api-query-params]]
+==== {api-query-parms-title}
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-==== Authorization
+[[sample-api-prereqs]]
+==== {api-prereq-title}
 
 You must have the `manage_ilm` cluster privilege to use this API.
 For more information, see <<security-privileges>>.
 
-==== Examples
+[[sample-api-example]]
+==== {api-examples-title}
 
 The following example stops the ILM plugin.
 

--- a/docs/reference/ilm/apis/stop.asciidoc
+++ b/docs/reference/ilm/apis/stop.asciidoc
@@ -10,12 +10,19 @@
 
 Stop the {ilm} ({ilm-init}) plugin.
 
-[[sample-api-request]]
+[[ilm-stop-request]]
 ==== {api-request-title}
 
 `POST /_ilm/stop`
 
-[[sample-api-desc]]
+[[ilm-stop-prereqs]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the `manage_ilm`
+cluster privilege to use this API. For more information, see
+<<security-privileges>>.
+
+[[ilm-stop-desc]]
 ==== {api-description-title}
 
 Halts all lifecycle management operations and stops the {ilm-init} plugin. This
@@ -27,18 +34,12 @@ plugin might continue to run until in-progress operations complete and the plugi
 can be safely stopped. Use the  <<ilm-get-status, Get ILM Status>> API to see
 if {ilm-init} is running.
 
-[[sample-api-query-params]]
+[[ilm-stop-query-params]]
 ==== {api-query-parms-title}
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-[[sample-api-prereqs]]
-==== {api-prereq-title}
-
-You must have the `manage_ilm` cluster privilege to use this API.
-For more information, see <<security-privileges>>.
-
-[[sample-api-example]]
+[[ilm-stop-example]]
 ==== {api-examples-title}
 
 The following example stops the ILM plugin.


### PR DESCRIPTION
This PR updates the ILM APIs to align with the new [API reference template](https://github.com/elastic/docs/blob/master/shared/api-ref-ex.asciidoc).

Relates to elastic/docs#937 

Preview: http://elasticsearch_49348.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/index-lifecycle-management-api.html
